### PR TITLE
chore: Update ruff command in py_autofix.yml to use 'ruff check' before 'ruff --fix-only'

### DIFF
--- a/.github/workflows/py_autofix.yml
+++ b/.github/workflows/py_autofix.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: install-pinned/ruff@b52a71f70b28264686d57d1efef1ba845b9cec6c
-      - run: ruff --fix-only .
+      - run: ruff check --fix-only .
       - run: ruff format .
 
       - uses: autofix-ci/action@dd55f44df8f7cdb7a6bf74c78677eb8acd40cd0a


### PR DESCRIPTION
Update ruff command to reflect new version's api.