### PR TITLE
fix: enhance error handling in build_flow and add error handling for Flow build

### DIFF
--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -264,6 +264,14 @@ export async function buildFlowVertices({
         useFlowStore.getState().setIsBuilding(false);
         return true;
       }
+      case "error": {
+        const errorMessage = data.error;
+        console.log(data);
+        onBuildError!("Error Running Flow", [errorMessage], []);
+        buildResults.push(false);
+        useFlowStore.getState().setIsBuilding(false);
+        return true;
+      }
       default:
         return true;
     }


### PR DESCRIPTION
This pull request enhances the error handling in the `build_flow` function and adds error handling for the Flow build process. The changes in `buildUtils.ts` include a new case for handling errors in the switch statement, which displays the error message and triggers the `onBuildError` function. This ensures that errors during the Flow build are properly handled and the build process is stopped.