### PR TITLE
docs: Update local run instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ This will set up the development environment by installing backend and frontend 
 
 It is advised to run `make lint`, `make format`, and `make unit_tests` before pushing to the repository.
 
-### Run locally (Poetry and Node.js)
+### Run locally (uv and Node.js)
 
 Langflow can run locally by cloning the repository and installing the dependencies. We recommend using a virtual environment to isolate the dependencies from your system.
 

--- a/Makefile
+++ b/Makefile
@@ -39,14 +39,8 @@ patch: ## bump the version in langflow and langflow-base
 check_tools:
 	@command -v uv >/dev/null 2>&1 || { echo >&2 "$(RED)uv is not installed. Aborting.$(NC)"; exit 1; }
 	@command -v npm >/dev/null 2>&1 || { echo >&2 "$(RED)NPM is not installed. Aborting.$(NC)"; exit 1; }
-	@command -v pipx >/dev/null 2>&1 || { echo >&2 "$(RED)pipx is not installed. Aborting.$(NC)"; exit 1; }
-	@$(MAKE) check_env
 	@echo "$(GREEN)All required tools are installed.$(NC)"
 
-# check if Python version is compatible
-check_env: ## check if Python version is compatible
-	@chmod +x scripts/setup/check_env.sh
-	@scripts/setup/check_env.sh "$(PYTHON_REQUIRED)"
 
 help: ## show this help message
 	@echo '----'


### PR DESCRIPTION
This PR updates the local run instructions in the CONTRIBUTING.md file to reflect the use of 'uv' instead of 'Poetry'. This change aims to provide clearer guidance for setting up the development environment. Check env script was importing distutils which raised a `ModuleNotFoundError` if it was the first time the contributor was running it.