### PR TITLE
feature: Hide integrations

### DIFF
--- a/src/frontend/src/customization/feature-flags.ts
+++ b/src/frontend/src/customization/feature-flags.ts
@@ -6,3 +6,4 @@ export const ENABLE_SOCIAL_LINKS = true;
 export const ENABLE_BRANDING = true;
 export const ENABLE_MVPS = false;
 export const ENABLE_CUSTOM_PARAM = false;
+export const ENABLE_INTEGRATIONS = false;

--- a/src/frontend/src/pages/FlowPage/components/extraSidebarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/extraSidebarComponent/index.tsx
@@ -1,4 +1,7 @@
-import { ENABLE_INTEGRATIONS, ENABLE_MVPS } from "@/customization/feature-flags";
+import {
+  ENABLE_INTEGRATIONS,
+  ENABLE_MVPS,
+} from "@/customization/feature-flags";
 import { useStoreStore } from "@/stores/storeStore";
 import { cloneDeep } from "lodash";
 import { useEffect, useState } from "react";

--- a/src/frontend/src/pages/FlowPage/components/extraSidebarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/extraSidebarComponent/index.tsx
@@ -1,4 +1,4 @@
-import { ENABLE_MVPS } from "@/customization/feature-flags";
+import { ENABLE_INTEGRATIONS, ENABLE_MVPS } from "@/customization/feature-flags";
 import { useStoreStore } from "@/stores/storeStore";
 import { cloneDeep } from "lodash";
 import { useEffect, useState } from "react";
@@ -245,7 +245,7 @@ export default function ExtraSidebar(): JSX.Element {
               <div key={index}></div>
             ),
           )}
-        <>
+        {ENABLE_INTEGRATIONS && (
           <ParentDisclosureComponent
             defaultOpen={true}
             key={`${search.length !== 0}-${getFilterEdge.length !== 0}-Bundle`}
@@ -273,7 +273,7 @@ export default function ExtraSidebar(): JSX.Element {
                 ),
               )}
           </ParentDisclosureComponent>
-        </>
+        )}
         <ParentDisclosureComponent
           defaultOpen={search.length !== 0 || getFilterEdge.length !== 0}
           key={`${search.length !== 0}-${getFilterEdge.length !== 0}-Advanced`}

--- a/src/frontend/tests/extended/regression/generalBugs-shard-12.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-12.spec.ts
@@ -86,7 +86,7 @@ test("user should be able to connect RetrieverTool to another components", async
   await chromaDbOutput.hover();
   await page.mouse.down();
   const retrieverToolInput = await page
-    .getByTestId("handle-nvidiarerankcomponent-shownode-retriever-left")
+    .getByTestId("handle-retrievertool-shownode-retriever-left")
     .nth(0);
   await retrieverToolInput.hover();
   await page.mouse.up();


### PR DESCRIPTION
This pull request hides the integrations feature by setting the `ENABLE_INTEGRATIONS` flag to false.