### PR TITLE
ci: Update Makefile to show output during frontend build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ install_frontend: ## install the frontend dependencies
 
 build_frontend: ## build the frontend static files
 	@echo 'Building frontend static files'
-	@cd src/frontend && CI='' npm run build > /dev/null 2>&1
+	@cd src/frontend && CI='' npm run build
 	$(call CLEAR_DIRS,src/backend/base/langflow/frontend)
 	@cp -r src/frontend/build/. src/backend/base/langflow/frontend
 


### PR DESCRIPTION
This PR modifies the build command in the Makefile for the frontend to display output during the build process, enhancing visibility into the build status. Previously, the output was suppressed, making it difficult to diagnose issues during the build.