### PR TITLE
(frontend): Remove NATIVE_CATEGORIES constant and simplify logic for checking template code value in GenericNode component

### DIFF
--- a/src/frontend/src/customNodes/genericNode/index.tsx
+++ b/src/frontend/src/customNodes/genericNode/index.tsx
@@ -10,7 +10,6 @@ import Loading from "../../components/ui/loading";
 import { Textarea } from "../../components/ui/textarea";
 import Xmark from "../../components/ui/xmark";
 import {
-  NATIVE_CATEGORIES,
   RUN_TIMESTAMP_PREFIX,
   STATUS_BUILD,
   STATUS_BUILDING,
@@ -77,18 +76,14 @@ export default function GenericNode({
     // This one should run only once
     // first check if data.type in NATIVE_CATEGORIES
     // if not return
-    if (
-      !NATIVE_CATEGORIES.includes(types[data.type]) ||
-      !data.node?.template?.code?.value
-    )
-      return;
+    if (!data.node?.template?.code?.value) return;
     const thisNodeTemplate = templates[data.type].template;
     // if the template does not have a code key
     // return
     if (!thisNodeTemplate.code) return;
     const currentCode = thisNodeTemplate.code?.value;
     const thisNodesCode = data.node!.template?.code?.value;
-    const componentsToIgnore = ["Custom Component", "Prompt"];
+    const componentsToIgnore = ["Custom Component"];
     if (
       currentCode !== thisNodesCode &&
       !componentsToIgnore.includes(data.node!.display_name)


### PR DESCRIPTION
This pull request removes the `NATIVE_CATEGORIES` constant and simplifies the logic for checking the template code value in the `GenericNode` component. The logic now checks if the `data.node.template.code.value` exists before proceeding. Additionally, the logic for checking the template code value has been simplified by removing the unnecessary check for `NATIVE_CATEGORIES.includes(types[data.type])`.