### PR TITLE
fix: typo inside teardown_superuser function

### DIFF
--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -88,7 +88,7 @@ def setup_superuser(settings_service, session: Session) -> None:
 
 def teardown_superuser(settings_service, session) -> None:
     """Teardown the superuser."""
-    # If AUTO_LOGIN is True, we will remove the default superuser
+    # If AUTO_LOGIN is False, we will remove the default superuser
     # from the database.
 
     if not settings_service.auth_settings.AUTO_LOGIN:


### PR DESCRIPTION
Based on the logic itself, the deletion of the superuser occurs when AUTO_LOGIN is enabled. The logic has been adjusted accordingly.