### PR TITLE
fix: make webhook api call honor webhook component as input

### DIFF
--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -336,7 +336,12 @@ class Graph:
 
         try:
             start_component_id = next(
-                (vertex_id for vertex_id in self._is_input_vertices if "chat" in vertex_id.lower()), None
+                (
+                    vertex_id
+                    for vertex_id in self._is_input_vertices
+                    if any(val in vertex_id.lower() for val in ["chat", "webhook"])
+                ),
+                None,
             )
             await self.process(start_component_id=start_component_id, fallback_to_env_vars=fallback_to_env_vars)
             self.increment_run_count()

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -335,14 +335,18 @@ class Graph:
             logger.exception(exc)
 
         try:
-            start_component_id = next(
-                (
-                    vertex_id
-                    for vertex_id in self._is_input_vertices
-                    if any(val in vertex_id.lower() for val in ["chat", "webhook"])
-                ),
-                None,
+            start_component_id = None
+            webhook_component_id = next(
+                (vertex_id for vertex_id in self._is_input_vertices if "webhook" in vertex_id.lower()), None
             )
+            if not webhook_component_id:
+                chat_component_id = next(
+                    (vertex_id for vertex_id in self._is_input_vertices if "chat" in vertex_id.lower()), None
+                )
+                start_component_id = chat_component_id
+            else:
+                start_component_id = webhook_component_id
+
             await self.process(start_component_id=start_component_id, fallback_to_env_vars=fallback_to_env_vars)
             self.increment_run_count()
         except Exception as exc:

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -335,6 +335,7 @@ class Graph:
             logger.exception(exc)
 
         try:
+            # Prioritize the webhook component if it exists
             start_component_id = None
             webhook_component_id = next(
                 (vertex_id for vertex_id in self._is_input_vertices if "webhook" in vertex_id.lower()), None

--- a/src/backend/base/langflow/graph/schema.py
+++ b/src/backend/base/langflow/graph/schema.py
@@ -54,6 +54,7 @@ class InterfaceComponentTypes(str, Enum, metaclass=ContainsEnumMeta):
     TextInput = "TextInput"
     TextOutput = "TextOutput"
     DataOutput = "DataOutput"
+    WebhookInput = "Webhook Input"
 
     def __contains__(cls, item):
         try:
@@ -69,6 +70,7 @@ RECORDS_COMPONENTS = [InterfaceComponentTypes.DataOutput]
 INPUT_COMPONENTS = [
     InterfaceComponentTypes.ChatInput,
     InterfaceComponentTypes.TextInput,
+    InterfaceComponentTypes.WebhookInput,
 ]
 OUTPUT_COMPONENTS = [
     InterfaceComponentTypes.ChatOutput,


### PR DESCRIPTION
Webhook API call runs all components but it should use the Webhook Input as start component and just run that path.