### PR TITLE
fix: update hidden secret_str load_from_db when adding flow

### DIFF
--- a/src/frontend/src/hooks/flows/use-add-flow.ts
+++ b/src/frontend/src/hooks/flows/use-add-flow.ts
@@ -1,8 +1,8 @@
-import { useGetRefreshFlows } from "@/controllers/API/queries/flows/use-get-refresh-flows";
 import { usePostAddFlow } from "@/controllers/API/queries/flows/use-post-add-flow";
 import useAlertStore from "@/stores/alertStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { useFolderStore } from "@/stores/foldersStore";
+import { useGlobalVariablesStore } from "@/stores/globalVariablesStore/globalVariables";
 import { useTypesStore } from "@/stores/typesStore";
 import { FlowType } from "@/types/flow";
 import {
@@ -28,6 +28,13 @@ const useAddFlow = () => {
 
   const myCollectionId = useFolderStore((state) => state.myCollectionId);
 
+  const unavailableFields = useGlobalVariablesStore(
+    (state) => state.unavailableFields,
+  );
+  const globalVariablesEntries = useGlobalVariablesStore(
+    (state) => state.globalVariablesEntries,
+  );
+
   const { mutate: postAddFlow } = usePostAddFlow();
 
   const addFlow = async (params?: {
@@ -41,7 +48,12 @@ const useAddFlow = () => {
         ? await processDataFromFlow(flow)
         : { nodes: [], edges: [], viewport: { zoom: 1, x: 0, y: 0 } };
       flowData?.nodes.forEach((node) => {
-        updateGroupRecursion(node, flowData?.edges);
+        updateGroupRecursion(
+          node,
+          flowData?.edges,
+          unavailableFields,
+          globalVariablesEntries,
+        );
       });
       // Create a new flow with a default name if no flow is provided.
       if (params?.override && flow) {

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -46,6 +46,7 @@ import { getInputsAndOutputs } from "../utils/storeUtils";
 import useAlertStore from "./alertStore";
 import { useDarkStore } from "./darkStore";
 import useFlowsManagerStore from "./flowsManagerStore";
+import { useGlobalVariablesStore } from "./globalVariablesStore/globalVariables";
 import { useMessagesStore } from "./messagesStore";
 import { useTypesStore } from "./typesStore";
 
@@ -397,7 +398,12 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
           id: newId,
         },
       };
-      updateGroupRecursion(newNode, selection.edges);
+      updateGroupRecursion(
+        newNode,
+        selection.edges,
+        useGlobalVariablesStore.getState().unavailableFields,
+        useGlobalVariablesStore.getState().globalVariablesEntries,
+      );
 
       // Add the new node to the list of nodes in state
       newNodes = newNodes


### PR DESCRIPTION
This pull request introduces several changes to the `use-add-flow` functionality and the handling of global variables within the flow management system. The most important changes include importing and utilizing the `useGlobalVariablesStore` in various parts of the code, and modifying the `updateGroupRecursion` function to accommodate global variables.

Enhancements to `use-add-flow` functionality:

* [`src/frontend/src/hooks/flows/use-add-flow.ts`](diffhunk://#diff-51f99cda7111618620f1f262ad11b34013662e517e589110a62b936f8e8f59e0L1-R5): Imported `useGlobalVariablesStore` and used it to access `unavailableFields` and `globalVariablesEntries` within the `useAddFlow` hook. These variables are then passed to the `updateGroupRecursion` function. [[1]](diffhunk://#diff-51f99cda7111618620f1f262ad11b34013662e517e589110a62b936f8e8f59e0L1-R5) [[2]](diffhunk://#diff-51f99cda7111618620f1f262ad11b34013662e517e589110a62b936f8e8f59e0R31-R37) [[3]](diffhunk://#diff-51f99cda7111618620f1f262ad11b34013662e517e589110a62b936f8e8f59e0L44-R56)

Updates to `flowStore`:

* [`src/frontend/src/stores/flowStore.ts`](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357R49): Imported `useGlobalVariablesStore` and passed its state values to the `updateGroupRecursion` function within the `useFlowStore` setup. [[1]](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357R49) [[2]](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357L400-R406)

Modifications to `reactflowUtils`:

* [`src/frontend/src/utils/reactflowUtils.ts`](diffhunk://#diff-a380d7691b7dad914af3baf94d210fa2df4f56c0f8533eb0e17c29bb8dc0e91cL1628-R1651): Updated the `updateGroupRecursion` function to accept `unavailableFields` and `globalVariablesEntries` parameters. Added a new function `updateGlobalVariables` to handle the logic for updating global variables within nodes. [[1]](diffhunk://#diff-a380d7691b7dad914af3baf94d210fa2df4f56c0f8533eb0e17c29bb8dc0e91cL1628-R1651) [[2]](diffhunk://#diff-a380d7691b7dad914af3baf94d210fa2df4f56c0f8533eb0e17c29bb8dc0e91cR1662-R1695)