### PR TITLE
fix: update message update logic and add comment

### DIFF
--- a/src/backend/base/langflow/memory.py
+++ b/src/backend/base/langflow/memory.py
@@ -136,6 +136,7 @@ async def aupdate_messages(messages: Message | list[Message]) -> list[Message]:
             msg = await session.get(MessageTable, message.id)
             if msg:
                 msg = msg.sqlmodel_update(message.model_dump(exclude_unset=True, exclude_none=True))
+                # Convert flow_id to UUID if it's a string preventing error when saving to database
                 if msg.flow_id and isinstance(msg.flow_id, str):
                     msg.flow_id = UUID(msg.flow_id)
                 session.add(msg)

--- a/src/backend/base/langflow/memory.py
+++ b/src/backend/base/langflow/memory.py
@@ -135,10 +135,9 @@ async def aupdate_messages(messages: Message | list[Message]) -> list[Message]:
         for message in messages:
             msg = await session.get(MessageTable, message.id)
             if msg:
-                if hasattr(message, "data"):
-                    msg = msg.sqlmodel_update(message.data)
-                else:
-                    msg = msg.sqlmodel_update(message.model_dump(exclude_unset=True, exclude_none=True))
+                msg = msg.sqlmodel_update(message.model_dump(exclude_unset=True, exclude_none=True))
+                if msg.flow_id and isinstance(msg.flow_id, str):
+                    msg.flow_id = UUID(msg.flow_id)
                 session.add(msg)
                 await session.commit()
                 await session.refresh(msg)


### PR DESCRIPTION
This pull request includes a refactoring of the message update logic in the `aupdate_messages` function. The logic has been simplified ensure all the message was updated. Additionally, a comment has been added to explain the purpose of converting the `flow_id` to a UUID if it's a string, which prevents errors when saving to the database.