### PR TITLE
feat: set sqlite pragma by env variable

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -47,7 +47,9 @@ class DatabaseService(Service):
 
     def _create_engine(self) -> "Engine":
         """Create the engine for the database."""
-        if self.settings_service.settings.database_url and self.settings_service.settings.database_url.startswith("sqlite"):
+        if self.settings_service.settings.database_url and self.settings_service.settings.database_url.startswith(
+            "sqlite"
+        ):
             connect_args = {"check_same_thread": False}
         else:
             connect_args = {}

--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -1,5 +1,4 @@
 import time
-import os
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional

--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -71,7 +71,14 @@ class Settings(BaseSettings):
     pool_size: int = 10
     """The number of connections to keep open in the connection pool. If not provided, the default is 10."""
     max_overflow: int = 20
-    """The number of connections to allow that can be opened beyond the pool size. If not provided, the default is 10."""
+    """The number of connections to allow that can be opened beyond the pool size.
+    If not provided, the default is 20."""
+
+    # sqlite configuration
+    sqlite_pragmas: Optional[dict] = {"synchronous": "NORMAL", "journal_mode": "WAL"}
+    """SQLite pragmas to use when connecting to the database."""
+
+    # cache configuration
     cache_type: str = "async"
     """The cache type can be 'async' or 'redis'."""
     cache_expire: int = 3600

--- a/src/backend/tests/unit/test_database.py
+++ b/src/backend/tests/unit/test_database.py
@@ -409,5 +409,6 @@ def test_sqlite_pragmas():
 
     with db_service as session:
         from sqlalchemy import text
+
         assert "wal" == session.execute(text("PRAGMA journal_mode;")).fetchone()[0]
         assert 1 == session.execute(text("PRAGMA synchronous;")).fetchone()[0]

--- a/src/backend/tests/unit/test_database.py
+++ b/src/backend/tests/unit/test_database.py
@@ -402,3 +402,12 @@ def test_migrate_transactions_no_duckdb(client: TestClient):
         migrate_transactions_from_monitor_service_to_database(session)
         new_trans = get_transactions_by_flow_id(session, UUID(flow_id))
         assert 0 == len(new_trans)
+
+
+def test_sqlite_pragmas():
+    db_service = get_db_service()
+
+    with db_service as session:
+        from sqlalchemy import text
+        assert "wal" == session.execute(text("PRAGMA journal_mode;")).fetchone()[0]
+        assert 1 == session.execute(text("PRAGMA synchronous;")).fetchone()[0]


### PR DESCRIPTION
SQLite Pragma should not be hardcoded. This PR introduce an env variable to all these PRAGMA statement to be configurable without code changes.

To change the pragams you can set the env variable LANGFLOW_SQLITE_PRAGMAS using a JSON dict

The default value is unchanged and is
```
LANGFLOW_SQLITE_PRAGMAS="{"synchronous": "NORMAL", "journal_mode": "WAL"}"
```
