### PR TITLE
fix: Update header button variant based on the active route (#4207)

### DIFF
--- a/src/frontend/src/components/headerComponent/index.tsx
+++ b/src/frontend/src/components/headerComponent/index.tsx
@@ -100,6 +100,7 @@ export default function Header(): JSX.Element {
             className="gap-2"
             variant={
               location.pathname.includes("/all") ||
+              location.pathname.includes("/flows") ||
               location.pathname.includes("/components")
                 ? "primary"
                 : "secondary"


### PR DESCRIPTION
- Added logic to change the **My Collection** button variant to "primary" or "secondary" in the header based on the current pathname, including the "/flows" route.

**Before**:

![image](https://github.com/user-attachments/assets/836ff9fa-94d1-445e-8d92-b06eb1f43605)

**After**:

![image](https://github.com/user-attachments/assets/7e4226c1-f028-452b-89ae-51cea7ade2f1)

