### PR TITLE
chore: add deprecation flag on base upload flow route

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -553,7 +553,6 @@ async def create_upload_file(
     """Upload a file for a specific flow (Deprecated).
     
     This endpoint is deprecated and will be removed in a future version.
-    Please use the /files/upload/{flow_id} endpoint instead.
     """
     try:
         flow_id_str = str(flow_id)

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -544,11 +544,17 @@ async def get_task_status(task_id: str) -> TaskStatusResponse:
 @router.post(
     "/upload/{flow_id}",
     status_code=HTTPStatus.CREATED,
+    deprecated=True,
 )
 async def create_upload_file(
     file: UploadFile,
     flow_id: UUID,
 ) -> UploadFileResponse:
+    """Upload a file for a specific flow (Deprecated).
+    
+    This endpoint is deprecated and will be removed in a future version.
+    Please use the /files/upload/{flow_id} endpoint instead.
+    """
     try:
         flow_id_str = str(flow_id)
         file_path = save_uploaded_file(file, folder_name=flow_id_str)

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -551,7 +551,7 @@ async def create_upload_file(
     flow_id: UUID,
 ) -> UploadFileResponse:
     """Upload a file for a specific flow (Deprecated).
-    
+
     This endpoint is deprecated and will be removed in a future version.
     """
     try:


### PR DESCRIPTION
Adds deprecated flag to an old route that I _believe_ is superseded by more specific upload routes like https://github.com/langflow-ai/langflow/blob/deprecate-upload-route/src/backend/base/langflow/api/v1/files.py#L40