### PR TITLE
ci: add astra integration tests to CI

### DIFF
--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -13,10 +13,3 @@ frontend:
   - "**/typescript_test.yml"
 docs:
   - "docs/**"
-integration:
-  - "src/backend/**.py"
-  - "tests/integration/**"
-astra_integration:
-  - "src/backend/base/langflow/backend/components/vectorstores/AstraDB.py"
-  - "src/backend/base/langflow/backend/components/embeddings/AstraVectorize.py"
-  - "tests/integration/astra/**"

--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -14,7 +14,7 @@ frontend:
 docs:
   - "docs/**"
 integration:
-  - "src/backend/base/langflow/backend/components/**"
+  - "src/backend/**.py"
   - "tests/integration/**"
 astra_integration:
   - "src/backend/base/langflow/backend/components/vectorstores/AstraDB.py"

--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -1,0 +1,19 @@
+# https://github.com/dorny/paths-filter
+python:
+  - "src/backend/**"
+  - "src/backend/**.py"
+  - "pyproject.toml"
+  - "poetry.lock"
+  - "**/python_test.yml"
+tests:
+  - "tests/**"
+  - "src/frontend/tests/**"
+frontend:
+  - "src/frontend/**"
+  - "**/typescript_test.yml"
+docs:
+  - "docs/**"
+astra_integration_tests:
+  - "src/backend/base/langflow/backend/components/vectorstores/AstraDB.py"
+  - "src/backend/base/langflow/backend/components/embeddings/AstraVectorize.py"
+  - "tests/integration/astra/**"

--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -13,7 +13,10 @@ frontend:
   - "**/typescript_test.yml"
 docs:
   - "docs/**"
-astra_integration_tests:
+integration:
+  - "src/backend/base/langflow/backend/components/**"
+  - "tests/integration/**"
+astra_integration:
   - "src/backend/base/langflow/backend/components/vectorstores/AstraDB.py"
   - "src/backend/base/langflow/backend/components/embeddings/AstraVectorize.py"
   - "tests/integration/astra/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ on:
         type: string
   pull_request:
 
-
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -42,21 +40,7 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          filters: |
-            python:
-              - "src/backend/**"
-              - "src/backend/**.py"
-              - "pyproject.toml"
-              - "poetry.lock"
-              - "**/python_test.yml"
-            tests:
-              - "tests/**"
-              - "src/frontend/tests/**"
-            frontend:
-              - "src/frontend/**"
-              - "**/typescript_test.yml"
-            docs:
-              - "docs/**"
+          filters: ./.github/changes-filter.yaml
 
   test-backend:
     needs: path-filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,18 +57,6 @@ jobs:
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
       STORE_API_KEY: "${{ secrets.STORE_API_KEY }}"
 
