### PR TITLE
ci: Update pre-commit configuration to use ruff for linting and formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,15 +11,13 @@ repos:
         args:
           - --fix=lf
       - id: trailing-whitespace
-  - repo: local
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.3
     hooks:
-      - id: ruff-check
+      - id: ruff
         name: ruff check
-        language: system
-        entry: bash -c "uv run ruff check"
-        types: [file, python]
+        types_or: [python, pyi]
+        args: [--fix]
       - id: ruff-format
-        name: ruff format
-        language: system
-        entry: bash -c "uv run ruff format"
-        types: [file, python]
+        types_or: [python, pyi]
+        args: [--config pyproject.toml]


### PR DESCRIPTION
This pull request updates the pre-commit configuration to integrate ruff for linting and formatting Python files. The configuration now uses the ruff pre-commit hook for both checking and formatting, streamlining the development process and ensuring consistent code quality.