### PR TITLE
ci: enables docker builds for nightly tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -118,7 +118,7 @@ jobs:
             nightly_suffix="-nightly"
           fi
 
-          if [[ "${{ nightly_suffix }}" == '' ]]; then
+          if [[ "$nightly_suffix" == '' ]]; then
             echo "Error: Nightly suffix is empty"
             exit 1
           fi

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -71,6 +71,7 @@ jobs:
           else
             echo "nightly_tag=" >> $GITHUB_OUTPUT
           fi
+
       - name: Check out the code at a specific ref (e.g., nightly tag)
         uses: actions/checkout@v4
         with:
@@ -105,16 +106,19 @@ jobs:
     outputs:
       tags: ${{ steps.set-vars.outputs.tags }}
       file: ${{ steps.set-vars.outputs.file }}
+    env:
+      NIGHTLY_TAG: ${{ needs.get-version.outputs.nightly-tag }}
     steps:
       - name: Check out the code at a specific ref (e.g., nightly tag)
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.get-version.outputs.nightly_tag || github.ref }} 
+          ref: ${{ env.NIGHTLY_TAG || github.ref }}
+
       - name: Set Dockerfile and Tags
         id: set-vars
         run: |
           nightly_suffix=''
-          if [[ "${{ needs.get-version.outputs.nightly_tag }}" != '' ]]; then
+          if [[ "${{ env.NIGHTLY_TAG }}" != '' ]]; then
             nightly_suffix="-nightly"
           fi
 
@@ -141,7 +145,7 @@ jobs:
       - name: Check out the code at a specific ref (e.g., nightly tag)
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.get-version.outputs.nightly_tag || github.ref }} 
+          ref: ${{ needs.get-version.outputs.nightly-tag || github.ref }} 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
@@ -177,7 +181,7 @@ jobs:
       - name: Check out the code at a specific ref (e.g., nightly tag)
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.get-version.outputs.nightly_tag || github.ref }} 
+          ref: ${{ needs.get-version.outputs.nightly-tag || github.ref }} 
  
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -118,6 +118,11 @@ jobs:
             nightly_suffix="-nightly"
           fi
 
+          if [[ "${{ nightly_suffix }}" == '' ]]; then
+            echo "Error: Nightly suffix is empty"
+            exit 1
+          fi
+
           if [[ "${{ inputs.release_type }}" == "base" ]]; then
             echo "tags=langflowai/langflow${nightly_suffix}:base-${{ needs.get-version.outputs.version }},langflowai/langflow${nightly_suffix}:base-latest" >> $GITHUB_OUTPUT
             echo "file=./docker/build_and_push_base.Dockerfile" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -122,11 +122,6 @@ jobs:
             nightly_suffix="-nightly"
           fi
 
-          if [[ "$nightly_suffix" == '' ]]; then
-            echo "Error: Nightly suffix is empty"
-            exit 1
-          fi
-
           if [[ "${{ inputs.release_type }}" == "base" ]]; then
             echo "tags=langflowai/langflow${nightly_suffix}:base-${{ needs.get-version.outputs.version }},langflowai/langflow${nightly_suffix}:base-latest" >> $GITHUB_OUTPUT
             echo "file=./docker/build_and_push_base.Dockerfile" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -113,8 +113,8 @@ jobs:
       - name: Set Dockerfile and Tags
         id: set-vars
         run: |
-          nightly_suffix=""
-          if [[ "${{ inputs.nightly_build }}" == "true" ]]; then
+          nightly_suffix=''
+          if [[ "${{ needs.get-version.outputs.nightly_tag }}" != '' ]]; then
             nightly_suffix="-nightly"
           fi
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,10 +12,17 @@ on:
         required: false
         type: boolean
         default: false
-      nightly_build:
+      nightly_tag_main:
+        description: "Tag for the nightly main build"
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ''
+      nightly_tag_base:
+        description: "Tag for the nightly base build"
+        required: false
+        type: string
+        default: ''
+ 
   workflow_dispatch:
     inputs:
       version:
@@ -31,12 +38,17 @@ on:
         required: false
         type: boolean
         default: false
-      nightly_build:
-        description: "Build nightly build"
+      nightly_tag_main:
+        description: "Tag for the nightly main build"
         required: false
-        type: boolean
-        default: false
-
+        type: string
+        default: ''
+      nightly_tag_base:
+        description: "Tag for the nightly base build"
+        required: false
+        type: string
+        default: ''
+ 
 env:
   POETRY_VERSION: "1.8.2"
   TEST_TAG: "langflowai/langflow:test"
@@ -45,11 +57,24 @@ jobs:
   get-version:
     name: Get Version
     runs-on: ubuntu-latest
