### PR TITLE
fix: optimize filtering of vertices in useFlowStore

### DIFF
--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -522,10 +522,14 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
           get().verticesBuild!.verticesLayers[
             get().verticesBuild!.verticesLayers.length - 1
           ];
+
         nextVertices = nextVertices.filter(
-          (vertex) =>
-            !lastLayer.some((layer) => layer.id === vertex.id) &&
-            !lastLayer.some((layer) => layer.reference === vertex.reference),
+          (vertexElement) =>
+            !lastLayer.some(
+              (layerElement) =>
+                layerElement.id === vertexElement.id &&
+                layerElement.reference === vertexElement.reference,
+            ),
         );
         const newLayers = [
           ...get().verticesBuild!.verticesLayers,


### PR DESCRIPTION
Refactor the filtering logic in the useFlowStore hook to optimize the performance. The code changes ensure that the nextVertices array is filtered correctly by excluding vertices that already exist in the last layer.