### PR TITLE
fix: Ensure chat inputs with dependencies are not prioritized in graph sorting

### DIFF
--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -1928,6 +1928,13 @@ class Graph:
         return [layer for layer in refined_layers if layer]
 
     def sort_chat_inputs_first(self, vertices_layers: list[list[str]]) -> list[list[str]]:
+        # First check if any chat inputs have dependencies
+        for layer in vertices_layers:
+            for vertex_id in layer:
+                if "ChatInput" in vertex_id and self.get_predecessors(self.get_vertex(vertex_id)):
+                    return vertices_layers
+
+        # If no chat inputs have dependencies, move them to first layer
         chat_inputs_first = []
         for layer in vertices_layers:
             layer_chat_inputs_first = [vertex_id for vertex_id in layer if "ChatInput" in vertex_id]
@@ -1935,6 +1942,7 @@ class Graph:
             for vertex_id in layer_chat_inputs_first:
                 # Remove the ChatInput from the layer
                 layer.remove(vertex_id)
+
         if not chat_inputs_first:
             return vertices_layers
 


### PR DESCRIPTION
This pull request modifies the sorting logic for chat inputs in the graph. It ensures that chat inputs with dependencies are not moved to the first layer, maintaining their original order when dependencies exist. This change improves the handling of chat inputs in the graph structure.

Fixes #4660