### PR TITLE
fix: Update Textarea component to have full height

### DIFF
--- a/src/frontend/src/components/ui/textarea.tsx
+++ b/src/frontend/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ export interface TextareaProps
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, password, editNode, ...props }, ref) => {
     return (
-      <div className="w-full h-full">
+      <div className="h-full w-full">
         <textarea
           className={cn(
             "nopan nodelete nodrag noflow textarea-primary",

--- a/src/frontend/src/components/ui/textarea.tsx
+++ b/src/frontend/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ export interface TextareaProps
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, password, editNode, ...props }, ref) => {
     return (
-      <div className="w-full">
+      <div className="w-full h-full">
         <textarea
           className={cn(
             "nopan nodelete nodrag noflow textarea-primary",


### PR DESCRIPTION
The Textarea component was updated to have a full height by adding the "h-full" class to the parent div. This ensures that the textarea takes up the entire available vertical space.