### PR TITLE
Fix custom_repr assignment in instantiate_custom_component function

### DIFF
--- a/src/backend/base/langflow/interface/initialize/loading.py
+++ b/src/backend/base/langflow/interface/initialize/loading.py
@@ -185,7 +185,7 @@ async def instantiate_custom_component(params, user_id, vertex):
         # Call the build method directly if it's sync
         build_result = custom_component.build(**params_copy)
     custom_repr = custom_component.custom_repr()
-    if not custom_repr and isinstance(build_result, (dict, Record, str)):
+    if custom_repr is None and isinstance(build_result, (dict, Record, str)):
         custom_repr = build_result
     if not isinstance(custom_repr, str):
         custom_repr = str(custom_repr)


### PR DESCRIPTION
This pull request fixes the assignment of the custom_repr variable in the instantiate_custom_component function. The previous code used the "not" operator to check if custom_repr was empty, but this caused incorrect behavior when custom_repr was set to an empty string. The fix changes the check to use "is None" instead, ensuring that custom_repr is correctly assigned.