### PR TITLE
refactor: Update getCurlRunCode function to export it as a named export

### DIFF
--- a/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
@@ -4,7 +4,7 @@
  * @param {boolean} isAuth - If the API is authenticated
  * @returns {string} - The curl code
  */
-export default function getCurlRunCode(
+export function getCurlRunCode(
   flowId: string,
   isAuth: boolean,
   tweaksBuildedObject,


### PR DESCRIPTION
The getCurlRunCode function in get-curl-code.tsx has been updated to export it as a named export instead of the default export. This change improves the code organization and allows for better import statements in other modules.

Note: The commit message has been generated based on the provided code changes and recent commits.