### PR TITLE
ci: Add dynamic shard count calculation for Playwright tests in CI workflow

### DIFF
--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -56,9 +56,9 @@ jobs:
   determine-test-suite:
     runs-on: ubuntu-latest
     outputs:
-      matrix-combinations: ${{ steps.setup-matrix.outputs.matrix-combinations }}
+      matrix: ${{ steps.setup-matrix.outputs.matrix }}
       test_grep: ${{ steps.set-matrix.outputs.test_grep }}
-      suites: ${{ steps.set-matrix.outputs.matrix }}
+      suites: ${{ steps.set-matrix.outputs.suites }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -197,21 +197,16 @@ jobs:
             SHARD_COUNT=10
           fi
 
-          # Create matrix combinations JSON
-          MATRIX_COMBINATIONS=$(jq -n \
-            --arg count "$SHARD_COUNT" \
-            '{
-              "include": [
-                range(1; ($count|tonumber) + 1) |
-                {
-                  "shardIndex": .,
-                  "shardTotal": ($count|tonumber)
-                }
-              ]
-            }')
+          # Create the matrix combinations string
+          MATRIX_COMBINATIONS=""
+          for i in $(seq 1 $SHARD_COUNT); do
+            if [ $i -gt 1 ]; then
+              MATRIX_COMBINATIONS="$MATRIX_COMBINATIONS,"
+            fi
+            MATRIX_COMBINATIONS="$MATRIX_COMBINATIONS{\"shardIndex\": $i, \"shardTotal\": $SHARD_COUNT}"
+          done
 
-          # Output the matrix combinations
-          echo "matrix-combinations=$MATRIX_COMBINATIONS" >> "$GITHUB_OUTPUT"
+          echo "matrix={\"include\":[$MATRIX_COMBINATIONS]}" >> "$GITHUB_OUTPUT"
 
   setup-and-test:
     name: Playwright Tests - Group ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
@@ -220,7 +215,7 @@ jobs:
     if: ${{ fromJson(needs.determine-test-suite.outputs.suites)[0] != null }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.determine-test-suite.outputs.matrix-combinations) }}
+      matrix: ${{ fromJson(needs.determine-test-suite.outputs.matrix) }}
     env:
       OPENAI_API_KEY: ${{ inputs.openai_api_key || secrets.OPENAI_API_KEY }}
       STORE_API_KEY: ${{ inputs.store_api_key || secrets.STORE_API_KEY }}
@@ -275,8 +270,8 @@ jobs:
           command: |
             cd src/frontend
             echo 'Running tests with pattern: ${{ needs.determine-test-suite.outputs.test_grep }}'
