### PR TITLE
fix: Remove unnecessary error return when all components are erased from a flow

### DIFF
--- a/src/frontend/src/hooks/flows/use-save-flow.ts
+++ b/src/frontend/src/hooks/flows/use-save-flow.ts
@@ -77,10 +77,6 @@ const useSaveFlow = () => {
             },
           );
         } else {
-          setErrorData({
-            title: "Failed to save flow",
-            list: ["Can't save empty flow"],
-          });
           setSaveLoading(false);
           reject(new Error("Can't save empty flow"));
         }


### PR DESCRIPTION
This PR fixes an issue where an unnecessary error was being returned when all components were removed from a flow. The error handling logic has been adjusted to ensure that removing all components does not trigger an error response.

🔧 (use-save-flow.ts): remove unnecessary error data setting when saving an empty flow to improve code readability and maintainability