### PR TITLE
refactor: Fix version extraction in GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -57,13 +57,13 @@ jobs:
         if : ${{ inputs.version == '' && inputs.release_type == 'base' }}
         id: get-version-base
         run: |
-          version=$(poetry version --short)
+          version=$(cd src/backend/base && poetry version --short)
           echo version=$version >> $GITHUB_OUTPUT
       - name: Get Version Base
         if : ${{ inputs.version == '' && inputs.release_type == 'main' }}
         id: get-version-main
         run: |
-          version=$(cd src/backend/base && poetry version --short)
+          version=$(poetry version --short)
           echo version=$version >> $GITHUB_OUTPUT
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Versions were mismatched causing prefix in the tags to be set incorrectly