### PR TITLE
fix: add padding to global variables input

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
@@ -68,9 +68,9 @@ const CustomInputPopover = ({
         <div
           data-testid={`anchor-${id}`}
           className={cn(
-            "primary-input noflow nowheel nopan nodelete nodrag border-1 flex h-full min-h-[2.375rem] cursor-default flex-wrap items-center px-3",
-            editNode && "min-h-7 p-0",
-            editNode && disabled && "min-h-5 border-muted p-0",
+            "primary-input noflow nowheel nopan nodelete nodrag border-1 flex h-full min-h-[2.375rem] cursor-default flex-wrap items-center px-2",
+            editNode && "min-h-7 p-0 px-1",
+            editNode && disabled && "min-h-5 border-muted",
             disabled && "bg-muted text-muted",
             isFocused &&
               "border-foreground ring-1 ring-foreground hover:border-foreground",
@@ -100,6 +100,7 @@ const CustomInputPopover = ({
               variant={nodeStyle ? "emerald" : "secondary"}
               className={cn(
                 "flex items-center gap-1 truncate",
+                editNode && "text-xs",
                 nodeStyle ? "font-jetbrains rounded-[3px] px-1" : "bg-muted",
               )}
             >
@@ -128,8 +129,8 @@ const CustomInputPopover = ({
               disabled={disabled}
               required={required}
               className={cn(
-                "popover-input nodrag truncate pr-4",
-                editNode && "px-3",
+                "popover-input nodrag truncate px-1 pr-4",
+                editNode && "px-2",
                 editNode && disabled && "h-fit w-fit",
                 disabled &&
                   "disabled:text-muted disabled:opacity-100 placeholder:disabled:text-muted-foreground",

--- a/src/frontend/src/components/ui/badge.tsx
+++ b/src/frontend/src/components/ui/badge.tsx
@@ -18,7 +18,7 @@ const badgeVariants = cva(
         secondaryStatic: "bg-muted text-muted-foreground border-0",
         pinkStatic: "bg-accent-pink text-accent-pink-foreground border-0",
         emerald:
-          "bg-accent-emerald text-accent-emerald-foreground hover:bg-accent-emerald-hover",
+          "bg-accent-emerald text-accent-emerald-foreground hover:bg-accent-emerald-hover border-0",
         successStatic:
           "bg-accent-emerald text-accent-emerald-foreground border-0",
         errorStatic: "bg-error-background text-error-foreground border-0",


### PR DESCRIPTION
This pull request includes several changes to the `CustomInputPopover` component and the `badgeVariants` styles in the frontend codebase. The main goal is to adjust the styling and improve the user interface consistency.

Styling adjustments in `CustomInputPopover`:

* Modified padding and margin values to improve the layout and appearance of the input component. (`src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx`, [src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsxL71-R73](diffhunk://#diff-6dd2f8aa520258e6efb0482b5419536b2eb345b1cccdcf29c1b4562971c4f0e4L71-R73))
* Added a conditional class to adjust the text size when `editNode` is true. (`src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx`, [src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsxR103](diffhunk://#diff-6dd2f8aa520258e6efb0482b5419536b2eb345b1cccdcf29c1b4562971c4f0e4R103))
* Adjusted padding for the input field to ensure better alignment and spacing. (`src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx`, [src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsxL131-R133](diffhunk://#diff-6dd2f8aa520258e6efb0482b5419536b2eb345b1cccdcf29c1b4562971c4f0e4L131-R133))

Styling adjustments in `badgeVariants`:

* Added `border-0` to the `emerald` variant to ensure consistency with other badge styles. (`src/frontend/src/components/ui/badge.tsx`, [src/frontend/src/components/ui/badge.tsxL21-R21](diffhunk://#diff-70d3368ea151210c3f900e0a1a8788f3ef87d1639e6ba8c70af34b2c485aa853L21-R21))