### PR TITLE
fix: getall is being called unnecessarily every time the user accesses the My Collection page

### DIFF
--- a/src/frontend/src/controllers/API/queries/folders/use-get-folders.ts
+++ b/src/frontend/src/controllers/API/queries/folders/use-get-folders.ts
@@ -37,10 +37,10 @@ export const useGetFoldersQuery: useQueryFunctionType<
     const myCollectionId = data?.find((f) => f.name === DEFAULT_FOLDER)?.id;
     setMyCollectionId(myCollectionId);
 
-    const { getTypes } = useTypesStore.getState();
+    const { getTypes, types } = useTypesStore.getState();
 
     await refreshFlows(undefined);
-    await getTypes();
+    if (!types || Object.keys(types).length === 0) await getTypes();
 
     return foldersWithoutStarterProjects;
   };

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -35,6 +35,7 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
   const { mutateAsync: refreshFlows } = useGetRefreshFlows();
   const setIsLoading = useFlowsManagerStore((state) => state.setIsLoading);
   const getTypes = useTypesStore((state) => state.getTypes);
+  const types = useTypesStore((state) => state.types);
 
   const updatedAt = currentSavedFlow?.updated_at;
 
@@ -74,7 +75,7 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
       } else if (!flows) {
         setIsLoading(true);
         await refreshFlows(undefined);
-        await getTypes();
+        if (!types || Object.keys(types).length === 0) await getTypes();
         setIsLoading(false);
       }
     };

--- a/src/frontend/src/pages/Playground/index.tsx
+++ b/src/frontend/src/pages/Playground/index.tsx
@@ -29,6 +29,7 @@ export default function PlaygroundPage() {
   const { mutateAsync: refreshFlows } = useGetRefreshFlows();
   const setIsLoading = useFlowsManagerStore((state) => state.setIsLoading);
   const getTypes = useTypesStore((state) => state.getTypes);
+  const types = useTypesStore((state) => state.types);
 
   // Set flow tab id
   useEffect(() => {
@@ -49,7 +50,7 @@ export default function PlaygroundPage() {
       } else if (!flows) {
         setIsLoading(true);
         await refreshFlows(undefined);
-        await getTypes();
+        if (!types || Object.keys(types).length === 0) await getTypes();
         setIsLoading(false);
       }
     };

--- a/src/frontend/src/pages/ViewPage/index.tsx
+++ b/src/frontend/src/pages/ViewPage/index.tsx
@@ -17,6 +17,7 @@ export default function ViewPage() {
   const { mutateAsync: refreshFlows } = useGetRefreshFlows();
   const setIsLoading = useFlowsManagerStore((state) => state.setIsLoading);
   const getTypes = useTypesStore((state) => state.getTypes);
+  const types = useTypesStore((state) => state.types);
 
   // Set flow tab id
   useEffect(() => {
@@ -33,7 +34,7 @@ export default function ViewPage() {
       } else if (!flows) {
         setIsLoading(true);
         await refreshFlows(undefined);
-        await getTypes();
+        if (!types || Object.keys(types).length === 0) await getTypes();
         setIsLoading(false);
       }
     };

--- a/src/frontend/src/stores/typesStore.ts
+++ b/src/frontend/src/stores/typesStore.ts
@@ -27,7 +27,6 @@ export const useTypesStore = create<TypesStoreType>((set, get) => ({
       getAll(force_refresh)
         .then((response) => {
           const data = response?.data;
-          useAlertStore.setState({ loading: false });
           set((old) => ({
             types: typesGenerator(data),
             data: { ...old.data, ...data },

--- a/src/frontend/src/stores/typesStore.ts
+++ b/src/frontend/src/stores/typesStore.ts
@@ -21,7 +21,7 @@ export const useTypesStore = create<TypesStoreType>((set, get) => ({
   types: {},
   templates: {},
   data: {},
-  getTypes: (force_refresh: boolean = false) => {
+  getTypes: (force_refresh: boolean = true) => {
     return new Promise<void>(async (resolve, reject) => {
       const setLoading = useFlowsManagerStore.getState().setIsLoading;
       getAll(force_refresh)


### PR DESCRIPTION
This PR addresses an issue where the /getall endpoint was being called unnecessarily every time a user accessed the 'My Collection' page. This redundant API call could lead to increased load times and unnecessary server strain.

✨ (use-get-folders.ts): Update useGetFoldersQuery to check if types are empty before calling getTypes to avoid unnecessary API calls
♻️ (typesStore.ts): Remove unnecessary useAlertStore setState call to improve code readability and maintainability