### PR TITLE
refactor: update StateVertex to function like a normal component unless specified not to

### DIFF
--- a/src/backend/base/langflow/components/prototypes/Listen.py
+++ b/src/backend/base/langflow/components/prototypes/Listen.py
@@ -23,5 +23,6 @@ class ListenComponent(CustomComponent):
         return state
 
     def _set_successors_ids(self):
+        self.vertex.is_state = True
         successors = self.vertex.graph.successor_map.get(self.vertex.id, [])
         return successors + self.vertex.graph.activated_vertices

--- a/src/backend/base/langflow/components/prototypes/Listen.py
+++ b/src/backend/base/langflow/components/prototypes/Listen.py
@@ -18,5 +18,10 @@ class ListenComponent(CustomComponent):
 
     def build(self, name: str) -> Data:
         state = self.get_state(name)
+        self._set_successors_ids()
         self.status = state
         return state
+
+    def _set_successors_ids(self):
+        successors = self.vertex.graph.successor_map.get(self.vertex.id, [])
+        return successors + self.vertex.graph.activated_vertices

--- a/src/backend/base/langflow/components/prototypes/Notify.py
+++ b/src/backend/base/langflow/components/prototypes/Notify.py
@@ -43,5 +43,6 @@ class NotifyComponent(CustomComponent):
         return data
 
     def _set_successors_ids(self):
+        self.vertex.is_state = True
         successors = self.vertex.graph.successor_map.get(self.vertex.id, [])
         return successors + self.vertex.graph.activated_vertices

--- a/src/backend/base/langflow/components/prototypes/Notify.py
+++ b/src/backend/base/langflow/components/prototypes/Notify.py
@@ -39,4 +39,9 @@ class NotifyComponent(CustomComponent):
         else:
             self.status = "No record provided."
         self.status = data
+        self._set_successors_ids()
         return data
+
+    def _set_successors_ids(self):
+        successors = self.vertex.graph.successor_map.get(self.vertex.id, [])
+        return successors + self.vertex.graph.activated_vertices

--- a/src/backend/base/langflow/graph/vertex/base.py
+++ b/src/backend/base/langflow/graph/vertex/base.py
@@ -71,6 +71,7 @@ class Vertex:
         self._built_object = UnbuiltObject()
         self._built_result = None
         self._built = False
+        self._successors_ids: Optional[List[str]] = None
         self.artifacts: Dict[str, Any] = {}
         self.artifacts_raw: Dict[str, Any] = {}
         self.artifacts_type: Dict[str, str] = {}

--- a/src/backend/base/langflow/graph/vertex/types.py
+++ b/src/backend/base/langflow/graph/vertex/types.py
@@ -406,7 +406,7 @@ class InterfaceVertex(ComponentVertex):
 
 class StateVertex(ComponentVertex):
     def __init__(self, data: Dict, graph):
-        super().__init__(data, graph=graph, base_type="custom_components")
+        super().__init__(data, graph=graph)
         self.steps = [self._build]
         self.is_state = False
 

--- a/src/backend/base/langflow/graph/vertex/types.py
+++ b/src/backend/base/langflow/graph/vertex/types.py
@@ -408,11 +408,12 @@ class StateVertex(ComponentVertex):
     def __init__(self, data: Dict, graph):
         super().__init__(data, graph=graph, base_type="custom_components")
         self.steps = [self._build]
-        self.is_state = True
+        self.is_state = False
 
     @property
     def successors_ids(self) -> List[str]:
         if self._successors_ids is None:
+            self.is_state = False
             return super().successors_ids
         return self._successors_ids
 

--- a/src/backend/base/langflow/graph/vertex/types.py
+++ b/src/backend/base/langflow/graph/vertex/types.py
@@ -404,7 +404,7 @@ class InterfaceVertex(ComponentVertex):
         return self.vertex_type == InterfaceComponentTypes.ChatInput and self.is_input
 
 
-class StateVertex(Vertex):
+class StateVertex(ComponentVertex):
     def __init__(self, data: Dict, graph):
         super().__init__(data, graph=graph, base_type="custom_components")
         self.steps = [self._build]
@@ -412,8 +412,9 @@ class StateVertex(Vertex):
 
     @property
     def successors_ids(self) -> List[str]:
-        successors = self.graph.successor_map.get(self.id, [])
-        return successors + self.graph.activated_vertices
+        if self._successors_ids is None:
+            return super().successors_ids
+        return self._successors_ids
 
     def _built_object_repr(self):
         if self.artifacts and "repr" in self.artifacts:


### PR DESCRIPTION
This commit adds a new method `_set_successors_ids` to the `ListenComponent` class in `Listen.py`. This method retrieves the successors of the vertex and sets the `successors_ids` attribute accordingly. This change improves the functionality and flexibility of the `ListenComponent` class.

Fixes #2919