### PR TITLE
fix: add initial setup validations 

### DIFF
--- a/src/backend/base/langflow/alembic/versions/b2fa308044b5_add_unique_constraints.py
+++ b/src/backend/base/langflow/alembic/versions/b2fa308044b5_add_unique_constraints.py
@@ -40,11 +40,17 @@ def upgrade() -> None:
                 batch_op.add_column(sa.Column("folder", sqlmodel.sql.sqltypes.AutoString(), nullable=True))
             if "user_id" not in flow_columns:
                 batch_op.add_column(sa.Column("user_id", sqlmodel.sql.sqltypes.types.Uuid(), nullable=True))
+
             indices = inspector.get_indexes("flow")
             indices_names = [index["name"] for index in indices]
             if "ix_flow_user_id" not in indices_names:
                 batch_op.create_index(batch_op.f("ix_flow_user_id"), ["user_id"], unique=False)
-            if "fk_flow_user_id_user" not in indices_names:
+
+            # Check for existing foreign key constraints
+            constraints = inspector.get_foreign_keys("flow")
+            constraint_names = [constraint["name"] for constraint in constraints]
+
+            if "fk_flow_user_id_user" not in constraint_names:
                 batch_op.create_foreign_key("fk_flow_user_id_user", "user", ["user_id"], ["id"])
 
     except Exception as e:

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -565,6 +565,13 @@ async def load_flows_from_directory() -> None:
                 flow["id"] = no_json_name
             flow_id = flow.get("id")
 
+            if isinstance(flow_id, str):
+                try:
+                    flow_id = UUID(flow_id)
+                except ValueError:
+                    logger.error(f"Invalid UUID string: {flow_id}")
+                    return None
+
             existing = await find_existing_flow(session, flow_id, flow_endpoint_name)
             if existing:
                 logger.debug(f"Found existing flow: {existing.name}")
@@ -583,17 +590,24 @@ async def load_flows_from_directory() -> None:
                     folder_id = await get_default_folder_id(session, user_id)
                     existing.folder_id = folder_id
 
+                if isinstance(existing.id, str):
+                    try:
+                        existing.id = UUID(existing.id)
+                    except ValueError:
+                        logger.error(f"Invalid UUID string: {existing.id}")
+                        return None
+
                 session.add(existing)
             else:
                 logger.info(f"Creating new flow: {flow_id} with endpoint name {flow_endpoint_name}")
 
                 # Current behavior loads all new flows into default folder
                 folder_id = await get_default_folder_id(session, user_id)
-
                 flow["user_id"] = user_id
                 flow["folder_id"] = folder_id
                 flow = Flow.model_validate(flow, from_attributes=True)
                 flow.updated_at = datetime.now(tz=timezone.utc).astimezone()
+
                 session.add(flow)
 
 
@@ -604,6 +618,7 @@ async def find_existing_flow(session, flow_id, flow_endpoint_name):
         if existing := (await session.exec(stmt)).first():
             logger.debug(f"Found existing flow by endpoint name: {existing.name}")
             return existing
+
     stmt = select(Flow).where(Flow.id == flow_id)
     if existing := (await session.exec(stmt)).first():
         logger.debug(f"Found existing flow by id: {flow_id}")

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -570,7 +570,7 @@ async def load_flows_from_directory() -> None:
                     flow_id = UUID(flow_id)
                 except ValueError:
                     logger.error(f"Invalid UUID string: {flow_id}")
-                    return None
+                    return
 
             existing = await find_existing_flow(session, flow_id, flow_endpoint_name)
             if existing:
@@ -595,7 +595,7 @@ async def load_flows_from_directory() -> None:
                         existing.id = UUID(existing.id)
                     except ValueError:
                         logger.error(f"Invalid UUID string: {existing.id}")
-                        return None
+                        return
 
                 session.add(existing)
             else:


### PR DESCRIPTION
This PR adds the following checks on initial setup:
* Validate the `flow_id` is a uuid before insertion to database. This addresses https://github.com/langflow-ai/langflow/issues/5370
  * Unknown why this was an issue only for this particular user in this scenario. 
* Updates a migration script to check for existence of fk relation - https://github.com/langflow-ai/langflow/issues/5371
  * @ogabrielluiz I believe this change to the migration script is backwards-compatible, since it's just an additional validation rather than an addition/removal of a relation, but please double check. 