### PR TITLE
fix: session error after retries + refactor on interceptor component

### DIFF
--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -2,6 +2,7 @@ import {
   LANGFLOW_ACCESS_TOKEN,
   LANGFLOW_AUTO_LOGIN_OPTION,
 } from "@/constants/constants";
+import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from "axios";
 import { useContext, useEffect } from "react";
 import { Cookies } from "react-cookie";
@@ -11,7 +12,6 @@ import { AuthContext } from "../../contexts/authContext";
 import useAlertStore from "../../stores/alertStore";
 import useFlowStore from "../../stores/flowStore";
 import { checkDuplicateRequestAndStoreRequest } from "./helpers/check-duplicate-requests";
-import useFlowsManagerStore from "@/stores/flowsManagerStore";
 
 // Create a new Axios instance
 const api: AxiosInstance = axios.create({
@@ -20,11 +20,10 @@ const api: AxiosInstance = axios.create({
 
 function ApiInterceptor() {
   const setErrorData = useAlertStore((state) => state.setErrorData);
-  let { accessToken,  logout, authenticationErrorCount, autoLogin } =
+  let { accessToken, logout, authenticationErrorCount, autoLogin } =
     useContext(AuthContext);
   const cookies = new Cookies();
   const setSaveLoading = useFlowsManagerStore((state) => state.setSaveLoading);
-
 
   useEffect(() => {
     const interceptor = api.interceptors.response.use(
@@ -42,7 +41,7 @@ function ApiInterceptor() {
             if (!stillRefresh) {
               return Promise.reject(error);
             }
-            
+
             await tryToRenewAccessToken(error);
 
             const accessToken = cookies.get(LANGFLOW_ACCESS_TOKEN);
@@ -135,7 +134,7 @@ function ApiInterceptor() {
   async function tryToRenewAccessToken(error: AxiosError) {
     try {
       if (window.location.pathname.includes("/login")) return;
-       await renewAccessToken();
+      await renewAccessToken();
     } catch (error) {
       clearBuildVerticesState(error);
       logout();
@@ -153,22 +152,21 @@ function ApiInterceptor() {
     }
   }
 
-
   async function remakeRequest(error: AxiosError) {
     const originalRequest = error.config as AxiosRequestConfig;
 
     try {
       const accessToken = cookies.get(LANGFLOW_ACCESS_TOKEN);
       if (!accessToken) {
-        throw new Error('Access token not found in cookies');
+        throw new Error("Access token not found in cookies");
       }
-  
+
       // Modify headers in originalRequest
       originalRequest.headers = {
         ...(originalRequest.headers as Record<string, string>), // Cast to suppress TypeScript error
         Authorization: `Bearer ${accessToken}`,
       };
-  
+
       const response = await axios.request(originalRequest);
       return response.data; // Or handle the response as needed
     } catch (err) {
@@ -176,8 +174,6 @@ function ApiInterceptor() {
     }
   }
 
-
-  
   return null;
 }
 

--- a/src/frontend/src/controllers/API/index.ts
+++ b/src/frontend/src/controllers/API/index.ts
@@ -49,7 +49,7 @@ const GITHUB_API_URL = "https://api.github.com";
 export async function getRepoStars(owner: string, repo: string) {
   try {
     const response = await api.get(`${GITHUB_API_URL}/repos/${owner}/${repo}`);
-    return response.data.stargazers_count;
+    return response?.data.stargazers_count;
   } catch (error) {
     console.error("Error fetching repository data:", error);
     return null;
@@ -101,7 +101,7 @@ export async function getExamples(): Promise<FlowType[]> {
     "https://api.github.com/repos/langflow-ai/langflow_examples/contents/examples?ref=main";
   const response = await api.get(url);
 
-  const jsonFiles = response.data.filter((file: any) => {
+  const jsonFiles = response?.data.filter((file: any) => {
     return file.name.endsWith(".json");
   });
 
@@ -143,7 +143,7 @@ export async function saveFlowToDatabase(newFlow: {
     if (response?.status !== 201) {
       throw new Error(`HTTP error! status: ${response?.status}`);
     }
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -168,10 +168,10 @@ export async function updateFlowInDatabase(
       endpoint_name: updatedFlow.endpoint_name,
     });
 
-    if (response?.status !== 200) {
+    if (response && response?.status !== 200) {
       throw new Error(`HTTP error! status: ${response?.status}`);
     }
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -187,10 +187,10 @@ export async function updateFlowInDatabase(
 export async function readFlowsFromDatabase() {
   try {
     const response = await api.get(`${BASE_URL_API}flows/`);
-    if (response?.status !== 200) {
+    if (response && response?.status !== 200) {
       throw new Error(`HTTP error! status: ${response?.status}`);
     }
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -200,10 +200,10 @@ export async function readFlowsFromDatabase() {
 export async function downloadFlowsFromDatabase() {
   try {
     const response = await api.get(`${BASE_URL_API}flows/download/`);
-    if (response?.status !== 200) {
+    if (response && response?.status !== 200) {
       throw new Error(`HTTP error! status: ${response?.status}`);
     }
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -217,7 +217,7 @@ export async function uploadFlowsToDatabase(flows: FormData) {
     if (response?.status !== 201) {
       throw new Error(`HTTP error! status: ${response?.status}`);
     }
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -237,7 +237,7 @@ export async function deleteFlowFromDatabase(flowId: string) {
     if (response.status !== 200) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -254,10 +254,10 @@ export async function deleteFlowFromDatabase(flowId: string) {
 export async function getFlowFromDatabase(flowId: number) {
   try {
     const response = await api.get(`${BASE_URL_API}flows/${flowId}`);
-    if (response?.status !== 200) {
+    if (response && response?.status !== 200) {
       throw new Error(`HTTP error! status: ${response?.status}`);
     }
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -276,7 +276,7 @@ export async function getFlowStylesFromDatabase() {
     if (response.status !== 200) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -302,7 +302,7 @@ export async function saveFlowStyleToDatabase(flowStyle: FlowStyleType) {
     if (response.status !== 201) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -316,7 +316,7 @@ export async function saveFlowStyleToDatabase(flowStyle: FlowStyleType) {
  */
 export async function getVersion() {
   const response = await api.get(`${BASE_URL_API}version`);
-  return response.data;
+  return response?.data;
 }
 
 /**
@@ -416,7 +416,7 @@ export async function onLogin(user: LoginType) {
     );
 
     if (response.status === 200) {
-      const data = response.data;
+      const data = response?.data;
       return data;
     }
   } catch (error) {
@@ -431,7 +431,7 @@ export async function autoLogin(abortSignal) {
     });
 
     if (response.status === 200) {
-      const data = response.data;
+      const data = response?.data;
       return data;
     }
   } catch (error) {
@@ -607,7 +607,7 @@ export async function saveFlowStore(
     if (response.status !== 201) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -862,7 +862,7 @@ export async function updateFlowStore(
     if (response.status !== 201) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -872,7 +872,7 @@ export async function updateFlowStore(
 export async function requestLogout() {
   try {
     const response = await api.post(`${BASE_URL_API}logout`);
-    return response.data;
+    return response?.data;
   } catch (error) {
     console.error(error);
     throw error;

--- a/src/frontend/src/controllers/API/index.ts
+++ b/src/frontend/src/controllers/API/index.ts
@@ -883,7 +883,7 @@ export async function getGlobalVariables(): Promise<{
   [key: string]: { id: string; type: string; default_fields: string[] };
 }> {
   const globalVariables = {};
-  (await api.get(`${BASE_URL_API}variables/`)).data.forEach((element) => {
+  (await api.get(`${BASE_URL_API}variables/`))?.data?.forEach((element) => {
     globalVariables[element.name] = {
       id: element.id,
       type: element.type,

--- a/src/frontend/src/stores/flowsManagerStore.ts
+++ b/src/frontend/src/stores/flowsManagerStore.ts
@@ -78,6 +78,7 @@ const useFlowsManagerStore = create<FlowsManagerStoreType>((set, get) => ({
   },
   currentFlow: undefined,
   saveLoading: false,
+  setSaveLoading: (saveLoading: boolean) => set({ saveLoading }),
   isLoading: true,
   setIsLoading: (isLoading: boolean) => set({ isLoading }),
   refreshFlows: () => {

--- a/src/frontend/src/types/zustand/flowsManager/index.ts
+++ b/src/frontend/src/types/zustand/flowsManager/index.ts
@@ -11,6 +11,7 @@ export type FlowsManagerStoreType = {
   currentFlowId: string;
   setCurrentFlowId: (currentFlowId: string) => void;
   saveLoading: boolean;
+  setSaveLoading: (saveLoading: boolean) => void;
   isLoading: boolean;
   setIsLoading: (isLoading: boolean) => void;
   refreshFlows: () => Promise<void>;


### PR DESCRIPTION
Fixes an issue where the error count in the interceptor fails to reset when auto-login is disabled, leading to unexpected user logouts.

This pull request addresses a critical issue affecting user sessions when autoLogin is set to false. Currently, the interceptor fails to reset error counts, which triggers premature user logouts without proper handling of error scenarios. By implementing a reset mechanism in the interceptor, this fix ensures that users remain authenticated under all conditions, providing a more reliable and seamless experience.