### PR TITLE
ci: add pytest failure annotations

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -27,6 +27,7 @@ on:
 env:
   POETRY_VERSION: "1.8.2"
   NODE_VERSION: "21"
+  PYTEST_RUN_PATH: "src/backend/tests"
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ ifeq ($(async), true)
 		--instafail -n auto -ra -m "not api_key_required" \
 		--durations-path src/backend/tests/.test_durations \
 		--splitting-algorithm least_duration \
+		--exclude-warning-annotations \
 		$(args)
 else
 	uv run pytest src/backend/tests \
@@ -148,6 +149,7 @@ else
 		--instafail -ra -m "not api_key_required" \
 		--durations-path src/backend/tests/.test_durations \
 		--splitting-algorithm least_duration \
+		--exclude-warning-annotations \
 		$(args)
 endif
 
@@ -157,16 +159,19 @@ unit_tests_looponfail:
 integration_tests:
 	uv run pytest src/backend/tests/integration \
 		--instafail -ra \
+		--exclude-warning-annotations \
 		$(args)
 
 integration_tests_no_api_keys:
 	uv run pytest src/backend/tests/integration \
 		--instafail -ra -m "not api_key_required" \
+		--exclude-warning-annotations \
 		$(args)
 
 integration_tests_api_keys:
 	uv run pytest src/backend/tests/integration \
 		--instafail -ra -m "api_key_required" \
+		--exclude-warning-annotations \
 		$(args)
 
 tests: ## run unit, integration, coverage tests

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,6 @@ ifeq ($(async), true)
 		--instafail -n auto -ra -m "not api_key_required" \
 		--durations-path src/backend/tests/.test_durations \
 		--splitting-algorithm least_duration \
-		--exclude-warning-annotations \
 		$(args)
 else
 	uv run pytest src/backend/tests \
@@ -149,7 +148,6 @@ else
 		--instafail -ra -m "not api_key_required" \
 		--durations-path src/backend/tests/.test_durations \
 		--splitting-algorithm least_duration \
-		--exclude-warning-annotations \
 		$(args)
 endif
 
@@ -159,19 +157,16 @@ unit_tests_looponfail:
 integration_tests:
 	uv run pytest src/backend/tests/integration \
 		--instafail -ra \
-		--exclude-warning-annotations \
 		$(args)
 
 integration_tests_no_api_keys:
 	uv run pytest src/backend/tests/integration \
 		--instafail -ra -m "not api_key_required" \
-		--exclude-warning-annotations \
 		$(args)
 
 integration_tests_api_keys:
 	uv run pytest src/backend/tests/integration \
 		--instafail -ra -m "api_key_required" \
-		--exclude-warning-annotations \
 		$(args)
 
 tests: ## run unit, integration, coverage tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ dev-dependencies = [
     "types-markdown>=3.7.0.20240822",
     "packaging>=23.2,<24.0",
     "asgi-lifespan>=2.1.0",
+    "pytest-github-actions-annotate-failures>=0.2.0",
 ]
 
 

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -76,6 +76,7 @@ ignore = [
 [tool.uv]
 dev-dependencies = [
     "asgi-lifespan>=2.1.0",
+    "pytest-github-actions-annotate-failures>=0.2.0",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -3687,6 +3687,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-flakefinder" },
+    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-instafail" },
     { name = "pytest-mock" },
     { name = "pytest-profiling" },
@@ -3812,6 +3813,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-flakefinder", specifier = ">=1.1.0" },
+    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.2.0" },
     { name = "pytest-instafail", specifier = ">=0.5.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-profiling", specifier = ">=1.7.0" },
@@ -6323,6 +6325,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ec/53/69c56a93ea057895b5761c5318455804873a6cd9d796d7c55d41c2358125/pytest-flakefinder-1.1.0.tar.gz", hash = "sha256:e2412a1920bdb8e7908783b20b3d57e9dad590cc39a93e8596ffdd493b403e0e", size = 6795 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/8b/06787150d0fd0cbd3a8054262b56f91631c7778c1bc91bf4637e47f909ad/pytest_flakefinder-1.1.0-py2.py3-none-any.whl", hash = "sha256:741e0e8eea427052f5b8c89c2b3c3019a50c39a59ce4df6a305a2c2d9ba2bd13", size = 4644 },
+]
+
+[[package]]
+name = "pytest-github-actions-annotate-failures"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/d6/76d074e1e4d78c5144397e6061af29bcc218dbf19bb64b39e5c296bf42f1/pytest-github-actions-annotate-failures-0.2.0.tar.gz", hash = "sha256:844ab626d389496e44f960b42f0a72cce29ae06d363426d17ea9ae1b4bef2288", size = 9450 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/86/9ffd9f10a7ba7387ce4ef4362505d739a48dd988051b41d255eb7f102c17/pytest_github_actions_annotate_failures-0.2.0-py3-none-any.whl", hash = "sha256:8bcef65fed503faaa0524b59cfeccc8995130972dd7b008d64193cc41b9cde85", size = 5496 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3953,6 +3953,7 @@ local = [
 [package.dev-dependencies]
 dev = [
     { name = "asgi-lifespan" },
+    { name = "pytest-github-actions-annotate-failures" },
 ]
 
 [package.metadata]
@@ -4058,7 +4059,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "asgi-lifespan", specifier = ">=2.1.0" }]
+dev = [
+    { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.2.0" },
+]
 
 [[package]]
 name = "langfuse"


### PR DESCRIPTION
Introduce the `--exclude-warning-annotations` option to pytest commands in the Makefile to enhance test output control. Update dependencies in `pyproject.toml` to include `pytest-github-actions-annotate-failures` for improved failure annotation in GitHub Actions.

* Added lgtm label to test ci