### PR TITLE
fix: Use AsyncSession in test_login_unsuccessful_wrong_password

### DIFF
--- a/src/backend/tests/unit/test_login.py
+++ b/src/backend/tests/unit/test_login.py
@@ -35,10 +35,10 @@ async def test_login_unsuccessful_wrong_username(client):
     assert response.json()["detail"] == "Incorrect username or password"
 
 
-async def test_login_unsuccessful_wrong_password(client, test_user, session):
+async def test_login_unsuccessful_wrong_password(client, test_user, async_session):
     # Adding the test user to the database
-    session.add(test_user)
-    session.commit()
+    async_session.add(test_user)
+    await async_session.commit()
 
     response = await client.post("api/v1/login", data={"username": "testuser", "password": "wrongpassword"})
     assert response.status_code == 401

--- a/src/backend/tests/unit/test_messages.py
+++ b/src/backend/tests/unit/test_messages.py
@@ -38,7 +38,7 @@ async def created_message():
 
 
 @pytest.fixture
-async def created_messages(session):  # noqa: ARG001
+async def created_messages(async_session):  # noqa: ARG001
     async with async_session_scope() as _session:
         messages = [
             MessageCreate(text="Test message 1", sender="User", sender_name="User", session_id="session_id2"),


### PR DESCRIPTION
Use AsyncSession in `test_login_unsuccessful_wrong_password`