### PR TITLE
openai model spec openai_api_base should be an advanced option

### DIFF
--- a/src/backend/base/langflow/components/model_specs/ChatOpenAISpecs.py
+++ b/src/backend/base/langflow/components/model_specs/ChatOpenAISpecs.py
@@ -28,7 +28,7 @@ class ChatOpenAIComponent(CustomComponent):
             "model_name": {"display_name": "Model Name", "advanced": False, "options": MODEL_NAMES},
             "openai_api_base": {
                 "display_name": "OpenAI API Base",
-                "advanced": False,
+                "advanced": True,
                 "required": False,
                 "info": (
                     "The base URL of the OpenAI API. Defaults to https://api.openai.com/v1.\n\n"


### PR DESCRIPTION
both the openai embeddings and chatOpenAI hide this option in the UI. 99% of the time you want to use the openai service so this option is useless