### PR TITLE
Store variables as Kubernetes Secrets

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -10622,4 +10622,4 @@ local = ["ctransformers", "llama-cpp-python", "sentence-transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "7293c21857dec24ef2e94bfaa794875a54da4e44c57b29552bee04559d9db18f"
+content-hash = "0338efca20505c0d71b4f8c54136698789c1270ca54c4b0671e094d5a9b519d0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4725,13 +4725,9 @@ files = [
     {file = "lxml-5.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:edcfa83e03370032a489430215c1e7783128808fd3e2e0a3225deee278585196"},
     {file = "lxml-5.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:28bf95177400066596cdbcfc933312493799382879da504633d16cf60bba735b"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a745cc98d504d5bd2c19b10c79c61c7c3df9222629f1b6210c0368177589fb8"},
-    {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b590b39ef90c6b22ec0be925b211298e810b4856909c8ca60d27ffbca6c12e6"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b336b0416828022bfd5a2e3083e7f5ba54b96242159f83c7e3eebaec752f1716"},
-    {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:c2faf60c583af0d135e853c86ac2735ce178f0e338a3c7f9ae8f622fd2eb788c"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:4bc6cb140a7a0ad1f7bc37e018d0ed690b7b6520ade518285dc3171f7a117905"},
-    {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7ff762670cada8e05b32bf1e4dc50b140790909caa8303cfddc4d702b71ea184"},
     {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:57f0a0bbc9868e10ebe874e9f129d2917750adf008fe7b9c1598c0fbbfdde6a6"},
-    {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:a6d2092797b388342c1bc932077ad232f914351932353e2e8706851c870bca1f"},
     {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:60499fe961b21264e17a471ec296dcbf4365fbea611bf9e303ab69db7159ce61"},
     {file = "lxml-5.2.2-cp37-cp37m-win32.whl", hash = "sha256:d9b342c76003c6b9336a80efcc766748a333573abf9350f4094ee46b006ec18f"},
     {file = "lxml-5.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b16db2770517b8799c79aa80f4053cd6f8b716f21f8aca962725a9565ce3ee40"},
@@ -10626,4 +10622,4 @@ local = ["ctransformers", "llama-cpp-python", "sentence-transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "332baeb07342a5ad1367ce6b13a87bd96504f628d2e91e33dfda1a8317b2de13"
+content-hash = "7293c21857dec24ef2e94bfaa794875a54da4e44c57b29552bee04559d9db18f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ cassio = { extras = ["cassio"], version = "^0.1.7", optional = true }
 unstructured = {extras = ["docx", "md", "pptx"], version = "^0.14.4"}
 langchain-aws = "^0.1.6"
 langchain-mongodb = "^0.1.6"
+kubernetes = "^30.1.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -73,6 +73,10 @@ class Settings(BaseSettings):
     max_overflow: int = 20
     """The number of connections to allow that can be opened beyond the pool size. If not provided, the default is 10."""
     cache_type: str = "async"
+
+    """The store can be 'db' or 'kubernetes'."""
+    variable_store: str = "db"
+
     remove_api_keys: bool = False
     components_path: List[str] = []
     langchain_cache: str = "InMemoryCache"

--- a/src/backend/base/langflow/services/variable/base.py
+++ b/src/backend/base/langflow/services/variable/base.py
@@ -9,10 +9,12 @@ from langflow.services.base import Service
 from langflow.services.database.models.variable.model import Variable
 from langflow.services.deps import get_session
 
+
 class VariableService(Service):
     """
     Abstract base class for a variable service.
     """
+
     name = "variable_service"
 
     @abc.abstractmethod
@@ -39,7 +41,7 @@ class VariableService(Service):
         Returns:
             The value of the variable.
         """
-    
+
     @abc.abstractmethod
     def list_variables(self, user_id: Union[UUID, str], session: Session) -> list[Optional[str]]:
         """
@@ -52,7 +54,7 @@ class VariableService(Service):
         Returns:
             A list of variable names.
         """
-    
+
     @abc.abstractmethod
     def update_variable(self, user_id: Union[UUID, str], name: str, value: str, session: Session) -> Variable:
         """
@@ -66,7 +68,7 @@ class VariableService(Service):
 
         Returns:
             The updated variable.
-        """ 
+        """
 
     @abc.abstractmethod
     def delete_variable(self, user_id: Union[UUID, str], name: str, session: Session) -> Variable:
@@ -80,8 +82,8 @@ class VariableService(Service):
 
         Returns:
             The deleted variable.
-        """ 
-    
+        """
+
     @abc.abstractmethod
     def create_variable(
         self,
@@ -106,4 +108,3 @@ class VariableService(Service):
         Returns:
             The created variable.
         """
-

--- a/src/backend/base/langflow/services/variable/base.py
+++ b/src/backend/base/langflow/services/variable/base.py
@@ -2,12 +2,10 @@ import abc
 from typing import Optional, Union
 from uuid import UUID
 
-from fastapi import Depends
 from sqlmodel import Session
 
 from langflow.services.base import Service
 from langflow.services.database.models.variable.model import Variable
-from langflow.services.deps import get_session
 
 
 class VariableService(Service):
@@ -90,9 +88,9 @@ class VariableService(Service):
         user_id: Union[UUID, str],
         name: str,
         value: str,
-        default_fields: list[str] = [],
-        _type: str = "Generic",
-        session: Session = Depends(get_session),
+        default_fields: list[str],
+        _type: str,
+        session: Session,
     ) -> Variable:
         """
         Create a variable.

--- a/src/backend/base/langflow/services/variable/base.py
+++ b/src/backend/base/langflow/services/variable/base.py
@@ -1,0 +1,109 @@
+import abc
+from typing import Optional, Union
+from uuid import UUID
+
+from fastapi import Depends
+from sqlmodel import Session
+
+from langflow.services.base import Service
+from langflow.services.database.models.variable.model import Variable
+from langflow.services.deps import get_session
+
+class VariableService(Service):
+    """
+    Abstract base class for a variable service.
+    """
+    name = "variable_service"
+
+    @abc.abstractmethod
+    def initialize_user_variables(self, user_id: Union[UUID, str], session: Session) -> None:
+        """
+        Initialize user variables.
+
+        Args:
+            user_id: The user ID.
+            session: The database session.
+        """
+
+    @abc.abstractmethod
+    def get_variable(self, user_id: Union[UUID, str], name: str, field: str, session: Session) -> str:
+        """
+        Get a variable value.
+
+        Args:
+            user_id: The user ID.
+            name: The name of the variable.
+            field: The field of the variable.
+            session: The database session.
+
+        Returns:
+            The value of the variable.
+        """
+    
+    @abc.abstractmethod
+    def list_variables(self, user_id: Union[UUID, str], session: Session) -> list[Optional[str]]:
+        """
+        List all variables.
+
+        Args:
+            user_id: The user ID.
+            session: The database session.
+
+        Returns:
+            A list of variable names.
+        """
+    
+    @abc.abstractmethod
+    def update_variable(self, user_id: Union[UUID, str], name: str, value: str, session: Session) -> Variable:
+        """
+        Update a variable.
+
+        Args:
+            user_id: The user ID.
+            name: The name of the variable.
+            value: The value of the variable.
+            session: The database session.
+
+        Returns:
+            The updated variable.
+        """ 
+
+    @abc.abstractmethod
+    def delete_variable(self, user_id: Union[UUID, str], name: str, session: Session) -> Variable:
+        """
+        Delete a variable.
+
+        Args:
+            user_id: The user ID.
+            name: The name of the variable.
+            session: The database session.
+
+        Returns:
+            The deleted variable.
+        """ 
+    
+    @abc.abstractmethod
+    def create_variable(
+        self,
+        user_id: Union[UUID, str],
+        name: str,
+        value: str,
+        default_fields: list[str] = [],
+        _type: str = "Generic",
+        session: Session = Depends(get_session),
+    ) -> Variable:
+        """
+        Create a variable.
+
+        Args:
+            user_id: The user ID.
+            name: The name of the variable.
+            value: The value of the variable.
+            default_fields: The default fields of the variable.
+            _type: The type of the variable.
+            session: The database session.
+
+        Returns:
+            The created variable.
+        """
+

--- a/src/backend/base/langflow/services/variable/factory.py
+++ b/src/backend/base/langflow/services/variable/factory.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from langflow.services.factory import ServiceFactory
-from langflow.services.variable.service import DatabaseVariableService, KubernetesSecretService
+from langflow.services.variable.service import VariableService, DatabaseVariableService, KubernetesSecretService
 
 if TYPE_CHECKING:
     from langflow.services.settings.service import SettingsService

--- a/src/backend/base/langflow/services/variable/factory.py
+++ b/src/backend/base/langflow/services/variable/factory.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from langflow.services.factory import ServiceFactory
-from langflow.services.variable.service import VariableService
+from langflow.services.variable.service import DatabaseVariableService, KubernetesSecretService
 
 if TYPE_CHECKING:
     from langflow.services.settings.service import SettingsService
@@ -12,4 +12,10 @@ class VariableServiceFactory(ServiceFactory):
         super().__init__(VariableService)
 
     def create(self, settings_service: "SettingsService"):
-        return VariableService(settings_service)
+        # here you would have logic to create and configure a VariableService
+        # based on the settings_service
+
+        if settings_service.settings.variable_store == "kubernetes":
+            return KubernetesSecretService(settings_service)
+        else:
+            return DatabaseVariableService(settings_service)

--- a/src/backend/base/langflow/services/variable/kubernetes_secrets.py
+++ b/src/backend/base/langflow/services/variable/kubernetes_secrets.py
@@ -1,8 +1,11 @@
 from kubernetes import client, config  # type: ignore
-from kubernetes.client.rest import ApiException
+from kubernetes.client.rest import ApiException  # type: ignore
 from base64 import b64encode, b64decode
 
 from loguru import logger
+from typing import Union
+from uuid import UUID
+
 
 class KubernetesSecretManager:
     """
@@ -38,15 +41,11 @@ class KubernetesSecretManager:
 
         secret_metadata = client.V1ObjectMeta(name=name)
         secret = client.V1Secret(
-            api_version="v1",
-            kind="Secret",
-            metadata=secret_metadata, 
-            type=secret_type,
-            data=encoded_data
+            api_version="v1", kind="Secret", metadata=secret_metadata, type=secret_type, data=encoded_data
         )
 
         return self.core_api.create_namespaced_secret(self.namespace, secret)
-    
+
     def upsert_secret(self, secret_name: str, data: dict, secret_type: str = "Opaque"):
         """
         Upsert a secret in the specified namespace.
@@ -60,18 +59,18 @@ class KubernetesSecretManager:
         try:
             # Try to read the existing secret
             existing_secret = self.core_api.read_namespaced_secret(secret_name, self.namespace)
-            
+
             # If secret exists, update it
             existing_data = {k: b64decode(v).decode() for k, v in existing_secret.data.items()}
             existing_data.update(data)
-            
+
             # Encode all data to base64
             encoded_data = {k: b64encode(v.encode()).decode() for k, v in existing_data.items()}
-            
+
             # Update the existing secret
             existing_secret.data = encoded_data
             return self.core_api.replace_namespaced_secret(secret_name, self.namespace, existing_secret)
-        
+
         except ApiException as e:
             if e.status == 404:
                 # Secret doesn't exist, create a new one
@@ -113,14 +112,14 @@ class KubernetesSecretManager:
         secret = self.core_api.read_namespaced_secret(name, self.namespace)
         if secret is None:
             raise ApiException(status=404, reason="Not Found", msg="Secret not found")
-        
+
         # Update the secret data
         encoded_data = {k: b64encode(v.encode()).decode() for k, v in data.items()}
         secret.data.update(encoded_data)
-        
+
         # Update the secret in Kubernetes
         return self.core_api.replace_namespaced_secret(name, self.namespace, secret)
-    
+
     def delete_secret_key(self, name: str, key: str):
         """
         Delete a key from the specified secret in the namespace.
@@ -136,16 +135,16 @@ class KubernetesSecretManager:
         secret = self.core_api.read_namespaced_secret(name, self.namespace)
         if secret is None:
             raise ApiException(status=404, reason="Not Found", msg="Secret not found")
-        
+
         # Delete the key from the secret data
         if key in secret.data:
             del secret.data[key]
         else:
             raise ApiException(status=404, reason="Not Found", msg="Key not found in the secret")
-        
+
         # Update the secret in Kubernetes
         return self.core_api.replace_namespaced_secret(name, self.namespace, secret)
-      
+
     def delete_secret(self, name: str):
         """
         Delete a secret from the specified namespace.
@@ -158,7 +157,39 @@ class KubernetesSecretManager:
         """
         return self.core_api.delete_namespaced_secret(name, self.namespace)
 
+
 # utility function to encode user_id to base64 lower case and numbers only
 # this is required by kubernetes secret name restrictions
-def encode_user_id(user_id: str) -> str:
-    return b64encode(user_id.encode()).decode().lower().replace("=", "").replace("+", "-").replace("/", "_")
+def encode_user_id(user_id: Union[UUID | str]) -> str:
+    # Handle UUID
+    if isinstance(user_id, UUID):
+        return f"uuid-{str(user_id).lower()}"[:253]
+
+    # Convert string to lowercase
+    id = str(user_id).lower()
+
+    # If the user_id looks like an email, replace @ and . with allowed characters
+    if "@" in id or "." in id:
+        id = id.replace("@", "-at-").replace(".", "-dot-")
+
+    # Encode the user_id to base64
+    # encoded = base64.b64encode(user_id.encode("utf-8")).decode("utf-8")
+
+    # Replace characters not allowed in Kubernetes names
+    id = id.replace("+", "-").replace("/", "_").rstrip("=")
+
+    # Ensure the name starts with an alphanumeric character
+    if not id[0].isalnum():
+        id = "a-" + id
+
+    # Truncate to 253 characters (Kubernetes name length limit)
+    id = id[:253]
+
+    if not all(c.isalnum() or c in "-_" for c in id):
+        raise ValueError(f"Invalid user_id: {id}")
+
+    # Ensure the name ends with an alphanumeric character
+    while not id[-1].isalnum():
+        id = id[:-1]
+
+    return id

--- a/src/backend/base/langflow/services/variable/kubernetes_secrets.py
+++ b/src/backend/base/langflow/services/variable/kubernetes_secrets.py
@@ -1,0 +1,164 @@
+from kubernetes import client, config  # type: ignore
+from kubernetes.client.rest import ApiException
+from base64 import b64encode, b64decode
+
+from loguru import logger
+
+class KubernetesSecretManager:
+    """
+    A class for managing Kubernetes secrets.
+    """
+
+    def __init__(self, namespace: str = "langflow"):
+        """
+        Initialize the KubernetesSecretManager class.
+
+        Args:
+            namespace (str): The namespace in which to perform secret operations.
+        """
+        config.load_kube_config()
+        self.namespace = namespace
+
+        # initialize the Kubernetes API client
+        self.core_api = client.CoreV1Api()
+
+    def create_secret(self, name: str, data: dict, secret_type: str = "Opaque"):
+        """
+        Create a new secret in the specified namespace.
+
+        Args:
+            name (str): The name of the secret to create.
+            data (dict): A dictionary containing the key-value pairs for the secret data.
+            secret_type (str, optional): The type of secret to create. Defaults to 'Opaque'.
+
+        Returns:
+            V1Secret: The created secret object.
+        """
+        encoded_data = {k: b64encode(v.encode()).decode() for k, v in data.items()}
+
+        secret_metadata = client.V1ObjectMeta(name=name)
+        secret = client.V1Secret(
+            api_version="v1",
+            kind="Secret",
+            metadata=secret_metadata, 
+            type=secret_type,
+            data=encoded_data
+        )
+
+        return self.core_api.create_namespaced_secret(self.namespace, secret)
+    
+    def upsert_secret(self, secret_name: str, data: dict, secret_type: str = "Opaque"):
+        """
+        Upsert a secret in the specified namespace.
+        If the secret doesn't exist, it will be created.
+        If it exists, it will be updated with new data while preserving existing keys.
+
+        :param secret_name: Name of the secret
+        :param new_data: Dictionary containing new key-value pairs for the secret
+        :return: Created or updated secret object
+        """
+        try:
+            # Try to read the existing secret
+            existing_secret = self.core_api.read_namespaced_secret(secret_name, self.namespace)
+            
+            # If secret exists, update it
+            existing_data = {k: b64decode(v).decode() for k, v in existing_secret.data.items()}
+            existing_data.update(data)
+            
+            # Encode all data to base64
+            encoded_data = {k: b64encode(v.encode()).decode() for k, v in existing_data.items()}
+            
+            # Update the existing secret
+            existing_secret.data = encoded_data
+            return self.core_api.replace_namespaced_secret(secret_name, self.namespace, existing_secret)
+        
+        except ApiException as e:
+            if e.status == 404:
+                # Secret doesn't exist, create a new one
+                return self.create_secret(secret_name, data)
+            else:
+                logger.error(f"Error upserting secret {secret_name}: {e}")
+                raise
+
+    def get_secret(self, name: str) -> dict | None:
+        """
+        Read a secret from the specified namespace.
+
+        Args:
+            name (str): The name of the secret to read.
+
+        Returns:
+            V1Secret: The secret object.
+        """
+        try:
+            secret = self.core_api.read_namespaced_secret(name, self.namespace)
+            return {k: b64decode(v).decode() for k, v in secret.data.items()}
+        except ApiException as e:
+            if e.status == 404:
+                return None
+            raise
+
+    def update_secret(self, name: str, data: dict):
+        """
+        Update an existing secret in the specified namespace.
+
+        Args:
+            name (str): The name of the secret to update.
+            data (dict): A dictionary containing the key-value pairs for the updated secret data.
+
+        Returns:
+            V1Secret: The updated secret object.
+        """
+        # Get the existing secret
+        secret = self.core_api.read_namespaced_secret(name, self.namespace)
+        if secret is None:
+            raise ApiException(status=404, reason="Not Found", msg="Secret not found")
+        
+        # Update the secret data
+        encoded_data = {k: b64encode(v.encode()).decode() for k, v in data.items()}
+        secret.data.update(encoded_data)
+        
+        # Update the secret in Kubernetes
+        return self.core_api.replace_namespaced_secret(name, self.namespace, secret)
+    
+    def delete_secret_key(self, name: str, key: str):
+        """
+        Delete a key from the specified secret in the namespace.
+
+        Args:
+            name (str): The name of the secret.
+            key (str): The key to delete from the secret.
+
+        Returns:
+            V1Secret: The updated secret object.
+        """
+        # Get the existing secret
+        secret = self.core_api.read_namespaced_secret(name, self.namespace)
+        if secret is None:
+            raise ApiException(status=404, reason="Not Found", msg="Secret not found")
+        
+        # Delete the key from the secret data
+        if key in secret.data:
+            del secret.data[key]
+        else:
+            raise ApiException(status=404, reason="Not Found", msg="Key not found in the secret")
+        
+        # Update the secret in Kubernetes
+        return self.core_api.replace_namespaced_secret(name, self.namespace, secret)
+      
+    def delete_secret(self, name: str):
+        """
+        Delete a secret from the specified namespace.
+
+        Args:
+            name (str): The name of the secret to delete.
+
+        Returns:
+            V1Status: The status object indicating the success or failure of the operation.
+        """
+        return self.core_api.delete_namespaced_secret(name, self.namespace)
+
+# utility function to encode user_id to base64 lower case and numbers only
+# this is required by kubernetes secret name restrictions
+def encode_user_id(user_id: str) -> str:
+    return b64encode(user_id.encode()).decode().lower().replace("=", "").replace("+", "-").replace("/", "_")

--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
 
 class DatabaseVariableService(VariableService, Service):
-
     def __init__(self, settings_service: "SettingsService"):
         self.settings_service = settings_service
 
@@ -129,9 +128,7 @@ class DatabaseVariableService(VariableService, Service):
         return variable
 
 
-
 class KubernetesSecretService(VariableService, Service):
-
     def __init__(self, settings_service: "SettingsService"):
         self.settings_service = settings_service
 
@@ -149,7 +146,7 @@ class KubernetesSecretService(VariableService, Service):
 
     def list_variables(self, user_id: Union[UUID, str], session: Session = Depends(get_session)) -> list[Optional[str]]:
         return []
-    
+
     def update_variable(
         self,
         user_id: Union[UUID, str],
@@ -158,15 +155,15 @@ class KubernetesSecretService(VariableService, Service):
         session: Session = Depends(get_session),
     ):
         return
-    
-    def delete_variable(    
+
+    def delete_variable(
         self,
         user_id: Union[UUID, str],
         name: str,
         session: Session = Depends(get_session),
     ):
         return
-    
+
     def create_variable(
         self,
         user_id: Union[UUID, str],

--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -8,6 +8,7 @@ from sqlmodel import Session, select
 
 from langflow.services.auth import utils as auth_utils
 from langflow.services.base import Service
+from langflow.services.variable.base import VariableService
 from langflow.services.database.models.variable.model import Variable, VariableCreate
 from langflow.services.deps import get_session
 
@@ -15,8 +16,7 @@ if TYPE_CHECKING:
     from langflow.services.settings.service import SettingsService
 
 
-class VariableService(Service):
-    name = "variable_service"
+class DatabaseVariableService(VariableService, Service):
 
     def __init__(self, settings_service: "SettingsService"):
         self.settings_service = settings_service
@@ -127,3 +127,53 @@ class VariableService(Service):
         session.commit()
         session.refresh(variable)
         return variable
+
+
+
+class KubernetesSecretService(VariableService, Service):
+
+    def __init__(self, settings_service: "SettingsService"):
+        self.settings_service = settings_service
+
+    def initialize_user_variables(self, user_id: Union[UUID, str], session: Session = Depends(get_session)):
+        return
+
+    def get_variable(
+        self,
+        user_id: Union[UUID, str],
+        name: str,
+        field: str,
+        session: Session = Depends(get_session),
+    ) -> str:
+        return ""
+
+    def list_variables(self, user_id: Union[UUID, str], session: Session = Depends(get_session)) -> list[Optional[str]]:
+        return []
+    
+    def update_variable(
+        self,
+        user_id: Union[UUID, str],
+        name: str,
+        value: str,
+        session: Session = Depends(get_session),
+    ):
+        return
+    
+    def delete_variable(    
+        self,
+        user_id: Union[UUID, str],
+        name: str,
+        session: Session = Depends(get_session),
+    ):
+        return
+    
+    def create_variable(
+        self,
+        user_id: Union[UUID, str],
+        name: str,
+        value: str,
+        default_fields: list[str] = [],
+        _type: str = "Generic",
+        session: Session = Depends(get_session),
+    ):
+        return

--- a/tests/unit/test_kubernetes_secrets.py
+++ b/tests/unit/test_kubernetes_secrets.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from kubernetes.client.rest import ApiException
+from kubernetes.client import V1ObjectMeta, V1Secret
+from base64 import b64encode
+
+from langflow.services.variable.kubernetes_secrets import KubernetesSecretManager
+
+@pytest.fixture
+def secret_manager():
+    return KubernetesSecretManager(namespace='test-namespace')
+
+def test_create_secret(secret_manager, mocker):
+    mocker.patch.object(secret_manager.core_api, 'create_namespaced_secret', return_value=V1Secret(metadata=V1ObjectMeta(name='test-secret')))
+    
+    secret_manager.create_secret(name='test-secret', data={'key': 'value'})
+    secret_manager.core_api.create_namespaced_secret.assert_called_once_with(
+        'test-namespace',
+        V1Secret(
+            api_version='v1',
+            kind='Secret',
+            metadata=V1ObjectMeta(name='test-secret'),
+            type='Opaque',
+            data={'key': b64encode('value'.encode()).decode()}
+        )
+    )
+
+def test_get_secret(secret_manager, mocker):
+    mock_secret = V1Secret(data={'key': b64encode('value'.encode()).decode()})
+    mocker.patch.object(secret_manager.core_api, 'read_namespaced_secret', return_value=mock_secret)
+    
+    secret_data = secret_manager.get_secret(name='test-secret')
+    secret_manager.core_api.read_namespaced_secret.assert_called_once_with('test-secret', 'test-namespace')
+    assert secret_data == {'key': 'value'}
+
+def test_update_secret(secret_manager, mocker):
+    mocker.patch.object(secret_manager.core_api, 'replace_namespaced_secret', return_value=V1Secret(metadata=V1ObjectMeta(name='test-secret')))
+    
+    secret_manager.update_secret(name='test-secret', data={'key': 'new-value'})
+    secret_manager.core_api.replace_namespaced_secret.assert_called_once_with(
+        'test-secret',
+        'test-namespace',
+        V1Secret(metadata=V1ObjectMeta(name='test-secret'), data={'key': 'new-value'})
+    )
+
+def test_delete_secret(secret_manager, mocker):
+    mocker.patch.object(secret_manager.core_api, 'delete_namespaced_secret', return_value=MagicMock(status='Success'))
+    
+    secret_manager.delete_secret(name='test-secret')
+    secret_manager.core_api.delete_namespaced_secret.assert_called_once_with('test-secret', 'test-namespace')

--- a/tests/unit/test_kubernetes_secrets.py
+++ b/tests/unit/test_kubernetes_secrets.py
@@ -8,7 +8,13 @@ from langflow.services.variable.kubernetes_secrets import KubernetesSecretManage
 
 
 @pytest.fixture
-def secret_manager():
+def mock_kube_config(mocker):
+    mocker.patch("kubernetes.config.load_kube_config")
+    mocker.patch("kubernetes.config.load_incluster_config")
+
+
+@pytest.fixture
+def secret_manager(mock_kube_config):
     return KubernetesSecretManager(namespace="test-namespace")
 
 

--- a/tests/unit/test_kubernetes_secrets.py
+++ b/tests/unit/test_kubernetes_secrets.py
@@ -1,50 +1,101 @@
 import pytest
-from unittest.mock import MagicMock, patch
-from kubernetes.client.rest import ApiException
+from unittest.mock import MagicMock
 from kubernetes.client import V1ObjectMeta, V1Secret
 from base64 import b64encode
+from uuid import UUID
 
-from langflow.services.variable.kubernetes_secrets import KubernetesSecretManager
+from langflow.services.variable.kubernetes_secrets import KubernetesSecretManager, encode_user_id
+
 
 @pytest.fixture
 def secret_manager():
-    return KubernetesSecretManager(namespace='test-namespace')
+    return KubernetesSecretManager(namespace="test-namespace")
+
 
 def test_create_secret(secret_manager, mocker):
-    mocker.patch.object(secret_manager.core_api, 'create_namespaced_secret', return_value=V1Secret(metadata=V1ObjectMeta(name='test-secret')))
-    
-    secret_manager.create_secret(name='test-secret', data={'key': 'value'})
-    secret_manager.core_api.create_namespaced_secret.assert_called_once_with(
-        'test-namespace',
-        V1Secret(
-            api_version='v1',
-            kind='Secret',
-            metadata=V1ObjectMeta(name='test-secret'),
-            type='Opaque',
-            data={'key': b64encode('value'.encode()).decode()}
-        )
+    mocker.patch.object(
+        secret_manager.core_api,
+        "create_namespaced_secret",
+        return_value=V1Secret(metadata=V1ObjectMeta(name="test-secret")),
     )
+
+    secret_manager.create_secret(name="test-secret", data={"key": "value"})
+    secret_manager.core_api.create_namespaced_secret.assert_called_once_with(
+        "test-namespace",
+        V1Secret(
+            api_version="v1",
+            kind="Secret",
+            metadata=V1ObjectMeta(name="test-secret"),
+            type="Opaque",
+            data={"key": b64encode("value".encode()).decode()},
+        ),
+    )
+
 
 def test_get_secret(secret_manager, mocker):
-    mock_secret = V1Secret(data={'key': b64encode('value'.encode()).decode()})
-    mocker.patch.object(secret_manager.core_api, 'read_namespaced_secret', return_value=mock_secret)
-    
-    secret_data = secret_manager.get_secret(name='test-secret')
-    secret_manager.core_api.read_namespaced_secret.assert_called_once_with('test-secret', 'test-namespace')
-    assert secret_data == {'key': 'value'}
+    mock_secret = V1Secret(data={"key": b64encode("value".encode()).decode()})
+    mocker.patch.object(secret_manager.core_api, "read_namespaced_secret", return_value=mock_secret)
 
-def test_update_secret(secret_manager, mocker):
-    mocker.patch.object(secret_manager.core_api, 'replace_namespaced_secret', return_value=V1Secret(metadata=V1ObjectMeta(name='test-secret')))
-    
-    secret_manager.update_secret(name='test-secret', data={'key': 'new-value'})
-    secret_manager.core_api.replace_namespaced_secret.assert_called_once_with(
-        'test-secret',
-        'test-namespace',
-        V1Secret(metadata=V1ObjectMeta(name='test-secret'), data={'key': 'new-value'})
-    )
+    secret_data = secret_manager.get_secret(name="test-secret")
+    secret_manager.core_api.read_namespaced_secret.assert_called_once_with("test-secret", "test-namespace")
+    assert secret_data == {"key": "value"}
+
 
 def test_delete_secret(secret_manager, mocker):
-    mocker.patch.object(secret_manager.core_api, 'delete_namespaced_secret', return_value=MagicMock(status='Success'))
-    
-    secret_manager.delete_secret(name='test-secret')
-    secret_manager.core_api.delete_namespaced_secret.assert_called_once_with('test-secret', 'test-namespace')
+    mocker.patch.object(secret_manager.core_api, "delete_namespaced_secret", return_value=MagicMock(status="Success"))
+
+    secret_manager.delete_secret(name="test-secret")
+    secret_manager.core_api.delete_namespaced_secret.assert_called_once_with("test-secret", "test-namespace")
+
+
+def test_encode_uuid():
+    uuid = UUID("123e4567-e89b-12d3-a456-426614174000")
+    result = encode_user_id(uuid)
+    assert result == "uuid-123e4567-e89b-12d3-a456-426614174000"
+    assert len(result) < 253
+    assert result[0].isalnum()
+    assert result[-1].isalnum()
+
+
+def test_encode_string():
+    string_id = "user@example.com"
+    result = encode_user_id(string_id)
+    # assert (result.isalnum() or '-' in result or '_' in result)
+    assert len(result) < 253
+    assert result[0].isalnum()
+    assert result[-1].isalnum()
+
+
+def test_long_string():
+    long_string = "a" * 300
+    result = encode_user_id(long_string)
+    assert len(result) <= 253
+
+
+def test_starts_with_non_alphanumeric():
+    non_alnum_start = "+user123"
+    result = encode_user_id(non_alnum_start)
+    assert result[0].isalnum()
+
+
+def test_ends_with_non_alphanumeric():
+    non_alnum_end = "user123+"
+    result = encode_user_id(non_alnum_end)
+    assert result[-1].isalnum()
+
+
+def test_email_address():
+    email = "User.Name@Example.com"
+    result = encode_user_id(email)
+    assert result.isalnum() or "-" in result or "_" in result
+    assert len(result) < 253
+    assert result[0].isalnum()
+    assert result[-1].isalnum()
+
+
+def test_uuid_case_insensitivity():
+    uuid_upper = UUID("123E4567-E89B-12D3-A456-426614174000")
+    uuid_lower = UUID("123e4567-e89b-12d3-a456-426614174000")
+    result_upper = encode_user_id(uuid_upper)
+    result_lower = encode_user_id(uuid_lower)
+    assert result_upper == result_lower


### PR DESCRIPTION
This PR introduces an alternate backend to store variable in kubernetes secrets.
It addresses these two feature requests
https://github.com/langflow-ai/langflow/issues/2151
https://github.com/langflow-ai/langflow/issues/2150

@ogabrielluiz 
This implementation stores both Credential and Generic variables in Kubernetes secrets when setting_service.variable_store = "kubernetes"

Or the second option is to only store the variable type is `Credential` to Kubernetes secrets while the rest `Generic` still are stored in `db`. For that we can introduce a flag `setting_service.credential_store` 

Let me know which one is more appropriate.
