### PR TITLE
docs: make astra vectorize provider key advanced param

### DIFF
--- a/src/backend/base/langflow/components/embeddings/AstraVectorize.py
+++ b/src/backend/base/langflow/components/embeddings/AstraVectorize.py
@@ -66,12 +66,13 @@ class AstraVectorizeComponent(Component):
         MessageTextInput(
             name="api_key_name",
             display_name="Provider API Key Name",
-            info="The name of the embeddings provider API key stored on Astra. If set, it will override the 'ProviderKey' in the authentication parameters.",
+            info="The name of the embeddings provider API key stored on Astra.",
         ),
         SecretStrInput(
             name="provider_api_key",
             display_name="Provider API Key",
             info="An alternative to the Astra Authentication that passes an API key for the provider with each request to Astra DB. This may be used when Vectorize is configured for the collection, but no corresponding provider secret is stored within Astra's key management system.",
+            advanced=True,
         ),
         DictInput(
             name="authentication",


### PR DESCRIPTION
Makes the astra vectorize provider key an advanced parameter, as the recommended workflow currently has users storing the key in Astra KMS. 

This key would only be used when a user creates the collection via LC or the Data API directly, then uses Langflow with that collection. This is possible, and we're working on ways to simplify that transition, but for now, this is more understandable for users.