### PR TITLE
fix: handle Message in path input in CSVAgentComponent

### DIFF
--- a/src/backend/base/langflow/components/langchain_utilities/csv.py
+++ b/src/backend/base/langflow/components/langchain_utilities/csv.py
@@ -52,7 +52,7 @@ class CSVAgentComponent(LCAgentComponent):
     ]
 
     def _path(self) -> str:
-        if isinstance(self.path, Message):
+        if isinstance(self.path, Message) and isinstance(self.path.text, str):
             return self.path.text
         return self.path
 

--- a/src/backend/base/langflow/components/langchain_utilities/csv.py
+++ b/src/backend/base/langflow/components/langchain_utilities/csv.py
@@ -51,6 +51,11 @@ class CSVAgentComponent(LCAgentComponent):
         Output(display_name="Agent", name="agent", method="build_agent"),
     ]
 
+    def _path(self) -> str:
+        if isinstance(self.path, Message):
+            return self.path.text
+        return self.path
+
     def build_agent_response(self) -> Message:
         agent_kwargs = {
             "verbose": self.verbose,
@@ -59,7 +64,7 @@ class CSVAgentComponent(LCAgentComponent):
 
         agent_csv = create_csv_agent(
             llm=self.llm,
-            path=self.path,
+            path=self._path(),
             agent_type=self.agent_type,
             handle_parsing_errors=self.handle_parsing_errors,
             **agent_kwargs,
@@ -76,7 +81,7 @@ class CSVAgentComponent(LCAgentComponent):
 
         agent_csv = create_csv_agent(
             llm=self.llm,
-            path=self.path,
+            path=self._path(),
             agent_type=self.agent_type,
             handle_parsing_errors=self.handle_parsing_errors,
             **agent_kwargs,


### PR DESCRIPTION
This pull request introduces a helper method to handle the `path` attribute in the `CSVAgentComponent` class in the `src/backend/base/langflow/components/langchain_utilities/csv.py` file. The main changes include the addition of the `_path` method and its integration into the existing methods for building agents.

Key changes:

* Added `_path` method to handle `path` attribute conversion from `Message` to `str`. (`src/backend/base/langflow/components/langchain_utilities/csv.py`)
* Updated `build_agent_response` method to use the new `_path` method for `path` attribute. (`src/backend/base/langflow/components/langchain_utilities/csv.py`)
* Updated `build_agent` method to use the new `_path` method for `path` attribute. (`src/backend/base/langflow/components/langchain_utilities/csv.py`)