### PR TITLE
fix: coroutine is not iterable when using redis

### DIFF
--- a/src/backend/base/langflow/interface/types.py
+++ b/src/backend/base/langflow/interface/types.py
@@ -76,10 +76,7 @@ async def get_and_cache_all_types_dict(
         Raises:
             None.
         """
-        if isinstance(cache_service, AsyncBaseCacheService):
-            return await cache_service.get(key=key, lock=lock)
-        else:
-            return cache_service.get(key=key, lock=lock)
+        return await cache_service.get(key=key, lock=lock)
 
     async def set_in_cache(key, value):
         """


### PR DESCRIPTION
when using redis you get the error `coroutine is not iterable `