### PR TITLE
fix: update condition to run end_all_traces

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -260,7 +260,7 @@ async def build_vertex(
         if graph.stop_vertex and graph.stop_vertex in next_runnable_vertices:
             next_runnable_vertices = [graph.stop_vertex]
 
-        if not graph.run_manager.vertices_to_run and not next_runnable_vertices:
+        if graph.run_manager.all_predecessors_are_fulfilled() and not next_runnable_vertices:
             background_tasks.add_task(graph.end_all_traces)
 
         build_response = VertexBuildResponse(

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -539,6 +539,8 @@ class Graph:
         """Marks a vertex in the graph."""
         vertex = self.get_vertex(vertex_id)
         vertex.set_state(state)
+        if state == VertexStates.INACTIVE:
+            self.run_manager.remove_from_predecessors(vertex_id)
 
     def mark_branch(self, vertex_id: str, state: str, visited: Optional[set] = None, output_name: Optional[str] = None):
         """Marks a branch of the graph."""

--- a/src/backend/base/langflow/graph/graph/runnable_vertices_manager.py
+++ b/src/backend/base/langflow/graph/graph/runnable_vertices_manager.py
@@ -41,6 +41,9 @@ class RunnableVerticesManager:
         self.run_predecessors = state["run_predecessors"]
         self.vertices_to_run = state["vertices_to_run"]
 
+    def all_predecessors_are_fulfilled(self) -> bool:
+        return all(not value for value in self.run_predecessors.values())
+
     def update_run_state(self, run_predecessors: dict, vertices_to_run: set):
         self.run_predecessors.update(run_predecessors)
         self.vertices_to_run.update(vertices_to_run)


### PR DESCRIPTION
This pull request adds a new method to the codebase that checks if all predecessors of a vertex are fulfilled. This method is used to determine if a vertex can be marked as inactive. Additionally, the code has been updated to remove a vertex from the predecessors when marking it as inactive. This improves the efficiency of the code and ensures that all traces are properly ended when necessary.