### PR TITLE
fix: assign frozen flag from group to node correctly

### DIFF
--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -869,8 +869,7 @@ class Graph:
         self.run_manager.add_to_vertices_being_run(vertex_id)
         try:
             params = ""
-            parent_vertex = self.get_vertex(vertex.parent_node_id) if vertex.parent_node_id else None
-            if vertex.frozen or (parent_vertex and parent_vertex.frozen):
+            if vertex.frozen:
                 # Check the cache for the vertex
                 cached_result = await chat_service.get_cache(key=vertex.id)
                 if isinstance(cached_result, CacheMiss):

--- a/src/backend/base/langflow/graph/graph/utils.py
+++ b/src/backend/base/langflow/graph/graph/utils.py
@@ -42,7 +42,7 @@ def add_frozen(nodes, frozen):
     This function receives a list of nodes and adds a frozen to each node.
     """
     for node in nodes:
-        node["frozen"] = frozen
+        node["data"]["node"]["frozen"] = frozen
 
 
 def ungroup_node(group_node_data, base_flow):


### PR DESCRIPTION
This pull request fixes the assignment of `node["frozen"]` in the `add_frozen` function by updating it to `node["data"]["node"]["frozen"]`. Additionally, it removes unnecessary code related to `vertex.parent_node_id` in the Graph class. These changes improve the accuracy and efficiency of the code.