### PR TITLE
Refactor SplitTextComponent to store parent and text data in Record object

### DIFF
--- a/src/backend/base/langflow/components/experimental/SplitText.py
+++ b/src/backend/base/langflow/components/experimental/SplitText.py
@@ -43,7 +43,7 @@ class SplitTextComponent(CustomComponent):
                 chunks = [chunk[:truncate_size] for chunk in chunks]
 
             for chunk in chunks:
-                outputs.append(Record(text=chunk, data={"parent": text}))
+                outputs.append(Record(data={"parent": text, "text": chunk}))
 
         self.status = outputs
         return outputs


### PR DESCRIPTION
This pull request refactors the SplitTextComponent to store the parent and text data in a Record object. This change improves the code structure and makes it easier to access and manipulate the data.
#1997