### PR TITLE
fix: move  client instantiation in AssistantsGetAssistantName and AssistantsListAssistants to inner function

### DIFF
--- a/src/backend/base/langflow/components/astra_assistants/get_assistant.py
+++ b/src/backend/base/langflow/components/astra_assistants/get_assistant.py
@@ -8,7 +8,6 @@ from langflow.template import Output
 
 
 class AssistantsGetAssistantName(Component):
-    client = patch(OpenAI())
     display_name = "Get Assistant name"
     description = "Assistant by id"
 
@@ -30,6 +29,7 @@ class AssistantsGetAssistantName(Component):
     ]
 
     def process_inputs(self) -> Message:
+        patch(OpenAI())
         assistant = self.client.beta.assistants.retrieve(
             assistant_id=self.assistant_id,
         )

--- a/src/backend/base/langflow/components/astra_assistants/list_assistants.py
+++ b/src/backend/base/langflow/components/astra_assistants/list_assistants.py
@@ -1,12 +1,12 @@
 from astra_assistants import patch  # type: ignore
-from langflow.template.field.base import Output
-from langflow.custom import Component
 from openai import OpenAI
+
+from langflow.custom import Component
 from langflow.schema.message import Message
+from langflow.template.field.base import Output
 
 
 class AssistantsListAssistants(Component):
-    client = patch(OpenAI())
     display_name = "List Assistants"
     description = "Returns a list of assistant id's"
 
@@ -15,6 +15,7 @@ class AssistantsListAssistants(Component):
     ]
 
     def process_inputs(self) -> Message:
+        patch(OpenAI())
         assistants = self.client.beta.assistants.list()
         id_list = [assistant.id for assistant in assistants]
         message = Message(

--- a/src/backend/base/langflow/components/astra_assistants/run.py
+++ b/src/backend/base/langflow/components/astra_assistants/run.py
@@ -11,8 +11,6 @@ from langflow.template import Output
 
 
 class AssistantsRun(Component):
-    client = patch(OpenAI())
-
     display_name = "Run Assistant"
     description = "Executes an Assistant Run against a thread"
 
@@ -59,6 +57,7 @@ class AssistantsRun(Component):
     outputs = [Output(display_name="Assistant Response", name="assistant_response", method="process_inputs")]
 
     def process_inputs(self) -> Message:
+        patch(OpenAI())
         try:
             text = ""
 


### PR DESCRIPTION
The OpenAI client instantiation was removed from the `AssistantsGetAssistantName` and `AssistantsListAssistants` components. This commit fixes the issue by adding back the OpenAI client instantiation in the `process_inputs` method of both components.