### PR TITLE
fix: improve file name generation in upload_file function to prevent files with the same name

### DIFF
--- a/src/backend/base/langflow/api/v1/files.py
+++ b/src/backend/base/langflow/api/v1/files.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import hashlib
 from http import HTTPStatus
 from io import BytesIO
@@ -45,9 +46,7 @@ async def upload_file(
     try:
         flow_id_str = str(flow_id)
         file_content = await file.read()
-        # get the extension of the file
-        file_extension = file.filename.split(".")[-1]
-        file_name = hashlib.sha256(file_content).hexdigest() + f".{file_extension}"
+        file_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + "_" + (file.filename or hashlib.sha256(file_content).hexdigest())
         folder = flow_id_str
         await storage_service.save_file(flow_id=folder, file_name=file_name, data=file_content)
         return UploadFileResponse(flowId=flow_id_str, file_path=f"{folder}/{file_name}")

--- a/src/backend/base/langflow/api/v1/files.py
+++ b/src/backend/base/langflow/api/v1/files.py
@@ -45,7 +45,9 @@ async def upload_file(
     try:
         flow_id_str = str(flow_id)
         file_content = await file.read()
-        file_name = file.filename or hashlib.sha256(file_content).hexdigest()
+        # get the extension of the file
+        file_extension = file.filename.split(".")[-1]
+        file_name = hashlib.sha256(file_content).hexdigest()+f".{file_extension}"
         folder = flow_id_str
         await storage_service.save_file(flow_id=folder, file_name=file_name, data=file_content)
         return UploadFileResponse(flowId=flow_id_str, file_path=f"{folder}/{file_name}")

--- a/src/backend/base/langflow/api/v1/files.py
+++ b/src/backend/base/langflow/api/v1/files.py
@@ -46,7 +46,11 @@ async def upload_file(
     try:
         flow_id_str = str(flow_id)
         file_content = await file.read()
-        file_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + "_" + (file.filename or hashlib.sha256(file_content).hexdigest())
+        file_name = (
+            datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            + "_"
+            + (file.filename or hashlib.sha256(file_content).hexdigest())
+        )
         folder = flow_id_str
         await storage_service.save_file(flow_id=folder, file_name=file_name, data=file_content)
         return UploadFileResponse(flowId=flow_id_str, file_path=f"{folder}/{file_name}")

--- a/src/backend/base/langflow/api/v1/files.py
+++ b/src/backend/base/langflow/api/v1/files.py
@@ -46,14 +46,12 @@ async def upload_file(
     try:
         flow_id_str = str(flow_id)
         file_content = await file.read()
-        file_name = (
-            datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-            + "_"
-            + (file.filename or hashlib.sha256(file_content).hexdigest())
-        )
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        file_name = file.filename or hashlib.sha256(file_content).hexdigest()
+        full_file_name = f"{timestamp}_{file_name}"
         folder = flow_id_str
-        await storage_service.save_file(flow_id=folder, file_name=file_name, data=file_content)
-        return UploadFileResponse(flowId=flow_id_str, file_path=f"{folder}/{file_name}")
+        await storage_service.save_file(flow_id=folder, file_name=full_file_name, data=file_content)
+        return UploadFileResponse(flowId=flow_id_str, file_path=f"{folder}/{full_file_name}")
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/src/backend/base/langflow/api/v1/files.py
+++ b/src/backend/base/langflow/api/v1/files.py
@@ -47,7 +47,7 @@ async def upload_file(
         file_content = await file.read()
         # get the extension of the file
         file_extension = file.filename.split(".")[-1]
-        file_name = hashlib.sha256(file_content).hexdigest()+f".{file_extension}"
+        file_name = hashlib.sha256(file_content).hexdigest() + f".{file_extension}"
         folder = flow_id_str
         await storage_service.save_file(flow_id=folder, file_name=file_name, data=file_content)
         return UploadFileResponse(flowId=flow_id_str, file_path=f"{folder}/{file_name}")

--- a/src/backend/tests/unit/test_files.py
+++ b/src/backend/tests/unit/test_files.py
@@ -88,7 +88,7 @@ def test_file_operations(client, created_api_key, flow):
     assert file_path_pattern.match(response_json["file_path"])
 
     # Extract the full file name with timestamp from the response
-    full_file_name = response_json["file_path"].split('/')[-1]
+    full_file_name = response_json["file_path"].split("/")[-1]
 
     # Step 2: List files in the folder
     response = client.get(f"api/v1/files/list/{flow_id}", headers=headers)

--- a/src/backend/tests/unit/test_files.py
+++ b/src/backend/tests/unit/test_files.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import MagicMock
 
 import pytest
@@ -29,10 +30,13 @@ def test_upload_file(client, mock_storage_service, created_api_key, flow):
         headers=headers,
     )
     assert response.status_code == 201
-    assert response.json() == {
-        "flowId": str(flow.id),
-        "file_path": f"{flow.id}/test.txt",
-    }
+
+    response_json = response.json()
+    assert response_json["flowId"] == str(flow.id)
+
+    # Check that the file_path matches the expected pattern
+    file_path_pattern = re.compile(rf"{flow.id}/\d{{4}}-\d{{2}}-\d{{2}}_\d{{2}}-\d{{2}}-\d{{2}}_test\.txt")
+    assert file_path_pattern.match(response_json["file_path"])
 
 
 def test_download_file(client, mock_storage_service, created_api_key, flow):


### PR DESCRIPTION
The file name generation in the `upload_file` function has been improved to prevent files with the same name. Previously, the function used the received file name, but now it also includes the file extension. This ensures that each file has a unique name.
fix #3400 