### PR TITLE
refactor: update tools output type to Tool

### DIFF
--- a/src/backend/base/langflow/base/langchain_utilities/model.py
+++ b/src/backend/base/langflow/base/langchain_utilities/model.py
@@ -1,11 +1,10 @@
 from abc import abstractmethod
 from typing import Union
 
-
 from langflow.custom import Component
+from langflow.field_typing import Tool
 from langflow.io import Output
 from langflow.schema import Data
-from langchain_core.tools import BaseTool
 
 
 class LCToolComponent(Component):
@@ -32,7 +31,7 @@ class LCToolComponent(Component):
         pass
 
     @abstractmethod
-    def build_tool(self) -> BaseTool:
+    def build_tool(self) -> Tool:
         """
         Build the tool.
         """

--- a/src/backend/base/langflow/components/tools/BingSearchAPI.py
+++ b/src/backend/base/langflow/components/tools/BingSearchAPI.py
@@ -2,8 +2,7 @@ from typing import List
 
 from langchain_community.tools.bing_search import BingSearchResults
 from langchain_community.utilities import BingSearchAPIWrapper
-from langchain_core.tools import BaseTool
-
+from langflow.field_typing import Tool
 from langflow.base.langchain_utilities.model import LCToolComponent
 from langflow.inputs import IntInput, MessageTextInput, MultilineInput, SecretStrInput
 from langflow.schema import Data
@@ -36,7 +35,7 @@ class BingSearchAPIComponent(LCToolComponent):
         self.status = data
         return data
 
-    def build_tool(self) -> BaseTool:
+    def build_tool(self) -> Tool:
         if self.bing_search_url:
             wrapper = BingSearchAPIWrapper(
                 bing_search_url=self.bing_search_url, bing_subscription_key=self.bing_subscription_key

--- a/src/backend/base/langflow/components/tools/BingSearchAPI.py
+++ b/src/backend/base/langflow/components/tools/BingSearchAPI.py
@@ -1,9 +1,10 @@
-from typing import List
+from typing import List, cast
 
 from langchain_community.tools.bing_search import BingSearchResults
 from langchain_community.utilities import BingSearchAPIWrapper
-from langflow.field_typing import Tool
+
 from langflow.base.langchain_utilities.model import LCToolComponent
+from langflow.field_typing import Tool
 from langflow.inputs import IntInput, MessageTextInput, MultilineInput, SecretStrInput
 from langflow.schema import Data
 
@@ -42,4 +43,4 @@ class BingSearchAPIComponent(LCToolComponent):
             )
         else:
             wrapper = BingSearchAPIWrapper(bing_subscription_key=self.bing_subscription_key)  # type: ignore
-        return BingSearchResults(api_wrapper=wrapper, num_results=self.k)
+        return cast(Tool, BingSearchResults(api_wrapper=wrapper, num_results=self.k))

--- a/src/backend/base/langflow/components/tools/GoogleSearchAPI.py
+++ b/src/backend/base/langflow/components/tools/GoogleSearchAPI.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from langchain_core.tools import BaseTool, Tool
+from langchain_core.tools import Tool
 
 from langflow.base.langchain_utilities.model import LCToolComponent
 from langflow.inputs import SecretStrInput, MultilineInput, IntInput
@@ -29,7 +29,7 @@ class GoogleSearchAPIComponent(LCToolComponent):
         self.status = data
         return data
 
