### PR TITLE
ci: allow specifying python versions and limit ci to 3.10 only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
     name: Run Backend Tests
     if: ${{ needs.path-filter.outputs.python == 'true' || needs.path-filter.outputs.tests == 'true' }}
     uses: ./.github/workflows/python_test.yml
+    with:
+      python-versions: "['3.10']"
 
   test-frontend:
     needs: path-filter

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -2,6 +2,12 @@ name: Python tests
 
 on:
   workflow_call:
+    inputs:
+      python-versions:
+        description: "(Optional) Python versions to test"
+        required: false
+        type: string
+        default: "['3.10', '3.11', '3.12']"
   workflow_dispatch:
     inputs:
       branch:
@@ -18,10 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-          - "3.12"
-          - "3.11"
-          - "3.10"
+        python-version: ${{ fromJson(inputs.python-versions) }}
         splitCount: [5]
         group: [1, 2, 3, 4, 5]
     env:
@@ -57,10 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-          - "3.12"
-          - "3.11"
-          - "3.10"
+        python-version: ${{ fromJson(inputs.python-versions) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }} + Poetry ${{ env.POETRY_VERSION }}

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       python-versions:
         description: "(Optional) Python versions to test"
-        required: false
+        required: true
         type: string
         default: "['3.10', '3.11', '3.12']"
   workflow_dispatch:


### PR DESCRIPTION
Update CI to limit the python versions running on every PR.

Reason we need to use `fromJson`: https://developer-friendly.blog/2024/03/09/github-actions-dynamic-matrix/#step-3-build-the-docker-images
