### PR TITLE
ci: update conditions at which CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ on:
         description: "Store API Key"
         required: false
         type: string
-  pull_request:
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,6 +25,8 @@ concurrency:
 
 jobs:
   path-filter:
+    # should run if the PR is approved,or if it's a manual run or if it is not a draft PR
+    if: ${{github.event.review.state == 'APPROVED' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false}}
     name: Filter Paths
     runs-on: ubuntu-latest
     outputs:
@@ -74,8 +77,7 @@ jobs:
   ci_success:
     name: "CI Success"
     needs: [test-backend, test-frontend, lint-backend, test-docs-build]
-    if: |
-      always()
+    if: always()
     runs-on: ubuntu-latest
     env:
       JOBS_JSON: ${{ toJSON(needs) }}

--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -3,7 +3,9 @@
 name: Label PRs with Conventional Commits
 on:
   pull_request_target:
-    types: [ opened, edited , reopened, auto_merge_enabled]
+    types: [opened, edited]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   validate-pr:


### PR DESCRIPTION
CI should run only when a PR is approved or by workflow_dispatch.

Conventional labels was updated as well to run less often.