### PR TITLE
ci: Add concurrency control to Run benchmarks workflow

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -13,6 +13,10 @@ on:
       - "src/backend/tests/performance/**"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codspeed:
     name: Run benchmarks


### PR DESCRIPTION
This PR introduces concurrency control to the Run benchmarks workflow by adding a configuration that cancels in-progress runs. This enhancement ensures that only the latest workflow run is executed, improving resource management and efficiency during concurrent executions.