### PR TITLE
feat: add a better scroll behave on playground's chat

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/index.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/index.tsx
@@ -1,3 +1,4 @@
+import { useUtilityStore } from "@/stores/utilityStore";
 import Convert from "ansi-to-html";
 import { useEffect, useMemo, useRef, useState } from "react";
 import Markdown from "react-markdown";
@@ -40,6 +41,13 @@ export default function ChatMessage({
   const eventSource = useRef<EventSource | undefined>(undefined);
   const setErrorData = useAlertStore((state) => state.setErrorData);
   const chatMessageRef = useRef(chatMessage);
+
+  const playgroundScrollBehaves = useUtilityStore(
+    (state) => state.playgroundScrollBehaves,
+  );
+  const setPlaygroundScrollBehaves = useUtilityStore(
+    (state) => state.setPlaygroundScrollBehaves,
+  );
 
   // Sync ref with state
   useEffect(() => {
@@ -107,9 +115,14 @@ export default function ChatMessage({
   useEffect(() => {
     const element = document.getElementById("last-chat-message");
     if (element) {
-      setTimeout(() => {
-        element.scrollIntoView({ behavior: "smooth" });
-      }, 200);
+      if (playgroundScrollBehaves === "instant") {
+        element.scrollIntoView({ behavior: playgroundScrollBehaves });
+        setPlaygroundScrollBehaves("smooth");
+      } else {
+        setTimeout(() => {
+          element.scrollIntoView({ behavior: playgroundScrollBehaves });
+        }, 200);
+      }
     }
   }, [lastMessage]);
 
@@ -231,6 +244,7 @@ export default function ChatMessage({
 
                                 return !inline ? (
                                   <CodeTabsComponent
+                                    open={undefined}
                                     isMessage
                                     tabs={[
                                       {

--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/index.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/index.tsx
@@ -244,7 +244,6 @@ export default function ChatMessage({
 
                                 return !inline ? (
                                   <CodeTabsComponent
-                                    open={undefined}
                                     isMessage
                                     tabs={[
                                       {

--- a/src/frontend/src/modals/IOModal/index.tsx
+++ b/src/frontend/src/modals/IOModal/index.tsx
@@ -2,6 +2,7 @@ import {
   useDeleteMessages,
   useGetMessagesQuery,
 } from "@/controllers/API/queries/messages";
+import { useUtilityStore } from "@/stores/utilityStore";
 import { useEffect, useState } from "react";
 import AccordionComponent from "../../components/accordionComponent";
 import IconComponent from "../../components/genericIconComponent";
@@ -171,6 +172,16 @@ export default function IOModal({
     setSessions(Array.from(sessions));
     sessions;
   }, [messages]);
+
+  const setPlaygroundScrollBehaves = useUtilityStore(
+    (state) => state.setPlaygroundScrollBehaves,
+  );
+
+  useEffect(() => {
+    if (open) {
+      setPlaygroundScrollBehaves("instant");
+    }
+  }, [open]);
 
   return (
     <BaseModal

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -15,4 +15,7 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   healthCheckTimeout: null,
   setHealthCheckTimeout: (timeout: string | null) =>
     set({ healthCheckTimeout: timeout }),
+  playgroundScrollBehaves: "instant",
+  setPlaygroundScrollBehaves: (behaves: ScrollBehavior) =>
+    set({ playgroundScrollBehaves: behaves }),
 }));

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -775,7 +775,7 @@ export type tabsArrayType = {
 };
 
 export type codeTabsPropsType = {
-  open: boolean;
+  open: boolean | undefined;
   tabs: Array<tabsArrayType>;
   activeTab: string;
   setActiveTab: (value: string) => void;

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -775,7 +775,7 @@ export type tabsArrayType = {
 };
 
 export type codeTabsPropsType = {
-  open: boolean | undefined;
+  open?: boolean;
   tabs: Array<tabsArrayType>;
   activeTab: string;
   setActiveTab: (value: string) => void;

--- a/src/frontend/src/types/zustand/utility/index.ts
+++ b/src/frontend/src/types/zustand/utility/index.ts
@@ -3,4 +3,6 @@ export type UtilityStoreType = {
   setSelectedItems: (itemId: any) => void;
   healthCheckTimeout: string | null;
   setHealthCheckTimeout: (timeout: string | null) => void;
+  playgroundScrollBehaves: ScrollBehavior;
+  setPlaygroundScrollBehaves: (behaves: ScrollBehavior) => void;
 };


### PR DESCRIPTION
This pull request adds the `useUtilityStore` hook to the `IOModal` component for managing the scroll behavior of the playground in the application. It also includes the `setPlaygroundScrollBehaves` function to update the `playgroundScrollBehaves` property in the `UtilityStoreType`. This allows for setting the scroll behavior of the playground to either "instant" or "smooth".