### PR TITLE
feat: flag to disable transaction and vertex_builds writes

### DIFF
--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -14,7 +14,7 @@ from langflow.services.database.models.transactions.crud import log_transaction 
 from langflow.services.database.models.vertex_builds.crud import log_vertex_build as crud_log_vertex_build
 from langflow.services.database.models.vertex_builds.model import VertexBuildBase
 from langflow.services.database.utils import session_getter
-from langflow.services.deps import get_db_service
+from langflow.services.deps import get_db_service, get_settings_service
 from loguru import logger
 
 if TYPE_CHECKING:
@@ -131,7 +131,10 @@ def _vertex_to_primitive_dict(target: "Vertex") -> dict:
 async def log_transaction(
     flow_id: Union[str, UUID], source: "Vertex", status, target: Optional["Vertex"] = None, error=None
 ) -> None:
+
     try:
+        if not get_settings_service().settings.transactions_storage_enabled:
+            return
         inputs = _vertex_to_primitive_dict(source)
         transaction = TransactionBase(
             vertex_id=source.id,
@@ -159,6 +162,8 @@ def log_vertex_build(
     artifacts: Optional[dict] = None,
 ):
     try:
+        if not get_settings_service().settings.vertex_builds_storage_enabled:
+            return
         vertex_build = VertexBuildBase(
             flow_id=flow_id,
             id=vertex_id,
@@ -166,7 +171,8 @@ def log_vertex_build(
             params=str(params) if params else None,
             # ugly hack to get the model dump with weird datatypes
             data=json.loads(data.model_dump_json()),
-            artifacts=artifacts,
+            # ugly hack to get the model dump with weird datatypes
+            artifacts=json.loads(json.dumps(artifacts, default=str)),
         )
         with session_getter(get_db_service()) as session:
             inserted = crud_log_vertex_build(session, vertex_build)

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -131,7 +131,6 @@ def _vertex_to_primitive_dict(target: "Vertex") -> dict:
 async def log_transaction(
     flow_id: Union[str, UUID], source: "Vertex", status, target: Optional["Vertex"] = None, error=None
 ) -> None:
-
     try:
         if not get_settings_service().settings.transactions_storage_enabled:
             return

--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -144,7 +144,6 @@ class Settings(BaseSettings):
     vertex_builds_storage_enabled: bool = True
     """If set to True, Langflow will keep track of each vertex builds (outputs) in the UI for any flow."""
 
-
     @field_validator("user_agent", mode="after")
     @classmethod
     def set_user_agent(cls, value):

--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -139,6 +139,11 @@ class Settings(BaseSettings):
     do_not_track: bool = False
     """If set to True, Langflow will not track telemetry."""
     telemetry_base_url: str = "https://langflow.gateway.scarf.sh"
+    transactions_storage_enabled: bool = True
+    """If set to True, Langflow will track transactions between flows."""
+    vertex_builds_storage_enabled: bool = True
+    """If set to True, Langflow will keep track of each vertex builds (outputs) in the UI for any flow."""
+
 
     @field_validator("user_agent", mode="after")
     @classmethod

--- a/src/backend/tests/unit/graph/test_graph.py
+++ b/src/backend/tests/unit/graph/test_graph.py
@@ -2,6 +2,7 @@ import copy
 import json
 import pickle
 from typing import Type, Union
+from uuid import UUID
 
 import pytest
 
@@ -18,6 +19,8 @@ from langflow.graph.graph.utils import (
 )
 from langflow.graph.vertex.base import Vertex
 from langflow.initial_setup.setup import load_starter_projects
+from langflow.services.database.models.transactions.crud import get_transactions_by_flow_id
+from langflow.services.deps import session_scope
 from langflow.utils.payload import get_root_vertex
 
 # Test cases for the graph module

--- a/src/backend/tests/unit/graph/test_graph.py
+++ b/src/backend/tests/unit/graph/test_graph.py
@@ -2,7 +2,6 @@ import copy
 import json
 import pickle
 from typing import Type, Union
-from uuid import UUID
 
 import pytest
 
@@ -19,8 +18,6 @@ from langflow.graph.graph.utils import (
 )
 from langflow.graph.vertex.base import Vertex
 from langflow.initial_setup.setup import load_starter_projects
-from langflow.services.database.models.transactions.crud import get_transactions_by_flow_id
-from langflow.services.deps import session_scope
 from langflow.utils.payload import get_root_vertex
 
 # Test cases for the graph module


### PR DESCRIPTION
Add setting to not write transactions or vertex_builds. Those option are useful for the UI but not for the runtime part. 
Since they now are written to the SQL db, it's important to make them able to be disabled them to avoid useless writes and costs