### PR TITLE
fix: aws components and model lists

### DIFF
--- a/src/backend/base/langflow/base/models/aws_constants.py
+++ b/src/backend/base/langflow/base/models/aws_constants.py
@@ -1,35 +1,57 @@
 AWS_MODEL_IDs = [
+    # Amazon Titan Models
     "amazon.titan-text-express-v1",
     "amazon.titan-text-lite-v1",
     "amazon.titan-text-premier-v1:0",
-    "amazon.titan-embed-text-v1",
-    "amazon.titan-embed-text-v2:0",
-    "amazon.titan-embed-image-v1",
-    "amazon.titan-image-generator-v1",
+    # Anthropic Models
     "anthropic.claude-v2",
     "anthropic.claude-v2:1",
     "anthropic.claude-3-sonnet-20240229-v1:0",
+    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
     "anthropic.claude-3-haiku-20240307-v1:0",
+    "anthropic.claude-3-5-haiku-20241022-v1:0",
     "anthropic.claude-3-opus-20240229-v1:0",
     "anthropic.claude-instant-v1",
+    # AI21 Labs Models
+    "ai21.jamba-instruct-v1:0",
     "ai21.j2-mid-v1",
     "ai21.j2-ultra-v1",
+    "ai21.jamba-1-5-large-v1:0",
+    "ai21.jamba-1-5-mini-v1:0",
+    # Cohere Models
     "cohere.command-text-v14",
     "cohere.command-light-text-v14",
     "cohere.command-r-v1:0",
     "cohere.command-r-plus-v1:0",
-    "cohere.embed-english-v3",
-    "cohere.embed-multilingual-v3",
+    # Meta Models
     "meta.llama2-13b-chat-v1",
     "meta.llama2-70b-chat-v1",
     "meta.llama3-8b-instruct-v1:0",
     "meta.llama3-70b-instruct-v1:0",
+    "meta.llama3-1-8b-instruct-v1:0",
+    "meta.llama3-1-70b-instruct-v1:0",
+    "meta.llama3-1-405b-instruct-v1:0",
+    "meta.llama3-2-1b-instruct-v1:0",
+    "meta.llama3-2-3b-instruct-v1:0",
+    "meta.llama3-2-11b-instruct-v1:0",
+    "meta.llama3-2-90b-instruct-v1:0",
+    # Mistral AI Models
     "mistral.mistral-7b-instruct-v0:2",
     "mistral.mixtral-8x7b-instruct-v0:1",
     "mistral.mistral-large-2402-v1:0",
+    "mistral.mistral-large-2407-v1:0",
     "mistral.mistral-small-2402-v1:0",
-    "stability.stable-diffusion-xl-v0",
-    "stability.stable-diffusion-xl-v1",
+]
+
+AWS_EMBEDDING_MODEL_IDS = [
+    # Amazon Titan Embedding Models
+    "amazon.titan-embed-text-v1",
+    "amazon.titan-embed-text-v2:0",
+    "amazon.titan-embed-image-v1",
+    # Cohere Embedding Models
+    "cohere.embed-english-v3",
+    "cohere.embed-multilingual-v3",
 ]
 
 AWS_REGIONS = [

--- a/src/backend/base/langflow/base/models/aws_constants.py
+++ b/src/backend/base/langflow/base/models/aws_constants.py
@@ -48,7 +48,6 @@ AWS_EMBEDDING_MODEL_IDS = [
     # Amazon Titan Embedding Models
     "amazon.titan-embed-text-v1",
     "amazon.titan-embed-text-v2:0",
-    "amazon.titan-embed-image-v1",
     # Cohere Embedding Models
     "cohere.embed-english-v3",
     "cohere.embed-multilingual-v3",

--- a/src/backend/base/langflow/components/embeddings/amazon_bedrock.py
+++ b/src/backend/base/langflow/components/embeddings/amazon_bedrock.py
@@ -1,4 +1,4 @@
-from langflow.base.models.aws_constants import AWS_REGIONS
+from langflow.base.models.aws_constants import AWS_EMBEDDING_MODEL_IDS, AWS_REGIONS
 from langflow.base.models.model import LCModelComponent
 from langflow.field_typing import Embeddings
 from langflow.inputs import SecretStrInput
@@ -15,7 +15,7 @@ class AmazonBedrockEmbeddingsComponent(LCModelComponent):
         DropdownInput(
             name="model_id",
             display_name="Model Id",
-            options=["amazon.titan-embed-text-v1"],
+            options=AWS_EMBEDDING_MODEL_IDS,
             value="amazon.titan-embed-text-v1",
         ),
         SecretStrInput(


### PR DESCRIPTION
This pull request includes updates to the AWS model IDs and the `AmazonBedrockEmbeddingsComponent` class to enhance the organization and functionality of the codebase. The most important changes include the addition of new model IDs, the removal of certain models, and the introduction of a new constant for embedding model IDs.

Updates to AWS model IDs:

* [`src/backend/base/langflow/base/models/aws_constants.py`](diffhunk://#diff-6904bd334c473029f81cec383046983131b3124b1652a6ef4a78a89a57dfca1cR2-R53): Added new model IDs for Amazon Titan, Anthropic, AI21 Labs, Cohere, Meta, and Mistral AI models. Removed certain model IDs and created a new constant `AWS_EMBEDDING_MODEL_IDS` for embedding models.

Enhancements to AmazonBedrockEmbeddingsComponent:

* [`src/backend/base/langflow/components/embeddings/amazon_bedrock.py`](diffhunk://#diff-910cdb375e26f702f43377e35a9aff7ccc9cba797b6509f4e777a4140cbc5a3dL1-R1): Updated import statements to include `AWS_EMBEDDING_MODEL_IDS`.
* [`src/backend/base/langflow/components/embeddings/amazon_bedrock.py`](diffhunk://#diff-910cdb375e26f702f43377e35a9aff7ccc9cba797b6509f4e777a4140cbc5a3dL18-R18): Modified the `DropdownInput` options for `model_id` to use `AWS_EMBEDDING_MODEL_IDS` instead of hardcoding the options.