### PR TITLE
feat: add payload validation, update Simple API Test fixture, run tests

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -81,6 +81,8 @@ def validate_input_and_tweaks(input_request: SimplifiedAPIRequest):
     # then we need to check the tweaks if the ChatInput component is present
     # and if its input_value is not None
     # if so, we raise an error
+    if input_request.tweaks is None:
+        return
     for key, value in input_request.tweaks.items():
         if "ChatInput" in key or "Chat Input" in key:
             if isinstance(value, dict):

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -23,6 +23,7 @@ from langflow.api.v1.schemas import (
 )
 from langflow.custom.custom_component.component import Component
 from langflow.custom.utils import build_custom_component_template, get_instance_name
+from langflow.exceptions.api import InvalidChatInputException
 from langflow.graph.graph.base import Graph
 from langflow.graph.schema import RunOutputs
 from langflow.helpers.flow import get_flow_by_id_or_endpoint_name
@@ -75,12 +76,38 @@ async def get_all(
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
+def validate_input_and_tweaks(input_request: SimplifiedAPIRequest):
+    # If the input_value is not None and the input_type is "chat"
+    # then we need to check the tweaks if the ChatInput component is present
+    # and if its input_value is not None
+    # if so, we raise an error
+    for key, value in input_request.tweaks.items():
+        if "ChatInput" in key or "Chat Input" in key:
+            if isinstance(value, dict):
+                has_input_value = value.get("input_value") is not None
+                input_value_is_chat = input_request.input_value is not None and input_request.input_type == "chat"
+                if has_input_value and input_value_is_chat:
+                    raise InvalidChatInputException(
+                        "If you pass an input_value to the chat input, you cannot pass a tweak with the same name."
+                    )
+        elif "Text Input" in key or "TextInput" in key:
+            if isinstance(value, dict):
+                has_input_value = value.get("input_value") is not None
+                input_value_is_text = input_request.input_value is not None and input_request.input_type == "text"
+                if has_input_value and input_value_is_text:
+                    raise InvalidChatInputException(
+                        "If you pass an input_value to the text input, you cannot pass a tweak with the same name."
+                    )
+
+
 async def simple_run_flow(
     flow: Flow,
     input_request: SimplifiedAPIRequest,
     stream: bool = False,
     api_key_user: Optional[User] = None,
 ):
+    if input_request.input_value is not None and input_request.tweaks is not None:
+        validate_input_and_tweaks(input_request)
     try:
         task_result: List[RunOutputs] = []
         user_id = api_key_user.id if api_key_user else None
@@ -232,6 +259,9 @@ async def simplified_run_flow(
         else:
             logger.exception(exc)
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+    except InvalidChatInputException as exc:
+        logger.error(exc)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
         logger.exception(exc)
         background_tasks.add_task(

--- a/src/backend/base/langflow/api/v1/schemas.py
+++ b/src/backend/base/langflow/api/v1/schemas.py
@@ -303,7 +303,7 @@ class InputValueRequest(BaseModel):
 
 
 class SimplifiedAPIRequest(BaseModel):
-    input_value: Optional[str] = Field(default="", description="The input value")
+    input_value: Optional[str] = Field(default=None, description="The input value")
     input_type: Optional[InputType] = Field(default="chat", description="The input type")
     output_type: Optional[OutputType] = Field(default="chat", description="The output type")
     output_component: Optional[str] = Field(

--- a/src/backend/base/langflow/components/inputs/ChatInput.py
+++ b/src/backend/base/langflow/components/inputs/ChatInput.py
@@ -24,6 +24,7 @@ class ChatInput(ChatComponent):
             display_name="Store Messages",
             info="Store the message in the history.",
             value=True,
+            advanced=True,
         ),
         DropdownInput(
             name="sender",

--- a/src/backend/base/langflow/components/outputs/ChatOutput.py
+++ b/src/backend/base/langflow/components/outputs/ChatOutput.py
@@ -22,6 +22,7 @@ class ChatOutput(ChatComponent):
             display_name="Store Messages",
             info="Store the message in the history.",
             value=True,
+            advanced=True,
         ),
         DropdownInput(
             name="sender",

--- a/src/backend/base/langflow/exceptions/api.py
+++ b/src/backend/base/langflow/exceptions/api.py
@@ -1,0 +1,2 @@
+class InvalidChatInputException(Exception):
+    pass

--- a/tests/data/SimpleAPITest.json
+++ b/tests/data/SimpleAPITest.json
@@ -1,9 +1,9 @@
 {
-    "id": "9f5e1c24-2b69-48e0-9f68-0c9c90ed703d",
+    "id": "e9380216-9300-41a1-bc35-7ee92fe4b30d",
     "data": {
         "nodes": [
             {
-                "id": "ChatInput-qBJin",
+                "id": "ChatInput-irFJf",
                 "type": "genericNode",
                 "position": {
                     "x": 180,
@@ -62,7 +62,7 @@
                                 "list": false,
                                 "show": true,
                                 "multiline": true,
-                                "value": "from langflow.base.data.utils import IMG_FILE_TYPES, TEXT_FILE_TYPES\nfrom langflow.base.io.chat import ChatComponent\nfrom langflow.io import DropdownInput, FileInput, MessageTextInput, MultilineInput, Output\nfrom langflow.schema.message import Message\n\n\nclass ChatInput(ChatComponent):\n    display_name = \"Chat Input\"\n    description = \"Get chat inputs from the Playground.\"\n    icon = \"ChatInput\"\n    name = \"ChatInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            value=\"\",\n            info=\"Message to be passed as input.\",\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[\"Machine\", \"User\"],\n            value=\"User\",\n            info=\"Type of sender.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=\"User\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\", display_name=\"Session ID\", info=\"Session ID for the message.\", advanced=True\n        ),\n        FileInput(\n            name=\"files\",\n            display_name=\"Files\",\n            file_types=TEXT_FILE_TYPES + IMG_FILE_TYPES,\n            info=\"Files to be sent with the message.\",\n            advanced=True,\n            is_list=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Message\", name=\"message\", method=\"message_response\"),\n    ]\n\n    def message_response(self) -> Message:\n        message = Message(\n            text=self.input_value,\n            sender=self.sender,\n            sender_name=self.sender_name,\n            session_id=self.session_id,\n            files=self.files,\n        )\n        if self.session_id and isinstance(message, Message) and isinstance(message.text, str):\n            self.store_message(message)\n            self.message.value = message\n\n        self.status = message\n        return message\n",
+                                "value": "from langflow.base.data.utils import IMG_FILE_TYPES, TEXT_FILE_TYPES\nfrom langflow.base.io.chat import ChatComponent\nfrom langflow.inputs import BoolInput\nfrom langflow.io import DropdownInput, FileInput, MessageTextInput, MultilineInput, Output\nfrom langflow.memory import store_message\nfrom langflow.schema.message import Message\n\n\nclass ChatInput(ChatComponent):\n    display_name = \"Chat Input\"\n    description = \"Get chat inputs from the Playground.\"\n    icon = \"ChatInput\"\n    name = \"ChatInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            value=\"\",\n            info=\"Message to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[\"Machine\", \"User\"],\n            value=\"User\",\n            info=\"Type of sender.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=\"User\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\", display_name=\"Session ID\", info=\"Session ID for the message.\", advanced=True\n        ),\n        FileInput(\n            name=\"files\",\n            display_name=\"Files\",\n            file_types=TEXT_FILE_TYPES + IMG_FILE_TYPES,\n            info=\"Files to be sent with the message.\",\n            advanced=True,\n            is_list=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Message\", name=\"message\", method=\"message_response\"),\n    ]\n\n    def message_response(self) -> Message:\n        message = Message(\n            text=self.input_value,\n            sender=self.sender,\n            sender_name=self.sender_name,\n            session_id=self.session_id,\n            files=self.files,\n        )\n\n        if self.session_id and isinstance(message, Message) and isinstance(message.text, str):\n            store_message(\n                message,\n                flow_id=self.graph.flow_id,\n            )\n            self.message.value = message\n\n        self.status = message\n        return message\n",
                                 "fileTypes": [],
                                 "file_path": "",
                                 "password": false,
@@ -151,6 +151,21 @@
                                 "info": "Session ID for the message.",
                                 "title_case": false,
                                 "type": "str"
+                            },
+                            "store_message": {
+                                "trace_as_metadata": true,
+                                "list": false,
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": true,
+                                "name": "store_message",
+                                "display_name": "Store Messages",
+                                "advanced": true,
+                                "dynamic": false,
+                                "info": "Store the message in the history.",
+                                "title_case": false,
+                                "type": "bool"
                             }
                         },
                         "description": "Get chat inputs from the Playground.",
@@ -180,6 +195,7 @@
                         ],
                         "field_order": [
                             "input_value",
+                            "store_message",
                             "sender",
                             "sender_name",
                             "session_id",
@@ -188,14 +204,16 @@
                         "beta": false,
                         "edited": false
                     },
-                    "id": "ChatInput-qBJin"
+                    "id": "ChatInput-irFJf",
+                    "description": "Get chat inputs from the Playground.",
+                    "display_name": "Chat Input"
                 },
                 "selected": false,
                 "width": 384,
                 "height": 309
             },
             {
-                "id": "TextInput-uORgD",
+                "id": "TextInput-tcoZg",
                 "type": "genericNode",
                 "position": {
                     "x": 186,
@@ -276,7 +294,7 @@
                         "beta": false,
                         "edited": false
                     },
-                    "id": "TextInput-uORgD"
+                    "id": "TextInput-tcoZg"
                 },
                 "selected": true,
                 "width": 384,
@@ -288,7 +306,7 @@
                 "dragging": false
             },
             {
-                "id": "ChatOutput-7pSZE",
+                "id": "ChatOutput-dJRst",
                 "type": "genericNode",
                 "position": {
                     "x": 820,
@@ -306,7 +324,7 @@
                                 "list": false,
                                 "show": true,
                                 "multiline": true,
-                                "value": "from langflow.base.io.chat import ChatComponent\nfrom langflow.io import DropdownInput, MessageTextInput, Output\nfrom langflow.schema.message import Message\n\n\nclass ChatOutput(ChatComponent):\n    display_name = \"Chat Output\"\n    description = \"Display a chat message in the Playground.\"\n    icon = \"ChatOutput\"\n    name = \"ChatOutput\"\n\n    inputs = [\n        MessageTextInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Message to be passed as output.\",\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[\"Machine\", \"User\"],\n            value=\"Machine\",\n            advanced=True,\n            info=\"Type of sender.\",\n        ),\n        MessageTextInput(\n            name=\"sender_name\", display_name=\"Sender Name\", info=\"Name of the sender.\", value=\"AI\", advanced=True\n        ),\n        MessageTextInput(\n            name=\"session_id\", display_name=\"Session ID\", info=\"Session ID for the message.\", advanced=True\n        ),\n        MessageTextInput(\n            name=\"data_template\",\n            display_name=\"Data Template\",\n            value=\"{text}\",\n            advanced=True,\n            info=\"Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.\",\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Message\", name=\"message\", method=\"message_response\"),\n    ]\n\n    def message_response(self) -> Message:\n        message = Message(\n            text=self.input_value,\n            sender=self.sender,\n            sender_name=self.sender_name,\n            session_id=self.session_id,\n        )\n        if self.session_id and isinstance(message, Message) and isinstance(message.text, str):\n            self.store_message(message)\n            self.message.value = message\n\n        self.status = message\n        return message\n",
+                                "value": "from langflow.base.io.chat import ChatComponent\nfrom langflow.inputs import BoolInput\nfrom langflow.io import DropdownInput, MessageTextInput, Output\nfrom langflow.memory import store_message\nfrom langflow.schema.message import Message\n\n\nclass ChatOutput(ChatComponent):\n    display_name = \"Chat Output\"\n    description = \"Display a chat message in the Playground.\"\n    icon = \"ChatOutput\"\n    name = \"ChatOutput\"\n\n    inputs = [\n        MessageTextInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Message to be passed as output.\",\n        ),\n        BoolInput(\n            name=\"store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[\"Machine\", \"User\"],\n            value=\"Machine\",\n            advanced=True,\n            info=\"Type of sender.\",\n        ),\n        MessageTextInput(\n            name=\"sender_name\", display_name=\"Sender Name\", info=\"Name of the sender.\", value=\"AI\", advanced=True\n        ),\n        MessageTextInput(\n            name=\"session_id\", display_name=\"Session ID\", info=\"Session ID for the message.\", advanced=True\n        ),\n        MessageTextInput(\n            name=\"data_template\",\n            display_name=\"Data Template\",\n            value=\"{text}\",\n            advanced=True,\n            info=\"Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.\",\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Message\", name=\"message\", method=\"message_response\"),\n    ]\n\n    def message_response(self) -> Message:\n        message = Message(\n            text=self.input_value,\n            sender=self.sender,\n            sender_name=self.sender_name,\n            session_id=self.session_id,\n        )\n        if self.session_id and isinstance(message, Message) and isinstance(message.text, str):\n            store_message(\n                message,\n                flow_id=self.graph.flow_id,\n            )\n            self.message.value = message\n\n        self.status = message\n        return message\n",
                                 "fileTypes": [],
                                 "file_path": "",
                                 "password": false,
@@ -386,7 +404,7 @@
                                 "value": "",
                                 "name": "sender_name",
                                 "display_name": "Sender Name",
-                                "advanced": false,
+                                "advanced": true,
                                 "input_types": [
                                     "Message"
                                 ],
@@ -414,6 +432,21 @@
                                 "info": "Session ID for the message.",
                                 "title_case": false,
                                 "type": "str"
+                            },
+                            "store_message": {
+                                "trace_as_metadata": true,
+                                "list": false,
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": true,
+                                "name": "store_message",
+                                "display_name": "Store Messages",
+                                "advanced": true,
+                                "dynamic": false,
+                                "info": "Store the message in the history.",
+                                "title_case": false,
+                                "type": "bool"
                             }
                         },
                         "description": "Display a chat message in the Playground.",
@@ -443,6 +476,7 @@
                         ],
                         "field_order": [
                             "input_value",
+                            "store_message",
                             "sender",
                             "sender_name",
                             "session_id",
@@ -451,7 +485,9 @@
                         "beta": false,
                         "edited": false
                     },
-                    "id": "ChatOutput-7pSZE"
+                    "id": "ChatOutput-dJRst",
+                    "description": "Display a chat message in the Playground.",
+                    "display_name": "Chat Output"
                 },
                 "selected": false,
                 "width": 384,
@@ -465,14 +501,14 @@
         ],
         "edges": [
             {
-                "source": "ChatInput-qBJin",
-                "sourceHandle": "{œdataTypeœ:œChatInputœ,œidœ:œChatInput-qBJinœ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}",
-                "target": "ChatOutput-7pSZE",
-                "targetHandle": "{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-7pSZEœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
+                "source": "ChatInput-irFJf",
+                "sourceHandle": "{œdataTypeœ:œChatInputœ,œidœ:œChatInput-irFJfœ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}",
+                "target": "ChatOutput-dJRst",
+                "targetHandle": "{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-dJRstœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
                 "data": {
                     "targetHandle": {
                         "fieldName": "input_value",
-                        "id": "ChatOutput-7pSZE",
+                        "id": "ChatOutput-dJRst",
                         "inputTypes": [
                             "Message"
                         ],
@@ -480,24 +516,25 @@
                     },
                     "sourceHandle": {
                         "dataType": "ChatInput",
-                        "id": "ChatInput-qBJin",
+                        "id": "ChatInput-irFJf",
                         "name": "message",
                         "output_types": [
                             "Message"
                         ]
                     }
                 },
-                "id": "reactflow__edge-ChatInput-qBJin{œdataTypeœ:œChatInputœ,œidœ:œChatInput-qBJinœ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}-ChatOutput-7pSZE{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-7pSZEœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}"
+                "id": "reactflow__edge-ChatInput-irFJf{œdataTypeœ:œChatInputœ,œidœ:œChatInput-irFJfœ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}-ChatOutput-dJRst{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-dJRstœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
+                "className": ""
             },
             {
-                "source": "TextInput-uORgD",
-                "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-uORgDœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-                "target": "ChatOutput-7pSZE",
-                "targetHandle": "{œfieldNameœ:œsender_nameœ,œidœ:œChatOutput-7pSZEœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
+                "source": "TextInput-tcoZg",
+                "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-tcoZgœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
+                "target": "ChatOutput-dJRst",
+                "targetHandle": "{œfieldNameœ:œsender_nameœ,œidœ:œChatOutput-dJRstœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
                 "data": {
                     "targetHandle": {
                         "fieldName": "sender_name",
-                        "id": "ChatOutput-7pSZE",
+                        "id": "ChatOutput-dJRst",
                         "inputTypes": [
                             "Message"
                         ],
@@ -505,14 +542,15 @@
                     },
                     "sourceHandle": {
                         "dataType": "TextInput",
-                        "id": "TextInput-uORgD",
+                        "id": "TextInput-tcoZg",
                         "name": "text",
                         "output_types": [
                             "Message"
                         ]
                     }
                 },
-                "id": "reactflow__edge-TextInput-uORgD{œdataTypeœ:œTextInputœ,œidœ:œTextInput-uORgDœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-ChatOutput-7pSZE{œfieldNameœ:œsender_nameœ,œidœ:œChatOutput-7pSZEœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}"
+                "id": "reactflow__edge-TextInput-tcoZg{œdataTypeœ:œTextInputœ,œidœ:œTextInput-tcoZgœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-ChatOutput-dJRst{œfieldNameœ:œsender_nameœ,œidœ:œChatOutput-dJRstœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
+                "className": ""
             }
         ],
         "viewport": {
@@ -523,7 +561,7 @@
     },
     "description": "Nurture NLP Nodes Here.",
     "name": "Simple API Test",
