### PR TITLE
feat: Add PlaygroundButton component to flow toolbar

### DIFF
--- a/src/frontend/src/components/flowToolbarComponent/components/playground-button.tsx
+++ b/src/frontend/src/components/flowToolbarComponent/components/playground-button.tsx
@@ -1,0 +1,50 @@
+import ForwardedIconComponent from "@/components/genericIconComponent";
+import ShadTooltip from "@/components/shadTooltipComponent";
+import IOModal from "@/modals/IOModal";
+
+const PlaygroundButton = ({ hasIO, open, setOpen, canvasOpen }) => {
+  const PlayIcon = () => (
+    <ForwardedIconComponent name="Play" className="h-4 w-4 transition-all" />
+  );
+
+  const ButtonLabel = () => <span className="hidden md:block">Playground</span>;
+
+  const ActiveButton = () => (
+    <div
+      data-testid="playground-btn-flow-io"
+      className="playground-btn-flow-toolbar hover:bg-accent"
+    >
+      <PlayIcon />
+      <ButtonLabel />
+    </div>
+  );
+
+  const DisabledButton = () => (
+    <div
+      className="playground-btn-flow-toolbar cursor-not-allowed text-muted-foreground duration-150"
+      data-testid="playground-btn-flow"
+    >
+      <PlayIcon />
+      <ButtonLabel />
+    </div>
+  );
+
+  return hasIO ? (
+    <IOModal
+      open={open}
+      setOpen={setOpen}
+      disable={!hasIO}
+      canvasOpen={canvasOpen}
+    >
+      <ActiveButton />
+    </IOModal>
+  ) : (
+    <ShadTooltip content="Add a Chat Input or Chat Output to use the playground">
+      <div>
+        <DisabledButton />
+      </div>
+    </ShadTooltip>
+  );
+};
+
+export default PlaygroundButton;

--- a/src/frontend/src/components/flowToolbarComponent/components/playground-button.tsx
+++ b/src/frontend/src/components/flowToolbarComponent/components/playground-button.tsx
@@ -1,6 +1,6 @@
 import ForwardedIconComponent from "@/components/genericIconComponent";
 import ShadTooltip from "@/components/shadTooltipComponent";
-import IOModal from "@/modals/IOModal";
+import IOModal from "@/modals/IOModal/newModal";
 
 const PlaygroundButton = ({ hasIO, open, setOpen, canvasOpen }) => {
   const PlayIcon = () => (

--- a/src/frontend/src/components/flowToolbarComponent/index.tsx
+++ b/src/frontend/src/components/flowToolbarComponent/index.tsx
@@ -15,6 +15,7 @@ import { useShortcutsStore } from "../../stores/shortcuts";
 import { useStoreStore } from "../../stores/storeStore";
 import { classNames, isThereModal } from "../../utils/utils";
 import ForwardedIconComponent from "../genericIconComponent";
+import PlaygroundButton from "./components/playground-button";
 
 export default function FlowToolbar(): JSX.Element {
   const preventDefault = true;
@@ -125,38 +126,12 @@ export default function FlowToolbar(): JSX.Element {
         >
           <div className="flex gap-1.5">
             <div className="flex h-full w-full gap-1.5 rounded-sm transition-all">
-              {hasIO ? (
-                <IOModal
-                  open={open}
-                  setOpen={setOpen}
-                  disable={!hasIO}
-                  canvasOpen
-                >
-                  <div
-                    data-testid="playground-btn-flow-io"
-                    className="relative inline-flex h-8 w-full items-center justify-center gap-1.5 rounded px-3 py-1.5 text-sm font-semibold transition-all duration-500 ease-in-out hover:bg-accent"
-                  >
-                    <ForwardedIconComponent
-                      name="Play"
-                      className={"h-4 w-4 transition-all"}
-                    />
-                    <span className="hidden md:block">Playground</span>
-                  </div>
-                </IOModal>
-              ) : (
-                <ShadTooltip content="Add a Chat Input or Chat Output to use the playground">
-                  <div
-                    className={`relative inline-flex h-8 w-full cursor-not-allowed items-center justify-center gap-1 px-5 py-3 text-sm font-semibold text-muted-foreground transition-all duration-150 ease-in-out`}
-                    data-testid="playground-btn-flow"
-                  >
-                    <ForwardedIconComponent
-                      name="BotMessageSquareIcon"
-                      className={"h-5 w-5 transition-all"}
-                    />
-                    <span className="hidden md:block">Playground</span>
-                  </div>
-                </ShadTooltip>
-              )}
+              <PlaygroundButton
+                hasIO={hasIO}
+                open={open}
+                setOpen={setOpen}
+                canvasOpen
+              />
             </div>
             {ENABLE_API && (
               <>

--- a/src/frontend/src/style/applies.css
+++ b/src/frontend/src/style/applies.css
@@ -1268,6 +1268,10 @@
   .toolbar-wrapper {
     @apply flex h-10 items-center gap-1 rounded-xl border border-border bg-background p-1 shadow-sm;
   }
+
+  .playground-btn-flow-toolbar {
+    @apply relative inline-flex h-8 w-full items-center justify-center gap-1.5 rounded px-3 py-1.5 text-sm font-semibold transition-all duration-500 ease-in-out;
+  }
 }
 
 /* Gradient background */


### PR DESCRIPTION
This pull request introduces a new `PlaygroundButton` component to the flow toolbar in the frontend. The `PlaygroundButton` component replaces the existing logic for displaying the playground button, providing a cleaner and more modular implementation.

**_This PR also fixes a bug in which the icon on Playground was the old one when we didn't have ChatInput or ChatOutput on Canvas._**

Key changes include:

### New Component Addition:
* Added `PlaygroundButton` component in `src/frontend/src/components/flowToolbarComponent/components/playground-button.tsx`. This component handles the display logic for the playground button, including active and disabled states.

### Integration with Flow Toolbar:
* Updated `FlowToolbar` component in `src/frontend/src/components/flowToolbarComponent/index.tsx` to use the new `PlaygroundButton` component instead of directly embedding the button logic. [[1]](diffhunk://#diff-1659e8f86b9d6fbf74da23d93e4cc0f6468f27774b87713816fb1eec5740fbf8R18) [[2]](diffhunk://#diff-1659e8f86b9d6fbf74da23d93e4cc0f6468f27774b87713816fb1eec5740fbf8L128-L159)

### Styling Adjustments:
* Added new CSS class `.playground-btn-flow-toolbar` to `src/frontend/src/style/applies.css` to style the playground button within the toolbar.