### PR TITLE
ci: Add Python version input to setup-uv action and update workflow configuration

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -1,6 +1,11 @@
 name: "Setup uv"
 description: "Checks out code, installs uv, and sets up Python environment"
 
+inputs:
+  python-version:
+    description: "Python version to use"
+    default: "3.12"
+
 runs:
   using: "composite"
   steps:
@@ -13,7 +18,7 @@ runs:
     - name: "Set up Python"
       uses: actions/setup-python@v5
       with:
-        python-version-file: "pyproject.toml"
+        python-version: ${{ inputs.python-version }}
 
     - name: Restore uv cache
       uses: actions/cache@v4

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
-          python-version-file: "pyproject.toml"
+          python-version: ${{ matrix.python-version }}
       - name: Restore uv cache
         uses: actions/cache@v4
         with:
@@ -94,7 +94,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
-          python-version-file: "pyproject.toml"
+          python-version: ${{ matrix.python-version }}
       - name: Restore uv cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/store_pytest_durations.yml
+++ b/.github/workflows/store_pytest_durations.yml
@@ -17,6 +17,9 @@ jobs:
       contents: write
       pull-requests: write
     env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
+      ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
       UV_CACHE_DIR: /tmp/.uv-cache
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/store_pytest_durations.yml
+++ b/.github/workflows/store_pytest_durations.yml
@@ -28,7 +28,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
-          python-version-file: "pyproject.toml"
+          python-version: "3.12"
       - name: Restore uv cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
This pull request introduces a new input parameter 'python-version' for the setup-uv action, allowing users to specify the Python version with a default of 3.12. The GitHub Actions workflow has been updated to utilize this new input, enhancing flexibility by using a matrix input instead of a version file. Additionally, the Python version is now directly specified in the workflow for consistency and clarity.