-
     outputs:
       version: ${{ steps.get-version-input.outputs.version || steps.get-version-base.outputs.version || steps.get-version-main.outputs.version }}
+      nightly-tag: ${{ steps.resolve-nightly-tag.outputs.nightly_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Resolve nightly tag
+        id: resolve-nightly-tag
+        run: |
+          if [[ "${{ inputs.nightly_tag_main }}" != '' ]]; then
+            echo "nightly_tag=${{ inputs.nightly_tag_main }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.nightly_tag_base }}" != '' ]]; then
+            echo "nightly_tag=${{ inputs.nightly_tag_base }}" >> $GITHUB_OUTPUT
+          else
+            echo "nightly_tag=" >> $GITHUB_OUTPUT
+          fi
+      - name: Check out the code at a specific ref (e.g., nightly tag)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.resolve-nightly-tag.outputs.nightly_tag || github.ref }}
       - name: Set up Python 3.12 + Poetry ${{ env.POETRY_VERSION }}
         uses: "./.github/actions/poetry_caching"
         with:
@@ -81,7 +106,10 @@ jobs:
       tags: ${{ steps.set-vars.outputs.tags }}
       file: ${{ steps.set-vars.outputs.file }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out the code at a specific ref (e.g., nightly tag)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.get-version.outputs.nightly_tag || github.ref }} 
       - name: Set Dockerfile and Tags
         id: set-vars
         run: |
@@ -103,9 +131,12 @@ jobs:
           fi
   build:
     runs-on: ubuntu-latest
-    needs: setup
+    needs: [get-version, setup]
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out the code at a specific ref (e.g., nightly tag)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.get-version.outputs.nightly_tag || github.ref }} 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
@@ -138,7 +169,11 @@ jobs:
             dockerfile: ./docker/frontend/build_and_push_frontend.Dockerfile
             tags: ${{ inputs.pre_release == 'true' && format('langflowai/langflow-frontend{0}:{1}', inputs.nightly_build && '-nightly' || '', needs.get-version.outputs.version) || format('langflowai/langflow-frontend{0}:{1},langflowai/langflow-frontend{0}:latest{1}',  inputs.nightly_build && '-nightly' || '', needs.get-version.outputs.version) }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out the code at a specific ref (e.g., nightly tag)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.get-version.outputs.nightly_tag || github.ref }} 
+ 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -49,9 +49,7 @@ jobs:
           # WARNING: These scripts must be run in this order.
           # Poetry will use a different cached virtual environment once the main pyproject.toml
           # project-name is updated, which does not have dependencies installed.
-          # BASE_TAG="$(poetry run python ./scripts/ci/pypi_nightly_tag.py base)"
-          BASE_TAG="0.0.95.dev5"
-
+          BASE_TAG="$(poetry run python ./scripts/ci/pypi_nightly_tag.py base)"
           echo "base_tag=$BASE_TAG" >> $GITHUB_OUTPUT
           poetry run python ./scripts/ci/update_pyproject_name.py langflow-base-nightly base
           poetry run python ./scripts/ci/update_pyproject_version.py $BASE_TAG base
@@ -59,37 +57,36 @@ jobs:
           # This updates the dependency of langflow-base to langflow-base-nightly in {project_root}/pyproject.toml
           poetry run python ./scripts/ci/update_lf_base_dependency.py $BASE_TAG
 
-          # MAIN_TAG="$(poetry run python ./scripts/ci/pypi_nightly_tag.py main)"
-          MAIN_TAG="1.0.17.dev5"
+          MAIN_TAG="$(poetry run python ./scripts/ci/pypi_nightly_tag.py main)"
           echo "main_tag=$MAIN_TAG" >> $GITHUB_OUTPUT
           poetry run python ./scripts/ci/update_pyproject_version.py $MAIN_TAG main
           poetry run python ./scripts/ci/update_pyproject_name.py langflow-nightly main
 
-          # git add pyproject.toml src/backend/base/pyproject.toml
-          # git commit -m "Update version and project name in files"
+          git add pyproject.toml src/backend/base/pyproject.toml
+          git commit -m "Update version and project name in files"
 
-          # git tag -a $MAIN_TAG -m "Langflow nightly $MAIN_TAG"
-          # git push origin $MAIN_TAG || echo "Tag push failed. Check if the tag already exists."
+          git tag -a $MAIN_TAG -m "Langflow nightly $MAIN_TAG"
+          git push origin $MAIN_TAG || echo "Tag push failed. Check if the tag already exists."
           # TODO: notify on failure
 
