### PR TITLE
refactor: Tool Output Management: Add Component-Specific Variable for Conditional Tool Output

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -91,9 +91,9 @@ class Component(CustomComponent):
         self.__inputs = inputs
         self.__config = config
         self._reset_all_output_values()
-        if FEATURE_FLAGS.add_toolkit_output and hasattr(self, "_append_tool_output"):
-            self._append_tool_output()
         super().__init__(**config)
+        if (FEATURE_FLAGS.add_toolkit_output) and hasattr(self, "_append_tool_output") and self.add_tool_output:
+            self._append_tool_output()
         if hasattr(self, "_trace_type"):
             self.trace_type = self._trace_type
         if not hasattr(self, "trace_type"):

--- a/src/backend/base/langflow/custom/custom_component/custom_component.py
+++ b/src/backend/base/langflow/custom/custom_component/custom_component.py
@@ -59,6 +59,8 @@ class CustomComponent(BaseComponent):
     is_input: bool | None = None
     """The input state of the component. Defaults to None.
     If True, the component must have a field named 'input_value'."""
+    add_tool_output: bool | None = False
+    """Indicates whether the component will be treated as a tool. Defaults to False."""
     is_output: bool | None = None
     """The output state of the component. Defaults to None.
     If True, the component must have a field named 'input_value'."""


### PR DESCRIPTION
This pull request introduces improvements to the tool output handling mechanism by incorporating both a feature flag and a new component-specific variable. The following changes have been made:

- **Conditional Tool Output in `component.py`:** 
  - Added logic to check for `FEATURE_FLAGS.add_toolkit_output`. If this flag is enabled and the component has the `_append_tool_output` method, it will be invoked when the new variable `add_tool_output` is set to True for that specific component. This means that if `add_tool_output` is set to True in the component code, the tool output will be added specifically for that component.

- **Integration in `custom_component.py`:**
  - Updated the component logic to utilize the `add_tool_output` variable, ensuring that each component can independently manage its tool output based on the feature flag and its own settings.

These changes enhance the flexibility and configurability of tool output handling across components, allowing for better feature management and customization.

Please review the changes and provide feedback. Thank you!

Testing:

https://github.com/user-attachments/assets/d999332d-59c1-4a76-9e7e-07b6115c8f10

