### PR TITLE
fix gcp deployment script

### DIFF
--- a/scripts/gcp/deploy_langflow_gcp.sh
+++ b/scripts/gcp/deploy_langflow_gcp.sh
@@ -48,8 +48,10 @@ apt -y upgrade
 
 # Install Python 3 pip, Langflow, and Nginx
 apt -y install python3-pip
-pip install langflow
-langflow --host 0.0.0.0 --port 7860
+pip3 install pip -U
+apt -y update
+pip3 install langflow
+langflow run --host 0.0.0.0 --port 7860
 EOF
 )
 


### PR DESCRIPTION
Resolved an issue with installing and running Langflow. The initial installation via pip install langflow and subsequent command langflow --host 0.0.0.0 --port 7860 encountered errors. The solution involved:

- Upgrading pip to the latest version.

- Updating the system packages.

- Reinstalling Langflow with pip3.

- Adjusting the execution command to langflow run --host 0.0.0.0 --port 7860.