### PR TITLE
chore: update dependencies and add lock step in py_autofix.yml

### DIFF
--- a/.github/workflows/py_autofix.yml
+++ b/.github/workflows/py_autofix.yml
@@ -18,5 +18,26 @@ jobs:
       - uses: install-pinned/ruff@b52a71f70b28264686d57d1efef1ba845b9cec6c
       - run: ruff check --fix-only .
       - run: ruff format .
+      - uses: autofix-ci/action@dd55f44df8f7cdb7a6bf74c78677eb8acd40cd0a
+  lock:
+    name: Check Poetry lock
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: "./.github/actions/poetry_caching"
+        with:
+          python-version: "3.12"
+          poetry-version: ${{ env.POETRY_VERSION }}
+          cache-key: ${{ runner.os }}-poetry-${{ env.POETRY_VERSION }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Check poetry.lock
+        id: check
+        run: |
+          poetry check --lock
+        continue-on-error: true
 
+      - name: Run lock
+        if : steps.check.outcome == 'failure'
+        run: |
+          make lock
       - uses: autofix-ci/action@dd55f44df8f7cdb7a6bf74c78677eb8acd40cd0a

--- a/Makefile
+++ b/Makefile
@@ -315,8 +315,8 @@ lock_langflow:
 lock: ## lock dependencies
 # Run both in parallel
 	@echo 'Locking dependencies'
-	cd src/backend/base && poetry lock
-	poetry lock
+	cd src/backend/base && poetry lock --no-update
+	poetry lock --no-update
 
 update: ## update dependencies
 	@echo 'Updating dependencies'


### PR DESCRIPTION
Update the dependencies in the py_autofix.yml workflow file to include a new step for checking the Poetry lock file. This ensures that the dependencies are locked and prevents any unintended changes in compatibility or functionality. The lock step is added to the existing workflow to ensure that the Poetry lock file is checked and updated if necessary.