### PR TITLE
fix lint - type mismatch

### DIFF
--- a/src/backend/base/langflow/base/curl/parse.py
+++ b/src/backend/base/langflow/base/curl/parse.py
@@ -16,7 +16,7 @@ from collections import OrderedDict, namedtuple
 from http.cookies import SimpleCookie
 
 ParsedArgs = namedtuple(
-    "ParsedContext",
+    "ParsedArgs",
     [
         "command",
         "url",

--- a/src/backend/base/langflow/services/monitor/service.py
+++ b/src/backend/base/langflow/services/monitor/service.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union, List
 
 import duckdb
 from loguru import logger
@@ -109,12 +109,21 @@ class MonitorService(Service):
 
         return self.exec_query(query)
 
-    def delete_messages(self, message_ids: list[int]):
-        query = f"DELETE FROM messages WHERE index IN ({','.join(map(str, message_ids))})"
+    def delete_messages(self, message_ids: Union[List[int], str]):
+        if isinstance(message_ids, list):
+            # If message_ids is a list, join the string representations of the integers
+            ids_str = ','.join(map(str, message_ids))
+        elif isinstance(message_ids, str):
+            # If message_ids is already a string, use it directly
+            ids_str = message_ids
+        else:
+            raise ValueError("message_ids must be a list of integers or a string")
+
+        query = f"DELETE FROM messages WHERE index IN ({ids_str})"
 
         return self.exec_query(query)
 
-    def update_message(self, message_id: int, **kwargs):
+    def update_message(self, message_id: str, **kwargs):
         query = (
             f"""UPDATE messages SET {', '.join(f"{k} = '{v}'" for k, v in kwargs.items())} WHERE index = {message_id}"""
         )


### PR DESCRIPTION
Current there are three lint errors that are type mismatch. cc @anovazzi1 @ogabrielluiz 
```
$ make lint
poetry run mypy --namespace-packages -p "langflow"
src/backend/base/langflow/base/curl/parse.py:18: error: First argument to namedtuple() should be "ParsedArgs", not "ParsedContext"  [name-match]

src/backend/base/langflow/memory.py:103: error: Argument 1 to "delete_messages" of "MonitorService" has incompatible type "str"; expected "list[int]"  [arg-type]

src/backend/base/langflow/api/v1/monitor.py:89: error: Argument "message_id" to "update_message" of "MonitorService" has incompatible type "str"; expected "int"  [arg-type]
```