### PR TITLE
refactor: Adjust timeout in buildUtils.ts

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -16296,12 +16296,6 @@
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
-    "node_modules/tinycolor2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
-      "license": "MIT"
-    },
     "node_modules/tmp": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -288,7 +288,7 @@ export async function buildFlowVertices({
         // await one milisencond so we avoid react batched updates
         await new Promise((resolve) => {
           useMessagesStore.getState().updateMessagePartial(data);
-          setTimeout(resolve, 10);
+          setTimeout(resolve, 100);
         });
         return true;
       }


### PR DESCRIPTION
This pull request includes a single commit that refactors the timeout in buildUtils.ts. The timeout value in the code has been adjusted from 10 milliseconds to 100 milliseconds. This change ensures that there is a slightly longer delay before resolving a promise, allowing for better handling of react batched updates.