### PR TITLE
ci: add version check in workflow to skip jobs for unreleased versions of langflow-base

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -69,14 +69,30 @@ jobs:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ env.POETRY_VERSION }}
           cache-key: ${{ runner.os }}-poetry-${{ env.POETRY_VERSION }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Check Version
+        id: check-version
+        run: |
+          version=$(cd src/backend/base && poetry version --short)
+          last_released_version=$(curl -s "https://pypi.org/pypi/langflow-base/json" | jq -r '.releases | keys | .[]' | sort -V | tail -n 1)
+          if [ "$version" != "$last_released_version" ]; then
+            echo "Version $version has not been released yet. Skipping the rest of the job."
+            echo skipped=true >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo version=$version >> $GITHUB_OUTPUT
+            echo skipped=false >> $GITHUB_OUTPUT
+          fi
       - name: Build wheel
+        if: steps.check-version.outputs.skipped == 'false'
         run: |
           poetry env use ${{ matrix.python-version }}
           make build main=true
       - name: Install wheel
+        if: steps.check-version.outputs.skipped == 'false'
         run: |
           python -m pip install dist/*.whl
       - name: Test CLI
+        if: steps.check-version.outputs.skipped == 'false'
         run: |
           python -m langflow run --host 127.0.0.1 --port 7860 --backend-only &
           SERVER_PID=$!


### PR DESCRIPTION
We need this because if there was a version bump the CI will always fail until we release the version.