### PR TITLE
fix: build version notification function

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -318,12 +318,19 @@ def is_prerelease(version: str) -> bool:
 
 
 def fetch_latest_version(package_name: str, include_prerelease: bool) -> Optional[str]:
-    response = httpx.get(f"https://pypi.org/pypi/{package_name}/json")
-    versions = response.json()["releases"].keys()
-    valid_versions = [v for v in versions if include_prerelease or not is_prerelease(v)]
-    if not valid_versions:
-        return None  # Handle case where no valid versions are found
-    return max(valid_versions, key=lambda v: pkg_version.parse(v))
+    valid_versions = []
+    try:
+        response = httpx.get(f"https://pypi.org/pypi/{package_name}/json")
+        versions = response.json()["releases"].keys()
+        valid_versions = [v for v in versions if include_prerelease or not is_prerelease(v)]
+
+    except Exception as e:
+        logger.exception(e)
+
+    finally:
+        if not valid_versions:
+            return None  # Handle case where no valid versions are found
+        return max(valid_versions, key=lambda v: pkg_version.parse(v))
 
 
 def build_version_notice(current_version: str, package_name: str) -> str:


### PR DESCRIPTION
Implemented a try/except block in the function that notifies users of new build versions to handle potential errors gracefully and ensure the application continues running smoothly even if the notification process fails.

Fixes #3523
