### PR TITLE
refactor: remove error handling for Graph loading in starter project setup

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -19,7 +19,6 @@ from langflow.base.constants import (
     NODE_FORMAT_ATTRIBUTES,
     ORJSON_OPTIONS,
 )
-from langflow.graph.graph.base import Graph
 from langflow.services.auth.utils import create_super_user
 from langflow.services.database.models.flow.model import Flow, FlowCreate
 from langflow.services.database.models.folder.model import Folder, FolderCreate
@@ -621,10 +620,6 @@ def create_or_update_starter_projects(all_types_dict: dict) -> None:
                 project_data.copy(), all_types_dict
             )
             updated_project_data = update_edges_with_latest_component_versions(updated_project_data)
-            try:
-                Graph.from_payload(updated_project_data)
-            except Exception:  # noqa: BLE001
-                logger.exception(f"Error loading project {project_name}")
             if updated_project_data != project_data:
                 project_data = updated_project_data
                 # We also need to update the project data in the file


### PR DESCRIPTION
This pull request includes changes to the `src/backend/base/langflow/initial_setup/setup.py` file to remove the `Graph` import and its usage in the `create_or_update_starter_projects` function. These changes simplify the initial setup process by eliminating unnecessary error handling related to `Graph` that caused all projects to be built and slowed startup.

Codebase simplification:

* Removed the import of `Graph` from `langflow.graph.graph.base` as it is no longer used.
* Removed the try-except block that attempted to create a `Graph` from the project data and logged an exception if it failed, simplifying the `create_or_update_starter_projects` function.