### PR TITLE
Refactor prompt validation and code processing in Component and PromptComponent classes

### DIFF
--- a/src/backend/base/langflow/api/utils.py
+++ b/src/backend/base/langflow/api/utils.py
@@ -69,87 +69,6 @@ def build_input_keys_response(langchain_object, artifacts):
     return input_keys_response
 
 
-def update_frontend_node_with_template_values(frontend_node, raw_frontend_node):
-    """
-    Updates the given frontend node with values from the raw template data.
-
-    :param frontend_node: A dict representing a built frontend node.
-    :param raw_template_data: A dict representing raw template data.
-    :return: Updated frontend node.
-    """
-    if not is_valid_data(frontend_node, raw_frontend_node):
-        return frontend_node
-
-    # Check if the display_name is different than "CustomComponent"
-    # if so, update the display_name in the frontend_node
-    if raw_frontend_node["display_name"] != "CustomComponent":
-        frontend_node["display_name"] = raw_frontend_node["display_name"]
-
-    update_template_values(frontend_node["template"], raw_frontend_node["template"])
-
-    old_code = raw_frontend_node["template"]["code"]["value"]
-    new_code = frontend_node["template"]["code"]["value"]
-    frontend_node["edited"] = old_code != new_code
-
-    return frontend_node
-
-
-def raw_frontend_data_is_valid(raw_frontend_data):
-    """Check if the raw frontend data is valid for processing."""
-    return "template" in raw_frontend_data and "display_name" in raw_frontend_data
-
-
-def is_valid_data(frontend_node, raw_frontend_data):
-    """Check if the data is valid for processing."""
-
-    return frontend_node and "template" in frontend_node and raw_frontend_data_is_valid(raw_frontend_data)
-
-
-def update_template_values(frontend_template, raw_template):
-    """Updates the frontend template with values from the raw template."""
-    for key, value_dict in raw_template.items():
-        if key == "code" or not isinstance(value_dict, dict):
-            continue
-
-        update_template_field(frontend_template, key, value_dict)
-
-
-def update_template_field(frontend_template, key, value_dict):
-    """Updates a specific field in the frontend template."""
-    template_field = frontend_template.get(key)
-    if not template_field or template_field.get("type") != value_dict.get("type"):
-        return
-
-    if "value" in value_dict and value_dict["value"]:
-        template_field["value"] = value_dict["value"]
-
-    if "file_path" in value_dict and value_dict["file_path"]:
-        file_path_value = get_file_path_value(value_dict["file_path"])
-        if not file_path_value:
-            # If the file does not exist, remove the value from the template_field["value"]
-            template_field["value"] = ""
-        template_field["file_path"] = file_path_value
-
-
-def get_file_path_value(file_path):
-    """Get the file path value if the file exists, else return empty string."""
-    try:
-        path = Path(file_path)
-    except TypeError:
-        return ""
-
-    # Check for safety
-    # If the path is not in the cache dir, return empty string
-    # This is to prevent access to files outside the cache dir
-    # If the path is not a file, return empty string
-    if not str(path).startswith(user_cache_dir("langflow", "langflow")):
-        return ""
-
-    if not path.exists():
-        return ""
-    return file_path
-
-
 def validate_is_component(flows: list["Flow"]):
     for flow in flows:
         if not flow.data or flow.is_component is not None:
@@ -325,5 +244,4 @@ def parse_exception(exc):
     """Parse the exception message."""
     if hasattr(exc, "body"):
         return exc.body["message"]
-    return str(exc)
     return str(exc)

--- a/src/backend/base/langflow/api/utils.py
+++ b/src/backend/base/langflow/api/utils.py
@@ -1,10 +1,8 @@
 import uuid
 import warnings
-from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from fastapi import HTTPException
-from platformdirs import user_cache_dir
 from sqlmodel import Session
 
 from langflow.graph.graph.base import Graph

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -8,7 +8,6 @@ from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Re
 from loguru import logger
 from sqlmodel import Session, select
 
