### PR TITLE
Rename Kubernetes deployment file to .md extension

### DIFF
--- a/docs/docs/deployment/kubernetes.md
+++ b/docs/docs/deployment/kubernetes.md
@@ -1,10 +1,6 @@
-import Admonition from "@theme/Admonition";
 
 # Kubernetes
 
-<Admonition type="warning" title="warning">
-This page may contain outdated information. It will be updated as soon as possible.
-</Admonition>
 
 This guide will help you get LangFlow up and running in Kubernetes cluster, including the following steps:
 


### PR DESCRIPTION
This pull request renames the Kubernetes deployment file to have a .md extension instead of the previous extension. This change is made to improve the readability and clarity of the file. No other changes are made in this pull request.