### PR TITLE
fix: is null sql statement

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -152,7 +152,7 @@ class DatabaseService(Service):
         settings_service = get_settings_service()
         if settings_service.auth_settings.AUTO_LOGIN:
             async with self.with_async_session() as session:
-                stmt = select(models.Flow).where(models.Flow.user_id is None)
+                stmt = select(models.Flow).where(models.Flow.user_id.is_(None))
                 flows = (await session.exec(stmt)).all()
                 if flows:
                     logger.debug("Migrating flows to default superuser")


### PR DESCRIPTION
Using `is None` evaluates the statement on the python client side rather than translating into a SQL `IS NULL` statement. 

```
stmt = select(models.Flow).where(models.Flow.user_id is None)
# if models.Flow.user_id is none, it would become
stmt = select(models.Flow).where(False)
# Results in SQL like:
# SELECT * FROM flow WHERE false;
```

https://docs.sqlalchemy.org/en/14/core/sqlelement.html#sqlalchemy.sql.expression.ColumnOperators.is_

