### PR TITLE
ci: update CI workflow to include new job 'set-ci-condition'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+
 jobs:
+  set-ci-condition:
+    name: Should Run CI
+    runs-on: ubuntu-latest
+    outputs:
+      should-run-ci:  ${{ (contains( github.event.pull_request.labels.*.name, 'lgtm') && github.event.pull_request.draft == false) || (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') }}
   path-filter:
-    if: ${{ (contains( github.event.pull_request.labels.*.name, 'lgtm') && github.event.pull_request.draft == false) || (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') }}
+    needs: set-ci-condition
+    if: ${{ needs.set-ci-condition.outputs.should-run-ci }}
 
     name: Filter Paths
     runs-on: ubuntu-latest
@@ -78,13 +85,13 @@ jobs:
   # https://github.com/langchain-ai/langchain/blob/master/.github/workflows/check_diffs.yml
   ci_success:
     name: "CI Success"
-    needs: [test-backend, test-frontend, lint-backend, test-docs-build]
+    needs: [test-backend, test-frontend, lint-backend, test-docs-build, set-ci-condition ]
     if: always()
     runs-on: ubuntu-latest
     env:
       JOBS_JSON: ${{ toJSON(needs) }}
       RESULTS_JSON: ${{ toJSON(needs.*.result) }}
-      EXIT_CODE: ${{!contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && '0' || '1'}}
+      EXIT_CODE: ${{!contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.set-ci-condition.outputs.should-run-ci == 'true' && '0' || '1'}}
     steps:
       - name: "CI Success"
         run: |


### PR DESCRIPTION
This pull request refactors the CI workflow to include a new job called 'set-ci-condition'. This job is responsible for determining if the CI should run based on conditions such as pull request labels and event type. By adding this job, we can improve the efficiency and control of our CI process.