### PR TITLE
ci: add outputs and conditional step to TypeScript test workflow

### DIFF
--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -34,6 +34,8 @@ jobs:
     env:
       OPENAI_API_KEY: ${{ inputs.openai_api_key || secrets.OPENAI_API_KEY }}
       STORE_API_KEY: ${{ inputs.store_api_key || secrets.STORE_API_KEY }}
+    outputs:
+      failed: ${{ steps.check-failure.outputs.failed }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -107,6 +109,15 @@ jobs:
         run: |
           cd src/frontend
           npx playwright test --trace on --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers 2
+        continue-on-error: true
+
+      # If the test fails, set a flag to indicate that the shard failed
+      - name: Set failure flag
+        id: check-failure
+        if: failure()
+        run: echo "failed=true" >> "$GITHUB_OUTPUT"
+
+
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: always()

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -127,9 +127,12 @@ jobs:
           path: src/frontend/blob-report
           retention-days: 1
 
+
+
   merge-reports:
     needs: setup-and-test
     runs-on: ubuntu-latest
+    if : ${{ needs.setup-and-test.outputs.failed != 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request adds outputs to the TypeScript test workflow to capture the status of the tests, improving visibility and tracking of test failures. Additionally, a conditional step is added to the merge-reports job in the workflow to prevent execution if the setup-and-test job fails.