### PR TITLE
fix (typescript_test) : change cache-key to avoid errors

### DIFF
--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -94,7 +94,8 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           poetry-version: ${{ env.POETRY_VERSION }}
-          cache-key: ${{ runner.os }}-poetry-${{ env.POETRY_VERSION }}-${{ hashFiles('**/poetry.lock') }}
+          cache-key: tests
+
       - name: Install Python dependencies
         run: |
           poetry env use ${{ env.PYTHON_VERSION }}


### PR DESCRIPTION
The `hashFiles` function was causing an error  in some instances but it is not needed since it is called by the poetry_caching action.