### PR TITLE
docs(readme): add instructions for running from a cloned repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,42 @@ You can install Langflow with pip:
 # Make sure you have >=Python 3.10 installed on your system.
 python -m pip install langflow -U
 ```
-Or
 
-If you would like to install from your cloned repo, you can build and install Langflow's frontend and backend with:
+Then, run Langflow with:
+
+```shell
+python -m langflow run
+```
+
+# Running Langflow from a Cloned Repository
+
+If you prefer to run Langflow from a cloned repository rather than installing it via pip, follow these steps:
+
+1. **Clone the Repository**
+
+First, clone the Langflow repository from GitHub:
+
+```shell
+git clone https://github.com/langflow/langflow.git
+```
+
+Navigate into the cloned directory:
+
+```shell
+cd langflow
+```
+
+2. **Build and Install Dependencies**
+
+To build and install Langflow’s frontend and backend, use the following commands:
 
 ```shell
 make install_frontend && make build_frontend && make install_backend
 ```
 
-Then, run Langflow with:
+3. **Run Langflow**
+
+Once the installation is complete, you can run Langflow with:
 
 ```shell
 python -m langflow run

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you prefer to run Langflow from a cloned repository rather than installing it
 First, clone the Langflow repository from GitHub:
 
 ```shell
-git clone https://github.com/langflow/langflow.git
+git clone https://github.com/langflow-ai/langflow.git
 ```
 
 Navigate into the cloned directory:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ make install_frontend && make build_frontend && make install_backend
 Once the installation is complete, you can run Langflow with:
 
 ```shell
-python -m langflow run
+poetry run python -m langflow run
 ```
 
 # 🎨 Create Flows

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 
 - [📝 Content](#-content)
 - [📦 Get Started](#-get-started)
+- [Running Langflow from a Cloned Repository](#-running-langflow-from-a-cloned-repository)
 - [🎨 Create Flows](#-create-flows)
 - [Deploy](#deploy)
   - [DataStax Langflow](#datastax-langflow)


### PR DESCRIPTION
## Description

Added instructions to the README for running the project from a cloned repository.

## Changes
- Step-by-step instructions for cloning the repository.
- Commands to install dependencies.
- Commands to start the project.