### PR TITLE
ci: Add GitHub Actions workflow for creating releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,8 +15,6 @@ on:
         required: true
         type: boolean
 
-env:
-  POETRY_VERSION: "1.8.2"
 jobs:
   create_release:
     name: Create Release Job

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,38 @@
+name: Create Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release"
+        required: true
+        type: string
+      ref:
+        description: "Commit to tag the release"
+        required: true
+        type: string
+      pre_release:
+        description: "Pre-release tag"
+        required: true
+        type: boolean
+
+env:
+  POETRY_VERSION: "1.8.2"
+jobs:
+  create_release:
+    name: Create Release Job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-main
+          path: dist
+      - name: Create Release Notes
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          generateReleaseNotes: true
+          prerelease: ${{ inputs.pre_release }}
+          tag: v${{ inputs.version }}
+          commit: ${{ inputs.ref }}


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow that facilitates the creation of releases. It allows users to specify the version, commit reference, and whether the release is a pre-release. Additionally, the POETRY_VERSION environment variable has been removed from the create-release workflow to streamline the process.