### PR TITLE
feat: return variable value if it is a generic variable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
         args: [--fix]
       - id: ruff-format
         types_or: [python, pyi]
-        args: [--config pyproject.toml]
+        args: [--config, pyproject.toml]

--- a/src/backend/base/langflow/api/v1/variable.py
+++ b/src/backend/base/langflow/api/v1/variable.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import NoResultFound
 from langflow.api.utils import CurrentActiveUser, DbSession
 from langflow.services.database.models.variable import VariableCreate, VariableRead, VariableUpdate
 from langflow.services.deps import get_variable_service
-from langflow.services.variable.constants import GENERIC_TYPE
+from langflow.services.variable.constants import CREDENTIAL_TYPE
 from langflow.services.variable.service import DatabaseVariableService
 
 router = APIRouter(prefix="/variables", tags=["Variables"])
@@ -38,7 +38,7 @@ async def create_variable(
             name=variable.name,
             value=variable.value,
             default_fields=variable.default_fields or [],
-            type_=variable.type or GENERIC_TYPE,
+            type_=variable.type or CREDENTIAL_TYPE,
             session=session,
         )
     except Exception as e:

--- a/src/backend/base/langflow/services/variable/base.py
+++ b/src/backend/base/langflow/services/variable/base.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from langflow.services.base import Service
-from langflow.services.database.models.variable.model import Variable
+from langflow.services.database.models.variable.model import Variable, VariableRead
 
 
 class VariableService(Service):
@@ -110,7 +110,7 @@ class VariableService(Service):
         """
 
     @abc.abstractmethod
-    async def get_all(self, user_id: UUID | str, session: AsyncSession) -> list[Variable]:
+    async def get_all(self, user_id: UUID | str, session: AsyncSession) -> list[VariableRead]:
         """Get all variables.
 
         Args:

