### PR TITLE
fix: remove autosize on textArea inside nodes

### DIFF
--- a/src/frontend/src/components/textAreaComponent/index.tsx
+++ b/src/frontend/src/components/textAreaComponent/index.tsx
@@ -39,7 +39,7 @@ export default function TextAreaComponent({
             "w-full",
             "resize-none",
           )}
-          rows={Math.min(3, value.split("\n").length)}
+          rows={1}
           placeholder={"Type something..."}
           onChange={(event) => {
             onChange(event.target.value);


### PR DESCRIPTION
This pull request removes the feature that automatically adjusts the rows of a text area based on its content within a node, resulting in a cleaner and more consistent user interface.

