### PR TITLE
chore: Update schema.py and service.py to handle file serialization and deserialization

### DIFF
--- a/src/backend/base/langflow/services/monitor/schema.py
+++ b/src/backend/base/langflow/services/monitor/schema.py
@@ -91,9 +91,17 @@ class MessageModel(DefaultModel):
     files: list[str] = []
 
     @field_validator("files", mode="before")
+    @classmethod
     def validate_files(cls, v):
         if isinstance(v, str):
-            return json.loads(v)
+            v = json.loads(v)
+        return v
+
+    @field_serializer("files")
+    @classmethod
+    def serialize_files(cls, v):
+        if isinstance(v, list):
+            return json.dumps(v)
         return v
 
     @classmethod

--- a/src/backend/base/langflow/services/monitor/service.py
+++ b/src/backend/base/langflow/services/monitor/service.py
@@ -140,7 +140,7 @@ class MonitorService(Service):
         order: Optional[str] = "DESC",
         limit: Optional[int] = None,
     ):
-        query = "SELECT index, flow_id, sender_name, sender, session_id, text, timestamp FROM messages"
+        query = "SELECT index, flow_id, sender_name, sender, session_id, text, files, timestamp FROM messages"
         conditions = []
         if sender:
             conditions.append(f"sender = '{sender}'")


### PR DESCRIPTION
Refactor the MessageModel class in schema.py to include methods for validating and serializing the 'files' field. This ensures that the 'files' field can be properly handled when it is a string or a list.

In service.py, update the query in the MonitorService class to include the 'files' field when retrieving messages from the database. This ensures that the 'files' field is included in the query results.