### PR TITLE
test: skip flaky playwright test

### DIFF
--- a/src/frontend/tests/core/integrations/Vector Store.spec.ts
+++ b/src/frontend/tests/core/integrations/Vector Store.spec.ts
@@ -2,7 +2,7 @@ import { expect, Page, test } from "@playwright/test";
 import path from "path";
 import uaParser from "ua-parser-js";
 
-test("Vector Store RAG", async ({ page }) => {
+test.skip("Vector Store RAG", async ({ page }) => {
   test.skip(
     !process?.env?.OPENAI_API_KEY,
     "OPENAI_API_KEY required to run this test",


### PR DESCRIPTION
This test has been consistently flaky, blocking the nightly builds. Ideally, @Cristhianzl can do a quick fix on this test to improve it, but in the meantime the other option is to skip to unblock builds. 