### PR TITLE
fix: change sync_get_file_content_dicts to use get_file_content_dicts

### DIFF
--- a/src/backend/base/langflow/schema/message.py
+++ b/src/backend/base/langflow/schema/message.py
@@ -164,7 +164,7 @@ class Message(Data):
         return value
 
     def sync_get_file_content_dicts(self):
-        coro = self.aget_file_content_dicts()
+        coro = self.get_file_content_dicts()
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(coro)
 


### PR DESCRIPTION
Refactor the `sync_get_file_content_dicts` method in the `Message` class to use the `get_file_content_dicts` method instead. This change improves the code by using a more descriptive and accurate method name.