-  # frontend-tests:
-  #   name: Run Frontend Tests
-  #   needs: create-nightly-tag
-  #   uses: ./.github/workflows/typescript_test.yml
-  #   with:
-  #     tests_folder: "tests/end-to-end"
-  #     ref: ${{ needs.create-nightly-tag.outputs.tag }}
-  #   secrets:
-  #     OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
-  #     STORE_API_KEY: "${{ secrets.STORE_API_KEY }}"
+  frontend-tests:
+    name: Run Frontend Tests
+    needs: create-nightly-tag
+    uses: ./.github/workflows/typescript_test.yml
+    with:
+      tests_folder: "tests/end-to-end"
+      ref: ${{ needs.create-nightly-tag.outputs.tag }}
+    secrets:
+      OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
+      STORE_API_KEY: "${{ secrets.STORE_API_KEY }}"
 
-  # backend-unit-tests:
-  #   name: Run Backend Unit Tests
-  #   needs: create-nightly-tag
-  #   uses: ./.github/workflows/python_test.yml
-  #   with:
-  #     python-versions: '["3.10", "3.11", "3.12"]'
-  #     ref: ${{ needs.create-nightly-tag.outputs.tag }}
+  backend-unit-tests:
+    name: Run Backend Unit Tests
+    needs: create-nightly-tag
+    uses: ./.github/workflows/python_test.yml
+    with:
+      python-versions: '["3.10", "3.11", "3.12"]'
+      ref: ${{ needs.create-nightly-tag.outputs.tag }}
 
   # Not making nightly builds dependent on integration test success
   # due to inherent flakiness of 3rd party integrations
@@ -104,7 +101,7 @@ jobs:
 
   release-nightly-build:
     name: Run Nightly Langflow Build
-    # needs: [frontend-tests, backend-unit-tests, create-nightly-tag]
+    needs: [frontend-tests, backend-unit-tests, create-nightly-tag]
     uses: ./.github/workflows/release_nightly.yml
     with:
       build_docker_base: true

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -49,7 +49,9 @@ jobs:
           # WARNING: These scripts must be run in this order.
           # Poetry will use a different cached virtual environment once the main pyproject.toml
           # project-name is updated, which does not have dependencies installed.
-          BASE_TAG="$(poetry run python ./scripts/ci/pypi_nightly_tag.py base)"
+          # BASE_TAG="$(poetry run python ./scripts/ci/pypi_nightly_tag.py base)"
+          BASE_TAG="0.0.95.dev5"
+
           echo "base_tag=$BASE_TAG" >> $GITHUB_OUTPUT
           poetry run python ./scripts/ci/update_pyproject_name.py langflow-base-nightly base
           poetry run python ./scripts/ci/update_pyproject_version.py $BASE_TAG base
@@ -57,36 +59,37 @@ jobs:
           # This updates the dependency of langflow-base to langflow-base-nightly in {project_root}/pyproject.toml
           poetry run python ./scripts/ci/update_lf_base_dependency.py $BASE_TAG
 
-          MAIN_TAG="$(poetry run python ./scripts/ci/pypi_nightly_tag.py main)"
+          # MAIN_TAG="$(poetry run python ./scripts/ci/pypi_nightly_tag.py main)"
+          MAIN_TAG="1.0.17.dev5"
           echo "main_tag=$MAIN_TAG" >> $GITHUB_OUTPUT
           poetry run python ./scripts/ci/update_pyproject_version.py $MAIN_TAG main
           poetry run python ./scripts/ci/update_pyproject_name.py langflow-nightly main
 
-          git add pyproject.toml src/backend/base/pyproject.toml
-          git commit -m "Update version and project name in files"
+          # git add pyproject.toml src/backend/base/pyproject.toml
+          # git commit -m "Update version and project name in files"
 
-          git tag -a $MAIN_TAG -m "Langflow nightly $MAIN_TAG"
-          git push origin $MAIN_TAG || echo "Tag push failed. Check if the tag already exists."
+          # git tag -a $MAIN_TAG -m "Langflow nightly $MAIN_TAG"
+          # git push origin $MAIN_TAG || echo "Tag push failed. Check if the tag already exists."
           # TODO: notify on failure
 
-  frontend-tests:
-    name: Run Frontend Tests
-    needs: create-nightly-tag
-    uses: ./.github/workflows/typescript_test.yml
-    with:
-      tests_folder: "tests/end-to-end"
-      ref: ${{ needs.create-nightly-tag.outputs.tag }}
-    secrets:
-      OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
-      STORE_API_KEY: "${{ secrets.STORE_API_KEY }}"
+  # frontend-tests:
+  #   name: Run Frontend Tests
+  #   needs: create-nightly-tag
+  #   uses: ./.github/workflows/typescript_test.yml
+  #   with:
+  #     tests_folder: "tests/end-to-end"
+  #     ref: ${{ needs.create-nightly-tag.outputs.tag }}
+  #   secrets:
+  #     OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
+  #     STORE_API_KEY: "${{ secrets.STORE_API_KEY }}"
 
