### PR TITLE
fix: set refetch on window focus to false for all queries on flow page

### DIFF
--- a/src/frontend/src/controllers/API/queries/auth/use-get-autologin.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-get-autologin.ts
@@ -54,7 +54,10 @@ export const useGetAutoLogin: useQueryFunctionType<undefined, undefined> = (
     return null;
   }
 
-  const queryResult = query(["useGetAutoLogin"], getAutoLoginFn, options);
+  const queryResult = query(["useGetAutoLogin"], getAutoLoginFn, {
+    refetchOnWindowFocus: false,
+    ...options,
+  });
 
   return queryResult;
 };

--- a/src/frontend/src/controllers/API/queries/config/use-get-config.ts
+++ b/src/frontend/src/controllers/API/queries/config/use-get-config.ts
@@ -41,7 +41,10 @@ export const useGetConfig: useQueryFunctionType<undefined, ConfigResponse> = (
     return data;
   };
 
-  const queryResult = query(["useGetConfig"], getConfigFn, options);
+  const queryResult = query(["useGetConfig"], getConfigFn, {
+    refetchOnWindowFocus: false,
+    ...options,
+  });
 
   return queryResult;
 };

--- a/src/frontend/src/controllers/API/queries/health/use-get-health.ts
+++ b/src/frontend/src/controllers/API/queries/health/use-get-health.ts
@@ -75,6 +75,7 @@ export const useGetHealthQuery: useQueryFunctionType<
       ? REFETCH_SERVER_HEALTH_INTERVAL
       : false,
     retry: false,
+    refetchOnWindowFocus: false,
     ...options,
   });
 

--- a/src/frontend/src/controllers/API/queries/store/use-get-tags.ts
+++ b/src/frontend/src/controllers/API/queries/store/use-get-tags.ts
@@ -25,7 +25,10 @@ export const useGetTagsQuery: useQueryFunctionType<
     return data;
   };
 
-  const queryResult = query(["useGetTagsQuery"], responseFn, { ...options });
+  const queryResult = query(["useGetTagsQuery"], responseFn, {
+    refetchOnWindowFocus: false,
+    ...options,
+  });
 
   return queryResult;
 };

--- a/src/frontend/src/controllers/API/queries/transactions/use-get-transactions.ts
+++ b/src/frontend/src/controllers/API/queries/transactions/use-get-transactions.ts
@@ -48,6 +48,7 @@ export const useGetTransactionsQuery: useQueryFunctionType<
 
   const queryResult = query(["useGetTransactionsQuery"], getTransactionsFn, {
     placeholderData: keepPreviousData,
+    refetchOnWindowFocus: false,
     ...options,
   });
 

--- a/src/frontend/src/controllers/API/queries/variables/use-get-global-variables.ts
+++ b/src/frontend/src/controllers/API/queries/variables/use-get-global-variables.ts
@@ -30,7 +30,10 @@ export const useGetGlobalVariables: useQueryFunctionType<
   const queryResult: UseQueryResult<GlobalVariable[], any> = query(
     ["useGetGlobalVariables"],
     getGlobalVariablesFn,
-    options,
+    {
+      refetchOnWindowFocus: false,
+      ...options,
+    },
   );
 
   return queryResult;

--- a/src/frontend/src/controllers/API/queries/version/use-get-version.ts
+++ b/src/frontend/src/controllers/API/queries/version/use-get-version.ts
@@ -26,7 +26,10 @@ export const useGetVersionQuery: useQueryFunctionType<
     return data;
   };
 
-  const queryResult = query(["useGetVersionQuery"], responseFn, { ...options });
+  const queryResult = query(["useGetVersionQuery"], responseFn, {
+    refetchOnWindowFocus: false,
+    ...options,
+  });
 
   return queryResult;
 };


### PR DESCRIPTION
This pull request updates all queries to set the `refetchOnWindowFocus` option to `false`. This ensures that the queries will not automatically refetch data when the window gains focus, improving performance and reducing unnecessary network requests.