### PR TITLE
Fix: Disable the ComponentAsTool shortcut when the component code does not have tool_mode=True + regression tests

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarDraggableComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarDraggableComponent/index.tsx
@@ -1,3 +1,4 @@
+import { convertTestName } from "@/components/common/storeCardComponent/utils/convert-test-name";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import useDeleteFlow from "@/hooks/flows/use-delete-flow";
@@ -176,6 +177,9 @@ export const SidebarDraggableComponent = forwardRef(
               <div className="flex shrink-0 items-center gap-1">
                 {!disabled && (
                   <Button
+                    data-testid={`add-component-button-${convertTestName(
+                      display_name,
+                    )}`}
                     variant="ghost"
                     size="icon"
                     tabIndex={-1}

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/hooks/use-shortcuts.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/hooks/use-shortcuts.tsx
@@ -18,6 +18,7 @@ export default function useShortcuts({
   ungroup,
   minimizeFunction,
   activateToolMode,
+  hasToolMode,
 }: {
   showOverrideModal?: boolean;
   showModalAdvanced?: boolean;
@@ -34,6 +35,7 @@ export default function useShortcuts({
   ungroup?: () => void;
   minimizeFunction?: () => void;
   activateToolMode?: () => void;
+  hasToolMode?: boolean;
 }) {
   const advancedSettings = useShortcutsStore((state) => state.advancedSettings);
   const minimize = useShortcutsStore((state) => state.minimize);
@@ -117,7 +119,8 @@ export default function useShortcuts({
     minimizeFunction();
   }
 
-  function handleToolModeWShortcut(e: KeyboardEvent) {
+  function handleToolModeWShortcut(e: KeyboardEvent, hasToolMode?: boolean) {
+    if (!hasToolMode) return;
     if (isWrappedWithClass(e, "noflow") || !activateToolMode) return;
     e.preventDefault();
     activateToolMode();
@@ -135,5 +138,7 @@ export default function useShortcuts({
   useHotkeys(download, handleDownloadWShortcut, { preventDefault: true });
   useHotkeys(freeze, handleFreeze);
   useHotkeys(freezeAll, handleFreezeAll);
-  useHotkeys(toolMode, handleToolModeWShortcut, { preventDefault: true });
+  useHotkeys(toolMode, (e) => handleToolModeWShortcut(e, hasToolMode), {
+    preventDefault: true,
+  });
 }

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -189,6 +189,7 @@ export default function NodeToolbarComponent({
     ungroup: handleungroup,
     minimizeFunction: minimize,
     activateToolMode: activateToolMode,
+    hasToolMode,
   });
 
   const paste = useFlowStore((state) => state.paste);

--- a/src/frontend/tests/core/integrations/Vector Store.spec.ts
+++ b/src/frontend/tests/core/integrations/Vector Store.spec.ts
@@ -1,6 +1,7 @@
 import { Page, test } from "@playwright/test";
 import path from "path";
 import uaParser from "ua-parser-js";
+import { extractAndCleanCode } from "../../utils/extract-and-clean-code";
 
 test(
   "Vector Store RAG",
@@ -192,24 +193,3 @@ test(
     await page.getByTestId("input-chat-playground").last().isVisible();
   },
 );
-
-async function extractAndCleanCode(page: Page): Promise<string> {
-  const outerHTML = await page
-    .locator('//*[@id="codeValue"]')
-    .evaluate((el) => el.outerHTML);
-
-  const valueMatch = outerHTML.match(/value="([\s\S]*?)"/);
-  if (!valueMatch) {
-    throw new Error("Could not find value attribute in the HTML");
-  }
-
-  let codeContent = valueMatch[1]
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&#x27;/g, "'")
-    .replace(/&#x2F;/g, "/");
-
-  return codeContent;
-}

--- a/src/frontend/tests/extended/regression/general-bugs-component-as-tool-shortcut.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-component-as-tool-shortcut.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/test";
+import { extractAndCleanCode } from "../../utils/extract-and-clean-code";
+
+test(
+  "user must be able to use component as tool shortcut only if has tool mode is True",
+  { tag: ["@release", "@components"] },
+  async ({ page }) => {
+    await page.goto("/");
+    await page.waitForTimeout(1000);
+    let modalCount = 0;
+    try {
+      const modalTitleElement = await page?.getByTestId("modal-title");
+      if (modalTitleElement) {
+        modalCount = await modalTitleElement.count();
+      }
+    } catch (error) {
+      modalCount = 0;
+    }
+
+    while (modalCount === 0) {
+      await page.getByText("New Flow", { exact: true }).click();
+      await page.waitForSelector('[data-testid="modal-title"]', {
+        timeout: 3000,
+      });
+      modalCount = await page.getByTestId("modal-title")?.count();
+    }
+
+    await page.getByTestId("blank-flow").click();
+
+    await page.waitForSelector('[data-testid="fit_view"]', {
+      timeout: 100000,
+    });
+    await page.getByTestId("sidebar-search-input").click();
+    await page.getByTestId("sidebar-search-input").fill("id generator");
+
+    await page
+      .getByTestId("helpersID Generator")
+      .hover()
+      .then(async () => {
+        await page.getByTestId("add-component-button-id-generator").click();
+      });
+
+    await page.waitForSelector('[data-testid="title-ID Generator"]', {
+      timeout: 3000,
+    });
+
+    expect(await page.getByText("Toolset", { exact: true }).count()).toBe(0);
+
+    await page.getByTestId("title-ID Generator").click();
+    await page.keyboard.press("ControlOrMeta+Shift+m");
+
+    expect(await page.getByText("Toolset", { exact: true }).count()).toBe(0);
+
+    await page.getByTestId("title-ID Generator").click();
+
+    await page.waitForSelector('[data-testid="code-button-modal"]', {
+      timeout: 3000,
+    });
+
+    await page.getByTestId("code-button-modal").click();
+
+    let code = await extractAndCleanCode(page);
+    code = code!.replace(
+      "refresh_button=True,",
+      "refresh_button=True,\n tool_mode=True,",
+    );
+
+    await page.locator("textarea").last().press(`ControlOrMeta+a`);
+    await page.keyboard.press("Backspace");
+    await page.locator("textarea").last().fill(code);
+    await page.locator('//*[@id="checkAndSaveBtn"]').click();
+
+    await page.waitForSelector('[data-testid="fit_view"]', {
+      timeout: 3000,
+    });
+
+    await page.getByTestId("title-ID Generator").click();
+    await page.keyboard.press("ControlOrMeta+Shift+m");
+
+    await page.waitForSelector('text="Toolset"', {
+      timeout: 3000,
+    });
+
+    expect(
+      await page.getByText("Toolset", { exact: true }).count(),
+    ).toBeGreaterThan(0);
+  },
+);

--- a/src/frontend/tests/utils/extract-and-clean-code.ts
+++ b/src/frontend/tests/utils/extract-and-clean-code.ts
@@ -1,0 +1,22 @@
+import { Page } from "playwright/test";
+
+export async function extractAndCleanCode(page: Page): Promise<string> {
+  const outerHTML = await page
+    .locator('//*[@id="codeValue"]')
+    .evaluate((el) => el.outerHTML);
+
+  const valueMatch = outerHTML.match(/value="([\s\S]*?)"/);
+  if (!valueMatch) {
+    throw new Error("Could not find value attribute in the HTML");
+  }
+
+  let codeContent = valueMatch[1]
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#x27;/g, "'")
+    .replace(/&#x2F;/g, "/");
+
+  return codeContent;
+}


### PR DESCRIPTION
This pull request includes several changes to the frontend codebase, focusing on the addition of new utilities, enhancements to existing components, and improvements to test cases. The most important changes include adding a new utility function for extracting and cleaning code, updating the `useShortcuts` hook to support a new tool mode, and enhancing the `SidebarDraggableComponent` with a data-testid attribute.

### New Utilities:
* Added `extractAndCleanCode` utility function in `src/frontend/tests/utils/extract-and-clean-code.ts` to centralize code extraction and cleaning logic.

### Component Enhancements:
* Updated `SidebarDraggableComponent` to include a `data-testid` attribute for the add component button, utilizing the `convertTestName` function for dynamic test IDs. [[1]](diffhunk://#diff-c94382f8e218f4b5d129a9052c8e0754e1b9cb791d077f41b4499442a4fefc6bR1) [[2]](diffhunk://#diff-c94382f8e218f4b5d129a9052c8e0754e1b9cb791d077f41b4499442a4fefc6bR180-R182)
* Modified `useShortcuts` hook to accept a new `hasToolMode` parameter and updated the `handleToolModeWShortcut` function to conditionally activate tool mode based on this parameter. [[1]](diffhunk://#diff-f161d2b55cc91b6a4997f044a60d04f741ae63c3f949a9cb73ecce5567eee21fR21) [[2]](diffhunk://#diff-f161d2b55cc91b6a4997f044a60d04f741ae63c3f949a9cb73ecce5567eee21fR38) [[3]](diffhunk://#diff-f161d2b55cc91b6a4997f044a60d04f741ae63c3f949a9cb73ecce5567eee21fL120-R123) [[4]](diffhunk://#diff-f161d2b55cc91b6a4997f044a60d04f741ae63c3f949a9cb73ecce5567eee21fL138-R143)
* Updated `NodeToolbarComponent` to pass the new `hasToolMode` parameter to the `useShortcuts` hook.

### Test Improvements:
* Refactored the `Vector Store.spec.ts` test file to use the new `extractAndCleanCode` utility function, removing the redundant local implementation. [[1]](diffhunk://#diff-e34d4f76464b628f513c090851fe50ff86c642be99c7a265bcb7bb55fd43c64bR4) [[2]](diffhunk://#diff-e34d4f76464b628f513c090851fe50ff86c642be99c7a265bcb7bb55fd43c64bL195-L215)
* Added a new regression test `general-bugs-component-as-tool-shortcut.spec.ts` to verify that the component can be used as a tool shortcut only if `hasToolMode` is true.