### PR TITLE
feat: StructuredOutput returns list of Data objects when multiple=True

### DIFF
--- a/src/backend/base/langflow/components/helpers/structured_output.py
+++ b/src/backend/base/langflow/components/helpers/structured_output.py
@@ -92,7 +92,7 @@ class StructuredOutputComponent(Component):
         Output(name="structured_output", display_name="Structured Output", method="build_structured_output"),
     ]
 
-    def build_structured_output(self) -> Data:
+    def build_structured_output(self) -> list[Data]:
         if not hasattr(self.llm, "with_structured_output"):
             msg = "Language model does not support structured output."
             raise TypeError(msg)
@@ -125,4 +125,8 @@ class StructuredOutputComponent(Component):
         else:
             msg = f"Output should be a Pydantic BaseModel, got {type(output)} ({output})"
             raise TypeError(msg)
-        return Data(data=output_dict)
+
+        if self.multiple:
+            return [Data(data=item) for item in output_dict["objects"]]
+        else:  # noqa: RET505
+            return [Data(data=output_dict)]


### PR DESCRIPTION
# Desctiption
This PR proposes a change in Structured Output behavior when Generate Multiple is set to true.

Currently when Generate Multiple is used component produces a single Data entry with single key `objects` which contains a string representation of a json list of records. This is a bit counterintuitive because Langflow supports input and output of lists of Data objects.

# Solution
We propose to change semantics of Structured Output to return a list Data objects when Generate Multiple is enabled