### PR TITLE
fix: Ensure Correct Focus on Playground Chat Input

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/textAreaWrapper/index.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/textAreaWrapper/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Textarea } from "../../../../../../../components/ui/textarea";
 import { classNames } from "../../../../../../../utils/utils";
 
@@ -42,6 +43,12 @@ const TextAreaWrapper = ({
       : "rounded-md border-t border-border focus:ring-0 focus:border-2 focus:border-ring";
 
   const additionalClassNames = "form-modal-lockchat pl-14";
+
+  useEffect(() => {
+    if (!lockChat && !noInput && !saveLoading) {
+      inputRef.current?.focus();
+    }
+  }, [lockChat, noInput, saveLoading]);
 
   return (
     <Textarea

--- a/src/frontend/src/pages/AppWrapperPage/index.tsx
+++ b/src/frontend/src/pages/AppWrapperPage/index.tsx
@@ -49,8 +49,6 @@ export function AppWrapperPage() {
 
   const [retryCount, setRetryCount] = useState(0);
 
-  console.log(healthCheckMaxRetries);
-
   useEffect(() => {
     const isServerBusy =
       (error as AxiosError)?.response?.status === 503 ||


### PR DESCRIPTION
- This pull request addresses an issue where the Playground's chat input was not consistently receiving focus when it should. The focus behavior is now managed using useEffect to ensure the input field receives focus under the appropriate conditions.

✨ (textAreaWrapper/index.tsx): add useEffect hook to focus on input when conditions are met
♻️ (AppWrapperPage/index.tsx): remove unnecessary console.log statement