### PR TITLE
fix: update Makefile to conditionally enable --reload based on worker count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,9 +265,8 @@ frontendc: install_frontendc
 	make run_frontend
 
 
-
 backend: setup_env install_backend ## run the backend in development mode
-	@-kill -9 $$(lsof -t -i:7860)
+	@-kill -9 $$(lsof -t -i:7860) || true
 ifdef login
 	@echo "Running backend autologin is $(login)";
 	LANGFLOW_AUTO_LOGIN=$(login) poetry run uvicorn \

--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ ifdef login
 		--factory langflow.main:create_app \
 		--host 0.0.0.0 \
 		--port $(port) \
-		$(if $(workers),,--reload) \
+		$(if $(filter-out 1,$(workers)),, --reload) \
 		--env-file $(env) \
 		--loop asyncio \
 		$(if $(workers),--workers $(workers),)
@@ -283,7 +283,7 @@ else
 		--factory langflow.main:create_app \
 		--host 0.0.0.0 \
 		--port $(port) \
-		$(if $(workers),,--reload) \
+		$(if $(filter-out 1,$(workers)),, --reload) \
 		--env-file $(env) \
 		--loop asyncio \
 		$(if $(workers),--workers $(workers),)


### PR DESCRIPTION
This pull request updates the Makefile to conditionally enable the --reload flag based on the worker count. It also handles backend port kill errors.