### PR TITLE
fix(TextAreaComponent): Update focus state padding and icon visibility

### DIFF
--- a/src/frontend/src/components/parameterRenderComponent/components/textAreaComponent/index.tsx
+++ b/src/frontend/src/components/parameterRenderComponent/components/textAreaComponent/index.tsx
@@ -73,6 +73,7 @@ export default function TextAreaComponent({
       editNode ? inputClasses.editNode : inputClasses.normal({ isFocused }),
       disabled && inputClasses.disabled,
       password && !passwordVisible && "text-clip",
+      isFocused && "pr-10",
     );
   };
 
@@ -81,7 +82,7 @@ export default function TextAreaComponent({
   };
 
   const renderIcon = () => (
-    <div className={cn(isFocused && "opacity-0")}>
+    <div>
       {!disabled && (
         <div
           className={cn(


### PR DESCRIPTION
This pull request includes a few small changes to the `TextAreaComponent` in the `index.tsx` file. The changes focus on updating the class names for better handling of focus states and icon rendering.

* Added a `pr-10` class when the `TextAreaComponent` is focused to provide padding. (`src/frontend/src/components/parameterRenderComponent/components/textAreaComponent/index.tsx` [src/frontend/src/components/parameterRenderComponent/components/textAreaComponent/index.tsxR76](diffhunk://#diff-697f5e35a4c3db88eeb823f8987b6f32c24d482cca67e4750538cac35b061984R76))
* Removed the conditional `opacity-0` class from the icon container to ensure the icon is always visible. (`src/frontend/src/components/parameterRenderComponent/components/textAreaComponent/index.tsx` [src/frontend/src/components/parameterRenderComponent/components/textAreaComponent/index.tsxL84-R85](diffhunk://#diff-697f5e35a4c3db88eeb823f8987b6f32c24d482cca67e4750538cac35b061984L84-R85))