### PR TITLE
docs: fix typos Update integrations-assemblyai.md

### DIFF
--- a/docs/docs/Integrations/integrations-assemblyai.md
+++ b/docs/docs/Integrations/integrations-assemblyai.md
@@ -57,7 +57,7 @@ This component allows you to submit an audio or video file for transcription.
     - Transcript ID: The id of the transcript
 
 
-### AssebmlyAI Poll Transcript
+### AssemblyAI Poll Transcript
 
 This components allows you to poll the transcripts. It checks the status of the transcript every few seconds until the transcription is completed.
 
@@ -69,7 +69,7 @@ This components allows you to poll the transcripts. It checks the status of the 
     - Transcription Result: The AssemblyAI JSON response of a completed transcript. Contains the text and other info.
 
 
-### AssebmlyAI Get Subtitles
+### AssemblyAI Get Subtitles
 
 This component allows you to generate subtitles in SRT or VTT format.
 
@@ -83,7 +83,7 @@ This component allows you to generate subtitles in SRT or VTT format.
     - Subtitles: A JSON response with the `subtitles` field containing the captions in SRT or VTT format.
 
 
-### AssebmlyAI LeMUR
+### AssemblyAI LeMUR
 
 This component allows you to apply Large Language Models to spoken data using the [AssemblyAI LeMUR framework](https://www.assemblyai.com/docs/lemur).
 


### PR DESCRIPTION
I've corrected several typographical errors in the AssemblyAI integration documentation to improve clarity and accuracy.

The following changes were made:

- "AssebmlyAI Poll Transcript" was corrected to "AssemblyAI Poll Transcript."
- "AssebmlyAI Get Subtitles" was corrected to "AssemblyAI Get Subtitles."
- "AssebmlyAI LeMUR" was corrected to "AssemblyAI LeMUR."

These fixes should help avoid confusion for developers using the AssemblyAI components in Langflow. 