### PR TITLE
feat: log retriever endpoint

### DIFF
--- a/src/backend/base/langflow/api/__init__.py
+++ b/src/backend/base/langflow/api/__init__.py
@@ -1,4 +1,5 @@
 from langflow.api.router import router
 from langflow.api.health_check_router import health_check_router
+from langflow.api.log_router import log_router
 
-__all__ = ["router", "health_check_router"]
+__all__ = ["router", "health_check_router", "log_router"]

--- a/src/backend/base/langflow/api/log_router.py
+++ b/src/backend/base/langflow/api/log_router.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, Query, HTTPException
+from fastapi.responses import JSONResponse
+from http import HTTPStatus
+from langflow.utils.logger import log_buffer
+
+log_router = APIRouter(tags=["Log"])
+
+
+@log_router.get("/logs")
+async def logs(
+    start_lines: int = Query(0, ge=1, description="The number of logs from the start"),
+    end_lines: int = Query(100, ge=1, description="The number of logs from the end"),
+    session_id: str = Query(None, description="The session UUID to retrieve logs from for pagination"),
+    page: int = Query(1, ge=1, description="The page number to retrieve logs from for pagination"),
+    # TODO: add time based query
+):
+    global log_buffer
+    if log_buffer.enabled() is False:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_IMPLEMENTED,
+            detail="Log retrieval is disabled",
+        )
+
+    if page > 1 and session_id is None:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="Session UUID is required for pagination",
+        )
+
+    if page == 1 and session_id is None:
+        session_id = log_buffer.create_session()
+
+    if session_id:
+        result = log_buffer.get_page(session_id, page)
+        if "error" in result:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                detail=result["error"],
+            )
+        return JSONResponse(content=result)
+
+    buffer_size = log_buffer.max_size()
+    if start_lines > 0:
+        index = min(start_lines, buffer_size)
+        return JSONResponse(
+            content={
+                "logs": log_buffer.readlines()[:index],
+                "page": 1,
+                "total_pages": 1,
+            }
+        )
+    else:
+        index = min(end_lines, buffer_size)
+        return JSONResponse(
+            content={
+                "logs": log_buffer.readlines()[-index:],
+                "page": 1,
+                "total_pages": 1,
+            }
+        )

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -17,7 +17,7 @@ from rich import print as rprint
 from starlette.middleware.base import BaseHTTPMiddleware
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
-from langflow.api import router, health_check_router
+from langflow.api import router, health_check_router, log_router
 from langflow.initial_setup.setup import (
     create_or_update_starter_projects,
     initialize_super_user_if_needed,
@@ -157,6 +157,7 @@ def create_app():
 
     app.include_router(router)
     app.include_router(health_check_router)
+    app.include_router(log_router)
 
     FastAPIInstrumentor.instrument_app(app)
 


### PR DESCRIPTION
Implemented a feature to allow all LangFlow logs to be retrieved through an API `/logs`

* `/logs` endpoint with pagination support
* `/logs` endpoint to support the last number lines
* implements a loguru sink to stream logs to an in-memory buffer. The size can be specified by OS env variable. If the size is 0, this feature is disabled.

Limitation, this endpoint does not filter out logs based on flow, nor user, therefore it's disabled by default. Once it's enabled the logs can be retrieved by any user.
