### PR TITLE
sqlite3 lockout timeout

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -50,7 +50,10 @@ class DatabaseService(Service):
         if self.settings_service.settings.database_url and self.settings_service.settings.database_url.startswith(
             "sqlite"
         ):
-            connect_args = {"check_same_thread": False}
+            connect_args = {
+                "check_same_thread": False,
+                "timeout": self.settings_service.settings.db_connect_timeout,
+            }
         else:
             connect_args = {}
         try:

--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -74,6 +74,8 @@ class Settings(BaseSettings):
     max_overflow: int = 20
     """The number of connections to allow that can be opened beyond the pool size.
     If not provided, the default is 20."""
+    db_connect_timeout: int = 20
+    """The number of seconds to wait before giving up on a lock to released or establishing a connection to the database."""
 
     # sqlite configuration
     sqlite_pragmas: Optional[dict] = {"synchronous": "NORMAL", "journal_mode": "WAL"}


### PR DESCRIPTION
Encountered a problem like this 
```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) database is locked
```

One suggestion is to add a db timeout value. This will allow us to set higher value in certain production deployment in an env variablem