### PR TITLE
Fix node size in nodeComponent

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
@@ -71,9 +71,6 @@ export default function NodeStatus({
     return frozen ? frozenClass : className;
   };
 
-  const getNodeSizeClass = (showNode) =>
-    showNode ? "w-96 rounded-lg" : "w-26 h-26 rounded-full";
-
   const getNodeBorderClassName = (
     selected: boolean,
     showNode: boolean,
@@ -87,10 +84,8 @@ export default function NodeStatus({
     );
 
     const baseBorderClass = getBaseBorderClass(selected);
-    const nodeSizeClass = getNodeSizeClass(showNode);
     const names = classNames(
       baseBorderClass,
-      nodeSizeClass,
       "generic-node-div group/node",
       specificClassFromBuildStatus,
     );

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -287,7 +287,7 @@ export default function GenericNode({
   return (
     <>
       {memoizedNodeToolbarComponent}
-      <div className={borderColor}>
+      <div className={cn(borderColor, showNode ? "w-96 rounded-lg" : "w-26 h-26 rounded-full")}>
         {data.node?.beta && showNode && (
           <div className="beta-badge-wrapper">
             <div className="beta-badge-content">BETA</div>

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -287,7 +287,12 @@ export default function GenericNode({
   return (
     <>
       {memoizedNodeToolbarComponent}
-      <div className={cn(borderColor, showNode ? "w-96 rounded-lg" : "w-26 h-26 rounded-full")}>
+      <div
+        className={cn(
+          borderColor,
+          showNode ? "w-96 rounded-lg" : "w-26 h-26 rounded-full",
+        )}
+      >
         {data.node?.beta && showNode && (
           <div className="beta-badge-wrapper">
             <div className="beta-badge-content">BETA</div>


### PR DESCRIPTION
The commit "fix: set node size directly in the nodeComponent" addresses an issue where the node size was not being set correctly in the nodeComponent. This caused incorrect rendering of the node border. The commit fixes this issue by setting the node size directly in the nodeComponent.