### PR TITLE
refactor: change node to component on FE constants

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -87,7 +87,7 @@ export default function NodeToolbarComponent({
     }
     setNoticeData({
       title:
-        "Minimization are only available for nodes with one handle or fewer.",
+        "Minimization are only available for components with one handle or fewer.",
     });
     return;
   }
@@ -762,7 +762,7 @@ export default function NodeToolbarComponent({
             onClose={setShowOverrideModal}
             onCancel={() => {
               saveComponent(cloneDeep(data), false);
-              setSuccessData({ title: "New node successfully saved!" });
+              setSuccessData({ title: "New component successfully saved!" });
             }}
           >
             <ConfirmationModal.Content>

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -476,7 +476,7 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
         const ids = errorsObjs.map((obj) => obj.id).flat();
 
         get().updateBuildStatus(ids, BuildStatus.ERROR);
-        throw new Error("Invalid nodes");
+        throw new Error("Invalid components");
       }
     }
     function handleBuildUpdate(

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -86,7 +86,7 @@ export async function updateVerticesOrder(
       });
       useFlowStore.getState().setIsBuilding(false);
       setLockChat && setLockChat(false);
-      throw new Error("Invalid nodes");
+      throw new Error("Invalid components");
     }
     // orderResponse.data.ids,
     // for each id we need to build the VertexLayerElementType object as

--- a/src/frontend/src/utils/parameterUtils.ts
+++ b/src/frontend/src/utils/parameterUtils.ts
@@ -12,7 +12,7 @@ export const handleUpdateValues = async (name: string, data: NodeDataType) => {
 
   const template = data.node?.template;
   if (!template) {
-    console.error("No template found in the node.");
+    console.error("No template found in the component.");
     return;
   }
 
@@ -27,7 +27,7 @@ export const handleUpdateValues = async (name: string, data: NodeDataType) => {
       return res.data.template;
     }
   } catch (error) {
-    console.error("Error occurred while updating the node:", error);
+    console.error("Error occurred while updating the component:", error);
     throw error;
   }
 };

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -348,7 +348,7 @@ Array<{ id: string; errors: Array<string> }> {
       {
         id: "",
         errors: [
-          "No nodes found in the flow. Please add at least one node to the flow.",
+          "No components found in the flow. Please add at least one component to the flow.",
         ],
       },
     ];
@@ -848,7 +848,7 @@ export function validateSelection(
   let errorsArray: Array<string> = [];
   // check if there is more than one node
   if (clonedSelection.nodes.length < 2) {
-    errorsArray.push("Please select more than one node");
+    errorsArray.push("Please select more than one component");
   }
   if (
     clonedSelection.nodes.some(
@@ -857,7 +857,7 @@ export function validateSelection(
         isOutputNode(node.data as NodeDataType),
     )
   ) {
-    errorsArray.push("Select non-input/output nodes only");
+    errorsArray.push("Select non-input/output components only");
   }
   //check if there are two or more nodes with free outputs
   if (
@@ -865,7 +865,7 @@ export function validateSelection(
       (n) => !clonedSelection.edges.some((e) => e.source === n.id),
     ).length > 1
   ) {
-    errorsArray.push("Select only one node with free outputs");
+    errorsArray.push("Select only one component with free outputs");
   }
 
   // check if there is any node that does not have any connection
@@ -876,7 +876,7 @@ export function validateSelection(
         !clonedSelection.edges.some((edge) => edge.source === node.id),
     )
   ) {
-    errorsArray.push("Select only connected nodes");
+    errorsArray.push("Select only connected components");
   }
   return errorsArray;
 }


### PR DESCRIPTION
This PR introduces a refactor to our front-end codebase, specifically changing the terminology from node to component in our constants. This change aims to improve code readability and maintain consistency with the terminology used throughout our application.