### PR TITLE
fix: endpoint /run api call could run same node twice

### DIFF
--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -1046,7 +1046,8 @@ class Graph:
         for v in vertices:
             next_runnable_vertices = await self.get_next_runnable_vertices(lock, vertex=v, cache=False)
             results.extend(next_runnable_vertices)
-        return results
+        no_duplicate_results = list(set(results))
+        return no_duplicate_results
 
     def topological_sort(self) -> List[Vertex]:
         """


### PR DESCRIPTION
if a node has two predecessor and they end up in the same layer of execution, the node is executed twice. This can cause problems for idempotent nodes, such as message memory

Fixes #3028