### PR TITLE
fix: handle unknown artifact type in post_process_raw function

### DIFF
--- a/src/backend/base/langflow/schema/artifact.py
+++ b/src/backend/base/langflow/schema/artifact.py
@@ -49,7 +49,7 @@ def get_artifact_type(value, build_result=None) -> str:
 def post_process_raw(raw, artifact_type: str):
     if artifact_type == ArtifactType.STREAM.value:
         raw = ""
-    elif artifact_type == ArtifactType.UNKNOWN.value:
+    elif artifact_type == ArtifactType.UNKNOWN.value and raw is not None:
         raw = "Built Successfully ✨"
 
     return raw


### PR DESCRIPTION
Handle the case where the artifact type is unknown and the raw value is not None in the post_process_raw function. Set the raw value to "Built Successfully ✨" in this case.