### PR TITLE
ci: Add condition to PyPI publish step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
             echo "Server terminated successfully"
           fi
       - name: Publish to PyPI
+        if: steps.check-version.outputs.skipped == 'false'
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |


### PR DESCRIPTION
This PR introduces a condition to the PyPI publish step in the release workflow, ensuring that the publish action only occurs if the version check step does not indicate a skip. This change enhances the workflow's efficiency by preventing unnecessary publish attempts.