### PR TITLE
Update chromadb import in ChromaSearch.py and Chroma.py

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4090,6 +4090,23 @@ langchain-core = ">=0.1.31,<0.3"
 numpy = ">=1,<2"
 
 [[package]]
+name = "langchain-chroma"
+version = "0.1.1"
+description = "An integration package connecting Chroma and LangChain"
+optional = false
+python-versions = "<3.13,>=3.8.1"
+files = [
+    {file = "langchain_chroma-0.1.1-py3-none-any.whl", hash = "sha256:7346ba749e5c5735e2a659bc5e3bb2901177bd08448d61682db5a7f882e27b87"},
+    {file = "langchain_chroma-0.1.1.tar.gz", hash = "sha256:fb17c0cc591a425179958ca8cdb25d6cc9e43f4954a1ad4f3fe9cc2d306c455a"},
+]
+
+[package.dependencies]
+chromadb = ">=0.4.0,<0.6.0"
+fastapi = ">=0.95.2,<1"
+langchain-core = ">=0.1.40,<0.3"
+numpy = ">=1,<2"
+
+[[package]]
 name = "langchain-cohere"
 version = "0.1.5"
 description = "An integration package connecting Cohere and LangChain"
@@ -10005,4 +10022,4 @@ local = ["ctransformers", "llama-cpp-python", "sentence-transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "90454066807e8ae6341a0b4e9569bfabb027b005081e94bbfb763ce8c72de10f"
+content-hash = "36778b105f6f6e5efd0c1d37651d7b97defb0bc0db74b868a41e38de22251924"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ langchain-mistralai = "^0.1.6"
 couchbase = "^4.2.1"
 youtube-transcript-api = "^0.6.2"
 markdown = "^3.6"
+langchain-chroma = "^0.1.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/backend/base/langflow/components/vectorsearch/ChromaSearch.py
+++ b/src/backend/base/langflow/components/vectorsearch/ChromaSearch.py
@@ -39,7 +39,7 @@ class ChromaSearchComponent(LCVectorStoreComponent):
                 "advanced": True,
             },
             "chroma_server_host": {"display_name": "Server Host", "advanced": True},
-            "chroma_server_port": {"display_name": "Server Port", "advanced": True},
+            "chroma_server_http_port": {"display_name": "Server HTTP Port", "advanced": True},
             "chroma_server_grpc_port": {
                 "display_name": "Server gRPC Port",
                 "advanced": True,
@@ -66,26 +66,27 @@ class ChromaSearchComponent(LCVectorStoreComponent):
         index_directory: Optional[str] = None,
         chroma_server_cors_allow_origins: List[str] = [],
         chroma_server_host: Optional[str] = None,
-        chroma_server_port: Optional[int] = None,
+        chroma_server_http_port: Optional[int] = None,
         chroma_server_grpc_port: Optional[int] = None,
     ) -> List[Record]:
         """
         Builds the Vector Store or BaseRetriever object.
 
         Args:
+        - input_value (Text): The input value.
+        - search_type (str): The type of search.
         - collection_name (str): The name of the collection.
-        - persist_directory (Optional[str]): The directory to persist the Vector Store to.
+        - embedding (Embeddings): The embeddings to use for the Vector Store.
         - chroma_server_ssl_enabled (bool): Whether to enable SSL for the Chroma server.
-        - persist (bool): Whether to persist the Vector Store or not.
-        - embedding (Optional[Embeddings]): The embeddings to use for the Vector Store.
-        - documents (Optional[Document]): The documents to use for the Vector Store.
-        - chroma_server_cors_allow_origins (List[str]): The CORS allow origins for the Chroma server.
-        - chroma_server_host (Optional[str]): The host for the Chroma server.
-        - chroma_server_port (Optional[int]): The port for the Chroma server.
-        - chroma_server_grpc_port (Optional[int]): The gRPC port for the Chroma server.
+        - number_of_results (int, optional): The number of results to retrieve. Defaults to 4.
+        - index_directory (str, optional): The directory to persist the Vector Store to. Defaults to None.
+        - chroma_server_cors_allow_origins (List[str], optional): The CORS allow origins for the Chroma server. Defaults to [].
+        - chroma_server_host (str, optional): The host for the Chroma server. Defaults to None.
+        - chroma_server_http_port (int, optional): The HTTP port for the Chroma server. Defaults to None.
+        - chroma_server_grpc_port (int, optional): The gRPC port for the Chroma server. Defaults to None.
 
         Returns:
-        - Union[VectorStore, BaseRetriever]: The Vector Store or BaseRetriever object.
+        - List[Record]: The list of records.
         """
 
         # Chroma settings
