### PR TITLE
fix: message list order

### DIFF
--- a/src/backend/base/langflow/base/models/model.py
+++ b/src/backend/base/langflow/base/models/model.py
@@ -166,7 +166,7 @@ class LCModelComponent(Component):
                 messages.append(HumanMessage(content=input_value))
 
         if system_message and not system_message_added:
-            messages.append(SystemMessage(content=system_message))
+            messages.insert(0, SystemMessage(content=system_message))
         inputs: list | dict = messages or {}
         try:
             if self.output_parser is not None:


### PR DESCRIPTION
The system message should be inserted into the first position of the message list instead of being appended at the last position.