### PR TITLE
tests: fix tests that use Chat Input

### DIFF
--- a/src/frontend/tests/extended/features/notifications.spec.ts
+++ b/src/frontend/tests/extended/features/notifications.spec.ts
@@ -13,16 +13,16 @@ test(
     });
 
     await page.getByTestId("disclosure-inputs").click();
-    await page.waitForSelector('[data-testid="inputsChat Input"]', {
+    await page.waitForSelector('[data-testid="inputsText Input"]', {
       timeout: 3000,
       state: "visible",
     });
     await page
-      .getByTestId("inputsChat Input")
+      .getByTestId("inputsText Input")
       .hover()
       .then(async () => {
-        await page.getByTestId("add-component-button-chat-input").click();
-        await page.getByTestId("button_run_chat input").click();
+        await page.getByTestId("add-component-button-text-input").click();
+        await page.getByTestId("button_run_text input").click();
       });
 
     await page.waitForSelector("text=built successfully", { timeout: 30000 });
@@ -58,7 +58,7 @@ test(
     await expect(runningComponentsText).toBeVisible();
 
     const builtSuccessfullyText = page
-      .getByText("Chat Input built successfully", { exact: true })
+      .getByText("Text Input built successfully", { exact: true })
       .last();
     await expect(builtSuccessfullyText).toBeVisible();
   },

--- a/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
@@ -73,8 +73,8 @@ test(
       timeout: 5000,
       state: "visible",
     });
-
-    await page.getByTestId("fit_view").click();
+    // This causes the Chat Input to be hidden
+    // await page.getByTestId("fit_view").click();
 
     const elementsChatInput = await page
       .locator('[data-testid="handle-chatinput-noshownode-message-source"]')


### PR DESCRIPTION
This pull request addresses visibility issues with the Chat Input in the test suite. The `fit view` action has been commented out to prevent it from hiding the Chat Input during tests. Additionally, the tests have been updated to use Text Input instead of Chat Input, as the latter starts minimized, ensuring that the tests run smoothly without UI interruptions.