### PR TITLE
feat: Add Pandas kwargs support for CSV Agent

### DIFF
--- a/src/backend/base/langflow/components/langchain_utilities/csv.py
+++ b/src/backend/base/langflow/components/langchain_utilities/csv.py
@@ -49,6 +49,7 @@ class CSVAgentComponent(LCAgentComponent):
             display_name="Pandas Kwargs",
             info="Pandas Kwargs to be passed to the agent.",
             advanced=True,
+            is_list=True,
         ),
     ]
 

--- a/src/backend/base/langflow/components/langchain_utilities/csv.py
+++ b/src/backend/base/langflow/components/langchain_utilities/csv.py
@@ -3,7 +3,7 @@ from langchain_experimental.agents.agent_toolkits.csv.base import create_csv_age
 from langflow.base.agents.agent import LCAgentComponent
 from langflow.field_typing import AgentExecutor
 from langflow.inputs import DropdownInput, FileInput, HandleInput
-from langflow.inputs.inputs import MessageTextInput
+from langflow.inputs.inputs import DictInput, MessageTextInput
 from langflow.schema.message import Message
 from langflow.template.field.base import Output
 
@@ -44,6 +44,12 @@ class CSVAgentComponent(LCAgentComponent):
             display_name="Text",
             info="Text to be passed as input and extract info from the CSV File.",
         ),
+        DictInput(
+            name="pandas_kwargs",
+            display_name="Pandas Kwargs",
+            info="Pandas Kwargs to be passed to the agent.",
+            advanced=True,
+        ),
     ]
 
     outputs = [
@@ -67,6 +73,7 @@ class CSVAgentComponent(LCAgentComponent):
             path=self._path(),
             agent_type=self.agent_type,
             handle_parsing_errors=self.handle_parsing_errors,
+            pandas_kwargs=self.pandas_kwargs,
             **agent_kwargs,
         )
 
@@ -84,6 +91,7 @@ class CSVAgentComponent(LCAgentComponent):
             path=self._path(),
             agent_type=self.agent_type,
             handle_parsing_errors=self.handle_parsing_errors,
+            pandas_kwargs=self.pandas_kwargs,
             **agent_kwargs,
         )
 


### PR DESCRIPTION
#5185

This pull request includes enhancements to the `CSVAgentComponent` class in the `src/backend/base/langflow/components/langchain_utilities/csv.py` file, focusing on adding support for Pandas keyword arguments.

Key changes include:

### Enhancements to `CSVAgentComponent`:

* Added `DictInput` for `pandas_kwargs` to the `inputs` list to allow passing Pandas keyword arguments to the agent.
* Updated the `build_agent_response` method to include `pandas_kwargs` in the agent's configuration.
* Updated the `build_agent` method to include `pandas_kwargs` in the agent's configuration.

### Import adjustments:

* Added `DictInput` import from `langflow.inputs.inputs`.

![image](https://github.com/user-attachments/assets/925b8a06-9957-40d7-9c26-bd617523b781)
