### PR TITLE
feat: improve suspend busy screen to check building

### DIFF
--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -624,7 +624,7 @@ export const FETCH_ERROR_DESCRIPION =
   "Check if everything is working properly and try again.";
 
 export const TIMEOUT_ERROR_MESSAGE =
-  "Please wait a few seconds to server process your request.";
+  "Please wait a few moments while the server processes your request.";
 export const TIMEOUT_ERROR_DESCRIPION = "Server is busy.";
 
 export const SIGN_UP_SUCCESS = "Account created! Await admin activation. ";

--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -24,6 +24,7 @@ function ApiInterceptor() {
   const { mutate: mutationRenewAccessToken } = useRefreshAccessToken();
   const logout = useAuthStore((state) => state.logout);
   const isLoginPage = location.pathname.includes("login");
+  const isBuilding = useFlowStore((state) => state.isBuilding);
 
   useEffect(() => {
     const interceptor = api.interceptors.response.use(
@@ -90,6 +91,11 @@ function ApiInterceptor() {
       (config) => {
         const controller = new AbortController();
         try {
+          if (isBuilding) {
+            controller.abort("Request aborted because a build is in progress");
+            return Promise.reject(null);
+          }
+
           checkDuplicateRequestAndStoreRequest(config);
         } catch (e) {
           const error = e as Error;
@@ -117,7 +123,7 @@ function ApiInterceptor() {
       api.interceptors.response.eject(interceptor);
       api.interceptors.request.eject(requestInterceptor);
     };
-  }, [accessToken, setErrorData]);
+  }, [accessToken, setErrorData, isBuilding]);
 
   function checkErrorCount() {
     if (isLoginPage) return;

--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -1,5 +1,6 @@
 import { LANGFLOW_ACCESS_TOKEN } from "@/constants/constants";
 import useAuthStore from "@/stores/authStore";
+import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from "axios";
 import { useContext, useEffect } from "react";
 import { Cookies } from "react-cookie";
@@ -25,6 +26,7 @@ function ApiInterceptor() {
   const logout = useAuthStore((state) => state.logout);
   const isLoginPage = location.pathname.includes("login");
   const isBuilding = useFlowStore((state) => state.isBuilding);
+  const isLoading = useFlowsManagerStore((state) => state.isLoading);
 
   useEffect(() => {
     const interceptor = api.interceptors.response.use(
@@ -91,7 +93,7 @@ function ApiInterceptor() {
       (config) => {
         const controller = new AbortController();
         try {
-          if (isBuilding) {
+          if (isBuilding || isLoading) {
             controller.abort("Request aborted because a build is in progress");
             return Promise.reject(null);
           }
@@ -123,7 +125,7 @@ function ApiInterceptor() {
       api.interceptors.response.eject(interceptor);
       api.interceptors.request.eject(requestInterceptor);
     };
-  }, [accessToken, setErrorData, isBuilding]);
+  }, [accessToken, setErrorData, isBuilding, isLoading]);
 
   function checkErrorCount() {
     if (isLoginPage) return;

--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -93,7 +93,7 @@ function ApiInterceptor() {
       (config) => {
         const controller = new AbortController();
         try {
-          if (isBuilding || isLoading) {
+          if (isBuilding) {
             controller.abort("Request aborted because a build is in progress");
             return Promise.reject(null);
           }

--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -26,7 +26,6 @@ function ApiInterceptor() {
   const logout = useAuthStore((state) => state.logout);
   const isLoginPage = location.pathname.includes("login");
   const isBuilding = useFlowStore((state) => state.isBuilding);
-  const isLoading = useFlowsManagerStore((state) => state.isLoading);
 
   useEffect(() => {
     const interceptor = api.interceptors.response.use(
@@ -125,7 +124,7 @@ function ApiInterceptor() {
       api.interceptors.response.eject(interceptor);
       api.interceptors.request.eject(requestInterceptor);
     };
-  }, [accessToken, setErrorData, isBuilding, isLoading]);
+  }, [accessToken, setErrorData, isBuilding]);
 
   function checkErrorCount() {
     if (isLoginPage) return;

--- a/src/frontend/src/controllers/API/queries/health/use-get-health.ts
+++ b/src/frontend/src/controllers/API/queries/health/use-get-health.ts
@@ -2,6 +2,7 @@ import {
   REFETCH_SERVER_HEALTH_INTERVAL,
   SERVER_HEALTH_INTERVAL,
 } from "@/constants/constants";
+import useFlowStore from "@/stores/flowStore";
 import { useUtilityStore } from "@/stores/utilityStore";
 import { createNewError503 } from "@/types/factory/axios-error-503";
 import { keepPreviousData } from "@tanstack/react-query";
@@ -29,6 +30,8 @@ export const useGetHealthQuery: useQueryFunctionType<
   const healthCheckTimeout = useUtilityStore(
     (state) => state.healthCheckTimeout,
   );
+  const isBuilding = useFlowStore((state) => state.isBuilding);
+
   /**
    * Fetches the health status of the API.
    *
@@ -49,9 +52,9 @@ export const useGetHealthQuery: useQueryFunctionType<
         healthCheckTimeout === null &&
         (error as AxiosError)?.response?.status === 503;
 
-      if (isServerBusy) {
+      if (isServerBusy && !isBuilding) {
         setHealthCheckTimeout("timeout");
-      } else if (healthCheckTimeout === null) {
+      } else if (healthCheckTimeout === null && !isBuilding) {
         setHealthCheckTimeout("serverDown");
       }
       throw error;


### PR DESCRIPTION
This pull request introduces a check to ensure that the flow is building before verifying the /health status. Additionally, it will block any requests while the flow is in the building status.

🐛 (api.tsx): Fix issue where requests were not being aborted during a build process
📝 (api.tsx, use-get-health.ts): Add isBuilding flag to prevent health check requests during a build process