### PR TITLE
fix: update Test Docker Images workflow to use get_version_info 

### DIFF
--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Test image
         run: |
           expected_version=$(cat pyproject.toml | grep version | head -n 1 | cut -d '"' -f 2)
-          version=$(docker run --rm --entrypoint bash langflowai/langflow:latest-dev -c 'python -c "from langflow.version.version import get_version; print(get_version())"')
+          version=$(docker run --rm --entrypoint bash langflowai/langflow:latest-dev -c "python -c 'from langflow.utils.version import get_version_info; print(get_version_info()[\"version\"])'")
           if [ "$expected_version" != "$version" ]; then
               echo "Expected version: $expected_version"
               echo "Actual version: $version"
@@ -51,7 +51,7 @@ jobs:
       - name: Test backend image
         run: |
           expected_version=$(cat pyproject.toml | grep version | head -n 1 | cut -d '"' -f 2)
-          version=$(docker run --rm --entrypoint bash langflowai/langflow-backend:latest-dev -c 'python -c "from langflow.version.version import get_version; print(get_version())"')
+          version=$(docker run --rm --entrypoint bash langflowai/langflow-backend:latest-dev -c "python -c 'from langflow.utils.version import get_version_info; print(get_version_info()[\"version\"])'")
           if [ "$expected_version" != "$version" ]; then
               echo "Expected version: $expected_version"
               echo "Actual version: $version"


### PR DESCRIPTION
This pull request includes updates to the `docker_test.yml` workflow file to improve the version checking mechanism for Docker images.

Improvements to version checking:

* [`.github/workflows/docker_test.yml`](diffhunk://#diff-91d171c86d0de252b57b744dff05648acb174351e56da20f59e5e242fb70984cL38-R38): Updated the `Test image` job to use the `get_version_info` method from `langflow.utils.version` instead of `get_version` from `langflow.version.version`.
* [`.github/workflows/docker_test.yml`](diffhunk://#diff-91d171c86d0de252b57b744dff05648acb174351e56da20f59e5e242fb70984cL54-R54): Updated the `Test backend image` job to use the `get_version_info` method from `langflow.utils.version` instead of `get_version` from `langflow.version.version`.