### PR TITLE
fix: correct issue with Milvus field name, renamed connection password to Token

### DIFF
--- a/src/backend/base/langflow/components/vectorstores/milvus.py
+++ b/src/backend/base/langflow/components/vectorstores/milvus.py
@@ -34,9 +34,9 @@ class MilvusVectorStoreComponent(LCVectorStoreComponent):
         ),
         SecretStrInput(
             name="password",
-            display_name="Connection Password",
+            display_name="Token",
             value="",
-            info="Ignore this field if no password is required to make connection.",
+            info="Ignore this field if no token is required to make connection.",
         ),
         DictInput(name="connection_args", display_name="Other Connection Arguments", advanced=True),
         StrInput(name="primary_field", display_name="Primary Field Name", value="pk"),


### PR DESCRIPTION
Hi, I have renamed the displayed name of field from Connection Password to Token, which is what it is usally refered to as. Nothing else has been changed, please check!