-    def build_tool(self) -> BaseTool:
+    def build_tool(self) -> Tool:
         wrapper = self._build_wrapper()
         return Tool(
             name="google_search",

--- a/src/backend/base/langflow/components/tools/GoogleSerperAPI.py
+++ b/src/backend/base/langflow/components/tools/GoogleSerperAPI.py
@@ -2,10 +2,10 @@ from typing import Union
 
 from langchain_community.utilities.google_serper import GoogleSerperAPIWrapper
 
-from langchain_core.tools import BaseTool, Tool
 from langflow.base.langchain_utilities.model import LCToolComponent
 from langflow.inputs import SecretStrInput, MultilineInput, IntInput
 from langflow.schema import Data
+from langflow.field_typing import Tool
 
 
 class GoogleSerperAPIComponent(LCToolComponent):
@@ -30,7 +30,7 @@ class GoogleSerperAPIComponent(LCToolComponent):
         self.status = data
         return data
 
-    def build_tool(self) -> BaseTool:
+    def build_tool(self) -> Tool:
         wrapper = self._build_wrapper()
         return Tool(
             name="google_search",

--- a/src/backend/base/langflow/components/tools/SearchAPI.py
+++ b/src/backend/base/langflow/components/tools/SearchAPI.py
@@ -3,9 +3,9 @@ from typing import Union
 from langchain_community.utilities.searchapi import SearchApiAPIWrapper
 
 from langflow.base.langchain_utilities.model import LCToolComponent
-from langchain_core.tools import BaseTool, Tool
 from langflow.inputs import SecretStrInput, MultilineInput, DictInput, MessageTextInput
 from langflow.schema import Data
+from langflow.field_typing import Tool
 
 
 class SearchAPIComponent(LCToolComponent):
@@ -32,7 +32,7 @@ class SearchAPIComponent(LCToolComponent):
         self.status = data
         return data
 
-    def build_tool(self) -> BaseTool:
+    def build_tool(self) -> Tool:
         wrapper = self._build_wrapper()
         return Tool(
             name="search_api",

--- a/src/backend/base/langflow/components/tools/SerpAPI.py
+++ b/src/backend/base/langflow/components/tools/SerpAPI.py
@@ -1,9 +1,9 @@
 from langchain_community.utilities.serpapi import SerpAPIWrapper
 
 from langflow.base.langchain_utilities.model import LCToolComponent
-from langchain_core.tools import BaseTool, Tool
 from langflow.inputs import SecretStrInput, DictInput, MultilineInput
 from langflow.schema import Data
+from langflow.field_typing import Tool
 
 
 class SerpAPIComponent(LCToolComponent):
@@ -28,7 +28,7 @@ class SerpAPIComponent(LCToolComponent):
         self.status = data
         return data
 
-    def build_tool(self) -> BaseTool:
+    def build_tool(self) -> Tool:
         wrapper = self._build_wrapper()
         return Tool(name="search_api", description="Search for recent results.", func=wrapper.run)
 

--- a/src/backend/base/langflow/components/tools/WikipediaAPI.py
+++ b/src/backend/base/langflow/components/tools/WikipediaAPI.py
@@ -1,8 +1,9 @@
+from langchain.tools import WikipediaQueryRun
 from langchain_community.utilities.wikipedia import WikipediaAPIWrapper
 
 from langflow.base.langchain_utilities.model import LCToolComponent
-from langchain.tools import WikipediaQueryRun, BaseTool
-from langflow.inputs import IntInput, MessageTextInput, BoolInput, MultilineInput
+from langflow.field_typing import Tool
+from langflow.inputs import BoolInput, IntInput, MessageTextInput, MultilineInput
 from langflow.schema import Data
 
 
@@ -31,7 +32,7 @@ class WikipediaAPIComponent(LCToolComponent):
         self.status = data
         return data
 
-    def build_tool(self) -> BaseTool:
+    def build_tool(self) -> Tool:
         wrapper = self._build_wrapper()
         return WikipediaQueryRun(api_wrapper=wrapper)
 

--- a/src/backend/base/langflow/components/tools/WolframAlphaAPI.py
+++ b/src/backend/base/langflow/components/tools/WolframAlphaAPI.py
@@ -1,7 +1,7 @@
 from langchain_community.utilities.wolfram_alpha import WolframAlphaAPIWrapper
 
 from langflow.base.langchain_utilities.model import LCToolComponent
-from langchain.tools import BaseTool, Tool
+from langflow.field_typing import Tool
 from langflow.inputs import MultilineInput, SecretStrInput
 from langflow.schema import Data
 
@@ -26,7 +26,7 @@ class WolframAlphaAPIComponent(LCToolComponent):
         self.status = data
         return data
 
-    def build_tool(self) -> BaseTool:
+    def build_tool(self) -> Tool:
         wrapper = self._build_wrapper()
         return Tool(name="wolfram_alpha_api", description="Answers mathematical questions.", func=wrapper.run)
 


### PR DESCRIPTION
This pull request refactors the output type of the tools in the codebase to use the `Tool` class from the `langflow.field_typing` module. This change ensures consistency and improves the readability of the code.