### PR TITLE
fix: process.py to use validate_and_repair_json from utils.py

### DIFF
--- a/src/backend/base/langflow/processing/process.py
+++ b/src/backend/base/langflow/processing/process.py
@@ -6,6 +6,7 @@ from loguru import logger
 from pydantic import BaseModel
 
 from langflow.graph.vertex.base import Vertex
+from langflow.processing.utils import validate_and_repair_json
 from langflow.schema.graph import InputValue, Tweaks
 from langflow.schema.schema import INPUT_FIELD_NAME
 from langflow.services.deps import get_settings_service
@@ -142,7 +143,10 @@ def apply_tweaks(node: dict[str, Any], node_tweaks: dict[str, Any]) -> None:
         if tweak_name not in template_data:
             continue
         if tweak_name in template_data:
-            if isinstance(tweak_value, dict):
+            if template_data[tweak_name]["type"] == "NestedDict":
+                value = validate_and_repair_json(tweak_value)
+                template_data[tweak_name]["value"] = value
+            elif isinstance(tweak_value, dict):
                 for k, v in tweak_value.items():
                     _k = "file_path" if template_data[tweak_name]["type"] == "file" else k
                     template_data[tweak_name][_k] = v

--- a/src/backend/base/langflow/processing/utils.py
+++ b/src/backend/base/langflow/processing/utils.py
@@ -1,0 +1,25 @@
+import json
+from typing import Any
+
+from json_repair import repair_json
+
+
+def validate_and_repair_json(json_str: str | dict) -> dict[str, Any] | str:
+    """Validates a JSON string and attempts to repair it if invalid.
+
+    Args:
+        json_str (str): The JSON string to validate/repair
+
+    Returns:
+        Union[Dict[str, Any], str]: The parsed JSON dict if valid/repairable,
+        otherwise returns the original string
+    """
+    if not isinstance(json_str, str):
+        return json_str
+    try:
+        # If invalid, attempt repair
+        repaired = repair_json(json_str)
+        return json.loads(repaired)
+    except (json.JSONDecodeError, ImportError):
+        # Return original if repair fails or module not found
+        return json_str


### PR DESCRIPTION
This pull request refactors the `process.py` file to use the `validate_and_repair_json` function from the `utils.py` file for nested dictionary tweaks. The `apply_tweaks` function now checks if the tweak value is a nested dictionary and calls `validate_and_repair_json` to validate and repair the JSON string if necessary. This ensures that the JSON string is valid and can be parsed correctly.