### PR TITLE
refactor: improve file handling in loading starter projects

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -343,12 +343,13 @@ def load_starter_projects() -> list[tuple[Path, dict]]:
     starter_projects = []
     folder = Path(__file__).parent / "starter_projects"
     for file in folder.glob("*.json"):
-        try:
-            project = orjson.loads(file.read_text(encoding="utf-8"))
-        except orjson.JSONDecodeError as e:
-            raise ValueError(f"Error loading starter project {file}: {e}")
-        starter_projects.append((file, project))
-        logger.info(f"Loaded starter project {file}")
+        with open(file, "r", encoding="utf-8") as f:
+            try:
+                project = orjson.loads(f.read())
+                starter_projects.append((file, project))
+                logger.info(f"Loaded starter project {file}")
+            except orjson.JSONDecodeError as e:
+                raise ValueError(f"Error loading starter project {file}: {e}")
     return starter_projects
 
 


### PR DESCRIPTION
Refactor the `load_starter_projects` function in `setup.py` to close the file once it is loaded. This could fix tests hanging in CI.