### PR TITLE
feat: Add Docker Hub propagation wait and HuggingFace Spaces build restart

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,3 +52,12 @@ jobs:
           push: true
           file: ${{ env.DOCKERFILE }}
           tags: ${{ env.TAGS }}
+      - name: Wait for Docker Hub to propagate
+        run: sleep 120
+      - name: Restart HuggingFace Spaces Build
+        #   There's a script in ./scripts/factory_reset_space.py that will reset the build
+        # using the HUGGINGFACE_API_TOKEN secret
+        run: |
+          python ./scripts/factory_reset_space.py
+        env:
+          HUGGINGFACE_API_TOKEN: ${{ secrets.HUGGINGFACE_API_TOKEN }}

--- a/scripts/factory_restart_space.py
+++ b/scripts/factory_restart_space.py
@@ -1,0 +1,16 @@
+import os
+
+from huggingface_hub import HfApi, list_models
+from rich import print
+
+# Use root method
+models = list_models()
+
+# Or configure a HfApi client
+hf_api = HfApi(
+    endpoint="https://huggingface.co",  # Can be a Private Hub endpoint.
+    token=os.getenv("HUGGINFACE_API_TOKEN") or "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",
+)
+
+space_runtime = hf_api.restart_space("Langflow/Langflow-Preview", factory_reboot=True)
+print(space_runtime)


### PR DESCRIPTION
The code changes include adding a new step in the `.github/workflows/docker-build.yml` file to wait for Docker Hub to propagate. Additionally, a new script `factory_restart_space.py` is added in the `scripts` directory to restart the HuggingFace Spaces build. This script uses the `HfApi` and `rich` libraries to interact with the HuggingFace Hub API and print the space runtime.

Note: The commit message has been generated based on the provided code changes and recent commits.