### PR TITLE
fix: clean invisible edge when toggling tool mode

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -54,7 +54,6 @@ import { useTypesStore } from "../../../../stores/typesStore";
 import { APIClassType } from "../../../../types/api";
 import { NodeType } from "../../../../types/flow";
 import {
-  checkOldComponents,
   generateFlow,
   generateNodeFromFlow,
   getNodeId,
@@ -535,7 +534,6 @@ export default function Page({ view }: { view?: boolean }): JSX.Element {
             onSelectionEnd={onSelectionEnd}
             onSelectionStart={onSelectionStart}
             connectionRadius={30}
-            elevateEdgesOnSelect={true}
             edgeTypes={edgeTypes}
             connectionLineComponent={ConnectionLineComponent}
             onDragOver={onDragOver}

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -32,7 +32,6 @@ import { FlowStoreType, VertexLayerElementType } from "../types/zustand/flow";
 import { buildFlowVerticesWithFallback } from "../utils/buildUtils";
 import {
   checkChatInput,
-  checkOldComponents,
   cleanEdges,
   detectBrokenEdgesEdges,
   getHandleId,
@@ -278,6 +277,8 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
         return node;
       });
 
+      const newEdges = cleanEdges(newNodes, get().edges);
+
       if (callback) {
         // Defer the callback execution to ensure it runs after state updates are fully applied.
         queueMicrotask(callback);
@@ -286,6 +287,7 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
       return {
         ...state,
         nodes: newNodes,
+        edges: newEdges,
       };
     });
   },


### PR DESCRIPTION
This pull request includes several changes to the `FlowPage` component and `flowStore` in the frontend. The primary focus is on removing unused functions and improving state management for nodes and edges.

Improvements to `FlowPage` component:

* [`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eL57): Removed the unused `checkOldComponents` import.
* [`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eL538): Removed the `elevateEdgesOnSelect` property from the component props.

Enhancements to `flowStore`:

* [`src/frontend/src/stores/flowStore.ts`](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357L35): Removed the unused `checkOldComponents` import.
* [`src/frontend/src/stores/flowStore.ts`](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357R280-R281): Added logic to clean edges when nodes are updated, ensuring the state remains consistent.
* [`src/frontend/src/stores/flowStore.ts`](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357R290): Updated the store state to include the newly cleaned edges.