### PR TITLE
fix(AstraDBCQL): resolve partition key error and improve AstraDB CQL component handling

### DIFF
--- a/src/backend/base/langflow/components/tools/astradb_cql.py
+++ b/src/backend/base/langflow/components/tools/astradb_cql.py
@@ -1,4 +1,3 @@
-import urllib
 from http import HTTPStatus
 from typing import Any
 
@@ -91,7 +90,11 @@ class AstraDBCQLToolComponent(LCToolComponent):
     ]
 
     def astra_rest(self, args):
-        headers = {"Accept": "application/json", "X-Cassandra-Token": f"{self.token}", "Content-Type": "application/json"}
+        headers = {
+            "Accept": "application/json",
+            "X-Cassandra-Token": f"{self.token}",
+            "Content-Type": "application/json",
+        }
 
         astra_url = f"{self.api_endpoint}/api/rest/v2/keyspaces/{self.keyspace}/{self.table_name}/rows"
 
@@ -99,20 +102,14 @@ class AstraDBCQLToolComponent(LCToolComponent):
 
         for key in self.partition_keys:
             if key in args:
-                where_clauses.append(
-                    {"column": key, "operator": "EQ", "value": args[key]}
-                )
+                where_clauses.append({"column": key, "operator": "EQ", "value": args[key]})
             elif key in self.static_filters:
-                where_clauses.append(
-                    {"column": key, "operator": "EQ", "value": self.static_filters[key]}
-                )
+                where_clauses.append({"column": key, "operator": "EQ", "value": self.static_filters[key]})
 
         for key in self.clustering_keys:
             clean_key = key[1:] if key.startswith("!") else key
             if clean_key in args and args[clean_key] is not None:
-                where_clauses.append(
-                    {"column": clean_key, "operator": "EQ", "value": args[clean_key]}
-                )
+                where_clauses.append({"column": clean_key, "operator": "EQ", "value": args[clean_key]})
             elif clean_key in self.static_filters:
                 where_clauses.append(
                     {
@@ -128,9 +125,7 @@ class AstraDBCQLToolComponent(LCToolComponent):
         }
 
         if self.projection_fields != "*":
-            params["fields"] = [
-                field.strip() for field in self.projection_fields.split(",")
-            ]
+            params["fields"] = [field.strip() for field in self.projection_fields.split(",")]
 
         res = requests.request(
             "GET",
@@ -148,12 +143,11 @@ class AstraDBCQLToolComponent(LCToolComponent):
             res_data = res.json()
             if isinstance(res_data, dict) and "data" in res_data:
                 return res_data["data"]
-            elif isinstance(res_data, list):
+            if isinstance(res_data, list):
                 return res_data
-            elif isinstance(res_data, dict):
+            if isinstance(res_data, dict):
                 return [res_data]
-            else:
-                return []
+            return []
         except ValueError:
             return res.status_code
 


### PR DESCRIPTION
While using the AstraDBCQL tool, despite specifying the partition key and ensuring the correct dictionary format, it returned empty data, failing to pass the data correctly.
I modified the functionality of astra_rest to handle the partition key dictionary and added a check to the run method.

<img width="854" alt="Screenshot 2025-01-03 at 3 56 54 AM" src="https://github.com/user-attachments/assets/d7397c7b-7f9e-4cea-b484-0083d0d15e6b" />

<img width="846" alt="Screenshot 2025-01-03 at 3 54 19 AM" src="https://github.com/user-attachments/assets/4edf96f6-9390-4cbd-9c4c-7e29ecdc9b79" />

<img width="688" alt="Screenshot 2025-01-03 at 3 55 17 AM" src="https://github.com/user-attachments/assets/4ededf64-1a3e-45a5-be94-727970e5981f" />

Above is the error message despite the column 'post_id' existing in the table.