### PR TITLE
fix: Fix flow addition to session and handle IntegrityError for orphaned flows

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -187,6 +187,7 @@ class DatabaseService(Service):
                 flow.user_id = superuser.id
                 flow.name = self._generate_unique_flow_name(flow.name, existing_names)
                 existing_names.add(flow.name)
+                session.add(flow)
 
             # Commit changes
             await session.commit()

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -243,9 +243,7 @@ async def initialize_services(*, fix_migration: bool = False) -> None:
         await setup_superuser(settings_service, session)
     try:
         await get_db_service().assign_orphaned_flows_to_superuser()
-    except Exception as exc:
-        msg = "Error assigning orphaned flows to the superuser"
-        logger.exception(msg)
-        raise RuntimeError(msg) from exc
+    except sqlalchemy_exc.IntegrityError as exc:
+        logger.warning(f"Error assigning orphaned flows to the superuser: {exc!s}")
     await clean_transactions(settings_service, session)
     await clean_vertex_builds(settings_service, session)


### PR DESCRIPTION
We have encountered an issue with this one more time. Since it is not a breaking issue I decided we could use a warning instead. 

I also added a `session.add` call for so we can update the flow.

