### PR TITLE
ref: Move get services out of API methods

### DIFF
--- a/src/backend/base/langflow/api/health_check_router.py
+++ b/src/backend/base/langflow/api/health_check_router.py
@@ -36,10 +36,10 @@ async def health():
 
 # /health_check evaluates key services
 # It's a reliable health check for a langflow instance
-@health_check_router.get("/health_check", response_model=HealthResponse)
+@health_check_router.get("/health_check")
 async def health_check(
     session: Annotated[Session, Depends(get_session)],
-):
+) -> HealthResponse:
     response = HealthResponse()
     # use a fixed valid UUId that UUID collision is very unlikely
     user_id = "da93c2bd-c857-4b10-8c8c-60988103320f"

--- a/src/backend/base/langflow/api/v1/api_key.py
+++ b/src/backend/base/langflow/api/v1/api_key.py
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
 router = APIRouter(tags=["APIKey"], prefix="/api_key")
 
 
-@router.get("/", response_model=ApiKeysResponse)
+@router.get("/")
 def get_api_keys_route(
     db: Annotated[Session, Depends(get_session)],
     current_user: Annotated[User, Depends(auth_utils.get_current_active_user)],
-):
+) -> ApiKeysResponse:
     try:
         user_id = current_user.id
         keys = get_api_keys(db, user_id)
@@ -33,12 +33,12 @@ def get_api_keys_route(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-@router.post("/", response_model=UnmaskedApiKeyRead)
+@router.post("/")
 def create_api_key_route(
     req: ApiKeyCreate,
     current_user: Annotated[User, Depends(auth_utils.get_current_active_user)],
     db: Annotated[Session, Depends(get_session)],
-):
+) -> UnmaskedApiKeyRead:
     try:
         user_id = current_user.id
         return create_api_key(db, req, user_id=user_id)

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -42,7 +42,6 @@ from langflow.services.auth.utils import get_current_active_user
 from langflow.services.chat.service import ChatService
 from langflow.services.deps import get_chat_service, get_session, get_telemetry_service
 from langflow.services.telemetry.schema import ComponentPayload, PlaygroundPayload
-from langflow.services.telemetry.service import TelemetryService
 
 if TYPE_CHECKING:
     from langflow.graph.vertex.types import InterfaceVertex
@@ -66,17 +65,15 @@ async def try_running_celery_task(vertex, user_id):
     return vertex
 
 
-@router.post("/build/{flow_id}/vertices", response_model=VerticesOrderResponse)
+@router.post("/build/{flow_id}/vertices")
 async def retrieve_vertices_order(
     flow_id: uuid.UUID,
     background_tasks: BackgroundTasks,
     data: Annotated[FlowDataRequest | None, Body(embed=True)] | None = None,
     stop_component_id: str | None = None,
     start_component_id: str | None = None,
-    chat_service: ChatService = Depends(get_chat_service),
     session=Depends(get_session),
-    telemetry_service: TelemetryService = Depends(get_telemetry_service),
-):
+) -> VerticesOrderResponse:
     """Retrieve the vertices order for a given flow.
 
     Args:
@@ -85,9 +82,7 @@ async def retrieve_vertices_order(
         data (Optional[FlowDataRequest], optional): The flow data. Defaults to None.
         stop_component_id (str, optional): The ID of the stop component. Defaults to None.
         start_component_id (str, optional): The ID of the start component. Defaults to None.
-        chat_service (ChatService, optional): The chat service dependency. Defaults to Depends(get_chat_service).
         session (Session, optional): The session dependency. Defaults to Depends(get_session).
-        telemetry_service (TelemetryService, optional): The telemetry service.
 
     Returns:
         VerticesOrderResponse: The response containing the ordered vertex IDs and the run ID.
@@ -95,6 +90,8 @@ async def retrieve_vertices_order(
     Raises:
         HTTPException: If there is an error checking the build status.
     """
+    chat_service = get_chat_service()
+    telemetry_service = get_telemetry_service()
     start_time = time.perf_counter()
     components_count = None
     try:
