### PR TITLE
fix: remove saving on flow pan and add fit view to reactflow

### DIFF
--- a/src/frontend/src/components/headerComponent/components/menuBar/index.tsx
+++ b/src/frontend/src/components/headerComponent/components/menuBar/index.tsx
@@ -53,8 +53,7 @@ export const MenuBar = ({}: {}): JSX.Element => {
   const stopBuilding = useFlowStore((state) => state.stopBuilding);
 
   const changesNotSaved =
-    customStringify(currentFlow) !== customStringify(currentSavedFlow) &&
-    !autoSaving;
+    customStringify(currentFlow) !== customStringify(currentSavedFlow);
 
   const savedText =
     updatedAt && changesNotSaved

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -26,7 +26,6 @@ import ReactFlow, {
   Controls,
   Edge,
   NodeDragHandler,
-  OnMove,
   OnSelectionChangeParams,
   SelectionDragHandler,
   updateEdge,
@@ -306,12 +305,6 @@ export default function Page({ view }: { view?: boolean }): JSX.Element {
     // 👉 you can place your event handlers here
   }, [takeSnapshot]);
 
-  const onMoveEnd: OnMove = useCallback(() => {
-    // 👇 make moving the canvas undoable
-    autoSaveFlow();
-    updateCurrentFlow({ viewport: reactFlowInstance?.getViewport() });
-  }, [takeSnapshot, autoSaveFlow, nodes, edges, reactFlowInstance]);
-
   const onNodeDragStop: NodeDragHandler = useCallback(() => {
     // 👇 make moving the canvas undoable
     autoSaveFlow();
@@ -465,7 +458,6 @@ export default function Page({ view }: { view?: boolean }): JSX.Element {
             onSelectionStart={onSelectionStart}
             connectionLineComponent={ConnectionLineComponent}
             onDragOver={onDragOver}
-            onMoveEnd={onMoveEnd}
             onNodeDragStop={onNodeDragStop}
             onDrop={onDrop}
             onSelectionChange={onSelectionChange}
@@ -479,6 +471,7 @@ export default function Page({ view }: { view?: boolean }): JSX.Element {
             panActivationKeyCode={""}
             proOptions={{ hideAttribution: true }}
             onPaneClick={onPaneClick}
+            fitView // Add this prop to make ReactFlow start with a fit view
           >
             <Background className="" />
             {!view && (
@@ -488,7 +481,6 @@ export default function Page({ view }: { view?: boolean }): JSX.Element {
                     data-testid="add_note"
                     onClick={() => {
                       const wrapper = reactFlowWrapper.current!;
-                      const viewport = reactFlowInstance?.getViewport();
                       const x = wrapper.getBoundingClientRect().width / 2;
                       const y = wrapper.getBoundingClientRect().height / 2;
                       const nodePosition =

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -471,7 +471,6 @@ export default function Page({ view }: { view?: boolean }): JSX.Element {
             panActivationKeyCode={""}
             proOptions={{ hideAttribution: true }}
             onPaneClick={onPaneClick}
-            fitView // Add this prop to make ReactFlow start with a fit view
           >
             <Background className="" />
             {!view && (

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -196,6 +196,7 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
   },
   setReactFlowInstance: (newState) => {
     set({ reactFlowInstance: newState });
+    get().reactFlowInstance?.fitView();
   },
   onNodesChange: (changes: NodeChange[]) => {
     set({

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -159,7 +159,6 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
   resetFlow: (flow) => {
     const nodes = flow?.data?.nodes ?? [];
     const edges = flow?.data?.edges ?? [];
-    const viewport = flow?.data?.viewport ?? { zoom: 1, x: 0, y: 0 };
     let brokenEdges = detectBrokenEdgesEdges(nodes, edges);
     if (brokenEdges.length > 0) {
       useAlertStore.getState().setErrorData({
@@ -180,7 +179,6 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
       flowPool: {},
       currentFlow: flow,
     });
-    get().reactFlowInstance?.setViewport(viewport);
   },
   setIsBuilding: (isBuilding) => {
     set({ isBuilding });
@@ -197,16 +195,6 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
   },
   setReactFlowInstance: (newState) => {
     set({ reactFlowInstance: newState });
-    const viewport = get().currentFlow?.data?.viewport ?? {
-      zoom: 1,
-      x: 0,
-      y: 0,
-    };
-    if (viewport.x == 0 && viewport.y == 0) {
-      newState.fitView();
-    } else {
-      newState.setViewport(viewport);
-    }
   },
   onNodesChange: (changes: NodeChange[]) => {
     set({
@@ -752,19 +740,18 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
   setCurrentFlow: (flow) => {
     set({ currentFlow: flow });
   },
-  updateCurrentFlow: ({ nodes, edges, viewport }) => {
+  updateCurrentFlow: ({ nodes, edges }) => {
     set({
       currentFlow: {
         ...get().currentFlow!,
         data: {
           nodes: nodes ?? get().currentFlow?.data?.nodes ?? [],
           edges: edges ?? get().currentFlow?.data?.edges ?? [],
-          viewport: viewport ??
-            get().currentFlow?.data?.viewport ?? {
-              x: 0,
-              y: 0,
-              zoom: 1,
-            },
+          viewport: get().currentFlow?.data?.viewport ?? {
+            x: 0,
+            y: 0,
+            zoom: 1,
+          },
         },
       },
     });


### PR DESCRIPTION
I have made the following changes:

- Removed the viewport setting on resetFlow and setReactflowInstance functions.

- Removed the onMoveEnd function and its usage.

- Added the fitView prop to the ReactFlow component to make it start with a fit view.

These changes ensure that the ReactFlow canvas starts with a fit view, providing a better initial visualization of the flow.