### PR TITLE
fix: bug langchain await

### DIFF
--- a/src/backend/base/langflow/base/agents/agent.py
+++ b/src/backend/base/langflow/base/agents/agent.py
@@ -144,7 +144,7 @@ class LCToolsAgentComponent(LCAgentComponent):
         if self.chat_history:
             input_dict["chat_history"] = data_to_messages(self.chat_history)
 
-        result = await runnable.ainvoke(
+        result = runnable.invoke(
             input_dict, config={"callbacks": [AgentAsyncHandler(self.log)] + self.get_langchain_callbacks()}
         )
         self.status = result

--- a/src/frontend/tests/extended/regression/generalBugs-shard-1.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-1.spec.ts
@@ -36,7 +36,6 @@ test("should delete rows from table message", async ({ page }) => {
   }
 
   await page.getByRole("heading", { name: "Basic Prompting" }).click();
-
   await page.waitForSelector('[title="fit view"]', {
     timeout: 100000,
   });


### PR DESCRIPTION
This PR resolve bug on langchain: TypeError: object LangfuseResponseGeneratorSync can't be used in 'await'