### PR TITLE
Fix: Ctrl + C not working on tooltips

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -228,7 +228,8 @@ export default function Page({
   }
 
   function handleCopy(e: KeyboardEvent) {
-    if (!isWrappedWithClass(e, "nocopy") && isWrappedWithClass(e, "react-flow__node")) {
+    const multipleSelection = lastSelection?.nodes ? lastSelection?.nodes.length > 0 : false;
+    if (!isWrappedWithClass(e, "nocopy") && (isWrappedWithClass(e, "react-flow__node") || multipleSelection)) {
       e.preventDefault();
       (e as unknown as Event).stopImmediatePropagation();
       if (window.getSelection()?.toString().length === 0 && lastSelection) {

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -228,8 +228,13 @@ export default function Page({
   }
 
   function handleCopy(e: KeyboardEvent) {
-    const multipleSelection = lastSelection?.nodes ? lastSelection?.nodes.length > 0 : false;
-    if (!isWrappedWithClass(e, "nocopy") && (isWrappedWithClass(e, "react-flow__node") || multipleSelection)) {
+    const multipleSelection = lastSelection?.nodes
+      ? lastSelection?.nodes.length > 0
+      : false;
+    if (
+      !isWrappedWithClass(e, "nocopy") &&
+      (isWrappedWithClass(e, "react-flow__node") || multipleSelection)
+    ) {
       e.preventDefault();
       (e as unknown as Event).stopImmediatePropagation();
       if (window.getSelection()?.toString().length === 0 && lastSelection) {

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -228,7 +228,7 @@ export default function Page({
   }
 
   function handleCopy(e: KeyboardEvent) {
-    if (!isWrappedWithClass(e, "nocopy")) {
+    if (!isWrappedWithClass(e, "nocopy") && isWrappedWithClass(e, "react-flow__node")) {
       e.preventDefault();
       (e as unknown as Event).stopImmediatePropagation();
       if (window.getSelection()?.toString().length === 0 && lastSelection) {


### PR DESCRIPTION
This PR addresses an issue where Ctrl + C was not working correctly within tooltips. This fix ensures that users can copy text from tooltips using the Ctrl + C shortcut without any issues.