### PR TITLE
fix: remove truncate to save data on DB

### DIFF
--- a/src/backend/base/langflow/services/database/models/transactions/model.py
+++ b/src/backend/base/langflow/services/database/models/transactions/model.py
@@ -2,13 +2,11 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
-from pydantic import field_serializer, field_validator
+from pydantic import field_validator
 from sqlmodel import JSON, Column, Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
     from langflow.services.database.models.flow.model import Flow
-
-from langflow.utils.util_strings import truncate_long_strings
 
 
 class TransactionBase(SQLModel):
@@ -33,10 +31,6 @@ class TransactionBase(SQLModel):
         if isinstance(value, str):
             value = UUID(value)
         return value
-
-    @field_serializer("outputs")
-    def serialize_outputs(self, data) -> dict:
-        return truncate_long_strings(data)
 
 
 class TransactionTable(TransactionBase, table=True):  # type: ignore

--- a/src/backend/base/langflow/services/database/models/vertex_builds/model.py
+++ b/src/backend/base/langflow/services/database/models/vertex_builds/model.py
@@ -8,8 +8,6 @@ from sqlmodel import JSON, Column, Field, Relationship, SQLModel
 if TYPE_CHECKING:
     from langflow.services.database.models.flow.model import Flow
 
-from langflow.utils.util_strings import truncate_long_strings
-
 
 class VertexBuildBase(SQLModel):
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
@@ -39,14 +37,6 @@ class VertexBuildBase(SQLModel):
         if value.tzinfo is None:
             value = value.replace(tzinfo=timezone.utc)
         return value
-
-    @field_serializer("data")
-    def serialize_data(self, data: dict) -> dict:
-        return truncate_long_strings(data)
-
-    @field_serializer("artifacts")
-    def serialize_artifacts(self, data) -> dict:
-        return truncate_long_strings(data)
 
 
 class VertexBuildTable(VertexBuildBase, table=True):  # type: ignore


### PR DESCRIPTION
🔧 (model.py): Remove unused imports and functions related to truncating long strings in database models to clean up the code and improve readability.