### PR TITLE
fix: Add validation for MessageBase type in message input conversion

### DIFF
--- a/src/backend/base/langflow/inputs/inputs.py
+++ b/src/backend/base/langflow/inputs/inputs.py
@@ -8,6 +8,7 @@ from pydantic import Field, field_validator
 from langflow.inputs.validators import CoalesceBool
 from langflow.schema.data import Data
 from langflow.schema.message import Message
+from langflow.services.database.models.message.model import MessageBase
 from langflow.template.field.base import Input
 
 from .input_mixin import (
@@ -151,6 +152,8 @@ class MessageInput(StrInput, InputTraceMixin):
             return v
         if isinstance(v, str | AsyncIterator | Iterator):
             return Message(text=v)
+        if isinstance(v, MessageBase):
+            return Message(**v.model_dump())
         msg = f"Invalid value type {type(v)}"
         raise ValueError(msg)
 


### PR DESCRIPTION
This PR introduces validation for the `MessageBase` type within the message input conversion process. It ensures that if an instance of `MessageBase` is provided, it is correctly transformed into a `Message` object using the model's data. This enhancement improves the robustness of input handling in the application.

This helps when you create a component, call `send_message` passing a Message and then return the result of the call (which now is a `MessageRead`, not a `Message` anymore).