### PR TITLE
returns flow if flow's user_id is empty

### DIFF
--- a/src/backend/base/langflow/api/v1/files.py
+++ b/src/backend/base/langflow/api/v1/files.py
@@ -30,7 +30,7 @@ def get_flow_id(
     flow = session.get(Flow, flow_id_str)
     if not flow:
         raise HTTPException(status_code=404, detail="Flow not found")
-    if flow.user_id != current_user.id:
+    if flow.user_id != current_user.id and flow.user_id != "":
         raise HTTPException(status_code=403, detail="You don't have access to this flow")
     return flow_id_str
 


### PR DESCRIPTION
In auto login mode, if there is one user, the flow might not have user_id. So should support a flow to be uploaded without user_id. The check can be only enforced if the flow's user_id exists.

The upload endpoint /api/v1/files/upload/{flow_id}
returns 403
response body 
```
{
     "details": "You don't have access to this flow"
}
```

The DB flow shows with no user_id.
sqlite> select name, id,user_id,folder_id from flow;
Memory Chatbot|a22d4f751b474d4a8698e3797269aa2e||a6ab703e3c814f01a859f3dbc1e74e97
Document QA|5a86ca4d9a2544e08af04735e8eea274||a6ab703e3c814f01a859f3dbc1e74e97

