### PR TITLE
fix: prevent to loop on keys of object profile pictures when It's not loaded yet

### DIFF
--- a/src/frontend/src/pages/SettingsPage/pages/GeneralPage/components/ProfilePictureForm/components/profilePictureChooserComponent/hooks/use-preload-images.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GeneralPage/components/ProfilePictureForm/components/profilePictureChooserComponent/hooks/use-preload-images.tsx
@@ -21,7 +21,7 @@ const usePreloadImages = (
   };
 
   useEffect(() => {
-    if (loading) return;
+    if (loading || !profilePictures) return;
     const imageArray: string[] = [];
 
     Object.keys(profilePictures).flatMap((folder) =>


### PR DESCRIPTION
🐛 (use-preload-images.tsx): add null check for profilePictures to prevent errors when profilePictures is undefined