### PR TITLE
docker: force python version to 3.12.3

### DIFF
--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -24,6 +24,7 @@ env:
 jobs:
   test-docker:
     runs-on: ubuntu-latest
+    name: Test docker images
     steps:
       - uses: actions/checkout@v4
       - name: Build image
@@ -61,24 +62,3 @@ jobs:
           docker build -t langflowai/langflow-frontend:latest-dev \
             -f docker/frontend/build_and_push_frontend.Dockerfile \
             .
-  test-multi-arch-build:
-    name: Test docker multi-arch build (${{ matrix.platform }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [linux/amd64, linux/arm64/v8]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        id: qemu
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: false
-          file: ./docker/build_and_push.Dockerfile
-          platforms: "${{ matrix.platform }}"
-          tags: langflowai/langflow:latest-dev

--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -62,7 +62,11 @@ jobs:
             -f docker/frontend/build_and_push_frontend.Dockerfile \
             .
   test-multi-arch-build:
+    name: Test docker multi-arch build (${{ matrix.platform }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64/v8]
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -76,5 +80,5 @@ jobs:
           context: .
           push: false
           file: ./docker/build_and_push.Dockerfile
-          platforms: "linux/amd64,linux/arm64/v8"
+          platforms: "${{ matrix.platform }}"
           tags: langflowai/langflow:latest-dev

--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -57,12 +57,15 @@ RUN python -m pip install requests --user && cd ./scripts && python update_depen
 # 2. Do not install dev dependencies
 # 3. Install all the extras to ensure all optionals are installed as well
 # 4. --sync to ensure nothing else is in the environment
+# 5. Build the wheel and install "langflow" package (mainly for version)
 
 # Note: moving to build and installing the wheel will make the docker images not reproducible.
 RUN $POETRY_HOME/bin/poetry lock --no-update \
       # install current lock file with fixed dependencies versions \
       # do not install dev dependencies \
-      && $POETRY_HOME/bin/poetry install --without dev --sync -E deploy -E couchbase -E cassio
+      && $POETRY_HOME/bin/poetry install --without dev --sync -E deploy -E couchbase -E cassio \
+      && $POETRY_HOME/bin/poetry build -f wheel \
+      && $POETRY_HOME/bin/poetry run pip install dist/*.whl
 
 ################################
 # RUNTIME

--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -52,9 +52,10 @@ COPY pyproject.toml poetry.lock README.md ./
 COPY src/ ./src
 COPY scripts/ ./scripts
 RUN python -m pip install requests --user && cd ./scripts && python update_dependencies.py
+
 RUN $POETRY_HOME/bin/poetry lock --no-update \
-      && $POETRY_HOME/bin/poetry build -f wheel \
-      && $POETRY_HOME/bin/poetry run pip install dist/*.whl --force-reinstall
+      # install current lock file with fixed dependencies versions
+      && $POETRY_HOME/bin/poetry install --without dev --sync -E deploy,couchbase,cassio
 
 ################################
 # RUNTIME

--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -8,7 +8,9 @@
 ################################
 
 # force platform to the current architecture to increase build speed time on multi-platform builds
-FROM --platform=$BUILDPLATFORM python:3.12-slim as builder-base
+
+# use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
+FROM --platform=$BUILDPLATFORM python:3.12.3-slim as builder-base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     \

--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -7,10 +7,9 @@
 # Used to build deps + create our virtual environment
 ################################
 
-# force platform to the current architecture to increase build speed time on multi-platform builds
-
-# use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
-FROM --platform=$BUILDPLATFORM python:3.12.3-slim as builder-base
+# 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
+# 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
+FROM python:3.12.3-slim as builder-base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     \
@@ -61,7 +60,7 @@ RUN $POETRY_HOME/bin/poetry lock --no-update \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12-slim as runtime
+FROM python:3.12.3-slim as runtime
 
 RUN apt-get -y update \
     && apt-get install --no-install-recommends -y \

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -10,7 +10,9 @@
 # PYTHON-BASE
 # Sets up all our shared environment variables
 ################################
-FROM python:3.12-slim as python-base
+
+# use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
+FROM python:3.12.3-slim as python-base
 
 # python
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/frontend/build_and_push_frontend.Dockerfile
+++ b/docker/frontend/build_and_push_frontend.Dockerfile
@@ -5,7 +5,7 @@
 # BUILDER-BASE
 ################################
 
-# force platform to the current architecture to increase build speed time on multi-platform builds
+# 1. force platform to the current architecture to increase build speed time on multi-platform builds
 FROM --platform=$BUILDPLATFORM node:lts-bookworm-slim as builder-base
 COPY src/frontend /frontend
 


### PR DESCRIPTION
Fixes #2142

After adding langsmith support, the backend throws `TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'`.
The root cause is pydantic https://github.com/pydantic/pydantic-core/issues/1292

the only workaround is to use <=3.12.3

this PR also fixes a problem running the image on arm64 (Mac M* family) `ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'`