-    "last_tested_version": "1.0.8",
+    "last_tested_version": "1.0.9",
     "endpoint_name": null,
     "is_component": false
 }

--- a/tests/data/SimpleAPITest.json
+++ b/tests/data/SimpleAPITest.json
@@ -1,0 +1,529 @@
+{
+    "id": "9f5e1c24-2b69-48e0-9f68-0c9c90ed703d",
+    "data": {
+        "nodes": [
+            {
+                "id": "ChatInput-qBJin",
+                "type": "genericNode",
+                "position": {
+                    "x": 180,
+                    "y": 200.296875
+                },
+                "data": {
+                    "type": "ChatInput",
+                    "node": {
+                        "template": {
+                            "_type": "Component",
+                            "files": {
+                                "trace_as_metadata": true,
+                                "file_path": "",
+                                "fileTypes": [
+                                    "txt",
+                                    "md",
+                                    "mdx",
+                                    "csv",
+                                    "json",
+                                    "yaml",
+                                    "yml",
+                                    "xml",
+                                    "html",
+                                    "htm",
+                                    "pdf",
+                                    "docx",
+                                    "py",
+                                    "sh",
+                                    "sql",
+                                    "js",
+                                    "ts",
+                                    "tsx",
+                                    "jpg",
+                                    "jpeg",
+                                    "png",
+                                    "bmp",
+                                    "image"
+                                ],
+                                "list": true,
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": "",
+                                "name": "files",
+                                "display_name": "Files",
+                                "advanced": true,
+                                "dynamic": false,
+                                "info": "Files to be sent with the message.",
+                                "title_case": false,
+                                "type": "file"
+                            },
+                            "code": {
+                                "type": "code",
+                                "required": true,
+                                "placeholder": "",
+                                "list": false,
+                                "show": true,
+                                "multiline": true,
+                                "value": "from langflow.base.data.utils import IMG_FILE_TYPES, TEXT_FILE_TYPES\nfrom langflow.base.io.chat import ChatComponent\nfrom langflow.io import DropdownInput, FileInput, MessageTextInput, MultilineInput, Output\nfrom langflow.schema.message import Message\n\n\nclass ChatInput(ChatComponent):\n    display_name = \"Chat Input\"\n    description = \"Get chat inputs from the Playground.\"\n    icon = \"ChatInput\"\n    name = \"ChatInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            value=\"\",\n            info=\"Message to be passed as input.\",\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[\"Machine\", \"User\"],\n            value=\"User\",\n            info=\"Type of sender.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=\"User\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\", display_name=\"Session ID\", info=\"Session ID for the message.\", advanced=True\n        ),\n        FileInput(\n            name=\"files\",\n            display_name=\"Files\",\n            file_types=TEXT_FILE_TYPES + IMG_FILE_TYPES,\n            info=\"Files to be sent with the message.\",\n            advanced=True,\n            is_list=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Message\", name=\"message\", method=\"message_response\"),\n    ]\n\n    def message_response(self) -> Message:\n        message = Message(\n            text=self.input_value,\n            sender=self.sender,\n            sender_name=self.sender_name,\n            session_id=self.session_id,\n            files=self.files,\n        )\n        if self.session_id and isinstance(message, Message) and isinstance(message.text, str):\n            self.store_message(message)\n            self.message.value = message\n\n        self.status = message\n        return message\n",
+                                "fileTypes": [],
+                                "file_path": "",
+                                "password": false,
+                                "name": "code",
+                                "advanced": true,
+                                "dynamic": true,
+                                "info": "",
+                                "load_from_db": false,
+                                "title_case": false
+                            },
+                            "input_value": {
+                                "trace_as_input": true,
+                                "multiline": true,
+                                "trace_as_metadata": true,
+                                "load_from_db": false,
+                                "list": false,
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": "",
+                                "name": "input_value",
+                                "display_name": "Text",
+                                "advanced": false,
+                                "input_types": [
+                                    "Message"
+                                ],
+                                "dynamic": false,
+                                "info": "Message to be passed as input.",
+                                "title_case": false,
+                                "type": "str"
+                            },
+                            "sender": {
+                                "trace_as_metadata": true,
+                                "options": [
+                                    "Machine",
+                                    "User"
+                                ],
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": "User",
+                                "name": "sender",
+                                "display_name": "Sender Type",
+                                "advanced": true,
+                                "dynamic": false,
+                                "info": "Type of sender.",
+                                "title_case": false,
+                                "type": "str"
+                            },
+                            "sender_name": {
+                                "trace_as_input": true,
+                                "trace_as_metadata": true,
+                                "load_from_db": false,
+                                "list": false,
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": "User",
+                                "name": "sender_name",
+                                "display_name": "Sender Name",
+                                "advanced": true,
+                                "input_types": [
+                                    "Message"
+                                ],
+                                "dynamic": false,
+                                "info": "Name of the sender.",
+                                "title_case": false,
+                                "type": "str"
+                            },
+                            "session_id": {
+                                "trace_as_input": true,
+                                "trace_as_metadata": true,
+                                "load_from_db": false,
+                                "list": false,
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": "",
+                                "name": "session_id",
+                                "display_name": "Session ID",
+                                "advanced": true,
+                                "input_types": [
+                                    "Message"
+                                ],
+                                "dynamic": false,
+                                "info": "Session ID for the message.",
+                                "title_case": false,
+                                "type": "str"
+                            }
+                        },
+                        "description": "Get chat inputs from the Playground.",
+                        "icon": "ChatInput",
+                        "base_classes": [
+                            "Message"
+                        ],
+                        "display_name": "Chat Input",
+                        "documentation": "",
+                        "custom_fields": {},
+                        "output_types": [],
+                        "pinned": false,
+                        "conditional_paths": [],
+                        "frozen": false,
+                        "outputs": [
+                            {
+                                "types": [
+                                    "Message"
+                                ],
+                                "selected": "Message",
+                                "name": "message",
+                                "display_name": "Message",
+                                "method": "message_response",
+                                "value": "__UNDEFINED__",
+                                "cache": true
+                            }
+                        ],
+                        "field_order": [
+                            "input_value",
+                            "sender",
+                            "sender_name",
+                            "session_id",
+                            "files"
+                        ],
+                        "beta": false,
+                        "edited": false
+                    },
+                    "id": "ChatInput-qBJin"
+                },
+                "selected": false,
+                "width": 384,
+                "height": 309
+            },
+            {
+                "id": "TextInput-uORgD",
+                "type": "genericNode",
+                "position": {
+                    "x": 186,
+                    "y": 549.296875
+                },
+                "data": {
+                    "type": "TextInput",
+                    "node": {
+                        "template": {
+                            "_type": "Component",
+                            "code": {
+                                "type": "code",
+                                "required": true,
+                                "placeholder": "",
+                                "list": false,
+                                "show": true,
+                                "multiline": true,
+                                "value": "from langflow.base.io.text import TextComponent\nfrom langflow.io import MessageTextInput, Output\nfrom langflow.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get text inputs from the Playground.\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MessageTextInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def text_response(self) -> Message:\n        message = Message(\n            text=self.input_value,\n        )\n        return message\n",
+                                "fileTypes": [],
+                                "file_path": "",
+                                "password": false,
+                                "name": "code",
+                                "advanced": true,
+                                "dynamic": true,
+                                "info": "",
+                                "load_from_db": false,
+                                "title_case": false
+                            },
+                            "input_value": {
+                                "trace_as_input": true,
+                                "trace_as_metadata": true,
+                                "load_from_db": false,
+                                "list": false,
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": "AI",
+                                "name": "input_value",
+                                "display_name": "Text",
+                                "advanced": false,
+                                "input_types": [
+                                    "Message"
+                                ],
+                                "dynamic": false,
+                                "info": "Text to be passed as input.",
+                                "title_case": false,
+                                "type": "str"
+                            }
+                        },
+                        "description": "Get text inputs from the Playground.",
+                        "icon": "type",
+                        "base_classes": [
+                            "Message"
+                        ],
+                        "display_name": "Text Input",
+                        "documentation": "",
+                        "custom_fields": {},
+                        "output_types": [],
+                        "pinned": false,
+                        "conditional_paths": [],
+                        "frozen": false,
+                        "outputs": [
+                            {
+                                "types": [
+                                    "Message"
+                                ],
+                                "selected": "Message",
+                                "name": "text",
+                                "display_name": "Text",
+                                "method": "text_response",
+                                "value": "__UNDEFINED__",
+                                "cache": true
+                            }
+                        ],
+                        "field_order": [
+                            "input_value"
+                        ],
+                        "beta": false,
+                        "edited": false
+                    },
+                    "id": "TextInput-uORgD"
+                },
+                "selected": true,
+                "width": 384,
+                "height": 309,
+                "positionAbsolute": {
+                    "x": 186,
+                    "y": 549.296875
+                },
+                "dragging": false
+            },
+            {
+                "id": "ChatOutput-7pSZE",
+                "type": "genericNode",
+                "position": {
+                    "x": 820,
+                    "y": 224.296875
+                },
+                "data": {
+                    "type": "ChatOutput",
+                    "node": {
+                        "template": {
+                            "_type": "Component",
+                            "code": {
+                                "type": "code",
+                                "required": true,
+                                "placeholder": "",
+                                "list": false,
+                                "show": true,
+                                "multiline": true,
+                                "value": "from langflow.base.io.chat import ChatComponent\nfrom langflow.io import DropdownInput, MessageTextInput, Output\nfrom langflow.schema.message import Message\n\n\nclass ChatOutput(ChatComponent):\n    display_name = \"Chat Output\"\n    description = \"Display a chat message in the Playground.\"\n    icon = \"ChatOutput\"\n    name = \"ChatOutput\"\n\n    inputs = [\n        MessageTextInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Message to be passed as output.\",\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[\"Machine\", \"User\"],\n            value=\"Machine\",\n            advanced=True,\n            info=\"Type of sender.\",\n        ),\n        MessageTextInput(\n            name=\"sender_name\", display_name=\"Sender Name\", info=\"Name of the sender.\", value=\"AI\", advanced=True\n        ),\n        MessageTextInput(\n            name=\"session_id\", display_name=\"Session ID\", info=\"Session ID for the message.\", advanced=True\n        ),\n        MessageTextInput(\n            name=\"data_template\",\n            display_name=\"Data Template\",\n            value=\"{text}\",\n            advanced=True,\n            info=\"Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.\",\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Message\", name=\"message\", method=\"message_response\"),\n    ]\n\n    def message_response(self) -> Message:\n        message = Message(\n            text=self.input_value,\n            sender=self.sender,\n            sender_name=self.sender_name,\n            session_id=self.session_id,\n        )\n        if self.session_id and isinstance(message, Message) and isinstance(message.text, str):\n            self.store_message(message)\n            self.message.value = message\n\n        self.status = message\n        return message\n",
+                                "fileTypes": [],
+                                "file_path": "",
+                                "password": false,
+                                "name": "code",
+                                "advanced": true,
+                                "dynamic": true,
+                                "info": "",
+                                "load_from_db": false,
+                                "title_case": false
+                            },
+                            "data_template": {
+                                "trace_as_input": true,
+                                "trace_as_metadata": true,
+                                "load_from_db": false,
+                                "list": false,
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": "{text}",
+                                "name": "data_template",
+                                "display_name": "Data Template",
+                                "advanced": true,
+                                "input_types": [
+                                    "Message"
+                                ],
+                                "dynamic": false,
+                                "info": "Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.",
+                                "title_case": false,
+                                "type": "str"
+                            },
+                            "input_value": {
+                                "trace_as_input": true,
+                                "trace_as_metadata": true,
+                                "load_from_db": false,
+                                "list": false,
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": "",
+                                "name": "input_value",
+                                "display_name": "Text",
+                                "advanced": false,
+                                "input_types": [
+                                    "Message"
+                                ],
+                                "dynamic": false,
+                                "info": "Message to be passed as output.",
+                                "title_case": false,
+                                "type": "str"
+                            },
+                            "sender": {
+                                "trace_as_metadata": true,
+                                "options": [
+                                    "Machine",
+                                    "User"
+                                ],
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": "Machine",
+                                "name": "sender",
+                                "display_name": "Sender Type",
+                                "advanced": true,
+                                "dynamic": false,
+                                "info": "Type of sender.",
+                                "title_case": false,
+                                "type": "str"
+                            },
+                            "sender_name": {
+                                "trace_as_input": true,
+                                "trace_as_metadata": true,
+                                "load_from_db": false,
+                                "list": false,
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": "",
+                                "name": "sender_name",
+                                "display_name": "Sender Name",
+                                "advanced": false,
+                                "input_types": [
+                                    "Message"
+                                ],
+                                "dynamic": false,
+                                "info": "Name of the sender.",
+                                "title_case": false,
+                                "type": "str"
+                            },
+                            "session_id": {
+                                "trace_as_input": true,
+                                "trace_as_metadata": true,
+                                "load_from_db": false,
+                                "list": false,
+                                "required": false,
+                                "placeholder": "",
+                                "show": true,
+                                "value": "",
+                                "name": "session_id",
+                                "display_name": "Session ID",
+                                "advanced": true,
+                                "input_types": [
+                                    "Message"
+                                ],
+                                "dynamic": false,
+                                "info": "Session ID for the message.",
+                                "title_case": false,
+                                "type": "str"
+                            }
+                        },
+                        "description": "Display a chat message in the Playground.",
+                        "icon": "ChatOutput",
+                        "base_classes": [
+                            "Message"
+                        ],
+                        "display_name": "Chat Output",
+                        "documentation": "",
+                        "custom_fields": {},
+                        "output_types": [],
+                        "pinned": false,
+                        "conditional_paths": [],
+                        "frozen": false,
+                        "outputs": [
+                            {
+                                "types": [
+                                    "Message"
+                                ],
+                                "selected": "Message",
+                                "name": "message",
+                                "display_name": "Message",
+                                "method": "message_response",
+                                "value": "__UNDEFINED__",
+                                "cache": true
+                            }
+                        ],
+                        "field_order": [
+                            "input_value",
+                            "sender",
+                            "sender_name",
+                            "session_id",
+                            "data_template"
+                        ],
+                        "beta": false,
+                        "edited": false
+                    },
+                    "id": "ChatOutput-7pSZE"
+                },
+                "selected": false,
+                "width": 384,
+                "height": 403,
+                "positionAbsolute": {
+                    "x": 820,
+                    "y": 224.296875
+                },
+                "dragging": false
+            }
+        ],
+        "edges": [
+            {
+                "source": "ChatInput-qBJin",
+                "sourceHandle": "{œdataTypeœ:œChatInputœ,œidœ:œChatInput-qBJinœ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}",
+                "target": "ChatOutput-7pSZE",
+                "targetHandle": "{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-7pSZEœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
+                "data": {
+                    "targetHandle": {
+                        "fieldName": "input_value",
+                        "id": "ChatOutput-7pSZE",
+                        "inputTypes": [
+                            "Message"
+                        ],
+                        "type": "str"
+                    },
+                    "sourceHandle": {
+                        "dataType": "ChatInput",
+                        "id": "ChatInput-qBJin",
+                        "name": "message",
+                        "output_types": [
+                            "Message"
+                        ]
+                    }
+                },
+                "id": "reactflow__edge-ChatInput-qBJin{œdataTypeœ:œChatInputœ,œidœ:œChatInput-qBJinœ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}-ChatOutput-7pSZE{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-7pSZEœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}"
+            },
+            {
+                "source": "TextInput-uORgD",
+                "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-uORgDœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
+                "target": "ChatOutput-7pSZE",
+                "targetHandle": "{œfieldNameœ:œsender_nameœ,œidœ:œChatOutput-7pSZEœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
+                "data": {
+                    "targetHandle": {
+                        "fieldName": "sender_name",
+                        "id": "ChatOutput-7pSZE",
+                        "inputTypes": [
+                            "Message"
+                        ],
+                        "type": "str"
+                    },
+                    "sourceHandle": {
+                        "dataType": "TextInput",
+                        "id": "TextInput-uORgD",
+                        "name": "text",
+                        "output_types": [
+                            "Message"
+                        ]
+                    }
+                },
+                "id": "reactflow__edge-TextInput-uORgD{œdataTypeœ:œTextInputœ,œidœ:œTextInput-uORgDœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-ChatOutput-7pSZE{œfieldNameœ:œsender_nameœ,œidœ:œChatOutput-7pSZEœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}"
+            }
+        ],
+        "viewport": {
+            "x": -117,
+            "y": -69,
+            "zoom": 1
+        }
+    },
+    "description": "Nurture NLP Nodes Here.",
+    "name": "Simple API Test",
+    "last_tested_version": "1.0.8",
+    "endpoint_name": null,
+    "is_component": false
+}

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -606,6 +606,20 @@ def test_successful_run_with_input_type_chat(client, simple_api_test, created_ap
     ), chat_input_outputs
 
 
