### PR TITLE
fix: add data field to returned object on flowheader if flow is a component

### DIFF
--- a/src/backend/base/langflow/services/database/models/flow/model.py
+++ b/src/backend/base/langflow/services/database/models/flow/model.py
@@ -27,14 +27,20 @@ HEX_COLOR_LENGTH = 7
 
 class FlowBase(SQLModel):
     name: str = Field(index=True)
-    description: str | None = Field(default=None, sa_column=Column(Text, index=True, nullable=True))
+    description: str | None = Field(
+        default=None, sa_column=Column(Text, index=True, nullable=True)
+    )
     icon: str | None = Field(default=None, nullable=True)
     icon_bg_color: str | None = Field(default=None, nullable=True)
     gradient: str | None = Field(default=None, nullable=True)
     data: dict | None = Field(default=None, nullable=True)
     is_component: bool | None = Field(default=False, nullable=True)
-    updated_at: datetime | None = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=True)
-    webhook: bool | None = Field(default=False, nullable=True, description="Can be used on the webhook endpoint")
+    updated_at: datetime | None = Field(
+        default_factory=lambda: datetime.now(timezone.utc), nullable=True
+    )
+    webhook: bool | None = Field(
+        default=False, nullable=True, description="Can be used on the webhook endpoint"
+    )
     endpoint_name: str | None = Field(default=None, nullable=True, index=True)
     tags: list[str] | None = None
     locked: bool | None = Field(default=False, nullable=True)
@@ -163,7 +169,9 @@ class Flow(FlowBase, table=True):  # type: ignore[call-arg]
     icon: str | None = Field(default=None, nullable=True)
     tags: list[str] | None = Field(sa_column=Column(JSON), default=[])
     locked: bool | None = Field(default=False, nullable=True)
-    folder_id: UUID | None = Field(default=None, foreign_key="folder.id", nullable=True, index=True)
+    folder_id: UUID | None = Field(
+        default=None, foreign_key="folder.id", nullable=True, index=True
+    )
     folder: Optional["Folder"] = Relationship(back_populates="flows")
     messages: list["MessageTable"] = Relationship(back_populates="flow")
     transactions: list["TransactionTable"] = Relationship(back_populates="flow")
@@ -203,15 +211,25 @@ class FlowHeader(BaseModel):
     id: UUID = Field(description="Unique identifier for the flow")
     name: str = Field(description="The name of the flow")
     folder_id: UUID | None = Field(
-        None, description="The ID of the folder containing the flow. None if not associated with a folder"
+        None,
+        description="The ID of the folder containing the flow. None if not associated with a folder",
     )
-    is_component: bool | None = Field(None, description="Flag indicating whether the flow is a component")
-    endpoint_name: str | None = Field(None, description="The name of the endpoint associated with this flow")
+    is_component: bool | None = Field(
+        None, description="Flag indicating whether the flow is a component"
+    )
+    endpoint_name: str | None = Field(
+        None, description="The name of the endpoint associated with this flow"
+    )
     description: str | None = Field(None, description="A description of the flow")
+    data: dict | None = Field(
+        None, description="The data of the component, if is_component is True"
+    )
 
     @model_validator(mode="before")
     @classmethod
-    def validate_flow_header(cls, data: dict):
+    def validate_flow_header(cls, data: Flow):
+        if not data.is_component:
+            data.data = None
         return data
 
 

--- a/src/backend/base/langflow/services/database/models/flow/model.py
+++ b/src/backend/base/langflow/services/database/models/flow/model.py
@@ -27,20 +27,14 @@ HEX_COLOR_LENGTH = 7
 
 class FlowBase(SQLModel):
     name: str = Field(index=True)
-    description: str | None = Field(
-        default=None, sa_column=Column(Text, index=True, nullable=True)
-    )
+    description: str | None = Field(default=None, sa_column=Column(Text, index=True, nullable=True))
     icon: str | None = Field(default=None, nullable=True)
     icon_bg_color: str | None = Field(default=None, nullable=True)
     gradient: str | None = Field(default=None, nullable=True)
     data: dict | None = Field(default=None, nullable=True)
     is_component: bool | None = Field(default=False, nullable=True)
-    updated_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc), nullable=True
-    )
-    webhook: bool | None = Field(
-        default=False, nullable=True, description="Can be used on the webhook endpoint"
-    )
+    updated_at: datetime | None = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=True)
+    webhook: bool | None = Field(default=False, nullable=True, description="Can be used on the webhook endpoint")
     endpoint_name: str | None = Field(default=None, nullable=True, index=True)
     tags: list[str] | None = None
     locked: bool | None = Field(default=False, nullable=True)
@@ -169,9 +163,7 @@ class Flow(FlowBase, table=True):  # type: ignore[call-arg]
     icon: str | None = Field(default=None, nullable=True)
     tags: list[str] | None = Field(sa_column=Column(JSON), default=[])
     locked: bool | None = Field(default=False, nullable=True)
-    folder_id: UUID | None = Field(
-        default=None, foreign_key="folder.id", nullable=True, index=True
-    )
+    folder_id: UUID | None = Field(default=None, foreign_key="folder.id", nullable=True, index=True)
     folder: Optional["Folder"] = Relationship(back_populates="flows")
     messages: list["MessageTable"] = Relationship(back_populates="flow")
     transactions: list["TransactionTable"] = Relationship(back_populates="flow")
@@ -214,16 +206,10 @@ class FlowHeader(BaseModel):
         None,
         description="The ID of the folder containing the flow. None if not associated with a folder",
     )
