### PR TITLE
fix: add correctly switch case to components on sidebar

### DIFF
--- a/src/frontend/src/components/headerComponent/index.tsx
+++ b/src/frontend/src/components/headerComponent/index.tsx
@@ -134,7 +134,7 @@ export default function Header(): JSX.Element {
           </Link>
         )}
       </div>
-      <div className="header-end-division lg:w-[407px]">
+      <div className="header-end-division">
         <div className="header-end-display">
           <a
             href="https://github.com/langflow-ai/langflow"

--- a/src/frontend/src/components/sidebarComponent/index.tsx
+++ b/src/frontend/src/components/sidebarComponent/index.tsx
@@ -1,7 +1,7 @@
 import { useLocation } from "react-router-dom";
 import { FolderType } from "../../pages/MainPage/entities";
 import { useFolderStore } from "../../stores/foldersStore";
-import { cn } from "../../utils/utils"; // Ensure cn function is correctly imported
+import { cn } from "../../utils/utils";
 import HorizontalScrollFadeComponent from "../horizontalScrollFadeComponent";
 import SideBarButtonsComponent from "./components/sideBarButtons";
 import SideBarFoldersButtonsComponent from "./components/sideBarFolderButtons";

--- a/src/frontend/src/components/sidebarComponent/index.tsx
+++ b/src/frontend/src/components/sidebarComponent/index.tsx
@@ -1,7 +1,7 @@
 import { useLocation } from "react-router-dom";
 import { FolderType } from "../../pages/MainPage/entities";
 import { useFolderStore } from "../../stores/foldersStore";
-import { cn } from "../../utils/utils";
+import { cn } from "../../utils/utils"; // Ensure cn function is correctly imported
 import HorizontalScrollFadeComponent from "../horizontalScrollFadeComponent";
 import SideBarButtonsComponent from "./components/sideBarButtons";
 import SideBarFoldersButtonsComponent from "./components/sideBarFolderButtons";
@@ -34,22 +34,22 @@ export default function SidebarNav({
   const pathValues = ["folder", "components", "flows", "all"];
   const isFolderPath = pathValues.some((value) => pathname.includes(value));
 
+  // Ensure all conditions are covered and provide a default case if necessary
+  const sidebarContent =
+    items.length > 0 ? (
+      <SideBarButtonsComponent items={items} pathname={pathname} />
+    ) : !loadingFolders && folders?.length > 0 && isFolderPath ? (
+      <SideBarFoldersButtonsComponent
+        pathname={pathname}
+        handleChangeFolder={handleChangeFolder}
+        handleDeleteFolder={handleDeleteFolder}
+      />
+    ) : null;
+
   return (
     <nav className={cn(className)} {...props}>
       <HorizontalScrollFadeComponent>
-        {items.length > 0 ? (
-          <SideBarButtonsComponent items={items} pathname={pathname} />
-        ) : (
-          !loadingFolders &&
-          folders?.length > 0 &&
-          isFolderPath && (
-            <SideBarFoldersButtonsComponent
-              pathname={pathname}
-              handleChangeFolder={handleChangeFolder}
-              handleDeleteFolder={handleDeleteFolder}
-            />
-          )
-        )}
+        {sidebarContent!}
       </HorizontalScrollFadeComponent>
     </nav>
   );


### PR DESCRIPTION
This pull request addresses a type error in the component, stemming from poorly organized switch cases.

📝 (headerComponent/index.tsx): Remove unnecessary width styling from header-end-division class
🔧 (sidebarComponent/index.tsx): Ensure correct import of cn function from utils/utils file
💡 (sidebarComponent/index.tsx): Refactor sidebarContent logic to cover all conditions and provide a default case if necessary