### PR TITLE
fix path to the unit test data folder

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -35,7 +35,7 @@ load_dotenv()
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "noclient: don't create a client for this test")
-    data_path = Path(__file__).parent.absolute() / "data"
+    data_path = Path(__file__).parent.parent.absolute() / "data"
 
     pytest.BASIC_EXAMPLE_PATH = data_path / "basic_example.json"
     pytest.COMPLEX_EXAMPLE_PATH = data_path / "complex_example.json"


### PR DESCRIPTION
All unit tests are relocated to tests/unit but it didn't refer to the data files in the correct ./data/ folder.

The bug might be introduced by this PR #2189 