### PR TITLE
fix: cartesian product warning in delete_folder

### DIFF
--- a/src/backend/base/langflow/api/v1/folders.py
+++ b/src/backend/base/langflow/api/v1/folders.py
@@ -213,7 +213,7 @@ async def delete_folder(
     current_user: CurrentActiveUser,
 ):
     try:
-        flows = session.exec(select(Flow).where(Flow.folder_id == folder_id, Folder.user_id == current_user.id)).all()
+        flows = session.exec(select(Flow).where(Flow.folder_id == folder_id, Flow.user_id == current_user.id)).all()
         if len(flows) > 0:
             for flow in flows:
                 await cascade_delete_flow(session, flow)


### PR DESCRIPTION
This pull request fixes a cartesian product warning in `delete_folder` by replacing Folder.user_id with Flow.user_id for correct filtering.

The query previously used Folder.user_id, leading to the warning: `SAWarning: SELECT statement has a cartesian product between FROM element(s) "flow" and FROM element "folder".`