### PR TITLE
fix: error on fetch for no headers on request

### DIFF
--- a/src/frontend/src/controllers/API/queries/files/use-download-files.ts
+++ b/src/frontend/src/controllers/API/queries/files/use-download-files.ts
@@ -22,8 +22,8 @@ export const useGetDownloadFileMutation: useMutationFunctionType<
     // need to use fetch because axios convert blob data to string, and this convertion can corrupt the file
     const response = await fetch(`${getURL("FILES")}/download/${params.path}`, {
       headers: {
-        'Accept': '*/*'
-      }
+        Accept: "*/*",
+      },
     });
     const blob = await response.blob();
     const url = URL.createObjectURL(blob);

--- a/src/frontend/src/controllers/API/queries/files/use-download-files.ts
+++ b/src/frontend/src/controllers/API/queries/files/use-download-files.ts
@@ -20,7 +20,11 @@ export const useGetDownloadFileMutation: useMutationFunctionType<
   const getDownloadImagesFn = async () => {
     if (!params) return;
     // need to use fetch because axios convert blob data to string, and this convertion can corrupt the file
-    const response = await fetch(`${getURL("FILES")}/download/${params.path}`);
+    const response = await fetch(`${getURL("FILES")}/download/${params.path}`, {
+      headers: {
+        'Accept': '*/*'
+      }
+    });
     const blob = await response.blob();
     const url = URL.createObjectURL(blob);
 


### PR DESCRIPTION
This pull request fixes an error that occurs when fetching data without any headers on the request. The issue was resolved by adding the 'Accept' header to the fetch request in order to handle the response correctly.