### PR TITLE
fix(bedrock): fix error 'Key cache already exists'

### DIFF
--- a/src/backend/base/langflow/components/langchain_utilities/FirecrawlCrawlApi.py
+++ b/src/backend/base/langflow/components/langchain_utilities/FirecrawlCrawlApi.py
@@ -5,6 +5,7 @@ from langflow.custom import CustomComponent
 from langflow.schema import Data
 
 
+
 class FirecrawlCrawlApi(CustomComponent):
     display_name: str = "FirecrawlCrawlApi"
     description: str = "Firecrawl Crawl API."

--- a/src/backend/base/langflow/components/langchain_utilities/FirecrawlCrawlApi.py
+++ b/src/backend/base/langflow/components/langchain_utilities/FirecrawlCrawlApi.py
@@ -5,7 +5,6 @@ from langflow.custom import CustomComponent
 from langflow.schema import Data
 
 
-
 class FirecrawlCrawlApi(CustomComponent):
     display_name: str = "FirecrawlCrawlApi"
     description: str = "Firecrawl Crawl API."

--- a/src/backend/base/langflow/components/models/AmazonBedrockModel.py
+++ b/src/backend/base/langflow/components/models/AmazonBedrockModel.py
@@ -3,6 +3,7 @@ from langchain_aws import ChatBedrock
 from langflow.base.constants import STREAM_INFO_TEXT
 from langflow.base.models.model import LCModelComponent
 from langflow.field_typing import LanguageModel
+from langflow.inputs import MessageTextInput
 from langflow.io import BoolInput, DictInput, DropdownInput, MessageInput, Output, StrInput
 
 
@@ -51,12 +52,11 @@ class AmazonBedrockComponent(LCModelComponent):
             ],
             value="anthropic.claude-3-haiku-20240307-v1:0",
         ),
-        StrInput(name="credentials_profile_name", display_name="Credentials Profile Name"),
-        StrInput(name="region_name", display_name="Region Name"),
-        DictInput(name="model_kwargs", display_name="Model Kwargs", advanced=True),
-        StrInput(name="endpoint_url", display_name="Endpoint URL"),
-        BoolInput(name="cache", display_name="Cache"),
-        StrInput(
+        MessageTextInput(name="credentials_profile_name", display_name="Credentials Profile Name"),
+        MessageTextInput(name="region_name", display_name="Region Name", value="us-east-1"),
+        DictInput(name="model_kwargs", display_name="Model Kwargs", advanced=True, is_list=True),
+        MessageTextInput(name="endpoint_url", display_name="Endpoint URL", advanced=True),
+        MessageTextInput(
             name="system_message",
             display_name="System Message",
             info="System message to pass to the model.",
@@ -75,7 +75,6 @@ class AmazonBedrockComponent(LCModelComponent):
         region_name = self.region_name
         model_kwargs = self.model_kwargs
         endpoint_url = self.endpoint_url
-        cache = self.cache
         stream = self.stream
         try:
             output = ChatBedrock(  # type: ignore
@@ -84,8 +83,7 @@ class AmazonBedrockComponent(LCModelComponent):
                 region_name=region_name,
                 model_kwargs=model_kwargs,
                 endpoint_url=endpoint_url,
-                streaming=stream,
-                cache=cache,
+                streaming=stream
             )
         except Exception as e:
             raise ValueError("Could not connect to AmazonBedrock API.") from e

--- a/src/backend/base/langflow/components/models/AmazonBedrockModel.py
+++ b/src/backend/base/langflow/components/models/AmazonBedrockModel.py
@@ -4,7 +4,7 @@ from langflow.base.constants import STREAM_INFO_TEXT
 from langflow.base.models.model import LCModelComponent
 from langflow.field_typing import LanguageModel
 from langflow.inputs import MessageTextInput
-from langflow.io import BoolInput, DictInput, DropdownInput, MessageInput, Output, StrInput
+from langflow.io import BoolInput, DictInput, DropdownInput, MessageInput, Output
 
 
 class AmazonBedrockComponent(LCModelComponent):
@@ -83,7 +83,7 @@ class AmazonBedrockComponent(LCModelComponent):
                 region_name=region_name,
                 model_kwargs=model_kwargs,
                 endpoint_url=endpoint_url,
-                streaming=stream
+                streaming=stream,
             )
         except Exception as e:
             raise ValueError("Could not connect to AmazonBedrock API.") from e

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -86,8 +86,10 @@ class Component(CustomComponent):
         _attributes = {}
         for key, value in params.items():
             if key in self.__dict__:
-                raise ValueError(f"{self.__class__.__name__} defines an input parameter named '{key}' "
-                                 f"that is a reserved word and cannot be used.")
+                raise ValueError(
+                    f"{self.__class__.__name__} defines an input parameter named '{key}' "
+                    f"that is a reserved word and cannot be used."
+                )
             _attributes[key] = value
         for key, input_obj in self._inputs.items():
             if key not in _attributes:

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -86,7 +86,8 @@ class Component(CustomComponent):
         _attributes = {}
         for key, value in params.items():
             if key in self.__dict__:
-                raise ValueError(f"Key {key} already exists in {self.__class__.__name__}")
+                raise ValueError(f"{self.__class__.__name__} defines an input parameter named '{key}' "
+                                 f"that is a reserved word and cannot be used.")
             _attributes[key] = value
         for key, input_obj in self._inputs.items():
             if key not in _attributes:


### PR DESCRIPTION
If you use Bedrock chat, you get `Error building Component Amazon Bedrock: Key cache already exists in AmazonBedrockComponent` with the latest version (1.0.5)