### PR TITLE
Improve test reliability and performance in toggleComponent.spec.ts

### DIFF
--- a/src/frontend/tests/core/unit/toggleComponent.spec.ts
+++ b/src/frontend/tests/core/unit/toggleComponent.spec.ts
@@ -25,7 +25,9 @@ test(
 
     while (modalCount === 0) {
       await page.getByText("New Flow", { exact: true }).click();
-      await page.waitForTimeout(3000);
+      await page.waitForSelector('[data-testid="modal-title"]', {
+        timeout: 3000,
+      });
       modalCount = await page.getByTestId("modal-title")?.count();
     }
     await page.waitForSelector('[data-testid="blank-flow"]', {
@@ -36,7 +38,9 @@ test(
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("directory");
 
-    await page.waitForTimeout(1000);
+    await page.waitForSelector('[data-testid="dataDirectory"]', {
+      timeout: 30000,
+    });
     await page
       .getByTestId("dataDirectory")
       .dragTo(page.locator('//*[@id="react-flow-id"]'));


### PR DESCRIPTION
This pull request includes a refactor that improves the reliability and performance of the tests in toggleComponent.spec.ts. The changes include using `waitForSelector` instead of `waitForTimeout` to ensure that the modals and elements are properly loaded before interacting with them. This helps to avoid potential timing issues and makes the tests more robust.