### PR TITLE
feat: add huggingface endpoint retry

### DIFF
--- a/src/backend/base/langflow/components/models/HuggingFaceModel.py
+++ b/src/backend/base/langflow/components/models/HuggingFaceModel.py
@@ -5,13 +5,7 @@ from langchain_community.llms.huggingface_endpoint import HuggingFaceEndpoint
 
 from langflow.base.models.model import LCModelComponent
 from langflow.field_typing import LanguageModel
-from langflow.io import (
-    DictInput,
-    DropdownInput,
-    SecretStrInput,
-    StrInput,
-    IntInput
-)
+from langflow.io import DictInput, DropdownInput, SecretStrInput, StrInput, IntInput
 
 
 class HuggingFaceEndpointsComponent(LCModelComponent):

--- a/src/backend/base/langflow/components/models/HuggingFaceModel.py
+++ b/src/backend/base/langflow/components/models/HuggingFaceModel.py
@@ -1,9 +1,17 @@
+from tenacity import retry, stop_after_attempt, wait_fixed
+
 from langchain_community.chat_models.huggingface import ChatHuggingFace
 from langchain_community.llms.huggingface_endpoint import HuggingFaceEndpoint
 
 from langflow.base.models.model import LCModelComponent
 from langflow.field_typing import LanguageModel
-from langflow.io import DictInput, DropdownInput, SecretStrInput, StrInput
+from langflow.io import (
+    DictInput,
+    DropdownInput,
+    SecretStrInput,
+    StrInput,
+    IntInput
+)
 
 
 class HuggingFaceEndpointsComponent(LCModelComponent):
@@ -26,7 +34,23 @@ class HuggingFaceEndpointsComponent(LCModelComponent):
         ),
         SecretStrInput(name="huggingfacehub_api_token", display_name="API token", password=True),
         DictInput(name="model_kwargs", display_name="Model Keyword Arguments", advanced=True),
+        IntInput(name="retry_attempts", display_name="Retry Attempts"),
     ]
+
+    def create_huggingface_endpoint(self, endpoint_url, task, huggingfacehub_api_token, model_kwargs):
+        @retry(stop=stop_after_attempt(self.retry_attempts), wait=wait_fixed(2))
+        def _attempt_create():
+            try:
+                return HuggingFaceEndpoint(  # type: ignore
+                    endpoint_url=endpoint_url,
+                    task=task,
+                    huggingfacehub_api_token=huggingfacehub_api_token,
+                    model_kwargs=model_kwargs,
+                )
+            except Exception as e:
+                raise ValueError("Could not connect to HuggingFace Endpoints API.") from e
+
+        return _attempt_create()
 
     def build_model(self) -> LanguageModel:  # type: ignore[type-var]
         endpoint_url = self.endpoint_url
@@ -35,12 +59,7 @@ class HuggingFaceEndpointsComponent(LCModelComponent):
         model_kwargs = self.model_kwargs or {}
 
         try:
-            llm = HuggingFaceEndpoint(  # type: ignore
-                endpoint_url=endpoint_url,
-                task=task,
-                huggingfacehub_api_token=huggingfacehub_api_token,
-                model_kwargs=model_kwargs,
-            )
+            llm = self.create_huggingface_endpoint(endpoint_url, task, huggingfacehub_api_token, model_kwargs)
         except Exception as e:
             raise ValueError("Could not connect to HuggingFace Endpoints API.") from e
 

--- a/src/backend/base/langflow/components/models/HuggingFaceModel.py
+++ b/src/backend/base/langflow/components/models/HuggingFaceModel.py
@@ -34,7 +34,7 @@ class HuggingFaceEndpointsComponent(LCModelComponent):
         ),
         SecretStrInput(name="huggingfacehub_api_token", display_name="API token", password=True),
         DictInput(name="model_kwargs", display_name="Model Keyword Arguments", advanced=True),
-        IntInput(name="retry_attempts", display_name="Retry Attempts"),
+        IntInput(name="retry_attempts", display_name="Retry Attempts", value=1),
     ]
 
     def create_huggingface_endpoint(self, endpoint_url, task, huggingfacehub_api_token, model_kwargs):


### PR DESCRIPTION
Sometimes when calling Hugging Face API model, it's failed and don't have any retry implemented, this PR just add the ability to user define a number of retry before the call fails.

https://github.com/langflow-ai/langflow/discussions/3210