### PR TITLE
Update Docker image references to langflowai in GitHub workflows and Docker Compose files

### DIFF
--- a/.github/workflows/pre-release-base.yml
+++ b/.github/workflows/pre-release-base.yml
@@ -74,4 +74,4 @@ jobs:
           push: true
           file: ./build_and_push_base.Dockerfile
           tags: |
-            logspace/langflow:base-${{ needs.release.outputs.version }}
+            langflowai/langflow:base-${{ needs.release.outputs.version }}

--- a/.github/workflows/pre-release-langflow.yml
+++ b/.github/workflows/pre-release-langflow.yml
@@ -80,8 +80,8 @@ jobs:
           push: true
           file: ./build_and_push.Dockerfile
           tags: |
-            logspace/langflow:${{ needs.release.outputs.version }}
-            logspace/langflow:1.0-alpha
+            langflowai/langflow:${{ needs.release.outputs.version }}
+            langflowai/langflow:1.0-alpha
 
   create_release:
     name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,8 @@ jobs:
           push: true
           file: ./build_and_push.Dockerfile
           tags: |
-            logspace/langflow:${{ steps.check-version.outputs.version }}
-            logspace/langflow:latest
+            langflowai/langflow:${{ steps.check-version.outputs.version }}
+            langflowai/langflow:latest
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -69,7 +69,7 @@ services:
         - traefik.http.routers.${STACK_NAME?Variable not set}-proxy-http.middlewares=${STACK_NAME?Variable not set}-www-redirect,${STACK_NAME?Variable not set}-https-redirect
 
   backend: &backend
-    image: "logspace/langflow:latest"
+    image: "langflowai/langflow:latest"
     depends_on:
       - db
       - broker

--- a/docker_example/Dockerfile
+++ b/docker_example/Dockerfile
@@ -1,3 +1,3 @@
-FROM logspace/langflow:latest
+FROM langflowai/langflow:latest
 
 CMD ["python", "-m", "langflow", "run", "--host", "0.0.0.0", "--port", "7860"]

--- a/docker_example/README.md
+++ b/docker_example/README.md
@@ -35,7 +35,7 @@ The Docker Compose configuration spins up two services: `langflow` and `postgres
 
 ### LangFlow Service
 
-The `langflow` service uses the `logspace/langflow:latest` Docker image and exposes port 7860. It depends on the `postgres` service.
+The `langflow` service uses the `langflowai/langflow:latest` Docker image and exposes port 7860. It depends on the `postgres` service.
 
 Environment variables:
 
@@ -62,4 +62,4 @@ Volumes:
 
 ## Switching to a Specific LangFlow Version
 
-If you want to use a specific version of LangFlow, you can modify the `image` field under the `langflow` service in the Docker Compose file. For example, to use version 1.0-alpha, change `logspace/langflow:latest` to `logspace/langflow:1.0-alpha`.
+If you want to use a specific version of LangFlow, you can modify the `image` field under the `langflow` service in the Docker Compose file. For example, to use version 1.0-alpha, change `langflowai/langflow:latest` to `langflowai/langflow:1.0-alpha`.

--- a/docker_example/docker-compose.yml
+++ b/docker_example/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   langflow:
-    image: logspace/langflow:latest
+    image: langflowai/langflow:latest
     ports:
       - "7860:7860"
     depends_on:

--- a/docker_example/pre.Dockerfile
+++ b/docker_example/pre.Dockerfile
@@ -1,3 +1,3 @@
-FROM logspace/langflow:1.0-alpha
+FROM langflowai/langflow:1.0-alpha
 
 CMD ["python", "-m", "langflow", "run", "--host", "0.0.0.0", "--port", "7860"]

--- a/docker_example/pre.docker-compose.yml
+++ b/docker_example/pre.docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   langflow:
-    image: logspace/langflow:1.0-alpha
+    image: langflowai/langflow:1.0-alpha
     ports:
       - "7860:7860"
     depends_on:

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM logspace/backend_build as backend_build
+FROM langflowai/backend_build as backend_build
 
 FROM python:3.10-slim
 WORKDIR /app


### PR DESCRIPTION
This pull request updates the Docker image references in the GitHub workflows and Docker Compose files from "logspace/langflow" to "langflowai/langflow". This ensures that the latest version of the LangFlow image is used and aligns with the new repository name.