### PR TITLE
fix: Update promptModalComponent.spec.ts to use waitForSelector instead of waitForTimeout

### DIFF
--- a/src/frontend/tests/core/unit/promptModalComponent.spec.ts
+++ b/src/frontend/tests/core/unit/promptModalComponent.spec.ts
@@ -25,7 +25,9 @@ test(
 
     while (modalCount === 0) {
       await page.getByText("New Flow", { exact: true }).click();
-      await page.waitForTimeout(3000);
+      await page.waitForSelector('[data-testid="modal-title"]', {
+        timeout: 3000,
+      });
       modalCount = await page.getByTestId("modal-title")?.count();
     }
     await page.waitForSelector('[data-testid="blank-flow"]', {
@@ -35,7 +37,9 @@ test(
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("prompt");
 
-    await page.waitForTimeout(1000);
+    await page.waitForSelector('[data-testid="promptsPrompt"]', {
+      timeout: 3000,
+    });
 
     await page
       .locator('//*[@id="promptsPrompt"]')


### PR DESCRIPTION
- Replaced the usage of waitForTimeout with waitForSelector in promptModalComponent.spec.ts to improve reliability and stability of the tests.