+def test_invalid_run_with_input_type_chat(client, simple_api_test, created_api_key):
+    headers = {"x-api-key": created_api_key.api_key}
+    flow_id = simple_api_test["id"]
+    payload = {
+        "input_type": "chat",
+        "output_type": "debug",
+        "input_value": "value1",
+        "tweaks": {"Chat Input": {"input_value": "value2"}},
+    }
+    response = client.post(f"/api/v1/run/{flow_id}", headers=headers, json=payload)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.text
+    assert "If you pass an input_value to the chat input, you cannot pass a tweak with the same name." in response.text
+
+
 def test_successful_run_with_input_type_any(client, simple_api_test, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
     flow_id = simple_api_test["id"]

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -455,7 +455,6 @@ def test_successful_run_no_payload(client, simple_api_test, created_api_key):
     assert all([result is not None for result in inner_results]), (outputs_dict, output_results_has_results)
 
 
-@pytest.mark.api_key_required
 def test_successful_run_with_output_type_text(client, simple_api_test, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
     flow_id = simple_api_test["id"]
@@ -486,7 +485,6 @@ def test_successful_run_with_output_type_text(client, simple_api_test, created_a
     assert all([key in result for result in inner_results for key in expected_keys]), outputs_dict
 
 
-@pytest.mark.api_key_required
 def test_successful_run_with_output_type_any(client, simple_api_test, created_api_key):
     # This one should have both the ChatOutput and TextOutput components
     headers = {"x-api-key": created_api_key.api_key}
@@ -518,7 +516,6 @@ def test_successful_run_with_output_type_any(client, simple_api_test, created_ap
     assert all([key in result for result in inner_results for key in expected_keys]), outputs_dict
 
 
-@pytest.mark.api_key_required
 def test_successful_run_with_output_type_debug(client, simple_api_test, created_api_key):
     # This one should return outputs for all components
     # Let's just check the amount of outputs(there should be 7)
@@ -544,8 +541,6 @@ def test_successful_run_with_output_type_debug(client, simple_api_test, created_
     assert len(outputs_dict.get("outputs")) == 3
 
 
-@pytest.mark.api_key_required
-# To test input_type wel'l just set it with output_type debug and check if the value is correct
 def test_successful_run_with_input_type_text(client, simple_api_test, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
     flow_id = simple_api_test["id"]
@@ -579,8 +574,6 @@ def test_successful_run_with_input_type_text(client, simple_api_test, created_ap
     ), text_input_outputs
 
 
-# Now do the same for "chat" input type
-@pytest.mark.api_key_required
 def test_successful_run_with_input_type_chat(client, simple_api_test, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
     flow_id = simple_api_test["id"]
@@ -613,7 +606,6 @@ def test_successful_run_with_input_type_chat(client, simple_api_test, created_ap
     ), chat_input_outputs
 
 
-@pytest.mark.api_key_required
 def test_successful_run_with_input_type_any(client, simple_api_test, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
     flow_id = simple_api_test["id"]

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -427,9 +427,9 @@ def test_build_vertex_invalid_vertex_id(client, added_flow_with_prompt_and_histo
 
 
 @pytest.mark.api_key_required
-def test_successful_run_no_payload(client, starter_project, created_api_key):
+def test_successful_run_no_payload(client, simple_api_test, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
-    flow_id = starter_project["id"]
+    flow_id = simple_api_test["id"]
     response = client.post(f"/api/v1/run/{flow_id}", headers=headers)
     assert response.status_code == status.HTTP_200_OK, response.text
     # Add more assertions here to validate the response content
@@ -456,9 +456,9 @@ def test_successful_run_no_payload(client, starter_project, created_api_key):
 
 
 @pytest.mark.api_key_required
-def test_successful_run_with_output_type_text(client, starter_project, created_api_key):
+def test_successful_run_with_output_type_text(client, simple_api_test, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
-    flow_id = starter_project["id"]
+    flow_id = simple_api_test["id"]
     payload = {
         "output_type": "text",
     }
@@ -487,10 +487,10 @@ def test_successful_run_with_output_type_text(client, starter_project, created_a
 
 
 @pytest.mark.api_key_required
-def test_successful_run_with_output_type_any(client, starter_project, created_api_key):
+def test_successful_run_with_output_type_any(client, simple_api_test, created_api_key):
     # This one should have both the ChatOutput and TextOutput components
     headers = {"x-api-key": created_api_key.api_key}
-    flow_id = starter_project["id"]
+    flow_id = simple_api_test["id"]
     payload = {
         "output_type": "any",
     }
@@ -519,11 +519,11 @@ def test_successful_run_with_output_type_any(client, starter_project, created_ap
 
 
 @pytest.mark.api_key_required
-def test_successful_run_with_output_type_debug(client, starter_project, created_api_key):
+def test_successful_run_with_output_type_debug(client, simple_api_test, created_api_key):
     # This one should return outputs for all components
     # Let's just check the amount of outputs(there should be 7)
     headers = {"x-api-key": created_api_key.api_key}
-    flow_id = starter_project["id"]
+    flow_id = simple_api_test["id"]
     payload = {
         "output_type": "debug",
     }
@@ -546,9 +546,9 @@ def test_successful_run_with_output_type_debug(client, starter_project, created_
 
 @pytest.mark.api_key_required
 # To test input_type wel'l just set it with output_type debug and check if the value is correct
-def test_successful_run_with_input_type_text(client, starter_project, created_api_key):
+def test_successful_run_with_input_type_text(client, simple_api_test, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
-    flow_id = starter_project["id"]
+    flow_id = simple_api_test["id"]
     payload = {
         "input_type": "text",
         "output_type": "debug",
@@ -578,9 +578,9 @@ def test_successful_run_with_input_type_text(client, starter_project, created_ap
 
 # Now do the same for "chat" input type
 @pytest.mark.api_key_required
-def test_successful_run_with_input_type_chat(client, starter_project, created_api_key):
+def test_successful_run_with_input_type_chat(client, simple_api_test, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
-    flow_id = starter_project["id"]
+    flow_id = simple_api_test["id"]
     payload = {
         "input_type": "chat",
         "output_type": "debug",
@@ -611,9 +611,9 @@ def test_successful_run_with_input_type_chat(client, starter_project, created_ap
 
 
 @pytest.mark.api_key_required
-def test_successful_run_with_input_type_any(client, starter_project, created_api_key):
+def test_successful_run_with_input_type_any(client, simple_api_test, created_api_key):
     headers = {"x-api-key": created_api_key.api_key}
-    flow_id = starter_project["id"]
+    flow_id = simple_api_test["id"]
     payload = {
         "input_type": "any",
         "output_type": "debug",


### PR DESCRIPTION
This pull request updates the Simple API Test fixture in the conftest.py file and modifies the test endpoints in the test_endpoints.py file. The changes ensure that the tests use the correct API test configuration and reflect the recent updates made to the codebase.

Update test assertions for successful runs with input types

The test assertions in the test_endpoints.py file have been updated to reflect the changes in the code. The assertions now correctly check the number of outputs and the values of the input_value for different input types. This ensures that the tests accurately verify the behavior of the API endpoints.

Remove api_key_required fixture from run endpoint tests

The api_key_required fixture has been removed from the run endpoint tests. This simplifies the test setup and ensures that the tests focus on the specific functionality being tested.

Update input_value default value in SimplifiedAPIRequest schema

The default value for the `input_value` field in the `SimplifiedAPIRequest` schema has been changed from an empty string to `None`. This ensures that the default value accurately represents the absence of an input value.

Add InvalidChatInputException to exceptions/api.py

This commit adds the `InvalidChatInputException` class to the `exceptions/api.py` file. This exception is raised when there is an invalid chat input value or tweak combination in the simplified run flow.

Validate input value and tweaks in simplified run flow