### PR TITLE
fix: Server is busy (#3878)

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -324,7 +324,7 @@ async def build_flow(
         client_consumed_queue: asyncio.Queue,
         event_manager: "EventManager",
     ) -> None:
-        build_task = asyncio.create_task(await asyncio.to_thread(_build_vertex, vertex_id, graph, event_manager))
+        build_task = asyncio.create_task(asyncio.to_thread(asyncio.run, _build_vertex(vertex_id, graph, event_manager)))
         try:
             await build_task
         except asyncio.CancelledError as exc:
@@ -359,7 +359,7 @@ async def build_flow(
     async def event_generator(event_manager: EventManager, client_consumed_queue: asyncio.Queue) -> None:
         if not data:
             # using another thread since the DB query is I/O bound
-            vertices_task = asyncio.create_task(await asyncio.to_thread(build_graph_and_get_order))
+            vertices_task = asyncio.create_task(asyncio.to_thread(asyncio.run, build_graph_and_get_order()))
             try:
                 await vertices_task
             except asyncio.CancelledError:


### PR DESCRIPTION
`_build_vertex` is `async`, so we should make it `sync` by `asyncio.run` before passing it to `asyncio.to_thread` 
```python
asyncio.create_task(asyncio.to_thread(asyncio.run, _build_vertex(vertex_id, graph, event_manager)))
```