### PR TITLE
fix: allow passing curly braces in messages to the Agent component

### DIFF
--- a/src/backend/base/langflow/components/langchain_utilities/tool_calling.py
+++ b/src/backend/base/langflow/components/langchain_utilities/tool_calling.py
@@ -44,7 +44,7 @@ class ToolCallingAgentComponent(LCToolsAgentComponent):
         messages = [
             ("system", self.system_prompt),
             ("placeholder", "{chat_history}"),
-            ("human", self.input_value),
+            ("human", "{input}"),
             ("placeholder", "{agent_scratchpad}"),
         ]
         prompt = ChatPromptTemplate.from_messages(messages)


### PR DESCRIPTION
This PR fixes an issue where LangChain would complain if you passed a curly brace in the message. 