### PR TITLE
feat: Add database cleanup functions for transactions and vertex builds

### DIFF
--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -173,6 +173,10 @@ class Settings(BaseSettings):
     """The maximum file size for the upload in MB."""
     deactivate_tracing: bool = False
     """If set to True, tracing will be deactivated."""
+    max_transactions_to_keep: int = 3000
+    """The maximum number of transactions to keep in the database."""
+    max_vertex_builds_to_keep: int = 3000
+    """The maximum number of vertex builds to keep in the database."""
 
     @field_validator("dev")
     @classmethod

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 from sqlalchemy import delete
+from sqlalchemy import exc as sqlalchemy_exc
 from sqlmodel import select
 
 from langflow.services.auth.utils import create_super_user, verify_password
@@ -193,7 +194,7 @@ async def clean_transactions(settings_service: SettingsService, session: AsyncSe
         await session.exec(delete_stmt)
         await session.commit()
         logger.debug("Successfully cleaned up old transactions")
-    except Exception as exc:  # noqa: BLE001
+    except (sqlalchemy_exc.SQLAlchemyError, asyncio.TimeoutError) as exc:
         logger.error(f"Error cleaning up transactions: {exc!s}")
         await session.rollback()
         # Don't re-raise since this is a cleanup task
@@ -225,7 +226,7 @@ async def clean_vertex_builds(settings_service: SettingsService, session: AsyncS
         await session.exec(delete_stmt)
         await session.commit()
         logger.debug("Successfully cleaned up old vertex builds")
-    except Exception as exc:  # noqa: BLE001
+    except (sqlalchemy_exc.SQLAlchemyError, asyncio.TimeoutError) as exc:
         logger.error(f"Error cleaning up vertex builds: {exc!s}")
         await session.rollback()
         # Don't re-raise since this is a cleanup task

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -182,16 +182,12 @@ async def clean_transactions(settings_service: SettingsService, session: AsyncSe
     """
     try:
         # Delete transactions using bulk delete
-        delete_stmt = (
-            delete(TransactionTable)
-            .where(
-                TransactionTable.id.in_(
-                    select(TransactionTable.id)
-                    .order_by(TransactionTable.timestamp.desc())
-                    .offset(settings_service.settings.max_transactions_to_keep)
-                )
+        delete_stmt = delete(TransactionTable).where(
+            TransactionTable.id.in_(
+                select(TransactionTable.id)
+                .order_by(TransactionTable.timestamp.desc())
+                .offset(settings_service.settings.max_transactions_to_keep)
             )
-            .execution_options(synchronize_session="evaluate")
         )
 
         await session.exec(delete_stmt)
@@ -218,16 +214,12 @@ async def clean_vertex_builds(settings_service: SettingsService, session: AsyncS
     """
     try:
         # Delete vertex builds using bulk delete
-        delete_stmt = (
-            delete(VertexBuildTable)
-            .where(
-                VertexBuildTable.id.in_(
-                    select(VertexBuildTable.id)
-                    .order_by(VertexBuildTable.timestamp.desc())
-                    .offset(settings_service.settings.max_vertex_builds_to_keep)
-                )
+        delete_stmt = delete(VertexBuildTable).where(
+            VertexBuildTable.id.in_(
+                select(VertexBuildTable.id)
+                .order_by(VertexBuildTable.timestamp.desc())
+                .offset(settings_service.settings.max_vertex_builds_to_keep)
             )
-            .execution_options(synchronize_session="evaluate")
         )
 
         await session.exec(delete_stmt)

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -1,16 +1,23 @@
 import asyncio
+from typing import TYPE_CHECKING
 
 from loguru import logger
+from sqlalchemy import delete
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from langflow.services.auth.utils import create_super_user, verify_password
 from langflow.services.cache.factory import CacheServiceFactory
+from langflow.services.database.models.transactions.model import TransactionTable
+from langflow.services.database.models.vertex_builds.model import VertexBuildTable
 from langflow.services.database.utils import initialize_database
 from langflow.services.schema import ServiceType
 from langflow.services.settings.constants import DEFAULT_SUPERUSER, DEFAULT_SUPERUSER_PASSWORD
 
 from .deps import get_db_service, get_service, get_settings_service
+
+if TYPE_CHECKING:
+    from langflow.services.settings.manager import SettingsService
 
 
 async def get_or_create_super_user(session: AsyncSession, username, password, is_default):
@@ -157,6 +164,66 @@ def initialize_session_service() -> None:
     )
 
 
+async def clean_transactions(settings_service: "SettingsService", session: AsyncSession) -> None:
+    """Clean up old transactions from the database.
+
+    This function deletes transactions that exceed the maximum number to keep (configured in settings).
+    It orders transactions by timestamp descending and removes the oldest ones beyond the limit.
+
+    Args:
+        settings_service: The settings service containing configuration like max_transactions_to_keep
+        session: The database session to use for the deletion
+
+    Returns:
+        None
+    """
+    # Delete transactions using bulk delete
+    delete_stmt = (
+        delete(TransactionTable)
+        .where(
+            TransactionTable.id.in_(
+                select(TransactionTable.id)
+                .order_by(TransactionTable.timestamp.desc())
+                .offset(settings_service.settings.max_transactions_to_keep)
+            )
+        )
+        .execution_options(synchronize_session="evaluate")
+    )
+
+    await session.exec(delete_stmt)
+    await session.commit()
+
+
+async def clean_vertex_builds(settings_service: "SettingsService", session: AsyncSession) -> None:
+    """Clean up old vertex builds from the database.
+
+    This function deletes vertex builds that exceed the maximum number to keep (configured in settings).
+    It orders vertex builds by timestamp descending and removes the oldest ones beyond the limit.
+
+    Args:
+        settings_service: The settings service containing configuration like max_vertex_builds_to_keep
+        session: The database session to use for the deletion
+
+    Returns:
+        None
+    """
+    # Delete vertex builds using bulk delete
+    delete_stmt = (
+        delete(VertexBuildTable)
+        .where(
+            VertexBuildTable.id.in_(
+                select(VertexBuildTable.id)
+                .order_by(VertexBuildTable.timestamp.desc())
+                .offset(settings_service.settings.max_vertex_builds_to_keep)
+            )
+        )
+        .execution_options(synchronize_session="evaluate")
+    )
+
+    await session.exec(delete_stmt)
+    await session.commit()
+
+
 async def initialize_services(*, fix_migration: bool = False) -> None:
     """Initialize all the services needed."""
     # Test cache connection
@@ -164,7 +231,10 @@ async def initialize_services(*, fix_migration: bool = False) -> None:
     # Setup the superuser
     await asyncio.to_thread(initialize_database, fix_migration=fix_migration)
     async with get_db_service().with_async_session() as session:
-        await setup_superuser(get_service(ServiceType.SETTINGS_SERVICE), session)
+        settings_service = get_service(ServiceType.SETTINGS_SERVICE)
+        await setup_superuser(settings_service, session)
+        await clean_transactions(settings_service, session)
+        await clean_vertex_builds(settings_service, session)
     try:
         await get_db_service().migrate_flows_if_auto_login()
     except Exception as exc:

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -244,12 +244,12 @@ async def initialize_services(*, fix_migration: bool = False) -> None:
     await asyncio.to_thread(initialize_database, fix_migration=fix_migration)
     async with get_db_service().with_async_session() as session:
         settings_service = get_service(ServiceType.SETTINGS_SERVICE)
+        await setup_superuser(settings_service, session)
     try:
         await get_db_service().migrate_flows_if_auto_login()
     except Exception as exc:
         msg = "Error migrating flows"
         logger.exception(msg)
         raise RuntimeError(msg) from exc
-        await setup_superuser(settings_service, session)
-        await clean_transactions(settings_service, session)
-        await clean_vertex_builds(settings_service, session)
+    await clean_transactions(settings_service, session)
+    await clean_vertex_builds(settings_service, session)

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 from sqlalchemy import delete
 from sqlalchemy import exc as sqlalchemy_exc
-from sqlmodel import select
+from sqlmodel import col, select
 
 from langflow.services.auth.utils import create_super_user, verify_password
 from langflow.services.cache.factory import CacheServiceFactory
@@ -184,9 +184,9 @@ async def clean_transactions(settings_service: SettingsService, session: AsyncSe
     try:
         # Delete transactions using bulk delete
         delete_stmt = delete(TransactionTable).where(
-            TransactionTable.id.in_(
+            col(TransactionTable.id).in_(
                 select(TransactionTable.id)
-                .order_by(TransactionTable.timestamp.desc())
+                .order_by(col(TransactionTable.timestamp).desc())
                 .offset(settings_service.settings.max_transactions_to_keep)
             )
         )
@@ -216,9 +216,9 @@ async def clean_vertex_builds(settings_service: SettingsService, session: AsyncS
     try:
         # Delete vertex builds using bulk delete
         delete_stmt = delete(VertexBuildTable).where(
-            VertexBuildTable.id.in_(
+            col(VertexBuildTable.id).in_(
                 select(VertexBuildTable.id)
-                .order_by(VertexBuildTable.timestamp.desc())
+                .order_by(col(VertexBuildTable.timestamp).desc())
                 .offset(settings_service.settings.max_vertex_builds_to_keep)
             )
         )

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import asyncio
 from typing import TYPE_CHECKING
 
 from loguru import logger
 from sqlalchemy import delete
 from sqlmodel import select
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from langflow.services.auth.utils import create_super_user, verify_password
 from langflow.services.cache.factory import CacheServiceFactory
@@ -17,6 +18,8 @@ from langflow.services.settings.constants import DEFAULT_SUPERUSER, DEFAULT_SUPE
 from .deps import get_db_service, get_service, get_settings_service
 
 if TYPE_CHECKING:
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
     from langflow.services.settings.manager import SettingsService
 
 
@@ -164,7 +167,7 @@ def initialize_session_service() -> None:
     )
 
 
-async def clean_transactions(settings_service: "SettingsService", session: AsyncSession) -> None:
+async def clean_transactions(settings_service: SettingsService, session: AsyncSession) -> None:
     """Clean up old transactions from the database.
 
     This function deletes transactions that exceed the maximum number to keep (configured in settings).
@@ -200,7 +203,7 @@ async def clean_transactions(settings_service: "SettingsService", session: Async
         # Don't re-raise since this is a cleanup task
 
 
-async def clean_vertex_builds(settings_service: "SettingsService", session: AsyncSession) -> None:
+async def clean_vertex_builds(settings_service: SettingsService, session: AsyncSession) -> None:
     """Clean up old vertex builds from the database.
 
     This function deletes vertex builds that exceed the maximum number to keep (configured in settings).


### PR DESCRIPTION
This pull request introduces functions to clean up old transactions and vertex builds in the database, ensuring that only a configured maximum number of each is retained. The `clean_transactions` function deletes transactions exceeding the specified limit, while `clean_vertex_builds` performs a similar cleanup for vertex builds. Additionally, these cleanup functions are integrated into the service initialization process, and new configuration options for maximum retention limits have been added.