### PR TITLE
ci: update Python version in release workflow and skip release if already released

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install poetry
         run: pipx install poetry==${{ env.POETRY_VERSION }}
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "poetry"
       - name: Set up Nodejs 20
         uses: actions/setup-node@v4
@@ -95,10 +95,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install poetry
         run: pipx install poetry==${{ env.POETRY_VERSION }}
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "poetry"
       - name: Set up Nodejs 20
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           last_released_version=$(curl -s "https://pypi.org/pypi/langflow-base/json" | jq -r '.releases | keys | .[]' | sort -V | tail -n 1)
           if [ "$version" = "$last_released_version" ]; then
             echo "Version $version is already released. Skipping release."
-            exit 1
+            exit 0
           else
             echo version=$version >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
This pull request updates the Python version in the release workflow from 3.10 to 3.12. This ensures that the latest version of Python is used for the release process.