### PR TITLE
ci: skip lint on personal forks

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   run-linters:
     name: Run Prettier
+    # do not run on personal forks since we don't have permissions to push
+    if: github.repository == 'langflow-ai/langflow'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -8,6 +8,7 @@ jobs:
   pr-checker:
     name: Check PR description
     runs-on: [ubuntu-latest]
+    if: github.repository == 'langflow-ai/langflow'
     steps:
       - name: Run PR title check
         uses: transferwise/actions-pr-checker@v3

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -8,7 +8,6 @@ jobs:
   pr-checker:
     name: Check PR description
     runs-on: [ubuntu-latest]
-    if: github.repository == 'langflow-ai/langflow'
     steps:
       - name: Run PR title check
         uses: transferwise/actions-pr-checker@v3


### PR DESCRIPTION
The CI job that check the style and commit the fix, can't work if the PR has been opened from a personal fork