### PR TITLE
fix: azure embeddings models with fixed dimensions fail

### DIFF
--- a/src/backend/base/langflow/components/embeddings/AzureOpenAIEmbeddings.py
+++ b/src/backend/base/langflow/components/embeddings/AzureOpenAIEmbeddings.py
@@ -1,5 +1,4 @@
 from langchain_openai import AzureOpenAIEmbeddings
-from pydantic.v1 import SecretStr
 
 from langflow.base.models.model import LCModelComponent
 from langflow.field_typing import Embeddings

--- a/src/backend/base/langflow/components/embeddings/AzureOpenAIEmbeddings.py
+++ b/src/backend/base/langflow/components/embeddings/AzureOpenAIEmbeddings.py
@@ -59,20 +59,15 @@ class AzureOpenAIEmbeddingsComponent(LCModelComponent):
     ]
 
     def build_embeddings(self) -> Embeddings:
-        if not self.api_key:
-            raise ValueError("API Key is required")
-
-        azure_api_key = SecretStr(self.api_key)
-
         try:
             embeddings = AzureOpenAIEmbeddings(
                 azure_endpoint=self.azure_endpoint,
                 azure_deployment=self.azure_deployment,
                 api_version=self.api_version,
-                api_key=azure_api_key,
-                dimensions=self.dimensions,
+                api_key=self.api_key,
+                dimensions=self.dimensions or None,
             )
         except Exception as e:
-            raise ValueError("Could not connect to AzureOpenAIEmbeddings API.") from e
+            raise ValueError(f"Could not connect to AzureOpenAIEmbeddings API: {str(e)}") from e
 
         return embeddings

--- a/src/backend/base/langflow/components/embeddings/OpenAIEmbeddings.py
+++ b/src/backend/base/langflow/components/embeddings/OpenAIEmbeddings.py
@@ -66,6 +66,12 @@ class OpenAIEmbeddingsComponent(LCEmbeddingsModel):
             value=True,
             info="If False, you must have transformers installed.",
         ),
+        IntInput(
+            name="dimensions",
+            display_name="Dimensions",
+            info="The number of dimensions the resulting output embeddings should have. Only supported by certain models.",
+            advanced=True,
+        ),
     ]
 
     def build_embeddings(self) -> Embeddings:
@@ -91,4 +97,5 @@ class OpenAIEmbeddingsComponent(LCEmbeddingsModel):
             show_progress_bar=self.show_progress_bar,
             skip_empty=self.skip_empty,
             tiktoken_model_name=self.tiktoken_model_name,
+            dimensions=self.dimensions or None,
         )


### PR DESCRIPTION
currently dimensions parameter is always passed as str or int making the langchain integration to fail (it accepts Optional[int]).
In this PR I also add back the dimensions to openai embeddings that has been lost in between the components refactor, originally implemented by @jordanrfrazier with #2146