-            npx playwright test ${{ inputs.tests_folder }} ${{ needs.determine-test-suite.outputs.test_grep }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --list
-            npx playwright test ${{ inputs.tests_folder }} ${{ needs.determine-test-suite.outputs.test_grep }} --trace on --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --workers 2
+            npx playwright test ${{ inputs.tests_folder }} ${{ needs.determine-test-suite.outputs.test_grep }} --shard ${{ matrix.shardIndex }} --list
+            npx playwright test ${{ inputs.tests_folder }} ${{ needs.determine-test-suite.outputs.test_grep }} --trace on --shard ${{ matrix.shardIndex }} --workers 2
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: always()

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -162,6 +162,12 @@ jobs:
           # Ensure proper JSON formatting for matrix output
           echo "matrix=$(echo $SUITES | jq -c .)" >> $GITHUB_OUTPUT
           echo "test_grep=$TEST_GREP" >> $GITHUB_OUTPUT
+
+      - name: Install Playwright
+        id: install-playwright
+        uses: ./.github/actions/install-playwright
+        with:
+          working-directory: ./src/frontend
       - name: Count Tests and Calculate Shards
         id: count-tests
         run: |

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -200,7 +200,7 @@ jobs:
       matrix:
         # Use the dynamically calculated shard count
         shardIndex: ${{ fromJson(format('[{0}]', join(range(1, needs.determine-test-suite.outputs.shard_count + 1), ','))) }}
-        shardTotal: [${{ needs.determine-test-suite.outputs.shard_count }}]
+        shardTotal: ${{ fromJson(format('[{0}]', needs.determine-test-suite.outputs.shard_count)) }}
     env:
       OPENAI_API_KEY: ${{ inputs.openai_api_key || secrets.OPENAI_API_KEY }}
       STORE_API_KEY: ${{ inputs.store_api_key || secrets.STORE_API_KEY }}

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -58,6 +58,7 @@ jobs:
     outputs:
       suites: ${{ steps.set-matrix.outputs.matrix }}
       test_grep: ${{ steps.set-matrix.outputs.test_grep }}
+      shard_count: ${{ steps.count-tests.outputs.shard_count }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -162,6 +163,33 @@ jobs:
           echo "matrix=$(echo $SUITES | jq -c .)" >> $GITHUB_OUTPUT
           echo "test_grep=$TEST_GREP" >> $GITHUB_OUTPUT
 
+      - name: Count Tests and Calculate Shards
+        id: count-tests
+        run: |
+          cd src/frontend
+
+          # Get the test count using playwright's built-in grep
+          if [ -n "${{ steps.set-matrix.outputs.test_grep }}" ]; then
+            # Use the grep pattern with playwright
+            TEST_COUNT=$(npx playwright test ${{ inputs.tests_folder }} ${{ steps.set-matrix.outputs.test_grep }} --list | wc -l)
+          else
+            # Count all tests if no pattern
+            TEST_COUNT=$(npx playwright test ${{ inputs.tests_folder }} --list | wc -l)
+          fi
+
+          echo "Total tests to run: $TEST_COUNT"
+
+          # Calculate optimal shard count - 1 shard per 5 tests, min 1, max 10
+          SHARD_COUNT=$(( (TEST_COUNT + 4) / 5 ))
+          if [ $SHARD_COUNT -lt 1 ]; then
+            SHARD_COUNT=1
+          elif [ $SHARD_COUNT -gt 10 ]; then
+            SHARD_COUNT=10
+          fi
+
+          echo "Calculated shard count: $SHARD_COUNT"
+          echo "shard_count=$SHARD_COUNT" >> $GITHUB_OUTPUT
+
   setup-and-test:
     name: Playwright Tests - Group ${{ matrix.shardIndex }}
     runs-on: ubuntu-latest
@@ -170,8 +198,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        shardTotal: [10]
+        # Use the dynamically calculated shard count
+        shardIndex: ${{ fromJson(format('[{0}]', join(range(1, needs.determine-test-suite.outputs.shard_count + 1), ','))) }}
+        shardTotal: [${{ needs.determine-test-suite.outputs.shard_count }}]
     env:
       OPENAI_API_KEY: ${{ inputs.openai_api_key || secrets.OPENAI_API_KEY }}
       STORE_API_KEY: ${{ inputs.store_api_key || secrets.STORE_API_KEY }}

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -182,10 +182,8 @@ jobs:
 
           # Get the test count using playwright's built-in grep
           if [ -n "${{ steps.set-matrix.outputs.test_grep }}" ]; then
-            # Use the grep pattern with playwright
             TEST_COUNT=$(npx playwright test ${{ inputs.tests_folder }} ${{ steps.set-matrix.outputs.test_grep }} --list | wc -l)
           else
-            # Count all tests if no pattern
             TEST_COUNT=$(npx playwright test ${{ inputs.tests_folder }} --list | wc -l)
           fi
 
@@ -199,12 +197,11 @@ jobs:
             SHARD_COUNT=10
           fi
 
-          # Create a JSON array of numbers from 1 to SHARD_COUNT using jq directly
-          INDEX_ARRAY=$(jq -n --arg count "$SHARD_COUNT" '[range(1; ($count|tonumber) + 1)]')
+          # Create a JSON array and ensure it's properly escaped for GitHub Actions output
+          INDEX_ARRAY=$(jq -c -n --arg count "$SHARD_COUNT" '[range(1; ($count|tonumber) + 1)]')
 
-          echo "Calculated shard count: $SHARD_COUNT"
-          echo "shard_count=$SHARD_COUNT" >> $GITHUB_OUTPUT
-          echo "shard_indices=$INDEX_ARRAY" >> $GITHUB_OUTPUT
+          echo "shard_count=${SHARD_COUNT}" >> "$GITHUB_OUTPUT"
+          echo "shard_indices=${INDEX_ARRAY}" >> "$GITHUB_OUTPUT"
 
   setup-and-test:
     name: Playwright Tests - Group ${{ matrix.shardIndex }}

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -187,8 +187,12 @@ jobs:
             SHARD_COUNT=10
           fi
 
+          # Create a JSON array of numbers from 1 to SHARD_COUNT
+          INDEX_ARRAY=$(seq -s, 1 $SHARD_COUNT | jq -Rc '[splits(",")[] | tonumber]')
+
           echo "Calculated shard count: $SHARD_COUNT"
           echo "shard_count=$SHARD_COUNT" >> $GITHUB_OUTPUT
+          echo "shard_indices=$INDEX_ARRAY" >> $GITHUB_OUTPUT
 
   setup-and-test:
     name: Playwright Tests - Group ${{ matrix.shardIndex }}
@@ -198,8 +202,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Use the dynamically calculated shard count
-        shardIndex: ${{ fromJson(format('[{0}]', join(range(1, needs.determine-test-suite.outputs.shard_count + 1), ','))) }}
+        shardIndex: ${{ fromJson(needs.determine-test-suite.outputs.shard_indices) }}
         shardTotal: ${{ fromJson(format('[{0}]', needs.determine-test-suite.outputs.shard_count)) }}
     env:
       OPENAI_API_KEY: ${{ inputs.openai_api_key || secrets.OPENAI_API_KEY }}

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -33,7 +33,7 @@ on:
         description: "Test suites to run (JSON array)"
         required: false
         type: string
-        default: '["starter-projects", "components", "workspace", "api", "database"]'
+        default: '[]'
       release:
         description: "Whether this is a release build"
         required: false

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -163,11 +163,18 @@ jobs:
           echo "matrix=$(echo $SUITES | jq -c .)" >> $GITHUB_OUTPUT
           echo "test_grep=$TEST_GREP" >> $GITHUB_OUTPUT
 
-      - name: Install Playwright
-        id: install-playwright
-        uses: ./.github/actions/install-playwright
+      - name: Setup Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        id: setup-node
         with:
-          working-directory: ./src/frontend
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: ./src/frontend/package-lock.json
+
+      - name: Install Node.js dependencies
+        run: npm ci
+        working-directory: ./src/frontend
+
       - name: Count Tests and Calculate Shards
         id: count-tests
         run: |

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -162,7 +162,6 @@ jobs:
           # Ensure proper JSON formatting for matrix output
           echo "matrix=$(echo $SUITES | jq -c .)" >> $GITHUB_OUTPUT
           echo "test_grep=$TEST_GREP" >> $GITHUB_OUTPUT
-
       - name: Count Tests and Calculate Shards
         id: count-tests
         run: |
@@ -187,8 +186,8 @@ jobs:
             SHARD_COUNT=10
           fi
 
-          # Create a JSON array of numbers from 1 to SHARD_COUNT
-          INDEX_ARRAY=$(seq -s, 1 $SHARD_COUNT | jq -Rc '[splits(",")[] | tonumber]')
+          # Create a JSON array of numbers from 1 to SHARD_COUNT using jq directly
+          INDEX_ARRAY=$(jq -n --arg count "$SHARD_COUNT" '[range(1; ($count|tonumber) + 1)]')
 
           echo "Calculated shard count: $SHARD_COUNT"
           echo "shard_count=$SHARD_COUNT" >> $GITHUB_OUTPUT

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -212,7 +212,6 @@ jobs:
     name: Playwright Tests - Group ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     runs-on: ubuntu-latest
     needs: determine-test-suite
-    if: ${{ fromJson(needs.determine-test-suite.outputs.suites)[0] != null }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.determine-test-suite.outputs.matrix) }}

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -56,9 +56,9 @@ jobs:
   determine-test-suite:
     runs-on: ubuntu-latest
     outputs:
