### PR TITLE
fix: correct issue with The "No suitable component" error is appearing on the OpenAI component and other components due to a missing check.

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
@@ -138,7 +138,7 @@ export default function NodeInputField({
           </div>
         </div>
 
-        {displayHandle && (
+        {(Array.isArray(displayHandle) ?  displayHandle.length > 0 :   displayHandle) && (
           <HandleRenderComponent
             left={true}
             nodes={nodes}

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
@@ -137,7 +137,6 @@ export default function NodeInputField({
             )}
           </div>
         </div>
-
         {(Array.isArray(displayHandle)
           ? displayHandle.length > 0
           : displayHandle) && (

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
@@ -138,7 +138,9 @@ export default function NodeInputField({
           </div>
         </div>
 
-        {(Array.isArray(displayHandle) ?  displayHandle.length > 0 :   displayHandle) && (
+        {(Array.isArray(displayHandle)
+          ? displayHandle.length > 0
+          : displayHandle) && (
           <HandleRenderComponent
             left={true}
             nodes={nodes}


### PR DESCRIPTION
Issue is attached here - 

https://github.com/langflow-ai/langflow/issues/3272

**Bug Description**
We have noticed that a check is missing when displaying edge dots on the left side of the component. As a result, an unnecessary dot appears, causing confusion for users.

**Reproduction**

1. Open Langflow.
2. Click on "Add New Project."
3. Select the "Basic Prompting" template.
4. You'll notice that the OpenAI node displays an unused edge dot on the left side.

**Expected behaviour**

https://github.com/user-attachments/assets/623f2ade-71cf-49b5-ab6d-7c36f415f3f6


There shouldn't be any dot on the left side, as there isn't a suitable component for this node.