### PR TITLE
fix: handle PydanticSerializationError that generates generic errors in the UI

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import warnings
 from contextlib import asynccontextmanager
@@ -70,8 +71,8 @@ class JavaScriptMIMETypeMiddleware(BaseHTTPMiddleware):
         except Exception as exc:
             if isinstance(exc, PydanticSerializationError):
                 message = "Something went wrong while serializing the response. Please share this error on our GitHub repository."
-                error_message = "\n".join([message, str(exc)])
-                raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message) from exc
+                error_messages = json.dumps([message, str(exc)])
+                raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_messages) from exc
             raise exc
         if "files/" not in request.url.path and request.url.path.endswith(".js") and response.status_code == 200:
             response.headers["Content-Type"] = "text/javascript"

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -69,8 +69,8 @@ class JavaScriptMIMETypeMiddleware(BaseHTTPMiddleware):
             response = await call_next(request)
         except Exception as exc:
             if isinstance(exc, PydanticSerializationError):
-                messages = [error["msg"].split(",", 1) for error in e.errors()]
-                error_message = "\n".join([message[1] if len(message) > 1 else message[0] for message in messages])
+                message = "Something went wrong while serializing the response. Please share this error on our GitHub repository."
+                error_message = "\n".join([message, str(exc)])
                 raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message) from exc
             raise exc
         if "files/" not in request.url.path and request.url.path.endswith(".js") and response.status_code == 200:

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -45,7 +45,6 @@ export default function App() {
   const {
     data: healthData,
     isFetching: fetchingHealth,
-    isLoading: isLoadingHealth,
     isError: isErrorHealth,
     refetch,
   } = useGetHealthQuery();
@@ -138,7 +137,7 @@ export default function App() {
               message={FETCH_ERROR_MESSAGE}
               openModal={
                 isErrorHealth ||
-                (!healthData && isLoadingHealth) ||
+                !healthData ||
                 (healthData &&
                   Object.values(healthData).some((value) => value !== "ok"))
               }

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -45,6 +45,7 @@ export default function App() {
   const {
     data: healthData,
     isFetching: fetchingHealth,
+    isLoading: isLoadingHealth,
     isError: isErrorHealth,
     refetch,
   } = useGetHealthQuery();
@@ -137,7 +138,7 @@ export default function App() {
               message={FETCH_ERROR_MESSAGE}
               openModal={
                 isErrorHealth ||
-                !healthData ||
+                (!healthData && isLoadingHealth) ||
                 (healthData &&
                   Object.values(healthData).some((value) => value !== "ok"))
               }

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -315,7 +315,6 @@ async function buildVertex({
     if (!Array.isArray(errorMessage)) {
       errorMessage = [errorMessage];
     }
-    console.log(errorMessage);
     onBuildError!(
       "Error Building Component",
       errorMessage,

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -7,6 +7,7 @@ import useFlowStore from "../stores/flowStore";
 import { VertexBuildTypeAPI } from "../types/api";
 import { isErrorLogType } from "../types/utils/typeCheckingUtils";
 import { VertexLayerElementType } from "../types/zustand/flow";
+import { tryParseJson } from "./utils";
 
 type BuildVerticesParams = {
   setLockChat?: (lock: boolean) => void;
@@ -306,12 +307,18 @@ async function buildVertex({
     buildResults.push(buildData.valid);
   } catch (error) {
     console.error(error);
+    let errorMessage: string | string[] =
+      (error as AxiosError<any>).response?.data?.detail ||
+      (error as AxiosError<any>).response?.data?.message ||
+      "An unexpected error occurred while building the Component. Please try again.";
+    errorMessage = tryParseJson(errorMessage as string) ?? errorMessage;
+    if (!Array.isArray(errorMessage)) {
+      errorMessage = [errorMessage];
+    }
+    console.log(errorMessage);
     onBuildError!(
       "Error Building Component",
-      [
-        (error as AxiosError<any>).response?.data?.detail || (error as AxiosError<any>).response?.data?.message ||
-          "An unexpected error occurred while building the Component. Please try again.",
-      ],
+      errorMessage,
       verticesIds.map((id) => ({ id })),
     );
     buildResults.push(false);

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -309,7 +309,7 @@ async function buildVertex({
     onBuildError!(
       "Error Building Component",
       [
-        (error as AxiosError<any>).response?.data?.detail ??
+        (error as AxiosError<any>).response?.data?.detail || (error as AxiosError<any>).response?.data?.message ||
           "An unexpected error occurred while building the Component. Please try again.",
       ],
       verticesIds.map((id) => ({ id })),

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -546,3 +546,19 @@ export function generateBackendColumnsFromValue(rows: Object[]): ColumnField[] {
     return newColumn;
   });
 }
+
+/**
+ * Tries to parse a JSON string and returns the parsed object.
+ * If parsing fails, returns undefined.
+ *
+ * @param json - The JSON string to parse.
+ * @returns The parsed JSON object, or undefined if parsing fails.
+ */
+export function tryParseJson(json: string) {
+  try {
+    const parsedJson = JSON.parse(json);
+    return parsedJson;
+  } catch (error) {
+    return;
+  }
+}


### PR DESCRIPTION
This pull request fixes the handling of PydanticSerializationError in the JavaScriptMIMETypeMiddleware. Previously, when a serialization error occurred, a generic error message was returned. With this fix, a more detailed error message is provided. This ensures that users can easily identify and troubleshoot serialization errors.