### PR TITLE
fix: resolve data keyword conflict in template formatting

### DIFF
--- a/src/backend/base/langflow/helpers/data.py
+++ b/src/backend/base/langflow/helpers/data.py
@@ -53,9 +53,8 @@ def data_to_text_list(template: str, data: Data | list[Data]) -> tuple[list[str]
     for value in data_:
         # Prevent conflict with 'data' keyword in template formatting
         kwargs = value.data.copy()
-        if "data" not in kwargs:
-            kwargs["data"] = value.data
-        formatted_text.append(template.format(**kwargs))
+        data = kwargs.pop("data", value.data)
+        formatted_text.append(template.format(data=data, **kwargs))
 
     return formatted_text, data_
 

--- a/src/backend/base/langflow/helpers/data.py
+++ b/src/backend/base/langflow/helpers/data.py
@@ -49,8 +49,14 @@ def data_to_text_list(template: str, data: Data | list[Data]) -> tuple[list[str]
         Data(text=value) if not isinstance(value, Data) else value
         for value in data
     ]
+    formatted_text = []
+    for value in data_:
+        # Prevent conflict with 'data' keyword in template formatting
+        kwargs = value.data.copy()
+        if "data" not in kwargs:
+            kwargs["data"] = value.data
+        formatted_text.append(template.format(**kwargs))
 
-    formatted_text = [template.format(data=value.data, **value.data) for value in data_]
     return formatted_text, data_
 
 

--- a/src/backend/tests/unit/helpers/test_data.py
+++ b/src/backend/tests/unit/helpers/test_data.py
@@ -1,5 +1,4 @@
 import pytest
-
 from langflow.helpers.data import data_to_text_list
 from langflow.schema import Data
 

--- a/src/backend/tests/unit/helpers/test_data.py
+++ b/src/backend/tests/unit/helpers/test_data.py
@@ -1,0 +1,115 @@
+import pytest
+
+from langflow.helpers.data import data_to_text_list
+from langflow.schema import Data
+
+
+@pytest.mark.parametrize(
+    (
+        "template",
+        "data",
+        "expected",
+    ),
+    [
+        (
+            "{name} is {age} years old",
+            Data(data={"name": "Alice", "age": 25}),
+            (["Alice is 25 years old"], [Data(data={"name": "Alice", "age": 25})]),
+        ),
+        (
+            "{name} is {age} years old",
+            [
+                Data(data={"name": "Alice", "age": 25}),
+                Data(data={"name": "Bob", "age": 30}),
+                Data(data={"name": "Alex", "age": 35}),
+            ],
+            (
+                [
+                    "Alice is 25 years old",
+                    "Bob is 30 years old",
+                    "Alex is 35 years old",
+                ],
+                [
+                    Data(data={"name": "Alice", "age": 25}),
+                    Data(data={"name": "Bob", "age": 30}),
+                    Data(data={"name": "Alex", "age": 35}),
+                ],
+            ),
+        ),
+    ],
+)
+def test_data_to_text_list(template, data, expected):
+    result = data_to_text_list(template, data)
+    assert result == expected
+
+
+def test_data_to_text_list__template_empty():
+    template = ""
+    data = Data(data={"key": "value"})
+
+    result = data_to_text_list(template, data)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert isinstance(result[0], list)
+    assert isinstance(result[1], list)
+    assert template in result[0]
+    assert data in result[1]
+
+
+def test_data_to_text_list__template_without_placeholder():
+    template = "My favorite color is gray"
+    data = Data(data={"color": "silver"})
+
+    result = data_to_text_list(template, data)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert isinstance(result[0], list)
+    assert isinstance(result[1], list)
+    assert template in result[0]
+    assert data in result[1]
+
+
+def test_data_to_text_list__template_without_placeholder_and_data_attribute_empty():
+    template = "My favorite color is gray"
+    data_list = [Data(data={})]
+
+    result = data_to_text_list(template, data_list)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert isinstance(result[0], list)
+    assert isinstance(result[1], list)
+    assert template in result[0]
+    assert data_list == result[1]
+
+
+def test_data_to_text_list__template_wrong_placeholder():
+    template = "My favorite color is {color}"
+    data = Data(data={"fruit": "apple"})
+
+    with pytest.raises(KeyError):
+        data_to_text_list(template, data)
+
+
+def test_data_to_text_list__data_with_data_attribute_empty():
+    template = "My favorite color is {color}"
+    data = Data(data={})
+
+    with pytest.raises(KeyError):
+        data_to_text_list(template, data)
+
+
+def test_data_to_text_list__data_contains_nested_data_key():
+    template = "My data is: {data}"
+    data = Data(data={"data": {"key": "value"}})
+
+    result = data_to_text_list(template, data)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert isinstance(result[0], list)
+    assert isinstance(result[1], list)
+    assert template not in result[0]
+    assert data in result[1]


### PR DESCRIPTION
Formatting templates caused a `TypeError` when the `data` dictionary contained a `data` key, due to keyword argument conflicts.

Adjusted the logic to avoid conflicts by checking for the `data` key before passing it explicitly. Added a comment for clarity.