### PR TITLE
fix: Add worker_task attribute to TelemetryService to prevent AttributeError

### DIFF
--- a/src/backend/base/langflow/services/telemetry/service.py
+++ b/src/backend/base/langflow/services/telemetry/service.py
@@ -41,7 +41,7 @@ class TelemetryService(Service):
 
         self.ot = OpenTelemetry(prometheus_enabled=settings_service.settings.prometheus_enabled)
         self.architecture: str | None = None
-
+        self.worker_task: asyncio.Task | None = None
         # Check for do-not-track settings
         self.do_not_track = (
             os.getenv("DO_NOT_TRACK", "False").lower() == "true" or settings_service.settings.do_not_track


### PR DESCRIPTION
This update introduces a `worker_task` attribute to the `TelemetryService` class, which helps avoid potential `AttributeError` issues. This change enhances the robustness of the telemetry service by ensuring that the attribute is properly initialized.