### PR TITLE
docker: add curl to the image

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -59,6 +59,12 @@ RUN $POETRY_HOME/bin/poetry lock --no-update \
 ################################
 FROM python:3.12-slim as runtime
 
+RUN apt-get -y update \
+    && apt-get install --no-install-recommends -y \
+    curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 LABEL org.opencontainers.image.title=langflow
 LABEL org.opencontainers.image.authors=['Langflow']
 LABEL org.opencontainers.image.licenses=MIT


### PR DESCRIPTION
After this PR https://github.com/langflow-ai/langflow/pull/2071 curl is nomore available in the container.

curl is very useful to test the endpoints locally and to download flows if needed