### PR TITLE
Correctly Handle Text File Encoding to Avoid 'GBK' Codec Errors

### DIFF
--- a/src/backend/base/langflow/base/data/utils.py
+++ b/src/backend/base/langflow/base/data/utils.py
@@ -3,7 +3,7 @@ import xml.etree.ElementTree as ET
 from concurrent import futures
 from pathlib import Path
 from typing import Callable, List, Optional, Text
-
+import chardet
 import yaml
 
 from langflow.schema.schema import Record
@@ -89,7 +89,12 @@ def retrieve_file_paths(
 
 
 def read_text_file(file_path: str) -> str:
-    with open(file_path, "r") as f:
+    with open(file_path, "rb") as f:
+        raw_data = f.read()
+        result = chardet.detect(raw_data)
+        encoding = result['encoding']
+
+    with open(file_path, "r", encoding=encoding) as f:
         return f.read()
 
 


### PR DESCRIPTION
### Problem:
The original read_text_file method encountered an error when importing a text file containing Chinese characters, specifically:


`Error building vertex File: Error loading file /tmp/test.txt: 'gbk' codec can't decode byte 0xaf in position 7: illegal multibyte sequence`

This error occurred due to incorrect or incompatible character encoding when reading the file.

### Solution:
To resolve this issue, the method was updated to automatically detect the file's encoding using the chardet library. The new implementation reads the file in binary mode to determine the encoding and then reopens the file with the detected encoding to properly read its content.

### Testing:

- The updated method was tested with various text files containing Chinese characters and other encodings to ensure compatibility and proper functionality.

- Files previously causing decoding errors were successfully read without issues after the update.

This PR resolves the encoding problem by implementing automatic encoding detection, improving the robustness and reliability of the read_text_file method when handling files with different character sets.