### PR TITLE
fix: fix building loop when renaming a folder and opening a new flow and running It

### DIFF
--- a/src/frontend/src/components/dropdownButtonComponent/index.tsx
+++ b/src/frontend/src/components/dropdownButtonComponent/index.tsx
@@ -1,4 +1,3 @@
-import { useIsFetching } from "@tanstack/react-query";
 import { useState } from "react";
 import { dropdownButtonPropsType } from "../../types/components";
 import IconComponent from "../genericIconComponent";
@@ -16,12 +15,9 @@ export default function DropdownButton({
   options,
   plusButton = false,
   dropdownOptions = true,
+  isFetchingFolders = false,
 }: dropdownButtonPropsType): JSX.Element {
   const [showOptions, setShowOptions] = useState<boolean>(false);
-  const isFetchingFolders = !!useIsFetching({
-    queryKey: ["useGetFolders"],
-    exact: false,
-  });
 
   return (
     <div>

--- a/src/frontend/src/components/dropdownButtonComponent/index.tsx
+++ b/src/frontend/src/components/dropdownButtonComponent/index.tsx
@@ -1,3 +1,4 @@
+import { useIsFetching } from "@tanstack/react-query";
 import { useState } from "react";
 import { dropdownButtonPropsType } from "../../types/components";
 import IconComponent from "../genericIconComponent";
@@ -17,6 +18,10 @@ export default function DropdownButton({
   dropdownOptions = true,
 }: dropdownButtonPropsType): JSX.Element {
   const [showOptions, setShowOptions] = useState<boolean>(false);
+  const isFetchingFolders = !!useIsFetching({
+    queryKey: ["useGetFolders"],
+    exact: false,
+  });
 
   return (
     <div>
@@ -33,6 +38,7 @@ export default function DropdownButton({
               event.preventDefault();
               onFirstBtnClick();
             }}
+            disabled={isFetchingFolders}
           >
             {plusButton && (
               <IconComponent name="Plus" className="main-page-nav-button" />

--- a/src/frontend/src/pages/MainPage/pages/mainPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/mainPage/index.tsx
@@ -3,6 +3,7 @@ import { useDeleteFolders } from "@/controllers/API/queries/folders";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import { track } from "@/customization/utils/analytics";
 import useAlertStore from "@/stores/alertStore";
+import { useIsFetching } from "@tanstack/react-query";
 import { useState } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import DropdownButton from "../../../../components/dropdownButtonComponent";
@@ -57,6 +58,11 @@ export default function HomePage(): JSX.Element {
     );
   };
 
+  const isFetchingFolders = !!useIsFetching({
+    queryKey: ["useGetFolders"],
+    exact: false,
+  });
+
   return (
     <>
       <PageLayout
@@ -73,6 +79,7 @@ export default function HomePage(): JSX.Element {
               options={dropdownOptions}
               plusButton={true}
               dropdownOptions={false}
+              isFetchingFolders={isFetchingFolders}
             />
           </div>
         }

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -827,6 +827,7 @@ export type dropdownButtonPropsType = {
   options: Array<{ name: string; onBtnClick: () => void }>;
   plusButton?: boolean;
   dropdownOptions?: boolean;
+  isFetchingFolders?: boolean;
 };
 
 export type IOFieldViewProps = {


### PR DESCRIPTION
This pull request addresses an issue where the application enters a build loop after renaming a folder, opening a new flow, and running the flow. The build loop caused unnecessary rebuilds and performance issues when these actions were performed in sequence.

#3823