### PR TITLE
ci: update changes filter to include lock files and base pyproject.toml

### DIFF
--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -3,7 +3,9 @@ python:
   - "src/backend/**"
   - "src/backend/**.py"
   - "pyproject.toml"
-  - "poetry.lock"
+  - "uv.lock"
+  - "src/backend/base/pyproject.toml"
+  - "src/backend/base/uv.lock"
   - "**/python_test.yml"
 components-changes:
   - "src/backend/base/langflow/components/**"


### PR DESCRIPTION
This PR updates the changes-filter.yaml to include the new 'uv.lock' and 'src/backend/base/uv.lock' files, as well as 'src/backend/base/pyproject.toml' for better tracking of changes in the backend project structure. The paths have been adjusted to ensure proper monitoring of relevant files.