### PR TITLE
fix: update font size of prompt when validated

### DIFF
--- a/src/frontend/src/components/common/sanitizedHTMLWrapper/index.tsx
+++ b/src/frontend/src/components/common/sanitizedHTMLWrapper/index.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/utils/utils";
 import DOMPurify from "dompurify";
 import { forwardRef } from "react";
 import { SanitizedHTMLWrapperType } from "../../../types/components";
@@ -15,7 +16,7 @@ const SanitizedHTMLWrapper = forwardRef<
       dangerouslySetInnerHTML={{ __html: sanitizedHTML }}
       suppressContentEditableWarning={suppressWarning}
       {...props}
-      className="m-1 w-full"
+      className={cn("m-1 w-full", props.className)}
     />
   );
 });

--- a/src/frontend/src/modals/promptModal/index.tsx
+++ b/src/frontend/src/modals/promptModal/index.tsx
@@ -257,7 +257,7 @@ export default function PromptModal({
           ) : (
             <SanitizedHTMLWrapper
               ref={previewRef}
-              className={getClassByNumberLength() + " bg-muted"}
+              className={getClassByNumberLength() + " m-0"}
               onClick={handlePreviewClick}
               content={coloredContent}
               suppressWarning={true}

--- a/src/frontend/src/modals/promptModal/utils/var-highlight-html.tsx
+++ b/src/frontend/src/modals/promptModal/utils/var-highlight-html.tsx
@@ -1,6 +1,6 @@
 import { IVarHighlightType } from "../../../types/components";
 
 export default function varHighlightHTML({ name }: IVarHighlightType): string {
-  const html = `<span class="font-semibold chat-message-highlight">{${name}}</span>`;
+  const html = `<span class="chat-message-highlight">{${name}}</span>`;
   return html;
 }

--- a/src/frontend/src/style/applies.css
+++ b/src/frontend/src/style/applies.css
@@ -1111,7 +1111,7 @@
   }
 
   .chat-message-highlight {
-    @apply rounded-md bg-indigo-100 px-0.5 dark:bg-indigo-900;
+    @apply rounded-md bg-indigo-100 px-0 font-semibold dark:bg-indigo-900;
   }
 
   .field-invalid {


### PR DESCRIPTION
This pull request includes several changes to the frontend components and styles to improve the consistency and appearance of the application. The most important changes include updates to class names and styles, as well as the introduction of a utility function for combining class names.

### Component updates:

* [`src/frontend/src/components/common/sanitizedHTMLWrapper/index.tsx`](diffhunk://#diff-aff22d9ecc15b2e529c15d3b5bc04c8b6573030bb77393454c033967a13a2e58R1): Imported the `cn` utility function and updated the `className` property to use `cn` for combining class names. [[1]](diffhunk://#diff-aff22d9ecc15b2e529c15d3b5bc04c8b6573030bb77393454c033967a13a2e58R1) [[2]](diffhunk://#diff-aff22d9ecc15b2e529c15d3b5bc04c8b6573030bb77393454c033967a13a2e58L18-R19)
* [`src/frontend/src/modals/promptModal/index.tsx`](diffhunk://#diff-8b5fddf2332af941065aed317cdcf81ba3ed57d0c51792fab0a5f01f52b4b24dL260-R260): Modified the `className` property to remove the `bg-muted` class and add the `m-0` class.

### Style updates:

* [`src/frontend/src/modals/promptModal/utils/var-highlight-html.tsx`](diffhunk://#diff-2e6eb3c4b518912633258fd6501eed44400e7ef60dbf05b4fbf10a8f9c03ddaeL4-R4): Removed the `font-semibold` class from the HTML string.
* [`src/frontend/src/style/applies.css`](diffhunk://#diff-f227a8805837a247ce52fbbc51e193ce8de9e83c5810af44a0887ee4d888baa2L1114-R1114): Added the `font-semibold` class to the `.chat-message-highlight` style.