### PR TITLE
chore: remove legacy component checks and alerts

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -182,15 +182,6 @@ export default function Page({ view }: { view?: boolean }): JSX.Element {
     !isFetching;
 
   useEffect(() => {
-    if (checkOldComponents({ nodes })) {
-      setNoticeData({
-        title:
-          "Components created before Langflow 1.0 may be unstable. Ensure components are up to date.",
-      });
-    }
-  }, [currentFlowId]);
-
-  useEffect(() => {
     useFlowStore.setState({ autoSaveFlow });
   });
 

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -347,14 +347,7 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
           selection.nodes.some((node) => edge.target === node.id),
       );
     }
-    if (selection.nodes) {
-      if (checkOldComponents({ nodes: selection.nodes ?? [] })) {
-        useAlertStore.getState().setNoticeData({
-          title:
-            "Components created before Langflow 1.0 may be unstable. Ensure components are up to date.",
-        });
-      }
-    }
+
     let minimumX = Infinity;
     let minimumY = Infinity;
     let idsMap = {};


### PR DESCRIPTION
This pull request includes changes to the `PageComponent` and `flowStore` to remove outdated checks and alerts for old components in Langflow. The most important changes are:

Code cleanup:

* [`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eL184-L192): Removed the `useEffect` hook that checked for old components and set a notice about their stability.
* [`src/frontend/src/stores/flowStore.ts`](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357L350-R350): Removed the conditional check and alert for old components within the `useFlowStore` store.