### PR TITLE
ci: fix release workflows for uv

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -1,10 +1,5 @@
 name: "Setup uv"
 description: "Checks out code, installs uv, and sets up Python environment"
-inputs:
-  ref:
-    description: "Reference to check out"
-    required: false
-    default: "github.ref"
 
 runs:
   using: "composite"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Check out the code at a specific ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.nightly_tag_main || inputs.version}}
+          ref: ${{ inputs.nightly_tag_main || github.ref }}
           persist-credentials: true
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
@@ -217,7 +217,8 @@ jobs:
           provenance: false
 
   build_components:
-    if: ${{ inputs.release_type == 'main' }}
+    # if: ${{ inputs.release_type == 'main' }}
+    if: false
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -191,7 +191,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push to Docker Hub
-        if: false
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -208,7 +207,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.TEMP_GHCR_TOKEN}}
       - name: Build and push to Github Container Registry
-        if: false
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -219,8 +217,7 @@ jobs:
           provenance: false
 
   build_components:
-    # if: ${{ inputs.release_type == 'main' }}
-    if: false
+    if: ${{ inputs.release_type == 'main' }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -286,10 +283,9 @@ jobs:
 
   restart-space:
     name: Restart HuggingFace Spaces
-    # if: ${{ inputs.release_type == 'main' && inputs.nightly_build == 'false' }}
-    if: false
+    if: ${{ inputs.release_type == 'main' && needs.get-version.outputs.nightly-build == 'false' }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, get-version]
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -99,13 +99,10 @@ jobs:
       - name: Check out the code at a specific ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.nightly_tag_main || github.ref }}
+          ref: ${{ inputs.nightly_tag_main || inputs.version}}
           persist-credentials: true
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ inputs.nightly_tag_main || github.ref }}
-
       - name: Install the project
         run: uv sync --dev
 
@@ -172,12 +169,10 @@ jobs:
       - name: Check out the code at a specific ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.nightly_tag_main || github.ref }}
           persist-credentials: true
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ inputs.nightly_tag_main || github.ref }}
 
       - name: Install the project
         run: |
@@ -288,7 +283,8 @@ jobs:
 
   restart-space:
     name: Restart HuggingFace Spaces
-    if: ${{ inputs.release_type == 'main' && inputs.nightly_build == 'false' }}
+    # if: ${{ inputs.release_type == 'main' && inputs.nightly_build == 'false' }}
+    if: false
     runs-on: ubuntu-latest
     needs: build
     strategy:
@@ -302,8 +298,6 @@ jobs:
           ref: ${{ inputs.nightly_tag_main || github.ref }}
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ inputs.nightly_tag_main || github.ref }}
 
       - name: Restart HuggingFace Spaces Build
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -191,6 +191,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push to Docker Hub
+        if: false
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -207,6 +208,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.TEMP_GHCR_TOKEN}}
       - name: Build and push to Github Container Registry
+        if: false
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -44,8 +44,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ inputs.ref || github.ref }}
       - name: Run integration tests with api keys
         timeout-minutes: 20
         run: |

--- a/.github/workflows/lint-py.yml
+++ b/.github/workflows/lint-py.yml
@@ -30,8 +30,6 @@ jobs:
           persist-credentials: true
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ inputs.branch || github.ref }}
       - name: Install the project
         run: uv sync --dev
       - name: Run Mypy

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -76,10 +76,6 @@ jobs:
           uv run ./scripts/ci/update_pyproject_name.py langflow-base-nightly base
           uv run ./scripts/ci/update_pyproject_version.py $BASE_TAG base
 
-          # This updates the dependency of langflow-base to langflow-base-nightly in {project_root}/pyproject.toml
-          # Note: Still necessary for poetry
-          uv run ./scripts/ci/update_lf_base_dependency.py $BASE_TAG
-
           # Use the main tag created earlier
           MAIN_TAG="${{ steps.generate_main_tag.outputs.main_tag }}"
           echo "Updating main project version to $MAIN_TAG"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -30,8 +30,6 @@ jobs:
           persist-credentials: true
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ github.ref }}
       - name: Install the project
         run: uv sync --dev
 

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -119,8 +119,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ inputs.ref || github.ref }}
 
       - name: Check Version
         id: check-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,7 @@ on:
 
 jobs:
   ci:
