### PR TITLE
fix: adjust mouse actions in regression test for proper drag-and-drop

### DIFF
--- a/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
@@ -64,8 +64,8 @@ test(
     await page
       .getByTestId("modelsOpenAI")
       .dragTo(page.locator('//*[@id="react-flow-id"]'));
-    await page.mouse.up();
     await page.mouse.down();
+    await page.mouse.up();
 
     await initialGPTsetup(page);
 


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts` file. The change reorders the mouse actions in a test to ensure the `mouse.up()` action occurs after `mouse.down()`.

* [`src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts`](diffhunk://#diff-c61d7345b8378427eeb622d524db04463e36b6e63e156b6f2e6d30b0b76ab473L67-R68): Reordered the mouse actions in a test to ensure `mouse.up()` occurs after `mouse.down()`