### PR TITLE
fix: do not open browser on backend_only mode

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -167,7 +167,7 @@ def run(
         else:
             # Run using gunicorn on Linux
             process = run_on_mac_or_linux(host, port, log_level, options, app)
-        if open_browser:
+        if open_browser and not backend_only:
             click.launch(f"http://{host}:{port}")
         if process:
             process.join()


### PR DESCRIPTION
it makes no sense to open the browser if the service is backend only mode so it's better to automatically turn it off