### PR TITLE
fix: swap descriptions for Load Data Flow and Retriever Flow in template

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -996,7 +996,7 @@
         "data": {
           "id": "note-UrQ0p",
           "node": {
-            "description": "## 📚 1. Load Data Flow\n\nRun this first! Load data from a local file and embed it into the vector database.\n\nSelect a Database and a Collection, or create new ones. \n\nClick ▶️ **Run component** on the **Astra DB** component to load your data.\n\n* If you're using OSS Langflow, add your Astra DB Application Token to the Astra DB component.\n\n#### Next steps:\n Experiment by changing the prompt and the contextual data to see how the retrieval flow's responses change.",
+            "description": "## 🐕 2. Retriever Flow\n\nThis flow answers your questions with contextual data retrieved from your vector database.\n\nOpen the **Playground** and ask, \n\n```\nWhat is this document about?\n```\n",
             "display_name": "",
             "documentation": "",
             "template": {
@@ -3242,7 +3242,7 @@
         "data": {
           "id": "note-igpjN",
           "node": {
-            "description": "## 🐕 2. Retriever Flow\n\nThis flow answers your questions with contextual data retrieved from your vector database.\n\nOpen the **Playground** and ask, \n\n```\nWhat is this document about?\n```\n",
+            "description": "## 📚 1. Load Data Flow\n\nRun this first! Load data from a local file and embed it into the vector database.\n\nSelect a Database and a Collection, or create new ones. \n\nClick ▶️ **Run component** on the **Astra DB** component to load your data.\n\n* If you're using OSS Langflow, add your Astra DB Application Token to the Astra DB component.\n\n#### Next steps:\n Experiment by changing the prompt and the contextual data to see how the retrieval flow's responses change.",
             "display_name": "",
             "documentation": "",
             "template": {


### PR DESCRIPTION
This pull request includes changes to the descriptions of nodes in the `Vector Store RAG.json` file to correct the order of steps in the flow. The most important changes include swapping the descriptions of the "Load Data Flow" and "Retriever Flow" nodes to ensure the correct sequence of operations.

Changes to node descriptions:

* [`src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json`](diffhunk://#diff-10837b87e2da91a231aa3ec84c3b6317cd239066c0c8979d2ce127f6408cf67dL999-R999): Updated the description of the node with `id: note-UrQ0p` to "## 🐕 2. Retriever Flow"
* [`src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json`](diffhunk://#diff-10837b87e2da91a231aa3ec84c3b6317cd239066c0c8979d2ce127f6408cf67dL3245-R3245): Updated the description of the node with `id: note-igpjN` to "## 📚 1. Load Data Flow"