### PR TITLE
css: Fix AG Grid cell line height by setting internal property to none

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -187,3 +187,7 @@ code {
 .ag-cell {
   --ag-internal-calculated-line-height: none !important;
 }
+
+.ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value) {
+  --ag-internal-calculated-line-height: none !important;
+}

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -183,3 +183,7 @@ body {
 code {
   font-family: var(--font-mono) s !important;
 }
+
+.ag-cell {
+  --ag-internal-calculated-line-height: none !important;
+}


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/src/App.css` file. The change adds a new CSS rule for `.ag-cell` to set the `--ag-internal-calculated-line-height` property to `none` with `!important` priority.

* [`src/frontend/src/App.css`](diffhunk://#diff-3e7904848c381eb53375a14db869438235df15b6e439845f23d09b12382c0d47R186-R189): Added a new CSS rule for `.ag-cell` to set `--ag-internal-calculated-line-height` to `none` with `!important` priority.

BEFORE:

![image](https://github.com/user-attachments/assets/a57cdef3-3c12-4763-abf5-4bc3a27c0d0d)


AFTER:

![image](https://github.com/user-attachments/assets/e3d475cb-9db7-4a60-b999-0e25ead64c4a)
