### PR TITLE
fix: update docs link

### DIFF
--- a/src/frontend/src/customization/config-constants.ts
+++ b/src/frontend/src/customization/config-constants.ts
@@ -4,7 +4,7 @@ export const PROXY_TARGET = "http://127.0.0.1:7860";
 export const API_ROUTES = ["^/api/v1/", "/health"];
 export const BASE_URL_API = "/api/v1/";
 export const HEALTH_CHECK_URL = "/health_check";
-export const DOCS_LINK = "https://docs.langflow.com";
+export const DOCS_LINK = "https://docs.langflow.org";
 
 export default {
   DOCS_LINK,


### PR DESCRIPTION
The docs link in the code was pointing to the wrong URL. This PR updates the docs link to the correct URL.