### PR TITLE
tests: improve delete rows from table message test

### DIFF
--- a/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-1.spec.ts
+++ b/src/frontend/tests/scheduled-end-to-end/generalBugs-shard-1.spec.ts
@@ -71,13 +71,27 @@ test("should delete rows from table message", async ({ page }) => {
   });
 
   await page.getByTestId("user-profile-settings").last().click();
+  await page.waitForSelector(
+    '[data-testid="user-profile-settings"]:last-child',
+  );
+
+  await page.waitForTimeout(500);
+
+  await page.waitForSelector('text="Settings"');
   await page.getByText("Settings").last().click();
+
+  await page.waitForSelector('text="Messages"');
   await page.getByText("Messages").last().click();
 
-  const label = "Press Space to toggle all rows selection (unchecked)";
-  await page.getByLabel(label).first().click();
+  await page.waitForSelector(".ag-checkbox-input");
+  await page.locator(".ag-checkbox-input").first().click();
 
+  await page.waitForTimeout(500);
+
+  await page.waitForSelector('[data-testid="icon-Trash2"]:first-child');
   await page.getByTestId("icon-Trash2").first().click();
+
+  await page.waitForTimeout(500);
 
   await page.waitForSelector("text=No Data Available", { timeout: 30000 });
   await page.getByText("No Data Available").isVisible();


### PR DESCRIPTION
🐛 (generalBugs-shard-1.spec.ts): Fix timing issues in end-to-end test by adding explicit waits for elements to be visible before interacting with them