### PR TITLE
fix: prevent nested scrolling in markdown code blocks

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx
@@ -149,7 +149,7 @@ export default function NodeDescription({
             <Markdown
               linkTarget="_blank"
               className={cn(
-                "markdown prose flex h-full w-full flex-col text-[13px] leading-5 word-break-break-word",
+                "markdown nowheel prose flex h-full w-full flex-col text-[13px] leading-5 word-break-break-word",
                 mdClassName,
               )}
             >


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx` file. The change adds the `nowheel` class to the `Markdown` component's className property to modify its styling.