### PR TITLE
chore: Add pyproject.toml configuration to ruff format command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ fix_codespell: ## run codespell to fix spelling errors
 	poetry run codespell --toml pyproject.toml --write
 
 format: ## run code formatters
-	@uv run ruff check . --fix --config pyproject.toml
+	@uv run ruff check . --fix
 	@uv run ruff format . --config pyproject.toml
 	@cd src/frontend && npm run format
 

--- a/Makefile
+++ b/Makefile
@@ -180,8 +180,8 @@ fix_codespell: ## run codespell to fix spelling errors
 	poetry run codespell --toml pyproject.toml --write
 
 format: ## run code formatters
-	@uv run ruff check . --fix
-	@uv run ruff format .
+	@uv run ruff check . --fix --config pyproject.toml
+	@uv run ruff format . --config pyproject.toml
 	@cd src/frontend && npm run format
 
 unsafe_fix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,7 @@ directory = "coverage"
 
 
 [tool.ruff]
-exclude = ["src/backend/langflow/alembic/*"]
+exclude = ["src/backend/base/langflow/alembic/*"]
 line-length = 120
 
 [tool.ruff.lint]

--- a/src/backend/base/langflow/api/v1/api_key.py
+++ b/src/backend/base/langflow/api/v1/api_key.py
@@ -1,4 +1,3 @@
-from typing import TYPE_CHECKING
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response
@@ -11,9 +10,6 @@ from langflow.services.auth import utils as auth_utils
 from langflow.services.database.models.api_key.crud import create_api_key, delete_api_key, get_api_keys
 from langflow.services.database.models.api_key.model import ApiKeyCreate, UnmaskedApiKeyRead
 from langflow.services.deps import get_settings_service
-
-if TYPE_CHECKING:
-    pass
 
 router = APIRouter(tags=["APIKey"], prefix="/api_key")
 


### PR DESCRIPTION
This PR updates the Makefile to include a configuration flag for ruff commands, allowing them to utilize the `pyproject.toml` file for settings. This change enhances the flexibility and maintainability of the code formatting and linting processes.

I did not add to check because there are a lot of errors so we should do it in a separate PR.