### PR TITLE
fix: Pass the OpenAI API Key to Crew()

### DIFF
--- a/src/backend/base/langflow/components/crewai/hierarchical_crew.py
+++ b/src/backend/base/langflow/components/crewai/hierarchical_crew.py
@@ -1,7 +1,9 @@
+import os
+
 from crewai import Crew, Process
 
 from langflow.base.agents.crewai.crew import BaseCrewComponent
-from langflow.io import HandleInput
+from langflow.io import HandleInput, SecretStrInput
 
 
 class HierarchicalCrewComponent(BaseCrewComponent):
@@ -18,10 +20,21 @@ class HierarchicalCrewComponent(BaseCrewComponent):
         HandleInput(name="tasks", display_name="Tasks", input_types=["HierarchicalTask"], is_list=True),
         HandleInput(name="manager_llm", display_name="Manager LLM", input_types=["LanguageModel"], required=False),
         HandleInput(name="manager_agent", display_name="Manager Agent", input_types=["Agent"], required=False),
+        SecretStrInput(
+            name="openai_api_key",
+            display_name="OpenAI API Key",
+            info="The OpenAI API Key to use for the OpenAI model.",
+            value="OPENAI_API_KEY",
+        ),
     ]
 
     def build_crew(self) -> Crew:
         tasks, agents = self.get_tasks_and_agents()
+
+        # Set the OpenAI API Key
+        if self.openai_api_key:
+            os.environ["OPENAI_API_KEY"] = self.openai_api_key
+
         return Crew(
             agents=agents,
             tasks=tasks,


### PR DESCRIPTION
This pull requests sets the OpenAI API Key as an environment variable and adds a new input to provide it in the hierarchical crew component