### PR TITLE
refactor: make set_class_code and to_frontend_node async

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -249,7 +249,7 @@ class Component(CustomComponent):
         memo[id(self)] = new_component
         return new_component
 
-    def set_class_code(self) -> None:
+    async def set_class_code(self) -> None:
         # Get the source code of the calling class
         if self._code:
             return
@@ -726,7 +726,7 @@ class Component(CustomComponent):
     def _update_template(self, frontend_node: dict):
         return frontend_node
 
-    def to_frontend_node(self):
+    async def to_frontend_node(self):
         # ! This part here is clunky but we need it like this for
         # ! backwards compatibility. We can change how prompt component
         # ! works and then update this later
@@ -742,7 +742,7 @@ class Component(CustomComponent):
 
         frontend_node = ComponentFrontendNode.from_dict(frontend_node_dict)
         if not self._code:
-            self.set_class_code()
+            await self.set_class_code()
         code_field = Input(
             dynamic=True,
             required=True,

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -260,7 +260,7 @@ class Graph:
         if component_id in self.vertex_map:
             msg = f"Component ID {component_id} already exists"
             raise ValueError(msg)
-        frontend_node = component.to_frontend_node()
+        frontend_node = run_until_complete(component.to_frontend_node())
         self._vertices.append(frontend_node)
         vertex = self._create_vertex(frontend_node)
         vertex.add_component_instance(component)

--- a/src/backend/tests/unit/components/prompts/test_prompt_component.py
+++ b/src/backend/tests/unit/components/prompts/test_prompt_component.py
@@ -24,9 +24,9 @@ class TestPromptComponent(ComponentTestBaseWithClient):
             {"version": "1.0.19", "module": "prompts", "file_name": "Prompt"},
         ]
 
-    def test_post_code_processing(self, component_class, default_kwargs):
+    async def test_post_code_processing(self, component_class, default_kwargs):
         component = component_class(**default_kwargs)
-        frontend_node = component.to_frontend_node()
+        frontend_node = await component.to_frontend_node()
         node_data = frontend_node["data"]["node"]
         assert node_data["template"]["template"]["value"] == "Hello {name}!"
         assert "name" in node_data["custom_fields"]["template"]


### PR DESCRIPTION
This pull request refactors several methods within the component to be asynchronous, including `set_class_code` and `to_frontend_node`. Additionally, the test for post code processing has been updated to utilize async/await syntax, ensuring compatibility with the new async methods. This change enhances the performance and responsiveness of the component's operations.