### PR TITLE
feat: add new azure-search-documents package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ dependencies = [
     "atlassian-python-api>=3.41.16,<4.0.0",
     "mem0ai>=0.1.26,<1.0.0",
     "aiofile>=3.9.0,<4.0.0",
+    "azure-search-documents>=11.5.2
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ dependencies = [
     "atlassian-python-api>=3.41.16,<4.0.0",
     "mem0ai>=0.1.26,<1.0.0",
     "aiofile>=3.9.0,<4.0.0",
-    "azure-search-documents>=11.5.2
+    "azure-search-documents>=11.5.2 
 ]
 
 [project.urls]


### PR DESCRIPTION
Creating custom components with this package fails with Module Not Found. I guess it needs to be a dependency before I can create custom components