### PR TITLE
ci: stop backend unit tests on first failure

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           timeout_minutes: 12
           max_attempts: 2
-          command: make unit_tests async=false args="--splits ${{ matrix.splitCount }} --group ${{ matrix.group }}"
+          command: make unit_tests async=false args="-x --splits ${{ matrix.splitCount }} --group ${{ matrix.group }}"
       - name: Minimize uv cache
         run: uv cache prune --ci
   integration-tests:


### PR DESCRIPTION
This change modifies the CI configuration to stop backend unit tests on the first failure. By doing this, we can save time and resources in the CI pipeline, as tests won’t continue to run after a failure is detected. This should speed up feedback loops and reduce unnecessary processing.

reference: https://docs.pytest.org/en/stable/how-to/failures.html