### PR TITLE
fix: Add unique keys to Badge components in HandleTooltipComponent

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/HandleTooltipComponent/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/HandleTooltipComponent/index.tsx
@@ -48,6 +48,7 @@ export default function HandleTooltipComponent({
           {tooltips.map((word, index) => (
             <Badge
               className="h-6 rounded-md p-1"
+              key={`${index}-${word.toLowerCase()}`}
               style={{
                 backgroundColor: left
                   ? `hsl(var(--${accentColorName}))`


### PR DESCRIPTION
This pull request includes a small, yet important change to the `HandleTooltipComponent` in the `index.tsx` file. The change ensures that each `Badge` component within the tooltip list has a unique key, which can help React efficiently update and render the list.

* [`src/frontend/src/CustomNodes/GenericNode/components/HandleTooltipComponent/index.tsx`](diffhunk://#diff-f286fd032653a39d18eb067d1981f06a2f81c02532353dce582ee272305cd271R51): Added a unique key to each `Badge` component in the `tooltips` map by combining the index and the lowercase version of the word.