### PR TITLE
test: Add test IDs and improve UI wait handling in frontend tests

### DIFF
--- a/src/frontend/src/pages/MainPage/components/header/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/index.tsx
@@ -141,6 +141,7 @@ const HeaderComponent = ({
                 className="!px-3 md:!px-4 md:!pl-3.5"
                 onClick={() => setNewProjectModal(true)}
                 id="new-project-btn"
+                data-testid="new-project-btn"
               >
                 <ForwardedIconComponent
                   name="Plus"

--- a/src/frontend/tests/extended/features/dragAndDrop.spec.ts
+++ b/src/frontend/tests/extended/features/dragAndDrop.spec.ts
@@ -8,9 +8,27 @@ test(
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
-    await page.locator("span").filter({ hasText: "Close" }).first().click();
+    //add a new flow just to have the workspace available
+    await page.getByTestId("side_nav_options_all-templates").click();
+    await page.getByRole("heading", { name: "Basic Prompting" }).click();
 
-    await page.locator("span").filter({ hasText: "My Projects" }).isVisible();
+    await page.waitForSelector('[data-testid="fit_view"]', {
+      timeout: 100000,
+    });
+
+    await page.waitForSelector('[data-testid="icon-ChevronLeft"]', {
+      timeout: 100000,
+    });
+
+    await page.getByTestId("icon-ChevronLeft").first().click();
+
+    await page.waitForSelector("text=my projects", {
+      timeout: 5000,
+    });
+
+    await page.waitForSelector('[data-testid="new-project-btn"]', {
+      timeout: 100000,
+    });
 
     await simulateDragAndDrop(
       page,
@@ -44,9 +62,27 @@ test(
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
-    await page.locator("span").filter({ hasText: "Close" }).first().click();
-    await page.locator("span").filter({ hasText: "My Projects" }).isVisible();
+    //add a new flow just to have the workspace available
+    await page.getByTestId("side_nav_options_all-templates").click();
+    await page.getByRole("heading", { name: "Basic Prompting" }).click();
 
+    await page.waitForSelector('[data-testid="fit_view"]', {
+      timeout: 100000,
+    });
+
+    await page.waitForSelector('[data-testid="icon-ChevronLeft"]', {
+      timeout: 100000,
+    });
+
+    await page.getByTestId("icon-ChevronLeft").first().click();
+
+    await page.waitForSelector("text=my projects", {
+      timeout: 5000,
+    });
+
+    await page.waitForSelector('[data-testid="new-project-btn"]', {
+      timeout: 100000,
+    });
     // Read your file into a buffer.
     const jsonContent = readFileSync(
       "tests/assets/flow_test_drag_and_drop.json",

--- a/src/frontend/tests/extended/features/lock-flow.spec.ts
+++ b/src/frontend/tests/extended/features/lock-flow.spec.ts
@@ -23,13 +23,17 @@ test(
 
     await page.waitForSelector('[data-testid="fit_view"]', {
       timeout: 100000,
+      state: "visible",
     });
 
     await page.getByTestId("lock_unlock").click();
+
+    //ensure the UI is updated
+    await page.waitForTimeout(500);
+
     await page.waitForSelector('[data-testid="icon-Lock"]', {
       timeout: 3000,
     });
-    expect(page.getByTestId("icon-Lock")).toBeVisible();
 
     await page.getByTestId("icon-ChevronLeft").click();
     await page.waitForSelector('[data-testid="mainpage_title"]', {
@@ -39,18 +43,20 @@ test(
     await page.getByTestId("list-card").first().click();
     await page.waitForSelector('[data-testid="fit_view"]', {
       timeout: 100000,
+      state: "visible",
     });
+
+    //ensure the UI is updated
+    await page.waitForTimeout(500);
 
     await page.waitForSelector('[data-testid="icon-Lock"]', {
       timeout: 3000,
     });
-    expect(page.getByTestId("icon-Lock")).toBeVisible();
 
     await page.getByTestId("lock_unlock").click();
     await page.waitForSelector('[data-testid="icon-LockOpen"]', {
       timeout: 3000,
     });
-    expect(page.getByTestId("icon-LockOpen")).toBeVisible();
 
     await page.getByTestId("icon-ChevronLeft").click();
     await page.waitForSelector('[data-testid="mainpage_title"]', {
@@ -58,13 +64,15 @@ test(
     });
 
     await page.getByTestId("list-card").first().click();
+
     await page.waitForSelector('[data-testid="fit_view"]', {
       timeout: 100000,
+      state: "visible",
     });
 
     await page.waitForSelector('[data-testid="icon-LockOpen"]', {
       timeout: 3000,
+      state: "visible",
     });
-    expect(page.getByTestId("icon-LockOpen")).toBeVisible();
   },
 );


### PR DESCRIPTION
This pull request includes several updates to the frontend test suite and a minor change to a component in the main page. The most important changes involve adding test IDs for better element targeting, ensuring UI updates are properly handled, and improving test reliability by adding necessary waits and actions.

### Component updates:
* [`src/frontend/src/pages/MainPage/components/header/index.tsx`](diffhunk://#diff-199241b1c40a4c34b8a20490e35826d94dbbc77765882d3324748bad1c01397aR144): Added `data-testid` attribute to the "new project" button for better test targeting.

### Test improvements:
* [`src/frontend/tests/extended/features/dragAndDrop.spec.ts`](diffhunk://#diff-b9839b9273615451795233816b37fb37abbb06550b928812d3137b6294d14139L11-R31): Added steps to ensure the workspace is available by interacting with the UI elements and added necessary waits to improve test reliability. [[1]](diffhunk://#diff-b9839b9273615451795233816b37fb37abbb06550b928812d3137b6294d14139L11-R31) [[2]](diffhunk://#diff-b9839b9273615451795233816b37fb37abbb06550b928812d3137b6294d14139L47-R85)
* [`src/frontend/tests/extended/features/lock-flow.spec.ts`](diffhunk://#diff-f0ac0c30832123ae0a2ae5aeee3c9de21ff17105e2c37d0682bc1fcc6534bb90R26-L32): Added `state: "visible"` to `waitForSelector` calls and added timeouts to ensure the UI is updated before proceeding with further actions. [[1]](diffhunk://#diff-f0ac0c30832123ae0a2ae5aeee3c9de21ff17105e2c37d0682bc1fcc6534bb90R26-L32) [[2]](diffhunk://#diff-f0ac0c30832123ae0a2ae5aeee3c9de21ff17105e2c37d0682bc1fcc6534bb90R46-L68)