### PR TITLE
fix: remove depth loop calls on folder's useEffect

### DIFF
--- a/src/frontend/src/components/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -156,7 +156,11 @@ const SideBarFoldersButtonsComponent = ({
   }
 
   useEffect(() => {
-    setEditFolderName(folders.map((obj) => ({ name: obj.name, edit: false })));
+    if (folders && folders.length > 0) {
+      setEditFolderName(
+        folders.map((obj) => ({ name: obj.name, edit: false })),
+      );
+    }
   }, [folders]);
 
   const handleEditNameFolder = async (item) => {


### PR DESCRIPTION
🐛 (index.tsx): Fix issue where setEditFolderName was being called with undefined or empty folders array, causing a crash. Added a check to ensure folders array is not empty before setting edit folder names.