### PR TITLE
chore: move alembic exception logging to debug

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -229,7 +229,7 @@ class DatabaseService(Service):
                 try:
                     session.exec(text("SELECT * FROM alembic_version"))
                 except Exception:  # noqa: BLE001
-                    logger.opt(exception=True).info("Alembic not initialized")
+                    logger.debug("Alembic not initialized")
                     should_initialize_alembic = True
 
             if should_initialize_alembic:


### PR DESCRIPTION
Alembic not being initialized is an expected scenario when running langflow for the first time. Sets the log to debug and removes the exception. 