### PR TITLE
fix: Refactor file reading and async task creation, fix return type in vertex_builds model

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -329,7 +329,7 @@ async def build_flow(
         client_consumed_queue: asyncio.Queue,
         event_manager: EventManager,
     ) -> None:
-        build_task = asyncio.create_task(asyncio.to_thread(asyncio.run, _build_vertex(vertex_id, graph, event_manager)))
+        build_task = asyncio.create_task(_build_vertex(vertex_id, graph, event_manager))
         try:
             await build_task
         except asyncio.CancelledError as exc:
@@ -361,8 +361,8 @@ async def build_flow(
 
     async def event_generator(event_manager: EventManager, client_consumed_queue: asyncio.Queue) -> None:
         if not data:
-            # using another thread since the DB query is I/O bound
-            vertices_task = asyncio.create_task(asyncio.to_thread(asyncio.run, build_graph_and_get_order()))
+            # using another task since the build_graph_and_get_order is now an async function
+            vertices_task = asyncio.create_task(build_graph_and_get_order())
             try:
                 await vertices_task
             except asyncio.CancelledError:

--- a/src/backend/base/langflow/custom/directory_reader/directory_reader.py
+++ b/src/backend/base/langflow/custom/directory_reader/directory_reader.py
@@ -93,15 +93,16 @@ class DirectoryReader:
         _file_path = Path(file_path)
         if not _file_path.is_file():
             return None
-        with _file_path.open(encoding="utf-8") as file:
-            # UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3069: character maps to <undefined>
-            try:
+        try:
+            with _file_path.open(encoding="utf-8") as file:
+                # UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3069:
+                # character maps to <undefined>
                 return file.read()
-            except UnicodeDecodeError:
-                # This is happening in Windows, so we need to open the file in binary mode
-                # The file is always just a python file, so we can safely read it as utf-8
-                with _file_path.open("rb") as f:
-                    return f.read().decode("utf-8")
+        except UnicodeDecodeError:
+            # This is happening in Windows, so we need to open the file in binary mode
+            # The file is always just a python file, so we can safely read it as utf-8
+            with _file_path.open("rb") as f:
+                return f.read().decode("utf-8")
 
     def get_files(self):
         """Walk through the directory path and return a list of all .py files."""

--- a/src/backend/base/langflow/services/database/models/vertex_builds/model.py
+++ b/src/backend/base/langflow/services/database/models/vertex_builds/model.py
@@ -50,7 +50,7 @@ class VertexBuildBase(SQLModel):
         return truncate_long_strings(data)
 
     @field_serializer("params")
-    def serialize_params(self, data) -> dict:
+    def serialize_params(self, data) -> str:
         return truncate_long_strings(data)
 
 


### PR DESCRIPTION
This pull request includes several changes aimed at improving asynchronous task handling, fixing encoding issues, and modifying serialization methods. The most important changes are grouped by their themes below:

### Asynchronous Task Handling Improvements:
* [`src/backend/base/langflow/api/v1/chat.py`](diffhunk://#diff-44baaabf1ab87d4713c828053d97a7f9f5dc8d1ab9c2f8d05c1a0bcdc43e999cL331-R331): Simplified the creation of asynchronous tasks by directly calling async functions instead of using `asyncio.to_thread`. [[1]](diffhunk://#diff-44baaabf1ab87d4713c828053d97a7f9f5dc8d1ab9c2f8d05c1a0bcdc43e999cL331-R331) [[2]](diffhunk://#diff-44baaabf1ab87d4713c828053d97a7f9f5dc8d1ab9c2f8d05c1a0bcdc43e999cL363-R364)

### Encoding Fixes:
* [`src/backend/base/langflow/custom/directory_reader/directory_reader.py`](diffhunk://#diff-800eb80c3693169ed81e9b469c1f8d26285b79e30f5b582e97d0e6b3ca492787L96-R99): Fixed an issue with reading files on Windows by handling `UnicodeDecodeError` and opening the file in binary mode if needed.

### Serialization Method Changes:
* [`src/backend/base/langflow/services/database/models/vertex_builds/model.py`](diffhunk://#diff-e5ef334f5855e4fc098e9367dfd427b606ec5c1b309d4103cf0c778893639ba0L53-R53): Changed the return type of the `serialize_params` method from `dict` to `str` to ensure proper serialization.Refactored the file reading logic to avoid unclosed resources and improved the async task creation by removing unnecessary thread usage. Additionally, fixed the return type of 'serialize_params' to string in the vertex_builds model. These changes enhance the efficiency and reliability of the code.