### PR TITLE
fix: improve node internal updates in setNodeClass function

### DIFF
--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -12,7 +12,7 @@ on:
         description: "Test suites to run (JSON array)"
         required: false
         type: string
-        default: '[]'
+        default: "[]"
       release:
         description: "Whether this is a release build"
         required: false
@@ -153,7 +153,8 @@ jobs:
 
           echo "Final test suites to run: $SUITES"
           echo "Test grep pattern: $TEST_GREP"
-          echo "matrix=$SUITES" >> $GITHUB_OUTPUT
+          # Ensure proper JSON formatting for matrix output
+          echo "matrix=$(echo $SUITES | jq -c .)" >> $GITHUB_OUTPUT
           echo "test_grep=$TEST_GREP" >> $GITHUB_OUTPUT
 
   setup-and-test:

--- a/src/frontend/src/CustomNodes/hooks/use-handle-new-value.tsx
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-new-value.tsx
@@ -103,7 +103,8 @@ const useHandleOnNewValue = ({
         };
       },
       true,
-      () => {
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 500));
         updateNodeInternals(nodeId);
       },
     );

--- a/src/frontend/src/CustomNodes/hooks/use-handle-new-value.tsx
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-new-value.tsx
@@ -72,14 +72,21 @@ const useHandleOnNewValue = ({
 
     const setNodeClass = (newNodeClass: APIClassType) => {
       options?.setNodeClass && options.setNodeClass(newNodeClass);
-      setNode(nodeId, (oldNode) => {
-        const newData = cloneDeep(oldNode.data);
-        newData.node = newNodeClass;
-        return {
-          ...oldNode,
-          data: newData,
-        };
-      });
+      setNode(
+        nodeId,
+        (oldNode) => {
+          const newData = cloneDeep(oldNode.data);
+          newData.node = newNodeClass;
+          return {
+            ...oldNode,
+            data: newData,
+          };
+        },
+        true,
+        () => {
+          updateNodeInternals(nodeId);
+        },
+      );
     };
 
     if (shouldUpdate && changes.value !== undefined) {
@@ -103,8 +110,7 @@ const useHandleOnNewValue = ({
         };
       },
       true,
-      async () => {
-        await new Promise((resolve) => setTimeout(resolve, 500));
+      () => {
         updateNodeInternals(nodeId);
       },
     );

--- a/src/frontend/src/CustomNodes/hooks/use-handle-new-value.tsx
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-new-value.tsx
@@ -37,7 +37,6 @@ const useHandleOnNewValue = ({
   const updateNodeInternals = useUpdateNodeInternals();
 
   const setErrorData = useAlertStore((state) => state.setErrorData);
-
   const postTemplateValue = usePostTemplateValue({
     parameterId: name,
     nodeId: nodeId,


### PR DESCRIPTION
This pull request includes a change to the `src/frontend/src/CustomNodes/hooks/use-handle-new-value.tsx` file to improve the handling of new node values. The most important change is the modification of the `setNodeClass` function to ensure node internals are updated correctly.

Enhancements to node value handling:

* [`src/frontend/src/CustomNodes/hooks/use-handle-new-value.tsx`](diffhunk://#diff-ad64cf66a29bad7dff76cae269058857414b87c120f9711f1e3cf4a124ee9fd8L75-R89): Modified the `setNodeClass` function to include additional parameters for `setNode`, ensuring that node internals are updated after setting the new node class.