### PR TITLE
fix: added model utils to get the model name

### DIFF
--- a/src/backend/base/langflow/base/models/model_utils.py
+++ b/src/backend/base/langflow/base/models/model_utils.py
@@ -5,6 +5,4 @@ def get_model_name(llm, display_name: str | None = "Custom"):
     model_name = next((getattr(llm, attr) for attr in attributes_to_check if hasattr(llm, attr)), None)
 
     # If no matching attribute is found, return the class name as a fallback
-    return (
-        model_name if display_name is None else (display_name if model_name is None else f"{display_name} {model_name}")
-    )
+    return model_name if model_name is not None else display_name

--- a/src/backend/base/langflow/base/models/model_utils.py
+++ b/src/backend/base/langflow/base/models/model_utils.py
@@ -1,0 +1,8 @@
+def get_model_name(llm):
+    attributes_to_check = ["model_name", "model", "model_id", "deployment_name"]
+
+    # Use a generator expression with next() to find the first matching attribute
+    model_name = next((getattr(llm, attr) for attr in attributes_to_check if hasattr(llm, attr)), None)
+
+    # If no matching attribute is found, return the class name as a fallback
+    return model_name if model_name is not None else llm.__class__.__name__

--- a/src/backend/base/langflow/base/models/model_utils.py
+++ b/src/backend/base/langflow/base/models/model_utils.py
@@ -1,8 +1,10 @@
-def get_model_name(llm):
+def get_model_name(llm, display_name: str | None = "Custom"):
     attributes_to_check = ["model_name", "model", "model_id", "deployment_name"]
 
     # Use a generator expression with next() to find the first matching attribute
     model_name = next((getattr(llm, attr) for attr in attributes_to_check if hasattr(llm, attr)), None)
 
     # If no matching attribute is found, return the class name as a fallback
-    return model_name if model_name is not None else llm.__class__.__name__
+    return (
+        model_name if display_name is None else (display_name if model_name is None else f"{display_name} {model_name}")
+    )

--- a/src/backend/base/langflow/components/agents/agent.py
+++ b/src/backend/base/langflow/components/agents/agent.py
@@ -56,8 +56,8 @@ class AgentComponent(ToolCallingAgentComponent):
     outputs = [Output(name="response", display_name="Response", method="message_response")]
 
     async def message_response(self) -> Message:
-        llm_model = self.get_llm()
-        self.model_name = get_model_name(llm_model)
+        llm_model, display_name = self.get_llm()
+        self.model_name = get_model_name(llm_model, display_name=display_name)
         if llm_model is None:
             msg = "No language model selected"
             raise ValueError(msg)
@@ -100,13 +100,14 @@ class AgentComponent(ToolCallingAgentComponent):
                 provider_info = MODEL_PROVIDERS_DICT.get(self.agent_llm)
                 if provider_info:
                     component_class = provider_info.get("component_class")
+                    display_name = component_class.display_name
                     inputs = provider_info.get("inputs")
                     prefix = provider_info.get("prefix", "")
-                    return self._build_llm_model(component_class, inputs, prefix)
+                    return self._build_llm_model(component_class, inputs, prefix), display_name
             except Exception as e:
                 msg = f"Error building {self.agent_llm} language model"
                 raise ValueError(msg) from e
-        return self.agent_llm
+        return self.agent_llm, None
 
     def _build_llm_model(self, component, inputs, prefix=""):
         model_kwargs = {input_.name: getattr(self, f"{prefix}{input_.name}") for input_ in inputs}

--- a/src/backend/base/langflow/components/agents/agent.py
+++ b/src/backend/base/langflow/components/agents/agent.py
@@ -2,6 +2,7 @@ from langchain_core.tools import StructuredTool
 
 from langflow.base.agents.agent import LCToolsAgentComponent
 from langflow.base.models.model_input_constants import ALL_PROVIDER_FIELDS, MODEL_PROVIDERS_DICT
+from langflow.base.models.model_utils import get_model_name
 from langflow.components.helpers import CurrentDateComponent
 from langflow.components.langchain_utilities.tool_calling import ToolCallingAgentComponent
 from langflow.components.memories.memory import MemoryComponent
@@ -56,6 +57,7 @@ class AgentComponent(ToolCallingAgentComponent):
 
     async def message_response(self) -> Message:
         llm_model = self.get_llm()
+        self.model_name = get_model_name(llm_model)
         if llm_model is None:
             msg = "No language model selected"
             raise ValueError(msg)


### PR DESCRIPTION
This pull request introduces a new utility function to extract the model name from a language model object and integrates this function into the agent component to enhance model handling.

Key changes include:

### New Utility Function:

* [`src/backend/base/langflow/base/models/model_utils.py`](diffhunk://#diff-3993cb22ffb3b497c82a36c953b945c89c6fffb36f90c33e635bbe18b9afdba8R1-R8): Added a `get_model_name` function to extract the model name from a language model object by checking for various attributes or falling back to the class name.

### Integration of Utility Function:

* [`src/backend/base/langflow/components/agents/agent.py`](diffhunk://#diff-b6bc6deb80f602f04a7fac26a6a51437042fbf4f791a9e35ac38bb204f846496R5): Imported the `get_model_name` function.
* [`src/backend/base/langflow/components/agents/agent.py`](diffhunk://#diff-b6bc6deb80f602f04a7fac26a6a51437042fbf4f791a9e35ac38bb204f846496R60): Updated the `message_response` method in the `AgentComponent` class to use the `get_model_name` function to set the model name.