### PR TITLE
fix: update SignUpPage component styling to use full screen height

### DIFF
--- a/src/frontend/src/pages/SignUpPage/index.tsx
+++ b/src/frontend/src/pages/SignUpPage/index.tsx
@@ -85,7 +85,7 @@ export default function SignUp(): JSX.Element {
         const data = Object.fromEntries(new FormData(event.currentTarget));
         event.preventDefault();
       }}
-      className="h-full w-full"
+      className="h-screen w-full"
     >
       <div className="flex h-full w-full flex-col items-center justify-center bg-muted">
         <div className="flex w-72 flex-col items-center justify-center gap-2">


### PR DESCRIPTION
Update the styling of the SignUpPage component to use the full screen height instead of a fixed height. This ensures that the page takes up the entire screen on all devices.