@@ -150,11 +147,11 @@ async def build_flow(
     stop_component_id: str | None = None,
     start_component_id: str | None = None,
     log_builds: bool | None = True,
-    chat_service: ChatService = Depends(get_chat_service),
     current_user=Depends(get_current_active_user),
-    telemetry_service: TelemetryService = Depends(get_telemetry_service),
     session=Depends(get_session),
 ):
+    chat_service = get_chat_service()
+    telemetry_service = get_telemetry_service()
     if not inputs:
         inputs = InputValueRequest(session=str(flow_id))
 
@@ -464,10 +461,8 @@ async def build_vertex(
     background_tasks: BackgroundTasks,
     inputs: Annotated[InputValueRequest | None, Body(embed=True)] = None,
     files: list[str] | None = None,
-    chat_service: ChatService = Depends(get_chat_service),
     current_user=Depends(get_current_active_user),
-    telemetry_service: TelemetryService = Depends(get_telemetry_service),
-):
+) -> VertexBuildResponse:
     """Build a vertex instead of the entire graph.
 
     Args:
@@ -476,9 +471,7 @@ async def build_vertex(
         background_tasks (BackgroundTasks): The background tasks dependency.
         inputs (Optional[InputValueRequest], optional): The input values for the vertex. Defaults to None.
         files (List[str], optional): The files to use. Defaults to None.
-        chat_service (ChatService, optional): The chat service dependency. Defaults to Depends(get_chat_service).
         current_user (Any, optional): The current user dependency. Defaults to Depends(get_current_active_user).
-        telemetry_service (TelemetryService, optional): The telemetry service.
 
     Returns:
         VertexBuildResponse: The response containing the built vertex information.
@@ -487,6 +480,8 @@ async def build_vertex(
         HTTPException: If there is an error building the vertex.
 
     """
+    chat_service = get_chat_service()
+    telemetry_service = get_telemetry_service()
     flow_id_str = str(flow_id)
 
     next_runnable_vertices = []
