### PR TITLE
(fix) Add gpt4 to openai_constants

### DIFF
--- a/src/backend/base/langflow/base/models/openai_constants.py
+++ b/src/backend/base/langflow/base/models/openai_constants.py
@@ -1,1 +1,1 @@
-MODEL_NAMES = ["gpt-4o", "gpt-4-turbo", "gpt-4-turbo-preview", "gpt-3.5-turbo", "gpt-3.5-turbo-0125"]
+MODEL_NAMES = ["gpt-4o", "gpt-4-turbo", "gpt-4-turbo-preview", "gpt-4", "gpt-3.5-turbo", "gpt-3.5-turbo-0125"]

--- a/src/backend/base/langflow/components/embeddings/AstraVectorize.py
+++ b/src/backend/base/langflow/components/embeddings/AstraVectorize.py
@@ -13,20 +13,39 @@ class AstraVectorize(Component):
     VECTORIZE_PROVIDERS_MAPPING = {
         "Azure OpenAI": ["azureOpenAI", ["text-embedding-3-small", "text-embedding-3-large", "text-embedding-ada-002"]],
         "Hugging Face - Dedicated": ["huggingfaceDedicated", ["endpoint-defined-model"]],
-        "Hugging Face - Serverless": ["huggingface",
-                                      ["sentence-transformers/all-MiniLM-L6-v2", "intfloat/multilingual-e5-large",
-                                       "intfloat/multilingual-e5-large-instruct", "BAAI/bge-small-en-v1.5",
-                                       "BAAI/bge-base-en-v1.5", "BAAI/bge-large-en-v1.5"]],
-        "Jina AI": ["jinaAI", ["jina-embeddings-v2-base-en", "jina-embeddings-v2-base-de", "jina-embeddings-v2-base-es",
-                               "jina-embeddings-v2-base-code", "jina-embeddings-v2-base-zh"]],
+        "Hugging Face - Serverless": [
+            "huggingface",
+            [
+                "sentence-transformers/all-MiniLM-L6-v2",
+                "intfloat/multilingual-e5-large",
+                "intfloat/multilingual-e5-large-instruct",
+                "BAAI/bge-small-en-v1.5",
+                "BAAI/bge-base-en-v1.5",
+                "BAAI/bge-large-en-v1.5",
+            ],
+        ],
+        "Jina AI": [
+            "jinaAI",
+            [
+                "jina-embeddings-v2-base-en",
+                "jina-embeddings-v2-base-de",
+                "jina-embeddings-v2-base-es",
+                "jina-embeddings-v2-base-code",
+                "jina-embeddings-v2-base-zh",
+            ],
+        ],
         "Mistral AI": ["mistral", ["mistral-embed"]],
         "NVIDIA": ["nvidia", ["NV-Embed-QA"]],
         "OpenAI": ["openai", ["text-embedding-3-small", "text-embedding-3-large", "text-embedding-ada-002"]],
         "Upstage": ["upstageAI", ["solar-embedding-1-large"]],
-        "Voyage AI": ["voyageAI",
-                      ["voyage-large-2-instruct", "voyage-law-2", "voyage-code-2", "voyage-large-2", "voyage-2"]]
+        "Voyage AI": [
+            "voyageAI",
+            ["voyage-large-2-instruct", "voyage-law-2", "voyage-code-2", "voyage-large-2", "voyage-2"],
+        ],
     }
