### PR TITLE
ci: add labeler job to automatically add 'lgtm' label when pull request review is approved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,15 @@ concurrency:
 
 
 jobs:
+  labeler:
+    if : ${{ github.event_name == 'pull_request_review' && github.event.review.state == 'approved' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: jsryudev/pr-review-labeler@v0.2.2
+      with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          target-approved-count: 1
+          label-to-be-added: 'lgtm'
   set-ci-condition:
     name: Should Run CI
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,6 @@ concurrency:
 
 
 jobs:
-  labeler:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: jsryudev/pr-review-labeler@v0.2.2
-      with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          target-approved-count: 1
-          label-to-be-added: 'lgtm'
   set-ci-condition:
     needs: labeler
     name: Should Run CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           target-approved-count: 1
           label-to-be-added: 'lgtm'
   set-ci-condition:
+    needs: labeler
     name: Should Run CI
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ concurrency:
 
 jobs:
   labeler:
-    if : ${{ github.event_name == 'pull_request_review' && github.event.review.state == 'approved' }}
     runs-on: ubuntu-latest
     steps:
     - uses: jsryudev/pr-review-labeler@v0.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,7 @@ on:
         required: false
         type: string
   pull_request:
-    types: [synchronize]
-  pull_request_review:
-    types: [submitted]
+    types: [synchronize, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,7 +26,6 @@ concurrency:
 
 jobs:
   set-ci-condition:
-    needs: labeler
     name: Should Run CI
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
This pull request adds a new job called "labeler" to the CI workflow. The labeler job is triggered when a pull request review is approved. It automatically adds the 'lgtm' label to the pull request. Additionally, a dependency has been added to ensure that the labeler job runs before the CI job.