### PR TITLE
chore: Add auto-update workflow

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,14 @@
+name: Auto-update
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+
+jobs:
+  Auto:
+    name: Auto-update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/auto-update@v2


### PR DESCRIPTION
The auto-update workflow has been added to the repository. This workflow will automatically trigger on pushes to the `dev` and `main` branches. It runs on the latest version of Ubuntu and uses the `tibdex/auto-update@v2` action to perform the auto-update process.