### PR TITLE
chore: Bump version to 1.1.0 and 0.1.0 for langflow and langflow-base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = ["src/backend/langflow"]
 
 [project]
 name = "langflow"
-version = "1.0.19.post2"
+version = "1.1.0"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.13"
 license = "MIT"

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -86,7 +86,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langflow-base"
-version = "0.0.97"
+version = "0.1.0"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.13"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3599,7 +3599,7 @@ wheels = [
 
 [[package]]
 name = "langflow"
-version = "1.0.19.post2"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "assemblyai" },
@@ -3875,7 +3875,7 @@ dev = [
 
 [[package]]
 name = "langflow-base"
-version = "0.0.97"
+version = "0.1.0"
 source = { editable = "src/backend/base" }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This pull request updates the version numbers for the `langflow` package to 1.1.0 and for the `langflow-base` package to 0.1.0 in their respective `pyproject.toml` files and the lock file. These changes reflect the latest updates and improvements made to the packages.