-    # if: ${{ github.event.inputs.release_package_base == 'true' || github.event.inputs.release_package_main == 'true' }}
-    if: false
+    if: ${{ github.event.inputs.release_package_base == 'true' || github.event.inputs.release_package_main == 'true' }}
     name: CI
     uses: ./.github/workflows/ci.yml
     with:
@@ -48,7 +47,7 @@ jobs:
 
   release-base:
     name: Release Langflow Base
-    # needs: [ci]
+    needs: [ci]
     if: inputs.release_package_base == true
     runs-on: ubuntu-latest
     outputs:
@@ -102,13 +101,11 @@ jobs:
             echo "Server terminated successfully"
           fi
       - name: Publish to PyPI
-        if: false
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           make publish base=true
       - name: Upload Artifact
-        if: false
         # if: steps.check-version.outputs.skipped == 'false'
         uses: actions/upload-artifact@v4
         with:
@@ -154,8 +151,7 @@ jobs:
             echo version=$version >> $GITHUB_OUTPUT
           fi
       - name: Wait for PyPI Propagation
-        # if: needs.release-base.outputs.skipped == 'false'
-        if: false
+        if: needs.release-base.outputs.skipped == 'false'
         run: sleep 300 # wait for 5 minutes to ensure PyPI propagation
 
       - name: Build project for distribution
@@ -178,13 +174,11 @@ jobs:
             echo "Server terminated successfully"
           fi
       - name: Publish to PyPI
-        if: false
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           make publish main=true
       - name: Upload Artifact
-        if: false
         uses: actions/upload-artifact@v4
         with:
           name: dist-main
@@ -214,7 +208,6 @@ jobs:
 
   create_release:
     name: Create Release
-    if: false
     runs-on: ubuntu-latest
     needs: release-main
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
   release-base:
     name: Release Langflow Base
-    needs: [ci]
+    # needs: [ci]
     if: inputs.release_package_base == true
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,12 @@ jobs:
       - name: Test CLI
         if: steps.check-version.outputs.skipped == 'false'
         run: |
