### PR TITLE
fix: surround a tag with feature flag for ENABLE_BRANDING

### DIFF
--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -108,16 +108,17 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
             </main>
           </div>
         )}
-        <a
-          target={"_blank"}
-          href="https://medium.com/logspace/langflow-datastax-better-together-1b7462cebc4d"
-          className="langflow-page-icon"
-        >
-          {FeatureFlags.ENABLE_BRANDING && version && (
+        {FeatureFlags.ENABLE_BRANDING && version && (
+          <a
+            target={"_blank"}
+            href="https://medium.com/logspace/langflow-datastax-better-together-1b7462cebc4d"
+            className="langflow-page-icon"
+          >
             <div className="mt-1">Langflow 🤝 DataStax</div>
-          )}
-          <div className={version ? "mt-2" : "mt-1"}>⛓️ v{version}</div>
-        </a>
+
+            <div className={version ? "mt-2" : "mt-1"}>⛓️ v{version}</div>
+          </a>
+        )}
       </div>
       {blocker.state === "blocked" && currentSavedFlow && (
         <SaveChangesModal


### PR DESCRIPTION
This fixes the version display not being removed with ENABLE_BRANDING=False