### PR TITLE
chore: Update CI workflow to include 'merge_group' event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ on:
         default: "['3.10']"
   pull_request:
     types: [synchronize, labeled]
-
+  merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -80,7 +80,7 @@ jobs:
     name: Should Run CI
     runs-on: ubuntu-latest
     outputs:
-      should-run-ci: ${{ (needs.check-nightly-status.outputs.should-proceed == 'true') && ((contains( github.event.pull_request.labels.*.name, 'lgtm') && github.event.pull_request.draft == false) || (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call')) }}
+      should-run-ci: ${{ (needs.check-nightly-status.outputs.should-proceed == 'true') && ((contains( github.event.pull_request.labels.*.name, 'lgtm') && github.event.pull_request.draft == false) || (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'merge_group')) }}
     steps:
       #  Do anything just to make the job run
       - run: echo "Debug CI Condition"

--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -4,6 +4,7 @@ name: Label PRs with Conventional Commits
 on:
   pull_request_target:
     types: [opened, edited, synchronize]
+  merge_group:
 
 jobs:
   validate-pr:


### PR DESCRIPTION
This pull request introduces changes to the GitHub Actions workflows to support the `merge_group` event, ensuring that CI runs appropriately for merge groups.

Changes to GitHub Actions workflows:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL42-R42): Added support for the `merge_group` event to the `on` section, enabling CI to trigger for merge groups.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL83-R83): Updated the `should-run-ci` output condition to include the `merge_group` event, ensuring CI runs when this event occurs.
* [`.github/workflows/conventional-labels.yml`](diffhunk://#diff-ff26597550dc7e886d568568618290e90ad2f9018fa0d65667783b1d6dcc00c2R7): Added the `merge_group` event to the `on` section to label PRs with conventional commits when they are part of a merge group.