### PR TITLE
feat: Add Gemma 2 to Groq model list

### DIFF
--- a/src/backend/base/langflow/base/models/groq_constants.py
+++ b/src/backend/base/langflow/base/models/groq_constants.py
@@ -1,1 +1,1 @@
-MODEL_NAMES = ["llama3-8b-8192", "llama3-70b-8192", "mixtral-8x7b-32768", "gemma-7b-it"]
+MODEL_NAMES = ["llama3-8b-8192", "llama3-70b-8192", "mixtral-8x7b-32768", "gemma-7b-it", "gemma2-9b-it"]


### PR DESCRIPTION
Groq now has Gemma 2 available: https://console.groq.com/docs/models