### PR TITLE
ci: update nick-fields/retry dependency to v3

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -46,7 +46,7 @@ jobs:
           poetry env use ${{ matrix.python-version }}
           poetry install
       - name: Run unit tests
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 12
           max_attempts: 2


### PR DESCRIPTION
This update silences a warning on Github