### PR TITLE
fix: animation of building edges on build stop

### DIFF
--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -82,6 +82,10 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
   isBuilding: false,
   stopBuilding: () => {
     get().buildController.abort();
+    get().updateEdgesRunningByNodes(
+      get().nodes.map((n) => n.id),
+      false,
+    );
     set({ isBuilding: false });
   },
   isPending: true,


### PR DESCRIPTION
This pull request fixes an issue where the animation of building edges would continue even after the build was stopped. The `stopBuilding` function now includes a call to `updateEdgesRunningByNodes` to update the edges running status for all nodes to false. This ensures that the animation stops when the build is stopped.