### PR TITLE
ci: Exclude components changes from Codspeed workflow paths

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "src/backend/base/**"
       - "src/backend/tests/performance/**"
+      - "!src/backend/base/langflow/components/**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This pull request modifies the Codspeed workflow configuration to exclude certain components from being processed. Specifically, the path for `src/backend/base/langflow/components/**` has been added to the exclusion list, ensuring that these components do not trigger the workflow.