### PR TITLE
fix: Refactor JSON serialization in build_flow and log_vertex_build

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -347,7 +347,7 @@ async def build_flow(
         vertex_build_response: VertexBuildResponse = build_task.result()
         # send built event or error event
         try:
-            vertex_build_response_json = json.dumps(vertex_build_response.model_dump(), default=str)
+            vertex_build_response_json = vertex_build_response.model_dump_json()
             build_data = json.loads(vertex_build_response_json)
         except Exception as exc:
             msg = f"Error serializing vertex build response: {exc}"

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -347,7 +347,7 @@ async def build_flow(
         vertex_build_response: VertexBuildResponse = build_task.result()
         # send built event or error event
         try:
-            vertex_build_response_json = vertex_build_response.model_dump_json()
+            vertex_build_response_json = json.dumps(vertex_build_response.model_dump(), default=str)
             build_data = json.loads(vertex_build_response_json)
         except Exception as exc:
             msg = f"Error serializing vertex build response: {exc}"

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -183,7 +183,7 @@ async def log_vertex_build(
             valid=valid,
             params=str(params) if params else None,
             # ugly hack to get the model dump with weird datatypes
-            data=json.loads(json.dumps(data.model_dump(), default=str)),
+            data=json.loads(data.model_dump_json()),
             # ugly hack to get the model dump with weird datatypes
             artifacts=json.loads(json.dumps(artifacts, default=str)),
         )

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -176,13 +176,14 @@ async def log_vertex_build(
     try:
         if not get_settings_service().settings.vertex_builds_storage_enabled:
             return
+
         vertex_build = VertexBuildBase(
             flow_id=flow_id,
             id=vertex_id,
             valid=valid,
             params=str(params) if params else None,
             # ugly hack to get the model dump with weird datatypes
-            data=json.loads(data.model_dump_json()),
+            data=json.loads(json.dumps(data.model_dump(), default=str)),
             # ugly hack to get the model dump with weird datatypes
             artifacts=json.loads(json.dumps(artifacts, default=str)),
         )

--- a/src/backend/base/langflow/services/tracing/schema.py
+++ b/src/backend/base/langflow/services/tracing/schema.py
@@ -1,5 +1,7 @@
+from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, field_serializer
 from pydantic.v1 import BaseModel as V1BaseModel
+from pydantic_core import PydanticSerializationError
 
 from langflow.schema.log import LoggableType
 
@@ -24,4 +26,8 @@ class Log(BaseModel):
             return value.to_json()
         if isinstance(value, BaseModel):
             return value.model_dump(exclude_none=True)
+        try:
+            value = jsonable_encoder(value)
+        except PydanticSerializationError:
+            return str(value)
         return value


### PR DESCRIPTION
This pull request refactors the JSON serialization in the `build_flow` and `log_vertex_build` functions. The `build_flow` function now uses the `model_dump` method instead of `model_dump_json` to serialize the vertex build response. Similarly, the `log_vertex_build` function now uses `model_dump` instead of `model_dump_json` to serialize the data and artifacts. This improves the JSON serialization process in these functions.