### PR TITLE
fix: handle sender_name passed as data or message

### DIFF
--- a/src/backend/base/langflow/graph/vertex/base.py
+++ b/src/backend/base/langflow/graph/vertex/base.py
@@ -15,6 +15,8 @@ from langflow.graph.utils import UnbuiltObject, UnbuiltResult
 from langflow.interface.initialize import loading
 from langflow.interface.listing import lazy_load_dict
 from langflow.schema.artifact import ArtifactType
+from langflow.schema.data import Data
+from langflow.schema.message import Message
 from langflow.schema.schema import INPUT_FIELD_NAME, OutputLog, build_output_logs
 from langflow.services.deps import get_storage_service
 from langflow.services.monitor.utils import log_transaction
@@ -435,16 +437,28 @@ class Vertex:
             List[str]: The extracted messages.
         """
         try:
+            text = artifacts["text"]
+            sender = artifacts.get("sender")
+            sender_name = artifacts.get("sender_name")
+            session_id = artifacts.get("session_id")
+            stream_url = artifacts.get("stream_url")
+            files = [{"path": file} if isinstance(file, str) else file for file in artifacts.get("files", [])]
+            component_id = self.id
+            _type = self.artifacts_type
+
+            if isinstance(sender_name, (Data, Message)):
+                sender_name = sender_name.get_text()
+
             messages = [
                 ChatOutputResponse(
-                    message=artifacts["text"],
-                    sender=artifacts.get("sender"),
-                    sender_name=artifacts.get("sender_name"),
-                    session_id=artifacts.get("session_id"),
-                    stream_url=artifacts.get("stream_url"),
-                    files=[{"path": file} if isinstance(file, str) else file for file in artifacts.get("files", [])],
-                    component_id=self.id,
-                    type=self.artifacts_type,
+                    message=text,
+                    sender=sender,
+                    sender_name=sender_name,
+                    session_id=session_id,
+                    stream_url=stream_url,
+                    files=files,
+                    component_id=component_id,
+                    type=_type,
                 ).model_dump(exclude_none=True)
             ]
         except KeyError:

--- a/src/backend/base/langflow/graph/vertex/types.py
+++ b/src/backend/base/langflow/graph/vertex/types.py
@@ -248,8 +248,13 @@ class InterfaceVertex(ComponentVertex):
                 message = str(text_output)
             # if the message is a generator or iterator
             # it means that it is a stream of messages
+
             else:
                 message = text_output
+
+            if hasattr(sender_name, "get_text"):
+                sender_name = sender_name.get_text()
+
             artifact_type = ArtifactType.STREAM if stream_url is not None else ArtifactType.OBJECT
             artifacts = ChatOutputResponse(
                 message=message,
@@ -335,10 +340,15 @@ class InterfaceVertex(ComponentVertex):
                 message = message.text if hasattr(message, "text") else message
                 yield message
                 complete_message += message
+
+        if hasattr(self.params.get("sender_name"), "get_text"):
+            sender_name = self.params.get("sender_name").get_text()
+        else:
+            sender_name = self.params.get("sender_name")
         self.artifacts = ChatOutputResponse(
             message=complete_message,
             sender=self.params.get("sender", ""),
-            sender_name=self.params.get("sender_name", ""),
+            sender_name=sender_name,
             files=[{"path": file} if isinstance(file, str) else file for file in self.params.get("files", [])],
             type=ArtifactType.OBJECT.value,
         ).model_dump()


### PR DESCRIPTION
This pull request fixes the handling of the `sender_name` parameter in the `InterfaceVertex` class. It ensures that the `sender_name` is converted to a string before being used in the `ChatOutputResponse` object. This prevents any potential errors or unexpected behavior when using the `sender_name` parameter.