### PR TITLE
fix: component card, streaming bug and fields order

### DIFF
--- a/src/frontend/src/components/cardComponent/index.tsx
+++ b/src/frontend/src/components/cardComponent/index.tsx
@@ -43,7 +43,6 @@ export default function CollectionCardComponent({
   onDelete,
   playground,
   control,
-  is_component,
 }: {
   data: storeComponent;
   authorized?: boolean;
@@ -53,7 +52,6 @@ export default function CollectionCardComponent({
   playground?: boolean;
   onDelete?: () => void;
   control?: Control<any, any>;
-  is_component?: boolean;
 }) {
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const setErrorData = useAlertStore((state) => state.setErrorData);
@@ -73,7 +71,6 @@ export default function CollectionCardComponent({
   const setNodes = useFlowStore((state) => state.setNodes);
   const setEdges = useFlowStore((state) => state.setEdges);
   const [openPlayground, setOpenPlayground] = useState(false);
-  const [openDelete, setOpenDelete] = useState(false);
   const setCurrentFlowId = useFlowsManagerStore(
     (state) => state.setCurrentFlowId,
   );
@@ -167,7 +164,9 @@ export default function CollectionCardComponent({
         data-testid={`card-${convertTestName(data.name)}`}
         //TODO check color schema
         className={cn(
-          "group relative flex h-[11rem] flex-col justify-between overflow-hidden hover:bg-muted/50 hover:shadow-md hover:dark:bg-[#5f5f5f0e]",
+          "group relative flex h-[11rem] flex-col justify-between overflow-hidden",
+          !data.is_component &&
+            "hover:bg-muted/50 hover:shadow-md hover:dark:bg-[#5f5f5f0e]",
           disabled ? "pointer-events-none opacity-50" : "",
           onClick ? "cursor-pointer" : "",
           isSelectedCard ? "border border-selected" : "",
@@ -517,18 +516,6 @@ export default function CollectionCardComponent({
         >
           <></>
         </IOModal>
-      )}
-      {openDelete && (
-        <DeleteConfirmationModal
-          open={openDelete}
-          setOpen={setOpenDelete}
-          onConfirm={() => {
-            if (onDelete) onDelete();
-          }}
-          description={` ${is_component ? "component" : "flow"}`}
-        >
-          <></>
-        </DeleteConfirmationModal>
       )}
     </>
   );

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -853,6 +853,8 @@ export const TITLE_ERROR_UPDATING_COMPONENT =
 
 export const EMPTY_INPUT_SEND_MESSAGE = "No input message provided.";
 
+export const EMPTY_OUTPUT_SEND_MESSAGE = "Message empty.";
+
 export const TABS_ORDER = [
   "run curl",
   "python api",

--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/index.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/index.tsx
@@ -9,7 +9,10 @@ import Robot from "../../../../../assets/robot.png";
 import CodeTabsComponent from "../../../../../components/codeTabsComponent";
 import IconComponent from "../../../../../components/genericIconComponent";
 import SanitizedHTMLWrapper from "../../../../../components/sanitizedHTMLWrapper";
-import { EMPTY_INPUT_SEND_MESSAGE } from "../../../../../constants/constants";
+import {
+  EMPTY_INPUT_SEND_MESSAGE,
+  EMPTY_OUTPUT_SEND_MESSAGE,
+} from "../../../../../constants/constants";
 import useAlertStore from "../../../../../stores/alertStore";
 import useFlowStore from "../../../../../stores/flowStore";
 import { chatMessagePropsType } from "../../../../../types/components";
@@ -251,8 +254,8 @@ export default function ChatMessage({
                               },
                             }}
                           >
-                            {chatMessage === ""
-                              ? EMPTY_INPUT_SEND_MESSAGE
+                            {chatMessage === "" && !chat.stream_url
+                              ? EMPTY_OUTPUT_SEND_MESSAGE
                               : chatMessage}
                           </Markdown>
                         ),
@@ -286,10 +289,8 @@ export default function ChatMessage({
                   className={cn(
                     "prose word-break-break-word dark:prose-invert",
                     chatMessage !== ""
-                      ? EMPTY_INPUT_SEND_MESSAGE
-                      : chatMessage
-                        ? "text-primary"
-                        : "text-chat-trigger-disabled",
+                      ? "text-primary"
+                      : "text-chat-trigger-disabled",
                   )}
                 >
                   {promptOpen

--- a/src/frontend/src/modals/editNodeModal/hooks/use-row-data.tsx
+++ b/src/frontend/src/modals/editNodeModal/hooks/use-row-data.tsx
@@ -1,5 +1,5 @@
+import sortFields from "@/CustomNodes/utils/sort-fields";
 import { useMemo } from "react";
-import { LANGFLOW_SUPPORTED_TYPES } from "../../../constants/constants";
 import { APIClassType } from "../../../types/api";
 import { NodeDataType } from "../../../types/flow";
 
@@ -21,6 +21,7 @@ const useRowData = (
           )
         );
       })
+      .sort((a, b) => sortFields(a, b, myData.node?.field_order ?? []))
       .map((key: string) => {
         const templateParam = myData.node!.template[key] as any;
         return {

--- a/src/frontend/src/pages/MainPage/components/componentsComponent/components/collectionCard/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/componentsComponent/components/collectionCard/index.tsx
@@ -44,7 +44,6 @@ const CollectionCard = ({ item, type, isLoading, control }) => {
     }
     return null;
   };
-  console.log(type);
 
   return (
     <CollectionCardComponent

--- a/src/frontend/src/pages/MainPage/components/componentsComponent/components/collectionCard/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/componentsComponent/components/collectionCard/index.tsx
@@ -44,10 +44,10 @@ const CollectionCard = ({ item, type, isLoading, control }) => {
     }
     return null;
   };
+  console.log(type);
 
   return (
     <CollectionCardComponent
-      is_component={type === "component"}
       data={{
         is_component: isComponent,
         ...item,

--- a/src/frontend/src/pages/MainPage/components/componentsComponent/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/componentsComponent/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import CollectionCardComponent from "../../../../components/cardComponent";
 import CardsWrapComponent from "../../../../components/cardsWrapComponent";
 import IconComponent from "../../../../components/genericIconComponent";
 import PaginatorComponent from "../../../../components/paginatorComponent";


### PR DESCRIPTION
## This PR fixes the following bugs:

- Empty message should not contain notice of empty message if the message is coming as a stream
- Order of the fields in the Advanced page should be the same of the code
- Component shouldn't appear as clickable on main screen