-    VECTORIZE_MODELS_STR = "\n\n".join([provider + ": " + (', '.join(models[1])) for provider, models in VECTORIZE_PROVIDERS_MAPPING.items()])
+    VECTORIZE_MODELS_STR = "\n\n".join(
+        [provider + ": " + (", ".join(models[1])) for provider, models in VECTORIZE_PROVIDERS_MAPPING.items()]
+    )
 
     inputs = [
         DropdownInput(
@@ -39,13 +58,13 @@ class AstraVectorize(Component):
             name="model_name",
             display_name="Model name",
             info=f"The embedding model to use for the selected provider. Each provider has a different set of models "
-                 f"available (full list at https://docs.datastax.com/en/astra-db-serverless/databases/embedding-generation.html):\n\n{VECTORIZE_MODELS_STR}",
-            required=True
+            f"available (full list at https://docs.datastax.com/en/astra-db-serverless/databases/embedding-generation.html):\n\n{VECTORIZE_MODELS_STR}",
+            required=True,
         ),
         MessageTextInput(
             name="api_key_name",
             display_name="API Key name",
-            info="The name of the embeddings provider API key stored on Astra. If set, it will override the 'ProviderKey' in the authentication parameters."
+            info="The name of the embeddings provider API key stored on Astra. If set, it will override the 'ProviderKey' in the authentication parameters.",
         ),
         DictInput(
             name="authentication",

--- a/src/backend/base/langflow/components/langchain_utilities/FirecrawlCrawlApi.py
+++ b/src/backend/base/langflow/components/langchain_utilities/FirecrawlCrawlApi.py
@@ -4,6 +4,7 @@ from langflow.custom import CustomComponent
 from langflow.schema import Data
 import uuid
 
+
 class FirecrawlCrawlApi(CustomComponent):
     display_name: str = "FirecrawlCrawlApi"
     description: str = "Firecrawl Crawl API."
@@ -53,12 +54,12 @@ class FirecrawlCrawlApi(CustomComponent):
         idempotency_key: Optional[str] = None,
     ) -> Data:
         if crawlerOptions:
-            crawler_options_dict = crawlerOptions.__dict__['data']['text']
+            crawler_options_dict = crawlerOptions.__dict__["data"]["text"]
         else:
             crawler_options_dict = {}
 
         if pageOptions:
-            page_options_dict = pageOptions.__dict__['data']['text']
+            page_options_dict = pageOptions.__dict__["data"]["text"]
         else:
             page_options_dict = {}
 
@@ -74,7 +75,7 @@ class FirecrawlCrawlApi(CustomComponent):
             },
             True,
             int(timeout / 1000),
-            idempotency_key
+            idempotency_key,
         )
 
         records = Data(data={"results": crawl_result})

--- a/src/backend/base/langflow/components/langchain_utilities/FirecrawlScrapeApi.py
+++ b/src/backend/base/langflow/components/langchain_utilities/FirecrawlScrapeApi.py
@@ -3,6 +3,7 @@ from firecrawl.firecrawl import FirecrawlApp
 from langflow.custom import CustomComponent
 from langflow.schema import Data
 
+
 class FirecrawlScrapeApi(CustomComponent):
     display_name: str = "FirecrawlScrapeApi"
     description: str = "Firecrawl Scrape API."
@@ -47,12 +48,12 @@ class FirecrawlScrapeApi(CustomComponent):
         extractorOptions: Optional[Data] = None,
     ) -> Data:
         if extractorOptions:
-            extractor_options_dict = extractorOptions.__dict__['data']['text']
+            extractor_options_dict = extractorOptions.__dict__["data"]["text"]
         else:
             extractor_options_dict = {}
 
         if pageOptions:
-            page_options_dict = pageOptions.__dict__['data']['text']
+            page_options_dict = pageOptions.__dict__["data"]["text"]
         else:
             page_options_dict = {}
 

--- a/src/backend/base/langflow/components/vectorstores/Cassandra.py
+++ b/src/backend/base/langflow/components/vectorstores/Cassandra.py
@@ -24,18 +24,20 @@ class CassandraVectorStoreComponent(LCVectorStoreComponent):
     icon = "Cassandra"
 
     inputs = [
-        MessageTextInput(name="database_ref",
-                         display_name="Contact Points / Astra Database ID",
-                         info="Contact points for the database (or AstraDB database ID)",
-                         required=True),
-        MessageTextInput(name="username",
-                         display_name="Username",
-                         info="Username for the database (leave empty for AstraDB)."),
+        MessageTextInput(
+            name="database_ref",
+            display_name="Contact Points / Astra Database ID",
+            info="Contact points for the database (or AstraDB database ID)",
+            required=True,
+        ),
+        MessageTextInput(
+            name="username", display_name="Username", info="Username for the database (leave empty for AstraDB)."
+        ),
         SecretStrInput(
             name="token",
             display_name="Password / AstraDB Token",
             info="User password for the database (or AstraDB token).",
-            required=True
+            required=True,
         ),
         MessageTextInput(
             name="keyspace",
@@ -81,7 +83,7 @@ class CassandraVectorStoreComponent(LCVectorStoreComponent):
             display_name="Cluster arguments",
             info="Optional dictionary of additional keyword arguments for the Cassandra cluster.",
             advanced=True,
-            is_list=True
+            is_list=True,
         ),
         MultilineInput(name="search_query", display_name="Search Query"),
         DataInput(


### PR DESCRIPTION
Add original "GPT4" model to MODEL_NAMES selection list and drop down menu

**Reason**
If the user wants to use the original gpt4, they user has to modify the source code of the component. This fix will allow users to simply select the model from the drop down menu.