### PR TITLE
refactor: update TelemetryService and change Service teardown methods to be async

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -99,7 +99,7 @@ def get_lifespan(fix_migration=False, socketio_server=None, version=None):
             raise
         # Shutdown message
         rprint("[bold red]Shutting down Langflow...[/bold red]")
-        teardown_services()
+        await teardown_services()
 
     return lifespan
 

--- a/src/backend/base/langflow/services/base.py
+++ b/src/backend/base/langflow/services/base.py
@@ -22,7 +22,7 @@ class Service(ABC):
             }
         return schema
 
-    def teardown(self):
+    async def teardown(self):
         pass
 
     def set_ready(self):

--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -294,7 +294,7 @@ class DatabaseService(Service):
 
         logger.debug("Database and tables created successfully")
 
-    def teardown(self):
+    async def teardown(self):
         logger.debug("Tearing down database")
         try:
             settings_service = get_settings_service()

--- a/src/backend/base/langflow/services/manager.py
+++ b/src/backend/base/langflow/services/manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import inspect
 from typing import TYPE_CHECKING, Dict, Optional
@@ -6,7 +7,6 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from langflow.services.base import Service
-
     from langflow.services.factory import ServiceFactory
     from langflow.services.schema import ServiceType
 
@@ -93,7 +93,7 @@ class ServiceManager:
             self.services.pop(service_name, None)
             self.get(service_name)
 
-    def teardown(self):
+    async def teardown(self):
         """
         Teardown all the services.
         """
@@ -102,7 +102,9 @@ class ServiceManager:
                 continue
             logger.debug(f"Teardown service {service.name}")
             try:
-                service.teardown()
+                result = service.teardown()
+                if asyncio.iscoroutine(result):
+                    await result
             except Exception as exc:
                 logger.exception(exc)
         self.services = {}

--- a/src/backend/base/langflow/services/plugins/service.py
+++ b/src/backend/base/langflow/services/plugins/service.py
@@ -53,7 +53,7 @@ class PluginService(Service):
             return plugin.get()
         return None
 
-    def teardown(self):
+    async def teardown(self):
         for plugin in self.plugins.values():
             plugin.teardown()
 

--- a/src/backend/base/langflow/services/storage/local.py
+++ b/src/backend/base/langflow/services/storage/local.py
@@ -90,6 +90,6 @@ class LocalStorageService(StorageService):
         else:
             logger.warning(f"Attempted to delete non-existent file {file_name} in flow {flow_id}.")
 
-    def teardown(self):
+    async def teardown(self):
         """Perform any cleanup operations when the service is being torn down."""
         pass  # No specific teardown actions required for local

--- a/src/backend/base/langflow/services/storage/service.py
+++ b/src/backend/base/langflow/services/storage/service.py
@@ -38,5 +38,5 @@ class StorageService(Service):
     async def delete_file(self, flow_id: str, file_name: str) -> bool:
         raise NotImplementedError
 
-    def teardown(self):
+    async def teardown(self):
         raise NotImplementedError

--- a/src/backend/base/langflow/services/telemetry/service.py
+++ b/src/backend/base/langflow/services/telemetry/service.py
@@ -61,7 +61,8 @@ class TelemetryService(Service):
         if path:
             url = f"{url}/{path}"
         try:
-            response = await self.client.get(url, params=payload.model_dump())
+            payload_dict = payload.model_dump(exclude_none=True, exclude_unset=True)
+            response = await self.client.get(url, params=payload_dict)
             if response.status_code != 200:
                 logger.error(f"Failed to send telemetry data: {response.status_code} {response.text}")
             else:

--- a/src/backend/base/langflow/services/telemetry/service.py
+++ b/src/backend/base/langflow/services/telemetry/service.py
@@ -134,3 +134,6 @@ class TelemetryService(Service):
             await self.client.aclose()
         except Exception as e:
             logger.error(f"Error stopping tracing service: {e}")
+
+    async def teardown(self):
+        await self.stop()

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -109,7 +109,7 @@ def teardown_superuser(settings_service, session):
             raise RuntimeError("Could not remove default superuser.") from exc
 
 
-def teardown_services():
+async def teardown_services():
     """
     Teardown all the services.
     """

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -120,7 +120,7 @@ async def teardown_services():
     try:
         from langflow.services.manager import service_manager
 
-        service_manager.teardown()
+        await service_manager.teardown()
     except Exception as exc:
         logger.exception(exc)
 


### PR DESCRIPTION
The `TelemetryService` and `Service` classes have been updated to convert the `teardown` methods to asynchronous functions. TelemetryService payload has been changed to only send existing data.