### PR TITLE
fix: Update NodeToolbarComponent to use setErrorData instead of setNoticeData

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -85,7 +85,7 @@ export default function NodeToolbarComponent({
       data.node!,
       handleNodeClass,
       postToolModeValue,
-      setNoticeData,
+      setErrorData,
       "tool_mode",
     );
     updateNodeInternals(data.id);
@@ -222,6 +222,7 @@ export default function NodeToolbarComponent({
 
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const setNoticeData = useAlertStore((state) => state.setNoticeData);
+  const setErrorData = useAlertStore((state) => state.setErrorData);
 
   useEffect(() => {
     setFlowComponent(createFlowComponent(cloneDeep(data), version));


### PR DESCRIPTION
This pull request refactors the NodeToolbarComponent by replacing the usage of the setNoticeData function with the setErrorData function. This change ensures that error data is properly handled.