### PR TITLE
fix(readme): correct urls in documentation

### DIFF
--- a/README.PT.md
+++ b/README.PT.md
@@ -13,7 +13,7 @@
     <a href="https://docs.langflow.org" style="text-decoration: underline;">Docs</a> -
     <a href="https://discord.com/invite/EqksyE2EX9" style="text-decoration: underline;">Junte-se ao nosso Discord</a> -
     <a href="https://twitter.com/langflow_ai" style="text-decoration: underline;">Siga-nos no X</a> -
-    <a href="https://huggingface.co/spaces/Langflow/Langflow-Preview" style="text-decoration: underline;">Demonstração</a>
+    <a href="https://huggingface.co/spaces/Langflow/Langflow" style="text-decoration: underline;">Demonstração</a>
 </p>
 
 <p align="center">
@@ -69,7 +69,7 @@ Então, execute o Langflow com:
 python -m langflow run
 ```
 
-Você também pode visualizar o Langflow no [HuggingFace Spaces](https://huggingface.co/spaces/Langflow/Langflow-Preview). [Clone o Space usando este link](https://huggingface.co/spaces/Langflow/Langflow-Preview?duplicate=true) para criar seu próprio workspace do Langflow em minutos.
+Você também pode visualizar o Langflow no [HuggingFace Spaces](https://huggingface.co/spaces/Langflow/Langflow). [Clone o Space usando este link](https://huggingface.co/spaces/Langflow/Langflow?duplicate=true) para criar seu próprio workspace do Langflow em minutos.
 
 # 🎨 Criar Fluxos
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     <a href="https://docs.langflow.org" style="text-decoration: underline;">Docs</a> -
     <a href="https://discord.com/invite/EqksyE2EX9" style="text-decoration: underline;">Join our Discord</a> -
     <a href="https://twitter.com/langflow_ai" style="text-decoration: underline;">Follow us on X</a> -
-    <a href="https://huggingface.co/spaces/Langflow/Langflow-Preview" style="text-decoration: underline;">Live demo</a>
+    <a href="https://huggingface.co/spaces/Langflow/Langflow" style="text-decoration: underline;">Live demo</a>
 </p>
 
 <p align="center">
@@ -105,7 +105,7 @@ DataStax Langflow is a hosted version of Langflow integrated with [AstraDB](http
 
 ## Deploy Langflow on Hugging Face Spaces
 
-You can also preview Langflow in [HuggingFace Spaces](https://huggingface.co/spaces/Langflow/Langflow-Preview). [Clone the space using this link](https://huggingface.co/spaces/Langflow/Langflow-Preview?duplicate=true) to create your own Langflow workspace in minutes.
+You can also preview Langflow in [HuggingFace Spaces](https://huggingface.co/spaces/Langflow/Langflow). [Clone the space using this link](https://huggingface.co/spaces/Langflow/Langflow?duplicate=true) to create your own Langflow workspace in minutes.
 
 ## Deploy Langflow on Google Cloud Platform
 


### PR DESCRIPTION
[Fixed all hugginface links in readme files. Which were redirecting to old link which is throwing 404 error right now. Its fixed in all language readme files](https://github.com/langflow-ai/langflow/pull/2794)