### PR TITLE
refactor: lock poetry dependencies without updating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ build_langflow_backup:
 
 build_langflow:
 	cd ./scripts && poetry run python update_dependencies.py
-	poetry lock
+	poetry lock --no-update
 	poetry build
 ifdef restore
 	mv pyproject.toml.bak pyproject.toml


### PR DESCRIPTION
Lock poetry dependencies without updating in the Makefile build_langflow target