@@ -699,7 +694,6 @@ async def _stream_vertex(flow_id: str, vertex_id: str, chat_service: ChatService
 async def build_vertex_stream(
     flow_id: uuid.UUID,
     vertex_id: str,
-    chat_service: ChatService = Depends(get_chat_service),
 ):
     """Build a vertex instead of the entire graph.
 
@@ -727,6 +721,8 @@ async def build_vertex_stream(
         HTTPException: If an error occurs while building the vertex.
     """
     try:
-        return StreamingResponse(_stream_vertex(str(flow_id), vertex_id, chat_service), media_type="text/event-stream")
+        return StreamingResponse(
+            _stream_vertex(str(flow_id), vertex_id, get_chat_service()), media_type="text/event-stream"
+        )
     except Exception as exc:
         raise HTTPException(status_code=500, detail="Error building Component") from exc

--- a/src/backend/base/langflow/api/v1/login.py
+++ b/src/backend/base/langflow/api/v1/login.py
@@ -16,7 +16,6 @@ from langflow.services.auth.utils import (
 from langflow.services.database.models.folder.utils import create_default_folder_if_it_doesnt_exist
 from langflow.services.database.models.user.crud import get_user_by_id
 from langflow.services.deps import get_session, get_settings_service, get_variable_service
-from langflow.services.settings.service import SettingsService
 from langflow.services.variable.service import VariableService
 
 router = APIRouter(tags=["Login"])
@@ -83,12 +82,10 @@ async def login_to_get_access_token(
 
 
 @router.get("/auto_login")
-async def auto_login(
-    response: Response, db: Annotated[Session, Depends(get_session)], settings_service=Depends(get_settings_service)
-):
-    auth_settings = settings_service.auth_settings
+async def auto_login(response: Response, db: Annotated[Session, Depends(get_session)]):
+    auth_settings = get_settings_service().auth_settings
 
-    if settings_service.auth_settings.AUTO_LOGIN:
+    if auth_settings.AUTO_LOGIN:
         user_id, tokens = create_user_longterm_token(db)
         response.set_cookie(
             "access_token_lf",
@@ -131,10 +128,9 @@ async def auto_login(
 async def refresh_token(
     request: Request,
     response: Response,
-    settings_service: Annotated[SettingsService, Depends(get_settings_service)],
     db: Annotated[Session, Depends(get_session)],
 ):
-    auth_settings = settings_service.auth_settings
+    auth_settings = get_settings_service().auth_settings
 
     token = request.cookies.get("refresh_token_lf")
 

--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -20,11 +20,11 @@ from langflow.services.deps import get_session
 router = APIRouter(prefix="/monitor", tags=["Monitor"])
 
 
-@router.get("/builds", response_model=VertexBuildMapModel)
+@router.get("/builds")
 async def get_vertex_builds(
     flow_id: Annotated[UUID, Query()],
     session: Annotated[Session, Depends(get_session)],
-):
+) -> VertexBuildMapModel:
     try:
         vertex_builds = get_vertex_builds_by_flow_id(session, flow_id)
         return VertexBuildMapModel.from_list_of_dicts(vertex_builds)
@@ -43,7 +43,7 @@ async def delete_vertex_builds(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@router.get("/messages", response_model=list[MessageResponse])
+@router.get("/messages")
 async def get_messages(
     session: Annotated[Session, Depends(get_session)],
     flow_id: Annotated[str | None, Query()] = None,
@@ -51,7 +51,7 @@ async def get_messages(
     sender: Annotated[str | None, Query()] = None,
     sender_name: Annotated[str | None, Query()] = None,
     order_by: Annotated[str | None, Query()] = "timestamp",
-):
+) -> list[MessageResponse]:
     try:
         stmt = select(MessageTable)
         if flow_id:
@@ -113,13 +113,12 @@ async def update_message(
 @router.patch(
     "/messages/session/{old_session_id}",
     dependencies=[Depends(get_current_active_user)],
-    response_model=list[MessageResponse],
 )
 async def update_session_id(
     old_session_id: str,
     new_session_id: Annotated[str, Query(..., description="The new session ID to update to")],
     session: Annotated[Session, Depends(get_session)],
-):
+) -> list[MessageResponse]:
     try:
         # Get all messages with the old session ID
         stmt = select(MessageTable).where(MessageTable.session_id == old_session_id)
@@ -166,11 +165,11 @@ async def delete_messages_session(
     return {"message": "Messages deleted successfully"}
 
 
-@router.get("/transactions", response_model=list[TransactionReadResponse])
+@router.get("/transactions")
 async def get_transactions(
     flow_id: Annotated[UUID, Query()],
     session: Annotated[Session, Depends(get_session)],
-):
+) -> list[TransactionReadResponse]:
     try:
         transactions = get_transactions_by_flow_id(session, flow_id)
         return [

--- a/src/backend/base/langflow/api/v1/starter_projects.py
+++ b/src/backend/base/langflow/api/v1/starter_projects.py
@@ -6,8 +6,8 @@ from langflow.services.auth.utils import get_current_active_user
 router = APIRouter(prefix="/starter-projects", tags=["Flows"])
 
 
-@router.get("/", dependencies=[Depends(get_current_active_user)], response_model=list[GraphDump], status_code=200)
-def get_starter_projects():
+@router.get("/", dependencies=[Depends(get_current_active_user)], status_code=200)
+def get_starter_projects() -> list[GraphDump]:
     """Get a list of starter projects."""
     from langflow.initial_setup.load import get_starter_projects_dump
 

--- a/src/backend/base/langflow/api/v1/store.py
+++ b/src/backend/base/langflow/api/v1/store.py
@@ -17,7 +17,6 @@ from langflow.services.store.schema import (
     TagResponse,
     UsersLikesResponse,
 )
-from langflow.services.store.service import StoreService
 
 router = APIRouter(prefix="/store", tags=["Components Store"])
 
@@ -48,24 +47,21 @@ def get_optional_user_store_api_key(
 
 
 @router.get("/check/")
-def check_if_store_is_enabled(
-    settings_service=Depends(get_settings_service),
-):
+def check_if_store_is_enabled():
     return {
-        "enabled": settings_service.settings.store,
+        "enabled": get_settings_service().settings.store,
     }
 
 
 @router.get("/check/api_key")
 async def check_if_store_has_api_key(
     api_key: Annotated[str | None, Depends(get_optional_user_store_api_key)],
-    store_service: Annotated[StoreService, Depends(get_store_service)],
 ):
     if api_key is None:
         return {"has_api_key": False, "is_valid": False}
 
     try:
-        is_valid = await store_service.check_api_key(api_key)
+        is_valid = await get_store_service().check_api_key(api_key)
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -75,31 +71,29 @@ async def check_if_store_has_api_key(
 @router.post("/components/", response_model=CreateComponentResponse, status_code=201)
 async def share_component(
     component: StoreComponentCreate,
-    store_service: Annotated[StoreService, Depends(get_store_service)],
     store_api_key: Annotated[str, Depends(get_user_store_api_key)],
-):
+) -> CreateComponentResponse:
     try:
         await check_langflow_version(component)
-        return await store_service.upload(store_api_key, component)
+        return await get_store_service().upload(store_api_key, component)
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-@router.patch("/components/{component_id}", response_model=CreateComponentResponse, status_code=201)
+@router.patch("/components/{component_id}", status_code=201)
 async def update_shared_component(
     component_id: UUID,
     component: StoreComponentCreate,
-    store_service: Annotated[StoreService, Depends(get_store_service)],
     store_api_key: Annotated[str, Depends(get_user_store_api_key)],
-):
+) -> CreateComponentResponse:
     try:
         await check_langflow_version(component)
-        return await store_service.update(store_api_key, component_id, component)
+        return await get_store_service().update(store_api_key, component_id, component)
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-@router.get("/components/", response_model=ListComponentResponseModel)
+@router.get("/components/")
 async def get_components(
     *,
     component_id: Annotated[str | None, Query()] = None,
@@ -113,11 +107,10 @@ async def get_components(
     fields: Annotated[list[str] | None, Query()] = None,
     page: int = 1,
     limit: int = 10,
-    store_service: StoreService = Depends(get_store_service),
     store_api_key: str | None = Depends(get_optional_user_store_api_key),
-):
+) -> ListComponentResponseModel:
     try:
-        return await store_service.get_list_component_response_model(
+        return await get_store_service().get_list_component_response_model(
             component_id=component_id,
             search=search,
             private=private,
@@ -140,11 +133,10 @@ async def get_components(
 @router.get("/components/{component_id}", response_model=DownloadComponentResponse)
 async def download_component(
     component_id: UUID,
-    store_service: Annotated[StoreService, Depends(get_store_service)],
     store_api_key: Annotated[str, Depends(get_user_store_api_key)],
-):
+) -> DownloadComponentResponse:
     try:
-        component = await store_service.download(store_api_key, component_id)
+        component = await get_store_service().download(store_api_key, component_id)
     except CustomError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
@@ -157,11 +149,9 @@ async def download_component(
 
 
 @router.get("/tags", response_model=list[TagResponse])
-async def get_tags(
-    store_service: Annotated[StoreService, Depends(get_store_service)],
-):
+async def get_tags():
     try:
-        return await store_service.get_tags()
+        return await get_store_service().get_tags()
     except CustomError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
@@ -170,24 +160,23 @@ async def get_tags(
 
 @router.get("/users/likes", response_model=list[UsersLikesResponse])
 async def get_list_of_components_liked_by_user(
-    store_service: Annotated[StoreService, Depends(get_store_service)],
     store_api_key: Annotated[str, Depends(get_user_store_api_key)],
 ):
     try:
-        return await store_service.get_user_likes(store_api_key)
+        return await get_store_service().get_user_likes(store_api_key)
     except CustomError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
-@router.post("/users/likes/{component_id}", response_model=UsersLikesResponse)
+@router.post("/users/likes/{component_id}")
 async def like_component(
     component_id: UUID,
-    store_service: Annotated[StoreService, Depends(get_store_service)],
     store_api_key: Annotated[str, Depends(get_user_store_api_key)],
-):
+) -> UsersLikesResponse:
     try:
+        store_service = get_store_service()
         result = await store_service.like_component(store_api_key, str(component_id))
         likes_count = await store_service.get_component_likes_count(str(component_id), store_api_key)
 

--- a/src/backend/base/langflow/api/v1/validate.py
+++ b/src/backend/base/langflow/api/v1/validate.py
@@ -9,21 +9,21 @@ from langflow.utils.validate import validate_code
 router = APIRouter(prefix="/validate", tags=["Validate"])
 
 
-@router.post("/code", status_code=200, response_model=CodeValidationResponse)
-def post_validate_code(code: Code):
+@router.post("/code", status_code=200)
+def post_validate_code(code: Code) -> CodeValidationResponse:
     try:
         errors = validate_code(code.code)
         return CodeValidationResponse(
             imports=errors.get("imports", {}),
             function=errors.get("function", {}),
         )
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.opt(exception=True).debug("Error validating code")
-        return HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@router.post("/prompt", status_code=200, response_model=PromptValidationResponse)
-def post_validate_prompt(prompt_request: ValidatePromptRequest):
+@router.post("/prompt", status_code=200)
+def post_validate_prompt(prompt_request: ValidatePromptRequest) -> PromptValidationResponse:
     try:
         if not prompt_request.frontend_node:
             return PromptValidationResponse(

--- a/src/backend/base/langflow/api/v1/variable.py
+++ b/src/backend/base/langflow/api/v1/variable.py
@@ -21,9 +21,9 @@ def create_variable(
     session: Session = Depends(get_session),
     variable: VariableCreate,
     current_user: User = Depends(get_current_active_user),
-    variable_service: DatabaseVariableService = Depends(get_variable_service),
 ):
     """Create a new variable."""
+    variable_service = get_variable_service()
     if not variable.name and not variable.value:
         raise HTTPException(status_code=400, detail="Variable name and value cannot be empty")
 

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -12,10 +12,10 @@ from uuid import UUID
 import orjson
 import pytest
 from asgi_lifespan import LifespanManager
-from base.langflow.components.inputs.ChatInput import ChatInput
 from dotenv import load_dotenv
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
+from langflow.components.inputs.ChatInput import ChatInput
 from langflow.graph.graph.base import Graph
 from langflow.initial_setup.setup import STARTER_FOLDER_NAME
 from langflow.services.auth.utils import get_password_hash

--- a/src/backend/tests/unit/test_files.py
+++ b/src/backend/tests/unit/test_files.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from asgi_lifespan import LifespanManager
 from httpx import ASGITransport, AsyncClient
-from langflow.services import deps
+from langflow.services.deps import get_storage_service
 from langflow.services.storage.service import StorageService
 from sqlmodel import Session
 
@@ -48,18 +48,17 @@ async def files_client_fixture(
             monkeypatch.setenv("LANGFLOW_LOAD_FLOWS_PATH", load_flows_dir)
             monkeypatch.setenv("LANGFLOW_AUTO_LOGIN", "true")
 
-        monkeypatch.setattr(deps, "get_storage_service", lambda: mock_storage_service)
-
         from langflow.main import create_app
 
         app = create_app()
 
+        app.dependency_overrides[get_storage_service] = lambda: mock_storage_service
         async with (
             LifespanManager(app, startup_timeout=None, shutdown_timeout=None) as manager,
             AsyncClient(transport=ASGITransport(app=manager.app), base_url="http://testserver/") as client,
         ):
             yield client
-
+        # app.dependency_overrides.clear()
         monkeypatch.undo()
         # clear the temp db
         with suppress(FileNotFoundError):


### PR DESCRIPTION
It doesn't have added value to put `get_xxx_service` methods in `Depends` injections. It even makes the code harder to read.
So this PR moves them to the code.
This PR also removes some `response_model` when they can be set as the method return type.