### PR TITLE
Update CLI command in docs

### DIFF
--- a/docs/docs/administration/custom-component.mdx
+++ b/docs/docs/administration/custom-component.mdx
@@ -391,13 +391,13 @@ The recommended way to load custom components is to set the _`LANGFLOW_COMPONENT
 
 ```bash
 export LANGFLOW_COMPONENTS_PATH='["/path/to/components"]'
-langflow
+langflow run
 ```
 
 Alternatively, you can specify the path to your custom components using the _`--components-path`_ argument when running the Langflow CLI, as shown below:
 
 ```bash
-langflow --components-path /path/to/components
+langflow run --components-path /path/to/components
 ```
 
 Langflow will attempt to load all of the components found in the specified directory. If a component fails to load due to errors in the component's code, Langflow will print an error message to the console but will continue loading the rest of the components.

--- a/docs/docs/administration/langfuse_integration.mdx
+++ b/docs/docs/administration/langfuse_integration.mdx
@@ -28,7 +28,9 @@ Langfuse is an open-source tracing and analytics tool designed for LLM applicati
    Alternatively, you can run the Langflow CLI command:
 
    ```bash
-   LANGFLOW_LANGFUSE_SECRET_KEY=<your secret key> LANGFLOW_LANGFUSE_PUBLIC_KEY=<your public key> langflow
+   LANGFLOW_LANGFUSE_SECRET_KEY=<your secret key>
+   LANGFLOW_LANGFUSE_PUBLIC_KEY=<your public key>
+   langflow
    ```
 
    If you are self-hosting Langfuse, you can also set the environment variable `LANGFLOW_LANGFUSE_HOST` to point to your Langfuse instance. By default, Langfuse points to the cloud instance at `https://cloud.langfuse.com`.


### PR DESCRIPTION
super minor doc pr that I ran into when starting to add custom components

previous versions of langflow would only call `langflow` in order to start up the langflow server, but now it is `langflow run`.

this PR updates docs to reflect that change.