### PR TITLE
fix: override modal not exiting

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -612,6 +612,7 @@ export default function NodeToolbarComponent({
                 override: true,
               });
               setSuccessData({ title: "New component successfully saved!" });
+              setShowOverrideModal(false);
             }}
           >
             <ConfirmationModal.Content>


### PR DESCRIPTION
This pull request fixes an issue where the override modal was not exiting properly. The patch includes a change to the NodeToolbarComponent file that ensures the modal is closed when the component is successfully saved.