-from langflow.api.utils import update_frontend_node_with_template_values
 from langflow.api.v1.schemas import (
     ConfigResponse,
     CustomComponentRequest,
@@ -466,9 +465,9 @@ async def custom_component(
 ):
     component = Component(code=raw_code.code)
 
-    built_frontend_node, _ = build_custom_component_template(component, user_id=user.id)
+    built_frontend_node, component_instance = build_custom_component_template(component, user_id=user.id)
 
-    built_frontend_node = update_frontend_node_with_template_values(built_frontend_node, raw_code.frontend_node)
+    built_frontend_node = component_instance.post_code_validation(built_frontend_node, raw_code.frontend_node)
     return built_frontend_node
 
 

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -467,7 +467,7 @@ async def custom_component(
 
     built_frontend_node, component_instance = build_custom_component_template(component, user_id=user.id)
 
-    built_frontend_node = component_instance.post_code_validation(built_frontend_node, raw_code.frontend_node)
+    built_frontend_node = component_instance.post_code_processing(built_frontend_node, raw_code.frontend_node)
     return built_frontend_node
 
 

--- a/src/backend/base/langflow/components/prompts/Prompt.py
+++ b/src/backend/base/langflow/components/prompts/Prompt.py
@@ -1,6 +1,8 @@
+from langflow.base.prompts.api_utils import process_prompt_template
 from langflow.custom import Component
 from langflow.io import Output, PromptInput
 from langflow.schema.message import Message
+from langflow.template.utils import update_template_values
 
 
 class PromptComponent(Component):
@@ -23,3 +25,20 @@ class PromptComponent(Component):
         prompt = await Message.from_template_and_variables(**self._attributes)
         self.status = prompt.text
         return prompt
+
+    def post_code_processing(self, new_build_config: dict, current_build_config: dict):
+        """
+        This function is called after the code validation is done.
+        """
+        frontend_node = super().post_code_processing(new_build_config, current_build_config)
+        template = frontend_node["template"]["template"]["value"]
+        _ = process_prompt_template(
+            template=template,
+            name="template",
+            custom_fields=frontend_node["custom_fields"],
+            frontend_node_template=frontend_node["template"],
+        )
+        # Now that template is updated, we need to grab any values that were set in the current_build_config
+        # and update the frontend_node with those values
+        update_template_values(frontend_template=frontend_node, raw_template=current_build_config["template"])
+        return frontend_node

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -226,7 +226,7 @@ class Component(CustomComponent):
     def build(self, **kwargs):
         self.set_attributes(kwargs)
 
-    def post_code_validation(self, new_build_config: dict, current_build_config: dict):
+    def post_code_processing(self, new_build_config: dict, current_build_config: dict):
         """
         This function is called after the code validation is done.
         """

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -10,6 +10,7 @@ from langflow.schema.artifact import get_artifact_type, post_process_raw
 from langflow.schema.data import Data
 from langflow.schema.message import Message
 from langflow.template.field.base import UNDEFINED, Output
+from langflow.template.utils import update_frontend_node_with_template_values
 
 from .custom_component import CustomComponent
 
@@ -224,3 +225,12 @@ class Component(CustomComponent):
 
     def build(self, **kwargs):
         self.set_attributes(kwargs)
+
+    def post_code_validation(self, new_build_config: dict, current_build_config: dict):
+        """
+        This function is called after the code validation is done.
+        """
+        frontend_node = update_frontend_node_with_template_values(
+            frontend_node=new_build_config, raw_frontend_node=current_build_config
+        )
+        return frontend_node

--- a/src/backend/base/langflow/custom/utils.py
+++ b/src/backend/base/langflow/custom/utils.py
@@ -385,7 +385,7 @@ def build_custom_component_template_from_inputs(
 def build_custom_component_template(
     custom_component: CustomComponent,
     user_id: Optional[Union[str, UUID]] = None,
-) -> Tuple[Dict[str, Any], CustomComponent]:
+) -> Tuple[Dict[str, Any], CustomComponent | Component]:
     """Build a custom component template"""
     try:
         if "inputs" in custom_component.template_config:

--- a/src/backend/base/langflow/template/utils.py
+++ b/src/backend/base/langflow/template/utils.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+from platformdirs import user_cache_dir
+
+
+def raw_frontend_data_is_valid(raw_frontend_data):
+    """Check if the raw frontend data is valid for processing."""
+    return "template" in raw_frontend_data and "display_name" in raw_frontend_data
+
+
+def get_file_path_value(file_path):
+    """Get the file path value if the file exists, else return empty string."""
+    try:
+        path = Path(file_path)
+    except TypeError:
+        return ""
+
+    # Check for safety
+    # If the path is not in the cache dir, return empty string
+    # This is to prevent access to files outside the cache dir
+    # If the path is not a file, return empty string
+    if not str(path).startswith(user_cache_dir("langflow", "langflow")):
+        return ""
+
+    if not path.exists():
+        return ""
+    return file_path
+
+
+def update_template_field(frontend_template, key, value_dict):
+    """Updates a specific field in the frontend template."""
+    template_field = frontend_template.get(key)
+    if not template_field or template_field.get("type") != value_dict.get("type"):
+        return
+
+    if "value" in value_dict and value_dict["value"]:
+        template_field["value"] = value_dict["value"]
+
+    if "file_path" in value_dict and value_dict["file_path"]:
+        file_path_value = get_file_path_value(value_dict["file_path"])
+        if not file_path_value:
+            # If the file does not exist, remove the value from the template_field["value"]
+            template_field["value"] = ""
+        template_field["file_path"] = file_path_value
+
+
+def is_valid_data(frontend_node, raw_frontend_data):
+    """Check if the data is valid for processing."""
+
+    return frontend_node and "template" in frontend_node and raw_frontend_data_is_valid(raw_frontend_data)
+
+
+def update_template_values(frontend_template, raw_template):
+    """Updates the frontend template with values from the raw template."""
+    for key, value_dict in raw_template.items():
+        if key == "code" or not isinstance(value_dict, dict):
+            continue
+
+        update_template_field(frontend_template, key, value_dict)
+
+
+def update_frontend_node_with_template_values(frontend_node, raw_frontend_node):
+    """
+    Updates the given frontend node with values from the raw template data.
+
+    :param frontend_node: A dict representing a built frontend node.
+    :param raw_template_data: A dict representing raw template data.
+    :return: Updated frontend node.
+    """
+    if not is_valid_data(frontend_node, raw_frontend_node):
+        return frontend_node
+
+    # Check if the display_name is different than "CustomComponent"
+    # if so, update the display_name in the frontend_node
+    if raw_frontend_node["display_name"] != "CustomComponent":
+        frontend_node["display_name"] = raw_frontend_node["display_name"]
+
+    update_template_values(frontend_node["template"], raw_frontend_node["template"])
+
+    old_code = raw_frontend_node["template"]["code"]["value"]
+    new_code = frontend_node["template"]["code"]["value"]
+    frontend_node["edited"] = old_code != new_code
+
+    return frontend_node

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -239,6 +239,14 @@ export default function GenericNode({
           }
         })
         .catch((err) => {
+          setErrorData({
+            title: "Error updating Compoenent code",
+            list: [
+              "There was an error updating the Component.",
+              "If the error persists, please report it on our Discord or GitHub.",
+            ],
+          });
+          setLoadingUpdate(false);
           console.log(err);
         });
     }

