### PR TITLE
Fix DB migration erro with Azure PostgreSQL Password with Langflow v0.6.14

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -133,7 +133,7 @@ class DatabaseService(Service):
         alembic_cfg = Config(stdout=buffer)
         # alembic_cfg.attributes["connection"] = session
         alembic_cfg.set_main_option("script_location", str(self.script_location))
-        alembic_cfg.set_main_option("sqlalchemy.url", self.database_url)
+        alembic_cfg.set_main_option("sqlalchemy.url", self.database_url.replace('%', '%%'))
 
         should_initialize_alembic = False
         with Session(self.engine) as session:


### PR DESCRIPTION
## Description
This pull request addresses an issue encountered when connecting a PostgreSQL database on Azure, where Azure requires an "@" symbol in all database usernames. Previously, changing passwords containing "@" was a workaround, but it's no longer feasible. Consequently, the migration process failed. To resolve this, a fix has been applied to handle passwords containing "@" by replacing "@" with "%40" in the code.

However, during the initialization of Alembic migrations, a single "%" symbol caused failure. This pull request resolves this issue by replacing single "%" with "%%".

## Changes Made
- Modified the `DatabaseService` class in `service.py` to handle passwords containing "@" by replacing "@" with "%40" in the database URL.
- Adjusted the `alembic_cfg.set_main_option("sqlalchemy.url", self.database_url.replace('%', '%%'))` line to replace single "%" with "%%" to prevent initialization failure during Alembic migrations.

## Related Issues
Error in DB migration with PostgreSQL for Langflow v0.6 #1432

## Checklist
- Tested the changes locally



