### PR TITLE
refactor: improve waiting logic in Basic Prompting test

### DIFF
--- a/src/frontend/tests/core/integrations/Basic Prompting.spec.ts
+++ b/src/frontend/tests/core/integrations/Basic Prompting.spec.ts
@@ -33,7 +33,9 @@ test("Basic Prompting (Hello, World)", async ({ page }) => {
 
   while (modalCount === 0) {
     await page.getByText("New Flow", { exact: true }).click();
-    await page.waitForTimeout(3000);
+    await page.waitForSelector('[data-testid="modal-title"]', {
+      timeout: 3000,
+    });
     modalCount = await page.getByTestId("modal-title")?.count();
   }
 
@@ -53,14 +55,12 @@ test("Basic Prompting (Hello, World)", async ({ page }) => {
 
   while (outdatedComponents > 0) {
     await page.getByTestId("icon-AlertTriangle").first().click();
-    await page.waitForTimeout(1000);
     outdatedComponents = await page.getByTestId("icon-AlertTriangle").count();
   }
 
   let filledApiKey = await page.getByTestId("remove-icon-badge").count();
   while (filledApiKey > 0) {
     await page.getByTestId("remove-icon-badge").first().click();
-    await page.waitForTimeout(1000);
     filledApiKey = await page.getByTestId("remove-icon-badge").count();
   }
 
@@ -73,8 +73,6 @@ test("Basic Prompting (Hello, World)", async ({ page }) => {
 
   await page.getByTestId("dropdown_str_model_name").click();
   await page.getByTestId("gpt-4o-1-option").click();
-
-  await page.waitForTimeout(1000);
 
   await page.getByTestId("button_run_chat output").click();
   await page.waitForSelector("text=built successfully", { timeout: 30000 });


### PR DESCRIPTION
This pull request refactors the waiting logic in the Basic Prompting test. The changes include using `waitForSelector` instead of `waitForTimeout` to improve the waiting behavior.