### PR TITLE
ci pr-checker enforce meaningful pr title and description

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -1,0 +1,26 @@
+name: PR checker
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+
+jobs:
+  pr-checker:
+    name: Check PR description
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Run PR title check
+        uses: transferwise/actions-pr-checker@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE_CONTAINS_PATTERN: ".{15,}" # Require at least 10 characters in the title
+          PR_COMMENT: |
+            Please provide a more meaningful PR title with at least 15 characters.
+
+      - name: Run PR description check
+        uses: transferwise/actions-pr-checker@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_CONTAINS_PATTERN: ".{25,}" # Require at least 10 characters in the description
+          PR_COMMENT: |
+            Please provide a more meaningful PR description with at least 25 characters.


### PR DESCRIPTION
add a `pr-checker` ci job to make sure sufficient PR title and description are provided.

For the description, we can use a template. So this job so far just make sure it meets 25 characters.

Sufficient PR description is needed because the repo has enforced merge-squash that only one commit is merged to the dev branch after squashing all the commits under a PR. The history may get lost because of that therefore we enforce the sufficient PR title.