### PR TITLE
fix(langflow): handle KeyboardInterrupt and terminate process in run function for graceful shutdown

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -199,6 +199,10 @@ def run(
     except KeyboardInterrupt:
         if process is not None:
             process.terminate()
+        sys.exit(0)
+    except Exception as e:
+        logger.exception(e)
+        sys.exit(1)
 
 
 def wait_for_server_ready(host, port):
@@ -421,23 +425,23 @@ def run_langflow(host, port, log_level, options, app):
     Run Langflow server on localhost
     """
 
-        if platform.system() in ["Windows"]:
-            # Run using uvicorn on MacOS and Windows
-            # Windows doesn't support gunicorn
-            # MacOS requires an env variable to be set to use gunicorn
-            import uvicorn
+    if platform.system() in ["Windows"]:
+        # Run using uvicorn on MacOS and Windows
+        # Windows doesn't support gunicorn
+        # MacOS requires an env variable to be set to use gunicorn
+        import uvicorn
 
-            uvicorn.run(
-                app,
-                host=host,
-                port=port,
-                log_level=log_level.lower(),
-                loop="asyncio",
-            )
-        else:
-            from langflow.server import LangflowApplication
+        uvicorn.run(
+            app,
+            host=host,
+            port=port,
+            log_level=log_level.lower(),
+            loop="asyncio",
+        )
+    else:
+        from langflow.server import LangflowApplication
 
-            LangflowApplication(app, options).run()
+        LangflowApplication(app, options).run()
 
 
 @app.command()

--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -420,7 +420,7 @@ def run_langflow(host, port, log_level, options, app):
     """
     Run Langflow server on localhost
     """
-    try:
+
         if platform.system() in ["Windows"]:
             # Run using uvicorn on MacOS and Windows
             # Windows doesn't support gunicorn
@@ -438,11 +438,6 @@ def run_langflow(host, port, log_level, options, app):
             from langflow.server import LangflowApplication
 
             LangflowApplication(app, options).run()
-    except KeyboardInterrupt:
-        sys.exit(0)
-    except Exception as e:
-        logger.exception(e)
-        sys.exit(1)
 
 
 @app.command()

--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -10,8 +10,8 @@ import click
 import httpx
 import typer
 from dotenv import dotenv_values, load_dotenv
-from multiprocess import cpu_count  # noqa
-from multiprocess.context import Process
+from multiprocess import cpu_count  # type: ignore
+from multiprocess.context import Process  # type: ignore
 from packaging import version as pkg_version
 from rich import box
 from rich import print as rprint


### PR DESCRIPTION
The process was not being terminated when the user pressed `Ctrl+C`.