### PR TITLE
fix: remove redundant and incorrect health check

### DIFF
--- a/src/backend/base/langflow/api/health_check_router.py
+++ b/src/backend/base/langflow/api/health_check_router.py
@@ -5,25 +5,22 @@ from loguru import logger
 from pydantic import BaseModel
 from sqlmodel import Session, select
 
-from langflow.services.auth.utils import get_password_hash
 from langflow.services.database.models.flow import Flow
-from langflow.services.database.models.folder.utils import create_default_folder_if_it_doesnt_exist
-from langflow.services.database.models.user.model import User
-from langflow.services.deps import get_chat_service, get_session, get_variable_service
-from langflow.services.variable.service import GENERIC_TYPE, VariableService
+from langflow.services.deps import get_chat_service, get_session
 
 health_check_router = APIRouter(tags=["Health Check"])
 
 
 class HealthResponse(BaseModel):
     status: str = "nok"
-    chat: str = "error"
-    db: str = "error"
-    folder: str = "error"
-    variables: str = "error"
+    chat: str = "error check the server logs"
+    db: str = "error check the server logs"
+    """
+    Do not send exceptions and detailed error messages to the client because it might contain credentials and other sensitive server information.
+    """
 
     def has_error(self) -> bool:
-        return any(v == "error" for v in self.model_dump().values())
+        return any(v.startswith("error") for v in self.model_dump().values())
 
 
 # /health is also supported by uvicorn
@@ -40,24 +37,13 @@ async def health():
 @health_check_router.get("/health_check", response_model=HealthResponse)
 async def health_check(
     session: Session = Depends(get_session),
-    variable_service: VariableService = Depends(get_variable_service),
 ):
     response = HealthResponse()
-    test_id = uuid.uuid4()
+    # use a fixed valid UUId that UUID collision is very unlikely
     user_id = "da93c2bd-c857-4b10-8c8c-60988103320f"
     try:
-        if not session.exec(select(User).where(User.id == user_id)).first():
-            session.add(
-                User(
-                    id=user_id,
-                    username="health_check",
-                    is_active=False,
-                    password=get_password_hash("health_check"),
-                )
-            )
-            session.commit()
         # Check database to query a bogus flow
-        stmt = select(Flow).where(Flow.id == test_id)
+        stmt = select(Flow).where(Flow.id == uuid.uuid4())
         session.exec(stmt).first()
         response.db = "ok"
     except Exception as e:
@@ -65,34 +51,9 @@ async def health_check(
 
     try:
         chat = get_chat_service()
-        await chat.set_cache("health_check", str(test_id))
-        if v := await chat.get_cache("health_check"):
-            if v.get("result") == str(test_id):
-                response.chat = "ok"
-            else:
-                logger.error("chat service get incorrect value")
-    except Exception as e:
-        logger.exception(e)
-
-    # use the same uuid for user_id for testing purpose
-    try:
-        variable_service.initialize_user_variables(user_id, session)
-        variable_service.create_variable(
-            user_id=user_id,
-            name="health_check_test",
-            value="ok",
-            default_fields=[],
-            _type=GENERIC_TYPE,
-            session=session,
-        )
-        variable_service.delete_variable(user_id=user_id, name="health_check_test", session=session)
-        response.variables = "ok"
-    except Exception as e:
-        logger.exception(e)
-
-    try:
-        create_default_folder_if_it_doesnt_exist(session, uuid.UUID(user_id))
-        response.folder = "ok"
+        await chat.set_cache("health_check", str(user_id))
+        await chat.get_cache("health_check")
+        response.chat = "ok"
     except Exception as e:
         logger.exception(e)
 


### PR DESCRIPTION
This PR addresses comments from https://github.com/langflow-ai/langflow/pull/2510 @nicoloboschi 

\health_check will only check db and cache service.

* Remove folder test for redundant test
* Remove Variable test. Kubernetes based test will be added if required later.
* Update chat/cache test to only evaluate the existence of key

Add a note to clarify why exceptions or detailed errors are not replied to the client because we might leak sensitive data. cc @jordanrfrazier 