### PR TITLE
chore(ui): add text-foreground class to NodeStatus build element

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/components/build-status-display.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/components/build-status-display.tsx
@@ -1,0 +1,72 @@
+import {
+  RUN_TIMESTAMP_PREFIX,
+  STATUS_BUILD,
+  STATUS_BUILDING,
+  STATUS_INACTIVE,
+} from "@/constants/constants";
+import { BuildStatus } from "@/constants/enums";
+
+const StatusMessage = ({ children, className = "text-foreground" }) => (
+  <span className={`flex ${className}`}>{children}</span>
+);
+
+const TimeStamp = ({ prefix, time }) => (
+  <div className="flex items-center text-sm text-secondary-foreground">
+    <div>{prefix}</div>
+    <div className="ml-1 text-secondary-foreground">{time}</div>
+  </div>
+);
+
+const Duration = ({ duration }) => (
+  <div className="flex items-center text-secondary-foreground">
+    <div>Duration:</div>
+    <div className="ml-1">{duration}</div>
+  </div>
+);
+
+const ValidationDetails = ({
+  validationString,
+  lastRunTime,
+  validationStatus,
+}) => (
+  <div className="max-h-100 px-1 py-2.5">
+    <div className="flex max-h-80 flex-col gap-2 overflow-auto">
+      {validationString && (
+        <div className="text-sm text-foreground">{validationString}</div>
+      )}
+      {lastRunTime && (
+        <TimeStamp prefix={RUN_TIMESTAMP_PREFIX} time={lastRunTime} />
+      )}
+      <Duration duration={validationStatus?.data.duration} />
+    </div>
+  </div>
+);
+
+const BuildStatusDisplay = ({
+  buildStatus,
+  validationStatus,
+  validationString,
+  lastRunTime,
+}) => {
+  if (buildStatus === BuildStatus.BUILDING) {
+    return <StatusMessage>{STATUS_BUILDING}</StatusMessage>;
+  }
+
+  if (buildStatus === BuildStatus.INACTIVE) {
+    return <StatusMessage>{STATUS_INACTIVE}</StatusMessage>;
+  }
+
+  if (!validationStatus) {
+    return <StatusMessage>{STATUS_BUILD}</StatusMessage>;
+  }
+
+  return (
+    <ValidationDetails
+      validationString={validationString}
+      lastRunTime={lastRunTime}
+      validationStatus={validationStatus}
+    />
+  );
+};
+
+export default BuildStatusDisplay;

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
@@ -204,7 +204,7 @@ export default function NodeStatus({
               ) : buildStatus === BuildStatus.INACTIVE ? (
                 <span> {STATUS_INACTIVE} </span>
               ) : !validationStatus ? (
-                <span className="flex">{STATUS_BUILD}</span>
+                <span className="flex text-foreground">{STATUS_BUILD}</span>
               ) : (
                 <div className="max-h-100 px-1 py-2.5">
                   <div className="flex max-h-80 flex-col gap-2 overflow-auto">

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
@@ -25,6 +25,7 @@ import { Check } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import IconComponent from "../../../../components/common/genericIconComponent";
+import BuildStatusDisplay from "./components/build-status-display";
 import { normalizeTimeString } from "./utils/format-run-time";
 
 export default function NodeStatus({
@@ -199,43 +200,12 @@ export default function NodeStatus({
                 : "border-destructive bg-error-background",
             )}
             content={
-              buildStatus === BuildStatus.BUILDING ? (
-                <span className="flex text-foreground">
-                  {" "}
-                  {STATUS_BUILDING}{" "}
-                </span>
-              ) : buildStatus === BuildStatus.INACTIVE ? (
-                <span className="flex text-foreground">
-                  {" "}
-                  {STATUS_INACTIVE}{" "}
-                </span>
-              ) : !validationStatus ? (
-                <span className="flex text-foreground">{STATUS_BUILD}</span>
-              ) : (
-                <div className="max-h-100 px-1 py-2.5">
-                  <div className="flex max-h-80 flex-col gap-2 overflow-auto">
-                    {validationString && (
-                      <div className="text-sm text-foreground">
-                        {validationString}
-                      </div>
-                    )}
-                    {lastRunTime && (
-                      <div className="flex items-center text-sm text-secondary-foreground">
-                        <div>{RUN_TIMESTAMP_PREFIX}</div>
-                        <div className="ml-1 text-secondary-foreground">
-                          {lastRunTime}
-                        </div>
-                      </div>
-                    )}
-                    <div className="flex items-center text-secondary-foreground">
-                      <div>Duration:</div>
-                      <div className="ml-1">
-                        {validationStatus?.data.duration}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )
+              <BuildStatusDisplay
+                buildStatus={buildStatus}
+                validationStatus={validationStatus}
+                validationString={validationString}
+                lastRunTime={lastRunTime}
+              />
             }
             side="bottom"
           >

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
@@ -200,9 +200,15 @@ export default function NodeStatus({
             )}
             content={
               buildStatus === BuildStatus.BUILDING ? (
-                <span> {STATUS_BUILDING} </span>
+                <span className="flex text-foreground">
+                  {" "}
+                  {STATUS_BUILDING}{" "}
+                </span>
               ) : buildStatus === BuildStatus.INACTIVE ? (
-                <span> {STATUS_INACTIVE} </span>
+                <span className="flex text-foreground">
+                  {" "}
+                  {STATUS_INACTIVE}{" "}
+                </span>
               ) : !validationStatus ? (
                 <span className="flex text-foreground">{STATUS_BUILD}</span>
               ) : (


### PR DESCRIPTION
This pull request includes a small change to the `NodeStatus` component in the `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx` file. The change updates the styling of the `STATUS_BUILD` element to include the `text-foreground` class.

* [`src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx`](diffhunk://#diff-a82985ebdf968b3b9ff88582d46208ef24ade91024f7e4bcdddc9451bfede45eL207-R207): Added the `text-foreground` class to the `STATUS_BUILD` span element to improve its styling.

Before:
![image](https://github.com/user-attachments/assets/895e1d63-6664-44fd-94e6-14a229968b48)

Now:
![image](https://github.com/user-attachments/assets/813a737d-cc3b-44b4-ba18-e5e2d4a4318c)

