### PR TITLE
fix: defined max length of folder name

### DIFF
--- a/src/frontend/src/components/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -455,6 +455,7 @@ const SideBarFoldersButtonsComponent = ({
                                 onChange={(e) => {
                                   handleEditFolderName(e, item.name);
                                 }}
+                                maxLength={38}
                                 ref={refInput}
                                 onKeyDown={(e) => {
                                   handleKeyDownFn(e, item);


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/src/components/folderSidebarComponent/components/sideBarFolderButtons/index.tsx` file. The change adds a `maxLength` attribute to an input element to limit the folder name length to 38 characters.

* [`src/frontend/src/components/folderSidebarComponent/components/sideBarFolderButtons/index.tsx`](diffhunk://#diff-ae621e138fb3b965eb6e10d0b87373c244b49f3b895f1f20aa7ff44e54ede7f8R458): Added `maxLength={38}` to the input element to restrict the folder name length.