### PR TITLE
ci: add GitHub Actions workflow for labeling PRs with Conventional Commits

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -23,6 +23,7 @@ changelog:
         - refactor
         - style
         - performance
+        - ci
     - title: ✅ Tests
       description: Changes to tests
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -22,7 +22,7 @@ changelog:
         - chore
         - refactor
         - style
-        - perf
+        - performance
     - title: ✅ Tests
       description: Changes to tests
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,7 +7,7 @@ changelog:
     - title: ✨ New Features
       description: New features and enhancements
       labels:
-        - feature
+        - enhancement
     - title: 🐛 Bug Fixes
       description: Bug fixes and patches
       labels:
@@ -15,7 +15,7 @@ changelog:
     - title: 📝 Documentation Updates
       description: Changes to documentation
       labels:
-        - docs
+        - documentation
     - title: 🛠 Maintenance Tasks
       description: Maintenance tasks and housekeeping
       labels:
@@ -23,7 +23,7 @@ changelog:
         - refactor
         - style
         - performance
-        - ci
+        - build
     - title: ✅ Tests
       description: Changes to tests
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+changelog:
+  categories:
+    - title: 🚨 Breaking Changes
+      description: Changes that break existing functionality
+      labels:
+        - breaking
+    - title: ✨ New Features
+      description: New features and enhancements
+      labels:
+        - feature
+    - title: 🐛 Bug Fixes
+      description: Bug fixes and patches
+      labels:
+        - fix
+    - title: 📝 Documentation Updates
+      description: Changes to documentation
+      labels:
+        - docs
+    - title: 🛠 Maintenance Tasks
+      description: Maintenance tasks and housekeeping
+      labels:
+        - chore
+        - refactor
+        - style
+        - perf
+    - title: ✅ Tests
+      description: Changes to tests
+      labels:
+        - test
+    - title: Others
+      description: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -6,6 +6,14 @@ on:
     types: [ opened, edited ]
 
 jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate the pull request
+        uses: Namchee/conventional-pr@v0.15.4
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          verbose: true
   label:
     runs-on: ubuntu-latest
     name: Lint PR

--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -1,0 +1,14 @@
+# Warning, do not check out untrusted code with
+# the pull_request_target event.
+name: Label PRs with Conventional Commits
+on:
+  pull_request_target:
+    types: [ opened, edited ]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@v1
+        with:
+          type_labels: '{"feat": "feature", "fix": "fix", "breaking": "breaking", "chore": "chore", "docs": "docs", "style": "style", "refactor": "refactor", "perf": "performance", "test": "test"}'

--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -3,7 +3,7 @@
 name: Label PRs with Conventional Commits
 on:
   pull_request_target:
-    types: [ opened, edited ]
+    types: [ opened, edited , synchronize]
 
 jobs:
   validate-pr:

--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: bcoe/conventional-release-labels@v1
         with:
-          type_labels: '{"feat": "feature", "fix": "fix", "breaking": "breaking", "chore": "chore", "docs": "docs", "style": "style", "refactor": "refactor", "perf": "performance", "test": "test"}'
+          type_labels: '{"feat": "feature", "fix": "fix", "breaking": "breaking", "chore": "chore", "docs": "docs", "style": "style", "refactor": "refactor", "perf": "performance", "test": "test", "ci":"ci"}'

--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
+    name: Lint PR
     steps:
-      - uses: bcoe/conventional-release-labels@v1
+      - name: label
+        uses: action-runner/conventional-labeler@v1
         with:
-          type_labels: '{"feat": "feature", "fix": "fix", "breaking": "breaking", "chore": "chore", "docs": "docs", "style": "style", "refactor": "refactor", "perf": "performance", "test": "test", "ci":"ci"}'
+          access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow that automatically labels pull requests based on Conventional Commits. The workflow uses predefined categories for changelog to improve consistency and clarity in release notes. This will help streamline the labeling process and ensure that pull requests are properly categorized.