### PR TITLE
feat: implement pagination for transaction log queries

### DIFF
--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -12,7 +12,7 @@ import orjson
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
-from fastapi_pagination import Page, Params, add_pagination
+from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlalchemy import paginate
 from sqlmodel import and_, col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -521,6 +521,3 @@ async def read_basic_examples(
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
-
-
-add_pagination(router)

--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -2,15 +2,16 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi_pagination.ext.sqlmodel import paginate
+from fastapi_pagination import Params
 from sqlalchemy import delete
 from sqlmodel import col, select
 
-from langflow.api.utils import DbSession
+from langflow.api.utils import DbSession, custom_params
 from langflow.schema.message import MessageResponse
 from langflow.services.auth.utils import get_current_active_user
 from langflow.services.database.models.message.model import MessageRead, MessageTable, MessageUpdate
-from langflow.services.database.models.transactions.crud import get_transactions_by_flow_id
-from langflow.services.database.models.transactions.model import TransactionReadResponse
+from langflow.services.database.models.transactions.model import TransactionReadResponse, TransactionTable
 from langflow.services.database.models.vertex_builds.crud import (
     delete_vertex_builds_by_flow_id,
     get_vertex_builds_by_flow_id,
@@ -160,22 +161,14 @@ async def delete_messages_session(
 async def get_transactions(
     flow_id: Annotated[UUID, Query()],
     session: DbSession,
-) -> list[TransactionReadResponse]:
+    params: Annotated[Params | None, Depends(custom_params)],
+):
     try:
-        transactions = await get_transactions_by_flow_id(session, flow_id)
-        return [
-            TransactionReadResponse(
-                transaction_id=t.id,
-                timestamp=t.timestamp,
-                vertex_id=t.vertex_id,
-                target_id=t.target_id,
-                inputs=t.inputs,
-                outputs=t.outputs,
-                status=t.status,
-                error=t.error,
-                flow_id=t.flow_id,
-            )
-            for t in transactions
-        ]
+        stmt = (
+            select(TransactionTable)
+            .where(TransactionTable.flow_id == flow_id)
+            .order_by(col(TransactionTable.timestamp))
+        )
+        return await paginate(session, stmt, params=params)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -11,6 +11,7 @@ from langflow.api.utils import DbSession, custom_params
 from langflow.schema.message import MessageResponse
 from langflow.services.auth.utils import get_current_active_user
 from langflow.services.database.models.message.model import MessageRead, MessageTable, MessageUpdate
+from langflow.services.database.models.transactions.crud import transform_transaction_table
 from langflow.services.database.models.transactions.model import TransactionTable
 from langflow.services.database.models.vertex_builds.crud import (
     delete_vertex_builds_by_flow_id,
@@ -169,6 +170,6 @@ async def get_transactions(
             .where(TransactionTable.flow_id == flow_id)
             .order_by(col(TransactionTable.timestamp))
         )
-        return await paginate(session, stmt, params=params)
+        return await paginate(session, stmt, params=params, transformer=transform_transaction_table)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -2,8 +2,8 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi_pagination.ext.sqlmodel import paginate
 from fastapi_pagination import Params
+from fastapi_pagination.ext.sqlmodel import paginate
 from sqlalchemy import delete
 from sqlmodel import col, select
 
@@ -11,7 +11,7 @@ from langflow.api.utils import DbSession, custom_params
 from langflow.schema.message import MessageResponse
 from langflow.services.auth.utils import get_current_active_user
 from langflow.services.database.models.message.model import MessageRead, MessageTable, MessageUpdate
-from langflow.services.database.models.transactions.model import TransactionReadResponse, TransactionTable
+from langflow.services.database.models.transactions.model import TransactionTable
 from langflow.services.database.models.vertex_builds.crud import (
     delete_vertex_builds_by_flow_id,
     get_vertex_builds_by_flow_id,

--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -2,7 +2,7 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi_pagination import Params
+from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlmodel import paginate
 from sqlalchemy import delete
 from sqlmodel import col, select
@@ -162,7 +162,7 @@ async def get_transactions(
     flow_id: Annotated[UUID, Query()],
     session: DbSession,
     params: Annotated[Params | None, Depends(custom_params)],
-):
+) -> Page[TransactionTable]:
     try:
         stmt = (
             select(TransactionTable)

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI, HTTPException, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi_pagination import add_pagination
 from loguru import logger
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from pydantic import PydanticDeprecatedSince20
@@ -229,6 +230,7 @@ def create_app():
 
     FastAPIInstrumentor.instrument_app(app)
 
+    add_pagination(app)
     return app
 
 

--- a/src/backend/base/langflow/services/database/models/transactions/crud.py
+++ b/src/backend/base/langflow/services/database/models/transactions/crud.py
@@ -4,7 +4,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from langflow.services.database.models.transactions.model import TransactionBase, TransactionTable
+from langflow.services.database.models.transactions.model import (
+    TransactionBase,
+    TransactionReadResponse,
+    TransactionTable,
+)
 
 
 async def get_transactions_by_flow_id(
@@ -31,3 +35,11 @@ async def log_transaction(db: AsyncSession, transaction: TransactionBase) -> Tra
         await db.rollback()
         raise
     return table
+
+
+def transform_transaction_table(
+    transaction: list[TransactionTable] | TransactionTable,
+) -> list[TransactionReadResponse]:
+    if isinstance(transaction, list):
+        return [TransactionReadResponse.model_validate(t, from_attributes=True) for t in transaction]
+    return TransactionReadResponse.model_validate(transaction, from_attributes=True)

--- a/src/backend/base/langflow/services/database/models/transactions/model.py
+++ b/src/backend/base/langflow/services/database/models/transactions/model.py
@@ -46,5 +46,5 @@ class TransactionTable(TransactionBase, table=True):  # type: ignore[call-arg]
 
 
 class TransactionReadResponse(TransactionBase):
-    transaction_id: UUID
+    id: UUID = Field(alias="transaction_id")
     flow_id: UUID

--- a/src/backend/tests/unit/test_database.py
+++ b/src/backend/tests/unit/test_database.py
@@ -324,7 +324,8 @@ async def test_delete_flows_with_transaction_and_build(client: AsyncClient, logg
             "GET", "api/v1/monitor/transactions", params={"flow_id": flow_id}, headers=logged_in_headers
         )
         assert response.status_code == 200
-        assert response.json() == []
+        json_response = response.json()
+        assert json_response["items"] == []
 
     for flow_id in flow_ids:
         response = await client.request(

--- a/src/backend/tests/unit/test_database.py
+++ b/src/backend/tests/unit/test_database.py
@@ -359,11 +359,15 @@ async def test_delete_folder_with_flows_with_transaction_and_build(client: Async
 
     class VertexTuple(NamedTuple):
         id: str
+        params: dict
 
     # Create a transaction for each flow
     for flow_id in flow_ids:
         await log_transaction(
-            str(flow_id), source=VertexTuple(id="vid"), target=VertexTuple(id="tid"), status="success"
+            str(flow_id),
+            source=VertexTuple(id="vid", params={}),
+            target=VertexTuple(id="tid", params={}),
+            status="success",
         )
 
     # Create a build for each flow
@@ -392,8 +396,9 @@ async def test_delete_folder_with_flows_with_transaction_and_build(client: Async
         response = await client.request(
             "GET", "api/v1/monitor/transactions", params={"flow_id": flow_id}, headers=logged_in_headers
         )
-        assert response.status_code == 200
-        assert response.json() == []
+        assert response.status_code == 200, response.json()
+        json_response = response.json()
+        assert json_response["items"] == []
 
     for flow_id in flow_ids:
         response = await client.request(

--- a/src/frontend/src/controllers/API/queries/transactions/use-get-transactions.ts
+++ b/src/frontend/src/controllers/API/queries/transactions/use-get-transactions.ts
@@ -9,11 +9,23 @@ import { UseRequestProcessor } from "../../services/request-processor";
 interface TransactionsQueryParams {
   id: string;
   params?: Record<string, unknown>;
-  mode?: "union" | "intersection";
+  mode: "union" | "intersection";
   excludedColumns?: string[];
 }
 
+interface PaginationType {
+  page?: number;
+  size?: number;
+  total?: number;
+  pages?: number;
+}
+
+interface TransactionsPagination extends PaginationType {
+  items?: Array<object>;
+}
+
 interface TransactionsResponse {
+  pagination: PaginationType;
   rows: Array<object>;
   columns: Array<ColDef | ColGroupDef>;
 }
@@ -25,13 +37,12 @@ export const useGetTransactionsQuery: useQueryFunctionType<
   // Function body remains unchanged
   const { query } = UseRequestProcessor();
 
-  const responseFn = (data: object[]) => {
-    if (mode) {
-      const columns = extractColumnsFromRows(data, mode, excludedColumns);
-      return { rows: data, columns };
-    } else {
-      return data;
-    }
+  const responseFn = (data: TransactionsPagination) => {
+    const pagination: PaginationType = {...data};
+
+    const rows = data.items ?? [];
+    const columns = extractColumnsFromRows(rows, mode, excludedColumns);
+    return {pagination: pagination, rows: rows, columns};
   };
 
   const getTransactionsFn = async () => {
@@ -41,12 +52,12 @@ export const useGetTransactionsQuery: useQueryFunctionType<
       config["params"] = { ...config["params"], ...params };
     }
 
-    const result = await api.get<object[]>(`${getURL("TRANSACTIONS")}`, config);
+    const result = await api.get<TransactionsPagination>(`${getURL("TRANSACTIONS")}`, config);
 
     return responseFn(result.data);
   };
 
-  const queryResult = query(["useGetTransactionsQuery"], getTransactionsFn, {
+  const queryResult = query(["useGetTransactionsQuery", id, {...params}], getTransactionsFn, {
     placeholderData: keepPreviousData,
     refetchOnWindowFocus: false,
     ...options,

--- a/src/frontend/src/controllers/API/queries/transactions/use-get-transactions.ts
+++ b/src/frontend/src/controllers/API/queries/transactions/use-get-transactions.ts
@@ -38,11 +38,11 @@ export const useGetTransactionsQuery: useQueryFunctionType<
   const { query } = UseRequestProcessor();
 
   const responseFn = (data: TransactionsPagination) => {
-    const pagination: PaginationType = {...data};
+    const pagination: PaginationType = { ...data };
 
     const rows = data.items ?? [];
     const columns = extractColumnsFromRows(rows, mode, excludedColumns);
-    return {pagination: pagination, rows: rows, columns};
+    return { pagination: pagination, rows: rows, columns };
   };
 
   const getTransactionsFn = async () => {
@@ -52,16 +52,23 @@ export const useGetTransactionsQuery: useQueryFunctionType<
       config["params"] = { ...config["params"], ...params };
     }
 
-    const result = await api.get<TransactionsPagination>(`${getURL("TRANSACTIONS")}`, config);
+    const result = await api.get<TransactionsPagination>(
+      `${getURL("TRANSACTIONS")}`,
+      config,
+    );
 
     return responseFn(result.data);
   };
 
-  const queryResult = query(["useGetTransactionsQuery", id, {...params}], getTransactionsFn, {
-    placeholderData: keepPreviousData,
-    refetchOnWindowFocus: false,
-    ...options,
-  });
+  const queryResult = query(
+    ["useGetTransactionsQuery", id, { ...params }],
+    getTransactionsFn,
+    {
+      placeholderData: keepPreviousData,
+      refetchOnWindowFocus: false,
+      ...options,
+    },
+  );
 
   return queryResult;
 };

--- a/src/frontend/src/modals/flowLogsModal/index.tsx
+++ b/src/frontend/src/modals/flowLogsModal/index.tsx
@@ -19,11 +19,7 @@ export default function FlowLogsModal({
   const [columns, setColumns] = useState<Array<ColDef | ColGroupDef>>([]);
   const [rows, setRows] = useState<any>([]);
 
-  const {
-    data: TransactionData,
-    isLoading,
-    refetch,
-  } = useGetTransactionsQuery({
+  const { data, isLoading, refetch } = useGetTransactionsQuery({
     id: currentFlowId,
     params: {
       page: pageIndex,
@@ -32,24 +28,13 @@ export default function FlowLogsModal({
     mode: "union",
   });
 
-  const data = {
-    rows: TransactionData?.rows ?? [],
-    columns: TransactionData?.columns ?? [],
-    pagination: {
-      page: TransactionData?.pagination?.page ?? 1,
-      size: TransactionData?.pagination?.size ?? 10,
-      total: TransactionData?.pagination?.total ?? 0,
-      pages: TransactionData?.pagination?.pages ?? 0,
-    },
-  };
-
   useEffect(() => {
-    if (TransactionData) {
+    if (data) {
       const { columns, rows } = data;
       setColumns(columns.map((col) => ({ ...col, editable: true })));
       setRows(rows);
     }
-  }, [TransactionData]);
+  }, [data]);
 
   useEffect(() => {
     if (open) {
@@ -84,15 +69,15 @@ export default function FlowLogsModal({
           rowData={rows}
           headerHeight={rows.length === 0 ? 0 : undefined}
         ></TableComponent>
-        {!isLoading && data.pagination.total >= 10 && (
+        {!isLoading && (data?.pagination.total ?? 0) >= 10 && (
           <div className="flex justify-end px-3 py-4">
             <PaginatorComponent
-              pageIndex={data.pagination.page}
-              pageSize={data.pagination.size}
+              pageIndex={(data?.pagination.page ?? 1)}
+              pageSize={(data?.pagination.size ?? 10)}
               rowsCount={[12, 24, 48, 96]}
-              totalRowsCount={data.pagination.total}
+              totalRowsCount={(data?.pagination.total ?? 0)}
               paginate={handlePageChange}
-              pages={data.pagination.pages}
+              pages={data?.pagination.pages}
             />
           </div>
         )}

--- a/src/frontend/src/modals/flowLogsModal/index.tsx
+++ b/src/frontend/src/modals/flowLogsModal/index.tsx
@@ -72,10 +72,10 @@ export default function FlowLogsModal({
         {!isLoading && (data?.pagination.total ?? 0) >= 10 && (
           <div className="flex justify-end px-3 py-4">
             <PaginatorComponent
-              pageIndex={(data?.pagination.page ?? 1)}
-              pageSize={(data?.pagination.size ?? 10)}
+              pageIndex={data?.pagination.page ?? 1}
+              pageSize={data?.pagination.size ?? 10}
               rowsCount={[12, 24, 48, 96]}
-              totalRowsCount={(data?.pagination.total ?? 0)}
+              totalRowsCount={data?.pagination.total ?? 0}
               paginate={handlePageChange}
               pages={data?.pagination.pages}
             />

--- a/src/frontend/src/modals/flowLogsModal/index.tsx
+++ b/src/frontend/src/modals/flowLogsModal/index.tsx
@@ -1,12 +1,12 @@
 import IconComponent from "@/components/common/genericIconComponent";
+import PaginatorComponent from "@/components/common/paginatorComponent";
 import TableComponent from "@/components/core/parameterRenderComponent/components/tableComponent";
 import { useGetTransactionsQuery } from "@/controllers/API/queries/transactions";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { FlowSettingsPropsType } from "@/types/components";
 import { ColDef, ColGroupDef } from "ag-grid-community";
-import {useCallback, useEffect, useState} from "react";
+import { useCallback, useEffect, useState } from "react";
 import BaseModal from "../baseModal";
-import PaginatorComponent from "@/components/common/paginatorComponent";
 
 export default function FlowLogsModal({
   open,
@@ -19,7 +19,11 @@ export default function FlowLogsModal({
   const [columns, setColumns] = useState<Array<ColDef | ColGroupDef>>([]);
   const [rows, setRows] = useState<any>([]);
 
-  const { data: TransactionData, isLoading, refetch } = useGetTransactionsQuery({
+  const {
+    data: TransactionData,
+    isLoading,
+    refetch,
+  } = useGetTransactionsQuery({
     id: currentFlowId,
     params: {
       page: pageIndex,
@@ -91,7 +95,7 @@ export default function FlowLogsModal({
               pages={data.pagination.pages}
             />
           </div>
-          )}
+        )}
       </BaseModal.Content>
     </BaseModal>
   );

--- a/src/frontend/src/modals/flowLogsModal/index.tsx
+++ b/src/frontend/src/modals/flowLogsModal/index.tsx
@@ -15,7 +15,7 @@ export default function FlowLogsModal({
   const currentFlowId = useFlowsManagerStore((state) => state.currentFlowId);
 
   const [pageIndex, setPageIndex] = useState(1);
-  const [pageSize, setPageSize] = useState(10);
+  const [pageSize, setPageSize] = useState(20);
   const [columns, setColumns] = useState<Array<ColDef | ColGroupDef>>([]);
   const [rows, setRows] = useState<any>([]);
 


### PR DESCRIPTION
This PR introduces pagination to the transactions log using `fastapi-pagination` on the backend and `PaginatorComponent` on the frontend.
These changes aim to enhance retrieval speed, reduce memory consumption, and prevent potential lags during frequent debugging sessions.