### PR TITLE
docker: add customizable port for frontend image

### DIFF
--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -7,7 +7,7 @@ server {
     gzip_vary  on;
     gzip_disable "MSIE [4-6] \.";
 
-    listen 80;
+    listen __FRONTEND_PORT__;
 
     location / {
         root /usr/share/nginx/html;

--- a/docker/frontend/start-nginx.sh
+++ b/docker/frontend/start-nginx.sh
@@ -4,11 +4,20 @@ trap 'kill -TERM $PID' TERM INT
 if [ -z "$BACKEND_URL" ]; then
   BACKEND_URL="$1"
 fi
+if [ -z "$FRONTEND_PORT" ]; then
+  FRONTEND_PORT="$2"
+fi
+if [ -z "$FRONTEND_PORT" ]; then
+  FRONTEND_PORT="80"
+fi
 if [ -z "$BACKEND_URL" ]; then
   echo "BACKEND_URL must be set as an environment variable or as first parameter. (e.g. http://localhost:7860)"
   exit 1
 fi
+echo "BACKEND_URL: $BACKEND_URL"
+echo "FRONTEND_PORT: $FRONTEND_PORT"
 sed -i "s|__BACKEND_URL__|$BACKEND_URL|g" /etc/nginx/conf.d/default.conf
+sed -i "s|__FRONTEND_PORT__|$FRONTEND_PORT|g" /etc/nginx/conf.d/default.conf
 cat /etc/nginx/conf.d/default.conf
 
 


### PR DESCRIPTION
currently the frontend image listens always only on port 80. 

Changes:
* added a parameter to configure to change it when running the container
* changed default to 8080 since port <1024 normally requires root access