### PR TITLE
chore: make error messages more generic

### DIFF
--- a/src/backend/base/langflow/custom/utils.py
+++ b/src/backend/base/langflow/custom/utils.py
@@ -393,9 +393,7 @@ def build_custom_component_template(
                 detail={
                     "error": (
                         "Please check if you are importing Component correctly."
-                        " It should be `from langflow.custom import Component`"
                     ),
-                    "traceback": traceback.format_exc(),
                 },
             )
         if "inputs" in custom_component.template_config:

--- a/src/backend/base/langflow/custom/utils.py
+++ b/src/backend/base/langflow/custom/utils.py
@@ -391,9 +391,7 @@ def build_custom_component_template(
             raise HTTPException(
                 status_code=400,
                 detail={
-                    "error": (
-                        "Please check if you are importing Component correctly."
-                    ),
+                    "error": ("Please check if you are importing Component correctly."),
                 },
             )
         if "inputs" in custom_component.template_config:


### PR DESCRIPTION
When attempting to import a non-existent library, the editor reports an import error, suggests a correction, and is supposed to display a traceback. However, the suggested correction is nonsensical, and there is no traceback information available to be returned.

![20240716110028_825x709](https://github.com/user-attachments/assets/f8161d09-8963-435f-ada4-cfcccacfa304)

This PR adjusts the error message to be more generic and removes the correction suggestion and traceback data.