### PR TITLE
fix: add double quotes to curl command generation

### DIFF
--- a/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
@@ -28,8 +28,8 @@ export function getCurlRunCode(
       !isAuth ? `\n  -H 'x-api-key: <your api key>'\\` : ""
     }
     -d '{"input_value": "message",
-    "output_type": ${hasChatOutput ? "chat" : "text"},
-    "input_type": ${hasChatInput ? "chat" : "text"},
+    "output_type": ${hasChatOutput ? '"chat"' : '"text"'},
+    "input_type": ${hasChatInput ? '"chat"' : '"text"'},
     "tweaks": ${tweaksString}}'
     `;
 }


### PR DESCRIPTION
This PR addresses an issue where the generated curl commands were missing double quotes around certain arguments. 

Fixes  #3320