### PR TITLE
feat: add azure search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ dependencies = [
     "atlassian-python-api>=3.41.16,<4.0.0",
     "mem0ai>=0.1.26,<1.0.0",
     "aiofile>=3.9.0,<4.0.0",
+    "azure-search-documents>=11.5.2
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ dependencies = [
     "atlassian-python-api>=3.41.16,<4.0.0",
     "mem0ai>=0.1.26,<1.0.0",
     "aiofile>=3.9.0,<4.0.0",
-    "azure-search-documents>=11.5.2
+    "azure-search-documents>=11.5.2 
 ]
 
 [project.urls]


### PR DESCRIPTION
I am not able to create custom components that rely on azure search with the error module not found, this PR only installs the dependency.