### PR TITLE
Fix permission error in Docker setup

### DIFF
--- a/docker_example/README.md
+++ b/docker_example/README.md
@@ -35,7 +35,7 @@ The Docker Compose configuration spins up two services: `langflow` and `postgres
 
 ### LangFlow Service
 
-The `langflow` service uses the `langflowai/langflow:latest` Docker image and exposes port 7860. It depends on the `postgres` service.
+The `langflow` service uses the `langflowai/langflow:latest` Docker image and exposes port 7860. It depends on the `postgres` service. To ensure the service has the necessary permissions to create and access files in `/var/lib/langflow`, it is run as the root user.
 
 Environment variables:
 
@@ -63,3 +63,7 @@ Volumes:
 ## Switching to a Specific LangFlow Version
 
 If you want to use a specific version of LangFlow, you can modify the `image` field under the `langflow` service in the Docker Compose file. For example, to use version 1.0-alpha, change `langflowai/langflow:latest` to `langflowai/langflow:1.0-alpha`.
+
+## Running as Root User
+
+The Docker Compose configuration specifies that the `langflow` service runs as the root user. This is necessary to avoid permission issues when accessing or creating files in directories owned by root or another user inside the container. While running containers as root can have security implications, it is a common practice for overcoming permission issues in development environments. Ensure to follow best practices for securing your Docker containers in production environments.

--- a/docker_example/docker-compose.yml
+++ b/docker_example/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.8"
 services:
   langflow:
     image: langflowai/langflow:latest
+    user: root
     ports:
       - "7860:7860"
     depends_on:


### PR DESCRIPTION
Related to #2440

Addresses the PermissionError issue encountered when running `docker compose up` by modifying the Docker Compose configuration and updating the documentation accordingly.

- Adds a `user: root` directive under the `langflow` service in `docker_example/docker-compose.yml` to ensure it has the necessary permissions to create and access files in `/var/lib/langflow`.
- Updates `docker_example/README.md` to explain the addition of `user: root` to the Docker Compose configuration and its implications for file permissions and security. This includes a new section on running the container as the root user, highlighting the necessity for this approach to avoid permission issues and advising on security practices in production environments.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/langflow-ai/langflow/issues/2440?shareId=d87094ec-0bf1-4e7f-a2d9-7ea32b67abe4).