### PR TITLE
fix: ContentBlockDisplay styling for block titles

### DIFF
--- a/src/frontend/src/components/chatComponents/ContentBlockDisplay.tsx
+++ b/src/frontend/src/components/chatComponents/ContentBlockDisplay.tsx
@@ -147,7 +147,7 @@ export function ContentBlockDisplay({
                   )}
                 >
                   <AnimatePresence>
-                    {!showBlockTitle && (
+                    {showBlockTitle && (
                       <motion.div
                         initial={{ opacity: 0, height: 0, marginBottom: 0 }}
                         animate={{

--- a/src/frontend/src/components/chatComponents/ContentBlockDisplay.tsx
+++ b/src/frontend/src/components/chatComponents/ContentBlockDisplay.tsx
@@ -157,7 +157,7 @@ export function ContentBlockDisplay({
                         }}
                         exit={{ opacity: 0, height: 0, marginBottom: 0 }}
                         transition={{ duration: 0.2 }}
-                        className="overflow-hidden font-medium pl-4 pt-[16px]"
+                        className="overflow-hidden pl-4 pt-[16px] font-medium"
                       >
                         <Markdown
                           className="text-[14px] font-semibold text-foreground"

--- a/src/frontend/src/components/chatComponents/ContentBlockDisplay.tsx
+++ b/src/frontend/src/components/chatComponents/ContentBlockDisplay.tsx
@@ -147,7 +147,7 @@ export function ContentBlockDisplay({
                   )}
                 >
                   <AnimatePresence>
-                    {showBlockTitle && (
+                    {!showBlockTitle && (
                       <motion.div
                         initial={{ opacity: 0, height: 0, marginBottom: 0 }}
                         animate={{
@@ -157,7 +157,7 @@ export function ContentBlockDisplay({
                         }}
                         exit={{ opacity: 0, height: 0, marginBottom: 0 }}
                         transition={{ duration: 0.2 }}
-                        className="overflow-hidden font-medium"
+                        className="overflow-hidden font-medium pl-4 pt-[16px]"
                       >
                         <Markdown
                           className="text-[14px] font-semibold text-foreground"


### PR DESCRIPTION
This PR fixes the issue with the ContentBlockDisplay component not displaying block titles correctly. The commit removes the reverse bug logic in the playground and updates the conditional rendering logic for the block title in ContentBlockDisplay. It also adjusts the styling to ensure proper alignment and spacing. Ref: #4533.