### PR TITLE
fix: refactor sidebar disposition for sidebar to not push main out of screen

### DIFF
--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -169,7 +169,7 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
           <div className="flex h-full overflow-hidden">
             <SidebarProvider width="17.5rem" defaultOpen={!isMobile}>
               {!view && <FlowSidebarComponent />}
-              <main className="flex flex-1">
+              <main className="flex w-full overflow-hidden">
                 <div className="h-full w-full">
                   <Page />
                 </div>

--- a/src/frontend/src/pages/MainPage/pages/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/index.tsx
@@ -72,7 +72,7 @@ export default function CollectionPage(): JSX.Element {
             }}
           />
         )}
-      <main className="flex flex-1">
+      <main className="flex w-full overflow-hidden">
         {flows && examples && folders ? (
           <div className={`relative mx-auto h-full w-full overflow-y-scroll`}>
             <CardsWrapComponent


### PR DESCRIPTION
This pull request includes updates to improve the layout and overflow handling of the `FlowPage` and `CollectionPage` components in the frontend codebase.

Layout and overflow improvements:

* [`src/frontend/src/pages/FlowPage/index.tsx`](diffhunk://#diff-37a243d7fe9faf77fead8ea245d2884933fc5373bb9b4200371887aa989e21feL172-R172): Updated the `main` element to use `w-full` and `overflow-hidden` classes to better handle overflow and ensure the main content occupies the full width.
* [`src/frontend/src/pages/MainPage/pages/index.tsx`](diffhunk://#diff-1298711fb00b5357b2e39b6bab21791701b73458092407d6732e0dd28ae49475L75-R75): Similarly updated the `main` element to use `w-full` and `overflow-hidden` classes to improve layout consistency and overflow handling.