### PR TITLE
Bugfix: Fix loop when auto_login = true

### DIFF
--- a/src/frontend/src/stores/typesStore.ts
+++ b/src/frontend/src/stores/typesStore.ts
@@ -29,6 +29,7 @@ export const useTypesStore = create<TypesStoreType>((set, get) => ({
         .catch((error) => {
           console.error("An error has occurred while fetching types.");
           console.log(error);
+          setLoading(false);
           reject();
         });
     });


### PR DESCRIPTION
 🐛 (typesStore.ts): set loading to false when an error occurs during fetching types to prevent infinite loading state