### PR TITLE
draft: return only results to user from run_flow_from_json

### DIFF
--- a/src/backend/base/langflow/graph/schema.py
+++ b/src/backend/base/langflow/graph/schema.py
@@ -9,9 +9,14 @@ from langflow.utils.schemas import ChatOutputResponse, ContainsEnumMeta
 
 
 class ResultData(BaseModel):
+    # TODO: What are all of these used for? 
+    # Does the FE need anything besides the `results`? 
+    # (And maybe time, duration, metadata etc)
+
     results: Any | None = Field(default_factory=dict)
     artifacts: Any | None = Field(default_factory=dict)
-    outputs: dict | None = Field(default_factory=dict)
+    # TODO: diff between results and outputs? 
+    # outputs: dict | None = Field(default_factory=dict)
     logs: dict | None = Field(default_factory=dict)
     messages: list[ChatOutputResponse] | None = Field(default_factory=list)
     timedelta: float | None = None

--- a/src/backend/base/langflow/graph/schema.py
+++ b/src/backend/base/langflow/graph/schema.py
@@ -9,13 +9,13 @@ from langflow.utils.schemas import ChatOutputResponse, ContainsEnumMeta
 
 
 class ResultData(BaseModel):
-    # TODO: What are all of these used for? 
-    # Does the FE need anything besides the `results`? 
+    # TODO: What are all of these used for?
+    # Does the FE need anything besides the `results`?
     # (And maybe time, duration, metadata etc)
 
     results: Any | None = Field(default_factory=dict)
     artifacts: Any | None = Field(default_factory=dict)
-    # TODO: diff between results and outputs? 
+    # TODO: diff between results and outputs?
     # outputs: dict | None = Field(default_factory=dict)
     logs: dict | None = Field(default_factory=dict)
     messages: list[ChatOutputResponse] | None = Field(default_factory=list)

--- a/src/backend/base/langflow/load/load.py
+++ b/src/backend/base/langflow/load/load.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 from loguru import logger
 
 from langflow.graph import Graph
-from langflow.graph.schema import RunOutputs
 from langflow.processing.process import process_tweaks, run_graph
 from langflow.logging.logger import configure
 from langflow.utils.util import update_settings
@@ -22,9 +21,11 @@ class UserFacingData(BaseModel):
     component_id: str | None = None
     used_frozen_result: bool | None = False
 
+
 class UserFacingOutputs(BaseModel):
     inputs: dict = Field(default_factory=dict)
     outputs: list[UserFacingData | None] = Field(default_factory=list)
+
 
 def load_flow_from_json(
     flow: Union[Path, str, dict],
@@ -156,10 +157,9 @@ def run_flow_from_json(
                     duration=output.duration,
                     component_display_name=output.component_display_name,
                     component_id=output.component_id,
-                    used_frozen_result=output.used_frozen_result
+                    used_frozen_result=output.used_frozen_result,
                 )
                 user_facing_output.outputs.append(user_facing_data)
         user_facing_outputs.append(user_facing_output)
 
     return user_facing_outputs
-


### PR DESCRIPTION
`RunOutputs` contains the `text` response of a chat flow five times, in various result objects. It is not immediately clear which are used and which are either legacy, prototyping, or just duplicate fields. This PR pretends to fix the issue by just pulling the `results` into a user facing output. 

This is not a solution - this is more my attempt to Cunningham's Law this. Need to sync up on the different output paths, figure out what is being used and how. 