### PR TITLE
fix: update run_manager on state changes

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -261,9 +261,9 @@ async def build_vertex(
             background_tasks.add_task(graph.end_all_traces)
 
         build_response = VertexBuildResponse(
-            inactivated_vertices=inactivated_vertices,
-            next_vertices_ids=next_runnable_vertices,
-            top_level_vertices=top_level_vertices,
+            inactivated_vertices=list(set(inactivated_vertices)),
+            next_vertices_ids=list(set(next_runnable_vertices)),
+            top_level_vertices=list(set(top_level_vertices)),
             valid=valid,
             params=params,
             id=vertex.id,

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -16,7 +16,7 @@ from langflow.graph.graph.runnable_vertices_manager import RunnableVerticesManag
 from langflow.graph.graph.state_manager import GraphStateManager
 from langflow.graph.graph.utils import find_start_component_id, process_flow
 from langflow.graph.schema import InterfaceComponentTypes, RunOutputs
-from langflow.graph.vertex.base import Vertex
+from langflow.graph.vertex.base import Vertex, VertexStates
 from langflow.graph.vertex.types import InterfaceVertex, StateVertex
 from langflow.schema import Data
 from langflow.schema.schema import INPUT_FIELD_NAME, InputType
@@ -155,6 +155,8 @@ class Graph:
                 for vertex in [vertex] + successors:
                     edges_set.update(vertex.edges)
                     vertices_ids.add(vertex.id)
+                    if vertex.state == VertexStates.INACTIVE:
+                        vertex.set_state("ACTIVE")
                 edges = list(edges_set)
                 predecessor_map, _ = self.build_adjacency_maps(edges)
                 new_predecessor_map.update(predecessor_map)

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -1495,7 +1495,7 @@ class Graph:
         successor_map = defaultdict(list)
         for edge in edges:
             if edge.source_id not in predecessor_map[edge.target_id]:
-            predecessor_map[edge.target_id].append(edge.source_id)
+                predecessor_map[edge.target_id].append(edge.source_id)
             if edge.target_id not in successor_map[edge.source_id]:
-            successor_map[edge.source_id].append(edge.target_id)
+                successor_map[edge.source_id].append(edge.target_id)
         return predecessor_map, successor_map

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -1459,7 +1459,7 @@ class Graph:
         Returns:
             None
         """
-        self.run_manager.build_run_map(self)
+        self.run_manager.build_run_map(predecessor_map=self.predecessor_map, vertices_to_run=self.vertices_to_run)
 
     def find_runnable_predecessors_for_successors(self, vertex_id: str) -> List[str]:
         """

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -1494,6 +1494,8 @@ class Graph:
         predecessor_map = defaultdict(list)
         successor_map = defaultdict(list)
         for edge in edges:
+            if edge.source_id not in predecessor_map[edge.target_id]:
             predecessor_map[edge.target_id].append(edge.source_id)
+            if edge.target_id not in successor_map[edge.source_id]:
             successor_map[edge.source_id].append(edge.target_id)
         return predecessor_map, successor_map

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -1491,8 +1491,8 @@ class Graph:
 
     def build_adjacency_maps(self, edges: List[ContractEdge]) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
         """Returns the adjacency maps for the graph."""
-        predecessor_map = defaultdict(list)
-        successor_map = defaultdict(list)
+        predecessor_map: dict[str, list[str]] = defaultdict(list)
+        successor_map: dict[str, list[str]] = defaultdict(list)
         for edge in edges:
             if edge.source_id not in predecessor_map[edge.target_id]:
                 predecessor_map[edge.target_id].append(edge.source_id)

--- a/src/backend/base/langflow/graph/graph/runnable_vertices_manager.py
+++ b/src/backend/base/langflow/graph/graph/runnable_vertices_manager.py
@@ -40,6 +40,11 @@ class RunnableVerticesManager:
         self.run_predecessors = state["run_predecessors"]
         self.vertices_to_run = state["vertices_to_run"]
 
+    def update_run_state(self, run_predecessors: dict, vertices_to_run: set):
+        self.run_predecessors.update(run_predecessors)
+        self.vertices_to_run.update(vertices_to_run)
+        self.build_run_map(self.run_predecessors, self.vertices_to_run)
+
     def is_vertex_runnable(self, vertex_id: str, inactivated_vertices: set[str]) -> bool:
         """Determines if a vertex is runnable."""
 

--- a/src/backend/base/langflow/graph/graph/runnable_vertices_manager.py
+++ b/src/backend/base/langflow/graph/graph/runnable_vertices_manager.py
@@ -73,14 +73,14 @@ class RunnableVerticesManager:
             if vertex_id in self.run_predecessors[predecessor]:
                 self.run_predecessors[predecessor].remove(vertex_id)
 
-    def build_run_map(self, graph):
+    def build_run_map(self, predecessor_map, vertices_to_run):
         """Builds a map of vertices and their runnable successors."""
         self.run_map = defaultdict(list)
-        for vertex_id, predecessors in graph.predecessor_map.items():
+        for vertex_id, predecessors in predecessor_map.items():
             for predecessor in predecessors:
                 self.run_map[predecessor].append(vertex_id)
-        self.run_predecessors = graph.predecessor_map.copy()
-        self.vertices_to_run = graph.vertices_to_run
+        self.run_predecessors = predecessor_map.copy()
+        self.vertices_to_run = vertices_to_run
 
     def update_vertex_run_state(self, vertex_id: str, is_runnable: bool):
         """Updates the runnable state of a vertex."""

--- a/src/frontend/src/components/headerComponent/components/menuBar/index.tsx
+++ b/src/frontend/src/components/headerComponent/components/menuBar/index.tsx
@@ -218,8 +218,7 @@ export const MenuBar = ({}: {}): JSX.Element => {
               />
               <div>{printByBuildStatus()}</div>
             </div>
-            {/* Deactivating this until we find a better solution */}
-            {/* <button
+            <button
               disabled={!isBuilding}
               onClick={(_) => {
                 if (isBuilding) {
@@ -237,7 +236,7 @@ export const MenuBar = ({}: {}): JSX.Element => {
             >
               <IconComponent name="Square" className="h-4 w-4" />
               <span>Stop</span>
-            </button> */}
+            </button>
           </div>
         </ShadTooltip>
       )}


### PR DESCRIPTION
This pull request refactors the `RunnableVerticesManager` class by updating the `build_run_map` method to take `predecessor_map` and `vertices_to_run` as parameters. This improves code readability and maintainability. Additionally, it fixes a bug in the `activate_state_vertices` method where the `vertices_ids` list was incorrectly used instead of a set. The `update_run_state` method is also added to update the run state with the new `run_predecessors` and `vertices_to_run` values.