### PR TITLE
fix: unnecessary split method in vertex_id that breaks playground

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -254,7 +254,7 @@ async def build_flow(
                 background_tasks.add_task(
                     log_vertex_build,
                     flow_id=flow_id_str,
-                    vertex_id=vertex_id.split("-")[0],
+                    vertex_id=vertex_id,
                     valid=valid,
                     params=params,
                     data=result_data_response,

--- a/src/frontend/src/controllers/API/queries/_builds/use-delete-builds.ts
+++ b/src/frontend/src/controllers/API/queries/_builds/use-delete-builds.ts
@@ -8,7 +8,7 @@ interface IDeleteBuilds {
 }
 
 // add types for error handling and success
-export const useDeleteBuilds: useMutationFunctionType<IDeleteBuilds> = (
+export const useDeleteBuilds: useMutationFunctionType<undefined,IDeleteBuilds> = (
   options,
 ) => {
   const { mutate } = UseRequestProcessor();


### PR DESCRIPTION
This pull request includes two commits that fix a wrong type and remove an unnecessary split method in the `vertex_id` function that broke the playground in #3020. The changes ensure that the `vertex_id` function works correctly and efficiently.