### PR TITLE
fix: graph process should raise the actual error when failing

### DIFF
--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -867,7 +867,7 @@ class Graph:
                 next_runnable_vertices = await self._execute_tasks(tasks)
             except Exception as e:
                 logger.error(f"Error executing tasks in layer {layer_index}: {e}")
-                break
+                raise e
             if not next_runnable_vertices:
                 break
             to_process.extend(next_runnable_vertices)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -222,6 +222,7 @@ def json_vector_store():
 
 @pytest.fixture(name="client", autouse=True)
 def client_fixture(session: Session, monkeypatch, request, load_flows_dir):
+    monkeypatch.setenv("LANGFLOW_LOG_LEVEL", "DEBUG")
     # Set the database url to a test database
     if "noclient" in request.keywords:
         yield

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -222,7 +222,6 @@ def json_vector_store():
 
 @pytest.fixture(name="client", autouse=True)
 def client_fixture(session: Session, monkeypatch, request, load_flows_dir):
-    monkeypatch.setenv("LANGFLOW_LOG_LEVEL", "DEBUG")
     # Set the database url to a test database
     if "noclient" in request.keywords:
         yield


### PR DESCRIPTION
Currently when a vertex fails to be processed for an internal problem, the real error is only logged and not raised. Then the exception is `ValueError: The message must be an iterator or an async iterator.`
which is misleading and hard to understand 