### PR TITLE
Refactor: update nestedComponent test to improve performance

### DIFF
--- a/src/frontend/tests/core/unit/nestedComponent.spec.ts
+++ b/src/frontend/tests/core/unit/nestedComponent.spec.ts
@@ -25,7 +25,9 @@ test(
 
     while (modalCount === 0) {
       await page.getByText("New Flow", { exact: true }).click();
-      await page.waitForTimeout(3000);
+      await page.waitForSelector('[data-testid="modal-title"]', {
+        timeout: 3000,
+      });
       modalCount = await page.getByTestId("modal-title")?.count();
     }
     await page.waitForSelector('[data-testid="blank-flow"]', {
@@ -35,7 +37,9 @@ test(
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("api request");
 
-    await page.waitForTimeout(1000);
+    await page.waitForSelector('[data-testid="dataAPI Request"]', {
+      timeout: 3000,
+    });
 
     await page
       .getByTestId("dataAPI Request")


### PR DESCRIPTION
The nestedComponent test was updated to use explicit timeouts when waiting for certain elements to appear. This ensures that the test waits for the elements to be present before proceeding, preventing any potential race conditions or flakiness in the test results.