### PR TITLE
fix: Add useUpdateNodeInternals hook to handle node class changes

### DIFF
--- a/src/frontend/src/CustomNodes/hooks/use-handle-node-class.tsx
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-node-class.tsx
@@ -29,7 +29,6 @@ const useHandleNodeClass = (
 
       return newNode;
     });
-
   };
 
   return { handleNodeClass };

--- a/src/frontend/src/CustomNodes/hooks/use-handle-node-class.tsx
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-node-class.tsx
@@ -1,6 +1,7 @@
 import useFlowStore from "@/stores/flowStore";
 import { NodeType } from "@/types/flow";
 import { cloneDeep } from "lodash";
+import { useUpdateNodeInternals } from "reactflow";
 
 const useHandleNodeClass = (
   nodeId: string,
@@ -10,6 +11,7 @@ const useHandleNodeClass = (
   ) => void,
 ) => {
   const setNode = setMyNode ?? useFlowStore((state) => state.setNode);
+  const updateNodeInternals = useUpdateNodeInternals();
 
   const handleNodeClass = (newNodeClass, type?: string) => {
     setNode(nodeId, (oldNode) => {
@@ -23,8 +25,11 @@ const useHandleNodeClass = (
         newNode.data.type = type;
       }
 
+      updateNodeInternals(nodeId);
+
       return newNode;
     });
+
   };
 
   return { handleNodeClass };


### PR DESCRIPTION
This pull request adds the `useUpdateNodeInternals` hook from the `reactflow` library to handle changes in the node class. Previously, the node class changes were not being reflected properly in the UI. With this hook, the node internals are updated correctly, ensuring that the UI reflects the updated node class.