### PR TITLE
feat: Add toolset component utilities and refactor tool mode handling

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -6,7 +6,6 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Annotated
 from uuid import UUID
 
-from langflow.template.field.base import UNDEFINED
 import sqlalchemy as sa
 from fastapi import (
     APIRouter,

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Annotated
 from uuid import UUID
 
+from langflow.template.field.base import UNDEFINED
 import sqlalchemy as sa
 from fastapi import (
     APIRouter,
@@ -615,6 +616,9 @@ async def custom_component_update(
             component,
             user_id=user.id,
         )
+
+        component_node["tool_mode"] = code_request.tool_mode
+
         if hasattr(cc_instance, "set_attributes"):
             template = code_request.get_template()
             params = {}

--- a/src/backend/base/langflow/api/v1/schemas.py
+++ b/src/backend/base/langflow/api/v1/schemas.py
@@ -204,7 +204,7 @@ class UpdateCustomComponentRequest(CustomComponentRequest):
     field: str
     field_value: str | int | float | bool | dict | list | None = None
     template: dict
-    tool_mode: bool | None = None
+    tool_mode: bool = False
 
     def get_template(self):
         return dotdict(self.template)

--- a/src/backend/base/langflow/api/v1/schemas.py
+++ b/src/backend/base/langflow/api/v1/schemas.py
@@ -204,6 +204,7 @@ class UpdateCustomComponentRequest(CustomComponentRequest):
     field: str
     field_value: str | int | float | bool | dict | list | None = None
     template: dict
+    tool_mode: bool | None = None
 
     def get_template(self):
         return dotdict(self.template)

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -397,13 +397,9 @@ class Component(CustomComponent):
     def run_and_validate_update_outputs(self, frontend_node: dict, field_name: str, field_value: Any):
         frontend_node = self.update_outputs(frontend_node, field_name, field_value)
         if field_name == "tool_mode" or frontend_node.get("tool_mode"):
-            # Replace all outputs with the tool_output value if tool_mode is True
-            # else replace it with the original outputs
-            frontend_node["outputs"] = (
-                [self._build_tool_output()]
-                if (field_value or frontend_node.get("tool_mode"))
-                else frontend_node["outputs"]
-            )
+            is_tool_mode = field_value or frontend_node.get("tool_mode")
+            frontend_node["outputs"] = [self._build_tool_output()] if is_tool_mode else frontend_node["outputs"]
+
         return self._validate_frontend_node(frontend_node)
 
     def _validate_frontend_node(self, frontend_node: dict):

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -396,10 +396,14 @@ class Component(CustomComponent):
 
     def run_and_validate_update_outputs(self, frontend_node: dict, field_name: str, field_value: Any):
         frontend_node = self.update_outputs(frontend_node, field_name, field_value)
-        if field_name == "tool_mode":
+        if field_name == "tool_mode" or frontend_node.get("tool_mode"):
             # Replace all outputs with the tool_output value if tool_mode is True
             # else replace it with the original outputs
-            frontend_node["outputs"] = [self._build_tool_output()] if field_value else frontend_node["outputs"]
+            frontend_node["outputs"] = (
+                [self._build_tool_output()]
+                if (field_value or frontend_node.get("tool_mode"))
+                else frontend_node["outputs"]
+            )
         return self._validate_frontend_node(frontend_node)
 
     def _validate_frontend_node(self, frontend_node: dict):

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
@@ -49,6 +49,7 @@ export default function NodeInputField({
     node: data.node!,
     nodeId: data.id,
     parameterId: name,
+    tool_mode: data.node!.tool_mode ?? false,
   });
   const setFilterEdge = useFlowStore((state) => state.setFilterEdge);
   const { handleNodeClass } = useHandleNodeClass(data.id);

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -17,7 +17,10 @@ import { useShortcutsStore } from "../../stores/shortcuts";
 import { useTypesStore } from "../../stores/typesStore";
 import { OutputFieldType, VertexBuildTypeAPI } from "../../types/api";
 import { NodeDataType } from "../../types/flow";
-import { scapedJSONStringfy } from "../../utils/reactflowUtils";
+import {
+  checkHasToolMode,
+  scapedJSONStringfy,
+} from "../../utils/reactflowUtils";
 import { classNames, cn } from "../../utils/utils";
 import { getNodeInputColors } from "../helpers/get-node-input-colors";
 import { getNodeInputColorsName } from "../helpers/get-node-input-colors-name";
@@ -332,9 +335,7 @@ export default function GenericNode({
     return null;
   };
 
-  const hasToolMode =
-    data.node?.template &&
-    Object.values(data.node.template).some((field) => field.tool_mode);
+  const hasToolMode = checkHasToolMode(data.node?.template ?? {});
 
   return (
     <div className={cn(isOutdated && !isUserEdited ? "relative -mt-10" : "")}>

--- a/src/frontend/src/CustomNodes/helpers/mutate-template.ts
+++ b/src/frontend/src/CustomNodes/helpers/mutate-template.ts
@@ -19,6 +19,7 @@ export const mutateTemplate = debounce(
     >,
     setErrorData,
     parameterName?: string,
+    callback?: () => void,
   ) => {
     try {
       const newNode = cloneDeep(node);
@@ -31,6 +32,7 @@ export const mutateTemplate = debounce(
         newNode.outputs = newTemplate.outputs;
       }
       setNodeClass(newNode);
+      callback?.();
     } catch (e) {
       const error = e as ResponseErrorDetailAPI;
       setErrorData({

--- a/src/frontend/src/CustomNodes/hooks/use-handle-new-value.tsx
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-new-value.tsx
@@ -41,6 +41,7 @@ const useHandleOnNewValue = ({
     parameterId: name,
     nodeId: nodeId,
     node: node,
+    tool_mode: node.tool_mode ?? false,
   });
 
   const handleOnNewValue: handleOnNewValueType = async (changes, options?) => {

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
@@ -62,6 +62,8 @@ const CustomInputPopover = ({
     }
   };
 
+  console.log(placeholder, value, id);
+
   return (
     <Popover modal open={showOptions} onOpenChange={setShowOptions}>
       <PopoverAnchor>

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
@@ -69,6 +69,7 @@ export default function InputGlobalComponent({
       });
     }
   }
+
   return (
     <InputComponent
       nodeStyle

--- a/src/frontend/src/components/core/parameterRenderComponent/components/refreshParameterComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/refreshParameterComponent/index.tsx
@@ -30,6 +30,7 @@ export function RefreshParameterComponent({
     parameterId: name,
     nodeId: nodeId,
     node: nodeClass,
+    tool_mode: nodeClass.tool_mode ?? false,
   });
 
   const setErrorData = useAlertStore((state) => state.setErrorData);

--- a/src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts
+++ b/src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts
@@ -10,12 +10,14 @@ import { UseRequestProcessor } from "../../services/request-processor";
 
 interface IPostTemplateValue {
   value: any;
+  tool_mode?: boolean;
 }
 
 interface IPostTemplateValueParams {
   node: APIClassType;
   nodeId: string;
   parameterId: string;
+  tool_mode: boolean;
 }
 
 export const usePostTemplateValue: useMutationFunctionType<
@@ -23,7 +25,7 @@ export const usePostTemplateValue: useMutationFunctionType<
   IPostTemplateValue,
   APIClassType,
   ResponseErrorDetailAPI
-> = ({ parameterId, nodeId, node }, options?) => {
+> = ({ parameterId, nodeId, node, tool_mode }, options?) => {
   const { mutate } = UseRequestProcessor();
 
   const postTemplateValueFn = async (
@@ -32,7 +34,6 @@ export const usePostTemplateValue: useMutationFunctionType<
     const template = node.template;
 
     if (!template) return;
-
     const response = await api.post<APIClassType>(
       getURL("CUSTOM_COMPONENT", { update: "update" }),
       {
@@ -40,6 +41,7 @@ export const usePostTemplateValue: useMutationFunctionType<
         template: template,
         field: parameterId,
         field_value: payload.value,
+        tool_mode: tool_mode,
       },
     );
 

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -5,6 +5,7 @@ import useHandleNodeClass from "@/CustomNodes/hooks/use-handle-node-class";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
 import ToggleShadComponent from "@/components/core/parameterRenderComponent/components/toggleShadComponent";
 import { Button } from "@/components/ui/button";
+import { usePatchUpdateFlow } from "@/controllers/API/queries/flows/use-patch-update-flow";
 import { usePostTemplateValue } from "@/controllers/API/queries/nodes/use-post-template-value";
 import { usePostRetrieveVertexOrder } from "@/controllers/API/queries/vertex";
 import useAddFlow from "@/hooks/flows/use-add-flow";
@@ -32,6 +33,7 @@ import { useStoreStore } from "../../../../stores/storeStore";
 import { nodeToolbarPropsType } from "../../../../types/components";
 import { FlowType } from "../../../../types/flow";
 import {
+  checkHasToolMode,
   createFlowComponent,
   downloadNode,
   expandGroupNode,
@@ -71,8 +73,11 @@ export default function NodeToolbarComponent({
   const [openModal, setOpenModal] = useState(false);
   const isGroup = data.node?.flow ? true : false;
   const frozen = data.node?.frozen ?? false;
+  const currentFlow = useFlowStore((state) => state.currentFlow);
 
   const addFlow = useAddFlow();
+
+  const { mutate: patchUpdateFlow } = usePatchUpdateFlow();
 
   const isMinimal = countHandlesFn(data) <= 1 && numberOfOutputHandles <= 1;
   function activateToolMode() {
@@ -80,6 +85,8 @@ export default function NodeToolbarComponent({
     setToolMode(newValue);
 
     updateToolMode(data.id, newValue);
+    data.node!.tool_mode = newValue;
+
     mutateTemplate(
       newValue,
       data.node!,
@@ -87,7 +94,24 @@ export default function NodeToolbarComponent({
       postToolModeValue,
       setErrorData,
       "tool_mode",
+      () => {
+        const node = currentFlow?.data?.nodes.find(
+          (node) => node.id === data.id,
+        );
+        const index = currentFlow?.data?.nodes.indexOf(node!)!;
+        currentFlow!.data!.nodes[index]!.data.node.tool_mode = newValue;
+
+        patchUpdateFlow({
+          id: currentFlow?.id!,
+          name: currentFlow?.name!,
+          data: currentFlow?.data!,
+          description: currentFlow?.description!,
+          folder_id: currentFlow?.folder_id!,
+          endpoint_name: currentFlow?.endpoint_name!,
+        });
+      },
     );
+
     updateNodeInternals(data.id);
   }
   function minimize() {
@@ -145,9 +169,7 @@ export default function NodeToolbarComponent({
   }
   // Check if any of the data.node.template fields have tool_mode as True
   // if so we can show the tool mode button
-  const hasToolMode =
-    data.node?.template &&
-    Object.values(data.node.template).some((field) => field.tool_mode);
+  const hasToolMode = checkHasToolMode(data.node?.template ?? {});
 
   function openDocs() {
     if (data.node?.documentation) {
@@ -370,6 +392,7 @@ export default function NodeToolbarComponent({
     node: data.node!,
     nodeId: data.id,
     parameterId: "tool_mode",
+    tool_mode: data.node!.tool_mode ?? false,
   });
 
   return (

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -1736,3 +1736,7 @@ export function someFlowTemplateFields(
     });
   });
 }
+
+export function checkHasToolMode(template: APITemplateType) {
+  return template && Object.values(template).some((field) => field.tool_mode);
+}


### PR DESCRIPTION
This pull request includes several changes to implement and handle a new `tool_mode` attribute across various components and files in the codebase. The most important changes include adding the `tool_mode` attribute to schemas, updating logic to handle `tool_mode` in backend and frontend components, and ensuring that the state and UI reflect the new attribute correctly.

### Backend Changes:
* Added `tool_mode` attribute to `UpdateCustomComponentRequest` schema in `src/backend/base/langflow/api/v1/schemas.py` to allow the attribute to be passed in API requests.
* Updated the `custom_component_update` function in `src/backend/base/langflow/api/v1/endpoints.py` to include the `tool_mode` attribute in the component node.

### Frontend Changes:
* Added `tool_mode` attribute handling in various frontend components, such as `NodeInputField`, `GenericNode`, and `RefreshParameterComponent`. [[1]](diffhunk://#diff-b68d4cff4ce636f41882b2e6c2fb46ce2e134bdf292e38bcf6df9c6c5807d518R52) [[2]](diffhunk://#diff-b6793e0279f94c374aae18db97958c0af6befc2b49b7ce30e0294f9c80ba0d0eL335-R338) [[3]](diffhunk://#diff-72a8fa6e78fabead86a50d5376264f115d35f8c8ed4e7260dc5c00b816d3a5eaR33)
* Implemented `checkHasToolMode` utility function in `src/frontend/src/utils/reactflowUtils.ts` to check if any template fields have `tool_mode` set to true. [[1]](diffhunk://#diff-b6793e0279f94c374aae18db97958c0af6befc2b49b7ce30e0294f9c80ba0d0eL20-R23) [[2]](diffhunk://#diff-a380d7691b7dad914af3baf94d210fa2df4f56c0f8533eb0e17c29bb8dc0e91cR1739-R1742)
* Updated `usePostTemplateValue` function in `src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts` to include `tool_mode` in the payload. [[1]](diffhunk://#diff-086a525c817d0a6f1c036817a9062e885c210bab590879ac029ce9632f091d80R13-R28) [[2]](diffhunk://#diff-086a525c817d0a6f1c036817a9062e885c210bab590879ac029ce9632f091d80L35-R44)

### UI and State Management:
* Modified `mutateTemplate` function to accept a callback, ensuring the state is updated correctly after mutating the template. [[1]](diffhunk://#diff-a65752801640d4acb83ee2c8787c474b31940dec9357cec061f4db81634b65cdR22) [[2]](diffhunk://#diff-a65752801640d4acb83ee2c8787c474b31940dec9357cec061f4db81634b65cdR35)
* Updated `NodeToolbarComponent` to handle `tool_mode` activation and ensure the flow state is patched and updated accordingly. [[1]](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaR76-R114) [[2]](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL148-R172) [[3]](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaR395)