### PR TITLE
chore: update Makefile to skip publishing if package already exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ update: ## update dependencies
 	poetry update
 
 publish_base:
-	cd src/backend/base && poetry publish
+	cd src/backend/base && poetry publish --skip-existing
 
 publish_langflow:
 	poetry publish


### PR DESCRIPTION
Skip without error base if it exists 