### PR TITLE
fix: force floatInputComponent to send Number

### DIFF
--- a/src/frontend/src/components/floatComponent/index.tsx
+++ b/src/frontend/src/components/floatComponent/index.tsx
@@ -30,7 +30,7 @@ export default function FloatComponent({
   };
 
   const handleChange = (event) => {
-    onChange(event.target.value);
+    onChange(Number(event.target.value));
   };
 
   return (


### PR DESCRIPTION
🔧 (floatComponent/index.tsx): update handleChange function to convert input value to a number before passing it to onChange function

This was causing an error because when the field was empty, it sent a string beside a number.
It is causing error on pydantic.

#2862 