### PR TITLE
chore: Add 'lf' and 'ff' options to Makefile for pytest configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ open_browser ?= true
 path = src/backend/base/langflow/frontend
 workers ?= 1
 async ?= true
+lf ?= false
+ff ?= true
 all: help
 
 ######################
@@ -130,26 +132,20 @@ endif
 coverage: ## run the tests and generate a coverage report
 	@uv run coverage run
 	@uv run coverage erase
-	#@poetry run coverage run
-	#@poetry run coverage erase
 
 unit_tests: ## run unit tests
 	@uv sync --extra dev --frozen
-ifeq ($(async), true)
-	uv run pytest src/backend/tests \
-		--ignore=src/backend/tests/integration \
-		--instafail -n auto -ra -m "not api_key_required" \
-		--durations-path src/backend/tests/.test_durations \
-		--splitting-algorithm least_duration \
-		$(args)
-else
-	uv run pytest src/backend/tests \
-		--ignore=src/backend/tests/integration \
-		--instafail -ra -m "not api_key_required" \
-		--durations-path src/backend/tests/.test_durations \
-		--splitting-algorithm least_duration \
-		$(args)
-endif
+	@EXTRA_ARGS=""
+	@if [ "$(async)" = "true" ]; then \
+		EXTRA_ARGS="$$EXTRA_ARGS --instafail -n auto"; \
+	fi; \
+	if [ "$(lf)" = "true" ]; then \
+		EXTRA_ARGS="$$EXTRA_ARGS --lf"; \
+	fi; \
+	if [ "$(ff)" = "true" ]; then \
+		EXTRA_ARGS="$$EXTRA_ARGS --ff"; \
+	fi; \
+	uv run pytest src/backend/tests --ignore=src/backend/tests/integration $$EXTRA_ARGS --instafail -ra -m 'not api_key_required' --durations-path src/backend/tests/.test_durations --splitting-algorithm least_duration $(args)
 
 unit_tests_looponfail:
 	@make unit_tests args="-f"


### PR DESCRIPTION
This pull request includes updates to the `Makefile` to enhance the flexibility and functionality of running unit tests. The most important changes include the addition of new flags for controlling test execution and the simplification of conditional logic for running tests.

Enhancements to test execution:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R22-R23): Added new flags `lf` and `ff` to control the behavior of the `pytest` command, allowing tests to run with the `--lf` (last-failed) and `--ff` (failed-first) options.

Simplification of conditional logic:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L133-R148): Simplified the conditional logic for running unit tests by consolidating the `pytest` command into a single block with dynamically constructed arguments based on the values of `async`, `lf`, and `ff`.