### PR TITLE
feat: Add support for metadata filtering and namespaces for the Upstash Vector component

### DIFF
--- a/docs/docs/Components/components-vector-stores.md
+++ b/docs/docs/Components/components-vector-stores.md
@@ -472,6 +472,27 @@ Ensure the Supabase service key, URL, and table name are properly configured.
 ---
 
 
+### Upstash Vector
+
+
+`UpstashVector` searches a Upstash Vector Store for documents similar to the input. It has it's own embedding
+model which can be used to search documents without needing an external embedding model.
+
+
+**Parameters:**
+
+- **Index URL:** The URL of the Upstash index.
+- **Index Token:** The token for the Upstash index.
+- **Text Key:** The key in the record to use as text.
+- **Namespace:** The namespace name. A new namespace is created if not found. Leave empty for default namespace.
+- **Search Query:** The search query.
+- **Metadata Filter:** The metadata filter. Filters documents by metadata. Look at the [docs](https://upstash.com/docs/vector/features/filtering) for more information.
+- **Embedding:** The embedding model used. To use Upstash's embeddings, don't provide an embedding.
+- **Number of Results:** The number of results to return.
+
+---
+
+
 ### Vectara {#b4e05230b62a47c792a89c5511af97ac}
 
 

--- a/src/backend/base/langflow/components/vectorstores/Upstash.py
+++ b/src/backend/base/langflow/components/vectorstores/Upstash.py
@@ -18,9 +18,7 @@ from langflow.schema import Data
 class UpstashVectorStoreComponent(LCVectorStoreComponent):
     display_name = "Upstash"
     description = "Upstash Vector Store with search capabilities"
-    documentation = (
-        "https://python.langchain.com/v0.2/docs/integrations/vectorstores/upstash/"
-    )
+    documentation = "https://python.langchain.com/v0.2/docs/integrations/vectorstores/upstash/"
     name = "Upstash"
     icon = "Upstash"
 
@@ -121,11 +119,7 @@ class UpstashVectorStoreComponent(LCVectorStoreComponent):
     def search_documents(self) -> List[Data]:
         vector_store = self._build_upstash()
 
-        if (
-            self.search_query
-            and isinstance(self.search_query, str)
-            and self.search_query.strip()
-        ):
+        if self.search_query and isinstance(self.search_query, str) and self.search_query.strip():
             docs = vector_store.similarity_search(
                 query=self.search_query,
                 k=self.number_of_results,

--- a/src/backend/base/langflow/components/vectorstores/Upstash.py
+++ b/src/backend/base/langflow/components/vectorstores/Upstash.py
@@ -4,21 +4,38 @@ from langchain_community.vectorstores import UpstashVectorStore
 
 from langflow.base.vectorstores.model import LCVectorStoreComponent
 from langflow.helpers.data import docs_to_data
-from langflow.io import HandleInput, IntInput, StrInput, SecretStrInput, DataInput, MultilineInput
+from langflow.io import (
+    HandleInput,
+    IntInput,
+    StrInput,
+    SecretStrInput,
+    DataInput,
+    MultilineInput,
+)
 from langflow.schema import Data
 
 
 class UpstashVectorStoreComponent(LCVectorStoreComponent):
     display_name = "Upstash"
     description = "Upstash Vector Store with search capabilities"
-    documentation = "https://python.langchain.com/v0.2/docs/integrations/vectorstores/upstash/"
+    documentation = (
+        "https://python.langchain.com/v0.2/docs/integrations/vectorstores/upstash/"
+    )
     name = "Upstash"
     icon = "Upstash"
 
     inputs = [
-        StrInput(name="index_url", display_name="Index URL", info="The URL of the Upstash index.", required=True),
+        StrInput(
+            name="index_url",
+            display_name="Index URL",
+            info="The URL of the Upstash index.",
+            required=True,
+        ),
         SecretStrInput(
-            name="index_token", display_name="Index Token", info="The token for the Upstash index.", required=True
+            name="index_token",
+            display_name="Index Token",
+            info="The token for the Upstash index.",
+            required=True,
         ),
         StrInput(
             name="text_key",
@@ -27,7 +44,17 @@ class UpstashVectorStoreComponent(LCVectorStoreComponent):
             value="text",
             advanced=True,
         ),
+        StrInput(
+            name="namespace",
+            display_name="Namespace",
+            info="Leave empty for default namespace.",
+        ),
         MultilineInput(name="search_query", display_name="Search Query"),
+        MultilineInput(
+            name="metadata_filter",
+            display_name="Metadata Filter",
+            info="Filters documents by metadata. Look at the documentation for more information.",
+        ),
         DataInput(
             name="ingest_data",
             display_name="Ingest Data",
@@ -68,6 +95,7 @@ class UpstashVectorStoreComponent(LCVectorStoreComponent):
                     text_key=self.text_key,
                     index_url=self.index_url,
                     index_token=self.index_token,
+                    namespace=self.namespace,
                 )
                 upstash_vs.add_documents(documents)
             else:
@@ -77,6 +105,7 @@ class UpstashVectorStoreComponent(LCVectorStoreComponent):
                     text_key=self.text_key,
                     index_url=self.index_url,
                     index_token=self.index_token,
+                    namespace=self.namespace,
                 )
         else:
             upstash_vs = UpstashVectorStore(
@@ -84,6 +113,7 @@ class UpstashVectorStoreComponent(LCVectorStoreComponent):
                 text_key=self.text_key,
                 index_url=self.index_url,
                 index_token=self.index_token,
+                namespace=self.namespace,
             )
 
         return upstash_vs
@@ -91,10 +121,15 @@ class UpstashVectorStoreComponent(LCVectorStoreComponent):
     def search_documents(self) -> List[Data]:
         vector_store = self._build_upstash()
 
-        if self.search_query and isinstance(self.search_query, str) and self.search_query.strip():
+        if (
+            self.search_query
+            and isinstance(self.search_query, str)
+            and self.search_query.strip()
+        ):
             docs = vector_store.similarity_search(
                 query=self.search_query,
                 k=self.number_of_results,
+                filter=self.metadata_filter,
             )
 
             data = docs_to_data(docs)


### PR DESCRIPTION
I was planning to add Upstash support to Langflow, but I noticed that you already have it implemented, and it works quite well.

We now support [namespaces](https://upstash.com/docs/vector/features/namespaces) and [metadata filtering](https://upstash.com/docs/vector/features/filtering). We’ve added these features to the Langchain integration, and it would be great to see them in Langflow as well.

I also updated the documentation, as Upstash Vector was missing from the vector stores page.

Please let me know if any changes are needed.