### PR TITLE
fix: add run_id parameter to set run ID in graph and handle exceptions in FlowTool

### DIFF
--- a/src/backend/base/langflow/base/tools/flow_tool.py
+++ b/src/backend/base/langflow/base/tools/flow_tool.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, List, Optional, Type
 
 from langchain_core.runnables import RunnableConfig
@@ -97,7 +98,11 @@ class FlowTool(BaseTool):
     ) -> str:
         """Use the tool asynchronously."""
         tweaks = self.build_tweaks_dict(args, kwargs)
-        run_id = self.graph.run_id if self.graph else None
+        try:
+            run_id = self.graph.run_id if self.graph else None
+        except Exception as e:
+            warnings.warn(f"Failed to set run_id: {e}")
+            run_id = None
         run_outputs = await run_flow(
             tweaks={key: {"input_value": value} for key, value in tweaks.items()},
             flow_id=self.flow_id,

--- a/src/backend/base/langflow/components/prototypes/FlowTool.py
+++ b/src/backend/base/langflow/components/prototypes/FlowTool.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, List, Optional
 
 from langflow.base.langchain_utilities.model import LCToolComponent
@@ -79,6 +80,10 @@ class FlowToolComponent(LCToolComponent):
         if not flow_data:
             raise ValueError("Flow not found.")
         graph = Graph.from_payload(flow_data.data["data"])
+        try:
+            graph.set_run_id(self.graph.run_id)
+        except Exception as e:
+            warnings.warn(f"Failed to set run_id: {e}")
         inputs = get_flow_inputs(graph)
         tool = FlowTool(
             name=self.name,


### PR DESCRIPTION
This pull request adds a `run_id` parameter to the `set_run_id` method in the `Graph` class and handles exceptions when setting the `run_id` in the `FlowTool` class. The `run_id` parameter allows for tracking runs in the graph, and the exception handling ensures that the code does not break if there is an error in setting the `run_id`.