### PR TITLE
chore: Add 'unsafe_fix' target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,9 @@ format: ## run code formatters
 	@uv run ruff format .
 	@cd src/frontend && npm run format
 
+unsafe_fix:
+	@uv run ruff check . --fix --unsafe-fixes
+
 lint: install_backend ## run linters
 	@uv run mypy --namespace-packages -p "langflow"
 


### PR DESCRIPTION
This pull request adds a new target called 'unsafe_fix' to the Makefile. The 'unsafe_fix' target allows applying unsafe fixes with ruff. This will help in resolving certain issues in the codebase.