### PR TITLE
ci: remove merge_group from workflows

### DIFF
--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     paths:
       - "docs/**"
-  merge_group:
-    types: [checks_requested]
 
 env:
   NODE_VERSION: "21"

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     paths:
       - "src/frontend/**"
-  merge_group:
-    types: [checks_requested]
+
 
 env:
   NODE_VERSION: "21"

--- a/.github/workflows/lint-py.yml
+++ b/.github/workflows/lint-py.yml
@@ -3,8 +3,6 @@ name: Lint Python
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  merge_group:
-    types: [checks_requested]
 env:
   POETRY_VERSION: "1.8.2"
 

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -3,9 +3,7 @@ name: Python tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [dev, main]
-  merge_group:
-    types: [checks_requested]
+    branches: [main]
 env:
   POETRY_VERSION: "1.8.2"
 

--- a/.github/workflows/style-check-py.yml
+++ b/.github/workflows/style-check-py.yml
@@ -1,9 +1,8 @@
 name: Ruff Style Check
 
 on:
-  pull_request: {}
-  merge_group:
-    branches: [dev]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 env:
   POETRY_VERSION: "1.8.2"

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
   pull_request:
-  merge_group:
+    types: [opened, synchronize, reopened]
 
 
 env:


### PR DESCRIPTION
Remove the merge_group configuration from the workflows to simplify the CI pipeline.