### PR TITLE
ci: add workflow dispatch to empty nightly build workflow

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,6 +1,7 @@
 name: Nightly Build
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # Run every day at midnight (UTC)
 


### PR DESCRIPTION
Allows me to actually run the workflow, whoops!