### PR TITLE
refactor(NodeToolbar): Remove open prop from Select component

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -554,7 +554,6 @@ export default function NodeToolbarComponent({
           onValueChange={handleSelectChange}
           value={selectedValue!}
           onOpenChange={handleOpenChange}
-          open
         >
           <SelectTrigger ref={selectTriggerRef} className="w-62">
             <></>


### PR DESCRIPTION
This pull request includes a small change to the `NodeToolbarComponent` in `src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx`. The change removes the `open` prop from the `Select` component to potentially manage the component's open state differently.

* [`src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx`](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL557): Removed the `open` prop from the `Select` component.