### PR TITLE
fix: validation for tool name

### DIFF
--- a/src/backend/base/langflow/components/langchain_utilities/tool_calling.py
+++ b/src/backend/base/langflow/components/langchain_utilities/tool_calling.py
@@ -48,6 +48,7 @@ class ToolCallingAgentComponent(LCToolsAgentComponent):
             ("placeholder", "{agent_scratchpad}"),
         ]
         prompt = ChatPromptTemplate.from_messages(messages)
+        self.validate_tool_names()
         try:
             return create_tool_calling_agent(self.llm, self.tools or [], prompt)
         except NotImplementedError as e:


### PR DESCRIPTION
Tool name validation based on open ai Schema for tool names

Note: In case of Agent as Tool. This doesnt work if it tool is a Tool for Agent as tool. Only check when the agent as tool is invoked.
This pull request introduces changes to the agent validation and creation process in the `src/backend/base/langflow/base/agents/agent.py` file. The most important changes include the addition of a tool name validation method and its integration into the agent-building process.

### Agent Validation and Creation Improvements:

* [`src/backend/base/langflow/base/agents/agent.py`](diffhunk://#diff-87ba96f91b4bbce3350ae83d5d4c7dfa3a7c800deeed21a60857dff1caaefe04R182-R193): Added a new method `validate_tool_names` to ensure tool names match a specific pattern using regular expressions. This method checks that tool names contain only letters, numbers, underscores, and dashes, and do not contain spaces.
* [`src/backend/base/langflow/base/agents/agent.py`](diffhunk://#diff-87ba96f91b4bbce3350ae83d5d4c7dfa3a7c800deeed21a60857dff1caaefe04R209): Integrated the `validate_tool_names` method into the `build_agent` method of the `LCToolsAgentComponent` class to validate tool names during agent construction.
* [`src/backend/base/langflow/components/langchain_utilities/tool_calling.py`](diffhunk://#diff-f471df7dd024398b17f74cb674546607197d5286ca9afead2570b9a1d11f6e40R51): Added a call to `validate_tool_names` in the `create_agent_runnable` method to ensure tool names are validated before creating the tool-calling agent.

### Miscellaneous:

* [`src/backend/base/langflow/base/agents/agent.py`](diffhunk://#diff-87ba96f91b4bbce3350ae83d5d4c7dfa3a7c800deeed21a60857dff1caaefe04R2): Imported the `re` module to support regular expression operations for tool name validation.