### PR TITLE
refactor: move import statement inside function to avoid unnecessary imports

### DIFF
--- a/src/backend/base/langflow/api/v1/starter_projects.py
+++ b/src/backend/base/langflow/api/v1/starter_projects.py
@@ -4,10 +4,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 
 from langflow.graph.graph.schema import GraphDump
-from langflow.services.database.models.user.model import User
 from langflow.services.auth.utils import get_current_active_user
-from langflow.initial_setup.load import get_starter_projects_dump
-
+from langflow.services.database.models.user.model import User
 
 router = APIRouter(prefix="/starter-projects", tags=["Flows"])
 
@@ -18,6 +16,8 @@ def get_starter_projects(
     current_user: User = Depends(get_current_active_user),
 ):
     """Get a list of starter projects."""
+    from langflow.initial_setup.load import get_starter_projects_dump
+
     try:
         flows = get_starter_projects_dump()
         return flows

--- a/src/backend/base/langflow/components/models/AnthropicModel.py
+++ b/src/backend/base/langflow/components/models/AnthropicModel.py
@@ -1,4 +1,3 @@
-from langchain_anthropic.chat_models import ChatAnthropic
 from pydantic.v1 import SecretStr
 
 from langflow.base.models.model import LCModelComponent
@@ -53,6 +52,12 @@ class AnthropicModelComponent(LCModelComponent):
     ]
 
     def build_model(self) -> LanguageModel:  # type: ignore[type-var]
+        try:
+            from langchain_anthropic.chat_models import ChatAnthropic
+        except ImportError:
+            raise ImportError(
+                "langchain_anthropic is not installed. Please install it with `pip install langchain_anthropic`."
+            )
         model = self.model
         anthropic_api_key = self.anthropic_api_key
         max_tokens = self.max_tokens

--- a/src/backend/base/langflow/custom/directory_reader/directory_reader.py
+++ b/src/backend/base/langflow/custom/directory_reader/directory_reader.py
@@ -348,7 +348,7 @@ class DirectoryReader:
                 try:
                     output_types = await self.get_output_types_from_code_async(result_content)
                 except Exception as exc:
-                    logger.exception(f"Error while getting output types from code: {str(exc)}")
+                    logger.error(f"Error while getting output types from code: {str(exc)}")
                     output_types = [component_name_camelcase]
             else:
                 output_types = [component_name_camelcase]


### PR DESCRIPTION
Makes sure components are not imported at startup.