### PR TITLE
Fix created_at field type in Variable and ApiKey models

### DIFF
--- a/src/backend/base/langflow/processing/load.py
+++ b/src/backend/base/langflow/processing/load.py
@@ -104,7 +104,7 @@ def run_flow_from_json(
     """
     # Set all streaming to false
     try:
-        import nest_asyncio
+        import nest_asyncio  # type: ignore
 
         nest_asyncio.apply()
     except Exception as e:

--- a/src/backend/base/langflow/services/database/models/api_key/model.py
+++ b/src/backend/base/langflow/services/database/models/api_key/model.py
@@ -22,7 +22,7 @@ class ApiKeyBase(SQLModel):
 
 class ApiKey(ApiKeyBase, table=True):
     id: UUID = Field(default_factory=uuid4, primary_key=True, unique=True)
-    created_at: datetime = Field(
+    created_at: Optional[datetime] = Field(
         default=None, sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     )
     api_key: str = Field(index=True, unique=True)

--- a/src/backend/base/langflow/services/database/models/variable/model.py
+++ b/src/backend/base/langflow/services/database/models/variable/model.py
@@ -25,7 +25,7 @@ class Variable(VariableBase, table=True):
         description="Unique ID for the variable",
     )
     # name is unique per user
-    created_at: datetime = Field(
+    created_at: Optional[datetime] = Field(
         default=None,
         sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=True),
         description="Creation time of the variable",

--- a/src/backend/base/langflow/services/monitor/utils.py
+++ b/src/backend/base/langflow/services/monitor/utils.py
@@ -101,10 +101,16 @@ def add_row_to_table(
         conn.execute(insert_sql, values)
     except Exception as e:
         # Log values types
+        column_error_message = ""
         for key, value in validated_dict.items():
             logger.error(f"{key}: {type(value)}")
+            if value in str(e):
+                column_error_message = f"Column: {key} Value: {value} Error: {e}"
 
-        logger.error(f"Error adding row to table: {e}")
+        if column_error_message:
+            logger.error(f"Error adding row to {table_name}: {column_error_message}")
+        else:
+            logger.error(f"Error adding row to {table_name}: {e}")
 
 
 async def log_message(


### PR DESCRIPTION
This pull request fixes the `created_at` field type in the Variable and ApiKey models. Previously, the `created_at` field was defined as `datetime`, but it should be `Optional[datetime]`. This PR updates the field type to `Optional[datetime]` in both models to ensure consistency and avoid potential issues.