### PR TITLE
fix: update button role in end-to-end test

### DIFF
--- a/src/frontend/tests/end-to-end/generalBugs-shard-6.spec.ts
+++ b/src/frontend/tests/end-to-end/generalBugs-shard-6.spec.ts
@@ -77,7 +77,7 @@ class CustomComponent(Component):
   await page.locator("textarea").press("Control+a");
   await page.locator("textarea").fill(customCodeWithError);
 
-  await page.getByText("Save").click();
+  await page.getByRole("button", { name: "Check & Save" }).click();
 
   await page.waitForTimeout(1000);
 


### PR DESCRIPTION
Update the button role in the end-to-end test to use "Check & Save" instead of "Save".