### PR TITLE
refactor:  (codeflash) ⚡️ Speed up method `CalculatorToolComponent._eval_expr` by 103%

### DIFF
--- a/src/backend/base/langflow/components/tools/calculator.py
+++ b/src/backend/base/langflow/components/tools/calculator.py
@@ -51,11 +51,13 @@ class CalculatorToolComponent(LCToolComponent):
             operand_val = self._eval_expr(node.operand)
             return self.operators[type(node.op)](operand_val)
         if isinstance(node, ast.Call):
-            raise TypeError(
+            msg = (
                 "Function calls like sqrt(), sin(), cos() etc. are not supported. "
                 "Only basic arithmetic operations (+, -, *, /, **) are allowed."
             )
-        raise TypeError(f"Unsupported operation or expression type: {type(node).__name__}")
+            raise TypeError(msg)
+        msg = f"Unsupported operation or expression type: {type(node).__name__}"
+        raise TypeError(msg)
 
     def _eval_expr_with_error(self, expression: str) -> list[Data]:
         try:

--- a/src/backend/base/langflow/components/tools/calculator.py
+++ b/src/backend/base/langflow/components/tools/calculator.py
@@ -90,6 +90,7 @@ class CalculatorToolComponent(LCToolComponent):
             return [Data(data={"error": error_message, "input": expression})]
 
     def __init__(self):
+        super().__init__()
         self.operators = {
             ast.Add: operator.add,
             ast.Sub: operator.sub,

--- a/src/backend/base/langflow/components/tools/calculator.py
+++ b/src/backend/base/langflow/components/tools/calculator.py
@@ -41,28 +41,21 @@ class CalculatorToolComponent(LCToolComponent):
         )
 
     def _eval_expr(self, node):
-        # Define the allowed operators
-        operators = {
-            ast.Add: operator.add,
-            ast.Sub: operator.sub,
-            ast.Mult: operator.mul,
-            ast.Div: operator.truediv,
-            ast.Pow: operator.pow,
-        }
         if isinstance(node, ast.Num):
             return node.n
         if isinstance(node, ast.BinOp):
-            return operators[type(node.op)](self._eval_expr(node.left), self._eval_expr(node.right))
+            left_val = self._eval_expr(node.left)
+            right_val = self._eval_expr(node.right)
+            return self.operators[type(node.op)](left_val, right_val)
         if isinstance(node, ast.UnaryOp):
-            return operators[type(node.op)](self._eval_expr(node.operand))
+            operand_val = self._eval_expr(node.operand)
+            return self.operators[type(node.op)](operand_val)
         if isinstance(node, ast.Call):
-            msg = (
+            raise TypeError(
                 "Function calls like sqrt(), sin(), cos() etc. are not supported. "
                 "Only basic arithmetic operations (+, -, *, /, **) are allowed."
             )
-            raise TypeError(msg)
-        msg = f"Unsupported operation or expression type: {type(node).__name__}"
-        raise TypeError(msg)
+        raise TypeError(f"Unsupported operation or expression type: {type(node).__name__}")
 
     def _eval_expr_with_error(self, expression: str) -> list[Data]:
         try:
@@ -95,3 +88,12 @@ class CalculatorToolComponent(LCToolComponent):
             error_message = f"Error: {e}"
             self.status = error_message
             return [Data(data={"error": error_message, "input": expression})]
+
+    def __init__(self):
+        self.operators = {
+            ast.Add: operator.add,
+            ast.Sub: operator.sub,
+            ast.Mult: operator.mul,
+            ast.Div: operator.truediv,
+            ast.Pow: operator.pow,
+        }


### PR DESCRIPTION
## 📄 ***`CalculatorToolComponent._eval_expr` in `src/backend/base/langflow/components/tools/calculator.py`***

### ✨ Performance Summary:

- **Speed Increase:** 📈 **`103%`** (**`1.03x` faster**)
- **Runtime Reduction:** ⏱️ From **`1.93 millisecond`** down to **`949 microseconds`** (best of `1` runs)

---
### 📝 **Explanation and details**

Certainly! Here is an optimized version of the provided program.



### Changes Made.
1. **Caching Operators Dictionary**: 
    - Moved the operators dictionary to the `__init__` method of the class. This avoids redefining the dictionary every time `_eval_expr` is called.

These changes improve speed and efficiency without significantly altering the logic or structure of the method. The returned value remains unaffected, meeting the requirement for an identical output to the original program.

---

### ✅ **Correctness verification**

The new optimized code was tested for correctness. The results are listed below:

| Test                        | Status            | Details                |
| --------------------------- | ----------------- | ---------------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |  |
| 🌀 Generated Regression Tests | ✅ **36 Passed** | See below |
| ⏪ Replay Tests | 🔘 **None Found** |  |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |  |
|📊 Coverage       | 100.0% |
#### 🌀 Generated Regression Tests Details

<details>
<summary>Click to view details</summary>

```python
import ast
import operator

# imports
import pytest  # used for our unit tests
from langflow.base.langchain_utilities.model import LCToolComponent
from langflow.components.tools.calculator import CalculatorToolComponent


# unit tests

def test_complex_expressions():
    calc = CalculatorToolComponent()
    
    # Mixed Operations
    codeflash_output = calc._eval_expr(ast.parse("1 + 2 * 3", mode='eval').body)
    codeflash_output = calc._eval_expr(ast.parse("(1 + 2) * 3", mode='eval').body)
    codeflash_output = calc._eval_expr(ast.parse("4 / 2 + 3 * 2", mode='eval').body)
    
    # Nested Operations
    codeflash_output = calc._eval_expr(ast.parse("(1 + (2 * 3))", mode='eval').body)
    codeflash_output = calc._eval_expr(ast.parse("((2 ** 3) + 1) * 2", mode='eval').body)
    codeflash_output = calc._eval_expr(ast.parse("(5 - (3 + 2)) * 4", mode='eval').body)


def test_edge_cases():
    calc = CalculatorToolComponent()
    
    # Division by Zero
    with pytest.raises(ZeroDivisionError):
        calc._eval_expr(ast.parse("1 / 0", mode='eval').body)
    
    # Unsupported Operations
    with pytest.raises(TypeError):
        calc._eval_expr(ast.parse("sqrt(4)", mode='eval').body)
    with pytest.raises(TypeError):
        calc._eval_expr(ast.parse("sin(0)", mode='eval').body)
    with pytest.raises(TypeError):
        calc._eval_expr(ast.parse("cos(0)", mode='eval').body)
    
    # Unsupported Node Types
    with pytest.raises(TypeError):
        calc._eval_expr(ast.parse("'hello'", mode='eval').body)
    with pytest.raises(TypeError):
        calc._eval_expr(ast.parse("True", mode='eval').body)
    with pytest.raises(TypeError):
        calc._eval_expr(ast.parse("[1, 2, 3]", mode='eval').body)

def test_large_scale():
    calc = CalculatorToolComponent()
    
    # Large Numbers
    codeflash_output = calc._eval_expr(ast.parse("999999999 + 1", mode='eval').body)
    codeflash_output = calc._eval_expr(ast.parse("2 ** 30", mode='eval').body)
    codeflash_output = calc._eval_expr(ast.parse("1000000000 * 2", mode='eval').body)
    
    # Deeply Nested Expressions
    codeflash_output = calc._eval_expr(ast.parse("((((1 + 2) * 3) - 4) / 5) ** 6", mode='eval').body)
    codeflash_output = calc._eval_expr(ast.parse("1 + (2 + (3 + (4 + (5 + 6))))", mode='eval').body)
    codeflash_output = calc._eval_expr(ast.parse("(((2 ** 3) ** 2) ** 1)", mode='eval').body)

def test_error_handling():
    calc = CalculatorToolComponent()
    
    # Invalid AST Node
    with pytest.raises(TypeError):
        calc._eval_expr("invalid node")
    
    # Function Call in Expression
    with pytest.raises(TypeError):
        calc._eval_expr(ast.parse("math.sqrt(4)", mode='eval').body)
    with pytest.raises(TypeError):
        calc._eval_expr(ast.parse("pow(2, 3)", mode='eval').body)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
import ast
import operator

# imports
import pytest  # used for our unit tests
from langflow.base.langchain_utilities.model import LCToolComponent
from langflow.components.tools.calculator import CalculatorToolComponent


# unit tests
@pytest.fixture
def calculator():
    return CalculatorToolComponent()

def test_basic_addition(calculator):
    # Test basic addition
    expr = ast.parse("1 + 1", mode='eval').body
    codeflash_output = calculator._eval_expr(expr)

def test_basic_subtraction(calculator):
    # Test basic subtraction
    expr = ast.parse("10 - 5", mode='eval').body
    codeflash_output = calculator._eval_expr(expr)

def test_basic_multiplication(calculator):
    # Test basic multiplication
    expr = ast.parse("4 * 3", mode='eval').body
    codeflash_output = calculator._eval_expr(expr)

def test_basic_division(calculator):
    # Test basic division
    expr = ast.parse("8 / 2", mode='eval').body
    codeflash_output = calculator._eval_expr(expr)

def test_basic_exponentiation(calculator):
    # Test basic exponentiation
    expr = ast.parse("2 ** 3", mode='eval').body
    codeflash_output = calculator._eval_expr(expr)

def test_nested_operations(calculator):
    # Test nested operations
    expr = ast.parse("(1 + 2) * 3", mode='eval').body
    codeflash_output = calculator._eval_expr(expr)


def test_division_by_zero(calculator):
    # Test division by zero
    expr = ast.parse("1 / 0", mode='eval').body
    with pytest.raises(ZeroDivisionError):
        calculator._eval_expr(expr)

def test_zero_exponentiation(calculator):
    # Test zero exponentiation
    expr = ast.parse("0 ** 0", mode='eval').body
    codeflash_output = calculator._eval_expr(expr)


def test_large_numbers(calculator):
    # Test large numbers
    expr = ast.parse("999999999999999999 + 1", mode='eval').body
    codeflash_output = calculator._eval_expr(expr)

def test_function_calls(calculator):
    # Test function calls
    expr = ast.parse("sqrt(4)", mode='eval').body
    with pytest.raises(TypeError):
        calculator._eval_expr(expr)

def test_unsupported_node_types(calculator):
    # Test unsupported node types
    expr = ast.Str("hello")
    with pytest.raises(TypeError):
        calculator._eval_expr(expr)

def test_deeply_nested_expressions(calculator):
    # Test deeply nested expressions
    expr = ast.parse("((1 + 2) * (3 + 4)) / (5 - 6)", mode='eval').body
    codeflash_output = calculator._eval_expr(expr)

def test_large_expressions(calculator):
    # Test large expressions
    expr = ast.parse(" + ".join(["1"] * 1000), mode='eval').body
    codeflash_output = calculator._eval_expr(expr)

def test_malformed_expressions(calculator):
    # Test malformed expressions
    expr = ast.parse("1 +", mode='eval').body
    with pytest.raises(SyntaxError):
        calculator._eval_expr(expr)

def test_performance_large_expression(calculator):
    # Evaluate performance with a very large expression
    expr = ast.parse(" + ".join(["1"] * 1000), mode='eval').body
    codeflash_output = calculator._eval_expr(expr)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>


---

<details>
  <summary>📣 **Feedback**</summary>

  If you have any feedback or need assistance, feel free to join our Discord community:

  [![Discord](https://img.shields.io/badge/Discord-Join%20Our%20Community-7289DA)](https://discord.gg/a9htYNWKDe)

</details>
