### PR TITLE
Bugfix langchain astradb metadata

### DIFF
--- a/src/backend/base/langflow/components/vectorstores/astradb.py
+++ b/src/backend/base/langflow/components/vectorstores/astradb.py
@@ -406,6 +406,11 @@ class AstraVectorStoreComponent(LCVectorStoreComponent):
                 ),
             }
 
+        # Get the indexing parameters, set to None if not provided
+        indexing_include = [s for s in self.metadata_indexing_include if s]
+        if not indexing_include:
+            indexing_include = None
+
         try:
             vector_store = AstraDBVectorStore(
                 collection_name=self.collection_name,
@@ -420,8 +425,8 @@ class AstraVectorStoreComponent(LCVectorStoreComponent):
                 bulk_delete_concurrency=self.bulk_delete_concurrency or None,
                 setup_mode=setup_mode_value,
                 pre_delete_collection=self.pre_delete_collection,
-                metadata_indexing_include=[s for s in self.metadata_indexing_include if s],
-                metadata_indexing_exclude=[s for s in self.metadata_indexing_exclude if s],
+                metadata_indexing_include=[s for s in self.metadata_indexing_include if s] or None,
+                metadata_indexing_exclude=[s for s in self.metadata_indexing_exclude if s] or None,
                 collection_indexing_policy=orjson.dumps(self.collection_indexing_policy)
                 if self.collection_indexing_policy
                 else None,

--- a/src/backend/base/langflow/components/vectorstores/astradb.py
+++ b/src/backend/base/langflow/components/vectorstores/astradb.py
@@ -406,11 +406,6 @@ class AstraVectorStoreComponent(LCVectorStoreComponent):
                 ),
             }
 
-        # Get the indexing parameters, set to None if not provided
-        indexing_include = [s for s in self.metadata_indexing_include if s]
-        if not indexing_include:
-            indexing_include = None
-
         try:
             vector_store = AstraDBVectorStore(
                 collection_name=self.collection_name,


### PR DESCRIPTION
This pull request fixes a bug in the Astra DB component which passes empty lists for the metadata include and exclude parameters, where the underlying `langchain-astradb` code explicitly expects them to be None (and providing empty lists for both results in an error).

```python
        """
        Validate the constructor indexing parameters and normalize them
        into a ready-to-use dict for the 'options' when creating a collection.
        """
        params = [
            metadata_indexing_include,
            metadata_indexing_exclude,
            collection_indexing_policy,
        ]
        if params.count(None) < len(params) - 1:
            msg = (
                "At most one of the parameters `metadata_indexing_include`,"
                " `metadata_indexing_exclude` and `collection_indexing_policy`"
                " can be specified as non null."
            )
            raise ValueError(msg)
```