### PR TITLE
ci: update cli command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
         run: make build main=true
       - name: Test CLI
         run: |
-          python -m pip install dist/*.whl
+          python -m pip install dist/*.whl --force-reinstall
           python -m langflow run --host 127.0.0.1 --port 7860 &
           SERVER_PID=$!
           # Wait for the server to start

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,8 +130,8 @@ jobs:
         run: make build main=true
       - name: Test CLI
         run: |
-          python -m pip install dist/*.whl --force-reinstall
-          python -m langflow run --host 127.0.0.1 --port 7860 &
+          python -m pip install dist/*.whl
+          python -m langflow run --host 127.0.0.1 --port 7860 --backend-only &
           SERVER_PID=$!
           # Wait for the server to start
           timeout 120 bash -c 'until curl -f http://127.0.0.1:7860/api/v1/health_check; do sleep 2; done' || (echo "Server did not start in time" && kill $SERVER_PID && exit 1)


### PR DESCRIPTION
This pull request updates the pip installation command in the release workflow to include the `--backend-only` flag when running the CLI test. This ensures that the server starts correctly before running the test.