### PR TITLE
fix: Indent JSON output for exported flow data

### DIFF
--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -1562,11 +1562,15 @@ export function downloadFlow(
   removeFileNameFromComponents(clonedFlow);
   // create a data URI with the current flow data
   const jsonString = `data:text/json;chatset=utf-8,${encodeURIComponent(
-    JSON.stringify({
-      ...clonedFlow,
-      name: flowName,
-      description: flowDescription,
-    }),
+    JSON.stringify(
+      {
+        ...clonedFlow,
+        name: flowName,
+        description: flowDescription,
+      },
+      null,
+      2,
+    ),
   )}`;
 
   // create a link element and set its properties


### PR DESCRIPTION
This was causing all starter projects to be reformatted in the backend because they were exported from the UI.

This pull request modifies the JSON output formatting for exported flow data in the `reactflowUtils.ts` file. The changes ensure that the JSON is indented for better readability by adding a spacing parameter to the `JSON.stringify` method.