### PR TITLE
fix: resolve message handling issues in MemoryComponent

### DIFF
--- a/src/backend/base/langflow/components/helpers/memory.py
+++ b/src/backend/base/langflow/components/helpers/memory.py
@@ -103,9 +103,24 @@ class MemoryComponent(Component):
                 sender=sender,
                 sender_name=sender_name,
                 session_id=session_id,
-                limit=n_messages,
+                limit=n_messages + 1,  # Fetch one extra to exclude current round's duplicate
                 order=order,
             )
+
+            # Reverse the order for descending, as they are fetched in inversion
+            if order == "DESC":
+                stored = stored[::-1]
+
+            # For the case where both "Machine and User" messages are considered, ensure
+            # the conversation history maintains a Q-A format.
+            # The last message should be an AI response (Machine), not a USER message.
+            if sender is None:
+                while len(stored) > 0 and stored[-1].sender == MESSAGE_SENDER_USER:
+                    stored.pop(-1)
+
+            # Adjust messages to meet the n_messages limit after initially fetching n_messages+1.
+            if len(stored) > n_messages:
+                stored = stored[-n_messages:] if order == 'DESC' else stored[:n_messages]
         self.status = stored
         return stored
 


### PR DESCRIPTION
This PR addresses three potential bugs in the `MemoryComponent`:
1. Adjusts the message retrieval limit to `n_messages + 1` to correctly exclude the current round's duplicate USER message which is already written to the database by the ChatInput component.  
2. When the `order` parameter is set to DESC, the stored messages are fetched in reverse chronological order from the database. An inverse operation is performed on the SQL result to ensure the messages are ordered from oldest to newest, allowing the llm to better understand the message history.  
3. If the `sender` parameter is set to 'Machine and User', ensures the conversation history maintains a Q-A format. The last message should be from the Machine, not the User.  