### PR TITLE
fix: handle coroutine check for on_disconnect callback in chat API

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -448,7 +448,9 @@ class DisconnectHandlerStreamingResponse(StreamingResponse):
             message = await receive()
             if message["type"] == "http.disconnect":
                 if self.on_disconnect:
-                    await self.on_disconnect()
+                    coro = self.on_disconnect()
+                    if asyncio.iscoroutine(coro):
+                        await coro
                 break
 
 


### PR DESCRIPTION
This pull request fixes an issue in the chat API where the on_disconnect callback was not properly handled when it returned a coroutine. The code now checks if the callback is a coroutine and awaits it if necessary.