### PR TITLE
fix: avoid checking variables with empty value

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -622,7 +622,7 @@ async def custom_component_update(
             load_from_db_fields = [
                 field_name
                 for field_name, field_dict in template.items()
-                if isinstance(field_dict, dict) and field_dict.get("load_from_db")
+                if isinstance(field_dict, dict) and field_dict.get("load_from_db") and field_dict.get("value")
             ]
             params = await update_params_with_load_from_db_fields(cc_instance, params, load_from_db_fields)
             cc_instance.set_attributes(params)

--- a/src/backend/base/langflow/interface/initialize/loading.py
+++ b/src/backend/base/langflow/interface/initialize/loading.py
@@ -111,7 +111,7 @@ async def update_params_with_load_from_db_fields(
     fallback_to_env_vars=False,
 ):
     for field in load_from_db_fields:
-        if field not in params:
+        if field not in params or not params[field]:
             continue
 
         try:


### PR DESCRIPTION
This pull request improves the robustness of the `custom_component_update` and `update_params_with_load_from_db_fields` functions by ensuring that only fields with defined values are included in the loading process. It updates the conditions to skip parameters that are either absent or have falsy values, enhancing the overall reliability of parameter handling.