### PR TITLE
fix: ensure cache is set for graph in build flow

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -261,6 +261,8 @@ async def build_flow(
                     data=result_data_response,
                     artifacts=artifacts,
                 )
+            else:
+                await chat_service.set_cache(flow_id_str, graph)
 
             timedelta = time.perf_counter() - start_time
             duration = format_elapsed_time(timedelta)


### PR DESCRIPTION
added a condition to set the cache for the graph when it is built.

this ensures that the latest graph state is stored in the chat service.

#3515 may be related