### PR TITLE
feat: add signal handler for graceful shutdown

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -1,7 +1,5 @@
 import asyncio
 import os
-import signal
-import sys
 import warnings
 from contextlib import asynccontextmanager
 from http import HTTPStatus

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -1,24 +1,26 @@
-import os
 import asyncio
+import os
+import signal
+import sys
 import warnings
 from contextlib import asynccontextmanager
+from http import HTTPStatus
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlencode
 
 import nest_asyncio  # type: ignore
-from fastapi import FastAPI, Request, Response, HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
-from http import HTTPStatus
 from loguru import logger
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from pydantic import PydanticDeprecatedSince20
 from rich import print as rprint
 from starlette.middleware.base import BaseHTTPMiddleware
-from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
-from langflow.api import router, health_check_router, log_router
+from langflow.api import health_check_router, log_router, router
 from langflow.initial_setup.setup import (
     create_or_update_starter_projects,
     initialize_super_user_if_needed,

--- a/src/backend/base/langflow/server.py
+++ b/src/backend/base/langflow/server.py
@@ -21,6 +21,7 @@ class LangflowUvicornWorker(UvicornWorker):
 
         loop = asyncio.get_running_loop()
         loop.add_signal_handler(signal.SIGINT, self.handle_exit, signal.SIGINT, None)
+        loop.add_signal_handler(signal.SIGTERM, self.handle_quit, signal.SIGTERM, None)
 
     async def _serve(self) -> None:
         # We do this to not log the "Worker (pid:XXXXX) was sent SIGINT"


### PR DESCRIPTION
Add a signal handler to gracefully shut down Langflow when a SIGTERM signal is received. The signal handler calls the `teardown_services` function to clean up resources before exiting. This improves the shutdown process and ensures that Langflow is properly terminated.