### PR TITLE
fix: connection_string_parser.py

### DIFF
--- a/src/backend/base/langflow/utils/connection_string_parser.py
+++ b/src/backend/base/langflow/utils/connection_string_parser.py
@@ -5,5 +5,5 @@ def transform_connection_string(connection_string):
     auth_part, db_url_name = connection_string.rsplit("@", 1)
     protocol_user, password_string = auth_part.rsplit(":", 1)
     encoded_password = quote(password_string)
-    transformed_connection_string = "".join([":".join([protocol_user, encoded_password]),"@",db_url_name])
+    transformed_connection_string = "".join([":".join([protocol_user, encoded_password]), "@", db_url_name])
     return transformed_connection_string

--- a/src/backend/base/langflow/utils/connection_string_parser.py
+++ b/src/backend/base/langflow/utils/connection_string_parser.py
@@ -5,5 +5,5 @@ def transform_connection_string(connection_string):
     auth_part, db_url_name = connection_string.rsplit("@", 1)
     protocol_user, password_string = auth_part.rsplit(":", 1)
     encoded_password = quote(password_string)
-    transformed_connection_string = "".join([":".join([protocol_user, encoded_password]), "@", db_url_name])
+    transformed_connection_string = f'{protocol_user}:{encoded_password}@{db_url_name}'
     return transformed_connection_string

--- a/src/backend/base/langflow/utils/connection_string_parser.py
+++ b/src/backend/base/langflow/utils/connection_string_parser.py
@@ -5,5 +5,5 @@ def transform_connection_string(connection_string):
     auth_part, db_url_name = connection_string.rsplit("@", 1)
     protocol_user, password_string = auth_part.rsplit(":", 1)
     encoded_password = quote(password_string)
-    transformed_connection_string = f'{protocol_user}:{encoded_password}@{db_url_name}'
+    transformed_connection_string = f"{protocol_user}:{encoded_password}@{db_url_name}"
     return transformed_connection_string

--- a/src/backend/base/langflow/utils/connection_string_parser.py
+++ b/src/backend/base/langflow/utils/connection_string_parser.py
@@ -2,10 +2,8 @@ from urllib.parse import quote
 
 
 def transform_connection_string(connection_string):
-    db_url_name = connection_string.split("@")[-1]
-    password_url = connection_string.split(":")[-1]
-    password_string = password_url.replace(f"@{db_url_name}", "")
+    auth_part, db_url_name = connection_string.rsplit("@", 1)
+    protocol_user, password_string = auth_part.rsplit(":", 1)
     encoded_password = quote(password_string)
-    protocol_user = connection_string.split(":")[:-1]
-    transformed_connection_string = f'{":".join(protocol_user)}:{encoded_password}@{db_url_name}'
+    transformed_connection_string = "".join([":".join([protocol_user, encoded_password]),"@",db_url_name])
     return transformed_connection_string


### PR DESCRIPTION
In version 1.0.14, a connection string that includes a port, like the following example, works without any issues: `test_connection_string = 'postgresql://postgres:password!!@pgdatabase.hosts:5432'`

However, in version 1.0.15, using this connection string causes an error. 
"Error building Component PGVector: invalid literal for int() with base 10"

This is because "5432", which is the result of parsing the password_url, is being used as the last element in the password_url list.