### PR TITLE
deactivate stop button until we have a better solution

### DIFF
--- a/src/frontend/src/components/headerComponent/components/menuBar/index.tsx
+++ b/src/frontend/src/components/headerComponent/components/menuBar/index.tsx
@@ -218,7 +218,8 @@ export const MenuBar = ({}: {}): JSX.Element => {
               />
               <div>{printByBuildStatus()}</div>
             </div>
-            <button
+            {/* Deactivating this until we find a better solution */}
+            {/* <button
               disabled={!isBuilding}
               onClick={(_) => {
                 if (isBuilding) {
@@ -236,7 +237,7 @@ export const MenuBar = ({}: {}): JSX.Element => {
             >
               <IconComponent name="Square" className="h-4 w-4" />
               <span>Stop</span>
-            </button>
+            </button> */}
           </div>
         </ShadTooltip>
       )}


### PR DESCRIPTION
The middleware breaks requests. Another solution should be created to re-enable this feature.

Should fix #2329 #2332 