### PR TITLE
feat: improve whitespace handling in NodeDescription component

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx
@@ -134,7 +134,7 @@ export default function NodeDescription({
           data-testid="generic-node-desc"
           ref={overflowRef}
           className={cn(
-            "nodoubleclick generic-node-desc-text h-full cursor-text text-[13px] text-muted-foreground word-break-break-word",
+            "nodoubleclick generic-node-desc-text h-full cursor-text whitespace-break-spaces text-[13px] text-muted-foreground word-break-break-word",
             description === "" || !description ? "font-light italic" : "",
             placeholderClassName,
           )}
@@ -149,7 +149,7 @@ export default function NodeDescription({
             <Markdown
               linkTarget="_blank"
               className={cn(
-                "markdown prose flex w-full flex-col text-[13px] leading-5 word-break-break-word [&_pre]:!bg-code-description-background [&_pre_code]:!bg-code-description-background",
+                "markdown prose flex w-full flex-col text-[13px] leading-5 word-break-break-word [&_pre]:whitespace-break-spaces [&_pre]:!bg-code-description-background [&_pre_code]:!bg-code-description-background",
                 mdClassName,
               )}
             >

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx
@@ -134,7 +134,7 @@ export default function NodeDescription({
           data-testid="generic-node-desc"
           ref={overflowRef}
           className={cn(
-            "nodoubleclick generic-node-desc-text h-full cursor-text whitespace-break-spaces text-[13px] text-muted-foreground word-break-break-word",
+            "nodoubleclick generic-node-desc-text h-full cursor-text text-[13px] text-muted-foreground word-break-break-word",
             description === "" || !description ? "font-light italic" : "",
             placeholderClassName,
           )}


### PR DESCRIPTION
This pull request includes changes to the `NodeDescription` component in the `src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx` file. The main goal of these changes is to improve the handling of whitespace in the node descriptions.

Improvements to whitespace handling:

* Modified the `className` property to include `whitespace-break-spaces` to ensure that whitespace is properly handled in the node description text.
* Updated the `Markdown` component's `className` property to include `whitespace-break-spaces` for better whitespace handling in code descriptions.