### PR TITLE
ci: add auto_merge_enabled to pull_request types in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ on:
         description: "Store API Key"
         required: false
         type: string
+  pull_request:
+    types: [auto_merge_enabled]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
Add auto_merge_enabled so we can force CI to run more easily.