### PR TITLE
fix: made sidebar collapse when screen is smaller

### DIFF
--- a/src/frontend/src/components/ui/sidebar.tsx
+++ b/src/frontend/src/components/ui/sidebar.tsx
@@ -5,6 +5,7 @@ import { VariantProps, cva } from "class-variance-authority";
 import { PanelLeft } from "lucide-react";
 import * as React from "react";
 
+import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "../../utils/utils";
 import ShadTooltip from "../shadTooltipComponent";
 import { Button } from "./button";
@@ -164,6 +165,7 @@ const Sidebar = React.forwardRef<
     ref,
   ) => {
     const { state, setOpen, defaultOpen } = useSidebar();
+    const isMobile = useIsMobile();
 
     React.useEffect(() => {
       if (collapsible === "none") {
@@ -172,6 +174,16 @@ const Sidebar = React.forwardRef<
         setOpen(defaultOpen);
       }
     }, [collapsible]);
+
+    React.useEffect(() => {
+      if (collapsible !== "none") {
+        if (isMobile) {
+          setOpen(false);
+        } else {
+          setOpen(defaultOpen);
+        }
+      }
+    }, [isMobile]);
 
     if (collapsible === "none") {
       return (


### PR DESCRIPTION
This pull request includes changes to the `src/frontend/src/components/ui/sidebar.tsx` file to improve responsiveness by incorporating mobile device detection. The most important changes are:

Enhancements for mobile responsiveness:

* [`src/frontend/src/components/ui/sidebar.tsx`](diffhunk://#diff-c3366f1c53140092f8bbc100e39829e6f4ed5040ad86d7941b54c52e2a07997dR8): Imported the `useIsMobile` hook to detect mobile devices.
* [`src/frontend/src/components/ui/sidebar.tsx`](diffhunk://#diff-c3366f1c53140092f8bbc100e39829e6f4ed5040ad86d7941b54c52e2a07997dR168): Added a `const isMobile = useIsMobile();` line within the `Sidebar` component to utilize the mobile detection.
* [`src/frontend/src/components/ui/sidebar.tsx`](diffhunk://#diff-c3366f1c53140092f8bbc100e39829e6f4ed5040ad86d7941b54c52e2a07997dR178-R187): Implemented a new `useEffect` hook to adjust the sidebar's open state based on whether the user is on a mobile device.