### PR TITLE
fix: support Astra Enhanced flag in new component

### DIFF
--- a/src/backend/base/langflow/components/vectorstores/astradb.py
+++ b/src/backend/base/langflow/components/vectorstores/astradb.py
@@ -104,8 +104,8 @@ class AstraDBVectorStoreComponent(LCVectorStoreComponent):
             name="collection_name_new",
             display_name="Collection Name",
             info="Name of the new collection to create.",
-            advanced=os.getenv("ASTRA_ENHANCED", "false").lower() != "true",
-            required=True,
+            advanced=os.getenv("LANGFLOW_HOST") is not None,
+            required=os.getenv("LANGFLOW_HOST") is None,
         ),
         StrInput(
             name="keyspace",
@@ -643,7 +643,7 @@ class AstraDBVectorStoreComponent(LCVectorStoreComponent):
         # Get Langflow version and platform information
         __version__ = get_version_info()["version"]
         langflow_prefix = ""
-        if os.getenv("ASTRA_ENHANCED", "false").lower() == "true":
+        if os.getenv("LANGFLOW_HOST") is not None:
             langflow_prefix = "ds-"
 
         try:

--- a/src/backend/base/langflow/components/vectorstores/astradb.py
+++ b/src/backend/base/langflow/components/vectorstores/astradb.py
@@ -104,7 +104,7 @@ class AstraDBVectorStoreComponent(LCVectorStoreComponent):
             name="collection_name_new",
             display_name="Collection Name",
             info="Name of the new collection to create.",
-            advanced=False,
+            advanced=os.getenv("ASTRA_ENHANCED", "false").lower() != "true",
             required=True,
         ),
         StrInput(


### PR DESCRIPTION
This pull request hides an input that is only required if running langflow OSS, so it doesnt appear in a hosted Astra environment.