### PR TITLE
fix: update chat components to make them backwards compatible

### DIFF
--- a/src/backend/base/langflow/base/io/chat.py
+++ b/src/backend/base/langflow/base/io/chat.py
@@ -49,6 +49,19 @@ class ChatComponent(Component):
             },
         }
 
+    # Keep this method for backward compatibility
+    def store_message(
+        self,
+        message: Message,
+    ) -> list[Message]:
+        messages = store_message(
+            message,
+            flow_id=self.graph.flow_id,
+        )
+
+        self.status = messages
+        return messages
+
     def build_with_data(
         self,
         sender: Optional[str] = "User",

--- a/src/backend/base/langflow/components/inputs/ChatInput.py
+++ b/src/backend/base/langflow/components/inputs/ChatInput.py
@@ -20,7 +20,7 @@ class ChatInput(ChatComponent):
             info="Message to be passed as input.",
         ),
         BoolInput(
-            name="store_message",
+            name="should_store_message",
             display_name="Store Messages",
             info="Store the message in the history.",
             value=True,
@@ -66,7 +66,12 @@ class ChatInput(ChatComponent):
             files=self.files,
         )
 
-        if self.session_id and isinstance(message, Message) and isinstance(message.text, str):
+        if (
+            self.session_id
+            and isinstance(message, Message)
+            and isinstance(message.text, str)
+            and self.should_store_message
+        ):
             store_message(
                 message,
                 flow_id=self.graph.flow_id,

--- a/src/backend/base/langflow/components/outputs/ChatOutput.py
+++ b/src/backend/base/langflow/components/outputs/ChatOutput.py
@@ -57,7 +57,7 @@ class ChatOutput(ChatComponent):
             sender_name=self.sender_name,
             session_id=self.session_id,
         )
-        if self.session_id and isinstance(message, Message) and isinstance(message.text, str):
+        if self.session_id and isinstance(message, Message) and isinstance(message.text, str) and self.store_message:
             store_message(
                 message,
                 flow_id=self.graph.flow_id,

--- a/src/backend/base/langflow/components/outputs/ChatOutput.py
+++ b/src/backend/base/langflow/components/outputs/ChatOutput.py
@@ -18,7 +18,7 @@ class ChatOutput(ChatComponent):
             info="Message to be passed as output.",
         ),
         BoolInput(
-            name="store_message",
+            name="should_store_message",
             display_name="Store Messages",
             info="Store the message in the history.",
             value=True,
@@ -57,7 +57,12 @@ class ChatOutput(ChatComponent):
             sender_name=self.sender_name,
             session_id=self.session_id,
         )
-        if self.session_id and isinstance(message, Message) and isinstance(message.text, str) and self.store_message:
+        if (
+            self.session_id
+            and isinstance(message, Message)
+            and isinstance(message.text, str)
+            and self.should_store_message
+        ):
             store_message(
                 message,
                 flow_id=self.graph.flow_id,


### PR DESCRIPTION
Restores `store_message` method so chat components stay backwards compatible and rename inputs so they don't collide with the method's name.