### PR TITLE
fix: Fix async usage in app startup

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -3,7 +3,6 @@ import json
 import shutil
 import time
 from collections import defaultdict
-from collections.abc import Awaitable
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
@@ -600,12 +599,7 @@ def find_existing_flow(session, flow_id, flow_endpoint_name):
     return None
 
 
-async def create_or_update_starter_projects(get_all_components_coro: Awaitable[dict]) -> None:
-    try:
-        all_types_dict = await get_all_components_coro
-    except Exception:
-        logger.exception("Error loading components")
-        raise
+def create_or_update_starter_projects(all_types_dict: dict) -> None:
     with session_scope() as session:
         new_folder = create_starter_folder(session)
         starter_projects = load_starter_projects()

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -8,7 +8,6 @@ from http import HTTPStatus
 from pathlib import Path
 from urllib.parse import urlencode
 
-import nest_asyncio
 from fastapi import FastAPI, HTTPException, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
@@ -87,28 +86,25 @@ class JavaScriptMIMETypeMiddleware(BaseHTTPMiddleware):
         return response
 
 
-telemetry_service_tasks = set()
-
-
 def get_lifespan(*, fix_migration=False, version=None):
+    def _initialize():
+        initialize_services(fix_migration=fix_migration)
+        setup_llm_caching()
+        initialize_super_user_if_needed()
+
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
-        nest_asyncio.apply()
         # Startup message
         if version:
             rprint(f"[bold green]Starting Langflow v{version}...[/bold green]")
         else:
             rprint("[bold green]Starting Langflow...[/bold green]")
         try:
-            initialize_services(fix_migration=fix_migration)
-            setup_llm_caching()
-            initialize_super_user_if_needed()
-            task = asyncio.create_task(get_and_cache_all_types_dict(get_settings_service()))
-            await create_or_update_starter_projects(task)
-            telemetry_service_task = asyncio.create_task(get_telemetry_service().start())
-            telemetry_service_tasks.add(telemetry_service_task)
-            telemetry_service_task.add_done_callback(telemetry_service_tasks.discard)
-            load_flows_from_directory()
+            await asyncio.to_thread(_initialize)
+            all_types_dict = await get_and_cache_all_types_dict(get_settings_service())
+            await asyncio.to_thread(create_or_update_starter_projects, all_types_dict)
+            get_telemetry_service().start()
+            await asyncio.to_thread(load_flows_from_directory)
             yield
         except Exception as exc:
             if "langflow migration --fix" not in str(exc):


### PR DESCRIPTION
Removes a lot of `Task was destroyed but it is pending!` warnings during tests