### PR TITLE
fix: create superuser at startup to avoid concurrency issues

### DIFF
--- a/src/backend/base/langflow/api/v1/login.py
+++ b/src/backend/base/langflow/api/v1/login.py
@@ -9,7 +9,6 @@ from langflow.services.auth.utils import (
     create_user_longterm_token,
     create_user_tokens,
 )
-from langflow.services.database.models.folder.utils import create_default_folder_if_it_doesnt_exist
 from langflow.services.deps import get_session, get_settings_service, get_variable_service
 from langflow.services.settings.manager import SettingsService
 from langflow.services.variable.service import VariableService
@@ -73,8 +72,7 @@ async def login_to_get_access_token(
 async def auto_login(
     response: Response,
     db: Session = Depends(get_session),
-    settings_service=Depends(get_settings_service),
-    variable_service: VariableService = Depends(get_variable_service),
+    settings_service=Depends(get_settings_service)
 ):
     auth_settings = settings_service.auth_settings
     if settings_service.auth_settings.AUTO_LOGIN:
@@ -88,8 +86,7 @@ async def auto_login(
             expires=None,  # Set to None to make it a session cookie
             domain=auth_settings.COOKIE_DOMAIN,
         )
-        variable_service.initialize_user_variables(user_id, db)
-        create_default_folder_if_it_doesnt_exist(db, user_id)
+
         return tokens
 
     raise HTTPException(

--- a/src/backend/base/langflow/api/v1/login.py
+++ b/src/backend/base/langflow/api/v1/login.py
@@ -9,6 +9,7 @@ from langflow.services.auth.utils import (
     create_user_longterm_token,
     create_user_tokens,
 )
+from langflow.services.database.models.folder.utils import create_default_folder_if_it_doesnt_exist
 from langflow.services.deps import get_session, get_settings_service, get_variable_service
 from langflow.services.settings.manager import SettingsService
 from langflow.services.variable.service import VariableService

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -10,9 +10,11 @@ from sqlmodel import select
 
 from langflow.base.constants import FIELD_FORMAT_ATTRIBUTES, NODE_FORMAT_ATTRIBUTES
 from langflow.interface.types import get_all_components
+from langflow.services.auth.utils import create_super_user
 from langflow.services.database.models.flow.model import Flow, FlowCreate
 from langflow.services.database.models.folder.model import Folder, FolderCreate
-from langflow.services.deps import get_settings_service, session_scope
+from langflow.services.database.models.folder.utils import create_default_folder_if_it_doesnt_exist
+from langflow.services.deps import get_settings_service, session_scope, get_variable_service
 
 STARTER_FOLDER_NAME = "Starter Projects"
 STARTER_FOLDER_DESCRIPTION = "Starter projects to help you get started in Langflow."
@@ -249,3 +251,20 @@ def create_or_update_starter_projects():
                     project_icon_bg_color,
                     new_folder.id,
                 )
+
+
+def initialize_super_user_if_needed():
+    settings_service = get_settings_service()
+    if not settings_service.auth_settings.AUTO_LOGIN:
+        return
+    username = settings_service.auth_settings.SUPERUSER
+    password = settings_service.auth_settings.SUPERUSER_PASSWORD
+    if not username or not password:
+        raise ValueError("SUPERUSER and SUPERUSER_PASSWORD must be set in the settings if AUTO_LOGIN is true.")
+
+    with session_scope() as session:
+        super_user = create_super_user(db=session, username=username, password=password)
+        get_variable_service().initialize_user_variables(super_user.id, session)
+        create_default_folder_if_it_doesnt_exist(session, super_user.id)
+        session.commit()
+        logger.info("Super user initialized")

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -14,7 +14,7 @@ from rich import print as rprint
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from langflow.api import router
-from langflow.initial_setup.setup import create_or_update_starter_projects
+from langflow.initial_setup.setup import create_or_update_starter_projects, initialize_super_user_if_needed
 from langflow.interface.utils import setup_llm_caching
 from langflow.services.plugins.langfuse_plugin import LangfuseInstance
 from langflow.services.utils import initialize_services, teardown_services
@@ -53,6 +53,7 @@ def get_lifespan(fix_migration=False, socketio_server=None):
             initialize_services(fix_migration=fix_migration, socketio_server=socketio_server)
             setup_llm_caching()
             LangfuseInstance.update()
+            initialize_super_user_if_needed()
             create_or_update_starter_projects()
             yield
         except Exception as exc:

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -33,6 +33,7 @@ async def api_key_security(
     db: Session = Depends(get_session),
 ) -> Optional[User]:
     settings_service = get_settings_service()
+    result: Optional[Union[ApiKey, User]] = None
     if settings_service.auth_settings.AUTO_LOGIN:
         # Get the first user
         if not settings_service.auth_settings.SUPERUSER:

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -214,6 +214,11 @@ def create_user_longterm_token(db: Session = Depends(get_session)) -> tuple[UUID
 
     username = settings_service.auth_settings.SUPERUSER
     super_user = get_user_by_username(db, username)
+    if not super_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Super user hasn't been created"
+        )
     access_token_expires_longterm = timedelta(days=365)
     access_token = create_token(
         data={"sub": str(super_user.id)},


### PR DESCRIPTION
Currently if auto_login = true, the super user is being initialized when the auto_login endpoint is called the first time. 
This has multiple problems:
1. If two concurrent calls happen, one of the client gets an error
2. since the API auth header is not needed in this mode, without calling auto_login is not possible to call other endpoints.

Changes:
* Moved superuser initialization at the startup
* The auto_login endpoint just generates the long term token   