### PR TITLE
Fix frontend crash when opening new project modal

### DIFF
--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -462,7 +462,13 @@ def read_basic_examples(
             return []
 
         # Get all flows in the starter folder
-        return session.exec(select(Flow).where(Flow.folder_id == starter_folder.id)).all()
+        flows = session.exec(select(Flow).where(Flow.folder_id == starter_folder.id)).all()
+
+        # Ensure the response is JSON
+        if not isinstance(flows, list):
+            raise HTTPException(status_code=500, detail="Invalid response format")
+
+        return flows
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/frontend/src/modals/templatesModal/components/GetStartedComponent/index.tsx
+++ b/src/frontend/src/modals/templatesModal/components/GetStartedComponent/index.tsx
@@ -1,6 +1,8 @@
 import BaseModal from "@/modals/baseModal";
+import { useAlertStore } from "@/stores/alertStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { CardData } from "@/types/templates/types";
+import { useEffect, useState } from "react";
 import memoryChatbotSpiral from "../../../../assets/artwork-spiral-1-def.svg";
 import vectorRagSpiral from "../../../../assets/artwork-spiral-2-def.svg";
 import multiAgentSpiral from "../../../../assets/artwork-spiral-3-def.svg";
@@ -8,8 +10,6 @@ import memoryChatbotBg from "../../../../assets/memory-chatbot-bg.png";
 import multiAgentBg from "../../../../assets/multi-agent-bg.png";
 import vectorRagBg from "../../../../assets/vector-rag-bg.png";
 import TemplateGetStartedCardComponent from "../TemplateGetStartedCardComponent";
-import { useState, useEffect } from "react";
-import { useAlertStore } from "@/stores/alertStore";
 
 export default function GetStartedComponent() {
   const examples = useFlowsManagerStore((state) => state.examples);
@@ -47,7 +47,9 @@ export default function GetStartedComponent() {
       title: "Vector RAG",
       description:
         "Ingest data into a native vector store and efficiently retrieve it.",
-      flow: validExamples.find((example) => example.name === "Vector Store RAG"),
+      flow: validExamples.find(
+        (example) => example.name === "Vector Store RAG",
+      ),
     },
     {
       bgImage: multiAgentBg,

--- a/src/frontend/src/modals/templatesModal/components/GetStartedComponent/index.tsx
+++ b/src/frontend/src/modals/templatesModal/components/GetStartedComponent/index.tsx
@@ -8,9 +8,24 @@ import memoryChatbotBg from "../../../../assets/memory-chatbot-bg.png";
 import multiAgentBg from "../../../../assets/multi-agent-bg.png";
 import vectorRagBg from "../../../../assets/vector-rag-bg.png";
 import TemplateGetStartedCardComponent from "../TemplateGetStartedCardComponent";
+import { useState, useEffect } from "react";
+import { useAlertStore } from "@/stores/alertStore";
 
 export default function GetStartedComponent() {
   const examples = useFlowsManagerStore((state) => state.examples);
+  const setErrorData = useAlertStore((state) => state.setErrorData);
+  const [validExamples, setValidExamples] = useState([]);
+
+  useEffect(() => {
+    if (Array.isArray(examples)) {
+      setValidExamples(examples);
+    } else {
+      setErrorData({
+        title: "Error",
+        message: "Failed to load examples. Please try again later.",
+      });
+    }
+  }, [examples]);
 
   // Define the card data
   const cardData: CardData[] = [
@@ -22,7 +37,7 @@ export default function GetStartedComponent() {
       title: "Memory Chatbot",
       description:
         "Get hands-on with Langflow by building a simple RAGbot that uses memory.",
-      flow: examples.find((example) => example.name === "Memory Chatbot"),
+      flow: validExamples.find((example) => example.name === "Memory Chatbot"),
     },
     {
       bgImage: vectorRagBg,
@@ -32,7 +47,7 @@ export default function GetStartedComponent() {
       title: "Vector RAG",
       description:
         "Ingest data into a native vector store and efficiently retrieve it.",
-      flow: examples.find((example) => example.name === "Vector Store RAG"),
+      flow: validExamples.find((example) => example.name === "Vector Store RAG"),
     },
     {
       bgImage: multiAgentBg,
@@ -40,7 +55,7 @@ export default function GetStartedComponent() {
       icon: "MessagesSquare",
       category: "Agents",
       title: "Multi-Agent",
-      flow: examples.find((example) => example.name === "Dynamic Agent"),
+      flow: validExamples.find((example) => example.name === "Dynamic Agent"),
       description:
         "Deploy a team of agents with a Manager-Worker structure to tackle complex tasks.",
     },


### PR DESCRIPTION
Related to #4172

Fix the frontend crash when opening the new project modal by ensuring the `/flows/basic_examples` endpoint returns JSON data.

* **Backend Changes:**
  - Add a check in `read_basic_examples` function in `src/backend/base/langflow/api/v1/flows.py` to ensure the response is JSON.
  - Update the `read_basic_examples` function to handle cases where the response is not JSON and raise an HTTPException if the response format is invalid.

* **Frontend Changes:**
  - Add error handling in `GetStartedComponent` in `src/frontend/src/modals/templatesModal/components/GetStartedComponent/index.tsx` for cases where `examples` is not an array.
  - Update the component to display an error message if `examples` is not an array.
  - Use a state variable `validExamples` to store valid examples and update the component to use `validExamples` instead of `examples`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/langflow-ai/langflow/issues/4172?shareId=5fb96e00-698d-4b2d-8d89-7fb4d738764c).