### PR TITLE
Fix Endpoint to Properly Delete Messages from Database

### DIFF
--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -80,7 +80,8 @@ async def delete_messages(
     current_user: User = Depends(get_current_active_user),
 ):
     try:
-        session.exec(select(MessageTable).where(MessageTable.id.in_(message_ids)))  # type: ignore
+        session.exec(delete(MessageTable).where(MessageTable.id.in_(message_ids)))  # type: ignore
+        session.commit()
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
This PR addresses an issue with the endpoint that was failing to delete messages from the database. The necessary corrections have been made to ensure that messages are now properly removed when the endpoint is called.