### PR TITLE
Fix API not passing input_value to Chat Input

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -109,6 +109,7 @@ async def simplified_run_flow(
     This endpoint provides a powerful interface for executing flows with enhanced flexibility and efficiency, supporting a wide range of applications by allowing for dynamic input and output configuration along with performance optimizations through session management and caching.
     """
     session_id = input_request.session_id
+
     try:
         task_result: List[RunOutputs] = []
         artifacts = {}
@@ -127,7 +128,8 @@ async def simplified_run_flow(
             if flow.data is None:
                 raise ValueError(f"Flow {flow_id} has no data")
             graph_data = flow.data
-            graph_data = process_tweaks(graph_data, input_request.tweaks or {})
+
+            graph_data = process_tweaks(graph_data, input_request.tweaks or {}, stream=stream)
             graph = Graph.from_payload(graph_data, flow_id=flow_id)
         inputs = [
             InputValueRequest(components=[], input_value=input_request.input_value, type=input_request.input_type)

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -130,7 +130,7 @@ async def simplified_run_flow(
             graph_data = flow.data
 
             graph_data = process_tweaks(graph_data, input_request.tweaks or {}, stream=stream)
-            graph = Graph.from_payload(graph_data, flow_id=flow_id)
+            graph = Graph.from_payload(graph_data, flow_id=flow_id, user_id=api_key_user.id)
         inputs = [
             InputValueRequest(components=[], input_value=input_request.input_value, type=input_request.input_type)
         ]

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -32,6 +32,7 @@ class Graph:
         nodes: List[Dict],
         edges: List[Dict[str, str]],
         flow_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> None:
         """
         Initializes a new instance of the Graph class.
@@ -47,6 +48,7 @@ class Graph:
         self._runs = 0
         self._updates = 0
         self.flow_id = flow_id
+        self.user_id = user_id
         self._is_input_vertices: List[str] = []
         self._is_output_vertices: List[str] = []
         self._is_state_vertices: List[str] = []
@@ -450,7 +452,7 @@ class Graph:
         self.__init__(**state)
 
     @classmethod
-    def from_payload(cls, payload: Dict, flow_id: Optional[str] = None) -> "Graph":
+    def from_payload(cls, payload: Dict, flow_id: Optional[str] = None, user_id: Optional[str] = None) -> "Graph":
         """
         Creates a graph from a payload.
 
@@ -465,7 +467,7 @@ class Graph:
         try:
             vertices = payload["nodes"]
             edges = payload["edges"]
-            return cls(vertices, edges, flow_id)
+            return cls(vertices, edges, flow_id, user_id)
         except KeyError as exc:
             logger.exception(exc)
             if "nodes" not in payload and "edges" not in payload:
@@ -772,7 +774,7 @@ class Graph:
                         lock=lock,
                         set_cache_coro=set_cache_coro,
                         vertex_id=vertex_id,
-                        user_id=None,
+                        user_id=self.user_id,
                         inputs_dict={},
                     ),
                     name=f"{vertex.display_name} Run {vertex_task_run_count.get(vertex_id, 0)}",

--- a/src/backend/base/langflow/processing/process.py
+++ b/src/backend/base/langflow/processing/process.py
@@ -243,7 +243,6 @@ def apply_tweaks(node: Dict[str, Any], node_tweaks: Dict[str, Any]) -> None:
 
     for tweak_name, tweak_value in node_tweaks.items():
         if tweak_name not in template_data:
-            logger.warning(f"Node {node.get('id')} does not have a tweak named {tweak_name}")
             continue
         if tweak_name in template_data:
             key = "file_path" if template_data[tweak_name]["type"] == "file" else "value"
@@ -256,21 +255,24 @@ def apply_tweaks_on_vertex(vertex: Vertex, node_tweaks: Dict[str, Any]) -> None:
             vertex.params[tweak_name] = tweak_value
 
 
-def process_tweaks(graph_data: Dict[str, Any], tweaks: Union["Tweaks", Dict[str, Dict[str, Any]]]) -> Dict[str, Any]:
+def process_tweaks(
+    graph_data: Dict[str, Any], tweaks: Union["Tweaks", Dict[str, Dict[str, Any]]], stream: bool = False
+) -> Dict[str, Any]:
     """
     This function is used to tweak the graph data using the node id and the tweaks dict.
 
     :param graph_data: The dictionary containing the graph data. It must contain a 'data' key with
                        'nodes' as its child or directly contain 'nodes' key. Each node should have an 'id' and 'data'.
     :param tweaks: The dictionary containing the tweaks. The keys can be the node id or the name of the tweak.
-                     The values can be a dictionary containing the tweaks for the node or the value of the tweak.
+                   The values can be a dictionary containing the tweaks for the node or the value of the tweak.
+    :param stream: A boolean flag indicating whether streaming should be deactivated across all components or not. Default is False.
     :return: The modified graph_data dictionary.
-
     :raises ValueError: If the input is not in the expected format.
     """
     if not isinstance(tweaks, dict):
         tweaks = tweaks.model_dump()
-
+    if "stream" not in tweaks:
+        tweaks["stream"] = stream
     nodes = validate_input(graph_data, tweaks)
     nodes_map = {node.get("id"): node for node in nodes}
     nodes_display_name_map = {node.get("data", {}).get("node", {}).get("display_name"): node for node in nodes}


### PR DESCRIPTION
This pull request fixes the issue where the input_value was being ignored and not passed into the Chat input node when calling the API endpoint run/<flow_id>. The problem was observed in Langflow v1.0.0a23. The fix includes updating the Graph.from_payload method to include the user_id parameter and fixing the process_tweaks function to handle the stream flag correctly. This resolves issue #1744.

Also fixes global variables not being honored when using the API