### PR TITLE
feat: rename MetaphorToolkit file to ExaSearchToolkit and update component icons

### DIFF
--- a/src/backend/base/langflow/components/tools/__init__.py
+++ b/src/backend/base/langflow/components/tools/__init__.py
@@ -5,10 +5,10 @@ from langchain_core._api.deprecation import LangChainDeprecationWarning
 from .bing_search_api import BingSearchAPIComponent
 from .calculator import CalculatorToolComponent
 from .duck_duck_go_search_run import DuckDuckGoSearchComponent
+from .exa_search import ExaSearchToolkit
 from .glean_search_api import GleanSearchAPIComponent
 from .google_search_api import GoogleSearchAPIComponent
 from .google_serper_api import GoogleSerperAPIComponent
-from .exa_search import ExaSearchToolkit
 from .python_code_structured_tool import PythonCodeStructuredTool
 from .python_repl import PythonREPLToolComponent
 from .retriever import RetrieverToolComponent

--- a/src/backend/base/langflow/components/tools/__init__.py
+++ b/src/backend/base/langflow/components/tools/__init__.py
@@ -8,7 +8,7 @@ from .duck_duck_go_search_run import DuckDuckGoSearchComponent
 from .glean_search_api import GleanSearchAPIComponent
 from .google_search_api import GoogleSearchAPIComponent
 from .google_serper_api import GoogleSerperAPIComponent
-from .metaphor import MetaphorToolkit
+from .exa_search import ExaSearchToolkit
 from .python_code_structured_tool import PythonCodeStructuredTool
 from .python_repl import PythonREPLToolComponent
 from .retriever import RetrieverToolComponent
@@ -36,7 +36,7 @@ __all__ = [
     "GleanSearchAPIComponent",
     "GoogleSearchAPIComponent",
     "GoogleSerperAPIComponent",
-    "MetaphorToolkit",
+    "ExaSearchToolkit",
     "PythonCodeStructuredTool",
     "PythonREPLToolComponent",
     "RetrieverToolComponent",

--- a/src/backend/base/langflow/components/tools/exa_search.py
+++ b/src/backend/base/langflow/components/tools/exa_search.py
@@ -6,12 +6,13 @@ from langflow.field_typing import Tool
 from langflow.io import BoolInput, IntInput, Output, SecretStrInput
 
 
-class MetaphorToolkit(Component):
+class ExaSearchToolkit(Component):
     display_name = "Exa Search"
     description = "Exa Search toolkit for search and content retrieval"
     documentation = "https://python.langchain.com/docs/integrations/tools/metaphor_search"
     beta = True
     name = "ExaSearch"
+    icon = "ExaSearch"
 
     inputs = [
         SecretStrInput(

--- a/src/backend/base/langflow/components/tools/wolfram_alpha_api.py
+++ b/src/backend/base/langflow/components/tools/wolfram_alpha_api.py
@@ -19,6 +19,8 @@ topics, delivering structured responses."""
         SecretStrInput(name="app_id", display_name="App ID", required=True),
     ]
 
+    icon = "WolframAlphaAPI"
+
     def run_model(self) -> list[Data]:
         wrapper = self._build_wrapper()
         result_str = wrapper.run(self.input_value)

--- a/src/backend/base/langflow/components/vectorstores/pgvector.py
+++ b/src/backend/base/langflow/components/vectorstores/pgvector.py
@@ -12,7 +12,7 @@ class PGVectorStoreComponent(LCVectorStoreComponent):
     description = "PGVector Vector Store with search capabilities"
     documentation = "https://python.langchain.com/v0.2/docs/integrations/vectorstores/pgvector/"
     name = "pgvector"
-    icon = "PGVector"
+    icon = "cpu"
 
     inputs = [
         SecretStrInput(name="pg_server_url", display_name="PostgreSQL Server Connection String", required=True),

--- a/src/backend/base/langflow/components/vectorstores/redis.py
+++ b/src/backend/base/langflow/components/vectorstores/redis.py
@@ -16,6 +16,7 @@ class RedisVectorStoreComponent(LCVectorStoreComponent):
     description: str = "Implementation of Vector Store using Redis"
     documentation = "https://python.langchain.com/docs/integrations/vectorstores/redis"
     name = "Redis"
+    icon = "Redis"
 
     inputs = [
         SecretStrInput(name="redis_server_url", display_name="Redis Server Connection String", required=True),

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -663,7 +663,6 @@ export const nodeIconsLucide: iconsType = {
   Discord: FaDiscord,
   MistralAI: MistralIcon,
   Upstash: UpstashSvgIcon,
-  PGVector: CpuIcon,
   Confluence: ConfluenceIcon,
   AIML: AIMLIcon,
   "AI/ML": AIMLIcon,


### PR DESCRIPTION
This pull request includes several changes to the `langflow` components and icons. The most important changes involve renaming a toolkit, updating icons, and adding new icons.

### Renaming and Updates to Toolkits:
* Renamed `MetaphorToolkit` to `ExaSearchToolkit` in `src/backend/base/langflow/components/tools/__init__.py` and updated the corresponding import and class name. [[1]](diffhunk://#diff-978762db35f605246f0bf595f91cfb0ff502fa74a15603d70ea3f6902f009175L11-R11) [[2]](diffhunk://#diff-978762db35f605246f0bf595f91cfb0ff502fa74a15603d70ea3f6902f009175L39-R39) [[3]](diffhunk://#diff-4412c0a8c32e1b4158a949ea5fd1da723420406911eda7891c6ed2d4458f8c03L9-R15)

### Icon Updates:
* Added an icon for `WolframAlphaAPIComponent` in `src/backend/base/langflow/components/tools/wolfram_alpha_api.py`.
* Changed the icon for `PGVectorStoreComponent` from "PGVector" to "cpu" in `src/backend/base/langflow/components/vectorstores/pgvector.py`.
* Added an icon for `RedisVectorStoreComponent` in `src/backend/base/langflow/components/vectorstores/redis.py`.
* Removed the `PGVector` icon from `src/frontend/src/utils/styleUtils.ts`.