### PR TITLE
ci: Add temporary database setup for performance tests

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -2,9 +2,15 @@ name: Run benchmarks
 
 on:
   push:
+    paths:
+      - "src/backend/base/**"
+      - "src/backend/tests/performance/**"
     branches:
       - "main" # or "master"
   pull_request:
+    paths:
+      - "src/backend/base/**"
+      - "src/backend/tests/performance/**"
   workflow_dispatch:
 
 jobs:

--- a/src/backend/tests/performance/test_server_init.py
+++ b/src/backend/tests/performance/test_server_init.py
@@ -4,12 +4,29 @@ import pytest
 from langflow.services.deps import get_settings_service
 
 
+@pytest.fixture(autouse=True)
+def setup_database_url(tmp_path, monkeypatch):
+    """Setup a temporary database URL for testing."""
+    db_path = tmp_path / "test_performance.db"
+    original_value = monkeypatch.delenv("LANGFLOW_DATABASE_URL", raising=False)
+    test_db_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("LANGFLOW_DATABASE_URL", test_db_url)
+    yield
+    # Restore original value if it existed
+    if original_value is not None:
+        monkeypatch.setenv("LANGFLOW_DATABASE_URL", original_value)
+    else:
+        monkeypatch.delenv("LANGFLOW_DATABASE_URL", raising=False)
+
+
 @pytest.mark.benchmark
 async def test_initialize_services():
     """Benchmark the initialization of services."""
     from langflow.services.utils import initialize_services
 
     await asyncio.to_thread(initialize_services, fix_migration=False)
+    settings_service = await asyncio.to_thread(get_settings_service)
+    assert "test_performance.db" in settings_service.settings.database_url
 
 
 @pytest.mark.benchmark
@@ -18,6 +35,8 @@ async def test_setup_llm_caching():
     from langflow.interface.utils import setup_llm_caching
 
     await asyncio.to_thread(setup_llm_caching)
+    settings_service = await asyncio.to_thread(get_settings_service)
+    assert "test_performance.db" in settings_service.settings.database_url
 
 
 @pytest.mark.benchmark
@@ -28,6 +47,8 @@ async def test_initialize_super_user():
 
     await asyncio.to_thread(initialize_services, fix_migration=False)
     await asyncio.to_thread(initialize_super_user_if_needed)
+    settings_service = await asyncio.to_thread(get_settings_service)
+    assert "test_performance.db" in settings_service.settings.database_url
 
 
 @pytest.mark.benchmark
@@ -38,6 +59,7 @@ async def test_get_and_cache_all_types_dict():
     settings_service = await asyncio.to_thread(get_settings_service)
     result = await asyncio.to_thread(get_and_cache_all_types_dict, settings_service)
     assert result is not None
+    assert "test_performance.db" in settings_service.settings.database_url
 
 
 @pytest.mark.benchmark
@@ -51,6 +73,7 @@ async def test_create_starter_projects():
     settings_service = await asyncio.to_thread(get_settings_service)
     types_dict = await get_and_cache_all_types_dict(settings_service)
     await asyncio.to_thread(create_or_update_starter_projects, types_dict)
+    assert "test_performance.db" in settings_service.settings.database_url
 
 
 @pytest.mark.benchmark
@@ -59,3 +82,5 @@ async def test_load_flows():
     from langflow.initial_setup.setup import load_flows_from_directory
 
     await asyncio.to_thread(load_flows_from_directory)
+    settings_service = await asyncio.to_thread(get_settings_service)
+    assert "test_performance.db" in settings_service.settings.database_url

--- a/src/backend/tests/unit/custom/custom_component/test_component_events.py
+++ b/src/backend/tests/unit/custom/custom_component/test_component_events.py
@@ -188,7 +188,7 @@ async def test_component_logging():
     assert event_id.startswith("info-")
 
 
-@pytest.mark.asyncio
+@pytest.mark.usefixtures("client")
 async def test_component_streaming_message():
     """Test component's streaming message functionality."""
     queue = await create_event_queue()

--- a/src/backend/tests/unit/custom/custom_component/test_component_events.py
+++ b/src/backend/tests/unit/custom/custom_component/test_component_events.py
@@ -60,6 +60,7 @@ async def test_component_message_sending():
     assert isinstance(sent_message.content_blocks[0].contents[0], TextContent)
 
 
+@pytest.mark.usefixtures("client")
 async def test_component_tool_output():
     """Test component's tool output functionality."""
     # Create event queue and manager
@@ -92,6 +93,7 @@ async def test_component_tool_output():
     assert isinstance(sent_message.content_blocks[0].contents[0], ToolContent)
 
 
+@pytest.mark.usefixtures("client")
 async def test_component_error_handling():
     """Test component's error handling."""
     # Create event queue and manager
@@ -123,6 +125,7 @@ async def test_component_error_handling():
     assert "Test error" in str(sent_message.text)
 
 
+@pytest.mark.usefixtures("client")
 async def test_component_build_results():
     """Test component's build_results functionality."""
     # Create event queue and manager
@@ -154,6 +157,7 @@ async def test_component_build_results():
     assert artifacts["text_output"]["type"] == "text"
 
 
+@pytest.mark.usefixtures("client")
 async def test_component_logging():
     """Test component's logging functionality."""
     # Create event queue and manager


### PR DESCRIPTION
This pull request introduces a temporary database setup for performance tests by creating a fixture that sets a test database URL. The fixture ensures that the original database URL is restored after the tests are completed. Additionally, assertions have been added to various performance tests to verify that the temporary database URL is being used during the tests. This change enhances the reliability of performance testing by isolating the test environment.