### PR TITLE
enhancement: Update useFileDrop hook to handle multiple file drops

### DIFF
--- a/src/frontend/src/pages/MainPage/hooks/use-on-file-drop.tsx
+++ b/src/frontend/src/pages/MainPage/hooks/use-on-file-drop.tsx
@@ -1,4 +1,5 @@
 import { useLocation } from "react-router-dom";
+import { XYPosition } from "reactflow";
 import {
   CONSOLE_ERROR_MSG,
   UPLOAD_ALERT_LIST,
@@ -6,19 +7,21 @@ import {
 } from "../../../constants/alerts_constants";
 import useAlertStore from "../../../stores/alertStore";
 import { useFolderStore } from "../../../stores/foldersStore";
-import { XYPosition } from "reactflow";
 
-const useFileDrop = (uploadFlow:({
-  newProject,
-  file,
-  isComponent,
-  position,
-}: {
-  newProject: boolean;
-  file?: File;
-  isComponent: boolean | null;
-  position?: XYPosition;
-}) => Promise<string | never>, type) => {
+const useFileDrop = (
+  uploadFlow: ({
+    newProject,
+    file,
+    isComponent,
+    position,
+  }: {
+    newProject: boolean;
+    file?: File;
+    isComponent: boolean | null;
+    position?: XYPosition;
+  }) => Promise<string | never>,
+  type,
+) => {
   const location = useLocation();
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const setErrorData = useAlertStore((state) => state.setErrorData);
@@ -26,52 +29,56 @@ const useFileDrop = (uploadFlow:({
   const folderId = location?.state?.folderId;
   const myCollectionId = useFolderStore((state) => state.myCollectionId);
 
-const handleFileDrop = (e) => {
-  e.preventDefault();
-  if (e.dataTransfer.types.some((type) => type === "Files")) {
-    const files: FileList = e.dataTransfer.files;
-    console.log(files);
+  const handleFileDrop = (e) => {
+    e.preventDefault();
+    if (e.dataTransfer.types.some((type) => type === "Files")) {
+      const files: FileList = e.dataTransfer.files;
+      console.log(files);
 
-    const uploadPromises:Promise<any>[] = [];
+      const uploadPromises: Promise<any>[] = [];
 
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i];
-      if (file.type === "application/json") {
-        const reader = new FileReader();
-        const FileReaderPromise:Promise<void> = new Promise((resolve, reject) => {
-          reader.onload = (event) => {
-            const fileContent = event.target!.result;
-            const fileContentJson = JSON.parse(fileContent as string);
-            const is_component = fileContentJson.is_component;
-            uploadFlow({
-              newProject: true,
-              file: file,
-              isComponent: type === "all" ? null : type === "component",
-            }).then(_=>resolve()).catch((error) => {
-              reject(error);
-            })
-          };
-          reader.readAsText(file);
-        })
-        uploadPromises.push(FileReaderPromise);
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i];
+        if (file.type === "application/json") {
+          const reader = new FileReader();
+          const FileReaderPromise: Promise<void> = new Promise(
+            (resolve, reject) => {
+              reader.onload = (event) => {
+                const fileContent = event.target!.result;
+                const fileContentJson = JSON.parse(fileContent as string);
+                const is_component = fileContentJson.is_component;
+                uploadFlow({
+                  newProject: true,
+                  file: file,
+                  isComponent: type === "all" ? null : type === "component",
+                })
+                  .then((_) => resolve())
+                  .catch((error) => {
+                    reject(error);
+                  });
+              };
+              reader.readAsText(file);
+            },
+          );
+          uploadPromises.push(FileReaderPromise);
+        }
       }
-    }
 
-    Promise.all(uploadPromises)
-      .then(() => {
-        setSuccessData({
-          title: `All files uploaded successfully`,
+      Promise.all(uploadPromises)
+        .then(() => {
+          setSuccessData({
+            title: `All files uploaded successfully`,
+          });
+          getFolderById(folderId ? folderId : myCollectionId);
+        })
+        .catch((error) => {
+          setErrorData({
+            title: CONSOLE_ERROR_MSG,
+            list: [error],
+          });
         });
-        getFolderById(folderId ? folderId : myCollectionId);
-      })
-      .catch((error) => {
-        setErrorData({
-          title: CONSOLE_ERROR_MSG,
-          list: [error],
-        });
-      });
-  }
-};
+    }
+  };
   return [handleFileDrop];
 };
 

--- a/src/frontend/src/pages/MainPage/hooks/use-on-file-drop.tsx
+++ b/src/frontend/src/pages/MainPage/hooks/use-on-file-drop.tsx
@@ -33,7 +33,6 @@ const useFileDrop = (
     e.preventDefault();
     if (e.dataTransfer.types.some((type) => type === "Files")) {
       const files: FileList = e.dataTransfer.files;
-      console.log(files);
 
       const uploadPromises: Promise<any>[] = [];
 

--- a/src/frontend/src/stores/foldersStore.tsx
+++ b/src/frontend/src/stores/foldersStore.tsx
@@ -94,6 +94,7 @@ export const useFolderStore = create<FoldersStoreType>((set, get) => ({
     if (id) {
       getFolderById(id).then((res) => {
         const setAllFlows = useFlowsManagerStore.getState().setAllFlows;
+        console.log(res);
         setAllFlows(res?.flows);
         set({ selectedFolder: res });
       });

--- a/src/frontend/src/stores/foldersStore.tsx
+++ b/src/frontend/src/stores/foldersStore.tsx
@@ -94,7 +94,6 @@ export const useFolderStore = create<FoldersStoreType>((set, get) => ({
     if (id) {
       getFolderById(id).then((res) => {
         const setAllFlows = useFlowsManagerStore.getState().setAllFlows;
-        console.log(res);
         setAllFlows(res?.flows);
         set({ selectedFolder: res });
       });


### PR DESCRIPTION
The useFileDrop hook in use-on-file-drop.tsx has been updated to handle multiple file drops. It now accepts an array of files instead of a single file, and processes each file individually. This allows for uploading multiple files at once and improves the user experience.