### PR TITLE
feat: make Agents not send message if not connected to an output component

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -25,7 +25,7 @@ from langflow.custom.tree_visitor import RequiredInputsVisitor
 from langflow.exceptions.component import StreamingError
 from langflow.field_typing import Tool  # noqa: TC001 Needed by _add_toolkit_output
 from langflow.graph.state.model import create_state_model
-from langflow.graph.utils import has_output_vertex
+from langflow.graph.utils import has_chat_output
 from langflow.helpers.custom import format_type
 from langflow.memory import astore_message, aupdate_messages, delete_message
 from langflow.schema.artifact import get_artifact_type, post_process_raw
@@ -1024,7 +1024,7 @@ class Component(CustomComponent):
         """Check if the message should be skipped based on vertex configuration and message type."""
         return (
             not (self._vertex.is_output or self._vertex.is_input)
-            and not has_output_vertex(self.graph.get_vertex_neighbors(self._vertex))
+            and not has_chat_output(self.graph.get_vertex_neighbors(self._vertex))
             and not isinstance(message, ErrorMessage)
         )
 

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -25,6 +25,7 @@ from langflow.custom.tree_visitor import RequiredInputsVisitor
 from langflow.exceptions.component import StreamingError
 from langflow.field_typing import Tool  # noqa: TC001 Needed by _add_toolkit_output
 from langflow.graph.state.model import create_state_model
+from langflow.graph.utils import has_output_vertex
 from langflow.helpers.custom import format_type
 from langflow.memory import astore_message, aupdate_messages, delete_message
 from langflow.schema.artifact import get_artifact_type, post_process_raw
@@ -1019,7 +1020,17 @@ class Component(CustomComponent):
                 )
             )
 
+    def _should_skip_message(self, message: Message) -> bool:
+        """Check if the message should be skipped based on vertex configuration and message type."""
+        return (
+            not (self._vertex.is_output or self._vertex.is_input)
+            and not has_output_vertex(self.graph.get_vertex_neighbors(self._vertex))
+            and not isinstance(message, ErrorMessage)
+        )
+
     async def send_message(self, message: Message, id_: str | None = None):
+        if self._should_skip_message(message):
+            return message
         if (hasattr(self, "graph") and self.graph.session_id) and (message is not None and not message.session_id):
             session_id = (
                 UUID(self.graph.session_id) if isinstance(self.graph.session_id, str) else self.graph.session_id

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -1023,7 +1023,8 @@ class Component(CustomComponent):
     def _should_skip_message(self, message: Message) -> bool:
         """Check if the message should be skipped based on vertex configuration and message type."""
         return (
-            not (self._vertex.is_output or self._vertex.is_input)
+            self._vertex is not None
+            and not (self._vertex.is_output or self._vertex.is_input)
             and not has_chat_output(self.graph.get_vertex_neighbors(self._vertex))
             and not isinstance(message, ErrorMessage)
         )

--- a/src/backend/base/langflow/graph/schema.py
+++ b/src/backend/base/langflow/graph/schema.py
@@ -60,13 +60,15 @@ CHAT_COMPONENTS = [InterfaceComponentTypes.ChatInput, InterfaceComponentTypes.Ch
 RECORDS_COMPONENTS = [InterfaceComponentTypes.DataOutput]
 INPUT_COMPONENTS = [
     InterfaceComponentTypes.ChatInput,
-    InterfaceComponentTypes.TextInput,
     InterfaceComponentTypes.WebhookInput,
+    # TODO: Add TextInput back in after add support for it in playground
+    # InterfaceComponentTypes.TextInput,
 ]
 OUTPUT_COMPONENTS = [
     InterfaceComponentTypes.ChatOutput,
-    InterfaceComponentTypes.TextOutput,
     InterfaceComponentTypes.DataOutput,
+    # TODO: Add TextOutput back in after add support for it in playground
+    # InterfaceComponentTypes.TextOutput,
 ]
 
 

--- a/src/backend/base/langflow/graph/schema.py
+++ b/src/backend/base/langflow/graph/schema.py
@@ -61,14 +61,12 @@ RECORDS_COMPONENTS = [InterfaceComponentTypes.DataOutput]
 INPUT_COMPONENTS = [
     InterfaceComponentTypes.ChatInput,
     InterfaceComponentTypes.WebhookInput,
-    # TODO: Add TextInput back in after add support for it in playground
-    # InterfaceComponentTypes.TextInput,
+    InterfaceComponentTypes.TextInput,
 ]
 OUTPUT_COMPONENTS = [
     InterfaceComponentTypes.ChatOutput,
     InterfaceComponentTypes.DataOutput,
-    # TODO: Add TextOutput back in after add support for it in playground
-    # InterfaceComponentTypes.TextOutput,
+    InterfaceComponentTypes.TextOutput,
 ]
 
 

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -208,3 +208,7 @@ def rewrite_file_path(file_path: str):
         consistent_file_path = "/".join(file_path_split)
 
     return [consistent_file_path]
+
+
+def has_output_vertex(vertices: dict[Vertex, int]):
+    return any(vertex.is_output for vertex in vertices)

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -212,3 +212,9 @@ def rewrite_file_path(file_path: str):
 
 def has_output_vertex(vertices: dict[Vertex, int]):
     return any(vertex.is_output for vertex in vertices)
+
+
+def has_chat_output(vertices: dict[Vertex, int]):
+    from langflow.graph.schema import InterfaceComponentTypes
+
+    return any(InterfaceComponentTypes.ChatOutput in vertex.id for vertex in vertices)


### PR DESCRIPTION
This pull request improve the logic for skipping messages in the codebase. The `TextInput` and `TextOutput` components have been commented out, and a new function has been added to check if a graph has an output vertex connected to it. Additionally, a function has been added to skip messages based on the vertex configuration and message type. These changes aim to enhance the overall efficiency and functionality of the code.