### PR TITLE
feat: add gpt-4o-mini to MODEL_NAMES constant

### DIFF
--- a/src/backend/base/langflow/base/models/openai_constants.py
+++ b/src/backend/base/langflow/base/models/openai_constants.py
@@ -1,1 +1,9 @@
-MODEL_NAMES = ["gpt-4o-mini", "gpt-4o", "gpt-4-turbo", "gpt-4-turbo-preview", "gpt-4", "gpt-3.5-turbo", "gpt-3.5-turbo-0125"]
+MODEL_NAMES = [
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4-turbo",
+    "gpt-4-turbo-preview",
+    "gpt-4",
+    "gpt-3.5-turbo",
+    "gpt-3.5-turbo-0125",
+]

--- a/src/backend/base/langflow/base/models/openai_constants.py
+++ b/src/backend/base/langflow/base/models/openai_constants.py
@@ -1,1 +1,1 @@
-MODEL_NAMES = ["gpt-4o", "gpt-4-turbo", "gpt-4-turbo-preview", "gpt-4", "gpt-3.5-turbo", "gpt-3.5-turbo-0125"]
+MODEL_NAMES = ["gpt-4o-mini", "gpt-4o", "gpt-4-turbo", "gpt-4-turbo-preview", "gpt-4", "gpt-3.5-turbo", "gpt-3.5-turbo-0125"]


### PR DESCRIPTION
This pull request adds the "gpt-4o-mini" model to the `MODEL_NAMES` constant in the `openai_constants.py` file. This allows the code to reference the new model in the application.

- Closes #2811 