### PR TITLE
fix: add memo to deepcopy call to avoid recursion error

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -138,8 +138,8 @@ class Component(CustomComponent):
     def __deepcopy__(self, memo):
         if id(self) in memo:
             return memo[id(self)]
-        kwargs = deepcopy(self.__config)
-        kwargs["inputs"] = deepcopy(self.__inputs)
+        kwargs = deepcopy(self.__config, memo)
+        kwargs["inputs"] = deepcopy(self.__inputs, memo)
         new_component = type(self)(**kwargs)
         new_component._code = self._code
         new_component._outputs_map = self._outputs_map

--- a/uv.lock
+++ b/uv.lock
@@ -3632,7 +3632,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "assemblyai", specifier = ">=0.33.0" },
-    { name = "astra-assistants", specifier = ">=2.2.2" },
+    { name = "astra-assistants", specifier = "~=2.2.2" },
     { name = "beautifulsoup4", specifier = ">=4.12.2" },
     { name = "boto3", specifier = "~=1.34.162" },
     { name = "cassio", marker = "extra == 'cassio'", specifier = ">=0.1.7" },


### PR DESCRIPTION
This pull request fixes a bug in the custom component where the `deepcopy` function was not correctly passing the `memo` argument. This caused issues when creating a deep copy of the component. The bug has been fixed by updating the `deepcopy` calls in the `__deepcopy__` method of the component.