### PR TITLE
fix: Refactor CSS class in newChatMessage component preventing wrong position of bullet points

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/newChatMessage.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/newChatMessage.tsx
@@ -551,7 +551,7 @@ export default function ChatMessage({
                                     components={{
                                       p({ node, ...props }) {
                                         return (
-                                          <span className="inline-block w-fit max-w-full">
+                                          <span className=" w-fit max-w-full">
                                             {props.children}
                                           </span>
                                         );


### PR DESCRIPTION
This pull request includes a single commit that updates the CSS class in the `newChatMessage` component. The `span` element with the class name "inline-block w-fit max-w-full" has been changed to "w-fit max-w-full". This refactor improves the styling of the chat message component.