### PR TITLE
chore: make calls to end_all_traces run concurrently

### DIFF
--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -343,10 +343,10 @@ class Graph:
         except Exception as exc:
             logger.exception(exc)
             tb = traceback.format_exc()
-            await self.end_all_traces(error=f"{exc.__class__.__name__}: {exc}\n\n{tb}")
+            asyncio.create_task(self.end_all_traces(error=f"{exc.__class__.__name__}: {exc}\n\n{tb}"))
             raise ValueError(f"Error running graph: {exc}") from exc
         finally:
-            await self.end_all_traces()
+            asyncio.create_task(self.end_all_traces())
         # Get the outputs
         vertex_outputs = []
         for vertex in self.vertices:


### PR DESCRIPTION
This PR makes so that end_all_traces does not block execution.