### PR TITLE
docs: document venv and dependency installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,12 @@ We also provide a .vscode/launch.json file for debugging the backend in VSCode, 
 
 ### Prepare the environment
 
+Activate the virtual environment and install dependencies:
+
+```bash
+uv venv && source .venv/bin/activate && uv pip install .
+```
+
 Setting up hooks:
 
 ```bash


### PR DESCRIPTION
Context: When I first followed the Contributing guide, I got this error:
```bash
Detected Python version: 3.12.5
Traceback (most recent call last):
  File "<string>", line 3, in <module>
ModuleNotFoundError: No module named 'distutils'
make[1]: *** [check_env] Error 1
make: *** [check_tools] Error 2
```
Which went away after I ran `uv venv && source .venv/bin/activate && uv pip install .`

So I thought it might be useful to add this to the guide. Totally happy to edit this if there's an alternative preferred way to get started. Let me know!