### PR TITLE
Fix: Add UTC timezone info to message.timestamp.

### DIFF
--- a/src/backend/base/langflow/services/database/models/message/model.py
+++ b/src/backend/base/langflow/services/database/models/message/model.py
@@ -42,7 +42,10 @@ class MessageBase(SQLModel):
                 message.files = image_paths
 
         if isinstance(message.timestamp, str):
-            timestamp = datetime.fromisoformat(message.timestamp)
+            # The message.timestamp is created using strftime("%Y-%m-%dT%H:%M:%S").
+            # This format is not fully ISO 8601 compliant because it lacks timezone information.
+            # Aadd timezone info (UTC) back to the timestamp here.
+            timestamp = datetime.fromisoformat(message.timestamp).replace(tzinfo=timezone.utc)
         else:
             timestamp = message.timestamp
         if not flow_id and message.flow_id:


### PR DESCRIPTION
This PR addresses the issue of inconsistent timestamps in the Message class due to missing timezone information. 
https://github.com/langflow-ai/langflow/blob/376e4cfdd3d20d655c3f04cefea474f74f4a5ddc/src/backend/base/langflow/schema/message.py#L53-L55 When creating timestamps, strftime("%Y-%m-%d %H:%M:%S") was used on `datetime.now(timezone.utc)`, resulting in strings without timezone data. 
Converting these strings back to datetime in the ORM led to lost timezone info, causing discrepancies between the `message` table and others. This fix ensures that timestamps are consistently stored with UTC timezone information, maintaining uniformity across database entries.