### PR TITLE
fix: raise ImportError instead of silencing AttributeError

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/base_component.py
+++ b/src/backend/base/langflow/custom/custom_component/base_component.py
@@ -1,4 +1,5 @@
 import operator
+import re
 from typing import Any, ClassVar
 from uuid import UUID
 
@@ -99,7 +100,11 @@ class BaseComponent:
             return self.get_template_config(component_instance)
 
         except AttributeError as e:
-            raise ImportError(e)
+            pattern = r"module '.*?' has no attribute '.*?'"
+            if re.search(pattern, str(e)):
+                raise ImportError(e) from e
+            raise
+        return {}
 
     def build(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError

--- a/src/backend/base/langflow/custom/custom_component/base_component.py
+++ b/src/backend/base/langflow/custom/custom_component/base_component.py
@@ -96,15 +96,15 @@ class BaseComponent:
 
         try:
             cc_class = eval_custom_component_code(self._code)
-            component_instance = cc_class(_code=self._code)
-            return self.get_template_config(component_instance)
 
         except AttributeError as e:
             pattern = r"module '.*?' has no attribute '.*?'"
             if re.search(pattern, str(e)):
                 raise ImportError(e) from e
             raise
-        return {}
+
+        component_instance = cc_class(_code=self._code)
+        return self.get_template_config(component_instance)
 
     def build(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError

--- a/src/backend/base/langflow/custom/custom_component/base_component.py
+++ b/src/backend/base/langflow/custom/custom_component/base_component.py
@@ -93,9 +93,13 @@ class BaseComponent:
         if not self._code:
             return {}
 
-        cc_class = eval_custom_component_code(self._code)
-        component_instance = cc_class(_code=self._code)
-        return self.get_template_config(component_instance)
+        try:
+            cc_class = eval_custom_component_code(self._code)
+            component_instance = cc_class(_code=self._code)
+            return self.get_template_config(component_instance)
+
+        except AttributeError as e:
+            raise ImportError(e)
 
     def build(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError

--- a/src/backend/base/langflow/schema/__init__.py
+++ b/src/backend/base/langflow/schema/__init__.py
@@ -1,4 +1,5 @@
 from .data import Data
 from .dotdict import dotdict
+from .message import Message
 
-__all__ = ["Data", "dotdict"]
+__all__ = ["Data", "dotdict", "Message"]


### PR DESCRIPTION
This PR raises ImportError to prevent silencing of AttributeError during custom component evaluation and adds the Message class to __init__ for easier, standardized imports