### PR TITLE
Docs: Correct Formatting and Syntax

### DIFF
--- a/docs/docs/migration/possible-installation-issues.mdx
+++ b/docs/docs/migration/possible-installation-issues.mdx
@@ -34,6 +34,7 @@ TLDR;
 This folder can be found at:
   - **Linux or WSL2 on Windows**: `home/<username>/.cache/langflow/`
   - **MacOS**: `/Users/<username>/Library/Caches/langflow/`
+
 If you wish to retain your files, ensure to back them up before clearing the folder.
 
-This error often occurs when upgrading Langflow, the new version can't override `langflow-pre.db in `.cache/langflow/`. Clearing the cache removes this file but will also erase your settings.
+This error often occurs when upgrading Langflow, the new version can't override `langflow-pre.db` in `.cache/langflow/`. Clearing the cache removes this file but will also erase your settings.


### PR DESCRIPTION
Fix formatting by:

* Adds a missing empty line following an unordered list.
* Corrects an unclosed backtick.