### PR TITLE
fix: make end_all_traces be called at the correct moment

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -161,7 +161,7 @@ async def build_vertex(
     Args:
         flow_id (str): The ID of the flow.
         vertex_id (str): The ID of the vertex to build.
-        background_tasks (BackgroundTasks): The background tasks object for logging.
+        background_tasks (BackgroundTasks): The background tasks dependency.
         inputs (Optional[InputValueRequest], optional): The input values for the vertex. Defaults to None.
         chat_service (ChatService, optional): The chat service dependency. Defaults to Depends(get_chat_service).
         current_user (Any, optional): The current user dependency. Defaults to Depends(get_current_active_user).
@@ -211,8 +211,6 @@ async def build_vertex(
                 lock, set_cache_coro, graph=graph, vertex=vertex, cache=False
             )
             top_level_vertices = graph.run_manager.get_top_level_vertices(graph, next_runnable_vertices)
-
-            result_data_response = ResultDataResponse(**result_dict.model_dump())
 
             result_data_response = ResultDataResponse.model_validate(result_dict, from_attributes=True)
         except Exception as exc:
@@ -266,7 +264,7 @@ async def build_vertex(
         if graph.stop_vertex and graph.stop_vertex in next_runnable_vertices:
             next_runnable_vertices = [graph.stop_vertex]
 
-        if not next_runnable_vertices:
+        if not graph.run_manager.vertices_to_run and not next_runnable_vertices:
             background_tasks.add_task(graph.end_all_traces)
 
         build_response = VertexBuildResponse(

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -111,6 +111,7 @@ async def retrieve_vertices_order(
         # which duplicates the results
         for vertex_id in first_layer:
             graph.remove_from_predecessors(vertex_id)
+            graph.remove_vertex_from_runnables(vertex_id)
 
         # Now vertices is a list of lists
         # We need to get the id of each vertex

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -1469,6 +1469,9 @@ class Graph:
     def remove_from_predecessors(self, vertex_id: str):
         self.run_manager.remove_from_predecessors(vertex_id)
 
+    def remove_vertex_from_runnables(self, vertex_id: str):
+        self.run_manager.remove_vertex_from_runnables(vertex_id)
+
     def build_in_degree(self, edges: List[ContractEdge]) -> Dict[str, int]:
         in_degree: Dict[str, int] = defaultdict(int)
         for edge in edges:

--- a/src/backend/base/langflow/services/telemetry/service.py
+++ b/src/backend/base/langflow/services/telemetry/service.py
@@ -123,8 +123,10 @@ class TelemetryService(Service):
         try:
             self.running = False
             await self.flush()
-            self.worker_task.cancel()
             if self.worker_task:
+                self.worker_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
                 await self.worker_task
+            await self.client.aclose()
         except Exception as e:
             logger.error(f"Error stopping tracing service: {e}")

--- a/src/backend/base/langflow/services/telemetry/service.py
+++ b/src/backend/base/langflow/services/telemetry/service.py
@@ -63,8 +63,12 @@ class TelemetryService(Service):
                 logger.error(f"Failed to send telemetry data: {response.status_code} {response.text}")
             else:
                 logger.debug("Telemetry data sent successfully.")
+        except httpx.HTTPStatusError as e:
+            logger.error(f"HTTP error occurred: {e}")
+        except httpx.RequestError as e:
+            logger.error(f"Request error occurred: {e}")
         except Exception as e:
-            logger.error(f"Failed to send telemetry data due to: {e}")
+            logger.error(f"Unexpected error occurred: {e}")
 
     async def log_package_run(self, payload: RunPayload):
         await self.telemetry_queue.put((self.send_telemetry_data, payload, "run"))

--- a/src/backend/base/langflow/services/telemetry/service.py
+++ b/src/backend/base/langflow/services/telemetry/service.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import os
 import platform
 from datetime import datetime, timezone
@@ -126,7 +127,7 @@ class TelemetryService(Service):
             if self.worker_task:
                 self.worker_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
-                await self.worker_task
+                    await self.worker_task
             await self.client.aclose()
         except Exception as e:
             logger.error(f"Error stopping tracing service: {e}")

--- a/src/backend/base/langflow/services/telemetry/service.py
+++ b/src/backend/base/langflow/services/telemetry/service.py
@@ -30,7 +30,7 @@ class TelemetryService(Service):
         self.settings_service = settings_service
         self.base_url = settings_service.settings.telemetry_base_url
         self.telemetry_queue: asyncio.Queue = asyncio.Queue()
-        self.client = httpx.AsyncClient(timeout=None)
+        self.client = httpx.AsyncClient(timeout=10.0)  # Set a reasonable timeout
         self.running = False
         self.package = get_version_info()["package"]
 

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -7,7 +7,6 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Optional
 from uuid import UUID
 
-from langchain.callbacks.tracers.langchain import wait_for_all_tracers
 from loguru import logger
 
 from langflow.schema.data import Data
@@ -292,5 +291,4 @@ class LangSmithTracer(BaseTracer):
             self._run_tree.add_metadata(metadata)
         self._run_tree.end(outputs=outputs, error=error)
         self._run_tree.post()
-        wait_for_all_tracers()
         self._run_link = self._run_tree.get_url()


### PR DESCRIPTION
This pull request includes several fixes and improvements to the TelemetryService class.

- The `send_telemetry_data` method now handles HTTPStatusError and RequestError exceptions separately, providing more specific error messages.

- The `stop` method now cancels the worker task and closes the client to ensure proper cleanup and prevent resource leaks. It also handles any exceptions that may occur during the cleanup process.

- An indentation issue in the `await` statement of the `build_vertex` method has been fixed to comply with PEP8 guidelines.

- The `remove_vertex_from_runnables` method has been added to the Graph class to remove a vertex from the runnables list.

- Several fixes have been made in the `chat.py` file to prevent duplication of results and define when the `end_all_traces` call should happen.

These changes improve error handling, resource cleanup, and code quality in the TelemetryService class.