### PR TITLE
Rename Kubernetes documentation file to use .md extension

### DIFF
--- a/docs/docs/deployment/kubernetes.md
+++ b/docs/docs/deployment/kubernetes.md
@@ -1,10 +1,4 @@
-import Admonition from "@theme/Admonition";
-
 # Kubernetes
-
-<Admonition type="warning" title="warning">
-This page may contain outdated information. It will be updated as soon as possible.
-</Admonition>
 
 This guide will help you get LangFlow up and running in Kubernetes cluster, including the following steps:
 


### PR DESCRIPTION
This pull request renames the Kubernetes documentation file to use the .md extension. This change ensures consistency with the file extensions used in the repository.