### PR TITLE
ci: Limit workflows to Python files and optimize environment setup

### DIFF
--- a/.github/workflows/py_autofix.yml
+++ b/.github/workflows/py_autofix.yml
@@ -2,9 +2,7 @@ name: autofix.ci
 on:
   pull_request:
     paths:
-      - "poetry.lock"
-      - "pyproject.toml"
-      - "src/backend/**"
+      - "**/*.py"
 env:
   POETRY_VERSION: "1.8.2"
 
@@ -14,7 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: install-pinned/ruff@9ebc31a5721a0fb034f915e4bbcb2ee6feeaecbc
-      - run: ruff check --fix-only .
-      - run: ruff format .
+      - name: "Setup Environment"
+        uses: ./.github/actions/setup-uv
+      - run: uv run ruff check --fix-only .
+      - run: uv run ruff format .
       - uses: autofix-ci/action@dd55f44df8f7cdb7a6bf74c78677eb8acd40cd0a
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/style-check-py.yml
+++ b/.github/workflows/style-check-py.yml
@@ -3,6 +3,8 @@ name: Ruff Style Check
 on:
   pull_request:
     types: [opened, synchronize, reopened, auto_merge_enabled]
+    paths:
+      - "**/*.py"
 
 
 


### PR DESCRIPTION
This pull request refines the CI workflows by limiting the style check and autofix processes to Python files only. Additionally, it optimizes the environment setup for the autofix workflow, improving efficiency and reducing unnecessary checks on non-Python files.