### PR TITLE
fix: updates file size limit to use middleware and add tests for uploads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,7 @@ dev-dependencies = [
     "pytest-github-actions-annotate-failures>=0.2.0",
     "pytest-codspeed>=3.0.0",
     "blockbuster>=1.1.1,<1.2",
+    "types-aiofiles>=24.1.0.20240626",
 ]
 
 

--- a/src/backend/base/langflow/api/v1/files.py
+++ b/src/backend/base/langflow/api/v1/files.py
@@ -12,7 +12,7 @@ from fastapi.responses import StreamingResponse
 from langflow.api.utils import AsyncDbSession, CurrentActiveUser
 from langflow.api.v1.schemas import UploadFileResponse
 from langflow.services.database.models.flow import Flow
-from langflow.services.deps import get_settings_service, get_storage_service
+from langflow.services.deps import get_storage_service
 from langflow.services.storage.service import StorageService
 from langflow.services.storage.utils import build_content_type_from_extension
 
@@ -46,16 +46,6 @@ async def upload_file(
     session: AsyncDbSession,
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
 ) -> UploadFileResponse:
-    try:
-        max_file_size_upload = get_settings_service().settings.max_file_size_upload
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
-
-    if file.size > max_file_size_upload * 1024 * 1024:
-        raise HTTPException(
-            status_code=413, detail=f"File size is larger than the maximum file size {max_file_size_upload}MB."
-        )
-
     try:
         flow_id_str = str(flow_id)
         flow = await session.get(Flow, flow_id_str)

--- a/src/backend/base/langflow/components/embeddings/cloudflare.py
+++ b/src/backend/base/langflow/components/embeddings/cloudflare.py
@@ -30,7 +30,7 @@ class CloudflareWorkersAIEmbeddingsComponent(LCModelComponent):
             display_name="Model Name",
             info="List of supported models https://developers.cloudflare.com/workers-ai/models/#text-embeddings",
             required=True,
-            value="@cf/baai/bge-base-en-v1.5"
+            value="@cf/baai/bge-base-en-v1.5",
         ),
         BoolInput(
             name="strip_new_lines",
@@ -75,6 +75,6 @@ class CloudflareWorkersAIEmbeddingsComponent(LCModelComponent):
                 strip_new_lines=self.strip_new_lines,
             )
         except Exception as e:
-            raise ValueError(f"Could not connect to CloudflareWorkersAIEmbeddings API: {str(e)}") from e
+            raise ValueError(f"Could not connect to CloudflareWorkersAIEmbeddings API: {e!s}") from e
 
         return embeddings

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -28,6 +28,7 @@ from langflow.initial_setup.setup import (
 from langflow.interface.types import get_and_cache_all_types_dict
 from langflow.interface.utils import setup_llm_caching
 from langflow.logging.logger import configure
+from langflow.middleware import ContentSizeLimitMiddleware
 from langflow.services.deps import get_settings_service, get_telemetry_service
 from langflow.services.utils import initialize_services, teardown_services
 
@@ -132,6 +133,10 @@ def create_app():
     configure()
     lifespan = get_lifespan(version=__version__)
     app = FastAPI(lifespan=lifespan, title="Langflow", version=__version__)
+    app.add_middleware(
+        ContentSizeLimitMiddleware,
+    )
+
     setup_sentry(app)
     origins = ["*"]
 

--- a/src/backend/base/langflow/middleware.py
+++ b/src/backend/base/langflow/middleware.py
@@ -1,0 +1,58 @@
+from fastapi import HTTPException
+from loguru import logger
+
+from langflow.services.deps import get_settings_service
+
+
+class MaxFileSizeException(HTTPException):
+    def __init__(self, detail: str = "File size is larger than the maximum file size {}MB"):
+        super().__init__(status_code=413, detail=detail)
+
+
+# Adapted from https://github.com/steinnes/content-size-limit-asgi/blob/master/content_size_limit_asgi/middleware.py#L26
+class ContentSizeLimitMiddleware:
+    """Content size limiting middleware for ASGI applications.
+
+    Args:
+      app (ASGI application): ASGI application
+      max_content_size (optional): the maximum content size allowed in bytes, None for no limit
+      exception_cls (optional): the class of exception to raise (ContentSizeExceeded is the default)
+    """
+
+    def __init__(
+        self,
+        app,
+    ):
+        self.app = app
+        self.logger = logger
+
+    def receive_wrapper(self, receive):
+        received = 0
+
+        async def inner():
+            max_file_size_upload = get_settings_service().settings.max_file_size_upload
+            nonlocal received
+            message = await receive()
+            if message["type"] != "http.request" or max_file_size_upload is None:
+                return message
+            body_len = len(message.get("body", b""))
+            received += body_len
+            if received > max_file_size_upload * 1024 * 1024:
+                # max_content_size is in bytes, convert to MB
+                received_in_mb = round(received / (1024 * 1024), 3)
+                msg = (
+                    f"Content size limit exceeded. Maximum allowed is {max_file_size_upload}MB"
+                    f" and got {received_in_mb}MB."
+                )
+                raise MaxFileSizeException(msg)
+            return message
+
+        return inner
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        wrapper = self.receive_wrapper(receive)
+        await self.app(scope, wrapper, send)

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -78,6 +78,7 @@ dev-dependencies = [
     "asgi-lifespan>=2.1.0",
     "pytest-codspeed>=3.0.0",
     "pytest-github-actions-annotate-failures>=0.2.0",
+    "types-aiofiles>=24.1.0.20240626",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -3649,6 +3649,7 @@ dev = [
     { name = "requests" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "types-aiofiles" },
     { name = "types-google-cloud-ndb" },
     { name = "types-markdown" },
     { name = "types-passlib" },
@@ -3780,6 +3781,7 @@ dev = [
     { name = "requests", specifier = ">=2.32.0" },
     { name = "respx", specifier = ">=0.21.1" },
     { name = "ruff", specifier = ">=0.6.2,<0.7.0" },
+    { name = "types-aiofiles", specifier = ">=24.1.0.20240626" },
     { name = "types-google-cloud-ndb", specifier = ">=2.2.0.0" },
     { name = "types-markdown", specifier = ">=3.7.0.20240822" },
     { name = "types-passlib", specifier = ">=1.7.7.13" },
@@ -3913,6 +3915,7 @@ dev = [
     { name = "asgi-lifespan" },
     { name = "pytest-codspeed" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "types-aiofiles" },
 ]
 
 [package.metadata]
@@ -4023,6 +4026,7 @@ dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
     { name = "pytest-codspeed", specifier = ">=3.0.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.2.0" },
+    { name = "types-aiofiles", specifier = ">=24.1.0.20240626" },
 ]
 
 [[package]]
@@ -7759,6 +7763,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/87/9eb07fdfa14e22ec7658b5b1147836d22df3848a22c85a4e18ed272303a5/typer-0.13.0.tar.gz", hash = "sha256:f1c7198347939361eec90139ffa0fd8b3df3a2259d5852a0f7400e476d95985c", size = 97572 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/7e/c8bfa8cbcd3ea1d25d2beb359b5c5a3f4339a7e2e5d9e3ef3e29ba3ab3b9/typer-0.13.0-py3-none-any.whl", hash = "sha256:d85fe0b777b2517cc99c8055ed735452f2659cd45e451507c76f48ce5c1d00e2", size = 44194 },
+]
+
+[[package]]
+name = "types-aiofiles"
+version = "24.1.0.20240626"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/e9/013940b017c313c2e15c64017268fdb0c25e0638621fb8a5d9ebe00fb0f4/types-aiofiles-24.1.0.20240626.tar.gz", hash = "sha256:48604663e24bc2d5038eac05ccc33e75799b0779e93e13d6a8f711ddc306ac08", size = 9357 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/ad/c4b3275d21c5be79487c4f6ed7cd13336997746fe099236cb29256a44a90/types_aiofiles-24.1.0.20240626-py3-none-any.whl", hash = "sha256:7939eca4a8b4f9c6491b6e8ef160caee9a21d32e18534a57d5ed90aee47c66b4", size = 9389 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces a new middleware for the FastAPI application to enforce content size limits on file uploads. It removes the previous file size limit check from the upload endpoint and adds tests to ensure the upload functionality adheres to the specified size constraints. Additionally, the `types-aiofiles` dependency has been added to the project configuration.