### PR TITLE
feat: Add NodeIcon component for displaying icons in GenericNode

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/nodeIcon/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/nodeIcon/index.tsx
@@ -1,0 +1,37 @@
+import { useTypesStore } from "@/stores/typesStore";
+import { nodeColors, nodeIconsLucide } from "@/utils/styleUtils";
+import emojiRegex from "emoji-regex";
+import IconComponent from "../../../../components/genericIconComponent";
+
+export function NodeIcon({
+    icon,
+    dataType,
+    showNode,
+    isGroup,
+}:{
+    icon?: string;
+    dataType: string;
+    showNode: boolean;
+    isGroup?: boolean;
+}){
+    const types = useTypesStore((state) => state.types);
+    const name = nodeIconsLucide[dataType] ? dataType : types[dataType];
+    const isEmoji = emojiRegex().test(icon??"");
+    const iconColor = nodeColors[types[dataType]];
+    const iconName =
+    icon || (isGroup ? "group_components" : name);
+    const iconClassName = `generic-node-icon ${
+        !showNode ? " absolute inset-x-6 h-12 w-12 " : ""
+      }`;
+    return (
+        icon && isEmoji ? (
+            <span className="text-lg">{icon}</span>
+        ):
+        <IconComponent
+        name={iconName}
+        className={iconClassName}
+        iconColor={iconColor}
+      />
+    )
+
+}

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -1,4 +1,3 @@
-import emojiRegex from "emoji-regex";
 import { useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { NodeToolbar, useUpdateNodeInternals } from "reactflow";
@@ -18,13 +17,11 @@ import { useTypesStore } from "../../stores/typesStore";
 import { OutputFieldType } from "../../types/api";
 import { NodeDataType } from "../../types/flow";
 import { scapedJSONStringfy } from "../../utils/reactflowUtils";
-import { nodeColors, nodeIconsLucide } from "../../utils/styleUtils";
+import { nodeIconsLucide } from "../../utils/styleUtils";
 import { classNames, cn } from "../../utils/utils";
-import { countHandlesFn } from "../helpers/count-handles";
 import { getNodeInputColors } from "../helpers/get-node-input-colors";
 import { getNodeOutputColors } from "../helpers/get-node-output-colors";
 import useCheckCodeValidity from "../hooks/use-check-code-validity";
-import useIconNodeRender from "../hooks/use-icon-render";
 import useUpdateNodeCode from "../hooks/use-update-node-code";
 import getFieldTitle from "../utils/get-field-title";
 import sortFields from "../utils/sort-fields";
@@ -33,6 +30,7 @@ import NodeInputField from "./components/NodeInputField";
 import NodeName from "./components/NodeName";
 import NodeOutputField from "./components/NodeOutputfield";
 import NodeStatus from "./components/NodeStatus";
+import { NodeIcon } from "./components/nodeIcon";
 
 export default function GenericNode({
   data,
@@ -66,22 +64,6 @@ export default function GenericNode({
 
   const name = nodeIconsLucide[data.type] ? data.type : types[data.type];
 
-  const nodeIconFragment = (icon) => {
-    return <span className="text-lg">{icon}</span>;
-  };
-
-  const checkNodeIconFragment = (iconColor, iconName, iconClassName) => {
-    return (
-      <IconComponent
-        name={iconName}
-        className={iconClassName}
-        iconColor={iconColor}
-      />
-    );
-  };
-
-  const isEmoji = emojiRegex().test(data?.node?.icon!);
-
   if (!data.node!.template) {
     setErrorData({
       title: `Error in component ${data.node!.display_name}`,
@@ -95,17 +77,6 @@ export default function GenericNode({
   }
 
   useCheckCodeValidity(data, templates, setIsOutdated, setIsUserEdited, types);
-
-  const iconNodeRender = useIconNodeRender(
-    data,
-    types,
-    nodeColors,
-    name,
-    showNode,
-    isEmoji,
-    nodeIconFragment,
-    checkNodeIconFragment,
-  );
 
   useEffect(() => {
     setShowNode(data.showNode ?? true);
@@ -201,6 +172,7 @@ export default function GenericNode({
       setShowHiddenOutputs(false);
     }
   }, [hiddenOutputs]);
+
 
   const memoizedNodeToolbarComponent = useMemo(() => {
     return (
@@ -316,7 +288,7 @@ export default function GenericNode({
               }
               data-testid="generic-node-title-arrangement"
             >
-              {iconNodeRender()}
+              <NodeIcon dataType={data.type} showNode={showNode} icon={data.node?.icon} isGroup={!!data.node?.flow} />
               {showNode && (
                 <div className="generic-node-tooltip-div">
                   <NodeName


### PR DESCRIPTION
This commit adds a new component called NodeIcon to the GenericNode module. The NodeIcon component is responsible for displaying icons based on the data type of the node. It uses the nodeIconsLucide object from the styleUtils module to map the data type to the corresponding icon name. The component also handles the display of emojis as icons by checking if the icon is an emoji using the emoji-regex library. The icon color is determined based on the data type using the nodeColors object from the styleUtils module. The NodeIcon component is used in the GenericNode component to render the icon of the node.