-    is_component: bool | None = Field(
-        None, description="Flag indicating whether the flow is a component"
-    )
-    endpoint_name: str | None = Field(
-        None, description="The name of the endpoint associated with this flow"
-    )
+    is_component: bool | None = Field(None, description="Flag indicating whether the flow is a component")
+    endpoint_name: str | None = Field(None, description="The name of the endpoint associated with this flow")
     description: str | None = Field(None, description="A description of the flow")
-    data: dict | None = Field(
-        None, description="The data of the component, if is_component is True"
-    )
+    data: dict | None = Field(None, description="The data of the component, if is_component is True")
 
     @model_validator(mode="before")
     @classmethod

--- a/src/backend/base/langflow/services/database/models/flow/model.py
+++ b/src/backend/base/langflow/services/database/models/flow/model.py
@@ -32,20 +32,14 @@ HEX_COLOR_LENGTH = 7
 
 class FlowBase(SQLModel):
     name: str = Field(index=True)
-    description: str | None = Field(
-        default=None, sa_column=Column(Text, index=True, nullable=True)
-    )
+    description: str | None = Field(default=None, sa_column=Column(Text, index=True, nullable=True))
     icon: str | None = Field(default=None, nullable=True)
     icon_bg_color: str | None = Field(default=None, nullable=True)
     gradient: str | None = Field(default=None, nullable=True)
     data: dict | None = Field(default=None, nullable=True)
     is_component: bool | None = Field(default=False, nullable=True)
-    updated_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc), nullable=True
-    )
-    webhook: bool | None = Field(
-        default=False, nullable=True, description="Can be used on the webhook endpoint"
-    )
+    updated_at: datetime | None = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=True)
+    webhook: bool | None = Field(default=False, nullable=True, description="Can be used on the webhook endpoint")
     endpoint_name: str | None = Field(default=None, nullable=True, index=True)
     tags: list[str] | None = None
     locked: bool | None = Field(default=False, nullable=True)
@@ -174,9 +168,7 @@ class Flow(FlowBase, table=True):  # type: ignore[call-arg]
     icon: str | None = Field(default=None, nullable=True)
     tags: list[str] | None = Field(sa_column=Column(JSON), default=[])
     locked: bool | None = Field(default=False, nullable=True)
-    folder_id: UUID | None = Field(
-        default=None, foreign_key="folder.id", nullable=True, index=True
-    )
+    folder_id: UUID | None = Field(default=None, foreign_key="folder.id", nullable=True, index=True)
     folder: Optional["Folder"] = Relationship(back_populates="flows")
     messages: list["MessageTable"] = Relationship(back_populates="flow")
     transactions: list["TransactionTable"] = Relationship(back_populates="flow")
@@ -219,16 +211,10 @@ class FlowHeader(BaseModel):
         None,
         description="The ID of the folder containing the flow. None if not associated with a folder",
     )
-    is_component: bool | None = Field(
-        None, description="Flag indicating whether the flow is a component"
-    )
-    endpoint_name: str | None = Field(
-        None, description="The name of the endpoint associated with this flow"
-    )
+    is_component: bool | None = Field(None, description="Flag indicating whether the flow is a component")
+    endpoint_name: str | None = Field(None, description="The name of the endpoint associated with this flow")
     description: str | None = Field(None, description="A description of the flow")
-    data: dict | None = Field(
-        None, description="The data of the component, if is_component is True"
-    )
+    data: dict | None = Field(None, description="The data of the component, if is_component is True")
 
     @field_validator("data", mode="before")
     @classmethod


### PR DESCRIPTION
This pull request includes several changes to improve the code readability and functionality in the `langflow` backend. The most important changes include reformatting imports, updating the `read_flows` function to use `FlowHeader.model_validate`, adding `model_validator` to `FlowHeader`, and reformatting the `FlowBase` and `Flow` classes for better readability.

### Code readability improvements:

* [`src/backend/base/langflow/api/v1/flows.py`](diffhunk://#diff-37c1756ce77874f858b4862cefff35a28b8d1d3ec6534381934b3db73782eb26L20-R20): Reformatted imports to a single line for better readability.
* [`src/backend/base/langflow/services/database/models/flow/model.py`](diffhunk://#diff-adeae5acd8e79a62451c8957c0b5c5f102c5ba8c34e41d440514da6169e37db9L30-R43): Reformatted the `FlowBase` and `Flow` classes to improve readability by breaking long lines into multiple lines. [[1]](diffhunk://#diff-adeae5acd8e79a62451c8957c0b5c5f102c5ba8c34e41d440514da6169e37db9L30-R43) [[2]](diffhunk://#diff-adeae5acd8e79a62451c8957c0b5c5f102c5ba8c34e41d440514da6169e37db9L166-R174)

### Functionality improvements:

* [`src/backend/base/langflow/api/v1/flows.py`](diffhunk://#diff-37c1756ce77874f858b4862cefff35a28b8d1d3ec6534381934b3db73782eb26L224-R218): Updated the `read_flows` function to use `FlowHeader.model_validate` for validating flow headers, simplifying the code.
* [`src/backend/base/langflow/services/database/models/flow/model.py`](diffhunk://#diff-adeae5acd8e79a62451c8957c0b5c5f102c5ba8c34e41d440514da6169e37db9L201-R233): Added `model_validator` to the `FlowHeader` class to ensure `data` is set to `None` if `is_component` is `False`.

### Import enhancements:

* [`src/backend/base/langflow/services/database/models/flow/model.py`](diffhunk://#diff-adeae5acd8e79a62451c8957c0b5c5f102c5ba8c34e41d440514da6169e37db9L12-R12): Added `model_validator` import from `pydantic` to support the new validation in `FlowHeader`.