-  backend-unit-tests:
-    name: Run Backend Unit Tests
-    needs: create-nightly-tag
-    uses: ./.github/workflows/python_test.yml
-    with:
-      python-versions: '["3.10", "3.11", "3.12"]'
-      ref: ${{ needs.create-nightly-tag.outputs.tag }}
+  # backend-unit-tests:
+  #   name: Run Backend Unit Tests
+  #   needs: create-nightly-tag
+  #   uses: ./.github/workflows/python_test.yml
+  #   with:
+  #     python-versions: '["3.10", "3.11", "3.12"]'
+  #     ref: ${{ needs.create-nightly-tag.outputs.tag }}
 
   # Not making nightly builds dependent on integration test success
   # due to inherent flakiness of 3rd party integrations
@@ -101,11 +104,11 @@ jobs:
 
   release-nightly-build:
     name: Run Nightly Langflow Build
-    needs: [frontend-tests, backend-unit-tests, create-nightly-tag]
+    # needs: [frontend-tests, backend-unit-tests, create-nightly-tag]
     uses: ./.github/workflows/release_nightly.yml
     with:
-      build_docker_base: false # TODO: Docker builds
-      build_docker_main: false
+      build_docker_base: true
+      build_docker_main: true
       nightly_tag_main: ${{ needs.create-nightly-tag.outputs.main_tag }}
       nightly_tag_base: ${{ needs.create-nightly-tag.outputs.base_tag }}
     secrets: inherit

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -50,6 +50,7 @@ env:
 jobs:
   release-nightly-base:
     name: Release Langflow Nightly Base
+    if: false # TODO: Temp skip
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -122,6 +123,7 @@ jobs:
 
   release-nightly-main:
     name: Release Langflow Nightly Main
+    if: false # TODO: temp skip
     needs: [release-nightly-base]
     runs-on: ubuntu-latest
     defaults:
@@ -193,7 +195,7 @@ jobs:
   call_docker_build_base:
     name: Call Docker Build Workflow for Langflow Base
     if: ${{ inputs.build_docker_base == 'true' }}
-    needs: [release-nightly-base]
+    # needs: [release-nightly-base]
     uses: ./.github/workflows/docker-build.yml
     strategy:
       matrix:
@@ -204,13 +206,13 @@ jobs:
       # version should be needs.release-main.outputs.version  if release_type is main
       version: ""
       release_type: ${{ matrix.release_type }}
-      nightly_build: true
+      nightly_tag_base: ${{ inputs.nightly_tag_base }}
     secrets: inherit
 
   call_docker_build_main:
     name: Call Docker Build Workflow for Langflow
     if: ${{ inputs.build_docker_main == 'true' }}
-    needs: [release-nightly-main]
+    # needs: [release-nightly-main]
     uses: ./.github/workflows/docker-build.yml
     strategy:
       matrix:
@@ -221,5 +223,5 @@ jobs:
       # version should be needs.release-main.outputs.version  if release_type is main
       version: ""
       release_type: ${{ matrix.release_type }}
-      nightly_build: true
+      nightly_tag_main: ${{ inputs.nightly_tag_main }}
     secrets: inherit

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -50,7 +50,6 @@ env:
 jobs:
   release-nightly-base:
     name: Release Langflow Nightly Base
-    if: false # TODO: Temp skip
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -123,7 +122,6 @@ jobs:
 
   release-nightly-main:
     name: Release Langflow Nightly Main
-    if: false # TODO: temp skip
     needs: [release-nightly-base]
     runs-on: ubuntu-latest
     defaults:
@@ -195,7 +193,7 @@ jobs:
   call_docker_build_base:
     name: Call Docker Build Workflow for Langflow Base
     if: ${{ inputs.build_docker_base == 'true' }}
-    # needs: [release-nightly-base]
+    needs: [release-nightly-base]
     uses: ./.github/workflows/docker-build.yml
     strategy:
       matrix:
@@ -212,7 +210,7 @@ jobs:
   call_docker_build_main:
     name: Call Docker Build Workflow for Langflow
     if: ${{ inputs.build_docker_main == 'true' }}
-    # needs: [release-nightly-main]
+    needs: [release-nightly-main]
     uses: ./.github/workflows/docker-build.yml
     strategy:
       matrix:


### PR DESCRIPTION
Enables nightly build workflows to create the corresponding docker images. 

It doesn't have an overview or anything - I'll need to be made an maintainer/admin on the langflowai org to do that, I believe. 

Test run: https://github.com/langflow-ai/langflow/actions/runs/10754060383
https://hub.docker.com/r/langflowai/langflow-nightly