### PR TITLE
use Astra DB Application Token for all Astra token's display_name

### DIFF
--- a/src/backend/base/langflow/components/vectorsearch/AstraDBSearch.py
+++ b/src/backend/base/langflow/components/vectorsearch/AstraDBSearch.py
@@ -28,7 +28,7 @@ class AstraDBSearchComponent(LCVectorStoreComponent):
                 "info": "The name of the collection within Astra DB where the vectors will be stored.",
             },
             "token": {
-                "display_name": "Token",
+                "display_name": "Astra DB Application Token",
                 "info": "Authentication token for accessing Astra DB.",
                 "password": True,
             },

--- a/src/backend/base/langflow/components/vectorstores/AstraDB.py
+++ b/src/backend/base/langflow/components/vectorstores/AstraDB.py
@@ -24,7 +24,7 @@ class AstraDBVectorStoreComponent(CustomComponent):
                 "info": "The name of the collection within Astra DB where the vectors will be stored.",
             },
             "token": {
-                "display_name": "Token",
+                "display_name": "Astra DB Application Token",
                 "info": "Authentication token for accessing Astra DB.",
                 "password": True,
             },


### PR DESCRIPTION
All Astra tokens' display_name should be using the same name as `Astra DB Application Token`

cc @erichare @jordanrfrazier 