### PR TITLE
perf: optimize vertex build query for recent records

### DIFF
--- a/src/backend/base/langflow/services/database/models/vertex_builds/crud.py
+++ b/src/backend/base/langflow/services/database/models/vertex_builds/crud.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import col, delete, select
+from sqlmodel import col, delete, select, func
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from langflow.services.database.models.vertex_builds.model import VertexBuildBase, VertexBuildTable
@@ -10,8 +10,19 @@ from langflow.services.database.models.vertex_builds.model import VertexBuildBas
 async def get_vertex_builds_by_flow_id(
     db: AsyncSession, flow_id: UUID, limit: int | None = 1000
 ) -> list[VertexBuildTable]:
+    subquery = (
+        select(
+            VertexBuildTable.id,
+            func.max(VertexBuildTable.timestamp).label("max_timestamp")
+        )
+        .where(VertexBuildTable.flow_id == flow_id)
+        .group_by(VertexBuildTable.id)
+        .subquery()
+    )
     stmt = (
         select(VertexBuildTable)
+        .join(subquery,
+              (VertexBuildTable.id == subquery.c.id) & (VertexBuildTable.timestamp == subquery.c.max_timestamp))
         .where(VertexBuildTable.flow_id == flow_id)
         .order_by(col(VertexBuildTable.timestamp))
         .limit(limit)


### PR DESCRIPTION
This PR optimizes the SQL query to retrieve only the most recent record for each vertex in the `VertexBuildTable`. Previously, all data was fetched and transmitted to the frontend, which only needed the latest entry per vertex, leading to excessive and unnecessary browser memory usage.