### PR TITLE
fix: make errors in build_flow function use the standardized ErrorMessage schema

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -411,7 +411,8 @@ async def build_flow(
             return
         except Exception as e:
             logger.error(f"Error building vertices: {e}")
-            trace_name = graph.get_vertex(vertex_id).custom_component.trace_name
+            custom_component = graph.get_vertex(vertex_id).custom_component
+            trace_name = custom_component.trace_name if custom_component else None
             error_message = ErrorMessage(
                 flow_id=flow_id,
                 exception=e,

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -392,7 +392,6 @@ async def build_flow(
                 error_message = ErrorMessage(
                     flow_id=flow_id,
                     exception=e,
-                    session_id=graph.session_id,
                 )
                 event_manager.on_error(data=error_message.data)
                 raise

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -412,7 +412,7 @@ async def build_flow(
         except Exception as e:
             logger.error(f"Error building vertices: {e}")
             custom_component = graph.get_vertex(vertex_id).custom_component
-            trace_name = custom_component.trace_name if custom_component else None
+            trace_name = getattr(custom_component, "trace_name", None)
             error_message = ErrorMessage(
                 flow_id=flow_id,
                 exception=e,

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -39,6 +39,7 @@ from langflow.events.event_manager import EventManager, create_default_event_man
 from langflow.exceptions.component import ComponentBuildError
 from langflow.graph.graph.base import Graph
 from langflow.graph.utils import log_vertex_build
+from langflow.schema.message import ErrorMessage
 from langflow.schema.schema import OutputValue
 from langflow.services.cache.utils import CacheMiss
 from langflow.services.chat.service import ChatService
@@ -376,10 +377,11 @@ async def build_flow(
                 vertices_task.cancel()
                 return
             except Exception as e:
-                if isinstance(e, HTTPException):
-                    event_manager.on_error(data={"error": str(e.detail), "statusCode": e.status_code})
-                    raise
-                event_manager.on_error(data={"error": str(e)})
+                error_message = ErrorMessage(
+                    flow_id=flow_id,
+                    exception=e,
+                )
+                event_manager.on_error(data=error_message.data)
                 raise
 
             ids, vertices_to_run, graph = vertices_task.result()
@@ -387,10 +389,12 @@ async def build_flow(
             try:
                 ids, vertices_to_run, graph = await build_graph_and_get_order()
             except Exception as e:
-                if isinstance(e, HTTPException):
-                    event_manager.on_error(data={"error": str(e.detail), "statusCode": e.status_code})
-                    raise
-                event_manager.on_error(data={"error": str(e)})
+                error_message = ErrorMessage(
+                    flow_id=flow_id,
+                    exception=e,
+                    session_id=graph.session_id,
+                )
+                event_manager.on_error(data=error_message.data)
                 raise
         event_manager.on_vertices_sorted(data={"ids": ids, "to_run": vertices_to_run})
         await client_consumed_queue.get()
@@ -408,7 +412,14 @@ async def build_flow(
             return
         except Exception as e:
             logger.error(f"Error building vertices: {e}")
-            event_manager.on_error(data={"error": str(e)})
+            trace_name = graph.get_vertex(vertex_id).custom_component.trace_name
+            error_message = ErrorMessage(
+                flow_id=flow_id,
+                exception=e,
+                session_id=graph.session_id,
+                trace_name=trace_name,
+            )
+            event_manager.on_error(data=error_message.data)
             raise
         event_manager.on_end(data={})
         await event_manager.queue.put((None, None, time.time))

--- a/src/backend/base/langflow/schema/message.py
+++ b/src/backend/base/langflow/schema/message.py
@@ -371,10 +371,10 @@ class ErrorMessage(Message):
     def __init__(
         self,
         exception: BaseException,
-        session_id: str,
-        source: Source,
+        session_id: str | None = None,
+        source: Source | None = None,
         trace_name: str | None = None,
-        flow_id: str | None = None,
+        flow_id: UUID | str | None = None,
     ) -> None:
         # This is done to avoid circular imports
         if exception.__class__.__name__ == "ExceptionWithMessageError" and exception.__cause__ is not None:
@@ -400,8 +400,8 @@ class ErrorMessage(Message):
 
         super().__init__(
             session_id=session_id,
-            sender=source.display_name,
-            sender_name=source.display_name,
+            sender=source.display_name if source else None,
+            sender_name=source.display_name if source else None,
             text=reason,
             properties=Properties(
                 text_color="red",
@@ -420,7 +420,7 @@ class ErrorMessage(Message):
                     contents=[
                         ErrorContent(
                             type="error",
-                            component=source.display_name,
+                            component=source.display_name if source else None,
                             field=str(exception.field) if hasattr(exception, "field") else None,
                             reason=reason,
                             solution=str(exception.solution) if hasattr(exception, "solution") else None,


### PR DESCRIPTION
This pull request improves error handling in the `build_flow` function by introducing the `ErrorMessage` schema, which standardizes error reporting. The changes include the removal of `session_id` from the error messages in the chat endpoint and enhancements to error handling logic, providing better context by including `flow_id`, `session_id`, and `trace_name`. This results in clearer and more maintainable error handling across various exception cases.