### PR TITLE
fix: use SecretStr get_secret_value for LMStudio API key handling

### DIFF
--- a/src/backend/base/langflow/components/models/lmstudiomodel.py
+++ b/src/backend/base/langflow/components/models/lmstudiomodel.py
@@ -3,7 +3,6 @@ from urllib.parse import urljoin
 
 import httpx
 from langchain_openai import ChatOpenAI
-from pydantic.v1 import SecretStr
 from typing_extensions import override
 
 from langflow.base.models.model import LCModelComponent

--- a/src/backend/base/langflow/components/models/lmstudiomodel.py
+++ b/src/backend/base/langflow/components/models/lmstudiomodel.py
@@ -103,14 +103,12 @@ class LMStudioModelComponent(LCModelComponent):
         base_url = self.base_url or "http://localhost:1234/v1"
         seed = self.seed
 
-        api_key = SecretStr(lmstudio_api_key).get_secret_value() if lmstudio_api_key else None
-
         return ChatOpenAI(
             max_tokens=max_tokens or None,
             model_kwargs=model_kwargs,
             model=model_name,
             base_url=base_url,
-            api_key=api_key,
+            api_key=lmstudio_api_key,
             temperature=temperature if temperature is not None else 0.1,
             seed=seed,
         )

--- a/src/backend/base/langflow/components/models/lmstudiomodel.py
+++ b/src/backend/base/langflow/components/models/lmstudiomodel.py
@@ -103,7 +103,7 @@ class LMStudioModelComponent(LCModelComponent):
         base_url = self.base_url or "http://localhost:1234/v1"
         seed = self.seed
 
-        api_key = SecretStr(lmstudio_api_key) if lmstudio_api_key else None
+        api_key = SecretStr(lmstudio_api_key).get_secret_value() if lmstudio_api_key else None
 
         return ChatOpenAI(
             max_tokens=max_tokens or None,


### PR DESCRIPTION
This pull request includes a change to the `build_model` method in the `lmstudiomodel.py` file to improve the handling of the `api_key`.

* [`src/backend/base/langflow/components/models/lmstudiomodel.py`](diffhunk://#diff-ed909b08aedd90a891a1da6a22826a994b10ce95ab806371662eb6dfbf8e9da4L105-R105): Modified the `api_key` assignment to use the `get_secret_value` method of `SecretStr` to ensure the actual secret value is retrieved.