### PR TITLE
fix: update type extraction to extract inner types correctly

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/custom_component.py
+++ b/src/backend/base/langflow/custom/custom_component/custom_component.py
@@ -17,10 +17,7 @@ from langflow.services.deps import get_storage_service, get_variable_service, se
 from langflow.services.storage.service import StorageService
 from langflow.services.tracing.schema import Log
 from langflow.template.utils import update_frontend_node_with_template_values
-from langflow.type_extraction.type_extraction import (
-    extract_inner_type_from_generic_alias,
-    extract_union_types_from_generic_alias,
-)
+from langflow.type_extraction.type_extraction import post_process_type
 from langflow.utils import validate
 
 if TYPE_CHECKING:
@@ -365,19 +362,7 @@ class CustomComponent(BaseComponent):
         return self.get_method_return_type(self._function_entrypoint_name)
 
     def _extract_return_type(self, return_type: Any) -> List[Any]:
-        if hasattr(return_type, "__origin__") and return_type.__origin__ in [
-            list,
-            List,
-        ]:
-            return_type = extract_inner_type_from_generic_alias(return_type)
-
-        # If the return type is not a Union, then we just return it as a list
-        inner_type = return_type[0] if isinstance(return_type, list) else return_type
-        if not hasattr(inner_type, "__origin__") or inner_type.__origin__ != Union:
-            return return_type if isinstance(return_type, list) else [return_type]
-        # If the return type is a Union, then we need to parse it
-        return_type = extract_union_types_from_generic_alias(return_type)
-        return return_type
+        return post_process_type(return_type)
 
     @property
     def get_main_class_name(self):

--- a/src/backend/base/langflow/initial_setup/starter_projects/Complex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Complex Agent.json
@@ -4037,8 +4037,7 @@
                 "name": "api_run_model",
                 "selected": "Data",
                 "types": [
-                  "Data",
-                  "list"
+                  "Data"
                 ],
                 "value": "__UNDEFINED__"
               },
@@ -4049,8 +4048,7 @@
                 "name": "api_build_tool",
                 "selected": "Tool",
                 "types": [
-                  "Tool",
-                  "Sequence"
+                  "Tool"
                 ],
                 "value": "__UNDEFINED__"
               }

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hierarchical Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hierarchical Agent.json
@@ -2615,8 +2615,7 @@
                 "name": "api_run_model",
                 "selected": "Data",
                 "types": [
-                  "Data",
-                  "list"
+                  "Data"
                 ],
                 "value": "__UNDEFINED__"
               },
@@ -2627,8 +2626,7 @@
                 "name": "api_build_tool",
                 "selected": "Tool",
                 "types": [
-                  "Tool",
-                  "Sequence"
+                  "Tool"
                 ],
                 "value": "__UNDEFINED__"
               }

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Agent.json
@@ -2953,8 +2953,7 @@
                 "name": "api_run_model",
                 "selected": "Data",
                 "types": [
-                  "Data",
-                  "list"
+                  "Data"
                 ],
                 "value": "__UNDEFINED__"
               },
@@ -2965,8 +2964,7 @@
                 "name": "api_build_tool",
                 "selected": "Tool",
                 "types": [
-                  "Tool",
-                  "Sequence"
+                  "Tool"
                 ],
                 "value": "__UNDEFINED__"
               }

--- a/src/backend/tests/test_schema.py
+++ b/src/backend/tests/test_schema.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Sequence, Union
 
 import pytest
 from pydantic import ValidationError
@@ -42,6 +42,8 @@ class TestInput:
         assert post_process_type(int) == [int]
         assert post_process_type(list[int]) == [int]
         assert post_process_type(Union[int, str]) == [int, str]
+        assert post_process_type(Union[int, Sequence[str]]) == [int, str]
+        assert post_process_type(Union[int, Sequence[int]]) == [int]
 
     def test_input_to_dict(self):
         input_obj = Input(field_type="str")

--- a/src/backend/tests/test_schema.py
+++ b/src/backend/tests/test_schema.py
@@ -128,4 +128,4 @@ class TestPostProcessType:
         class CustomType:
             pass
 
-        assert post_process_type(Union[CustomType, int]) == [CustomType, int]
+        assert set(post_process_type(Union[CustomType, int])) == {CustomType, int}


### PR DESCRIPTION
This PR updates the post_process_type function to extract inner types of inner types. 

This mainly fixes an error in which extra types were passed in the component's output leading to invalid handles.

#3445 