### PR TITLE
fix: Delete folder from cache after successful deletion

### DIFF
--- a/src/frontend/src/controllers/API/queries/folders/use-delete-folders.ts
+++ b/src/frontend/src/controllers/API/queries/folders/use-delete-folders.ts
@@ -32,7 +32,10 @@ export const useDeleteFolders: useMutationFunctionType<
       queryClient.refetchQueries({ queryKey: ["useGetFolders"] });
     },
     onSuccess: (id) => {
-      queryClient.removeQueries({ queryKey: ["useGetFolder",{ id }],exact: true });
+      queryClient.removeQueries({
+        queryKey: ["useGetFolder", { id }],
+        exact: true,
+      });
     },
   });
 

--- a/src/frontend/src/controllers/API/queries/folders/use-delete-folders.ts
+++ b/src/frontend/src/controllers/API/queries/folders/use-delete-folders.ts
@@ -18,7 +18,8 @@ export const useDeleteFolders: useMutationFunctionType<
     folder_id,
   }: DeleteFoldersParams): Promise<any> => {
     const res = await api.delete(`${getURL("FOLDERS")}/${folder_id}`);
-    return res.data;
+    // returning id to use it in onSuccess and delete the folder from the cache
+    return folder_id;
   };
 
   const mutation: UseMutationResult<
@@ -29,6 +30,9 @@ export const useDeleteFolders: useMutationFunctionType<
     ...options,
     onSettled: () => {
       queryClient.refetchQueries({ queryKey: ["useGetFolders"] });
+    },
+    onSuccess: (id) => {
+      queryClient.removeQueries({ queryKey: ["useGetFolder",{ id }],exact: true });
     },
   });
 


### PR DESCRIPTION
This pull request includes a commit that adds functionality to delete a folder from the cache after a successful deletion. The commit modifies the `useDeleteFolders` function to return the folder ID, which is then used in the `onSuccess` callback to remove the folder from the cache. This ensures that the cache is updated correctly after a folder is deleted.