### PR TITLE
fix: prevent possible race condition on upload flows/folders

### DIFF
--- a/src/frontend/src/helpers/create-file-upload.ts
+++ b/src/frontend/src/helpers/create-file-upload.ts
@@ -12,8 +12,8 @@ export function createFileUpload(props?: {
     let isResolved = false;
 
     const cleanup = () => {
-      if (input && input.parentNode) {
-        input.parentNode.removeChild(input);
+      if (input && document.body.contains(input)) {
+        document.body.removeChild(input);
       }
       window.removeEventListener("focus", handleFocus);
     };
@@ -43,12 +43,13 @@ export function createFileUpload(props?: {
     document.body.appendChild(input);
     input.click();
 
+    // Fallback timeout to ensure resolution
     setTimeout(() => {
       if (!isResolved) {
         isResolved = true;
         cleanup();
         resolve([]);
       }
-    }, 60000);
+    }, 60000); // 1 minute timeout
   });
 }

--- a/src/frontend/src/helpers/create-file-upload.ts
+++ b/src/frontend/src/helpers/create-file-upload.ts
@@ -1,35 +1,54 @@
-export async function createFileUpload(props?: {
+export function createFileUpload(props?: {
   accept?: string;
   multiple?: boolean;
 }): Promise<File[]> {
-  let lock = false;
   return new Promise((resolve) => {
     const input = document.createElement("input");
     input.type = "file";
     input.accept = props?.accept ?? ".json";
     input.multiple = props?.multiple ?? true;
     input.style.display = "none";
-    // add a change event listener to the file input
-    input.onchange = async (e: Event) => {
-      lock = true;
-      resolve(Array.from((e.target as HTMLInputElement).files!));
-      document.body.removeChild(input);
+
+    let isResolved = false;
+
+    const cleanup = () => {
+      if (input && input.parentNode) {
+        input.parentNode.removeChild(input);
+      }
+      window.removeEventListener("focus", handleFocus);
     };
-    window.addEventListener(
-      "focus",
-      () => {
-        setTimeout(() => {
-          if (!lock) {
-            resolve([]);
-            document.body.removeChild(input);
-          }
-        }, 300);
-      },
-      { once: true },
-    );
-    // add the input element to the body to ensure it is part of the DOM
+
+    const handleChange = (e: Event) => {
+      if (!isResolved) {
+        isResolved = true;
+        const files = Array.from((e.target as HTMLInputElement).files!);
+        cleanup();
+        resolve(files);
+      }
+    };
+
+    const handleFocus = () => {
+      setTimeout(() => {
+        if (!isResolved) {
+          isResolved = true;
+          cleanup();
+          resolve([]);
+        }
+      }, 300);
+    };
+
+    input.addEventListener("change", handleChange);
+    window.addEventListener("focus", handleFocus);
+
     document.body.appendChild(input);
-    // trigger the file input click event to open the file dialog
     input.click();
+
+    setTimeout(() => {
+      if (!isResolved) {
+        isResolved = true;
+        cleanup();
+        resolve([]);
+      }
+    }, 60000);
   });
 }

--- a/src/frontend/src/helpers/create-file-upload.ts
+++ b/src/frontend/src/helpers/create-file-upload.ts
@@ -12,8 +12,13 @@ export async function createFileUpload(props?: {
     let isResolved = false;
 
     const cleanup = () => {
+      // Check if the input element still exists in the DOM before attempting to remove it
       if (input && document.body.contains(input)) {
-        document.body.removeChild(input);
+        try {
+          document.body.removeChild(input);
+        } catch (error) {
+          console.warn("Error removing input element:", error);
+        }
       }
       window.removeEventListener("focus", handleFocus);
     };
@@ -50,6 +55,6 @@ export async function createFileUpload(props?: {
         cleanup();
         resolve([]);
       }
-    }, 60000); // 1 minute timeout
+    }, 60000);
   });
 }

--- a/src/frontend/src/helpers/create-file-upload.ts
+++ b/src/frontend/src/helpers/create-file-upload.ts
@@ -1,4 +1,4 @@
-export function createFileUpload(props?: {
+export async function createFileUpload(props?: {
   accept?: string;
   multiple?: boolean;
 }): Promise<File[]> {


### PR DESCRIPTION
This pull request improves the createFileUpload function by adding better DOM checks and handling potential race conditions that could arise during file or folder uploads.

- Added a check to ensure the input element still exists in the DOM before attempting to remove it, preventing the "failed to execute 'RemoveChild' on 'Node': the node to be removed is not a child of this node" error.

#4070 