### PR TITLE
fix: iomodal and folders api calls

### DIFF
--- a/src/frontend/src/modals/IOModal/components/SessionView/index.tsx
+++ b/src/frontend/src/modals/IOModal/components/SessionView/index.tsx
@@ -1,15 +1,10 @@
 import Loading from "@/components/ui/loading";
 import {
   useDeleteMessages,
-  useGetMessagesQuery,
   useUpdateMessage,
 } from "@/controllers/API/queries/messages";
 import { useIsFetching } from "@tanstack/react-query";
-import {
-  CellEditRequestEvent,
-  NewValueParams,
-  SelectionChangedEvent,
-} from "ag-grid-community";
+import { NewValueParams, SelectionChangedEvent } from "ag-grid-community";
 import cloneDeep from "lodash/cloneDeep";
 import { useMemo, useState } from "react";
 import TableComponent from "../../../../components/tableComponent";

--- a/src/frontend/src/modals/IOModal/index.tsx
+++ b/src/frontend/src/modals/IOModal/index.tsx
@@ -1,5 +1,7 @@
-import { useDeleteMessages } from "@/controllers/API/queries/messages";
-import { useQueryClient } from "@tanstack/react-query";
+import {
+  useDeleteMessages,
+  useGetMessagesQuery,
+} from "@/controllers/API/queries/messages";
 import { useEffect, useState } from "react";
 import AccordionComponent from "../../components/accordionComponent";
 import IconComponent from "../../components/genericIconComponent";
@@ -111,13 +113,14 @@ export default function IOModal({
   const [sessions, setSessions] = useState<string[]>([]);
   const messages = useMessagesStore((state) => state.messages);
   const flowPool = useFlowStore((state) => state.flowPool);
-  const queryClient = useQueryClient();
 
-  function refetch() {
-    queryClient.invalidateQueries({
-      queryKey: ["useGetMessagesQuery", { id: currentFlowId }],
-    });
-  }
+  const { refetch } = useGetMessagesQuery(
+    {
+      mode: "union",
+      id: currentFlowId,
+    },
+    { enabled: open },
+  );
 
   async function sendMessage({
     repeat = 1,
@@ -157,10 +160,6 @@ export default function IOModal({
   useEffect(() => {
     setSelectedTab(inputs.length > 0 ? 1 : outputs.length > 0 ? 2 : 0);
   }, [allNodes.length]);
-
-  useEffect(() => {
-    refetch();
-  }, [open]);
 
   useEffect(() => {
     const sessions = new Set<string>();

--- a/src/frontend/src/modals/IOModal/index.tsx
+++ b/src/frontend/src/modals/IOModal/index.tsx
@@ -1,7 +1,5 @@
-import {
-  useDeleteMessages,
-  useGetMessagesQuery,
-} from "@/controllers/API/queries/messages";
+import { useDeleteMessages } from "@/controllers/API/queries/messages";
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import AccordionComponent from "../../components/accordionComponent";
 import IconComponent from "../../components/genericIconComponent";
@@ -113,11 +111,13 @@ export default function IOModal({
   const [sessions, setSessions] = useState<string[]>([]);
   const messages = useMessagesStore((state) => state.messages);
   const flowPool = useFlowStore((state) => state.flowPool);
+  const queryClient = useQueryClient();
 
-  const { refetch } = useGetMessagesQuery({
-    mode: "union",
-    id: currentFlowId,
-  });
+  function refetch() {
+    queryClient.invalidateQueries({
+      queryKey: ["useGetMessagesQuery", { id: currentFlowId }],
+    });
+  }
 
   async function sendMessage({
     repeat = 1,

--- a/src/frontend/src/pages/MainPage/components/myCollectionComponent/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/myCollectionComponent/index.tsx
@@ -1,6 +1,6 @@
 import { useGetFolderQuery } from "@/controllers/API/queries/folders/use-get-folder";
-import { useGetFoldersQuery } from "@/controllers/API/queries/folders/use-get-folders";
 import { useFolderStore } from "@/stores/foldersStore";
+import { useIsFetching } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 import ComponentsComponent from "../componentsComponent";
 import HeaderTabsSearchComponent from "./components/headerTabsSearchComponent";
@@ -13,10 +13,17 @@ const MyCollectionComponent = ({ type }: MyCollectionComponentProps) => {
   const { folderId } = useParams();
   const myCollectionId = useFolderStore((state) => state.myCollectionId);
 
-  const { data, isLoading } = useGetFolderQuery({
-    id: folderId ?? myCollectionId ?? "",
+  const { data, isLoading } = useGetFolderQuery(
+    {
+      id: folderId ?? myCollectionId ?? "",
+    },
+    { enabled: !!folderId || !!myCollectionId },
+  );
+
+  const isLoadingFolders = !!useIsFetching({
+    queryKey: ["useGetFolders"],
+    exact: false,
   });
-  const { isLoading: isLoadingFolders } = useGetFoldersQuery();
 
   return (
     <>

--- a/src/frontend/tests/end-to-end/auto-login-off.spec.ts
+++ b/src/frontend/tests/end-to-end/auto-login-off.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "@playwright/test";
-import { before, beforeEach } from "node:test";
 
 test("when auto_login is false, admin can CRUD user's and should see just your own flows", async ({
   page,
@@ -144,7 +143,7 @@ test("when auto_login is false, admin can CRUD user's and should see just your o
 
   await page.getByTestId("icon-ChevronLeft").first().click();
 
-  await page.waitForSelector('[id="new-project-btn"]', {
+  await page.waitForSelector('[data-testid="search-store-input"]:enabled', {
     timeout: 30000,
   });
 
@@ -214,9 +213,14 @@ test("when auto_login is false, admin can CRUD user's and should see just your o
 
   await page.getByTestId("icon-ChevronLeft").first().click();
 
+  await page.waitForSelector('[data-testid="search-store-input"]:enabled', {
+    timeout: 30000,
+  });
+
   expect(
     await page.getByText(secondRandomFlowName, { exact: true }).isVisible(),
   ).toBe(true);
+
   expect(
     await page.getByText(randomFlowName, { exact: true }).isVisible(),
   ).toBe(false);
@@ -236,7 +240,7 @@ test("when auto_login is false, admin can CRUD user's and should see just your o
     timeout: 30000,
   });
 
-  await page.waitForSelector('[id="new-project-btn"]', {
+  await page.waitForSelector('[data-testid="search-store-input"]:enabled', {
     timeout: 30000,
   });
 


### PR DESCRIPTION
Fixed an issue where the IOModal was calling the getMessages API again unnecessarily. Also fixed an issue where the folders API was being called twice. These changes ensure that the API calls are made only when necessary, improving performance and reducing unnecessary network requests.