### PR TITLE
fix: Improve timeout handling in Blog Writer integration test

### DIFF
--- a/src/frontend/tests/core/integrations/Blog Writer.spec.ts
+++ b/src/frontend/tests/core/integrations/Blog Writer.spec.ts
@@ -42,7 +42,7 @@ test("Blog Writer", async ({ page }) => {
   await page.getByTestId("side_nav_options_all-templates").click();
   await page.getByRole("heading", { name: "Blog Writer" }).click();
   await page.waitForSelector('[data-testid="fit_view"]', {
-    timeout: 1000,
+    timeout: 5000,
   });
 
   await page.getByTestId("fit_view").click();


### PR DESCRIPTION
This pull request refactors the timeout handling in the Blog Writer integration test. The timeout for waiting for the selector '[data-testid="fit_view"]' has been increased from 1000ms to 5000ms to ensure that the element is properly loaded before proceeding with the test.