### PR TITLE
LangWatch workaround to capture nested workflow as a tool in traces

### DIFF
--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -124,7 +124,8 @@ class TracingService(Service):
 
     def _initialize_langwatch_tracer(self):
         if (
-            "langwatch" not in self._tracers or self._tracers["langwatch"].trace_id != self.run_id  # type: ignore
+            "langwatch" not in self._tracers or
+            (self._tracers["langwatch"].trace_id != self.run_id and self._tracers["langwatch"].is_completed())  # type: ignore
         ):
             langwatch_tracer = _get_langwatch_tracer()
             self._tracers["langwatch"] = langwatch_tracer(
@@ -133,6 +134,9 @@ class TracingService(Service):
                 project_name=self.project_name,
                 trace_id=self.run_id,
             )
+        elif self._tracers["langwatch"].trace_id != self.run_id:  # type: ignore
+            # Workaround to capture Flow as a Tool in the same trace
+            self._tracers["langwatch"].inc_nested()  # type: ignore
 
     def _initialize_langfuse_tracer(self):
         self.project_name = os.getenv("LANGCHAIN_PROJECT", "Langflow")

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -124,8 +124,8 @@ class TracingService(Service):
 
     def _initialize_langwatch_tracer(self):
         if (
-            "langwatch" not in self._tracers or
-            (self._tracers["langwatch"].trace_id != self.run_id and self._tracers["langwatch"].is_completed())  # type: ignore
+            "langwatch" not in self._tracers
+            or (self._tracers["langwatch"].trace_id != self.run_id and self._tracers["langwatch"].is_completed())  # type: ignore
         ):
             langwatch_tracer = _get_langwatch_tracer()
             self._tracers["langwatch"] = langwatch_tracer(


### PR DESCRIPTION
Hello there 👋 

Right now when using "Flow as a Tool", the nested flows are captured by LangWatch but the main flow ends up being lost, this is because of issue https://github.com/langflow-ai/langflow/issues/3831, where we have a singleton tracing service, which gets restarted and overwritten every time a new nested flow starts running

For a fix in the meantime, I added a ref count to be sure all previous flows were done before starting a new trace, this guarantees that everything gets captured inside the same trace, and users can see their full execution in a single place:

![image](https://github.com/user-attachments/assets/f9fa9064-c047-4eae-babd-f3189b549ab3)

Now, because those are executed in parallel and the last one ends up overriding the singleton run_id, you can see the two flow as a tool calls in parallel get a bit mixed up there, but at least they are visible as the correct children of the main flow