### PR TITLE
fix: Qdrant shows Qdrant.from_documents() missing 1 required positional argument: ‘embedding’

### DIFF
--- a/src/backend/base/langflow/components/vectorstores/Qdrant.py
+++ b/src/backend/base/langflow/components/vectorstores/Qdrant.py
@@ -87,17 +87,16 @@ class QdrantVectorStoreComponent(LCVectorStoreComponent):
             else:
                 documents.append(_input)
 
-        embedding = self.embedding
-        if not isinstance(embedding, Embeddings):
+        if not isinstance(self.embedding, Embeddings):
             raise ValueError("Invalid embedding object")
 
         if documents:
-            qdrant = Qdrant.from_documents(documents, embeddings=embedding, **qdrant_kwargs)
+            qdrant = Qdrant.from_documents(documents, embeddings=self.embedding, **qdrant_kwargs)
         else:
             from qdrant_client import QdrantClient
 
             client = QdrantClient(**server_kwargs)
-            qdrant = Qdrant(embeddings=embedding, client=client, **qdrant_kwargs)
+            qdrant = Qdrant(embeddings=self.embedding, client=client, **qdrant_kwargs)
 
         return qdrant
 


### PR DESCRIPTION
fixes the error caused by the same naming assignment.