### PR TITLE
fix: Fix Text Splitters

### DIFF
--- a/src/backend/base/langflow/base/textsplitters/model.py
+++ b/src/backend/base/langflow/base/textsplitters/model.py
@@ -4,8 +4,6 @@ from langchain_core.documents import BaseDocumentTransformer
 from langchain_text_splitters import TextSplitter
 
 from langflow.base.document_transformers.model import LCDocumentTransformerComponent
-from langflow.io import Output
-from langflow.schema import Data
 
 
 class LCTextSplitterComponent(LCDocumentTransformerComponent):

--- a/src/backend/base/langflow/base/textsplitters/model.py
+++ b/src/backend/base/langflow/base/textsplitters/model.py
@@ -10,9 +10,6 @@ from langflow.schema import Data
 
 class LCTextSplitterComponent(LCDocumentTransformerComponent):
     trace_type = "text_splitter"
-    outputs = [
-        Output(display_name="Data", name="data", method="split_data"),
-    ]
 
     def _validate_outputs(self):
         required_output_methods = ["text_splitter"]
@@ -22,9 +19,6 @@ class LCTextSplitterComponent(LCDocumentTransformerComponent):
                 raise ValueError(f"Output with name '{method_name}' must be defined.")
             elif not hasattr(self, method_name):
                 raise ValueError(f"Method '{method_name}' must be defined.")
-
-    def split_data(self) -> list[Data]:
-        return self.transform_data()
 
     def build_document_transformer(self) -> BaseDocumentTransformer:
         return self.build_text_splitter()


### PR DESCRIPTION
It seems the change in https://github.com/langflow-ai/langflow/pull/3757 creates some kind of conflicts and the Data output of text splitters cannot be linked anymore.
This PR fixes this and also makes the code simpler.