### PR TITLE
chore:Add Alembic Commands to Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,3 +443,34 @@ ifdef main
 	poetry config repositories.test-pypi https://test.pypi.org/legacy/
 	make publish_langflow_testpypi
 endif
+
+
+# example make alembic-revision message="Add user table"
+alembic-revision: ## generate a new migration
+	@echo 'Generating a new Alembic revision'
+	cd src/backend/base/langflow/ && uv run alembic revision --autogenerate -m "$(message)"
+
+
+alembic-upgrade: ## upgrade database to the latest version
+	@echo 'Upgrading database to the latest version'
+	cd src/backend/base/langflow/ && uv run alembic upgrade head
+
+alembic-downgrade: ## downgrade database by one version
+	@echo 'Downgrading database by one version'
+	cd src/backend/base/langflow/ && uv run alembic downgrade -1
+
+alembic-current: ## show current revision
+	@echo 'Showing current Alembic revision'
+	cd src/backend/base/langflow/ && uv run alembic current
+
+alembic-history: ## show migration history
+	@echo 'Showing Alembic migration history'
+	cd src/backend/base/langflow/ && uv run alembic history --verbose
+
+alembic-check: ## check migration status
+	@echo 'Running alembic check'
+	cd src/backend/base/langflow/ && uv run alembic check
+
+alembic-stamp: ## stamp the database with a specific revision
+	@echo 'Stamping the database with revision $(revision)'
+	cd src/backend/base/langflow/ && uv run alembic stamp $(revision)


### PR DESCRIPTION
This PR introduces a set of Makefile targets to streamline database migration management using Alembic within our project. The following commands have been added:

- **`alembic-revision`**: Generates a new migration script with an autogenerated schema change. Usage: `make alembic-revision message="Your message here"`.
- **`alembic-upgrade`**: Upgrades the database to the latest version. Usage: `make alembic-upgrade`.
- **`alembic-downgrade`**: Downgrades the database by one version. Usage: `make alembic-downgrade`.
- **`alembic-current`**: Displays the current migration version applied to the database. Usage: `make alembic-current`.
- **`alembic-history`**: Shows the history of all migrations. Usage: `make alembic-history`.
- **`alembic-check`**: Checks the migration status. Usage: `make alembic-check`.
- **`alembic-stamp`**: Stamps the database with a specific revision without running any migrations. Usage: `make alembic-stamp revision="revision_id"`.

