### PR TITLE
fix: astra vectorize auth error

### DIFF
--- a/src/backend/base/langflow/components/vectorstores/AstraDB.py
+++ b/src/backend/base/langflow/components/vectorstores/AstraDB.py
@@ -195,9 +195,12 @@ class AstraVectorStoreComponent(LCVectorStoreComponent):
             }
             dict_options["parameters"] = {k: v for k, v in dict_options.get("parameters", {}).items() if k and v}
             embedding_dict = {
-                "collection_vector_service_options": CollectionVectorServiceOptions.from_dict(dict_options),
-                "collection_embedding_api_key": self.embedding.get("collection_embedding_api_key"),
+                "collection_vector_service_options": CollectionVectorServiceOptions.from_dict(dict_options)
             }
+            collection_embedding_api_key = self.embedding.get("collection_embedding_api_key")
+            if collection_embedding_api_key:
+                embedding_dict["collection_embedding_api_key"] = collection_embedding_api_key
+
         vector_store_kwargs = {
             **embedding_dict,
             "collection_name": self.collection_name,


### PR DESCRIPTION
currently if you're using the key from astra, you get `Error Message: You didn't provide an API key.`