### PR TITLE
fix: add underline to name of component to make it look clickable on error

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/newChatMessage.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/newChatMessage.tsx
@@ -264,7 +264,7 @@ export default function ChatMessage({
                                   <span
                                     className={cn(
                                       closeChat
-                                        ? "cursor-pointer hover:underline"
+                                        ? "cursor-pointer underline"
                                         : "",
                                     )}
                                     onClick={() => {


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/src/modals/IOModal/components/chatView/chatMessage/newChatMessage.tsx` file. The change modifies the styling of a `span` element to always underline when `closeChat` is true, removing the hover effect.

Styling change:

* [`src/frontend/src/modals/IOModal/components/chatView/chatMessage/newChatMessage.tsx`](diffhunk://#diff-a5c2764955c9d507dd134f3add3fec7958daa183ee41cfabe54f5c5702a483e7L267-R267): Changed the `className` condition to always apply "underline" instead of "hover:underline" when `closeChat` is true.