### PR TITLE
ci: always run required checks

### DIFF
--- a/.github/workflows/lint-py.yml
+++ b/.github/workflows/lint-py.yml
@@ -3,11 +3,6 @@ name: Lint Python
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "poetry.lock"
-      - "pyproject.toml"
-      - "src/backend/**"
-      - "tests/**"
   merge_group:
     types: [checks_requested]
 env:

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [dev, main]
-    paths:
-      - "poetry.lock"
-      - "pyproject.toml"
-      - "src/backend/**"
   merge_group:
     types: [checks_requested]
 env:

--- a/.github/workflows/style-check-py.yml
+++ b/.github/workflows/style-check-py.yml
@@ -1,12 +1,7 @@
 name: Ruff Style Check
 
 on:
-  pull_request:
-    paths:
-      - "poetry.lock"
-      - "pyproject.toml"
-      - "src/backend/**"
-      - "tests/**"
+  pull_request: {}
   merge_group:
     branches: [dev]
 


### PR DESCRIPTION
Now to merge a PR there are required checks. Those are not ran if no meaningful changes has been made by a PR, but now those are not mergeable without enforcing  