@@ -95,7 +96,7 @@ class ChromaSearchComponent(LCVectorStoreComponent):
             chroma_settings = Settings(
                 chroma_server_cors_allow_origins=chroma_server_cors_allow_origins or [],
                 chroma_server_host=chroma_server_host,
-                chroma_server_port=chroma_server_port or None,
+                chroma_server_http_port=chroma_server_http_port or None,
                 chroma_server_grpc_port=chroma_server_grpc_port or None,
                 chroma_server_ssl_enabled=chroma_server_ssl_enabled,
             )

--- a/src/backend/base/langflow/components/vectorsearch/ChromaSearch.py
+++ b/src/backend/base/langflow/components/vectorsearch/ChromaSearch.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
-import chromadb  # type: ignore
-from langchain_community.vectorstores.chroma import Chroma
+from chromadb.config import Settings
+from langchain_chroma import Chroma
 
 from langflow.components.vectorstores.base.model import LCVectorStoreComponent
 from langflow.field_typing import Embeddings, Text
@@ -64,7 +64,7 @@ class ChromaSearchComponent(LCVectorStoreComponent):
         chroma_server_ssl_enabled: bool,
         number_of_results: int = 4,
         index_directory: Optional[str] = None,
-        chroma_server_cors_allow_origins: Optional[str] = None,
+        chroma_server_cors_allow_origins: List[str] = [],
         chroma_server_host: Optional[str] = None,
         chroma_server_port: Optional[int] = None,
         chroma_server_grpc_port: Optional[int] = None,
@@ -79,7 +79,7 @@ class ChromaSearchComponent(LCVectorStoreComponent):
         - persist (bool): Whether to persist the Vector Store or not.
         - embedding (Optional[Embeddings]): The embeddings to use for the Vector Store.
         - documents (Optional[Document]): The documents to use for the Vector Store.
-        - chroma_server_cors_allow_origins (Optional[str]): The CORS allow origins for the Chroma server.
+        - chroma_server_cors_allow_origins (List[str]): The CORS allow origins for the Chroma server.
         - chroma_server_host (Optional[str]): The host for the Chroma server.
         - chroma_server_port (Optional[int]): The port for the Chroma server.
         - chroma_server_grpc_port (Optional[int]): The gRPC port for the Chroma server.
@@ -92,8 +92,8 @@ class ChromaSearchComponent(LCVectorStoreComponent):
         chroma_settings = None
 
         if chroma_server_host is not None:
-            chroma_settings = chromadb.config.Settings(
-                chroma_server_cors_allow_origins=chroma_server_cors_allow_origins or None,
+            chroma_settings = Settings(
+                chroma_server_cors_allow_origins=chroma_server_cors_allow_origins or [],
                 chroma_server_host=chroma_server_host,
                 chroma_server_port=chroma_server_port or None,
                 chroma_server_grpc_port=chroma_server_grpc_port or None,

--- a/src/backend/base/langflow/components/vectorstores/Chroma.py
+++ b/src/backend/base/langflow/components/vectorstores/Chroma.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Union
 
-import chromadb  # type: ignore
-from langchain_community.vectorstores.chroma import Chroma
+from chromadb.config import Settings
+from langchain_chroma import Chroma
 from langchain_core.embeddings import Embeddings
 from langchain_core.retrievers import BaseRetriever
 from langchain_core.vectorstores import VectorStore
@@ -56,7 +56,7 @@ class ChromaComponent(CustomComponent):
         chroma_server_ssl_enabled: bool,
         index_directory: Optional[str] = None,
         inputs: Optional[List[Record]] = None,
-        chroma_server_cors_allow_origins: Optional[str] = None,
+        chroma_server_cors_allow_origins: List[str] = [],
         chroma_server_host: Optional[str] = None,
         chroma_server_port: Optional[int] = None,
         chroma_server_grpc_port: Optional[int] = None,
@@ -83,8 +83,8 @@ class ChromaComponent(CustomComponent):
         chroma_settings = None
 
         if chroma_server_host is not None:
-            chroma_settings = chromadb.config.Settings(
-                chroma_server_cors_allow_origins=chroma_server_cors_allow_origins or None,
+            chroma_settings = Settings(
+                chroma_server_cors_allow_origins=chroma_server_cors_allow_origins or [],
                 chroma_server_host=chroma_server_host,
                 chroma_server_port=chroma_server_port or None,
                 chroma_server_grpc_port=chroma_server_grpc_port or None,

--- a/src/backend/base/langflow/components/vectorstores/Chroma.py
+++ b/src/backend/base/langflow/components/vectorstores/Chroma.py
@@ -38,7 +38,7 @@ class ChromaComponent(CustomComponent):
                 "advanced": True,
             },
             "chroma_server_host": {"display_name": "Server Host", "advanced": True},
-            "chroma_server_port": {"display_name": "Server Port", "advanced": True},
+            "chroma_server_http_port": {"display_name": "Server HTTP Port", "advanced": True},
             "chroma_server_grpc_port": {
                 "display_name": "Server gRPC Port",
                 "advanced": True,
@@ -58,7 +58,7 @@ class ChromaComponent(CustomComponent):
         inputs: Optional[List[Record]] = None,
         chroma_server_cors_allow_origins: List[str] = [],
         chroma_server_host: Optional[str] = None,
-        chroma_server_port: Optional[int] = None,
+        chroma_server_http_port: Optional[int] = None,
         chroma_server_grpc_port: Optional[int] = None,
     ) -> Union[VectorStore, BaseRetriever]:
         """
@@ -66,13 +66,13 @@ class ChromaComponent(CustomComponent):
 
         Args:
         - collection_name (str): The name of the collection.
-        - index_directory (Optional[str]): The directory to persist the Vector Store to.
+        - embedding (Embeddings): The embeddings to use for the Vector Store.
         - chroma_server_ssl_enabled (bool): Whether to enable SSL for the Chroma server.
-        - embedding (Optional[Embeddings]): The embeddings to use for the Vector Store.
-        - documents (Optional[Document]): The documents to use for the Vector Store.
-        - chroma_server_cors_allow_origins (Optional[str]): The CORS allow origins for the Chroma server.
+        - index_directory (Optional[str]): The directory to persist the Vector Store to.
+        - inputs (Optional[List[Record]]): The input records to use for the Vector Store.
+        - chroma_server_cors_allow_origins (List[str]): The CORS allow origins for the Chroma server.
         - chroma_server_host (Optional[str]): The host for the Chroma server.
-        - chroma_server_port (Optional[int]): The port for the Chroma server.
+        - chroma_server_http_port (Optional[int]): The HTTP port for the Chroma server.
         - chroma_server_grpc_port (Optional[int]): The gRPC port for the Chroma server.
 
         Returns:
@@ -86,7 +86,7 @@ class ChromaComponent(CustomComponent):
             chroma_settings = Settings(
                 chroma_server_cors_allow_origins=chroma_server_cors_allow_origins or [],
                 chroma_server_host=chroma_server_host,
-                chroma_server_port=chroma_server_port or None,
+                chroma_server_http_port=chroma_server_http_port or None,
                 chroma_server_grpc_port=chroma_server_grpc_port or None,
                 chroma_server_ssl_enabled=chroma_server_ssl_enabled,
             )


### PR DESCRIPTION
This pull request updates the import statements for `chromadb` in `ChromaSearch.py` and `Chroma.py` files. The previous import statements were outdated and needed to be updated to the latest version. This change ensures that the code is compatible with the latest version of `chromadb`.

This also fixes #1882