### PR TITLE
docs: add CNAME file for custom domain

### DIFF
--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,0 +1,1 @@
+docs.langflow.org


### PR DESCRIPTION
Added a new file `CNAME` to the `docs/static` directory. The file contains the custom domain `docs.langflow.org` for the documentation website.