### PR TITLE
fix(OpenAIModel): Move seed assignment to correct position

### DIFF
--- a/src/backend/base/langflow/components/models/OpenAIModel.py
+++ b/src/backend/base/langflow/components/models/OpenAIModel.py
@@ -93,7 +93,6 @@ class OpenAIModelComponent(LCModelComponent):
         openai_api_base = self.openai_api_base or "https://api.openai.com/v1"
         json_mode = bool(output_schema_dict) or self.json_mode
         seed = self.seed
-        model_kwargs["seed"] = seed
 
         if openai_api_key:
             api_key = SecretStr(openai_api_key)
@@ -106,6 +105,7 @@ class OpenAIModelComponent(LCModelComponent):
             base_url=openai_api_base,
             api_key=api_key,
             temperature=temperature or 0.1,
+            seed=seed
         )
         if json_mode:
             if output_schema_dict:


### PR DESCRIPTION
This pull request addresses a bug in the `OpenAIModel` class within the `build_model` method, specifically related to the incorrect assignment position of the `seed` parameter.

#### Details

- **File Affected**: `src/backend/base/langflow/components/models/OpenAIModel.py`
- The `seed` parameter assignment was moved to the correct position within the `OpenAIModel` initialization block.

#### Impact

This change ensures that the `seed` parameter is correctly passed to the `OpenAIModel` during its initialization, which helps maintain consistent and reproducible results when the model is used.

#### Testing

- Verified that the `seed` parameter is correctly assigned and utilized within the `OpenAIModel`.
- Ensured that the model initialization works as expected with the corrected `seed` parameter.

