### PR TITLE
fix: fixes Ollama Embeddings component

### DIFF
--- a/src/backend/base/langflow/components/embeddings/ollama.py
+++ b/src/backend/base/langflow/components/embeddings/ollama.py
@@ -2,7 +2,7 @@ from langchain_ollama import OllamaEmbeddings
 
 from langflow.base.models.model import LCModelComponent
 from langflow.field_typing import Embeddings
-from langflow.io import FloatInput, MessageTextInput, Output
+from langflow.io import MessageTextInput, Output
 
 
 class OllamaEmbeddingsComponent(LCModelComponent):
@@ -16,18 +16,12 @@ class OllamaEmbeddingsComponent(LCModelComponent):
         MessageTextInput(
             name="model",
             display_name="Ollama Model",
-            value="llama3.1",
+            value="nomic-embed-text",
         ),
         MessageTextInput(
             name="base_url",
             display_name="Ollama Base URL",
             value="http://localhost:11434",
-        ),
-        FloatInput(
-            name="temperature",
-            display_name="Model Temperature",
-            value=0.1,
-            advanced=True,
         ),
     ]
 
@@ -37,11 +31,7 @@ class OllamaEmbeddingsComponent(LCModelComponent):
 
     def build_embeddings(self) -> Embeddings:
         try:
-            output = OllamaEmbeddings(
-                model=self.model,
-                base_url=self.base_url,
-                temperature=self.temperature,
-            )
+            output = OllamaEmbeddings(model=self.model, base_url=self.base_url)
         except Exception as e:
             msg = "Could not connect to Ollama API."
             raise ValueError(msg) from e


### PR DESCRIPTION
Removed unwanted parameter temperature for embedding
closes https://github.com/langflow-ai/langflow/issues/4728
This pull request includes several changes to the `OllamaEmbeddingsComponent` class in the `src/backend/base/langflow/components/embeddings/ollama.py` file. The changes focus on simplifying the component by removing an unused import and the `temperature` parameter.

Codebase simplification:

* Removed the unused `FloatInput` import from `langflow.io`. (`[src/backend/base/langflow/components/embeddings/ollama.pyL5-R5](diffhunk://#diff-9a66812daa372619c9b34060e9fd280defa5a1717e3e947098676466ae9ccc6dL5-R5)`)
* Changed the default value of the `model` parameter from `"llama3.1"` to `"nomic-embed-text"`. (`[src/backend/base/langflow/components/embeddings/ollama.pyL19-L31](diffhunk://#diff-9a66812daa372619c9b34060e9fd280defa5a1717e3e947098676466ae9ccc6dL19-L31)`)
* Removed the `FloatInput` parameter for `temperature` and its associated attributes. (`[src/backend/base/langflow/components/embeddings/ollama.pyL19-L31](diffhunk://#diff-9a66812daa372619c9b34060e9fd280defa5a1717e3e947098676466ae9ccc6dL19-L31)`)
* Updated the `build_embeddings` method to exclude the `temperature` parameter when creating an `OllamaEmbeddings` instance. (`[src/backend/base/langflow/components/embeddings/ollama.pyL40-R34](diffhunk://#diff-9a66812daa372619c9b34060e9fd280defa5a1717e3e947098676466ae9ccc6dL40-R34)`)