### PR TITLE
fix: Execute event manager callbacks in asyncio thread

### DIFF
--- a/src/backend/base/langflow/base/agents/agent.py
+++ b/src/backend/base/langflow/base/agents/agent.py
@@ -169,7 +169,7 @@ class LCAgentComponent(Component):
         except ExceptionWithMessageError as e:
             msg_id = e.agent_message.id
             await delete_message(id_=msg_id)
-            self._send_message_event(e.agent_message, category="remove_message")
+            await self._send_message_event(e.agent_message, category="remove_message")
             raise
         except Exception:
             raise

--- a/src/backend/base/langflow/base/tools/component_tool.py
+++ b/src/backend/base/langflow/base/tools/component_tool.py
@@ -134,11 +134,11 @@ def _build_output_async_function(
     async def output_function(*args, **kwargs):
         try:
             if event_manager:
-                event_manager.on_build_start(data={"id": component._id})
+                await asyncio.to_thread(event_manager.on_build_start, data={"id": component._id})
             component.set(*args, **kwargs)
             result = await output_method()
             if event_manager:
-                event_manager.on_build_end(data={"id": component._id})
+                await asyncio.to_thread(event_manager.on_build_end, data={"id": component._id})
         except Exception as e:
             raise ToolException(e) from e
         if isinstance(result, Message):


### PR DESCRIPTION
The user-defined event manager callbacks may be blocking so they should be run in a thread-pool when executed from a coroutine.