### PR TITLE
ci: remove pull_request_review event type from workflow configuration

### DIFF
--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -4,8 +4,6 @@ name: Label PRs with Conventional Commits
 on:
   pull_request_target:
     types: [opened, edited]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   validate-pr:


### PR DESCRIPTION
This pull request removes the unnecessary pull_request_review event type from the workflow configuration file, streamlining the workflow setup.