### PR TITLE
fix: add correct id to vertices_being_run and change condition to end traces

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -258,7 +258,7 @@ async def build_vertex(
         if graph.stop_vertex and graph.stop_vertex in next_runnable_vertices:
             next_runnable_vertices = [graph.stop_vertex]
 
-        if not graph.run_manager.vertices_to_run and not next_runnable_vertices:
+        if not graph.run_manager.vertices_being_run and not next_runnable_vertices:
             background_tasks.add_task(graph.end_all_traces)
 
         build_response = VertexBuildResponse(

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -998,11 +998,11 @@ class Graph:
             self.run_manager.remove_vertex_from_runnables(v_id)
             next_runnable_vertices = self.find_next_runnable_vertices(v_id, v_successors_ids)
 
-            for i in set(next_runnable_vertices):  # Use set to avoid duplicates
-                if i == v_id:
+            for next_v_id in set(next_runnable_vertices):  # Use set to avoid duplicates
+                if next_v_id == v_id:
                     next_runnable_vertices.remove(v_id)
                 else:
-                    self.run_manager.add_to_vertices_being_run(v_id)
+                    self.run_manager.add_to_vertices_being_run(next_v_id)
             if cache:
                 set_cache_coro = partial(get_chat_service().set_cache, key=self.flow_id)
                 await set_cache_coro(self, lock)


### PR DESCRIPTION
This pull request fixes two issues in the graph build process. The first commit updates the condition for ending all traces in the `build_vertex` function. The second commit adds the correct vertex ID to the `vertices_being_run` list. These changes ensure that the graph build process runs smoothly and accurately.