--- a/src/backend/base/langflow/services/variable/base.py
+++ b/src/backend/base/langflow/services/variable/base.py
@@ -108,3 +108,12 @@ class VariableService(Service):
         Returns:
             The created variable.
         """
+
+    @abc.abstractmethod
+    async def get_all(self, user_id: UUID | str, session: AsyncSession) -> list[Variable]:
+        """Get all variables.
+
+        Args:
+            user_id: The user ID.
+            session: The database session.
+        """

--- a/src/backend/base/langflow/services/variable/kubernetes.py
+++ b/src/backend/base/langflow/services/variable/kubernetes.py
@@ -9,7 +9,7 @@ from typing_extensions import override
 
 from langflow.services.auth import utils as auth_utils
 from langflow.services.base import Service
-from langflow.services.database.models.variable.model import Variable, VariableCreate
+from langflow.services.database.models.variable.model import Variable, VariableCreate, VariableRead
 from langflow.services.variable.base import VariableService
 from langflow.services.variable.constants import CREDENTIAL_TYPE, GENERIC_TYPE
 from langflow.services.variable.kubernetes_secrets import KubernetesSecretManager, encode_user_id
@@ -170,3 +170,35 @@ class KubernetesSecretService(VariableService, Service):
             default_fields=default_fields,
         )
         return Variable.model_validate(variable_base, from_attributes=True, update={"user_id": user_id})
+
+    @override
+    async def get_all(self, user_id: UUID | str, session: AsyncSession) -> list[Variable | None]:
+        secret_name = encode_user_id(user_id)
+        variables = await asyncio.to_thread(self.kubernetes_secrets.get_secret, name=secret_name)
+        if not variables:
+            return []
+
+        variables_read = []
+        for key, value in variables.items():
+            name = key
+            type_ = GENERIC_TYPE
+            if key.startswith(CREDENTIAL_TYPE + "_"):
+                name = key[len(CREDENTIAL_TYPE) + 1 :]
+                type_ = CREDENTIAL_TYPE
+
+            decrypted_value = None
+            if type_ == GENERIC_TYPE:
+                decrypted_value = value
+
+            variable_base = VariableCreate(
+                name=name,
+                type=type_,
+                value=auth_utils.encrypt_api_key(value, settings_service=self.settings_service),
+                default_fields=[],
+            )
+            variable = Variable.model_validate(variable_base, from_attributes=True, update={"user_id": user_id})
+            variable_read = VariableRead.model_validate(variable, from_attributes=True)
+            variable_read.value = decrypted_value
+            variables_read.append(variable_read)
+
+        return variables_read

--- a/src/backend/base/langflow/services/variable/kubernetes.py
+++ b/src/backend/base/langflow/services/variable/kubernetes.py
@@ -172,7 +172,7 @@ class KubernetesSecretService(VariableService, Service):
         return Variable.model_validate(variable_base, from_attributes=True, update={"user_id": user_id})
 
     @override
-    async def get_all(self, user_id: UUID | str, session: AsyncSession) -> list[Variable | None]:
+    async def get_all(self, user_id: UUID | str, session: AsyncSession) -> list[VariableRead]:
         secret_name = encode_user_id(user_id)
         variables = await asyncio.to_thread(self.kubernetes_secrets.get_secret, name=secret_name)
         if not variables:

--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -79,7 +79,7 @@ class DatabaseVariableService(VariableService, Service):
         # we decrypt the value
         return auth_utils.decrypt_api_key(variable.value, settings_service=self.settings_service)
 
-    async def get_all(self, user_id: UUID | str, session: AsyncSession) -> list[Variable | None]:
+    async def get_all(self, user_id: UUID | str, session: AsyncSession) -> list[VariableRead]:
         stmt = select(Variable).where(Variable.user_id == user_id)
         variables = list((await session.exec(stmt)).all())
         # If the variable is of type 'Generic' we decrypt the value

--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -9,7 +9,7 @@ from sqlmodel import select
 
 from langflow.services.auth import utils as auth_utils
 from langflow.services.base import Service
-from langflow.services.database.models.variable.model import Variable, VariableCreate, VariableUpdate
+from langflow.services.database.models.variable.model import Variable, VariableCreate, VariableRead, VariableUpdate
 from langflow.services.variable.base import VariableService
 from langflow.services.variable.constants import CREDENTIAL_TYPE, GENERIC_TYPE
 
@@ -81,7 +81,18 @@ class DatabaseVariableService(VariableService, Service):
 
     async def get_all(self, user_id: UUID | str, session: AsyncSession) -> list[Variable | None]:
         stmt = select(Variable).where(Variable.user_id == user_id)
-        return list((await session.exec(stmt)).all())
+        variables = list((await session.exec(stmt)).all())
+        # If the variable is of type 'Generic' we decrypt the value
+        variables_read = []
+        for variable in variables:
+            value = None
+            if variable.type == GENERIC_TYPE:
+                value = auth_utils.decrypt_api_key(variable.value, settings_service=self.settings_service)
+
+            variable_read = VariableRead.model_validate(variable, from_attributes=True)
+            variable_read.value = value
+            variables_read.append(variable_read)
+        return variables_read
 
     async def list_variables(self, user_id: UUID | str, session: AsyncSession) -> list[str | None]:
         variables = await self.get_all(user_id=user_id, session=session)
@@ -160,7 +171,7 @@ class DatabaseVariableService(VariableService, Service):
         value: str,
         *,
         default_fields: Sequence[str] = (),
-        type_: str = GENERIC_TYPE,
+        type_: str = CREDENTIAL_TYPE,
         session: AsyncSession,
     ):
         variable_base = VariableCreate(

--- a/src/backend/tests/unit/services/variable/test_service.py
+++ b/src/backend/tests/unit/services/variable/test_service.py
@@ -6,7 +6,7 @@ import pytest
 from langflow.services.database.models.variable.model import VariableUpdate
 from langflow.services.deps import get_settings_service
 from langflow.services.settings.constants import VARIABLES_TO_GET_FROM_ENVIRONMENT
-from langflow.services.variable.constants import CREDENTIAL_TYPE, GENERIC_TYPE
+from langflow.services.variable.constants import CREDENTIAL_TYPE
 from langflow.services.variable.service import DatabaseVariableService
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
@@ -237,6 +237,6 @@ async def test_create_variable(service, session: AsyncSession):
     assert result.name == name
     assert result.value != value
     assert result.default_fields == []
-    assert result.type == GENERIC_TYPE
+    assert result.type == CREDENTIAL_TYPE
     assert isinstance(result.created_at, datetime)
     assert isinstance(result.updated_at, datetime)

--- a/src/backend/tests/unit/services/variable/test_service.py
+++ b/src/backend/tests/unit/services/variable/test_service.py
@@ -137,7 +137,7 @@ async def test_update_variable(service, session: AsyncSession):
     assert result.value != old_value
     assert result.value != new_value
     assert result.default_fields == []
-    assert result.type == GENERIC_TYPE
+    assert result.type == CREDENTIAL_TYPE
     assert isinstance(result.created_at, datetime)
     assert isinstance(result.updated_at, datetime)
 


### PR DESCRIPTION
This pull request refactors the variable tests to improve clarity and reusability by utilizing fixtures for generic and credential types. It implements a `get_all` method in the `KubernetesSecretService` to retrieve and decrypt user variables, and adds an abstract method in `VariableService` for retrieving all variables for a user. Additionally, the variable service is enhanced to handle decryption for generic types, and the default variable type is updated to `CREDENTIAL_TYPE`. Minor fixes include updating the variable type constant and adjusting the pre-commit configuration for formatting.