### PR TITLE
refactor: Include Missing Field in Tool Status

### DIFF
--- a/src/backend/base/langflow/base/tools/base.py
+++ b/src/backend/base/langflow/base/tools/base.py
@@ -9,7 +9,7 @@ def build_status_from_tool(tool: Tool):
         tool (Tool): The tool object to build the status for.
 
     Returns:
-        str: The status string representation of the tool, including its name, description, and arguments (if any).
+        str: The status string representation of the tool, including its name, description, arguments (if any), and args_schema (if any).
     """
     description_repr = repr(tool.description).strip("'")
     args_str = "\n".join(
@@ -19,5 +19,8 @@ def build_status_from_tool(tool: Tool):
             if "description" in arg_data
         ]
     )
+    # Include args_schema information
+    args_schema_str = repr(tool.args_schema) if tool.args_schema else "None"
     status = f"Name: {tool.name}\nDescription: {description_repr}"
+    status += f"\nArgs Schema: {args_schema_str}"
     return status + (f"\nArguments:\n{args_str}" if args_str else "")


### PR DESCRIPTION
Modified the status to include args_schema when the tool has it.

You can use this translation in your commit message.