### PR TITLE
fix: Use global var if available for api endpoint in Astra DB Tool

### DIFF
--- a/src/backend/base/langflow/components/tools/astradb.py
+++ b/src/backend/base/langflow/components/tools/astradb.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 from astrapy import Collection, DataAPIClient, Database

--- a/src/backend/base/langflow/components/tools/astradb.py
+++ b/src/backend/base/langflow/components/tools/astradb.py
@@ -10,7 +10,7 @@ from langflow.schema import Data
 
 
 class AstraDBToolComponent(LCToolComponent):
-    display_name: str = "Astra DB"
+    display_name: str = "Astra DB Tool"
     description: str = "Create a tool to get transactional data from DataStax Astra DB Collection"
     documentation: str = "https://docs.langflow.org/Components/components-tools#astra-db-tool"
     icon: str = "AstraDB"
@@ -48,9 +48,9 @@ class AstraDBToolComponent(LCToolComponent):
             value="ASTRA_DB_APPLICATION_TOKEN",
             required=True,
         ),
-        StrInput(
+        SecretStrInput(
             name="api_endpoint",
-            display_name="API Endpoint",
+            display_name="Database" if os.getenv("ASTRA_ENHANCED", "false").lower() == "true" else "API Endpoint",
             info="API endpoint URL for the Astra DB service.",
             value="ASTRA_DB_API_ENDPOINT",
             required=True,


### PR DESCRIPTION
This pull request renames the Astra DB component in tools to "Astra DB Tool" (for distinguishability) and sets the API endpoint to be a SecretStrInput with parameters matching other Astra components, to use the global variable set.