### PR TITLE
fix: update storeMessageComponent input types

### DIFF
--- a/src/backend/base/langflow/components/helpers/StoreMessage.py
+++ b/src/backend/base/langflow/components/helpers/StoreMessage.py
@@ -1,5 +1,5 @@
 from langflow.custom import Component
-from langflow.inputs import HandleInput, MessageInput, StrInput
+from langflow.inputs import HandleInput, MessageInput
 from langflow.memory import get_messages, store_message
 from langflow.schema.message import Message
 from langflow.template import Output

--- a/src/backend/base/langflow/components/helpers/StoreMessage.py
+++ b/src/backend/base/langflow/components/helpers/StoreMessage.py
@@ -20,19 +20,19 @@ class StoreMessageComponent(Component):
             input_types=["BaseChatMessageHistory"],
             info="The external memory to store the message. If empty, it will use the Langflow tables.",
         ),
-        StrInput(
+        MessageInput(
             name="sender",
             display_name="Sender",
             info="The sender of the message. Might be Machine or User. If empty, the current sender parameter will be used.",
             advanced=True,
         ),
-        StrInput(
+        MessageInput(
             name="sender_name",
             display_name="Sender Name",
             info="The name of the sender. Might be AI or User. If empty, the current sender parameter will be used.",
             advanced=True,
         ),
-        StrInput(
+        MessageInput(
             name="session_id",
             display_name="Session ID",
             info="The session ID of the chat. If empty, the current session ID parameter will be used.",


### PR DESCRIPTION
📝 (StoreMessage.py): Change StrInput to MessageInput for sender, sender_name, and session_id inputs to improve clarity and consistency in the code.

#3873