### PR TITLE
feat: add log_builds parameter to build_flow for optional vertex build logging

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -146,6 +146,7 @@ async def build_flow(
     files: Optional[list[str]] = None,
     stop_component_id: Optional[str] = None,
     start_component_id: Optional[str] = None,
+    log_builds: Optional[bool] = True,
     chat_service: "ChatService" = Depends(get_chat_service),
     current_user=Depends(get_current_active_user),
     telemetry_service: "TelemetryService" = Depends(get_telemetry_service),
@@ -250,7 +251,7 @@ async def build_flow(
             result_data_response.message = artifacts
 
             # Log the vertex build
-            if not vertex.will_stream:
+            if not vertex.will_stream and log_builds:
                 background_tasks.add_task(
                     log_vertex_build,
                     flow_id=flow_id_str,


### PR DESCRIPTION
This is needed so that calls from outside the workspace don't affect the playground in the workspace. 


`log_builds` should be used as a query param just like `start_component_id`. 