### PR TITLE
fix: StructuredOutputComponent tool name generation for multiple=True mode

### DIFF
--- a/src/backend/base/langflow/components/helpers/structured_output.py
+++ b/src/backend/base/langflow/components/helpers/structured_output.py
@@ -93,6 +93,8 @@ class StructuredOutputComponent(Component):
     ]
 
     def build_structured_output(self) -> Data:
+        schema_name = self.schema_name or "OutputModel"
+
         if not hasattr(self.llm, "with_structured_output"):
             msg = "Language model does not support structured output."
             raise TypeError(msg)
@@ -103,8 +105,8 @@ class StructuredOutputComponent(Component):
         output_model_ = build_model_from_schema(self.output_schema)
         if self.multiple:
             output_model = create_model(
-                self.schema_name,
-                objects=(list[output_model_], Field(description=f"A list of {self.schema_name}.")),  # type: ignore[valid-type]
+                schema_name,
+                objects=(list[output_model_], Field(description=f"A list of {schema_name}.")),  # type: ignore[valid-type]
             )
         else:
             output_model = output_model_


### PR DESCRIPTION
# Description
This PR fixes Structured Output component in case when user did not provide Schema Name and set Generate Multiple flag

# Issue
Current behavior results in somewhat cryptic error message from OpenAI:

`BadRequestError: Error code: 400 - {'error': {'message': "Invalid 'tools[0].function.name': empty string. Expected a string with minimum length 1, but got an empty string instead.", 'type': 'invalid_request_error', 'param': 'tools[0].function.name', 'code': 'empty_string'}}`

# Solution
Introduce a sane default, consistent with `langflow.helpers.base_model.build_model_from_schema` that handles situation when user did not provide schema name