### PR TITLE
fix: building vertices not working on Safari and improve stop button

### DIFF
--- a/src/frontend/src/components/headerComponent/components/menuBar/index.tsx
+++ b/src/frontend/src/components/headerComponent/components/menuBar/index.tsx
@@ -315,9 +315,6 @@ export const MenuBar = ({}: {}): JSX.Element => {
               disabled={!isBuilding}
               onClick={(_) => {
                 if (isBuilding) {
-                  setIsBuilding(false);
-                  revertBuiltStatusFromBuilding();
-                  setLockChat(false);
                   window.stop();
                 }
               }}

--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -217,7 +217,7 @@ async function performStreamingRequest({
   onData,
   body,
   onError,
-  onNetworkError
+  onNetworkError,
 }: StreamingRequestParams) {
   let headers = {
     "Content-Type": "application/json",
@@ -253,7 +253,7 @@ async function performStreamingRequest({
   try {
     const reader = response.body.getReader();
     while (true) {
-      const {done, value} = await reader.read();
+      const { done, value } = await reader.read();
       if (done) {
         break;
       }
@@ -291,7 +291,7 @@ async function performStreamingRequest({
     if (onNetworkError) {
       onNetworkError(e);
     } else {
-      throw e
+      throw e;
     }
   }
 }

--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -248,8 +248,13 @@ async function performStreamingRequest({
   if (response.body === null) {
     return;
   }
-  for await (const chunk of response.body) {
-    const decodedChunk = await textDecoder.decode(chunk);
+  const reader = response.body.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    const decodedChunk = textDecoder.decode(value);
     let all = decodedChunk.split("\n\n");
     for (const string of all) {
       if (string.endsWith("}")) {

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -642,6 +642,15 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
         get().setLockChat(false);
       },
       onBuildUpdate: handleBuildUpdate,
+      onBuildStopped: () => {
+        get().setIsBuilding(false);
+        setErrorData({
+            title:
+              "Build stopped",
+          });
+        get().revertBuiltStatusFromBuilding();
+        get().setLockChat(false);
+      },
       onBuildError: (title: string, list: string[], elementList) => {
         const idList = elementList
           .map((element) => element.id)

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -645,9 +645,8 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
       onBuildStopped: () => {
         get().setIsBuilding(false);
         setErrorData({
-            title:
-              "Build stopped",
-          });
+          title: "Build stopped",
+        });
         get().revertBuiltStatusFromBuilding();
         get().setLockChat(false);
       },

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -402,6 +402,7 @@ export async function buildVertices({
           buildResults.push(false);
           return;
         }
+        console.log("tak")
 
         // Build the vertex
         await buildVertex({

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -26,6 +26,7 @@ type BuildVerticesParams = {
   ) => void; // Replace any with the actual type if it's not any
   onBuildComplete?: (allNodesValid: boolean) => void;
   onBuildError?: (title, list, idList: VertexLayerElementType[]) => void;
+  onBuildStopped?: () => void;
   onBuildStart?: (idList: VertexLayerElementType[]) => void;
   onValidateNodes?: (nodes: string[]) => void;
   nodes?: Node[];
@@ -143,6 +144,7 @@ export async function buildFlowVertices({
   onBuildUpdate,
   onBuildComplete,
   onBuildError,
+  onBuildStopped,
   onBuildStart,
   onValidateNodes,
   nodes,
@@ -297,6 +299,8 @@ export async function buildFlowVertices({
       }
       throw new Error("error in streaming request");
     },
+    // network error are likely caused by the window.stop() called in the stopBuild function
+    onNetworkError: onBuildStopped,
   });
 }
 

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -402,7 +402,6 @@ export async function buildVertices({
           buildResults.push(false);
           return;
         }
-        console.log("tak")
 
         // Build the vertex
         await buildVertex({


### PR DESCRIPTION
This PR addresses two problems: 
1. the current client implementation to read chunks from the response using Fetch API is not standard and not compatible with Safari (and probably others). The right way is to use `body.getReader()` which has much larger support
2. The Stop button stops the build but it appears to not be working since no feedback is given to users