### PR TITLE
fix: make user_id variable valid and fix type signature in messages endpoints

### DIFF
--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -41,7 +41,7 @@ async def delete_vertex_builds(flow_id: Annotated[UUID, Query()], session: DbSes
 async def get_messages(
     session: DbSession,
     flow_id: Annotated[UUID | None, Query()] = None,
-    session_id: Annotated[UUID | None, Query()] = None,
+    session_id: Annotated[str | None, Query()] = None,
     sender: Annotated[str | None, Query()] = None,
     sender_name: Annotated[str | None, Query()] = None,
     order_by: Annotated[str | None, Query()] = "timestamp",

--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -40,8 +40,8 @@ async def delete_vertex_builds(flow_id: Annotated[UUID, Query()], session: DbSes
 @router.get("/messages")
 async def get_messages(
     session: DbSession,
-    flow_id: Annotated[str | None, Query()] = None,
-    session_id: Annotated[str | None, Query()] = None,
+    flow_id: Annotated[UUID | None, Query()] = None,
+    session_id: Annotated[UUID | None, Query()] = None,
     sender: Annotated[str | None, Query()] = None,
     sender_name: Annotated[str | None, Query()] = None,
     order_by: Annotated[str | None, Query()] = "timestamp",

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -1011,6 +1011,8 @@ class Component(CustomComponent):
                 UUID(self.graph.session_id) if isinstance(self.graph.session_id, str) else self.graph.session_id
             )
             message.session_id = session_id
+        if hasattr(message, "flow_id") and isinstance(message.flow_id, str):
+            message.flow_id = UUID(message.flow_id)
         stored_message = await self._store_message(message)
 
         self._stored_message_id = stored_message.id

--- a/src/backend/base/langflow/custom/custom_component/custom_component.py
+++ b/src/backend/base/langflow/custom/custom_component/custom_component.py
@@ -440,9 +440,14 @@ class CustomComponent(BaseComponent):
             raise ValueError(msg)
         variable_service = get_variable_service()  # Get service instance
         # Retrieve and decrypt the variable by name for the current user
+        if isinstance(self.user_id, str):
+            user_id = uuid.UUID(self.user_id)
+        elif isinstance(self.user_id, uuid.UUID):
+            user_id = self.user_id
+        else:
+            msg = f"Invalid user id: {self.user_id}"
+            raise TypeError(msg)
         async with async_session_scope() as session:
-            if isinstance(self.user_id, str):
-                user_id = uuid.UUID(self.user_id)
             return await variable_service.get_variable(user_id=user_id, name=name, field=field, session=session)
 
     async def list_key_names(self):

--- a/src/backend/base/langflow/memory.py
+++ b/src/backend/base/langflow/memory.py
@@ -343,6 +343,8 @@ async def astore_message(
         raise ValueError(msg)
     if hasattr(message, "id") and message.id:
         return await aupdate_messages([message])
+    if flow_id and not isinstance(flow_id, UUID):
+        flow_id = UUID(flow_id)
     return await aadd_messages([message], flow_id=flow_id)
 
 


### PR DESCRIPTION
This pull request includes several changes to improve type consistency and error handling in the backend of the Langflow application. The most important changes involve updating type annotations for UUIDs, adding type checks, and improving error messages.

### Type Consistency Improvements:

* [`src/backend/base/langflow/api/v1/monitor.py`](diffhunk://#diff-3ec73bcad57a386eda3d6a958899bc825249632a5cd6093376b153d10bf18d8aL43-R44): Updated type annotations for `flow_id` and `session_id` in the `get_messages` function to use `UUID` instead of `str`.
* [`src/backend/base/langflow/custom/custom_component/component.py`](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169R1014-R1015): Added a check to convert `flow_id` to `UUID` if it is a string in the `send_message` method.
* [`src/backend/base/langflow/memory.py`](diffhunk://#diff-81aea4bf9debe8a32a04f193be5e27b529315847560090339a81b64c21f3a38bR346-R347): Added a check to convert `flow_id` to `UUID` if it is not already a `UUID` in the `astore_message` function.

### Error Handling Enhancements:

* [`src/backend/base/langflow/custom/custom_component/custom_component.py`](diffhunk://#diff-010449088e429212d46c7455250d37f399c727ed8e5ab77b99cb155242e879f3L443-R450): Added type checks and improved error messages for `user_id` in the `variables` method.