### PR TITLE
refactor: update docs link to be modular

### DIFF
--- a/src/frontend/src/components/headerComponent/index.tsx
+++ b/src/frontend/src/components/headerComponent/index.tsx
@@ -12,6 +12,7 @@ import { AuthContext } from "../../contexts/authContext";
 
 import { useLogout } from "@/controllers/API/queries/auth";
 import { CustomLink } from "@/customization/components/custom-link";
+import { DOCS_LINK } from "@/customization/config-constants";
 import {
   ENABLE_DARK_MODE,
   ENABLE_PROFILE_ICONS,
@@ -257,7 +258,10 @@ export default function Header(): JSX.Element {
                 <DropdownMenuItem
                   className="cursor-pointer gap-2"
                   onClick={() =>
-                    window.open("https://docs.langflow.org/", "_blank")
+                    window.open(
+                      DOCS_LINK || "https://docs.langflow.org/",
+                      "_blank",
+                    )
                   }
                 >
                   <ForwardedIconComponent name="FileText" className="w-4" />

--- a/src/frontend/src/customization/config-constants.ts
+++ b/src/frontend/src/customization/config-constants.ts
@@ -4,8 +4,10 @@ export const PROXY_TARGET = "http://127.0.0.1:7860";
 export const API_ROUTES = ["^/api/v1/", "/health"];
 export const BASE_URL_API = "/api/v1/";
 export const HEALTH_CHECK_URL = "/health_check";
+export const DOCS_LINK = "https://docs.langflow.com";
 
 export default {
+  DOCS_LINK,
   BASENAME,
   PORT,
   PROXY_TARGET,


### PR DESCRIPTION
This pull request updates the docs link in the header component to be modular. Previously, the link was hard-coded, but now it is sourced from the `config-constants` file. This allows for easier customization and configuration of the docs link.