### PR TITLE
ci: Add nightly build status check and synchronize event to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ concurrency:
 
 jobs:
   check-nightly-status:
+    name: Check Nightly Status
     runs-on: ubuntu-latest
     outputs:
       should-proceed: ${{ steps.check-workflow.outputs.success }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,17 +45,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-nightly-status:
+    runs-on: ubuntu-latest
+    outputs:
+      should-proceed: ${{ steps.check-workflow.outputs.success }}
+    steps:
+      - name: Check nightly workflow status
+        id: check-workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workflow_name = 'nightly_build.yml';
+            const { data: runs } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflow_name,
+              per_page: 1,
+              status: 'completed'
+            });
+
+            if (runs.workflow_runs.length === 0) {
+              console.log('No completed workflow runs found');
+              return core.setOutput('success', 'true');
+            }
+
+            const lastRun = runs.workflow_runs[0];
+            const success = lastRun.conclusion === 'success';
+            console.log(`Last nightly build status: ${lastRun.conclusion}`);
+            core.setOutput('success', success.toString());
+
   set-ci-condition:
+    needs: check-nightly-status
     name: Should Run CI
     runs-on: ubuntu-latest
     outputs:
-      should-run-ci: ${{ (contains( github.event.pull_request.labels.*.name, 'lgtm') && github.event.pull_request.draft == false) || (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') }}
+      should-run-ci: ${{ (needs.check-nightly-status.outputs.should-proceed == 'true') && ((contains( github.event.pull_request.labels.*.name, 'lgtm') && github.event.pull_request.draft == false) || (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call')) }}
     steps:
       #  Do anything just to make the job run
       - run: echo "Debug CI Condition"
       - run: echo "Labels -> ${{ join(github.event.pull_request.labels.*.name, ',') }}"
       - run: echo "IsDraft -> ${{ github.event.pull_request.draft }}"
       - run: echo "Event name -> ${{ github.event_name }}"
+      - run: echo "Nightly build status -> ${{ needs.check-nightly-status.outputs.should-proceed }}"
+
   path-filter:
     needs: set-ci-condition
     if: ${{ needs.set-ci-condition.outputs.should-run-ci == 'true' }}

--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -3,7 +3,7 @@
 name: Label PRs with Conventional Commits
 on:
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
 
 jobs:
   validate-pr:


### PR DESCRIPTION
This pull request introduces a nightly build status check to the CI workflow, ensuring that the CI process only proceeds if the latest nightly build was successful. Additionally, it updates the PR label workflow to trigger on the 'synchronize' event, allowing for better handling of PR updates.