### PR TITLE
fix: remove redundant superuser only if it has never logged in

### DIFF
--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -97,12 +97,13 @@ def teardown_superuser(settings_service, session):
             from langflow.services.database.models.user.model import User
 
             user = session.exec(select(User).where(User.username == username)).first()
-            if user and user.is_superuser is True:
+            # Check if super was ever logged in, if not delete it
+            # if it has logged in, it means the user is using it to login
+            if user and user.is_superuser is True and not user.last_login_at:
                 session.delete(user)
                 session.commit()
                 logger.debug("Default superuser removed successfully.")
-            else:
-                logger.debug("Default superuser not found.")
+
         except Exception as exc:
             logger.exception(exc)
             raise RuntimeError("Could not remove default superuser.") from exc

--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -131,14 +131,6 @@ function ApiInterceptor() {
       if (res?.data?.access_token && res?.data?.refresh_token) {
         login(res?.data?.access_token);
       }
-      if (error?.config?.headers) {
-        delete error.config.headers["Authorization"];
-        error.config.headers["Authorization"] = `Bearer ${cookies.get(
-          "access_token_lf",
-        )}`;
-        const response = await axios.request(error.config);
-        return response;
-      }
     } catch (error) {
       clearBuildVerticesState(error);
       logout();

--- a/src/frontend/src/stores/foldersStore.tsx
+++ b/src/frontend/src/stores/foldersStore.tsx
@@ -98,7 +98,7 @@ export const useFolderStore = create<FoldersStoreType>((set, get) => ({
     if (id) {
       getFolderById(id).then((res) => {
         const setAllFlows = useFlowsManagerStore.getState().setAllFlows;
-        setAllFlows(res.flows);
+        setAllFlows(res?.flows);
         set({ selectedFolder: res });
       });
     }


### PR DESCRIPTION
The code changes in `utils.py` check if the superuser exists and if it has never logged in. If both conditions are true, the superuser is deleted from the database. This improves the efficiency and security of the application.