+          echo "Testing CLI"
+          echo $(ls)
+          echo $(dist)
+          echo $(src/backend/base/dist)
+          mkdir src/backend/base/dist
+          mv dist/*.whl src/backend/base/dist
           uv pip install src/backend/base/dist/*.whl
           uv run python -m langflow run --host 127.0.0.1 --port 7860 --backend-only &
           SERVER_PID=$!

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,7 @@ jobs:
       - name: Test CLI
         if: steps.check-version.outputs.skipped == 'false'
         run: |
-          echo "Testing CLI"
-          echo $(ls)
-          echo $(dist)
-          echo $(src/backend/base/dist)
+          # TODO: Unsure why the whl is not built in src/backend/base/dist
           mkdir src/backend/base/dist
           mv dist/*.whl src/backend/base/dist
           uv pip install src/backend/base/dist/*.whl
@@ -106,7 +103,7 @@ jobs:
         run: |
           make publish base=true
       - name: Upload Artifact
-        # if: steps.check-version.outputs.skipped == 'false'
+        if: steps.check-version.outputs.skipped == 'false'
         uses: actions/upload-artifact@v4
         with:
           name: dist-base

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,8 @@ on:
 
 jobs:
   ci:
-    if: ${{ github.event.inputs.release_package_base == 'true' || github.event.inputs.release_package_main == 'true' }}
+    # if: ${{ github.event.inputs.release_package_base == 'true' || github.event.inputs.release_package_main == 'true' }}
+    if: false
     name: CI
     uses: ./.github/workflows/ci.yml
     with:
@@ -58,8 +59,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ github.ref }} 
       - name: Install the project
         run: uv sync --dev
       - name: Check Version
@@ -97,12 +96,14 @@ jobs:
             echo "Server terminated successfully"
           fi
       - name: Publish to PyPI
+        if: false
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           make publish base=true
       - name: Upload Artifact
-        if: steps.check-version.outputs.skipped == 'false'
+        if: false
+        # if: steps.check-version.outputs.skipped == 'false'
         uses: actions/upload-artifact@v4
         with:
           name: dist-base
@@ -120,8 +121,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ github.ref }}
       - name: Install the project
         run: uv sync --dev
 
@@ -172,11 +171,13 @@ jobs:
             echo "Server terminated successfully"
           fi
       - name: Publish to PyPI
+        if: false
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           make publish main=true
       - name: Upload Artifact
+        if: false
         uses: actions/upload-artifact@v4
         with:
           name: dist-main
@@ -198,10 +199,6 @@ jobs:
     if: inputs.build_docker_main == true
     needs: release-main
     uses: ./.github/workflows/docker-build.yml
-    strategy:
-      matrix:
-        release_type:
-          - main
     with:
       version: ${{ needs.release-main.outputs.version }}
       release_type: main
@@ -210,6 +207,7 @@ jobs:
 
   create_release:
     name: Create Release
+    if: false
     runs-on: ubuntu-latest
     needs: release-main
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Test CLI
         if: steps.check-version.outputs.skipped == 'false'
         run: |
-          uv run python -m pip install src/backend/base/dist/*.whl
+          uv pip install src/backend/base/dist/*.whl
           uv run python -m langflow run --host 127.0.0.1 --port 7860 --backend-only &
           SERVER_PID=$!
           # Wait for the server to start

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,6 @@ on:
         type: boolean
         default: true
 
-env:
-  POETRY_VERSION: "1.8.2"
 
 jobs:
   ci:
@@ -59,7 +57,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Environment
-        uses: ./.github/workflows/setup-uv.yml
+        uses: ./.github/actions/setup-uv
         with:
           ref: ${{ github.ref }} 
       - name: Install the project
@@ -67,7 +65,7 @@ jobs:
       - name: Check Version
         id: check-version
         run: |
-          version=$(cd src/backend/base && poetry version --short)
+          version=$(uv tree | grep 'langflow-base' | awk '{print $3}')
           last_released_version=$(curl -s "https://pypi.org/pypi/langflow-base/json" | jq -r '.releases | keys | .[]' | sort -V | tail -n 1)
           if [ "$version" = "$last_released_version" ]; then
             echo "Version $version is already released. Skipping release."
@@ -83,8 +81,8 @@ jobs:
       - name: Test CLI
         if: steps.check-version.outputs.skipped == 'false'
         run: |
-          python -m pip install src/backend/base/dist/*.whl
-          python -m langflow run --host 127.0.0.1 --port 7860 &
+          uv run python -m pip install src/backend/base/dist/*.whl
+          uv run python -m langflow run --host 127.0.0.1 --port 7860 --backend-only &
           SERVER_PID=$!
           # Wait for the server to start
           timeout 120 bash -c 'until curl -f http://127.0.0.1:7860/api/v1/auto_login; do sleep 2; done' || (echo "Server did not start in time" && kill $SERVER_PID && exit 1)
@@ -100,7 +98,7 @@ jobs:
           fi
       - name: Publish to PyPI
         env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           make publish base=true
       - name: Upload Artifact
@@ -121,7 +119,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Environment
-        uses: ./.github/workflows/setup-uv.yml
+        uses: ./.github/actions/setup-uv
         with:
           ref: ${{ github.ref }}
       - name: Install the project
@@ -158,8 +156,8 @@ jobs:
         run: make build main=true
       - name: Test CLI
         run: |
-          python -m pip install dist/*.whl
-          python -m langflow run --host 127.0.0.1 --port 7860 --backend-only &
+          uv pip install dist/*.whl
+          uv run python -m langflow run --host 127.0.0.1 --port 7860 --backend-only &
           SERVER_PID=$!
           # Wait for the server to start
           timeout 120 bash -c 'until curl -f http://127.0.0.1:7860/health_check; do sleep 2; done' || (echo "Server did not start in time" && kill $SERVER_PID && exit 1)
@@ -187,32 +185,26 @@ jobs:
   call_docker_build_base:
     name: Call Docker Build Workflow for Langflow Base
     if: inputs.build_docker_base == true
+    needs: release-base
     uses: ./.github/workflows/docker-build.yml
-    strategy:
-      matrix:
-        release_type:
-          - base
     with:
-      # version should be needs.release-base.outputs.version  if release_type is base
-      # version should be needs.release-main.outputs.version  if release_type is main
-      version: ""
-      release_type: ${{ matrix.release_type }}
+      version: ${{ needs.release-base.outputs.version }}
+      release_type: base
       pre_release: ${{ inputs.pre_release }}
     secrets: inherit
 
   call_docker_build_main:
     name: Call Docker Build Workflow for Langflow
     if: inputs.build_docker_main == true
+    needs: release-main
     uses: ./.github/workflows/docker-build.yml
     strategy:
       matrix:
         release_type:
           - main
     with:
-      # version should be needs.release-base.outputs.version  if release_type is base
-      # version should be needs.release-main.outputs.version  if release_type is main
-      version: ""
-      release_type: ${{ matrix.release_type }}
+      version: ${{ needs.release-main.outputs.version }}
+      release_type: main
       pre_release: ${{ inputs.pre_release }}
     secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,8 @@ jobs:
             echo version=$version >> $GITHUB_OUTPUT
           fi
       - name: Wait for PyPI Propagation
-        if: needs.release-base.outputs.skipped == 'false'
+        # if: needs.release-base.outputs.skipped == 'false'
+        if: false
         run: sleep 300 # wait for 5 minutes to ensure PyPI propagation
 
       - name: Build project for distribution

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           fi
       - name: Build project for distribution
         if: steps.check-version.outputs.skipped == 'false'
-        run: make build base=true
+        run: make build base=true args="--wheel"
       - name: Test CLI
         if: steps.check-version.outputs.skipped == 'false'
         run: |
@@ -153,7 +153,7 @@ jobs:
         run: sleep 300 # wait for 5 minutes to ensure PyPI propagation
 
       - name: Build project for distribution
-        run: make build main=true
+        run: make build main=true args="--no-sources --wheel"
       - name: Test CLI
         run: |
           uv pip install dist/*.whl

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -220,3 +220,5 @@ jobs:
       release_type: main
       nightly_tag_main: ${{ inputs.nightly_tag_main }}
     secrets: inherit
+
+  

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -89,8 +89,7 @@ jobs:
 
       - name: Test CLI
         run: |
-          # TODO: unsure why the whl is not built in src/backend/base
-          # uv pip install src/backend/base/dist/*.whl
+          # TODO: Unsure why the whl is not built in src/backend/base/dist
           mkdir src/backend/base/dist
           mv dist/*.whl src/backend/base/dist/
           uv pip install src/backend/base/dist/*.whl

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -64,8 +64,6 @@ jobs:
           persist-credentials: true
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ inputs.nightly_tag_main }}
       - name: Install the project
         run: uv sync --dev
 
@@ -141,8 +139,6 @@ jobs:
           persist-credentials: true
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ inputs.nightly_tag_main }}
       - name: Install the project
         run: uv sync --dev
 

--- a/.github/workflows/style-check-py.yml
+++ b/.github/workflows/style-check-py.yml
@@ -21,8 +21,6 @@ jobs:
         uses: actions/checkout@v4
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ github.ref }}
       - name: Register problem matcher
         run: echo "::add-matcher::.github/workflows/matchers/ruff.json"
       - name: Run Ruff Check

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -104,8 +104,6 @@ jobs:
 
       - name: "Setup Environment"
         uses: ./.github/actions/setup-uv
-        with:
-          ref: ${{ inputs.ref || github.ref }}
       - name: Install the project
         run: uv sync --dev
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ maintainers = [
 
 # Define your main dependencies here
 dependencies = [
-    "langflow-base==0.0.96",
+    "langflow-base==0.0.97",
     "beautifulsoup4>=4.12.2",
     "google-search-results>=2.4.1",
     "google-api-python-client>=2.130.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = ["src/backend/langflow"]
 
 [project]
 name = "langflow"
-version = "1.0.19"
+version = "1.0.18"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.13"
 license = "MIT"
@@ -29,7 +29,7 @@ maintainers = [
 
 # Define your main dependencies here
 dependencies = [
-    "langflow-base==0.0.97",
+    "langflow-base==0.0.96",
     "beautifulsoup4>=4.12.2",
     "google-search-results>=2.4.1",
     "google-api-python-client>=2.130.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ maintainers = [
 
 # Define your main dependencies here
 dependencies = [
-    "langflow-base==0.0.97",
+    "langflow-base==0.0.96",
     "beautifulsoup4>=4.12.2",
     "google-search-results>=2.4.1",
     "google-api-python-client>=2.130.0",

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -101,7 +101,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langflow-base"
-version = "0.0.97"
+version = "0.0.96"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.13"
 license = "MIT"


### PR DESCRIPTION
Few more updates for the swap to `uv`

Test workflow (skipped publishing) that succeeded - https://github.com/langflow-ai/langflow/actions/runs/11221324879