### PR TITLE
feat: update GenericNode to include lf_version in node data

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -216,22 +216,21 @@ export default function GenericNode({
   }, [data.showNode]);
 
   useEffect(() => {
-    if(buildStatus===BuildStatus.BUILT&& !isBuilding){
-      setNode(data.id,(old)=>{
+    if (buildStatus === BuildStatus.BUILT && !isBuilding) {
+      setNode(data.id, (old) => {
         return {
           ...old,
-          data:{
+          data: {
             ...old.data,
-            node:{
+            node: {
               ...old.data.node,
-              lf_version:version
-
-            }
-        }
-      }
-      })
+              lf_version: version,
+            },
+          },
+        };
+      });
     }
-  },[buildStatus,isBuilding])
+  }, [buildStatus, isBuilding]);
 
   const [loadingUpdate, setLoadingUpdate] = useState(false);
 

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -65,7 +65,7 @@ export default function GenericNode({
   const updateNodeInternals = useUpdateNodeInternals();
   const setErrorData = useAlertStore((state) => state.setErrorData);
   const isDark = useDarkStore((state) => state.dark);
-
+  const version = useDarkStore((state) => state.version);
   const takeSnapshot = useFlowsManagerStore((state) => state.takeSnapshot);
 
   const [inputName, setInputName] = useState(false);
@@ -214,6 +214,24 @@ export default function GenericNode({
   useEffect(() => {
     setShowNode(data.showNode ?? true);
   }, [data.showNode]);
+
+  useEffect(() => {
+    if(buildStatus===BuildStatus.BUILT&& !isBuilding){
+      setNode(data.id,(old)=>{
+        return {
+          ...old,
+          data:{
+            ...old.data,
+            node:{
+              ...old.data.node,
+              lf_version:version
+
+            }
+        }
+      }
+      })
+    }
+  },[buildStatus,isBuilding])
 
   const [loadingUpdate, setLoadingUpdate] = useState(false);
 

--- a/src/frontend/src/types/api/index.ts
+++ b/src/frontend/src/types/api/index.ts
@@ -43,6 +43,7 @@ export type APIClassType = {
   official?: boolean;
   outputs?: Array<OutputFieldType>;
   frozen?: boolean;
+  lf_version?: string;
   flow?: FlowType;
   field_order?: string[];
   [key: string]:


### PR DESCRIPTION
This PR introduces an enhancement to the GenericNode component by adding a new field, `lf_version`, to the node data. This update aims to improve the metadata tracking and version control of nodes within our system.