### PR TITLE
chore: update HuggingFace Spaces build script to use correct space name

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -137,4 +137,4 @@ jobs:
 
       - name: Restart HuggingFace Spaces Build
         run: |
-          poetry run python ./scripts/factory_restart_space.py --space "Langflow/Langflow-Preview" --token ${{ secrets.HUGGINGFACE_API_TOKEN }}
+          poetry run python ./scripts/factory_restart_space.py --space "Langflow/Langflow" --token ${{ secrets.HUGGINGFACE_API_TOKEN }}


### PR DESCRIPTION
The HuggingFace Spaces build script has been updated to use the correct space name "Langflow/Langflow" instead of "Langflow/Langflow-Preview". This ensures that the correct space is restarted when triggered.