### PR TITLE
tests: Reduce Timeout on Tests for Basic Examples Modal

### DIFF
--- a/src/frontend/tests/end-to-end/Basic Prompting.spec.ts
+++ b/src/frontend/tests/end-to-end/Basic Prompting.spec.ts
@@ -27,7 +27,7 @@ test("Basic Prompting (Hello, World)", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/Blog Writer.spec.ts
+++ b/src/frontend/tests/end-to-end/Blog Writer.spec.ts
@@ -27,7 +27,7 @@ test("Blog Writer", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/Complex Agent.spec.ts
+++ b/src/frontend/tests/end-to-end/Complex Agent.spec.ts
@@ -32,7 +32,7 @@ test("Complex Agent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/Document QA.spec.ts
+++ b/src/frontend/tests/end-to-end/Document QA.spec.ts
@@ -27,7 +27,7 @@ test("Document QA", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/Hierarchical Tasks Agent.spec.ts
+++ b/src/frontend/tests/end-to-end/Hierarchical Tasks Agent.spec.ts
@@ -32,7 +32,7 @@ test("Hierarchical Tasks Agent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/Memory Chatbot.spec.ts
+++ b/src/frontend/tests/end-to-end/Memory Chatbot.spec.ts
@@ -27,7 +27,7 @@ test("Memory Chatbot", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/Sequential Tasks Agent.spec.ts
+++ b/src/frontend/tests/end-to-end/Sequential Tasks Agent.spec.ts
@@ -32,7 +32,7 @@ test("Sequential Tasks Agent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/Vector Store.spec.ts
+++ b/src/frontend/tests/end-to-end/Vector Store.spec.ts
@@ -32,7 +32,7 @@ test("Vector Store RAG", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/actionsMainPage-shard-1.spec.ts
+++ b/src/frontend/tests/end-to-end/actionsMainPage-shard-1.spec.ts
@@ -16,7 +16,7 @@ test("select and delete all", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.getByRole("heading", { name: "Basic Prompting" }).click();
@@ -52,7 +52,7 @@ test("select and delete a flow", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.getByRole("heading", { name: "Basic Prompting" }).click();
@@ -87,7 +87,7 @@ test("search flows", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.getByRole("heading", { name: "Basic Prompting" }).click();
@@ -137,7 +137,7 @@ test("search components", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.getByRole("heading", { name: "Basic Prompting" }).click();

--- a/src/frontend/tests/end-to-end/chatInputOutputUser-shard-0.spec.ts
+++ b/src/frontend/tests/end-to-end/chatInputOutputUser-shard-0.spec.ts
@@ -29,7 +29,7 @@ test("user must be able to send an image on chat", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/decisionFlow.spec.ts
+++ b/src/frontend/tests/end-to-end/decisionFlow.spec.ts
@@ -28,7 +28,7 @@ test("should create a flow with decision", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/filterEdge-shard-0.spec.ts
+++ b/src/frontend/tests/end-to-end/filterEdge-shard-0.spec.ts
@@ -18,7 +18,7 @@ test("user must see on handle hover a tooltip with possibility connections", asy
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/filterSidebar.spec.ts
+++ b/src/frontend/tests/end-to-end/filterSidebar.spec.ts
@@ -18,7 +18,7 @@ test("user must see on handle click the possibility connections - LLMChain", asy
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForTimeout(1000);

--- a/src/frontend/tests/end-to-end/folders.spec.ts
+++ b/src/frontend/tests/end-to-end/folders.spec.ts
@@ -17,7 +17,7 @@ test("CRUD folders", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.getByRole("heading", { name: "Basic Prompting" }).click();
@@ -68,7 +68,9 @@ test("CRUD folders", async ({ page }) => {
 test("add folder by drag and drop", async ({ page }) => {
   await page.goto("/");
 
-  await page.waitForTimeout(5000); // Consider using a more reliable waiting mechanism
+  await page.waitForSelector("text=my collection", {
+    timeout: 50000,
+  });
 
   const jsonContent = readFileSync(
     "tests/end-to-end/assets/collection.json",
@@ -119,7 +121,7 @@ test("change flow folder", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.getByRole("heading", { name: "Basic Prompting" }).click();

--- a/src/frontend/tests/end-to-end/freeze-path.spec.ts
+++ b/src/frontend/tests/end-to-end/freeze-path.spec.ts
@@ -27,7 +27,7 @@ test("user must be able to freeze a path", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/freeze.spec.ts
+++ b/src/frontend/tests/end-to-end/freeze.spec.ts
@@ -18,7 +18,7 @@ test("user must be able to freeze a component", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/generalBugs-shard-4.spec.ts
+++ b/src/frontend/tests/end-to-end/generalBugs-shard-4.spec.ts
@@ -24,7 +24,7 @@ test("should be able to move flow from folder, rename it and be displayed on cor
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/generalBugs-shard-5.spec.ts
+++ b/src/frontend/tests/end-to-end/generalBugs-shard-5.spec.ts
@@ -21,7 +21,7 @@ test("should be able to see output preview from grouped components", async ({
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/generalBugs-shard-9.spec.ts
+++ b/src/frontend/tests/end-to-end/generalBugs-shard-9.spec.ts
@@ -28,7 +28,7 @@ test("memory should work as expect", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/generalBugs-shard-9.spec.ts
+++ b/src/frontend/tests/end-to-end/generalBugs-shard-9.spec.ts
@@ -103,7 +103,7 @@ test("memory should work as expect", async ({ page }) => {
 
 User: {user_input}
 
-AI: 
+AI:
   `;
 
   await page

--- a/src/frontend/tests/end-to-end/globalVariables.spec.ts
+++ b/src/frontend/tests/end-to-end/globalVariables.spec.ts
@@ -18,7 +18,7 @@ test("user must be able to save or delete a global variable", async ({
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/end-to-end/inputListComponent.spec.ts
+++ b/src/frontend/tests/end-to-end/inputListComponent.spec.ts
@@ -16,7 +16,7 @@ test("InputListComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/keyPairListComponent.spec.ts
+++ b/src/frontend/tests/end-to-end/keyPairListComponent.spec.ts
@@ -16,7 +16,7 @@ test("KeypairListComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/end-to-end/logs.spec.ts
+++ b/src/frontend/tests/end-to-end/logs.spec.ts
@@ -28,7 +28,7 @@ test("should able to see and interact with logs", async ({ page }) => {
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
 
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/nestedComponent.spec.ts
+++ b/src/frontend/tests/end-to-end/nestedComponent.spec.ts
@@ -16,7 +16,7 @@ test("NestedComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/end-to-end/saveComponents.spec.ts
+++ b/src/frontend/tests/end-to-end/saveComponents.spec.ts
@@ -17,7 +17,7 @@ test.describe("save component tests", () => {
 
     while (modalCount === 0) {
       await page.getByText("New Project", { exact: true }).click();
-      await page.waitForTimeout(5000);
+      await page.waitForTimeout(3000);
       modalCount = await page.getByTestId("modal-title")?.count();
     }
     await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/end-to-end/stop-building.spec.ts
+++ b/src/frontend/tests/end-to-end/stop-building.spec.ts
@@ -16,7 +16,7 @@ test("user must be able to stop a building", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    // await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/store-shard-2.spec.ts
+++ b/src/frontend/tests/end-to-end/store-shard-2.spec.ts
@@ -94,7 +94,7 @@ test("should share component with share button", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForTimeout(1000);
@@ -128,7 +128,7 @@ test("should share component with share button", async ({ page }) => {
   await page.getByText("Export").first().isVisible();
   await page.getByText("Share Flow").first().isVisible();
 
-  await page.waitForTimeout(5000);
+  await page.waitForTimeout(3000);
 
   await page.getByText("Agent").first().isVisible();
   await page.getByText("Memory").first().isVisible();

--- a/src/frontend/tests/end-to-end/textInputOutput.spec.ts
+++ b/src/frontend/tests/end-to-end/textInputOutput.spec.ts
@@ -27,7 +27,7 @@ test("TextInputOutputComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/end-to-end/tweaksTest.spec.ts
+++ b/src/frontend/tests/end-to-end/tweaksTest.spec.ts
@@ -14,7 +14,7 @@ test("curl_api_generation", async ({ page, context }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 
@@ -72,7 +72,7 @@ test("check if tweaks are updating when someothing on the flow changes", async (
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/actionsMainPage-shard-0.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/actionsMainPage-shard-0.spec.ts
@@ -18,7 +18,7 @@ test("user should be able to download a flow or a component", async ({
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 
@@ -103,7 +103,7 @@ test("user should be able to duplicate a flow or a component", async ({
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/chatInputOutput.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/chatInputOutput.spec.ts
@@ -17,7 +17,7 @@ test("chat_io_teste", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/chatInputOutputUser-shard-1.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/chatInputOutputUser-shard-1.spec.ts
@@ -29,7 +29,7 @@ test("user must be able to see output inspection", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/chatInputOutputUser-shard-2.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/chatInputOutputUser-shard-2.spec.ts
@@ -28,7 +28,7 @@ test("user must interact with chat with Input/Output", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/codeAreaModalComponent.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/codeAreaModalComponent.spec.ts
@@ -16,7 +16,7 @@ test("CodeAreaModalComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/curlApiGeneration.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/curlApiGeneration.spec.ts
@@ -14,7 +14,7 @@ test("curl_api_generation", async ({ page, context }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.getByRole("heading", { name: "Basic Prompting" }).click();

--- a/src/frontend/tests/scheduled-end-to-end/dragAndDrop.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/dragAndDrop.spec.ts
@@ -18,7 +18,7 @@ test.describe("drag and drop test", () => {
 
     while (modalCount === 0) {
       await page.getByText("New Project", { exact: true }).click();
-      await page.waitForTimeout(5000);
+      await page.waitForTimeout(3000);
       modalCount = await page.getByTestId("modal-title")?.count();
     }
     await page.locator("span").filter({ hasText: "Close" }).first().click();

--- a/src/frontend/tests/scheduled-end-to-end/dropdownComponent.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/dropdownComponent.spec.ts
@@ -16,7 +16,7 @@ test("dropDownComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/scheduled-end-to-end/fileUploadComponent.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/fileUploadComponent.spec.ts
@@ -17,7 +17,7 @@ test("should be able to upload a file", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/scheduled-end-to-end/filterEdge-shard-1.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/filterEdge-shard-1.spec.ts
@@ -18,7 +18,7 @@ test("user must see on handle click the possibility connections - RetrievalQA", 
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForTimeout(1000);

--- a/src/frontend/tests/scheduled-end-to-end/floatComponent.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/floatComponent.spec.ts
@@ -16,7 +16,7 @@ test("FloatComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/scheduled-end-to-end/flowPage.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/flowPage.spec.ts
@@ -17,7 +17,7 @@ test.describe("Flow Page tests", () => {
 
     while (modalCount === 0) {
       await page.getByText("New Project", { exact: true }).click();
-      await page.waitForTimeout(5000);
+      await page.waitForTimeout(3000);
       modalCount = await page.getByTestId("modal-title")?.count();
     }
 

--- a/src/frontend/tests/scheduled-end-to-end/flowSettings.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/flowSettings.spec.ts
@@ -16,7 +16,7 @@ test("flowSettings", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-0.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-0.spec.ts
@@ -28,7 +28,7 @@ test("erase button should clear the chat messages", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-1.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-1.spec.ts
@@ -25,7 +25,7 @@ test("should delete rows from table message", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-10.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-10.spec.ts
@@ -30,7 +30,7 @@ test("freeze must work correctly", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-2.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-2.spec.ts
@@ -25,7 +25,7 @@ test("should use webhook component on API", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-3.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-3.spec.ts
@@ -28,7 +28,7 @@ test("should copy code from playground modal", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 
@@ -214,7 +214,7 @@ test("playground button should be enabled or disabled", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-6.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-6.spec.ts
@@ -18,7 +18,7 @@ test("should be able to see error when something goes wrong on Code Modal", asyn
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-7.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-7.spec.ts
@@ -19,7 +19,7 @@ test("should be able to select all with ctrl + A on advanced modal", async ({
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-8.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-8.spec.ts
@@ -16,7 +16,7 @@ test("should interact with api request", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.getByTestId("blank-flow").click();

--- a/src/frontend/tests/scheduled-end-to-end/inputComponent.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/inputComponent.spec.ts
@@ -16,7 +16,7 @@ test("InputComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/scheduled-end-to-end/intComponent.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/intComponent.spec.ts
@@ -16,7 +16,7 @@ test("IntComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/scheduled-end-to-end/langflowShortcuts.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/langflowShortcuts.spec.ts
@@ -15,7 +15,7 @@ test("LangflowShortcuts", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 

--- a/src/frontend/tests/scheduled-end-to-end/promptModalComponent.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/promptModalComponent.spec.ts
@@ -16,7 +16,7 @@ test("PromptTemplateComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/scheduled-end-to-end/pythonApiGeneration.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/pythonApiGeneration.spec.ts
@@ -14,7 +14,7 @@ test("python_api_generation", async ({ page, context }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.getByRole("heading", { name: "Basic Prompting" }).click();

--- a/src/frontend/tests/scheduled-end-to-end/textAreaModalComponent.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/textAreaModalComponent.spec.ts
@@ -16,7 +16,7 @@ test("TextAreaModalComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/scheduled-end-to-end/toggleComponent.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/toggleComponent.spec.ts
@@ -16,7 +16,7 @@ test("ToggleComponent", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/src/frontend/tests/scheduled-end-to-end/twoEdges.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/twoEdges.spec.ts
@@ -18,13 +18,13 @@ test("user should be able to see multiple edges and interact with them", async (
 
   while (modalCount === 0) {
     await page.getByText("New Project", { exact: true }).click();
-    await page.waitForTimeout(5000);
+    await page.waitForTimeout(3000);
     modalCount = await page.getByTestId("modal-title")?.count();
   }
   await page.waitForTimeout(1000);
 
   await page.getByText("Vector Store RAG", { exact: true }).last().click();
-  await page.waitForTimeout(5000);
+  await page.waitForTimeout(3000);
   await page.getByText("Retriever", { exact: true }).first().isVisible();
   await page.getByText("Search Results", { exact: true }).first().isVisible();
 

--- a/src/frontend/tests/scheduled-end-to-end/userSettings.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/userSettings.spec.ts
@@ -44,7 +44,7 @@ test("should interact with global variables", async ({ page }) => {
     .fill("testtesttesttesttesttesttesttest");
   await page.getByTestId("popover-anchor-apply-to-fields").click();
 
-  await page.waitForTimeout(5000);
+  await page.waitForTimeout(3000);
 
   await page.getByPlaceholder("Search options...").fill("System Message");
 


### PR DESCRIPTION
This pull request reduces the timeout duration for tests related to the Basic Examples Modal. The adjustment aims to optimize the test suite's performance by shortening the wait times during modal interactions, ensuring quicker feedback during test runs.