### PR TITLE
fix: correctly call the /variable endpoint after the user is authenticated

### DIFF
--- a/src/frontend/src/contexts/authContext.tsx
+++ b/src/frontend/src/contexts/authContext.tsx
@@ -5,9 +5,10 @@ import {
   LANGFLOW_REFRESH_TOKEN,
 } from "@/constants/constants";
 import { useGetUserData } from "@/controllers/API/queries/auth";
+import { useGetGlobalVariablesMutation } from "@/controllers/API/queries/variables/use-get-mutation-global-variables";
 import useAuthStore from "@/stores/authStore";
 import { createContext, useEffect, useState } from "react";
-import Cookies from "universal-cookie";
+import { Cookies } from "react-cookie";
 import { useStoreStore } from "../stores/storeStore";
 import { Users } from "../types/api";
 import { AuthContextType } from "../types/contexts/auth";
@@ -41,6 +42,7 @@ export function AuthProvider({ children }): React.ReactElement {
   const setIsAuthenticated = useAuthStore((state) => state.setIsAuthenticated);
 
   const { mutate: mutateLoggedUser } = useGetUserData();
+  const { mutate: mutateGetGlobalVariables } = useGetGlobalVariablesMutation();
 
   useEffect(() => {
     const storedAccessToken = cookies.get(LANGFLOW_ACCESS_TOKEN);
@@ -86,10 +88,15 @@ export function AuthProvider({ children }): React.ReactElement {
     setAccessToken(newAccessToken);
     setIsAuthenticated(true);
     getUser();
+    getGlobalVariables();
   }
 
   function storeApiKey(apikey: string) {
     setApiKey(apikey);
+  }
+
+  function getGlobalVariables() {
+    mutateGetGlobalVariables({});
   }
 
   return (

--- a/src/frontend/src/controllers/API/queries/folders/use-get-folders.ts
+++ b/src/frontend/src/controllers/API/queries/folders/use-get-folders.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_FOLDER, STARTER_FOLDER_NAME } from "@/constants/constants";
 import { FolderType } from "@/pages/MainPage/entities";
+import useAuthStore from "@/stores/authStore";
 import { useFolderStore } from "@/stores/foldersStore";
 import { useTypesStore } from "@/stores/typesStore";
 import { useQueryFunctionType } from "@/types/api";
@@ -18,7 +19,10 @@ export const useGetFoldersQuery: useQueryFunctionType<
   const setMyCollectionId = useFolderStore((state) => state.setMyCollectionId);
   const setFolders = useFolderStore((state) => state.setFolders);
 
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
   const getFoldersFn = async (): Promise<FolderType[]> => {
+    if (!isAuthenticated) return [];
     const res = await api.get(`${getURL("FOLDERS")}/`);
     const data = res.data;
 

--- a/src/frontend/src/controllers/API/queries/variables/use-get-mutation-global-variables.ts
+++ b/src/frontend/src/controllers/API/queries/variables/use-get-mutation-global-variables.ts
@@ -1,18 +1,16 @@
-import useAuthStore from "@/stores/authStore";
 import { useGlobalVariablesStore } from "@/stores/globalVariablesStore/globalVariables";
 import getUnavailableFields from "@/stores/globalVariablesStore/utils/get-unavailable-fields";
-import { useQueryFunctionType } from "@/types/api";
+import { useMutationFunctionType } from "@/types/api";
 import { GlobalVariable } from "@/types/global_variables";
-import { UseQueryResult } from "@tanstack/react-query";
+import { UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
 
-export const useGetGlobalVariables: useQueryFunctionType<
-  undefined,
-  GlobalVariable[]
+export const useGetGlobalVariablesMutation: useMutationFunctionType<
+  undefined
 > = (options?) => {
-  const { query } = UseRequestProcessor();
+  const { mutate } = UseRequestProcessor();
 
   const setGlobalVariablesEntries = useGlobalVariablesStore(
     (state) => state.setGlobalVariablesEntries,
@@ -21,24 +19,15 @@ export const useGetGlobalVariables: useQueryFunctionType<
     (state) => state.setUnavailableFields,
   );
 
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-
   const getGlobalVariablesFn = async (): Promise<GlobalVariable[]> => {
-    if (!isAuthenticated) return [];
     const res = await api.get(`${getURL("VARIABLES")}/`);
     setGlobalVariablesEntries(res.data.map((entry) => entry.name));
     setUnavailableFields(getUnavailableFields(res.data));
     return res.data;
   };
 
-  const queryResult: UseQueryResult<GlobalVariable[], any> = query(
-    ["useGetGlobalVariables"],
-    getGlobalVariablesFn,
-    {
-      refetchOnWindowFocus: false,
-      ...options,
-    },
-  );
+  const mutation: UseMutationResult<undefined, Error, GlobalVariable[]> =
+    mutate(["useGetGlobalVariables"], getGlobalVariablesFn, options);
 
-  return queryResult;
+  return mutation;
 };

--- a/src/frontend/src/stores/authStore.ts
+++ b/src/frontend/src/stores/authStore.ts
@@ -1,7 +1,7 @@
 // authStore.js
 import { LANGFLOW_ACCESS_TOKEN } from "@/constants/constants";
 import { AuthStoreType } from "@/types/zustand/auth";
-import Cookies from "universal-cookie";
+import { Cookies } from "react-cookie";
 import { create } from "zustand";
 
 const cookies = new Cookies();


### PR DESCRIPTION


✨ (authContext.tsx): Add functionality to fetch global variables on authentication
🔧 (api.tsx): Replace universal-cookie import with react-cookie for consistency
🔧 (authStore.ts): Replace universal-cookie import with react-cookie for consistency
🔧 (use-get-global-variables.ts): Add check to only fetch global variables if user is authenticated
✨ (use-get-mutation-global-variables.ts): Add mutation function to fetch and update global variables
🔧 (authStore.ts): Replace universal-cookie import with react-cookie for consistency