### PR TITLE
fix: correct user_id access logic

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/custom_component.py
+++ b/src/backend/base/langflow/custom/custom_component/custom_component.py
@@ -185,7 +185,7 @@ class CustomComponent(BaseComponent):
 
     @property
     def user_id(self):
-        if hasattr(self, "_user_id"):
+        if hasattr(self, "_user_id") and self._user_id:
             return self._user_id
         return self.graph.user_id
 
@@ -477,7 +477,7 @@ class CustomComponent(BaseComponent):
         if not self.user_id:
             msg = "Session is invalid"
             raise ValueError(msg)
-        return await load_flow(user_id=str(self._user_id), flow_id=flow_id, tweaks=tweaks)
+        return await load_flow(user_id=str(self.user_id), flow_id=flow_id, tweaks=tweaks)
 
     async def run_flow(
         self,
@@ -493,7 +493,7 @@ class CustomComponent(BaseComponent):
             flow_id=flow_id,
             flow_name=flow_name,
             tweaks=tweaks,
-            user_id=str(self._user_id),
+            user_id=str(self.user_id),
             run_id=self.graph.run_id,
         )
 
@@ -502,7 +502,7 @@ class CustomComponent(BaseComponent):
             msg = "Session is invalid"
             raise ValueError(msg)
         try:
-            return list_flows(user_id=str(self._user_id))
+            return list_flows(user_id=str(self.user_id))
         except Exception as e:
             msg = f"Error listing flows: {e}"
             raise ValueError(msg) from e


### PR DESCRIPTION
This pull request addresses an issue with the `user_id` access logic within the `CustomComponent` class. Previously, there were inconsistencies in how the `user_id` attribute was accessed, leading to potential errors when the attribute was not set or incorrectly retrieved. 
In the BaseComponent, the default setting of `self._user_id` to None led to inaccurate user_id retrieval: 
https://github.com/langflow-ai/langflow/blob/2f96dbbdd4d26f5c837f4d651ec9bc42a03a97b5/src/backend/base/langflow/custom/custom_component/base_component.py#L31
The use of `hasattr(self, '_user_id')` always returned True, causing `_user_id` to be returned even when it was None.
https://github.com/langflow-ai/langflow/blob/2f96dbbdd4d26f5c837f4d651ec9bc42a03a97b5/src/backend/base/langflow/custom/custom_component/custom_component.py#L186-L190
This behavior resulted in a SQL error when using the SubFlow component's `run_flow` method, as user_id was unexpectedly None. The fix ensures user_id is correctly handled and prevents unintended None values from causing SQL execution errors.