### PR TITLE
fix: Handle DataFrame serialization and export in langflow.io

### DIFF
--- a/src/backend/base/langflow/io/__init__.py
+++ b/src/backend/base/langflow/io/__init__.py
@@ -1,6 +1,7 @@
 from langflow.inputs import (
     BoolInput,
     CodeInput,
+    DataFrameInput,
     DataInput,
     DefaultPromptField,
     DictInput,
@@ -50,4 +51,5 @@ __all__ = [
     "SliderInput",
     "StrInput",
     "TableInput",
+    "DataFrameInput",
 ]

--- a/src/backend/base/langflow/schema/schema.py
+++ b/src/backend/base/langflow/schema/schema.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from langflow.schema.data import Data
+from langflow.schema.dataframe import DataFrame
 from langflow.schema.message import Message
 from langflow.schema.serialize import recursive_serialize_or_str
 
@@ -51,7 +52,7 @@ def get_type(payload):
         case dict():
             result = LogType.OBJECT
 
-        case list():
+        case list() | DataFrame():
             result = LogType.ARRAY
 
         case str():
@@ -107,6 +108,8 @@ def build_output_logs(vertex, result) -> dict:
                 message = ""
 
             case LogType.ARRAY:
+                if isinstance(message, DataFrame):
+                    message = message.to_dict(orient="records")
                 message = [recursive_serialize_or_str(item) for item in message]
         name = output.get("name", f"output_{index}")
         outputs |= {name: OutputValue(message=message, type=_type).model_dump()}


### PR DESCRIPTION
This pull request introduces support for handling DataFrame types in log message serialization, ensuring that DataFrames are correctly converted to dictionaries for logging purposes. Additionally, it adds the `DataFrameInput` to the exports of `langflow.io`, enhancing the input options available for users.

If the Output of the component is a DataFrame you should be able to inspect it in the UI now without setting self.status