### PR TITLE
fix: fix overflow for lists in markdown render

### DIFF
--- a/src/frontend/src/components/chatComponents/ContentDisplay.tsx
+++ b/src/frontend/src/components/chatComponents/ContentDisplay.tsx
@@ -155,6 +155,20 @@ export default function ContentDisplay({
                 pre({ node, ...props }) {
                   return <>{props.children}</>;
                 },
+                ol({ node, ...props }) {
+                  return (
+                    <ol className="max-w-full">
+                      {props.children}
+                    </ol>
+                  );
+                },
+                ul({ node, ...props }) {
+                  return (
+                    <ul className="max-w-full">
+                      {props.children}
+                    </ul>
+                  );
+                },
                 code: ({ node, inline, className, children, ...props }) => {
                   const match = /language-(\w+)/.exec(className || "");
                   return !inline ? (

--- a/src/frontend/src/components/chatComponents/ContentDisplay.tsx
+++ b/src/frontend/src/components/chatComponents/ContentDisplay.tsx
@@ -156,18 +156,10 @@ export default function ContentDisplay({
                   return <>{props.children}</>;
                 },
                 ol({ node, ...props }) {
-                  return (
-                    <ol className="max-w-full">
-                      {props.children}
-                    </ol>
-                  );
+                  return <ol className="max-w-full">{props.children}</ol>;
                 },
                 ul({ node, ...props }) {
-                  return (
-                    <ul className="max-w-full">
-                      {props.children}
-                    </ul>
-                  );
+                  return <ul className="max-w-full">{props.children}</ul>;
                 },
                 code: ({ node, inline, className, children, ...props }) => {
                   const match = /language-(\w+)/.exec(className || "");

--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/newChatMessage.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/newChatMessage.tsx
@@ -552,6 +552,20 @@ export default function ChatMessage({
                                           </span>
                                         );
                                       },
+                                      ol({ node, ...props }) {
+                                        return (
+                                          <ol className="max-w-full">
+                                            {props.children}
+                                          </ol>
+                                        );
+                                      },
+                                      ul({ node, ...props }) {
+                                        return (
+                                          <ul className="max-w-full">
+                                            {props.children}
+                                          </ul>
+                                        );
+                                      },
                                       pre({ node, ...props }) {
                                         return <>{props.children}</>;
                                       },


### PR DESCRIPTION
This pull request adds support for ordered and unordered lists in the ContentDisplay and ChatMessage components. Previously, lists were not properly displayed and could cause overflow. With this change, lists are now rendered correctly and have a maximum width to prevent overflow.