### PR TITLE
Fix Image Display Issue on Windows by Setting a Static Path

### DIFF
--- a/src/backend/base/langflow/api/v1/files.py
+++ b/src/backend/base/langflow/api/v1/files.py
@@ -131,8 +131,8 @@ async def list_profile_pictures(storage_service: StorageService = Depends(get_st
         people = await storage_service.list_files(flow_id=people_path)  # type: ignore
         space = await storage_service.list_files(flow_id=space_path)  # type: ignore
 
-        files = [Path("People") / i for i in people]
-        files += [Path("Space") / i for i in space]
+        files = [f"People/{i}" for i in people]
+        files += [f"Space/{i}" for i in space]
 
         return {"files": files}
 


### PR DESCRIPTION
This PR addresses the issue of image display on Windows systems by editing the string that determines the image path. By setting a fixed path for the images, we ensure consistent display across different environments.