### PR TITLE
Fix optional import for variable service

### DIFF
--- a/src/backend/base/langflow/services/variable/factory.py
+++ b/src/backend/base/langflow/services/variable/factory.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from langflow.services.factory import ServiceFactory
-from langflow.services.variable.service import VariableService, DatabaseVariableService, KubernetesSecretService
+from langflow.services.variable.service import DatabaseVariableService, VariableService
 
 if TYPE_CHECKING:
     from langflow.services.settings.service import SettingsService
@@ -16,6 +16,9 @@ class VariableServiceFactory(ServiceFactory):
         # based on the settings_service
 
         if settings_service.settings.variable_store == "kubernetes":
+            # Keep it here to avoid import errors
+            from langflow.services.variable.service import KubernetesSecretService
+
             return KubernetesSecretService(settings_service)
         else:
             return DatabaseVariableService(settings_service)


### PR DESCRIPTION
This pull request fixes an issue where the optional import for the variable service was happening even if it wasn't used. The import has been moved inside the conditional block to ensure it only happens when needed.