### PR TITLE
Refactor CustomComponentResponse and GenericNode to handle component type

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -11,6 +11,7 @@ from sqlmodel import Session, select
 from langflow.api.v1.schemas import (
     ConfigResponse,
     CustomComponentRequest,
+    CustomComponentResponse,
     InputValueRequest,
     ProcessResponse,
     RunResponse,
@@ -458,7 +459,7 @@ def get_version():
     return {"version": version, "package": package}
 
 
-@router.post("/custom_component", status_code=HTTPStatus.OK)
+@router.post("/custom_component", status_code=HTTPStatus.OK, response_model=CustomComponentResponse)
 async def custom_component(
     raw_code: CustomComponentRequest,
     user: User = Depends(get_current_active_user),
@@ -468,7 +469,7 @@ async def custom_component(
     built_frontend_node, component_instance = build_custom_component_template(component, user_id=user.id)
     if raw_code.frontend_node is not None:
         built_frontend_node = component_instance.post_code_processing(built_frontend_node, raw_code.frontend_node)
-    return built_frontend_node
+    return CustomComponentResponse(data=built_frontend_node, type=component_instance.__class__.__name__)
 
 
 @router.post("/custom_component/update", status_code=HTTPStatus.OK)

--- a/src/backend/base/langflow/api/v1/schemas.py
+++ b/src/backend/base/langflow/api/v1/schemas.py
@@ -182,6 +182,11 @@ class CustomComponentRequest(BaseModel):
     frontend_node: Optional[dict] = None
 
 
+class CustomComponentResponse(BaseModel):
+    data: dict
+    type: str
+
+
 class UpdateCustomComponentRequest(CustomComponentRequest):
     field: str
     field_value: Optional[Union[str, int, float, bool, dict, list]] = None

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -232,9 +232,9 @@ export default function GenericNode({
     if (data.node) {
       postCustomComponent(currentCode, data.node)
         .then((apiReturn) => {
-          const { data } = apiReturn;
-          if (data && updateNodeCode) {
-            updateNodeCode(data, currentCode, "code");
+          const { data, type } = apiReturn.data;
+          if (data && type && updateNodeCode) {
+            updateNodeCode(data, currentCode, "code", type);
             setLoadingUpdate(false);
           }
         })

--- a/src/frontend/src/CustomNodes/hooks/use-handle-node-class.tsx
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-node-class.tsx
@@ -7,7 +7,7 @@ const useHandleNodeClass = (
   setNode,
   updateNodeInternals,
 ) => {
-  const handleNodeClass = (newNodeClass, code) => {
+  const handleNodeClass = (newNodeClass, code, type?: string) => {
     if (!data.node) return;
     if (data.node!.template[name].value !== code) {
       takeSnapshot();
@@ -22,7 +22,9 @@ const useHandleNodeClass = (
         description: newNodeClass.description ?? data.node!.description,
         display_name: newNodeClass.display_name ?? data.node!.display_name,
       };
-
+      if (type) {
+        newNode.data.node.template[name].type = type;
+      }
       newNode.data.node.template[name].value = code;
 
       return newNode;

--- a/src/frontend/src/CustomNodes/hooks/use-update-node-code.tsx
+++ b/src/frontend/src/CustomNodes/hooks/use-update-node-code.tsx
@@ -11,7 +11,7 @@ const useUpdateNodeCode = (
   updateNodeInternals: (id: string) => void,
 ) => {
   const updateNodeCode = useCallback(
-    (newNodeClass: APIClassType, code: string, name: string) => {
+    (newNodeClass: APIClassType, code: string, name: string, type: string) => {
       setNode(dataId, (oldNode) => {
         let newNode = cloneDeep(oldNode);
 
@@ -22,6 +22,9 @@ const useUpdateNodeCode = (
           display_name: newNodeClass.display_name ?? dataNode.display_name,
           edited: false,
         };
+        if (type) {
+          newNode.data.type = type;
+        }
 
         newNode.data.node.template[name].value = code;
         setIsOutdated(false);

--- a/src/frontend/src/controllers/API/index.ts
+++ b/src/frontend/src/controllers/API/index.ts
@@ -7,6 +7,7 @@ import {
   APIObjectType,
   APITemplateType,
   Component,
+  CustomComponentRequest,
   LoginType,
   ProfilePicturesTypeAPI,
   Users,
@@ -386,7 +387,7 @@ export async function getProfilePictures(): Promise<ProfilePicturesTypeAPI | nul
 export async function postCustomComponent(
   code: string,
   apiClass: APIClassType,
-): Promise<AxiosResponse<APIClassType>> {
+): Promise<AxiosResponse<CustomComponentRequest>> {
   // let template = apiClass.template;
   return await api.post(`${BASE_URL_API}custom_component`, {
     code,

--- a/src/frontend/src/modals/codeAreaModal/index.tsx
+++ b/src/frontend/src/modals/codeAreaModal/index.tsx
@@ -102,9 +102,9 @@ export default function CodeAreaModal({
   function processDynamicField() {
     postCustomComponent(code, nodeClass!)
       .then((apiReturn) => {
-        const { data } = apiReturn;
-        if (data) {
-          setNodeClass(data, code);
+        const { data, type } = apiReturn.data;
+        if (data && type) {
+          setNodeClass(data, code, type);
           setError({ detail: { error: undefined, traceback: undefined } });
           setOpen(false);
         }

--- a/src/frontend/src/types/api/index.ts
+++ b/src/frontend/src/types/api/index.ts
@@ -13,6 +13,11 @@ export type CustomFieldsType = {
   [key: string]: Array<string>;
 };
 
+export type CustomComponentRequest = {
+  data: APIClassType;
+  type: string;
+};
+
 export type APIClassType = {
   base_classes?: Array<string>;
   description: string;

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -595,7 +595,11 @@ export type codeAreaModalPropsType = {
   setOpenModal?: (bool: boolean) => void;
   value: string;
   nodeClass: APIClassType | undefined;
-  setNodeClass: (Class: APIClassType, code?: string) => void | undefined;
+  setNodeClass: (
+    Class: APIClassType,
+    code?: string,
+    type?: string,
+  ) => void | undefined;
   children: ReactNode;
   dynamic?: boolean;
   readonly?: boolean;


### PR DESCRIPTION
This pull request includes changes to the codebase that improve the handling of component types in the CustomComponentResponse model and the GenericNode component. The CustomComponentResponse model now includes a "type" field, and the GenericNode component has been updated to handle this field when updating the node code. These changes enhance the consistency and clarity of the API response and ensure that the GenericNode component can correctly handle different types of components.