--- a/src/frontend/src/CustomNodes/hooks/use-check-code-validity.tsx
+++ b/src/frontend/src/CustomNodes/hooks/use-check-code-validity.tsx
@@ -24,7 +24,7 @@ const useCheckCodeValidity = (
     if (!thisNodeTemplate.code) return;
     const currentCode = thisNodeTemplate.code?.value;
     const thisNodesCode = data.node!.template?.code?.value;
-    const componentsToIgnore = ["CustomComponent", "Prompt"];
+    const componentsToIgnore = ["CustomComponent"]
     setIsOutdated(
       currentCode !== thisNodesCode && !componentsToIgnore.includes(data.type),
     );

--- a/src/frontend/src/CustomNodes/hooks/use-check-code-validity.tsx
+++ b/src/frontend/src/CustomNodes/hooks/use-check-code-validity.tsx
@@ -24,7 +24,7 @@ const useCheckCodeValidity = (
     if (!thisNodeTemplate.code) return;
     const currentCode = thisNodeTemplate.code?.value;
     const thisNodesCode = data.node!.template?.code?.value;
-    const componentsToIgnore = ["CustomComponent"]
+    const componentsToIgnore = ["CustomComponent"];
     setIsOutdated(
       currentCode !== thisNodesCode && !componentsToIgnore.includes(data.type),
     );


### PR DESCRIPTION
Adds a `post_code_processing` method that runs right after the component code is validated. The previous logic was moved into the `Component` class and classes that override this method should call the `super()` class almost always.  

Components can now define post validation logic such as setting values dynamically when updated.

This PR also fixes the PromptComponent not being allowed to update its code.

Additionally, refactor the prompt validation process in the `validate.py`.