### PR TITLE
fix: external memory messages history is reversed

### DIFF
--- a/src/backend/base/langflow/components/helpers/Memory.py
+++ b/src/backend/base/langflow/components/helpers/Memory.py
@@ -89,7 +89,8 @@ class MemoryComponent(Component):
             self.memory.session_id = session_id
 
             stored = self.memory.messages
-            if order == "ASC":
+            # langchain memories are supposed to return messages in ascending order
+            if order == "DESC":
                 stored = stored[::-1]
             if n_messages:
                 stored = stored[:n_messages]


### PR DESCRIPTION
 langchain memories are supposed to return messages in ascending order. Currently the Memory components sort them on the other way around 