### PR TITLE
fix: Improve waiting logic in tweksTest.spec.ts

### DIFF
--- a/src/frontend/tests/core/features/tweaksTest.spec.ts
+++ b/src/frontend/tests/core/features/tweaksTest.spec.ts
@@ -14,13 +14,14 @@ test("curl_api_generation", async ({ page, context }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Flow", { exact: true }).click();
-    await page.waitForTimeout(3000);
+    await page.waitForSelector('[data-testid="modal-title"]', {
+      timeout: 3000,
+    });
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 
   await page.getByTestId("side_nav_options_all-templates").click();
   await page.getByRole("heading", { name: "Basic Prompting" }).click();
-  await page.waitForTimeout(1000);
   await page.getByText("API", { exact: true }).click();
   await page.getByRole("tab", { name: "cURL" }).click();
   await page.getByTestId("icon-Copy").click();
@@ -37,7 +38,12 @@ test("curl_api_generation", async ({ page, context }) => {
     .first()
     .click();
 
-  await page.waitForTimeout(1000);
+  await page.waitForSelector(
+    '[data-testid="popover-anchor-input-openai_api_base-edit"]',
+    {
+      timeout: 1000,
+    },
+  );
 
   await page
     .getByTestId("popover-anchor-input-openai_api_base-edit")
@@ -79,7 +85,9 @@ test("check if tweaks are updating when someothing on the flow changes", async (
 
   while (modalCount === 0) {
     await page.getByText("New Flow", { exact: true }).click();
-    await page.waitForTimeout(3000);
+    await page.waitForSelector('[data-testid="modal-title"]', {
+      timeout: 3000,
+    });
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 
@@ -91,7 +99,9 @@ test("check if tweaks are updating when someothing on the flow changes", async (
   await page.getByTestId("sidebar-search-input").click();
   await page.getByTestId("sidebar-search-input").fill("Chroma");
 
-  await page.waitForTimeout(1000);
+  await page.waitForSelector('[data-testid="vectorstoresChroma DB"]', {
+    timeout: 1000,
+  });
 
   await page
     .getByTestId("vectorstoresChroma DB")


### PR DESCRIPTION
Improve the waiting logic in the tweksTest.spec.ts file to ensure that the necessary elements are loaded before interacting with them. This includes using the waitForSelector function with appropriate timeouts for the modal and popover elements.