### PR TITLE
refactor(Agent): remove unused parameters

### DIFF
--- a/src/backend/base/langflow/base/agents/agent.py
+++ b/src/backend/base/langflow/base/agents/agent.py
@@ -47,7 +47,6 @@ class LCAgentComponent(Component):
             advanced=True,
             info="Should the Agent fix errors when reading user input for better processing?",
         ),
-        BoolInput(name="verbose", display_name="Verbose", value=True, advanced=True),
         IntInput(
             name="max_iterations",
             display_name="Max Iterations",
@@ -98,7 +97,6 @@ class LCAgentComponent(Component):
     def get_agent_kwargs(self, *, flatten: bool = False) -> dict:
         base = {
             "handle_parsing_errors": self.handle_parsing_errors,
-            "verbose": self.verbose,
             "allow_dangerous_code": True,
         }
         agent_kwargs = {
@@ -127,13 +125,11 @@ class LCAgentComponent(Component):
                 msg = "Tools are required to run the agent."
                 raise ValueError(msg)
             handle_parsing_errors = hasattr(self, "handle_parsing_errors") and self.handle_parsing_errors
-            verbose = hasattr(self, "verbose") and self.verbose
             max_iterations = hasattr(self, "max_iterations") and self.max_iterations
             runnable = AgentExecutor.from_agent_and_tools(
                 agent=agent,
                 tools=self.tools,
                 handle_parsing_errors=handle_parsing_errors,
-                verbose=verbose,
                 max_iterations=max_iterations,
             )
         input_dict: dict[str, str | list[BaseMessage]] = {"input": self.input_value}

--- a/src/backend/base/langflow/components/models/openai.py
+++ b/src/backend/base/langflow/components/models/openai.py
@@ -27,27 +27,6 @@ class OpenAIModelComponent(LCModelComponent):
             info="The maximum number of tokens to generate. Set to 0 for unlimited tokens.",
             range_spec=RangeSpec(min=0, max=128000),
         ),
-        DictInput(
-            name="model_kwargs",
-            display_name="Model Kwargs",
-            advanced=True,
-            info="Additional keyword arguments to pass to the model.",
-        ),
-        BoolInput(
-            name="json_mode",
-            display_name="JSON Mode",
-            advanced=True,
-            info="If True, it will output JSON regardless of passing a schema.",
-        ),
-        DictInput(
-            name="output_schema",
-            is_list=True,
-            display_name="Schema",
-            advanced=True,
-            info="The schema for the Output of the model. "
-            "You must pass the word JSON in the prompt. "
-            "If left blank, JSON mode will be disabled. [DEPRECATED]",
-        ),
         DropdownInput(
             name="model_name",
             display_name="Model Name",
@@ -78,43 +57,25 @@ class OpenAIModelComponent(LCModelComponent):
             advanced=True,
             value=1,
         ),
-        HandleInput(
-            name="output_parser",
-            display_name="Output Parser",
-            info="The parser to use to parse the output of the model",
-            advanced=True,
-            input_types=["OutputParser"],
-        ),
     ]
 
     def build_model(self) -> LanguageModel:  # type: ignore[type-var]
-        # self.output_schema is a list of dictionaries
-        # let's convert it to a dictionary
-        output_schema_dict: dict[str, str] = reduce(operator.ior, self.output_schema or {}, {})
         openai_api_key = self.api_key
         temperature = self.temperature
         model_name: str = self.model_name
         max_tokens = self.max_tokens
-        model_kwargs = self.model_kwargs or {}
         openai_api_base = self.openai_api_base or "https://api.openai.com/v1"
-        json_mode = bool(output_schema_dict) or self.json_mode
         seed = self.seed
 
         api_key = SecretStr(openai_api_key).get_secret_value() if openai_api_key else None
         output = ChatOpenAI(
             max_tokens=max_tokens or None,
-            model_kwargs=model_kwargs,
             model=model_name,
             base_url=openai_api_base,
             api_key=api_key,
             temperature=temperature if temperature is not None else 0.1,
             seed=seed,
         )
-        if json_mode:
-            if output_schema_dict:
-                output = output.with_structured_output(schema=output_schema_dict, method="json_mode")
-            else:
-                output = output.bind(response_format={"type": "json_object"})
 
         return output
 

--- a/src/backend/base/langflow/components/models/openai.py
+++ b/src/backend/base/langflow/components/models/openai.py
@@ -1,6 +1,3 @@
-import operator
-from functools import reduce
-
 from langchain_openai import ChatOpenAI
 from pydantic.v1 import SecretStr
 
@@ -8,8 +5,7 @@ from langflow.base.models.model import LCModelComponent
 from langflow.base.models.openai_constants import OPENAI_MODEL_NAMES
 from langflow.field_typing import LanguageModel
 from langflow.field_typing.range_spec import RangeSpec
-from langflow.inputs import BoolInput, DictInput, DropdownInput, IntInput, SecretStrInput, SliderInput, StrInput
-from langflow.inputs.inputs import HandleInput
+from langflow.inputs import DropdownInput, IntInput, SecretStrInput, SliderInput, StrInput
 
 
 class OpenAIModelComponent(LCModelComponent):


### PR DESCRIPTION
This PR removes several unused and deprecated parameters to clean up the codebase:

Changes:
- Remove JSON Mode from OpenAI component (redundant functionality)
- Remove Schema (output_schema) from OpenAI component (deprecated)
- Remove Model Kwargs from OpenAI component (unused)
- Remove Output Parser from OpenAI component (non-functional)
- Remove Verbose parameter from agent component (unused)

These changes simplify the components by removing parameters that were either deprecated, redundant, or not being used effectively.