### PR TITLE
ci: update path-filter job condition in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
   pull_request:
-    types: [auto_merge_enabled]
+    types: [synchronize]
   pull_request_review:
     types: [submitted]
 
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   path-filter:
     # should run if the PR is approved,or if it's a manual run or if it is not a draft PR
-    if: ${{github.event.review.state == 'APPROVED' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false}}
+    if: ${{ (github.event.review.state == 'APPROVED' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' }}
     name: Filter Paths
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
The path-filter job condition in ci.yml has been updated to include an additional check for the 'workflow_dispatch' event. This change ensures that the job runs when the event is triggered manually, in addition to when the pull request is approved or when it is not a draft PR. The updated condition improves the flexibility and coverage of the path-filter job.