### PR TITLE
fix: sorting on advanced modal parameters

### DIFF
--- a/src/frontend/src/modals/editNodeModal/hooks/use-row-data.tsx
+++ b/src/frontend/src/modals/editNodeModal/hooks/use-row-data.tsx
@@ -1,5 +1,5 @@
+import sortFields from "@/CustomNodes/utils/sort-fields";
 import { useMemo } from "react";
-import { LANGFLOW_SUPPORTED_TYPES } from "../../../constants/constants";
 import { APIClassType } from "../../../types/api";
 import { NodeDataType } from "../../../types/flow";
 
@@ -21,6 +21,7 @@ const useRowData = (
           )
         );
       })
+      .sort((a, b) => sortFields(a, b, myData.node?.field_order ?? []))
       .map((key: string) => {
         const templateParam = myData.node!.template[key] as any;
         return {


### PR DESCRIPTION
### This PR fixes this bug:
- Order of the fields in the Advanced page should be the same of the code