### PR TITLE
fix: Rename `namespace` to `keyspace` in astra db

### DIFF
--- a/src/backend/base/langflow/components/vectorstores/astradb.py
+++ b/src/backend/base/langflow/components/vectorstores/astradb.py
@@ -95,9 +95,9 @@ class AstraVectorStoreComponent(LCVectorStoreComponent):
             is_list=True,
         ),
         StrInput(
-            name="namespace",
-            display_name="Namespace",
-            info="Optional namespace within Astra DB to use for the collection.",
+            name="keyspace",
+            display_name="Keyspace",
+            info="Optional keyspace within Astra DB to use for the collection.",
             advanced=True,
         ),
         DropdownInput(
@@ -440,7 +440,7 @@ class AstraVectorStoreComponent(LCVectorStoreComponent):
                 collection_name=self.collection_name,
                 token=self.token,
                 api_endpoint=self.api_endpoint,
-                namespace=self.namespace or None,
+                namespace=self.keyspace or None,
                 environment=parse_api_endpoint(self.api_endpoint).environment if self.api_endpoint else None,
                 metric=self.metric or None,
                 batch_size=self.batch_size or None,

--- a/src/backend/base/langflow/components/vectorstores/astradb_graph.py
+++ b/src/backend/base/langflow/components/vectorstores/astradb_graph.py
@@ -55,12 +55,6 @@ class AstraGraphVectorStoreComponent(LCVectorStoreComponent):
             info="Metadata key used for incoming links.",
             advanced=True,
         ),
-        StrInput(
-            name="namespace",
-            display_name="Namespace",
-            info="Optional namespace within Astra DB to use for the collection.",
-            advanced=True,
-        ),
         MultilineInput(
             name="search_input",
             display_name="Search Input",
@@ -71,9 +65,9 @@ class AstraGraphVectorStoreComponent(LCVectorStoreComponent):
             is_list=True,
         ),
         StrInput(
-            name="namespace",
-            display_name="Namespace",
-            info="Optional namespace within Astra DB to use for the collection.",
+            name="keyspace",
+            display_name="Keyspace",
+            info="Optional keyspace within Astra DB to use for the collection.",
             advanced=True,
         ),
         HandleInput(
@@ -211,7 +205,7 @@ class AstraGraphVectorStoreComponent(LCVectorStoreComponent):
                 metadata_incoming_links_key=self.metadata_incoming_links_key or "incoming_links",
                 token=self.token,
                 api_endpoint=self.api_endpoint,
-                namespace=self.namespace or None,
+                namespace=self.keyspace or None,
                 environment=parse_api_endpoint(self.api_endpoint).environment if self.api_endpoint else None,
                 metric=self.metric or None,
                 batch_size=self.batch_size or None,


### PR DESCRIPTION
This pull request changes the terminology of "namespace" to "keyspace" to match changes in Astra DB.