### PR TITLE
ci: Enable release flag for TypeScript tests in nightly build workflow

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -132,6 +132,7 @@ jobs:
     uses: ./.github/workflows/typescript_test.yml
     with:
       tests_folder: "tests"
+      release: true
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       STORE_API_KEY: ${{ secrets.STORE_API_KEY }}


### PR DESCRIPTION
This PR updates the nightly build workflow to enable the release flag for TypeScript tests, ensuring that the tests run in a release mode during the nightly builds. This change aims to improve the testing process and ensure better coverage of release scenarios.