### PR TITLE
refactor: reduce logging of SQLite pragmas and enhance model provider type safety

### DIFF
--- a/src/backend/base/langflow/base/models/model_input_constants.py
+++ b/src/backend/base/langflow/base/models/model_input_constants.py
@@ -7,12 +7,12 @@ from langflow.components.models.azure_openai import AzureChatOpenAIComponent
 from langflow.components.models.groq import GroqModel
 from langflow.components.models.nvidia import NVIDIAModelComponent
 from langflow.components.models.openai import OpenAIModelComponent
-from langflow.inputs.inputs import SecretStrInput
+from langflow.inputs.inputs import InputTypes, SecretStrInput
 
 
 class ModelProvidersDict(TypedDict):
-    fields: list[str]
-    inputs: list[str]
+    fields: dict
+    inputs: list[InputTypes]
     prefix: str
     component_class: LCModelComponent
 

--- a/src/backend/base/langflow/base/models/model_input_constants.py
+++ b/src/backend/base/langflow/base/models/model_input_constants.py
@@ -1,3 +1,5 @@
+from typing_extensions import TypedDict
+
 from langflow.base.models.model import LCModelComponent
 from langflow.components.models.amazon_bedrock import AmazonBedrockComponent
 from langflow.components.models.anthropic import AnthropicModelComponent
@@ -6,6 +8,13 @@ from langflow.components.models.groq import GroqModel
 from langflow.components.models.nvidia import NVIDIAModelComponent
 from langflow.components.models.openai import OpenAIModelComponent
 from langflow.inputs.inputs import SecretStrInput
+
+
+class ModelProvidersDict(TypedDict):
+    fields: list[str]
+    inputs: list[str]
+    prefix: str
+    component_class: LCModelComponent
 
 
 def get_filtered_inputs(component_class):
@@ -99,7 +108,7 @@ def _get_amazon_bedrock_inputs_and_fields():
     return amazon_bedrock_inputs, create_input_fields_dict(amazon_bedrock_inputs, "")
 
 
-MODEL_PROVIDERS_DICT = {}
+MODEL_PROVIDERS_DICT: dict[str, ModelProvidersDict] = {}
 
 # Try to add each provider
 try:
@@ -167,6 +176,7 @@ try:
     }
 except ImportError:
     pass
+
 
 MODEL_PROVIDERS = list(MODEL_PROVIDERS_DICT.keys())
 ALL_PROVIDER_FIELDS: list[str] = [field for provider in MODEL_PROVIDERS_DICT.values() for field in provider["fields"]]

--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -62,6 +62,7 @@ class DatabaseService(Service):
         else:
             # Construct the path using the langflow directory.
             self.alembic_log_path = Path(langflow_dir) / alembic_log_file
+        self._logged_pragma = False
 
     def reload_engine(self) -> None:
         self._sanitize_database_url()
@@ -122,7 +123,9 @@ class DatabaseService(Service):
             pragmas_list = []
             for key, val in pragmas.items():
                 pragmas_list.append(f"PRAGMA {key} = {val}")
-            logger.debug(f"sqlite connection, setting pragmas: {pragmas_list}")
+            if not self._logged_pragma:
+                logger.debug(f"sqlite connection, setting pragmas: {pragmas_list}")
+                self._logged_pragma = True
             if pragmas_list:
                 cursor = dbapi_connection.cursor()
                 try:


### PR DESCRIPTION
This pull request addresses two main improvements. First, it prevents duplicate logging of SQLite pragmas in the `DatabaseService` by introducing a flag that ensures the debug message for setting pragmas is logged only once per session, enhancing logging efficiency. Second, it introduces `ModelProvidersDict` as a `TypedDict` to define the structure for model provider configurations, updating the `MODEL_PROVIDERS_DICT` type annotation for improved type safety and clarity, which enhances code readability and maintainability.