-      suites: ${{ steps.set-matrix.outputs.matrix }}
+      matrix-combinations: ${{ steps.setup-matrix.outputs.matrix-combinations }}
       test_grep: ${{ steps.set-matrix.outputs.test_grep }}
-      shard_count: ${{ steps.count-tests.outputs.shard_count }}
+      suites: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -175,8 +175,8 @@ jobs:
         run: npm ci
         working-directory: ./src/frontend
 
-      - name: Count Tests and Calculate Shards
-        id: count-tests
+      - name: Setup Matrix Combinations
+        id: setup-matrix
         run: |
           cd src/frontend
 
@@ -197,22 +197,30 @@ jobs:
             SHARD_COUNT=10
           fi
 
-          # Create a JSON array and ensure it's properly escaped for GitHub Actions output
-          INDEX_ARRAY=$(jq -c -n --arg count "$SHARD_COUNT" '[range(1; ($count|tonumber) + 1)]')
+          # Create matrix combinations JSON
+          MATRIX_COMBINATIONS=$(jq -n \
+            --arg count "$SHARD_COUNT" \
+            '{
+              "include": [
+                range(1; ($count|tonumber) + 1) |
+                {
+                  "shardIndex": .,
+                  "shardTotal": ($count|tonumber)
+                }
+              ]
+            }')
 
