### PR TITLE
ci: update test job in release.yml to include both Typescript and Python tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,19 +20,17 @@ env:
   POETRY_VERSION: "1.8.2"
 
 jobs:
-  test:
-    name: Run Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Call Typescript Test Workflow
-        uses: langflow-ai/langflow/.github/workflows/typescript_test.yml@main
-        with:
-          branch: ${{ github.ref }}
-      - name: Call Python Test Workflow
-        uses: langflow-ai/langflow/.github/workflows/python_test.yml@main
+  test_frontend:
+    name: Call Typescript Test Workflow
+    uses: langflow-ai/langflow/.github/workflows/typescript_test.yml@main
+
+  test_backend:
+    name: Call Python Test Workflow
+    uses: langflow-ai/langflow/.github/workflows/python_test.yml@main
+
   release-base:
     name: Release Langflow Base
-    needs: test
+    needs: [test_backend, test_frontend]
     if: inputs.release_package == true
     runs-on: ubuntu-latest
     outputs:
@@ -93,7 +91,7 @@ jobs:
   release-main:
     name: Release Langflow Main
     if: inputs.release_package == true
-    needs: [release-base, test]
+    needs: [release-base]
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check-version.outputs.version }}


### PR DESCRIPTION
This pull request updates the test job in the release.yml file to include both Typescript and Python tests. Previously, only the Typescript tests were being run. Now, the pull request ensures that both Typescript and Python tests are executed when the test job is triggered.