### PR TITLE
Update parent disclosure title in ExtraSidebar component

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/extraSidebarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/extraSidebarComponent/index.tsx
@@ -284,7 +284,7 @@ export default function ExtraSidebar(): JSX.Element {
       <div className="side-bar-components-div-arrangement">
         <div className="parent-disclosure-arrangement">
           <div className="flex items-center gap-4 align-middle">
-            <span className="parent-disclosure-title">Core Components</span>
+            <span className="parent-disclosure-title">Basic Components</span>
           </div>
         </div>
         {Object.keys(dataFilter)
@@ -361,9 +361,9 @@ export default function ExtraSidebar(): JSX.Element {
           )}{" "}
         <ParentDisclosureComponent
           openDisc={false}
-          key={"Extended"}
+          key={"Advanced"}
           button={{
-            title: "Extended",
+            title: "Advanced",
             Icon: nodeIconsLucide.unknown,
           }}
           testId="extended-disclosure"


### PR DESCRIPTION
This pull request updates the parent disclosure title in the ExtraSidebar component from "Core Components" to "Basic Components". Additionally, it changes the key for the ParentDisclosureComponent from "Extended" to "Advanced". These changes improve the clarity and consistency of the component's labels.