### PR TITLE
Support returning sub flow outputs

### DIFF
--- a/src/backend/base/langflow/base/flow_processing/utils.py
+++ b/src/backend/base/langflow/base/flow_processing/utils.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from loguru import logger
+
 from langflow.graph.schema import ResultData, RunOutputs
 from langflow.schema import Record
 
@@ -37,9 +39,29 @@ def build_records_from_result_data(result_data: ResultData, get_final_results_on
 
     """
     messages = result_data.messages
-    if not messages:
-        return []
     records = []
+
+    # Handle results without chat messages (calling flow)
+    if not messages:
+        # Result with a single record
+        if isinstance(result_data.artifacts, dict):
+            records.append(Record(data=result_data.artifacts))
+        # List of artifacts
+        elif isinstance(result_data.artifacts, list):
+            for artifact in result_data.artifacts:
+                # If multiple records are found as artifacts, return as-is
+                if isinstance(artifact, Record):
+                    records.append(artifact)
+                else:
+                    # Warn about unknown output type
+                    logger.warning(f"Unable to build record output from unknown ResultData.artifact: {str(artifact)}")
+        # Chat or text output
+        elif result_data.results:
+            records.append(Record(data={"result": result_data.results}, text_key="result"))
+            return records
+        else:
+            return []
+
     for message in messages:
         message_dict = message if isinstance(message, dict) else message.model_dump()
         if get_final_results_only:

--- a/src/backend/base/langflow/graph/schema.py
+++ b/src/backend/base/langflow/graph/schema.py
@@ -71,6 +71,7 @@ INPUT_COMPONENTS = [
 OUTPUT_COMPONENTS = [
     InterfaceComponentTypes.ChatOutput,
     InterfaceComponentTypes.TextOutput,
+    InterfaceComponentTypes.RecordsOutput,
 ]
 
 


### PR DESCRIPTION
These changes fix the issue in #2061.

## Changes:
* Updated `build_records_from_result_data`, because the SubFlow and RunFlow component uses this function to collect the outputs to return from the build method. The updates make sure that the function handles results that don't contain messages (ResultData.messages)
* Updated the schema to consider the Records output type as an output type. I'm not sure why it wasn't but if you have a subflow that returns records via  records output node, the records aren't considered outputs. This update makes sure they are returned.

## Testing Notes:

### Working as expected:
* I build a subflow that takes an input, transforms it, then returns each of the output types (text, chat, record, records)
* I build a parent flow that calls the flow using the SubFlow node and tested each case to make sure the outputs are returned
* I tested these cases with the RunFlow node as well
* I created one more example with multiple inputs and that works as well

### Not sure what should happen:
* I made one more example with multiple inputs, each passing into a ollama completion, then returning each to their own output. So, two inputs, two outputs. I made a parent flow to call the subflow with the two inputs, but wasn't sure what to do about the outputs. I setup a single text output and that worked, but the output was two records and you don't know which output is which
* I could update these cases to always return a record and add attributes to the record for the output component name and output component id, or leave it as-is

### Example Testing Screenshots

#### Example sub flow setup and testing
<img width="1369" alt="Screen Shot 2024-06-14 at 2 15 47 PM" src="https://github.com/langflow-ai/langflow/assets/452052/5c0b1f29-69fa-4df4-887d-3626bfea8502">
<img width="1520" alt="Screen Shot 2024-06-14 at 2 16 32 PM" src="https://github.com/langflow-ai/langflow/assets/452052/e41b76e7-3074-4225-b613-76fa8a8240fe">
<img width="1114" alt="Screen Shot 2024-06-14 at 2 16 44 PM" src="https://github.com/langflow-ai/langflow/assets/452052/c4254b0c-4932-427c-8bca-75c3d0864897">

#### Example parent flow setup and testing
<img width="1315" alt="Screen Shot 2024-06-14 at 2 41 11 PM" src="https://github.com/langflow-ai/langflow/assets/452052/07c00137-5dea-4c58-bf75-b2ab8a6968d0">
<img width="1084" alt="Screen Shot 2024-06-14 at 2 45 06 PM" src="https://github.com/langflow-ai/langflow/assets/452052/0c80862b-b2df-4afa-ace3-9f9116e22284">
