### PR TITLE
Fix: Clicking tags on share modal updates store immediately

### DIFF
--- a/src/frontend/src/components/tagsSelectorComponent/index.tsx
+++ b/src/frontend/src/components/tagsSelectorComponent/index.tsx
@@ -26,7 +26,7 @@ export function TagsSelector({
 
   return (
     <HorizontalScrollFadeComponent isFolder={false}>
-      {!loadingTags &&
+      {!loadingTags ? (
         tags.map((tag, idx) => (
           <button
             disabled={disabled}
@@ -35,7 +35,9 @@ export function TagsSelector({
                 ? "cursor-not-allowed"
                 : "overflow-hidden whitespace-nowrap"
             }
-            onClick={() => {
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
               updateTags(tag.name);
             }}
             key={idx}
@@ -54,7 +56,8 @@ export function TagsSelector({
               {tag.name}
             </Badge>
           </button>
-        ))}
+        ))
+      ) : []}
     </HorizontalScrollFadeComponent>
   );
 }

--- a/src/frontend/src/components/tagsSelectorComponent/index.tsx
+++ b/src/frontend/src/components/tagsSelectorComponent/index.tsx
@@ -26,38 +26,38 @@ export function TagsSelector({
 
   return (
     <HorizontalScrollFadeComponent isFolder={false}>
-      {!loadingTags ? (
-        tags.map((tag, idx) => (
-          <button
-            disabled={disabled}
-            className={
-              disabled
-                ? "cursor-not-allowed"
-                : "overflow-hidden whitespace-nowrap"
-            }
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              updateTags(tag.name);
-            }}
-            key={idx}
-            data-testid={`tag-selector-${tag.name}`}
-          >
-            <Badge
+      {!loadingTags
+        ? tags.map((tag, idx) => (
+            <button
+              disabled={disabled}
+              className={
+                disabled
+                  ? "cursor-not-allowed"
+                  : "overflow-hidden whitespace-nowrap"
+              }
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                updateTags(tag.name);
+              }}
               key={idx}
-              variant="outline"
-              size="sq"
-              className={cn(
-                selectedTags.some((category) => category === tag.name)
-                  ? "min-w-min bg-beta-foreground text-background hover:bg-beta-foreground"
-                  : "",
-              )}
+              data-testid={`tag-selector-${tag.name}`}
             >
-              {tag.name}
-            </Badge>
-          </button>
-        ))
-      ) : []}
+              <Badge
+                key={idx}
+                variant="outline"
+                size="sq"
+                className={cn(
+                  selectedTags.some((category) => category === tag.name)
+                    ? "min-w-min bg-beta-foreground text-background hover:bg-beta-foreground"
+                    : "",
+                )}
+              >
+                {tag.name}
+              </Badge>
+            </button>
+          ))
+        : []}
     </HorizontalScrollFadeComponent>
   );
 }


### PR DESCRIPTION
This PR addresses a bug where selecting tags on the share modal would immediately update the store without requiring a confirmation click. The changes ensure that the changes are only dispatched to the store after the user clicks the confirmation button.