### PR TITLE
test: Enhance tool mode spec with zoom controls and drag-drop functionality

### DIFF
--- a/src/frontend/tests/extended/features/tool-mode.spec.ts
+++ b/src/frontend/tests/extended/features/tool-mode.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { zoomOut } from "../../utils/zoom-out";
 
 test(
   "User should be able to use components as tool",
@@ -113,16 +114,21 @@ test(
 
     await page.getByTestId("disclosure-agents").click();
 
+    await page.getByTestId("fit_view").click();
+
+    await zoomOut(page, 4);
+
     await page.waitForSelector('[data-testid="agentsAgent"]', {
       timeout: 3000,
       state: "visible",
     });
     await page
       .getByTestId("agentsAgent")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-agent").click();
+      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+        targetPosition: { x: 350, y: 100 },
       });
+
+    await page.getByTestId("fit_view").click();
 
     // Move the Agent node a bit
 


### PR DESCRIPTION
This pull request includes changes to the `src/frontend/tests/extended/features/tool-mode.spec.ts` file to enhance the tool mode test functionality. The most important changes include adding a new utility import, incorporating zoom functionality, and modifying the agent interaction steps.

Enhancements to tool mode test functionality:

* [`src/frontend/tests/extended/features/tool-mode.spec.ts`](diffhunk://#diff-c1473350bc51716fab29cedef6c555fd3bc79ac0202b7df11897f8ae0cd0e3d4R3): Added import for the `zoomOut` utility function.
* [`src/frontend/tests/extended/features/tool-mode.spec.ts`](diffhunk://#diff-c1473350bc51716fab29cedef6c555fd3bc79ac0202b7df11897f8ae0cd0e3d4R117-R132): Added steps to click the "fit view" button and perform a zoom out action.
* [`src/frontend/tests/extended/features/tool-mode.spec.ts`](diffhunk://#diff-c1473350bc51716fab29cedef6c555fd3bc79ac0202b7df11897f8ae0cd0e3d4R117-R132): Changed the agent interaction from hover and click to drag and drop with specified target position.