### PR TITLE
fix: Ensure safe assignment to tool_blocks_map in agent_message handling

### DIFF
--- a/src/backend/base/langflow/base/agents/events.py
+++ b/src/backend/base/langflow/base/agents/events.py
@@ -149,7 +149,8 @@ async def handle_on_tool_start(
     agent_message.content_blocks[0].contents.append(tool_content)
 
     agent_message = await send_message_method(message=agent_message)
-    tool_blocks_map[tool_key] = agent_message.content_blocks[0].contents[-1]
+    if agent_message.content_blocks and agent_message.content_blocks[0].contents:
+        tool_blocks_map[tool_key] = agent_message.content_blocks[0].contents[-1]
     return agent_message, new_start_time
 
 


### PR DESCRIPTION
This PR adds a safety check to ensure that the assignment to `tool_blocks_map` is only performed when `agent_message.content_blocks` and its contents are available. This prevents potential errors when accessing these properties.