### PR TITLE
♻️ (code_parser.py): remove redundant condition that caused Component to not be parsed

### DIFF
--- a/src/backend/base/langflow/custom/code_parser/code_parser.py
+++ b/src/backend/base/langflow/custom/code_parser/code_parser.py
@@ -329,8 +329,6 @@ class CodeParser:
         """
         Extracts "classes" from the code, including inheritance and init methods.
         """
-        if node.name in ["CustomComponent", "Component", "BaseComponent"]:
-            return
         bases = self.get_base_classes()
         nodes = []
         for base in bases:


### PR DESCRIPTION
When a component was named CustomComponent it would break the parsing.