### PR TITLE
feat: remove unnecessary condition in App component

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -137,7 +137,6 @@ export default function App() {
               message={FETCH_ERROR_MESSAGE}
               openModal={
                 isErrorHealth ||
-                !healthData ||
                 (healthData &&
                   Object.values(healthData).some((value) => value !== "ok"))
               }


### PR DESCRIPTION
The unnecessary condition in the App component was causing the error modal to not appear when there was an error in the health data. This commit removes the unnecessary condition to ensure that the error modal is displayed correctly.