### PR TITLE
fix: ParseJSONDataComponent prevent unnecessary array wrapping

### DIFF
--- a/src/backend/base/langflow/components/processing/parse_json_data.py
+++ b/src/backend/base/langflow/components/processing/parse_json_data.py
@@ -36,8 +36,7 @@ class ParseJSONDataComponent(Component):
     ]
 
     outputs = [
-        Output(display_name="Filtered Data",
-               name="filtered_data", method="filter_data"),
+        Output(display_name="Filtered Data", name="filtered_data", method="filter_data"),
     ]
 
     def _parse_data(self, input_value) -> str:

--- a/src/backend/tests/integration/components/helpers/test_parse_json_data.py
+++ b/src/backend/tests/integration/components/helpers/test_parse_json_data.py
@@ -37,7 +37,7 @@ async def test_from_message():
         ParseJSONDataComponent,
         inputs={
             "input_value": ComponentInputHandle(clazz=ChatInput, inputs={}, output_name="message"),
-            "query": ".[0].key",
+            "query": ".key",
         },
         run_input="{'key':'value1'}",
     )
@@ -47,7 +47,7 @@ async def test_from_message():
         ParseJSONDataComponent,
         inputs={
             "input_value": ComponentInputHandle(clazz=ChatInput, inputs={}, output_name="message"),
-            "query": ".[0].key.[0].field2",
+            "query": ".key.[0].field2",
         },
         run_input='{"key":[{"field1": 1, "field2": 2}]}',
     )


### PR DESCRIPTION
Summary: Prevent wrapping non-array inputs in arrays to ensure correct JSON parsing and filtering.

This PR addresses an issue where the ParseJSONDataComponent was always wrapping the input in an array, even if the input was not an array. This caused incorrect JSON parsing and filtering.
Changes
Modified the filter_data method to check if the input is a list before wrapping it.
If the input is not a list, it is processed as a single value.
If the input is a list, each item is processed separately.

Testing:
Run jq query - `.`
- input non array
![image](https://github.com/user-attachments/assets/928d8951-bb59-4ff3-a124-9a333f49432f)

output
![image](https://github.com/user-attachments/assets/84489d09-7fb4-4713-a855-1ffbbe82cd64)

- input array
![image](https://github.com/user-attachments/assets/a27dbcb8-ef30-4cf2-a7b2-388edf4847d3)

output
![image](https://github.com/user-attachments/assets/8896528d-c159-42c0-a078-be06d4dfc3bb)

