### PR TITLE
fix: error message issue when "exception.body" is None

### DIFF
--- a/src/backend/base/langflow/schema/message.py
+++ b/src/backend/base/langflow/schema/message.py
@@ -381,7 +381,7 @@ class ErrorMessage(Message):
             exception = exception.__cause__
         # Get the error reason
         reason = f"**{exception.__class__.__name__}**\n"
-        if hasattr(exception, "body") and "message" in exception.body:
+        if hasattr(exception, "body") and isinstance(exception.body, dict) and "message" in exception.body:
             reason += f" - **{exception.body.get('message')}**\n"
         elif hasattr(exception, "code"):
             reason += f" - **Code: {exception.code}**\n"


### PR DESCRIPTION
https://github.com/langflow-ai/langflow/blob/0118e98b5c432ba0690c8feffedeb6808e91d4c9/src/backend/base/langflow/schema/message.py#L384

```
/Users/feng/Work/my/forks/langflow-main/src/backend/base/langflow/schema/message.            
                             py", line 384, in __init__                                                                    
                                 if hasattr(exception, "body") and "message" in exception.body:                            
                                            |                                   |         -> None                          
                                            |                                   ->                                         
                             APIConnectionError('Connection error.')                                                       
                                            -> APIConnectionError('Connection error.')                                     
                                                                                                                           
                             TypeError: argument of type 'NoneType' is not iterable 

```

the exception body could be None which will throw " TypeError: argument of type 'NoneType' is not iterable "  and block the real error message to display on frontend 

![image](https://github.com/user-attachments/assets/e5ff7b02-3bdd-4290-92b6-b440eb83c61c)

it should be 

![image](https://github.com/user-attachments/assets/e2090237-dbbd-413c-8103-d92fe05a5b72)
