### PR TITLE
fix: save store API key in database after encryption

### DIFF
--- a/src/backend/base/langflow/api/v1/api_key.py
+++ b/src/backend/base/langflow/api/v1/api_key.py
@@ -71,6 +71,7 @@ def save_store_api_key(
         # Encrypt the API key
         encrypted = auth_utils.encrypt_api_key(api_key, settings_service=settings_service)
         current_user.store_api_key = encrypted
+        db.add(current_user)
         db.commit()
         return {"detail": "API Key saved"}
     except Exception as e:


### PR DESCRIPTION
Add user to the db just in case this could be causing the api key decryption to fail.