### PR TITLE
refactor: Improve keyPairListComponent.spec.ts test reliability and performance

### DIFF
--- a/src/frontend/tests/core/unit/keyPairListComponent.spec.ts
+++ b/src/frontend/tests/core/unit/keyPairListComponent.spec.ts
@@ -25,7 +25,9 @@ test(
 
     while (modalCount === 0) {
       await page.getByText("New Flow", { exact: true }).click();
-      await page.waitForTimeout(3000);
+      await page.waitForSelector('[data-testid="modal-title"]', {
+        timeout: 3000,
+      });
       modalCount = await page.getByTestId("modal-title")?.count();
     }
     await page.waitForSelector('[data-testid="blank-flow"]', {
@@ -35,7 +37,9 @@ test(
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("amazon bedrock");
 
-    await page.waitForTimeout(1000);
+    await page.waitForSelector('[data-testid="modelsAmazon Bedrock"]', {
+      timeout: 3000,
+    });
 
     await page
       .getByTestId("modelsAmazon Bedrock")


### PR DESCRIPTION
This commit refactors the keyPairListComponent.spec.ts file to improve the reliability and performance of the tests. It replaces the usage of `waitForTimeout` with `waitForSelector` to ensure that the necessary elements are present before proceeding with the test. This change enhances the stability and efficiency of the test suite.