### PR TITLE
ci: remove unnecessary ref checkout for nightly tests

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -149,7 +149,6 @@ jobs:
     uses: ./.github/workflows/typescript_test.yml
     with:
       tests_folder: "tests/core"
-      ref: ${{ needs.create-nightly-tag.outputs.main_tag }}
     secrets: inherit
 
   backend-unit-tests:
@@ -159,7 +158,6 @@ jobs:
     uses: ./.github/workflows/python_test.yml
     with:
       python-versions: '["3.10", "3.11", "3.12"]'
-      ref: ${{ needs.create-nightly-tag.outputs.main_tag }}
 
   # Not making nightly builds dependent on integration test success
   # due to inherent flakiness of 3rd party integrations


### PR DESCRIPTION
The `ref` checkout failed because the `langflow-base-nightly` tag was not yet pushed to pypi, but the project dependency has already been updated to point to the new base nightly version from main nightly. 

I realize that we don't need to checkout out the main tag for testing. The `github.ref` default will point to the same ref that triggered the workflow, so it will test the same code that we are tagging. The only risk is if our scripts actually modify the codebase itself, but that's low-risk and shouldn't happen. 