### PR TITLE
fix: removed beta from current date

### DIFF
--- a/src/backend/base/langflow/components/embeddings/cloudflare.py
+++ b/src/backend/base/langflow/components/embeddings/cloudflare.py
@@ -75,6 +75,7 @@ class CloudflareWorkersAIEmbeddingsComponent(LCModelComponent):
                 strip_new_lines=self.strip_new_lines,
             )
         except Exception as e:
-            raise ValueError(f"Could not connect to CloudflareWorkersAIEmbeddings API: {e!s}") from e
+            msg = f"Could not connect to CloudflareWorkersAIEmbeddings API: {e!s}"
+            raise ValueError(msg) from e
 
         return embeddings

--- a/src/backend/base/langflow/components/helpers/current_date.py
+++ b/src/backend/base/langflow/components/helpers/current_date.py
@@ -12,7 +12,6 @@ class CurrentDateComponent(Component):
     display_name = "Current Date"
     description = "Returns the current date and time in the selected timezone."
     icon = "clock"
-    beta = True
     name = "CurrentDate"
 
     inputs = [
@@ -60,7 +59,9 @@ class CurrentDateComponent(Component):
         ),
     ]
     outputs = [
-        Output(display_name="Current Date", name="current_date", method="get_current_date"),
+        Output(
+            display_name="Current Date", name="current_date", method="get_current_date"
+        ),
     ]
 
     def get_current_date(self) -> Message:

--- a/src/backend/base/langflow/components/helpers/current_date.py
+++ b/src/backend/base/langflow/components/helpers/current_date.py
@@ -59,9 +59,7 @@ class CurrentDateComponent(Component):
         ),
     ]
     outputs = [
-        Output(
-            display_name="Current Date", name="current_date", method="get_current_date"
-        ),
+        Output(display_name="Current Date", name="current_date", method="get_current_date"),
     ]
 
     def get_current_date(self) -> Message:

--- a/src/frontend/tests/core/features/filterSidebar.spec.ts
+++ b/src/frontend/tests/core/features/filterSidebar.spec.ts
@@ -106,7 +106,9 @@ test(
       page.getByTestId("langchain_utilitiesConversationChain"),
     ).toBeVisible();
 
-    await expect(page.getByTestId("helpersCurrent Date")).toBeVisible();
+    await expect(
+      page.getByTestId("langchain_utilitiesPrompt Hub"),
+    ).toBeVisible();
 
     await page.getByTestId("sidebar-options-trigger").click();
     await page.getByTestId("sidebar-beta-switch").isVisible({ timeout: 5000 });
@@ -114,7 +116,9 @@ test(
     await expect(page.getByTestId("sidebar-beta-switch")).not.toBeChecked();
     await page.getByTestId("sidebar-options-trigger").click();
 
-    await expect(page.getByTestId("helpersCurrent Date")).not.toBeVisible();
+    await expect(
+      page.getByTestId("langchain_utilitiesPrompt Hub"),
+    ).not.toBeVisible();
 
     await page.getByTestId("sidebar-filter-reset").click();
 


### PR DESCRIPTION
This pull request includes changes to the `CurrentDateComponent` class in the `src/backend/base/langflow/components/helpers/current_date.py` file. The main modifications involve removing the beta flag and reformatting the `outputs` list for better readability.

Changes to `CurrentDateComponent` class:

* Removed the `beta` attribute from the `CurrentDateComponent` class.
* Reformatted the `outputs` list to improve readability by breaking the `Output` instantiation into multiple lines.