### PR TITLE
fix: Enhance extract_class_name function to identify Component subclasses

### DIFF
--- a/src/backend/base/langflow/utils/validate.py
+++ b/src/backend/base/langflow/utils/validate.py
@@ -345,6 +345,7 @@ def extract_class_name(code: str) -> str:
                 continue
 
             # Check bases for Component inheritance
+            # TODO: Build a more robust check for Component inheritance
             for base in node.bases:
                 if isinstance(base, ast.Name) and any(pattern in base.id for pattern in ["Component", "LC"]):
                     return node.name

--- a/src/backend/base/langflow/utils/validate.py
+++ b/src/backend/base/langflow/utils/validate.py
@@ -351,7 +351,7 @@ def extract_class_name(code: str) -> str:
                     return node.name
 
         msg = f"No Component subclass found in the code string. Code snippet: {code[:100]}"
-        raise ValueError(msg)
+        raise TypeError(msg)
     except SyntaxError as e:
         msg = f"Invalid Python code: {e!s}"
         raise ValueError(msg) from e

--- a/src/backend/base/langflow/utils/validate.py
+++ b/src/backend/base/langflow/utils/validate.py
@@ -326,10 +326,31 @@ def extract_function_name(code):
     raise ValueError(msg)
 
 
-def extract_class_name(code):
-    module = ast.parse(code)
-    for node in module.body:
-        if isinstance(node, ast.ClassDef):
-            return node.name
-    msg = f"No class definition found in the code string. Code snippet: {code[:100]}"
-    raise ValueError(msg)
+def extract_class_name(code: str) -> str:
+    """Extract the name of the first Component subclass found in the code.
+
+    Args:
+        code (str): The source code to parse
+
+    Returns:
+        str: Name of the first Component subclass found
+
+    Raises:
+        ValueError: If no Component subclass is found in the code
+    """
+    try:
+        module = ast.parse(code)
+        for node in module.body:
+            if not isinstance(node, ast.ClassDef):
+                continue
+
+            # Check bases for Component inheritance
+            for base in node.bases:
+                if isinstance(base, ast.Name) and any(pattern in base.id for pattern in ["Component", "LC"]):
+                    return node.name
+
+        msg = f"No Component subclass found in the code string. Code snippet: {code[:100]}"
+        raise ValueError(msg)
+    except SyntaxError as e:
+        msg = f"Invalid Python code: {e!s}"
+        raise ValueError(msg) from e


### PR DESCRIPTION
This pull request includes improvements to the `extract_class_name` function in the `src/backend/base/langflow/utils/validate.py` file. The changes enhance the function's robustness and readability by adding type annotations, a detailed docstring, and additional error handling.

Improvements to `extract_class_name` function:

* Added type annotations to specify that the `code` parameter is a string and the function returns a string.
* Included a detailed docstring that describes the function's purpose, arguments, return value, and potential exceptions.
* Enhanced error handling by adding a `try-except` block to catch `SyntaxError` exceptions and raise a `ValueError` with a descriptive message.
* Improved the logic for checking class inheritance by iterating through the `bases` of class definitions and checking for inheritance from `Component` or `LC`. This can be improved to a more generic solution but it fixes the problem for now