### PR TITLE
fix: make sure old secret keys are handled as before

### DIFF
--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -345,16 +345,14 @@ def ensure_valid_key(s: str) -> bytes:
         random.seed(s)
         # Generate 32 random bytes
         key = bytes(random.getrandbits(8) for _ in range(32))
+        key = base64.urlsafe_b64encode(key)
     else:
-        # If the key is long enough, use the first 32 bytes
-        key = s[:32].encode()
-
-    # Ensure the key is URL-safe base64-encoded
-    return base64.urlsafe_b64encode(key)
+        key = add_padding(s).encode()
+    return key
 
 
 def get_fernet(settings_service=Depends(get_settings_service)):
-    SECRET_KEY = settings_service.auth_settings.SECRET_KEY.get_secret_value()
+    SECRET_KEY: str = settings_service.auth_settings.SECRET_KEY.get_secret_value()
     valid_key = ensure_valid_key(SECRET_KEY)
     fernet = Fernet(valid_key)
     return fernet

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -332,6 +332,12 @@ def authenticate_user(username: str, password: str, db: Session = Depends(get_se
     return user if verify_password(password, user.password) else None
 
 
+def add_padding(s):
+    # Calculate the number of padding characters needed
+    padding_needed = 4 - len(s) % 4
+    return s + "=" * padding_needed
+
+
 def ensure_valid_key(s: str) -> bytes:
     # If the key is too short, we'll use it as a seed to generate a valid key
     if len(s) < 32:


### PR DESCRIPTION
This pull request includes a refactoring of the auth utils module to add a padding function for strings. Additionally, it fixes an issue in the auth utils module where the `add_padding` function was not being called if the secret key was valid. The `ensure_valid_key` function now properly handles both cases.