### PR TITLE
ci: refactor CI workflow conditions to run only when PR is approved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-reviews:
+    name: Check Reviews
+    runs-on: ubuntu-latest
+    outputs:
+      approved: ${{ steps.reviewsCount.outputs.approved }}
+    steps:
+      - uses: github-actions-tools/gh-reviews-count@v0.0.2
+        id: reviewsCount
+
   path-filter:
     # should run if the PR is approved,or if it's a manual run or if it is not a draft PR
     if: ${{ (github.event.review.state == 'APPROVED' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,9 @@ jobs:
         id: reviewsCount
 
   path-filter:
-    # should run if the PR is approved,or if it's a manual run or if it is not a draft PR
-    if: ${{ (github.event.review.state == 'APPROVED' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' }}
+    needs: check-reviews
+    if: ${{ (needs.check-reviews.outputs.approved != 0 && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' }}
+
     name: Filter Paths
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,18 +26,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-reviews:
-    name: Check Reviews
-    runs-on: ubuntu-latest
-    outputs:
-      approved: ${{ steps.reviewsCount.outputs.approved }}
-    steps:
-      - uses: github-actions-tools/gh-reviews-count@v0.0.2
-        id: reviewsCount
-
   path-filter:
-    needs: check-reviews
-    if: ${{ (needs.check-reviews.outputs.approved != 0 && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (contains( github.event.pull_request.labels.*.name, 'lgtm') && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' }}
 
     name: Filter Paths
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request refactors the CI workflow by adding a new job called "check-reviews" and updating the "path-filter" job to depend on the output of the "check-reviews" job. This improves the readability and maintainability of the workflow.