### PR TITLE
fix(ordering): correctly remove vertex from list of runnable vertices

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -105,13 +105,6 @@ async def retrieve_vertices_order(
                 first_layer = graph.sort_vertices()
         else:
             first_layer = graph.sort_vertices()
-        # When we send vertices to the frontend
-        # we need to remove them from the predecessors
-        # so they are not considered for building again
-        # which duplicates the results
-        for vertex_id in first_layer:
-            graph.remove_from_predecessors(vertex_id)
-            graph.remove_vertex_from_runnables(vertex_id)
 
         # Now vertices is a list of lists
         # We need to get the id of each vertex

--- a/src/backend/base/langflow/graph/graph/runnable_vertices_manager.py
+++ b/src/backend/base/langflow/graph/graph/runnable_vertices_manager.py
@@ -107,7 +107,7 @@ class RunnableVerticesManager:
 
         """
         async with lock:
-            self.remove_from_predecessors(vertex.id)
+            self.remove_vertex_from_runnables(vertex.id)
             direct_successors_ready = [
                 v for v in vertex.successors_ids if self.is_vertex_runnable(v, graph.inactivated_vertices)
             ]


### PR DESCRIPTION
Vertices in the first layer were being removed from runnable vertices at `/build/{flow_id}/vertices` call but they should actually be removed at the `get_next_runnable_vertices` call.

Also, in `get_next_runnable_vertices` they were being remove only from predecessors but should actually be removed from runnable vertices.