-          echo "shard_count=${SHARD_COUNT}" >> "$GITHUB_OUTPUT"
-          echo "shard_indices=${INDEX_ARRAY}" >> "$GITHUB_OUTPUT"
+          # Output the matrix combinations
+          echo "matrix-combinations=$MATRIX_COMBINATIONS" >> "$GITHUB_OUTPUT"
 
   setup-and-test:
-    name: Playwright Tests - Group ${{ matrix.shardIndex }}
+    name: Playwright Tests - Group ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     runs-on: ubuntu-latest
     needs: determine-test-suite
     if: ${{ fromJson(needs.determine-test-suite.outputs.suites)[0] != null }}
     strategy:
       fail-fast: false
-      matrix:
-        shardIndex: ${{ fromJson(needs.determine-test-suite.outputs.shard_indices) }}
-        shardTotal: ${{ fromJson(format('[{0}]', needs.determine-test-suite.outputs.shard_count)) }}
+      matrix: ${{ fromJson(needs.determine-test-suite.outputs.matrix-combinations) }}
     env:
       OPENAI_API_KEY: ${{ inputs.openai_api_key || secrets.OPENAI_API_KEY }}
       STORE_API_KEY: ${{ inputs.store_api_key || secrets.STORE_API_KEY }}

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -87,8 +87,8 @@ jobs:
           if [[ "$RELEASE" == "true" ]]; then
             SUITES='["release"]'
             echo "Release build detected - setting suites to: $SUITES"
-            # No grep pattern for release - run all tests
-            TEST_GREP=""
+            # grep pattern for release is the @release tag - run all tests
+            TEST_GREP="--grep=\"@release\""
           else
             # If input suites were not provided, determine based on changes
             if [[ "$SUITES" == "[]" ]]; then
@@ -211,6 +211,7 @@ jobs:
   setup-and-test:
     name: Playwright Tests - Group ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     runs-on: ubuntu-latest
+    if: ${{ needs.determine-test-suite.outputs.test_grep != '' }}
     needs: determine-test-suite
     strategy:
       fail-fast: false


### PR DESCRIPTION
This pull request introduces a dynamic calculation for the shard count in the Playwright test workflow within the CI pipeline. The shard count is determined based on the total number of tests, optimizing the distribution of tests across shards. The calculation ensures a minimum of 1 shard and a maximum of 10, with the logic implemented to count tests based on specified patterns or all tests if no pattern is provided. This enhancement aims to improve test execution efficiency in the CI process.