### PR TITLE
fix: improve UUID handling in custom component variables

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/custom_component.py
+++ b/src/backend/base/langflow/custom/custom_component/custom_component.py
@@ -440,7 +440,8 @@ class CustomComponent(BaseComponent):
         variable_service = get_variable_service()  # Get service instance
         # Retrieve and decrypt the variable by name for the current user
         async with async_session_scope() as session:
-            user_id = uuid.UUID(self.user_id)
+            if isinstance(self.user_id, str):
+                user_id = uuid.UUID(self.user_id)
             return await variable_service.get_variable(user_id=user_id, name=name, field=field, session=session)
 
     async def list_key_names(self):

--- a/src/backend/base/langflow/custom/custom_component/custom_component.py
+++ b/src/backend/base/langflow/custom/custom_component/custom_component.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
+import uuid
 
 import yaml
 from cachetools import TTLCache
@@ -439,7 +440,7 @@ class CustomComponent(BaseComponent):
         variable_service = get_variable_service()  # Get service instance
         # Retrieve and decrypt the variable by name for the current user
         async with async_session_scope() as session:
-            user_id = self.user_id or ""
+            user_id = uuid.UUID(self.user_id)
             return await variable_service.get_variable(user_id=user_id, name=name, field=field, session=session)
 
     async def list_key_names(self):


### PR DESCRIPTION
This pull request includes a few changes to the `custom_component.py` file to enhance the handling of user IDs in the `variables` method and to import the `uuid` module.

**Codebase improvements:**

* [`src/backend/base/langflow/custom/custom_component/custom_component.py`](diffhunk://#diff-010449088e429212d46c7455250d37f399c727ed8e5ab77b99cb155242e879f3R7): Imported the `uuid` module to handle UUID conversions.
* [`src/backend/base/langflow/custom/custom_component/custom_component.py`](diffhunk://#diff-010449088e429212d46c7455250d37f399c727ed8e5ab77b99cb155242e879f3L442-R443): Modified the `variables` method to convert `self.user_id` to a `UUID` object before using it.