### PR TITLE
fix: SQLDatabase has no attribute set_event_manager

### DIFF
--- a/src/backend/base/langflow/components/langchain_utilities/sql_database.py
+++ b/src/backend/base/langflow/components/langchain_utilities/sql_database.py
@@ -1,11 +1,12 @@
 from langchain_community.utilities.sql_database import SQLDatabase
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
-from langflow.io import (
-    StrInput,
-    Output,
-)
+
 from langflow.custom import Component
+from langflow.io import (
+    Output,
+    StrInput,
+)
 
 
 class SQLDatabaseComponent(Component):

--- a/src/backend/base/langflow/components/langchain_utilities/sql_database.py
+++ b/src/backend/base/langflow/components/langchain_utilities/sql_database.py
@@ -1,27 +1,33 @@
 from langchain_community.utilities.sql_database import SQLDatabase
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
+from langflow.io import (
+    StrInput,
+    Output,
+)
+from langflow.custom import Component
 
-from langflow.custom import CustomComponent
 
-
-class SQLDatabaseComponent(CustomComponent):
+class SQLDatabaseComponent(Component):
     display_name = "SQLDatabase"
     description = "SQL Database"
     name = "SQLDatabase"
 
-    def build_config(self):
-        return {
-            "uri": {"display_name": "URI", "info": "URI to the database."},
-        }
+    inputs = [
+        StrInput(name="uri", display_name="URI", info="URI to the database.", required=True),
+    ]
+
+    outputs = [
+        Output(display_name="SQLDatabase", name="SQLDatabase", method="build_sqldatabase"),
+    ]
 
     def clean_up_uri(self, uri: str) -> str:
         if uri.startswith("postgres://"):
             uri = uri.replace("postgres://", "postgresql://")
         return uri.strip()
 
-    def build(self, uri: str) -> SQLDatabase:
-        uri = self.clean_up_uri(uri)
+    def build_sqldatabase(self) -> SQLDatabase:
+        uri = self.clean_up_uri(self.uri)
         # Create an engine using SQLAlchemy with StaticPool
         engine = create_engine(uri, poolclass=StaticPool)
         return SQLDatabase(engine)


### PR DESCRIPTION
When running the SQLDatabase component, it gives an error that it does not have the set_event_manager. To fix this, I changed the inherited class to Component, which has the newly implemented event control.

![Screenshot from 2024-10-17 16-05-16](https://github.com/user-attachments/assets/4b42deba-ae47-4c87-bb10-1d609f04470f)
