### PR TITLE
fix: component-set-handle-list-tools

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, get_type_hints
 
 import nanoid
 import yaml
+from langchain_core.tools import StructuredTool
 from pydantic import BaseModel, ValidationError
 
 from langflow.base.tools.constants import TOOL_OUTPUT_DISPLAY_NAME, TOOL_OUTPUT_NAME
@@ -494,7 +495,7 @@ class Component(CustomComponent):
         # if value is a list of components, we need to process each component
         # Note this update make sure it is not a list str | int | float | bool | type(None)
         if isinstance(value, list) and not any(
-            isinstance(val, str | int | float | bool | type(None) | Message | Data) for val in value
+            isinstance(val, str | int | float | bool | type(None) | Message | Data | StructuredTool) for val in value
         ):
             for val in value:
                 self._process_connection_or_parameter(key, val)

--- a/src/backend/tests/unit/components/agents/test_agent_component.py
+++ b/src/backend/tests/unit/components/agents/test_agent_component.py
@@ -24,5 +24,5 @@ async def test_agent_component_with_calculator():
         temperature=temperature,
     )
 
-    response = await agent.get_response()
+    response = await agent.message_response()
     assert "4" in response.data.get("text")


### PR DESCRIPTION
I added a StructuredTool to define the set function in the component. This change resolved an error that occurred when the list of tools was set by the component. In the future, we may need to add tests to manage unexpected situations in the component's set function.

I also updated the pytest related to Agent which had the wrong function of getting the response.


---------
This pull request includes changes to the `src/backend/base/langflow/custom/custom_component/component.py` and `src/backend/tests/unit/components/agents/test_agent_component.py` files to enhance functionality and improve the testing process.

### Enhancements to functionality:

* [`src/backend/base/langflow/custom/custom_component/component.py`](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169R13): Imported `StructuredTool` from `langchain_core.tools` to expand the types of tools that can be processed.
* [`src/backend/base/langflow/custom/custom_component/component.py`](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169L497-R498): Updated the `_process_connection_or_parameters` method to include `StructuredTool` in the list of valid types for processing components.

### Improvements to testing:

* [`src/backend/tests/unit/components/agents/test_agent_component.py`](diffhunk://#diff-d7de28e9622e36e9ba3e7a4e04816eadbdd69464b0a58af3ea5be4b187d70b74L27-R27): Modified the `test_agent_component_with_calculator` function to use `message_response` instead of `get_response` for better accuracy in testing agent responses.