### PR TITLE
fix: Update import path for IOModal to new naming convention

### DIFF
--- a/src/frontend/src/pages/Playground/index.tsx
+++ b/src/frontend/src/pages/Playground/index.tsx
@@ -1,7 +1,7 @@
 import { useGetFlow } from "@/controllers/API/queries/flows/use-get-flow";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import { track } from "@/customization/utils/analytics";
-import IOModal from "@/modals/IOModal/newModal";
+import IOModal from "@/modals/IOModal/new-modal";
 import { useStoreStore } from "@/stores/storeStore";
 import { useEffect } from "react";
 import { useParams } from "react-router-dom";


### PR DESCRIPTION
This pull request updates the import path for the IOModal component to align with the new naming convention. This change ensures consistency in the codebase and prevents potential import errors.