### PR TITLE
refactor: updates import statements to use Pydantic in aiml_embeddings.py

### DIFF
--- a/src/backend/base/langflow/base/embeddings/aiml_embeddings.py
+++ b/src/backend/base/langflow/base/embeddings/aiml_embeddings.py
@@ -2,8 +2,8 @@ import concurrent.futures
 import json
 
 import httpx
-from langchain_core.pydantic_v1 import BaseModel, SecretStr
 from loguru import logger
+from pydantic import BaseModel, SecretStr
 
 from langflow.field_typing import Embeddings
 


### PR DESCRIPTION
This PR updates the import statements in `aiml_embeddings.py` to correctly reference Pydantic, ensuring compatibility and proper functionality of the code. The previous imports from `langchain_core.pydantic_v1` have been replaced with direct imports from `pydantic`.