### PR TITLE
fix: prevent a glitch displaying run duration

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
@@ -187,8 +187,6 @@ export default function NodeStatus({
     return "Run component";
   };
 
-  console.log(validationStatus?.data?.duration);
-
   return showNode ? (
     <>
       <div className="flex flex-shrink-0 items-center">

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
@@ -61,9 +61,7 @@ export default function NodeStatus({
 
   const conditionSuccess =
     buildStatus === BuildStatus.BUILT ||
-    (!(!buildStatus || buildStatus === BuildStatus.TO_BUILD) &&
-      validationStatus &&
-      validationStatus.valid);
+    (buildStatus !== BuildStatus.TO_BUILD && validationStatus?.valid);
 
   const lastRunTime = useFlowStore(
     (state) => state.flowBuildStatus[nodeId_]?.timestamp,
@@ -164,7 +162,6 @@ export default function NodeStatus({
       return;
     }
     if (buildStatus === BuildStatus.BUILDING || isBuilding) return;
-    setValidationStatus(null);
     buildFlow({ stopNodeId: nodeId });
     track("Flow Build - Clicked", { stopNodeId: nodeId });
   };
@@ -189,6 +186,8 @@ export default function NodeStatus({
     }
     return "Run component";
   };
+
+  console.log(validationStatus?.data?.duration);
 
   return showNode ? (
     <>


### PR DESCRIPTION
This pull request includes changes to the `NodeStatus` component in the `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx` file to improve the handling of build and validation statuses.

Improvements to build and validation status handling:

* Simplified the condition that determines `conditionSuccess` by removing redundant checks and using optional chaining for `validationStatus`.
* Removed the line that sets `validationStatus` to `null` when the build status is `BUILDING` or `isBuilding` to prevent unnecessary state changes.