### PR TITLE
fix: Filter orphaned flows and extract constants to avoid circular imports

### DIFF
--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -25,7 +25,7 @@ from langflow.api.utils import (
     validate_is_component,
 )
 from langflow.api.v1.schemas import FlowListCreate
-from langflow.initial_setup.setup import STARTER_FOLDER_NAME
+from langflow.initial_setup.constants import STARTER_FOLDER_NAME
 from langflow.services.database.models.flow import Flow, FlowCreate, FlowRead, FlowUpdate
 from langflow.services.database.models.flow.model import FlowHeader
 from langflow.services.database.models.flow.utils import get_webhook_component_in_flow

--- a/src/backend/base/langflow/api/v1/folders.py
+++ b/src/backend/base/langflow/api/v1/folders.py
@@ -19,7 +19,7 @@ from langflow.api.v1.flows import create_flows
 from langflow.api.v1.schemas import FlowListCreate
 from langflow.helpers.flow import generate_unique_flow_name
 from langflow.helpers.folders import generate_unique_folder_name
-from langflow.initial_setup.setup import STARTER_FOLDER_NAME
+from langflow.initial_setup.constants import STARTER_FOLDER_NAME
 from langflow.services.database.models.flow.model import Flow, FlowCreate, FlowRead
 from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NAME
 from langflow.services.database.models.folder.model import (

--- a/src/backend/base/langflow/initial_setup/constants.py
+++ b/src/backend/base/langflow/initial_setup/constants.py
@@ -1,0 +1,2 @@
+STARTER_FOLDER_NAME = "Starter Projects"
+STARTER_FOLDER_DESCRIPTION = "Starter projects to help you get started in Langflow."

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -14,11 +14,8 @@ from loguru import logger
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import select
 
-from langflow.base.constants import (
-    FIELD_FORMAT_ATTRIBUTES,
-    NODE_FORMAT_ATTRIBUTES,
-    ORJSON_OPTIONS,
-)
+from langflow.base.constants import FIELD_FORMAT_ATTRIBUTES, NODE_FORMAT_ATTRIBUTES, ORJSON_OPTIONS
+from langflow.initial_setup.constants import STARTER_FOLDER_DESCRIPTION, STARTER_FOLDER_NAME
 from langflow.services.auth.utils import create_super_user
 from langflow.services.database.models.flow.model import Flow, FlowCreate
 from langflow.services.database.models.folder.model import Folder, FolderCreate
@@ -36,9 +33,6 @@ from langflow.services.deps import (
 )
 from langflow.template.field.prompt import DEFAULT_PROMPT_INTUT_TYPES
 from langflow.utils.util import escape_json_dump
-
-STARTER_FOLDER_NAME = "Starter Projects"
-STARTER_FOLDER_DESCRIPTION = "Starter projects to help you get started in Langflow."
 
 # In the folder ./starter_projects we have a few JSON files that represent
 # starter projects. We want to load these into the database so that users

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -17,7 +17,7 @@ from dotenv import load_dotenv
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 from langflow.graph import Graph
-from langflow.initial_setup.setup import STARTER_FOLDER_NAME
+from langflow.initial_setup.constants import STARTER_FOLDER_NAME
 from langflow.services.auth.utils import get_password_hash
 from langflow.services.database.models.api_key.model import ApiKey
 from langflow.services.database.models.flow.model import Flow, FlowCreate

--- a/src/backend/tests/unit/test_initial_setup.py
+++ b/src/backend/tests/unit/test_initial_setup.py
@@ -3,11 +3,9 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-from langflow.custom.directory_reader.utils import (
-    abuild_custom_component_list_from_path,
-)
+from langflow.custom.directory_reader.utils import abuild_custom_component_list_from_path
+from langflow.initial_setup.constants import STARTER_FOLDER_NAME
 from langflow.initial_setup.setup import (
-    STARTER_FOLDER_NAME,
     get_project_data,
     load_starter_projects,
     update_projects_components_with_latest_component_versions,


### PR DESCRIPTION
This pull request enhances the flow filtering mechanism by excluding orphaned flows that belong to the starter folder. Additionally, it extracts the `STARTER_FOLDER_NAME` and `STARTER_FOLDER_DESCRIPTION` constants into a dedicated module for improved code organization and maintainability. This change helps streamline the codebase and makes it easier to manage folder-related constants.