### PR TITLE
[Fix] unhandled http errors in background tasks

### DIFF
--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -170,9 +170,9 @@ def get_current_active_user(current_user: Annotated[User, Depends(get_current_us
 
 def get_current_active_superuser(current_user: Annotated[User, Depends(get_current_user)]) -> User:
     if not current_user.is_active:
-        raise HTTPException(status_code=401, detail="Inactive user")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive user")
     if not current_user.is_superuser:
-        raise HTTPException(status_code=400, detail="The user doesn't have enough privileges")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="The user doesn't have enough privileges")
     return current_user
 
 
@@ -324,8 +324,8 @@ def authenticate_user(username: str, password: str, db: Session = Depends(get_se
 
     if not user.is_active:
         if not user.last_login_at:
-            raise HTTPException(status_code=400, detail="Waiting for approval")
-        raise HTTPException(status_code=400, detail="Inactive user")
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Waiting for approval")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive user")
 
     return user if verify_password(password, user.password) else None
 

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -170,9 +170,9 @@ def get_current_active_user(current_user: Annotated[User, Depends(get_current_us
 
 def get_current_active_superuser(current_user: Annotated[User, Depends(get_current_user)]) -> User:
     if not current_user.is_active:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive user")
+        raise HTTPException(status_code=401, detail="Inactive user")
     if not current_user.is_superuser:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="The user doesn't have enough privileges")
+        raise HTTPException(status_code=400, detail="The user doesn't have enough privileges")
     return current_user
 
 
@@ -324,8 +324,8 @@ def authenticate_user(username: str, password: str, db: Session = Depends(get_se
 
     if not user.is_active:
         if not user.last_login_at:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Waiting for approval")
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive user")
+            raise HTTPException(status_code=400, detail="Waiting for approval")
+        raise HTTPException(status_code=400, detail="Inactive user")
 
     return user if verify_password(password, user.password) else None
 


### PR DESCRIPTION
In the simple_run_flow function under the endpoint.py, there are unhandled StatementErrors and the simplified_run_flow handler (the route "/run/{flow_id_or_name}") already has a logic to manage different ValueErrors. So change the code to throw ValueError as is.

The second problem is the simple_run_flow is submitted to BackgroundTasks to run in a background. But the FastAPI background task runner does not handle the exception, so this PR introduces a new function to log the exception without throw to BackgroundTask manager. An error reported by the task group

"/app/.venv/lib/python3.11/site-pa ckages/starlette/middleware/base.p y", line 189, in __call__ | with collapse_excgroups(): | -> <function collapse_excgroups at 0x7fe9dfbd00e0> | File "/usr/local/lib/python3.11/context lib.py", line 158, in __exit__ | self.gen.throw(typ, value, traceback) | | | | | | -> <traceback object at 0x7fe9ba7e1d80> | | | | | -> ExceptionGroup('unhandled errors in a TaskGroup', [RuntimeError('No response returned.')]) 