### PR TITLE
Fix endpoint URL interpolation issue in getCurlCode

### DIFF
--- a/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
@@ -13,9 +13,9 @@ export default function getCurlCode(
   const tweaksObject = tweaksBuildedObject[0];
   // show the endpoint name in the curl command if it exists
   return `curl -X POST \\
-    ${window.location.protocol}//${window.location.host}/api/v1/run/${
+    "${window.location.protocol}//${window.location.host}/api/v1/run/${
     endpointName || flowId
-  }?stream=false \\
+  }?stream=false" \\
     -H 'Content-Type: application/json'\\${
       !isAuth ? `\n  -H 'x-api-key: <your api key>'\\` : ""
     }


### PR DESCRIPTION
This pull request fixes an issue in the `getCurlCode` function where the endpoint URL was not being interpolated correctly. The patch updates the URL interpolation to ensure that the correct URL is used when generating the curl command.