### PR TITLE
bugfix: fix missing condition to open disconnect modal when backend is down

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -137,6 +137,7 @@ export default function App() {
               message={FETCH_ERROR_MESSAGE}
               openModal={
                 isErrorHealth ||
+                !healthData ||
                 (healthData &&
                   Object.values(healthData).some((value) => value !== "ok"))
               }

--- a/src/frontend/src/controllers/API/queries/health/use-get-health.ts
+++ b/src/frontend/src/controllers/API/queries/health/use-get-health.ts
@@ -30,6 +30,7 @@ export const useGetHealthQuery: useQueryFunctionType<
   const queryResult = query(["useGetHealthQuery"], getHealthFn, {
     placeholderData: keepPreviousData,
     refetchInterval: 20000,
+    retry: false,
     ...options,
   });
 


### PR DESCRIPTION
This pull request will ensure that disconnect modal is showing properly.

🐛 (App.tsx): Fix logic to correctly display error modal when health data is missing or not "ok"
🔧 (use-get-health.ts): Disable retry option in useGetHealthQuery to prevent unnecessary refetching of health data

#2968 