### PR TITLE
feat: Add option to deactivate tracing in service settings

### DIFF
--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -171,6 +171,8 @@ class Settings(BaseSettings):
     """The maximum number of retries for the health check."""
     max_file_size_upload: int = 100
     """The maximum file size for the upload in MB."""
+    deactivate_tracing: bool = False
+    """If set to True, tracing will be deactivated."""
 
     @field_validator("dev")
     @classmethod

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -277,6 +277,13 @@ def json_memory_chatbot_no_llm():
     return pytest.MEMORY_CHATBOT_NO_LLM.read_text(encoding="utf-8")
 
 
+@pytest.fixture(autouse=True)
+def deactivate_tracing(monkeypatch):
+    monkeypatch.setenv("LANGFLOW_DEACTIVATE_TRACING", "true")
+    yield
+    monkeypatch.undo()
+
+
 @pytest.fixture(name="client")
 async def client_fixture(
     session: Session,  # noqa: ARG001


### PR DESCRIPTION
This pull request introduces a new setting to deactivate tracing within the service settings, allowing for more flexible testing and configuration. Additionally, a fixture has been added to automatically deactivate tracing in tests using monkeypatch, ensuring that tracing does not interfere with test outcomes.