### PR TITLE
fix: add condition to not block component from building when input is filled by tool mode

### DIFF
--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -413,6 +413,7 @@ export function validateNode(node: NodeType, edges: Edge[]): Array<string> {
   return Object.keys(template).reduce((errors: Array<string>, t) => {
     if (
       template[t].required &&
+      !(template[t].tool_mode && node?.data?.node?.tool_mode) &&
       template[t].show &&
       (template[t].value === undefined ||
         template[t].value === null ||


### PR DESCRIPTION
This pull request includes a change to the `validateNode` function in the `src/frontend/src/utils/reactflowUtils.ts` file. The change ensures that the validation logic properly accounts for the `tool_mode` attribute when determining if a template field should be considered required.

Validation logic improvement:

* [`src/frontend/src/utils/reactflowUtils.ts`](diffhunk://#diff-a380d7691b7dad914af3baf94d210fa2df4f56c0f8533eb0e17c29bb8dc0e91cR416): Updated the `validateNode` function to include a check for `tool_mode` in the node data, ensuring that required fields are only validated if the `tool_mode` condition is not met.…ool mode