### PR TITLE
fix: deepcopy component output to avoid overriding previous outputs

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -233,7 +233,7 @@ class Component(CustomComponent):
             setattr(output, key, value)
 
     def set_output_value(self, name: str, value: Any):
-        if name in self.outputs:
+        if name in self._outputs:
             self._outputs[name].value = value
         else:
             raise ValueError(f"Output {name} not found in {self.__class__.__name__}")

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -42,7 +42,6 @@ class Component(CustomComponent):
     def __init__(self, **kwargs):
         # if key starts with _ it is a config
         # else it is an input
-        self._reset_all_output_values()
         inputs = {}
         config = {}
         for key, value in kwargs.items():
@@ -69,6 +68,7 @@ class Component(CustomComponent):
             config |= {"_id": f"{self.__class__.__name__}-{nanoid.generate(size=5)}"}
         self.__inputs = inputs
         self.__config = config
+        self._reset_all_output_values()
         super().__init__(**config)
         if hasattr(self, "_trace_type"):
             self.trace_type = self._trace_type
@@ -443,8 +443,8 @@ class Component(CustomComponent):
             return self.__dict__["_attributes"][name]
         if "_inputs" in self.__dict__ and name in self.__dict__["_inputs"]:
             return self.__dict__["_inputs"][name].value
-        if "_outputs" in self.__dict__ and name in self.__dict__["_outputs"]:
-            return self.__dict__["_outputs"][name]
+        if "_outputs_map" in self.__dict__ and name in self.__dict__["_outputs_map"]:
+            return self.__dict__["_outputs_map"][name]
         if name in BACKWARDS_COMPATIBLE_ATTRIBUTES:
             return self.__dict__[f"_{name}"]
         if name.startswith("_") and name[1:] in BACKWARDS_COMPATIBLE_ATTRIBUTES:

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -250,11 +250,12 @@ class Component(CustomComponent):
         Returns:
             None
         """
-        self.outputs = outputs
         for output in outputs:
             if output.name is None:
                 raise ValueError("Output name cannot be None.")
-            self._outputs[output.name] = output
+            # Deepcopy is required to avoid modifying the original component;
+            # allows each instance of each component to modify its own output
+            self._outputs[output.name] = deepcopy(output)
 
     def map_inputs(self, inputs: list["InputTypes"]):
         """
@@ -267,7 +268,6 @@ class Component(CustomComponent):
             ValueError: If the input name is None.
 
         """
-        self.inputs = inputs
         for input_ in inputs:
             if input_.name is None:
                 raise ValueError("Input name cannot be None.")

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -319,7 +319,7 @@ class Graph:
         for vertex in self.vertices:
             if vertex._custom_component is None:
                 continue
-            for output in vertex._custom_component._outputs.values():
+            for output in vertex._custom_component._outputs_map.values():
                 for key, value in config["output"].items():
                     setattr(output, key, value)
 

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -319,7 +319,7 @@ class Graph:
         for vertex in self.vertices:
             if vertex._custom_component is None:
                 continue
-            for output in vertex._custom_component.outputs:
+            for output in vertex._custom_component._outputs.values():
                 for key, value in config["output"].items():
                     setattr(output, key, value)
 

--- a/src/backend/base/langflow/template/field/base.py
+++ b/src/backend/base/langflow/template/field/base.py
@@ -178,6 +178,7 @@ class Output(BaseModel):
     """The method to use for the output."""
 
     value: Any | None = Field(default=UNDEFINED)
+    """The result of the Output. Dynamically updated as execution occurs."""
 
     cache: bool = Field(default=True)
 

--- a/src/backend/tests/unit/test_custom_component.py
+++ b/src/backend/tests/unit/test_custom_component.py
@@ -400,6 +400,7 @@ def test_custom_component_get_function_entrypoint_args_no_args():
     the CustomComponent class with a build method with no arguments.
     """
     my_code = """
+from langflow.custom import CustomComponent
 class MyMainClass(CustomComponent):
     def build():
         pass"""

--- a/src/backend/tests/unit/test_database.py
+++ b/src/backend/tests/unit/test_database.py
@@ -73,10 +73,11 @@ def test_read_flows(client: TestClient, json_flow: str, active_user, logged_in_h
     assert len(response.json()) > 0
 
 
-def test_read_flow(client: TestClient, json_flow: str, active_user, logged_in_headers):
+def test_read_flow(client: TestClient, json_flow: str, logged_in_headers):
     flow = orjson.loads(json_flow)
     data = flow["data"]
-    flow = FlowCreate(name="Test Flow", description="description", data=data)
+    unique_name = str(uuid4())
+    flow = FlowCreate(name=unique_name, description="description", data=data)
     response = client.post("api/v1/flows/", json=flow.model_dump(), headers=logged_in_headers)
     flow_id = response.json()["id"]  # flow_id should be a UUID but is a string
     # turn it into a UUID


### PR DESCRIPTION
This was a bug that @edwinjosechittilappilly noticed in the linked issue. Outputs of subsequently created components were overriding outputs of previously created components of the same name - i.e. two Model outputs may interchange their `Outputs`, regardless of where in the flow they were. 

This is due to how the class variable `Outputs` is structured -- as class variables, it gives us this potential for cross-component leakage, but I have no better ideas at the moment on how to allow initializing the component with Outputs and then allowing for dynamic updates to that variable to provide the `result`. 

Closes https://github.com/langflow-ai/langflow/issues/3619