### PR TITLE
refactor: dynamically retrieve maximum buffer size from environment in SizedLogBuffer

### DIFF
--- a/src/backend/base/langflow/logging/logger.py
+++ b/src/backend/base/langflow/logging/logger.py
@@ -32,11 +32,6 @@ class SizedLogBuffer:
         The buffer can be overwritten by an env variable LANGFLOW_LOG_RETRIEVER_BUFFER_SIZE
         because the logger is initialized before the settings_service are loaded.
         """
-        self.max: int = 0
-        env_buffer_size = os.getenv("LANGFLOW_LOG_RETRIEVER_BUFFER_SIZE", "0")
-        if env_buffer_size.isdigit():
-            self.max = int(env_buffer_size)
-
         self.buffer: deque = deque()
 
         self._max_readers = max_readers
@@ -105,6 +100,14 @@ class SizedLogBuffer:
             return dict(as_list[-last_idx:])
         finally:
             self._rsemaphore.release()
+
+    @property
+    def max(self) -> int:
+        # Get it dynamically to allow for env variable changes
+        env_buffer_size = os.getenv("LANGFLOW_LOG_RETRIEVER_BUFFER_SIZE", "0")
+        if env_buffer_size.isdigit():
+            return int(env_buffer_size)
+        return 0
 
     def enabled(self) -> bool:
         return self.max > 0

--- a/src/backend/base/langflow/logging/logger.py
+++ b/src/backend/base/langflow/logging/logger.py
@@ -37,6 +37,7 @@ class SizedLogBuffer:
         self._max_readers = max_readers
         self._wlock = Lock()
         self._rsemaphore = Semaphore(max_readers)
+        self._max = 0
 
     def get_write_lock(self) -> Lock:
         return self._wlock
@@ -104,10 +105,15 @@ class SizedLogBuffer:
     @property
     def max(self) -> int:
         # Get it dynamically to allow for env variable changes
-        env_buffer_size = os.getenv("LANGFLOW_LOG_RETRIEVER_BUFFER_SIZE", "0")
-        if env_buffer_size.isdigit():
-            return int(env_buffer_size)
-        return 0
+        if self._max == 0:
+            env_buffer_size = os.getenv("LANGFLOW_LOG_RETRIEVER_BUFFER_SIZE", "0")
+            if env_buffer_size.isdigit():
+                self._max = int(env_buffer_size)
+        return self._max
+
+    @max.setter
+    def max(self, value: int) -> None:
+        self._max = value
 
     def enabled(self) -> bool:
         return self.max > 0


### PR DESCRIPTION
This pull request refactors the logger to dynamically retrieve the maximum buffer size from the environment variable `LANGFLOW_LOG_RETRIEVER_BUFFER_SIZE`. This change allows for more flexibility as the buffer size can now be adjusted without needing to restart the application, improving the overall logging functionality.