### PR TITLE
fix: changed cursor on slider to cursor-pointer

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/index.tsx
@@ -179,7 +179,7 @@ export default function SliderComponent({
           <SliderPrimitive.Thumb
             data-testid={`slider_thumb${editNode ? "_advanced" : ""}`}
             className={clsx(
-              "block h-6 w-6 rounded-full border-2 border-background bg-pink-500 shadow-lg",
+              "block h-6 w-6 cursor-pointer rounded-full border-2 border-background bg-pink-500 shadow-lg",
             )}
           />
         </SliderPrimitive.Root>


### PR DESCRIPTION
This pull request includes a small change to the `SliderComponent` in the `src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/index.tsx` file. The change adds a `cursor-pointer` class to the `SliderPrimitive.Thumb` component to improve the user experience by indicating that the slider thumb is interactive.

* [`src/frontend/src/components/core/parameterRenderComponent/components/sliderComponent/index.tsx`](diffhunk://#diff-6958133e6992160edd970404518b518af12d81049a6562bdcb8264fad54e272dL182-R182): Added `cursor-pointer` class to `SliderPrimitive.Thumb` component.