### PR TITLE
fix: ensure monitor duckdb cache dir exists

### DIFF
--- a/src/backend/base/langflow/services/monitor/service.py
+++ b/src/backend/base/langflow/services/monitor/service.py
@@ -21,7 +21,7 @@ class MonitorService(Service):
         from langflow.services.monitor.schema import DuckDbMessageModel, TransactionModel, VertexBuildModel
 
         self.settings_service = settings_service
-        self.base_cache_dir = Path(user_cache_dir("langflow"))
+        self.base_cache_dir = Path(user_cache_dir("langflow"), ensure_exists=True)
         self.db_path = self.base_cache_dir / "monitor.duckdb"
         self.table_map: dict[str, type[TransactionModel | DuckDbMessageModel | VertexBuildModel]] = {
             "transactions": TransactionModel,


### PR DESCRIPTION
To fix runtime error
 log_vertex_build Error logging vertex build: IO Error: Cannot open file "/app/data/.cache/langflow/monitor.duckdb": No such file or directory


 ls /app/data
ls: cannot access '/app/data': No such file or directory