### PR TITLE
fix: Removed condition for importing flows

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -529,9 +529,6 @@ def load_flows_from_directory() -> None:
     flows_path = settings_service.settings.load_flows_path
     if not flows_path:
         return
-    if not settings_service.auth_settings.AUTO_LOGIN:
-        logger.warning("AUTO_LOGIN is disabled, not loading flows from directory")
-        return
 
     with session_scope() as session:
         user = get_user_by_username(session, settings_service.auth_settings.SUPERUSER)


### PR DESCRIPTION
After deploying 1.1.0 in a clean environment (no prior DB files, etc.), the auto import of flows stopped working. 

Further investigation revealed that `LANGFLOW_AUTO_LOGIN=True` resolves the issue.
This PR removes this condition from the flow auto-import. 

