### PR TITLE
test: increase timeout in Market Research tests

### DIFF
--- a/src/frontend/tests/core/integrations/Market Research.spec.ts
+++ b/src/frontend/tests/core/integrations/Market Research.spec.ts
@@ -1,14 +1,9 @@
 import { expect, test } from "@playwright/test";
 import * as dotenv from "dotenv";
 import path from "path";
-import { addNewApiKeys } from "../../utils/add-new-api-keys";
-import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { getAllResponseMessage } from "../../utils/get-all-response-message";
 import { initialGPTsetup } from "../../utils/initialGPTsetup";
-import { removeOldApiKeys } from "../../utils/remove-old-api-keys";
-import { selectGptModel } from "../../utils/select-gpt-model";
-import { updateOldComponents } from "../../utils/update-old-components";
 import { waitForOpenModalWithChatInput } from "../../utils/wait-for-open-modal";
 
 test(
@@ -46,7 +41,9 @@ test(
       .fill(process.env.TAVILY_API_KEY ?? "");
 
     await page.getByTestId("button_run_chat output").click();
-    await page.waitForSelector("text=built successfully", { timeout: 30000 });
+    await page.waitForSelector("text=built successfully", {
+      timeout: 60000 * 3,
+    });
 
     await page.getByText("built successfully").last().click({
       timeout: 15000,


### PR DESCRIPTION
This pull request includes changes to the `src/frontend/tests/core/integrations/Market Research.spec.ts` file to streamline the test imports and adjust the timeout for a specific test.

Test import streamlining:

* Removed unnecessary imports such as `addNewApiKeys`, `adjustScreenView`, `removeOldApiKeys`, `selectGptModel`, and `updateOldComponents` from the test file.

Test timeout adjustment:

* Increased the timeout for the `page.waitForSelector` method from 30 seconds to 3 minutes to accommodate longer build times.