### PR TITLE
ci: Update Python version matrix in CI workflows to exclude 3.13

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -145,7 +145,7 @@ jobs:
     needs: create-nightly-tag
     uses: ./.github/workflows/python_test.yml
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      python-versions: '["3.10", "3.11", "3.12"]'
 
   # Not making nightly builds dependent on integration test success
   # due to inherent flakiness of 3rd party integrations

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -37,7 +37,7 @@ jobs:
       UV_CACHE_DIR: /tmp/.uv-cache
     strategy:
       matrix:
-        python-version: ${{ fromJson(inputs.python-versions || '["3.10", "3.11", "3.12", "3.13"]' ) }}
+        python-version: ${{ fromJson(inputs.python-versions || '["3.10", "3.11", "3.12"]' ) }}
         splitCount: [5]
         group: [1, 2, 3, 4, 5]
     steps:
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ${{ fromJson(inputs.python-versions || '["3.10", "3.11", "3.12", "3.13"]' ) }}
+        python-version: ${{ fromJson(inputs.python-versions || '["3.10", "3.11", "3.12"]' ) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ${{ fromJson(inputs.python-versions || '["3.10", "3.11", "3.12", "3.13"]') }}
+        python-version: ${{ fromJson(inputs.python-versions || '["3.10", "3.11", "3.12"]') }}
     steps:
       - name: Check out the code at a specific ref
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request modifies the Python version matrix in the GitHub Actions workflows to remove Python 3.13. This change enhances compatibility and streamlines the testing process by clarifying the supported Python versions in the CI configuration.