### PR TITLE
fix: add !important to shadcn aggrid styling

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -187,3 +187,7 @@ code {
 .ag-cell {
   --ag-internal-calculated-line-height: none !important;
 }
+
+.ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value) {
+  --ag-internal-calculated-line-height: none !important;
+}

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -183,3 +183,7 @@ body {
 code {
   font-family: var(--font-mono) s !important;
 }
+
+.ag-cell {
+  --ag-internal-calculated-line-height: none !important;
+}

--- a/src/frontend/src/style/ag-theme-shadcn.css
+++ b/src/frontend/src/style/ag-theme-shadcn.css
@@ -1,23 +1,23 @@
 /* set the background color of many elements across the grid */
 .ag-theme-shadcn {
-  --ag-foreground-color: hsl(var(--foreground));
-  --ag-background-color: hsl(var(--background));
-  --ag-secondary-foreground-color: hsl(var(--secondary-foreground));
-  --ag-data-color: hsl(var(--foreground));
-  --ag-header-foreground-color: hsl(var(--muted-foreground));
-  --ag-header-background-color: hsl(var(--background));
-  --ag-tooltip-background-color: hsl(var(--muted));
-  --ag-disabled-foreground-color: hsl(var(--muted-foreground));
-  --ag-border-color: hsl(var(--border));
-  --ag-selected-row-background-color: hsl(var(--accent));
-  --ag-menu-background-color: hsl(var(--accent));
-  --ag-panel-background-color: hsl(var(--accent));
-  --ag-row-hover-color: hsl(var(--primary-foreground));
-  --ag-header-height: 2.5rem;
+  --ag-foreground-color: hsl(var(--foreground)) !important;
+  --ag-background-color: hsl(var(--background)) !important;
+  --ag-secondary-foreground-color: hsl(var(--secondary-foreground)) !important;
+  --ag-data-color: hsl(var(--foreground)) !important;
+  --ag-header-foreground-color: hsl(var(--muted-foreground)) !important;
+  --ag-header-background-color: hsl(var(--background)) !important;
+  --ag-tooltip-background-color: hsl(var(--muted)) !important;
+  --ag-disabled-foreground-color: hsl(var(--muted-foreground)) !important;
+  --ag-border-color: hsl(var(--border)) !important;
+  --ag-selected-row-background-color: hsl(var(--accent)) !important;
+  --ag-menu-background-color: hsl(var(--accent)) !important;
+  --ag-panel-background-color: hsl(var(--accent)) !important;
+  --ag-row-hover-color: hsl(var(--primary-foreground)) !important;
+  --ag-header-height: 2.5rem !important;
 }
 
 .ag-theme-shadcn .ag-paging-panel {
-  height: 3rem;
+  height: 3rem !important;
 }
 
 .ag-row .ag-cell {


### PR DESCRIPTION
This pull request includes changes to the CSS files to improve the styling and ensure consistency across the grid. The most important changes include adding new CSS rules for the `.ag-cell` class and updating existing CSS rules in the `ag-theme-shadcn` class to use `!important`.

Styling improvements:

* [`src/frontend/src/App.css`](diffhunk://#diff-3e7904848c381eb53375a14db869438235df15b6e439845f23d09b12382c0d47R186-R193): Added new CSS rules for the `.ag-cell` class and its child elements to set the `--ag-internal-calculated-line-height` to `none` with `!important`.
* [`src/frontend/src/style/ag-theme-shadcn.css`](diffhunk://#diff-6cc8681a29a2d481a5c25262d479622a2af6884f86499e6da1e0b2e1723179b2L3-R20): Updated existing CSS rules in the `ag-theme-shadcn` class to use `!important` for various properties to ensure they take precedence.