### PR TITLE
fix: Refactor API key header and remove streaming

### DIFF
--- a/src/frontend/src/modals/apiModal/utils/get-js-api-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-js-api-code.tsx
@@ -26,8 +26,8 @@ export default function getJsApiCode({
     }
 
     async post(endpoint, body, headers = {"Content-Type": "application/json"}) {
-      if (this.apiKey) {
-            headers["Authorization"] = \`Bearer \${this.apiKey}\`;
+        if (this.apiKey) {
+            headers["x-api-key"] = \`\${this.apiKey}\`;
         }
         const url = \`\${this.baseURL}\${endpoint}\`;
         try {
@@ -48,59 +48,22 @@ export default function getJsApiCode({
         }
     }
 
-    async initiateSession(flowId, inputValue, inputType = 'chat', outputType = 'chat', stream = false, tweaks = {}) {
-        const endpoint = \`/api/v1/run/\${flowId}?stream=\${stream}\`;
+    async initiateSession(flowId, inputValue, inputType = 'chat', outputType = 'chat', tweaks = {}) {
+        const endpoint = \`/api/v1/run/\${flowId}\`;
         return this.post(endpoint, { ${activeTweaks ? "" : "input_value: inputValue, "}input_type: inputType, output_type: outputType, tweaks: tweaks });
     }
 
-    async handleStream(streamUrl, onUpdate, onClose, onError) {
-      try {
-        const response = await fetch(streamUrl);
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) {
-            onClose('Stream closed');
-            break;
-          }
-          const chunk = decoder.decode(value);
-          const lines = chunk.split(\'\\n\').filter(line => line.trim() !== '');
-
-          for (const line of lines) {
-            if (line.startsWith('data: ')) {
-              try {
-                const data = JSON.parse(line.slice(6));
-                onUpdate(data);
-              } catch (error) {
-                console.error('Error parsing JSON:', error);
-              }
-            }
-          }
-        }
-      } catch (error) {
-        console.error('Stream Error:', error);
-        onError(error);
-      }
-    }
-
-    async runFlow(flowIdOrName, inputValue, inputType = 'chat', outputType = 'chat', tweaks, stream = false, onUpdate, onClose, onError) {
+    async runFlow(flowIdOrName, inputValue, inputType = 'chat', outputType = 'chat', tweaks, onError) {
         try {
-            const initResponse = await this.initiateSession(flowIdOrName, inputValue, inputType, outputType, stream, tweaks);
-            if (stream && initResponse?.outputs?.[0]?.outputs?.[0]?.artifacts?.stream_url) {
-                const streamUrl = this.baseURL + initResponse.outputs[0].outputs[0].artifacts.stream_url;
-                console.log(\`Streaming from: \${streamUrl}\`);
-                this.handleStream(streamUrl, onUpdate, onClose, onError);
-            }
+            const initResponse = await this.initiateSession(flowIdOrName, inputValue, inputType, outputType, tweaks);
             return initResponse;
         } catch (error) {
-          onError('Error initiating session');
+            onError('Error initiating session');
         }
     }
   }
 
-  async function main(inputValue, inputType = 'chat', outputType = 'chat', stream = false) {
+  async function main(inputValue, inputType = 'chat', outputType = 'chat') {
     const flowIdOrName = '${endpointName || flowId}';
     const langflowClient = new LangflowClient('${window.location.protocol}//${window.location.host}',
           ${isAuth ? "'your-api-key'" : "null"});
@@ -113,13 +76,10 @@ export default function getJsApiCode({
             inputType,
             outputType,
             tweaks,
-            stream,
-            (data) => console.log("Received:", data.chunk), // onUpdate
-            (message) => console.log("Stream Closed:", message), // onClose
-            (error) => console.error("Stream Error:", error) // onError
+            (error) => console.error("Error:", error) // onError
         );
 
-        if (!stream && response) {
+        if (response) {
             const flowOutputs = response.outputs[0];
             const firstComponentOutputs = flowOutputs.outputs[0];
             const output = firstComponentOutputs.outputs.message;
@@ -136,7 +96,6 @@ export default function getJsApiCode({
     args[0], // inputValue
     args[1], // inputType
     args[2], // outputType
-    args[3] === 'true' // streaming
   );
   `;
 }


### PR DESCRIPTION
This pull request refactors the API key header in the `get-js-api-code.tsx` file to use the `x-api-key` header instead of the `Authorization` header. It also removes the streaming functionality from the `initiateSession` and `runFlow` functions. This change improves the code by simplifying the API key handling and removing unnecessary streaming code.