### PR TITLE
fix: limit file upload size to 10mb to prevent LF crashing due data render component limitations

### DIFF
--- a/src/frontend/src/components/inputFileComponent/index.tsx
+++ b/src/frontend/src/components/inputFileComponent/index.tsx
@@ -49,7 +49,7 @@ export default function InputFileComponent({
         const file = files[0];
         if (file.size > maxSizeFilesInBytes) {
           setErrorData({
-            title: INVALID_FILE_SIZE_ALERT(9),
+            title: INVALID_FILE_SIZE_ALERT(10),
           });
           return;
         }

--- a/src/frontend/src/components/inputFileComponent/index.tsx
+++ b/src/frontend/src/components/inputFileComponent/index.tsx
@@ -1,9 +1,11 @@
+import { maxSizeFilesInBytes } from "@/constants/constants";
 import { usePostUploadFile } from "@/controllers/API/queries/files/use-post-upload-file";
 import { createFileUpload } from "@/helpers/create-file-upload";
 import { useEffect } from "react";
 import {
   CONSOLE_ERROR_MSG,
   INVALID_FILE_ALERT,
+  INVALID_FILE_SIZE_ALERT,
 } from "../../constants/alerts_constants";
 import useAlertStore from "../../stores/alertStore";
 import useFlowsManagerStore from "../../stores/flowsManagerStore";
@@ -45,6 +47,12 @@ export default function InputFileComponent({
     createFileUpload({ multiple: false, accept: fileTypes?.join(",") }).then(
       (files) => {
         const file = files[0];
+        if (file.size > maxSizeFilesInBytes) {
+          setErrorData({
+            title: INVALID_FILE_SIZE_ALERT(9),
+          });
+          return;
+        }
         if (file) {
           if (checkFileType(file.name)) {
             // Upload the file

--- a/src/frontend/src/constants/alerts_constants.tsx
+++ b/src/frontend/src/constants/alerts_constants.tsx
@@ -60,5 +60,6 @@ export const DEL_KEY_SUCCESS_ALERT = "Success! Key deleted!";
 export const DEL_KEY_SUCCESS_ALERT_PLURAL = "Success! Keys deleted!";
 export const FLOW_BUILD_SUCCESS_ALERT = `Flow built successfully`;
 export const SAVE_SUCCESS_ALERT = "Changes saved successfully!";
-
-// Generic Node
+export const INVALID_FILE_SIZE_ALERT = (maxSizeMB) => {
+  return `The file size is too large. Please select a file smaller than ${maxSizeMB}MB.`;
+};

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -916,4 +916,4 @@ export const COLOR_OPTIONS = {
   red: "var(--note-red)",
 };
 
-export const maxSizeFilesInBytes = 9 * 1024 * 1024; // 9MB in bytes
+export const maxSizeFilesInBytes = 10 * 1024 * 1024; // 10MB in bytes

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -915,3 +915,5 @@ export const COLOR_OPTIONS = {
   amber: "var(--note-amber)",
   red: "var(--note-red)",
 };
+
+export const maxSizeFilesInBytes = 9 * 1024 * 1024; // 9MB in bytes


### PR DESCRIPTION
This PR addresses an issue where file uploads larger than 10MB would cause the application to crash due to limitations in the data render component.

*** **While this isn't a comprehensive solution, it will prevent Langflow from crashing during use, ensuring a more stable experience for users.**