-  test-integrations:
-    needs: path-filter
-    name: Run Integrations Tests
-    if: ${{ needs.path-filter.outputs.integration == 'true' || needs.path-filter.outputs.tests == 'true' }}
-    uses: ./.github/workflows/integration_test.yml
-    with:
-      astra: ${{ needs.path-filter.outputs.astra_integration }}
-    secrets:
-      OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
-      ASTRA_DB_API_KEY: "${{ secrets.ASTRA_DB_API_KEY }}"
-      ASTRA_DB_APPLICATION_TOKEN: "${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}"
-
   lint-backend:
     needs: path-filter
     if: ${{ needs.path-filter.outputs.python == 'true' || needs.path-filter.outputs.tests == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,18 @@ jobs:
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
       STORE_API_KEY: "${{ secrets.STORE_API_KEY }}"
 
+  test-integrations:
+    needs: path-filter
+    name: Run Integrations Tests
+    if: ${{ needs.path-filter.outputs.integration == 'true' || needs.path-filter.outputs.tests == 'true' }}
+    uses: ./.github/workflows/integration_test.yml
+    with:
+      astra: ${{ needs.path-filter.outputs.astra_integration }}
+    secrets:
+      OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
+      ASTRA_DB_API_KEY: "${{ secrets.ASTRA_DB_API_KEY }}"
+      ASTRA_DB_APPLICATION_TOKEN: "${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}"
+
   lint-backend:
     needs: path-filter
     if: ${{ needs.path-filter.outputs.python == 'true' || needs.path-filter.outputs.tests == 'true' }}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,0 +1,70 @@
+name: Integration tests
+
+on:
+  workflow_call:
+    secrets:
+      OPENAI_API_KEY:
+        required: true
+      ASTRA_DB_API_KEY:
+        required: true
+      ASTRA_DB_APPLICATION_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "(Optional) Branch to checkout"
+        required: false
+        type: string
+      astra_integration:
+        description: "Run Astra DB integration tests"
+        required: false
+        type: boolean
+
+env:
+  POETRY_VERSION: "1.8.2"
+
+jobs:
+  setup-environment:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.12"
+          - "3.11"
+          - "3.10"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+      - name: Set up Python ${{ matrix.python-version }} + Poetry ${{ env.POETRY_VERSION }}
+        uses: "./.github/actions/poetry_caching"
+        with:
+          python-version: ${{ matrix.python-version }}
+          poetry-version: ${{ env.POETRY_VERSION }}
+          cache-key: ${{ runner.os }}-poetry-${{ env.POETRY_VERSION }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Install Python dependencies
+        run: |
+          poetry env use ${{ matrix.python-version }}
+          poetry install
+
+  test-astra-integration:
+    needs: setup-environment
+    if: ${{ inputs.astra_integration == 'true' }}
+    name: Run Astra DB Integration Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.12"
+          - "3.11"
+          - "3.10"
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ASTRA_DB_API_KEY: ${{ secrets.ASTRA_DB_API_KEY }}
+      ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
+    steps:
+      - name: Run astra integration tests
+        timeout-minutes: 12
+        run: |
+          poetry run pytest tests/integration -ra

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -2,6 +2,7 @@ name: Python tests
 
 on:
   workflow_call:
+
   workflow_dispatch:
     inputs:
       branch:
@@ -10,7 +11,6 @@ on:
         type: string
 env:
   POETRY_VERSION: "1.8.2"
-
 
 jobs:
   build:

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -2,7 +2,6 @@ name: Python tests
 
 on:
   workflow_call:
-
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/scheduled_integration_test.yml
+++ b/.github/workflows/scheduled_integration_test.yml
@@ -1,24 +1,14 @@
 name: Integration tests
 
 on:
-  workflow_call:
-    secrets:
-      OPENAI_API_KEY:
-        required: true
-      ASTRA_DB_API_KEY:
-        required: true
-      ASTRA_DB_APPLICATION_TOKEN:
-        required: true
   workflow_dispatch:
     inputs:
       branch:
         description: "(Optional) Branch to checkout"
         required: false
         type: string
-      astra_integration:
-        description: "Run Astra DB integration tests"
-        required: false
-        type: boolean
+  schedule:
+    - cron: "0 0 */2 * *" # Run every 2 days
 
 env:
   POETRY_VERSION: "1.8.2"
@@ -48,10 +38,9 @@ jobs:
           poetry env use ${{ matrix.python-version }}
           poetry install
 
-  test-astra-integration:
+  test-integration:
     needs: setup-environment
-    if: ${{ inputs.astra_integration == 'true' }}
-    name: Run Astra DB Integration Tests
+    name: Run Integration Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -64,7 +53,7 @@ jobs:
       ASTRA_DB_API_KEY: ${{ secrets.ASTRA_DB_API_KEY }}
       ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
     steps:
-      - name: Run astra integration tests
+      - name: Run integration tests
         timeout-minutes: 12
         run: |
-          poetry run pytest tests/integration -ra
+          make integration_tests


### PR DESCRIPTION
This adds a scheduled integration test to Langflow CI. The appropriate keys will need to be created and added to github secrets. 