### PR TITLE
fix: handle different output formats in agent message processing

### DIFF
--- a/src/backend/base/langflow/base/agents/events.py
+++ b/src/backend/base/langflow/base/agents/events.py
@@ -85,7 +85,14 @@ def handle_on_chain_end(
 ) -> tuple[Message, float]:
     data_output = event["data"].get("output")
     if data_output and isinstance(data_output, AgentFinish) and data_output.return_values.get("output"):
-        agent_message.text = data_output.return_values.get("output")
+        output = data_output.return_values.get("output")
+        if isinstance(output, str):
+            agent_message.text = output
+        elif isinstance(output, list) and len(output) > 1 and isinstance(output[0], dict) and "text" in output[0]:
+            agent_message.text = output[0]["text"]
+        else:
+            msg = f"Output is not a string or list of dictionaries with 'text' key: {output}"
+            raise ValueError(msg)
         agent_message.properties.state = "complete"
         # Add duration to the last content if it exists
         if agent_message.content_blocks:

--- a/src/backend/base/langflow/base/agents/events.py
+++ b/src/backend/base/langflow/base/agents/events.py
@@ -88,7 +88,7 @@ def handle_on_chain_end(
         output = data_output.return_values.get("output")
         if isinstance(output, str):
             agent_message.text = output
-        elif isinstance(output, list) and len(output) > 1 and isinstance(output[0], dict) and "text" in output[0]:
+        elif isinstance(output, list) and len(output) == 1 and isinstance(output[0], dict) and "text" in output[0]:
             agent_message.text = output[0]["text"]
         else:
             msg = f"Output is not a string or list of dictionaries with 'text' key: {output}"


### PR DESCRIPTION
This pull request addresses the issue of processing agent messages by adding support for various output formats. It ensures that the output can be a string or a list of dictionaries containing a 'text' key, improving the robustness of the message handling. If the output does not conform to these formats, a descriptive error is raised.


This fixes the experience with Anthropic models.