### PR TITLE
fix: description of url component

### DIFF
--- a/src/backend/base/langflow/components/data/URL.py
+++ b/src/backend/base/langflow/components/data/URL.py
@@ -17,7 +17,7 @@ class URLComponent(Component):
         MessageTextInput(
             name="urls",
             display_name="URLs",
-            info="Enter one or more URLs, separated by commas.",
+            info="Enter one or more URLs, by clicking the '+' button.",
             is_list=True,
         ),
     ]


### PR DESCRIPTION
- Fix description that tells the user that he can put URLs separated by commas