### PR TITLE
[DO NOT MERGE] cache components loaded from components_path when the /all is called

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -38,6 +38,8 @@ from langflow.services.task.service import TaskService
 if TYPE_CHECKING:
     from langflow.services.settings.manager import SettingsService
 
+all_types_dict = {}
+
 router = APIRouter(tags=["Base"])
 
 
@@ -49,7 +51,9 @@ def get_all(
 
     logger.debug("Building langchain types dict")
     try:
-        all_types_dict = get_all_types_dict(settings_service.settings.components_path)
+        global all_types_dict
+        if len(all_types_dict) == 0:
+            all_types_dict = get_all_types_dict(settings_service.settings.components_path)
         return all_types_dict
     except Exception as exc:
         logger.exception(exc)


### PR DESCRIPTION
api/v1/all can take seconds to build components from the component folder. This is an improvement to cache the build results from the components_path folder. 

Since it's permanently cached, I assume the content from the components_path folder only been loaded once.