### PR TITLE
(refactor) Update pytest arguments in Makefile for better test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ coverage:
 
 # allow passing arguments to pytest
 tests:
-	poetry run pytest tests --instafail $(args)
-# Use like:
+	poetry run pytest tests --instafail -ra -n auto -m "not api_key_required" $(args)
+
 
 format:
 	poetry run ruff check . --fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ testpaths = ["tests", "integration"]
 console_output_style = "progress"
 filterwarnings = ["ignore::DeprecationWarning"]
 log_cli = true
-markers = ["async_test"]
+markers = ["async_test", "api_key_required"]
 
 
 [tool.ruff]

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -4,6 +4,7 @@ from uuid import UUID, uuid4
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
+
 from langflow.custom.directory_reader.directory_reader import DirectoryReader
 from langflow.services.deps import get_settings_service
 
@@ -632,6 +633,7 @@ def test_successful_run_with_input_type_any(client, starter_project, created_api
     assert all([output.get("results").get("result") == "value1" for output in any_input_outputs]), any_input_outputs
 
 
+@pytest.mark.api_key_required
 def test_run_with_inputs_and_outputs(client, starter_project, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
     flow_id = starter_project["id"]
@@ -659,6 +661,7 @@ def test_invalid_flow_id(client, created_api_key):
     # Check if the error detail is as expected
 
 
+@pytest.mark.api_key_required
 def test_run_flow_with_caching_success(client: TestClient, starter_project, created_api_key):
     flow_id = starter_project["id"]
     headers = {"x-api-key": created_api_key.api_key}
@@ -676,6 +679,7 @@ def test_run_flow_with_caching_success(client: TestClient, starter_project, crea
     assert "session_id" in data
 
 
+@pytest.mark.api_key_required
 def test_run_flow_with_caching_invalid_flow_id(client: TestClient, created_api_key):
     invalid_flow_id = uuid4()
     headers = {"x-api-key": created_api_key.api_key}
@@ -687,6 +691,7 @@ def test_run_flow_with_caching_invalid_flow_id(client: TestClient, created_api_k
     assert f"Flow identifier {invalid_flow_id} not found" in data["detail"]
 
 
+@pytest.mark.api_key_required
 def test_run_flow_with_caching_invalid_input_format(client: TestClient, starter_project, created_api_key):
     flow_id = starter_project["id"]
     headers = {"x-api-key": created_api_key.api_key}
@@ -695,6 +700,7 @@ def test_run_flow_with_caching_invalid_input_format(client: TestClient, starter_
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
+@pytest.mark.api_key_required
 def test_run_flow_with_session_id(client, starter_project, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
     flow_id = starter_project["id"]
@@ -726,6 +732,7 @@ def test_run_flow_with_invalid_session_id(client, starter_project, created_api_k
     assert f"Session {payload['session_id']} not found" in data["detail"]
 
 
+@pytest.mark.api_key_required
 def test_run_flow_with_invalid_tweaks(client, starter_project, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
     flow_id = starter_project["id"]


### PR DESCRIPTION
The Makefile has been modified to update the pytest arguments in the `tests` target. The `--instafail` flag has been replaced with `-ra -n auto -m "not api_key_required"`. This change allows for better test execution by including additional options for reporting, parallelization, and test selection.

(test_endpoints.py) Add pytest marker 'api_key_required' to mark tests that require an API key for authorization