### PR TITLE
docs: add icons component with lucide-react integration

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -20,6 +20,7 @@
         "clsx": "^1.2.1",
         "docusaurus-node-polyfills": "^1.0.0",
         "docusaurus-plugin-image-zoom": "^2.0.0",
+        "lucide-react": "^0.460.0",
         "prism-react-renderer": "^1.3.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -11293,6 +11294,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.460.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.460.0.tgz",
+      "integrity": "sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/lunr": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,7 @@
     "clsx": "^1.2.1",
     "docusaurus-node-polyfills": "^1.0.0",
     "docusaurus-plugin-image-zoom": "^2.0.0",
+    "lucide-react": "^0.460.0",
     "prism-react-renderer": "^1.3.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/docs/src/components/icon/index.tsx
+++ b/docs/src/components/icon/index.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import * as LucideIcons from "lucide-react";
+
+/*
+How to use this component:
+
+import Icon from "@site/src/components/icon";
+
+<Icon name="AlertCircle" size={24} color="red" />
+*/
+
+type IconProps = {
+  name: string;
+};
+
+export default function Icon({ name, ...props }: IconProps) {
+  const Icon = LucideIcons[name];
+  return Icon ? <Icon {...props} /> : null;
+}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6759,6 +6759,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lucide-react@^0.460.0:
+  version "0.460.0"
+  resolved "https://registry.npmjs.org/lucide-react/-/lucide-react-0.460.0.tgz"
+  integrity sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==
+
 lunr-languages@^1.4.0:
   version "1.14.0"
   resolved "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.14.0.tgz"


### PR DESCRIPTION
This pull request introduces the `lucide-react` package and adds a new `Icon` component in the `docs` project. The most important changes include updates to the package files and the creation of the new component.

### Package Updates:
* [`docs/package-lock.json`](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R23): Added `lucide-react` package with version `0.460.0`. [[1]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R23) [[2]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R11299-R11307)
* [`docs/package.json`](diffhunk://#diff-adfa337ce44dc2902621da20152a048dac41878cf3716dfc4cc56d03aa212a56R26): Added `lucide-react` package with version `0.460.0`.

### New Component:
* [`docs/src/components/icon/index.tsx`](diffhunk://#diff-823e1fe8833b55b9306143a018dd0ed6df5cdb4aac249888725c814203e7ed87R1-R19): Created a new `Icon` component that imports and uses icons from the `lucide-react` package.