### PR TITLE
refactor: prompt validation functionality

### DIFF
--- a/src/frontend/src/controllers/API/index.ts
+++ b/src/frontend/src/controllers/API/index.ts
@@ -19,7 +19,6 @@ import {
   APIClassType,
   BuildStatusTypeAPI,
   InitTypeAPI,
-  PromptTypeAPI,
   UploadFileTypeAPI,
 } from "./../../types/api/index";
 
@@ -55,25 +54,6 @@ export async function getRepoStars(owner: string, repo: string) {
  */
 export async function sendAll(data: sendAllProps) {
   return await api.post(`${BASE_URL_API}predict`, data);
-}
-
-/**
- * Checks the prompt for the code block by sending it to an API endpoint.
- * @param {string} name - The name of the field to check.
- * @param {string} template - The template string of the prompt to check.
- * @param {APIClassType} frontend_node - The frontend node to check.
- * @returns {Promise<AxiosResponse<PromptTypeAPI>>} A promise that resolves to an AxiosResponse containing the validation results.
- */
-export async function postValidatePrompt(
-  name: string,
-  template: string,
-  frontend_node: APIClassType,
-): Promise<AxiosResponse<PromptTypeAPI>> {
-  return api.post(`${BASE_URL_API}validate/prompt`, {
-    name,
-    template,
-    frontend_node,
-  });
 }
 
 /**

--- a/src/frontend/src/controllers/API/queries/nodes/use-post-validate-prompt.ts
+++ b/src/frontend/src/controllers/API/queries/nodes/use-post-validate-prompt.ts
@@ -1,0 +1,48 @@
+import {
+  APIClassType,
+  PromptTypeAPI,
+  ResponseErrorDetailAPI,
+  useMutationFunctionType,
+} from "@/types/api";
+import { UseMutationResult } from "@tanstack/react-query";
+import { api } from "../../api";
+import { getURL } from "../../helpers/constants";
+import { UseRequestProcessor } from "../../services/request-processor";
+
+interface IPostValidatePrompt {
+  name: string;
+  template: string;
+  frontend_node: APIClassType;
+}
+
+export const usePostValidatePrompt: useMutationFunctionType<
+  undefined,
+  IPostValidatePrompt,
+  PromptTypeAPI,
+  ResponseErrorDetailAPI
+> = (options?) => {
+  const { mutate } = UseRequestProcessor();
+
+  const postValidatePromptFn = async (
+    payload: IPostValidatePrompt,
+  ): Promise<PromptTypeAPI> => {
+    const response = await api.post<PromptTypeAPI>(
+      getURL("VALIDATE", { 1: "prompt" }),
+      {
+        name: payload.name,
+        template: payload.template,
+        frontend_node: payload.frontend_node,
+      },
+    );
+
+    return response.data;
+  };
+
+  const mutation: UseMutationResult<
+    PromptTypeAPI,
+    ResponseErrorDetailAPI,
+    IPostValidatePrompt
+  > = mutate(["usePostValidatePrompt"], postValidatePromptFn, options);
+
+  return mutation;
+};


### PR DESCRIPTION
This pull request refactors the prompt validation functionality by introducing a new mutation for validating prompts. The `postValidatePrompt` function has been removed from the API file and replaced with the `usePostValidatePrompt` hook. The prompt modal component has been updated to use the new mutation for validating prompts. This refactor improves code organization and separates concerns related to prompt validation.