### PR TITLE
fix: improve end_traces so it doesn't block the build loop

### DIFF
--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -60,9 +60,8 @@ class Graph:
             edges (List[Dict[str, str]]): A list of dictionaries representing the edges of the graph.
             flow_id (Optional[str], optional): The ID of the flow. Defaults to None.
         """
-        if not log_config:
-            log_config = {"disable": False}
-        configure(**log_config)
+        if log_config:
+            configure(**log_config)
         self._start = start
         self._state_model = None
         self._end = end


### PR DESCRIPTION
This is an attempt at fixing a weird bug that causes the build loop to freeze and the logging to break.