### PR TITLE
fix: node status display when node minimized

### DIFF
--- a/src/backend/base/langflow/components/astra_assistants/create_assistant.py
+++ b/src/backend/base/langflow/components/astra_assistants/create_assistant.py
@@ -40,9 +40,7 @@ class AssistantsCreateAssistant(Component):
     ]
 
     outputs = [
-        Output(
-            display_name="Assistant ID", name="assistant_id", method="process_inputs"
-        ),
+        Output(display_name="Assistant ID", name="assistant_id", method="process_inputs"),
     ]
 
     def process_inputs(self) -> Message:

--- a/src/backend/base/langflow/components/astra_assistants/create_assistant.py
+++ b/src/backend/base/langflow/components/astra_assistants/create_assistant.py
@@ -40,7 +40,9 @@ class AssistantsCreateAssistant(Component):
     ]
 
     outputs = [
-        Output(display_name="Assistant ID", name="assistant_id", method="process_inputs"),
+        Output(
+            display_name="Assistant ID", name="assistant_id", method="process_inputs"
+        ),
     ]
 
     def process_inputs(self) -> Message:

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
@@ -1,12 +1,10 @@
 import { cloneDeep } from "lodash";
-import { useEffect, useRef, useState } from "react";
-import { useHotkeys } from "react-hotkeys-hook";
+import { useEffect, useRef } from "react";
 import { useUpdateNodeInternals } from "reactflow";
 import { default as IconComponent } from "../../../../components/genericIconComponent";
 import ShadTooltip from "../../../../components/shadTooltipComponent";
 import { Button } from "../../../../components/ui/button";
 import useFlowStore from "../../../../stores/flowStore";
-import { useShortcutsStore } from "../../../../stores/shortcuts";
 import { useTypesStore } from "../../../../stores/typesStore";
 import { NodeOutputFieldComponentType } from "../../../../types/components";
 import {
@@ -44,7 +42,6 @@ export default function NodeOutputField({
   const myData = useTypesStore((state) => state.data);
   const updateNodeInternals = useUpdateNodeInternals();
   const setFilterEdge = useFlowStore((state) => state.setFilterEdge);
-  const [openOutputModal, setOpenOutputModal] = useState(false);
   const flowPool = useFlowStore((state) => state.flowPool);
 
   let flowPoolId = data.id;
@@ -75,17 +72,6 @@ export default function NodeOutputField({
     internalOutputName,
   );
   const errorOutput = logTypeIsError(flowPoolNode?.data, internalOutputName);
-
-  const preventDefault = true;
-
-  function handleOutputWShortcut() {
-    if (!displayOutputPreview || unknownOutput) return;
-    if (selected) {
-      setOpenOutputModal((state) => !state);
-    }
-  }
-  const output = useShortcutsStore((state) => state.output);
-  useHotkeys(output, handleOutputWShortcut, { preventDefault });
 
   let disabledOutput =
     edges.some((edge) => edge.sourceHandle === scapedJSONStringfy(id)) ?? false;

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -51,7 +51,7 @@ export default function GenericNode({
   const [isOutdated, setIsOutdated] = useState(false);
   const [isUserEdited, setIsUserEdited] = useState(false);
   const [borderColor, setBorderColor] = useState<string>("");
-  const [showNode, setShowNode] = useState(data.showNode ?? true);
+  const showNode = data.showNode ?? true;
 
   const updateNodeCode = useUpdateNodeCode(
     data?.id,
@@ -77,10 +77,6 @@ export default function GenericNode({
   }
 
   useCheckCodeValidity(data, templates, setIsOutdated, setIsUserEdited, types);
-
-  useEffect(() => {
-    setShowNode(data.showNode ?? true);
-  }, [data.showNode]);
 
   const [loadingUpdate, setLoadingUpdate] = useState(false);
 
@@ -193,7 +189,6 @@ export default function GenericNode({
               data: { ...old.data, showNode: show },
             }));
           }}
-          setShowState={setShowNode}
           numberOfOutputHandles={shownOutputs.length ?? 0}
           showNode={showNode}
           openAdvancedModal={false}
@@ -208,7 +203,6 @@ export default function GenericNode({
     deleteNode,
     takeSnapshot,
     setNode,
-    setShowNode,
     showNode,
     updateNodeCode,
     isOutdated,
@@ -333,14 +327,16 @@ export default function GenericNode({
                 </>
               )}
             </div>
-            <NodeStatus
-              frozen={data.node?.frozen}
-              showNode={showNode}
-              display_name={data.node?.display_name!}
-              nodeId={data.id}
-              selected={selected}
-              setBorderColor={setBorderColor}
-            />
+            {!showNode && (
+              <NodeStatus
+                frozen={data.node?.frozen}
+                showNode={showNode}
+                display_name={data.node?.display_name!}
+                nodeId={data.id}
+                selected={selected}
+                setBorderColor={setBorderColor}
+              />
+            )}
           </div>
         </div>
 

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -327,7 +327,7 @@ export default function GenericNode({
                 </>
               )}
             </div>
-            {!showNode && (
+            {showNode && (
               <NodeStatus
                 frozen={data.node?.frozen}
                 showNode={showNode}

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -323,7 +323,12 @@ export default function GenericNode({
                   {renderInputParameter}
                   {shownOutputs &&
                     shownOutputs.length > 0 &&
-                    renderOutputParameter(shownOutputs[0], 0)}
+                    renderOutputParameter(
+                      shownOutputs[0],
+                      data.node!.outputs?.findIndex(
+                        (out) => out.name === shownOutputs[0].name,
+                      ) ?? 0,
+                    )}
                 </>
               )}
             </div>

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -50,7 +50,6 @@ export default function NodeToolbarComponent({
   numberOfOutputHandles,
   showNode,
   name = "code",
-  setShowState,
   onCloseAdvancedModal,
   updateNode,
   isOutdated,
@@ -79,7 +78,6 @@ export default function NodeToolbarComponent({
 
   function minimize() {
     if (isMinimal) {
-      setShowState((show) => !show);
       setShowNode((data.showNode ?? true) ? false : true);
       return;
     }

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -1,5 +1,5 @@
 import { handleOnNewValueType } from "@/CustomNodes/hooks/use-handle-new-value";
-import { ReactElement, ReactNode, SetStateAction } from "react";
+import { ReactElement, ReactNode } from "react";
 import { ReactFlowJsonObject } from "reactflow";
 import { InputOutput } from "../../constants/enums";
 import {
@@ -633,7 +633,6 @@ export type nodeToolbarPropsType = {
   openAdvancedModal?: boolean;
   onCloseAdvancedModal?: (close: boolean) => void;
   isOutdated: boolean;
-  setShowState: (show: boolean | SetStateAction<boolean>) => void;
   updateNode: () => void;
 };
 


### PR DESCRIPTION
This pull request removes unused code and fixes an issue where the node status was still being displayed when the node was minimized. It also fixes a bug where the node wouldn't expand after being minimized if an output was hidden. Additionally, some linting has been done to improve code quality.