### PR TITLE
fix: ui - rename upload button to 'Upload Folder'

### DIFF
--- a/src/frontend/src/components/sidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/sidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -123,7 +123,7 @@ const SideBarFoldersButtonsComponent = ({
           onClick={handleUploadFlowsToFolder}
           data-testid="upload-folder-button"
         >
-          <ForwardedIconComponent name="Upload" className="w-4" />
+          <ForwardedIconComponent name="Upload Folder" className="w-4" />
         </Button>
       </div>
 


### PR DESCRIPTION
I have header several people trying to import their single flow clicking on the "Upload" button in the front page. That is meant for folders. 
A good way to fix is to change the label to "Upload Folder" 