### PR TITLE
fix: allow setting temperature to 0 in OpenAIModel.py

### DIFF
--- a/src/backend/base/langflow/components/models/OpenAIModel.py
+++ b/src/backend/base/langflow/components/models/OpenAIModel.py
@@ -100,7 +100,7 @@ class OpenAIModelComponent(LCModelComponent):
             model=model_name,
             base_url=openai_api_base,
             api_key=api_key,
-            temperature=temperature or 0.1,
+            temperature=temperature if temperature is not None else 0.1,
             seed=seed,
         )
         if json_mode:


### PR DESCRIPTION
As when the input temperature is 0, the condition would become False , so this expressing set it to 0.1, it become impossible to set it to 0.