### PR TITLE
fix: add null type to allowable target onchange

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/parameterComponent/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/parameterComponent/index.tsx
@@ -156,8 +156,8 @@ export default function ParameterComponent({
   );
 
   const handleOnNewValue = async (
-    newValue: string | string[] | boolean | Object[],
-    skipSnapshot: boolean | undefined = false
+    newValue: string | string[] | boolean | Object[] | null,
+    skipSnapshot: boolean | undefined = false,
   ): Promise<void> => {
     handleOnNewValueHook(newValue, skipSnapshot);
   };

--- a/src/frontend/src/components/intComponent/index.tsx
+++ b/src/frontend/src/components/intComponent/index.tsx
@@ -19,7 +19,7 @@ export default function IntComponent({
   // Clear component state
   useEffect(() => {
     if (disabled && value !== "") {
-      onChange("", true);
+      onChange(null, true);
     }
   }, [disabled, onChange]);
 
@@ -45,7 +45,9 @@ export default function IntComponent({
         disabled={disabled}
         placeholder={editNode ? "Integer number" : "Type an integer number"}
         onChange={(event) => {
-          onChange(event.target.value);
+          const newValue =
+            event.target.value === "" ? null : event.target.value;
+          onChange(newValue);
         }}
         data-testid={id}
       />

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -184,8 +184,8 @@ export type RangeSpecType = {
 export type IntComponentType = {
   value: string;
   disabled?: boolean;
-  rangeSpec: RangeSpecType;
-  onChange: (value: string, skipSnapshot?: boolean) => void;
+  rangeSpec?: RangeSpecType;
+  onChange: (value: string | null, skipSnapshot?: boolean) => void;
   editNode?: boolean;
   id?: string;
 };
@@ -691,8 +691,8 @@ export type codeTabsPropsType = {
     ) => string;
     buildTweakObject?: (
       tw: string,
-      changes: string | string[] | boolean | number | Object[] | Object,
-      template: TemplateVariableType
+      changes: string | string[] | boolean | number | Object[] | Object | null,
+      template: TemplateVariableType,
     ) => Promise<string | void>;
   };
   activeTweaks?: boolean;


### PR DESCRIPTION
Preface: I don't know javascript. 

For typed fields from the UI, when you entered a value then removed it, it would act as an empty string rather than reset to `null`. For many fields, this is an invalid type, causing errors on build. 

This PR adds the `null` type to the allowed `onchange` events, which is interpreted as the correct `None` in python backend. Note this does mean that an empty string is no longer accepted as a valid input, but that seems okay. If this is the correct fix, I'll replicate on the other typed fields. 

