### PR TITLE
fix: make chat lock when building

### DIFF
--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -456,6 +456,7 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
     setLockChat?: (lock: boolean) => void;
   }) => {
     get().setIsBuilding(true);
+    get().setLockChat(true);
     const currentFlow = useFlowsManagerStore.getState().currentFlow;
     const setSuccessData = useAlertStore.getState().setSuccessData;
     const setErrorData = useAlertStore.getState().setErrorData;
@@ -578,6 +579,7 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
           }
         }
         get().setIsBuilding(false);
+        get().setLockChat(false);
       },
       onBuildUpdate: handleBuildUpdate,
       onBuildError: (title: string, list: string[], elementList) => {
@@ -587,6 +589,7 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
         useFlowStore.getState().updateBuildStatus(idList, BuildStatus.BUILT);
         setErrorData({ list, title });
         get().setIsBuilding(false);
+        get().setLockChat(false);
       },
       onBuildStart: (elementList) => {
         const idList = elementList
@@ -600,6 +603,7 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
       edges: !get().onFlowPage ? get().edges : undefined,
     });
     get().setIsBuilding(false);
+    get().setLockChat(false);
     get().revertBuiltStatusFromBuilding();
   },
   getFlow: () => {


### PR DESCRIPTION
This pull request fixes a bug where the chat was not being locked properly during the build process. The bug was causing the chat to remain unlocked even when the build was in progress. This pull request adds the necessary code to properly lock and unlock the chat during the build process.