### PR TITLE
fix: ensure tweaks object exists

### DIFF
--- a/src/frontend/src/modals/apiModal/utils/get-python-api-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-python-api-code.tsx
@@ -2,19 +2,27 @@
  * Function to get the python code for the API
  * @param {string} flowId - The id of the flow
  * @param {boolean} isAuth - If the API is authenticated
- * @param {any[]} tweak - The tweaks
+ * @param {any[]} tweaksBuildedObject - The tweaks
+ * @param {string} [endpointName] - The optional endpoint name
  * @returns {string} - The python code
  */
 export default function getPythonApiCode(
   flowId: string,
   isAuth: boolean,
-  tweaksBuildedObject,
-  endpointName?: string
+  tweaksBuildedObject: any[],
+  endpointName?: string,
 ): string {
-  const tweaksObject = tweaksBuildedObject[0];
-  const tweaksString = JSON.stringify(tweaksObject, null, 2)
-    .replace(/true/g, "True")
-    .replace(/false/g, "False");
+  let tweaksString = "";
+  if (tweaksBuildedObject && tweaksBuildedObject.length > 0) {
+    const tweaksObject = tweaksBuildedObject[0];
+    if (!tweaksObject) {
+      throw new Error("expected tweaks");
+    }
+    tweaksString = JSON.stringify(tweaksObject, null, 2)
+      .replace(/true/g, "True")
+      .replace(/false/g, "False");
+  }
+
   return `import argparse
 import json
 from argparse import RawTextHelpFormatter

--- a/src/frontend/src/modals/apiModal/utils/get-python-api-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-python-api-code.tsx
@@ -12,7 +12,7 @@ export default function getPythonApiCode(
   tweaksBuildedObject: any[],
   endpointName?: string,
 ): string {
-  let tweaksString = "";
+  let tweaksString = "{}";
   if (tweaksBuildedObject && tweaksBuildedObject.length > 0) {
     const tweaksObject = tweaksBuildedObject[0];
     if (!tweaksObject) {

--- a/src/frontend/src/modals/apiModal/utils/get-python-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-python-code.tsx
@@ -1,17 +1,26 @@
 /**
  * Function to get the python code for the API
  * @param {string} flow - The current flow
- * @param {any[]} tweak - The tweaks
+ * @param {any[]} tweaksBuildedObject - The tweaks
  * @returns {string} - The python code
  */
 export default function getPythonCode(
   flowName: string,
-  tweaksBuildedObject
+  tweaksBuildedObject: any[],
 ): string {
-  const tweaksObject = tweaksBuildedObject[0];
+  let tweaksString = "{}";
+  if (tweaksBuildedObject && tweaksBuildedObject.length > 0) {
+    const tweaksObject = tweaksBuildedObject[0];
+    if (!tweaksObject) {
+      throw new Error("expected tweaks");
+    }
+    tweaksString = JSON.stringify(tweaksObject, null, 2)
+      .replace(/true/g, "True")
+      .replace(/false/g, "False");
+  }
 
   return `from langflow.load import run_flow_from_json
-TWEAKS = ${JSON.stringify(tweaksObject, null, 2)}
+TWEAKS = ${tweaksString}
 
 result = run_flow_from_json(flow="${flowName}.json",
                             input_value="message",


### PR DESCRIPTION
Ensures that the tweaks object exists before calling stringify on it. Before this change, attempting to create an empty project would result in an error, prompting us to restart langflow. (@ogabrielluiz perhaps that is a good test to add, creation of empty project?) 

Tweaks correctly showing empty with empty project:
```
# You can tweak the flow by adding a tweaks dictionary
# e.g {"OpenAI-XXXXX": {"model_name": "gpt-4"}}
TWEAKS = {}
```
