### PR TITLE
fix: uv update fixes issues from crosshair-tool versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,8 +117,9 @@ dependencies = [
     "crewai~=0.86.0",
     "mcp>=0.9.1",
     "uv>=0.5.7",
-    "ag2",
+    "ag2>=0.1.0",
     "pydantic-ai>=0.0.12",
+    "crosshair-tool==0.0.81",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,9 +117,8 @@ dependencies = [
     "crewai~=0.86.0",
     "mcp>=0.9.1",
     "uv>=0.5.7",
-    "ag2>=0.1.0",
+    "ag2",
     "pydantic-ai>=0.0.12",
-    "crosshair-tool==0.0.81",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -3935,7 +3935,6 @@ dependencies = [
     { name = "composio-core" },
     { name = "composio-langchain" },
     { name = "crewai" },
-    { name = "crosshair-tool" },
     { name = "dspy-ai" },
     { name = "duckduckgo-search" },
     { name = "elasticsearch" },
@@ -4076,7 +4075,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ag2", specifier = ">=0.1.0" },
+    { name = "ag2" },
     { name = "aiofile", specifier = ">=3.9.0,<4.0.0" },
     { name = "arize-phoenix-otel", specifier = ">=0.6.1" },
     { name = "assemblyai", specifier = "==0.35.1" },
@@ -4094,7 +4093,6 @@ requires-dist = [
     { name = "composio-langchain", specifier = "==0.6.7" },
     { name = "couchbase", marker = "extra == 'couchbase'", specifier = ">=4.2.1" },
     { name = "crewai", specifier = "~=0.86.0" },
-    { name = "crosshair-tool", specifier = "==0.0.81" },
     { name = "ctransformers", marker = "extra == 'local'", specifier = ">=0.2.10" },
     { name = "dspy-ai", specifier = "==2.5.41" },
     { name = "duckduckgo-search", specifier = "==6.3.7" },

--- a/uv.lock
+++ b/uv.lock
@@ -1353,7 +1353,7 @@ wheels = [
 
 [[package]]
 name = "crosshair-tool"
-version = "0.0.80"
+version = "0.0.81"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
@@ -1364,36 +1364,44 @@ dependencies = [
     { name = "typing-inspect" },
     { name = "z3-solver" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/b6/37221c2e35a05a8f959d2f33a09e2e717e47101359a9611c54d0ab1223e3/crosshair-tool-0.0.80.tar.gz", hash = "sha256:f7aa846243033ceedba6c186b7211fca926dd60c677d829ccb2b47cdbb871964", size = 448138 }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/f4/b45adec17030225eed752db6948aa91410c866e71e7b087b43e4dce5b431/crosshair-tool-0.0.81.tar.gz", hash = "sha256:fb978bf4648b886700ee0baeebee4945521dd2e459bb43188fa91a483557917b", size = 448147 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/64/61b115c174c54165df914030276297ba2b04ee6d70b7f4a5f8b2fa693549/crosshair_tool-0.0.80-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5399b23b96096015023151a7f718288d086ab39b840cfb7757df470253e1bdd6", size = 503556 },
-    { url = "https://files.pythonhosted.org/packages/1b/4a/7c519e5386443d867eaac0fd1b8fb1540b68f72bf17901ffcb8e73b3da95/crosshair_tool-0.0.80-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83056ceabb5ae1a403939c8de04161f19213dd38a64b9583b4995e16191c1398", size = 524692 },
-    { url = "https://files.pythonhosted.org/packages/39/a4/17b1554d61ed8a2263c6784bbd61facbd7ff59e7a298bc12da9b86ed7cf0/crosshair_tool-0.0.80-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fe53af53b512f599d680f6d2ca68ac7099dc069a3cf459156342374a4eef795", size = 526932 },
-    { url = "https://files.pythonhosted.org/packages/27/6d/45fe33297e2f700e8ce17ed091abfdcb9021f1437fb45c6b5b08b0dfbf32/crosshair_tool-0.0.80-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:aaa9099457ca489e1792b7ada59cf5968536e963081a6f0197c7ab084b3cf8e1", size = 524502 },
-    { url = "https://files.pythonhosted.org/packages/28/c0/cbcb0479aa1d5712d777b5544dd5287da8dc3fd778ecfa785de9d1262f3c/crosshair_tool-0.0.80-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fec7a64e9020347c4e185c1467141b4cf894ad721a6f6283c2318d83ebdcf248", size = 526121 },
-    { url = "https://files.pythonhosted.org/packages/a8/4e/83982ea9042ad648450ee1557c26972cf51fa6e0c92cb7a38e2a4e2bfc61/crosshair_tool-0.0.80-cp310-cp310-win32.whl", hash = "sha256:5a03c0dc7b4483e29832288fd7a76c1195f8287e3d7fb222a96fdf52a9c1a3a4", size = 505887 },
-    { url = "https://files.pythonhosted.org/packages/21/51/95b4737595bfb50308ed3ca437a340e366dd28c0d60beaf3903169f81c24/crosshair_tool-0.0.80-cp310-cp310-win_amd64.whl", hash = "sha256:918e4e00a9ac52bf82a82d461cf475198bf2f898c67c13778c21bf329fc989b7", size = 506837 },
-    { url = "https://files.pythonhosted.org/packages/3f/81/fac6e8e8778dc6cd1d85bf72577fb3e33107f1fdfa7f721fa676fbcf7275/crosshair_tool-0.0.80-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e3d00ac24be5dc8ac3f616c0d399da5fdfc90c439580a7bc5ace3dbf7920990c", size = 503619 },
-    { url = "https://files.pythonhosted.org/packages/be/63/fa1c4cd0a5aacf75044ab12bbaa8d584775a1eec44c660bfe039545bb06d/crosshair_tool-0.0.80-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f024616e0157ff1901e9b5a1bf9dbd5bec939e1f4595bc25d092ca9ac98c667f", size = 525302 },
-    { url = "https://files.pythonhosted.org/packages/59/b9/86a585421c23582957a46fcfe6136ad70569dd3109a037eb0a44f24a8aae/crosshair_tool-0.0.80-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d12c1ebd3cc026d8b2d04a82d7f70b4372b893a14ef0906f07cec2a3bf61c7b", size = 527584 },
-    { url = "https://files.pythonhosted.org/packages/22/00/d0f149791572c4902f11783c69d9d252e02cdca60e3510d34908598ff544/crosshair_tool-0.0.80-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:29a3c7613c92a5e1ca0e5d0832b197c650254d5ca8d41b29a8a2bf9e08999d41", size = 525263 },
-    { url = "https://files.pythonhosted.org/packages/d1/c9/d9dceb1ffdbe36292bfbcbb94d6287fcb54be9e9bc9c90413ed20b6e0496/crosshair_tool-0.0.80-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d89eb6718cf2ce85bbe88811da310e58b7087699028eb25c1df7ea2bc1d3d8fe", size = 526905 },
-    { url = "https://files.pythonhosted.org/packages/7b/ca/6c3958ce8da00e6a44e876fa13da1d720d6fa9aa020253b3488f583362d0/crosshair_tool-0.0.80-cp311-cp311-win32.whl", hash = "sha256:67ad48acccf518bb2e04acbc485ca938d7652fc283fbca54b8d182761864bc43", size = 505916 },
-    { url = "https://files.pythonhosted.org/packages/33/79/e16454a7f6aabbf49e7e0c713300601c391d1976091ace16fa789ceca0c5/crosshair_tool-0.0.80-cp311-cp311-win_amd64.whl", hash = "sha256:aa1cf648f775eab62df3b95da7e37861fa928a4cc9d826850e97a3e408d4c422", size = 506895 },
-    { url = "https://files.pythonhosted.org/packages/8f/b6/49f22a8380298fc01fcd15270f3a3bb6f0e501cc63ec40282648d8cb8db2/crosshair_tool-0.0.80-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1142d277272ae5f6f37cc6e9e1ef00a65dbdae5380de36e1cba8b0029d240b4a", size = 506129 },
-    { url = "https://files.pythonhosted.org/packages/3e/c4/3079ac9f16eae4c7666feaf5fd5b1dca51f41e427109bf7727a757e6285a/crosshair_tool-0.0.80-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b3628a1fa61db08ed453093a213a3125006e99726a34127cc0f0ac397b565ce", size = 534232 },
-    { url = "https://files.pythonhosted.org/packages/1e/e2/059b94fff68597fd3a16dc144537224fec924f6b80d8f2a352b5be6b4f27/crosshair_tool-0.0.80-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e77bb31fe1f52a753b416190d905390b8a564aa3c9301590199107c838cfdc04", size = 536911 },
-    { url = "https://files.pythonhosted.org/packages/7f/af/d8db5c79989f8e3b79a7b9a13819ce82e63e55c072da5223886a97e584cd/crosshair_tool-0.0.80-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e4fcb9a5184a6896ac3975fb23b5b7752d08baa5c09662a6a23024efc5abf124", size = 534754 },
-    { url = "https://files.pythonhosted.org/packages/2e/ed/4308a20c7ad614b1c36d8ba4fb4afbb9cd45406dc23d0ef0990bac299381/crosshair_tool-0.0.80-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a55f39d4cb7c55b5c45b33c64edf420c920b2486dddb1aed47d7359f09a3ee89", size = 535785 },
-    { url = "https://files.pythonhosted.org/packages/e7/55/9fbd69192643a94cf32810d989b4fd45a6a99e2ee504f466caaab1849406/crosshair_tool-0.0.80-cp312-cp312-win32.whl", hash = "sha256:057ae9b60bd862340319df67542cefba1ea9c70ba88db6722668f6e01f6d35b6", size = 507934 },
-    { url = "https://files.pythonhosted.org/packages/a3/4a/bfd80d2e55895dc5ac1bcdf059d4cd4d1c1c0a9eabe3243e64a2f98d7fdd/crosshair_tool-0.0.80-cp312-cp312-win_amd64.whl", hash = "sha256:5ad2380aade99212e0d67ee62f074eb611bb025b7372e3cdfdba26532b660abc", size = 509133 },
-    { url = "https://files.pythonhosted.org/packages/c5/15/253f9e45ca48269c3535a06b4c10e85dd4adfc1e09c2b921d1de299ace11/crosshair_tool-0.0.80-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f39e363a2c83015d2f7ee0fc5a01db7c1247757162b00d7e49c9d2c84c69f732", size = 506157 },
-    { url = "https://files.pythonhosted.org/packages/e8/67/118fd94f7bd88311a7aa5ee5295f005784e11f46a1f6fff85681dfb19e33/crosshair_tool-0.0.80-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:098d346856cbf199750422dc5588de773e00b6bcf8a3e3ee6281096b4e867131", size = 534473 },
-    { url = "https://files.pythonhosted.org/packages/61/85/d07ef4c0c6550f40b7e6bcc5cb507cb575dea1082cf6ba83358f69e60a56/crosshair_tool-0.0.80-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8f830707bfdd03c66bdd5a76171940e71ec8c9dd8504615d0aec3a124d3d9c", size = 537085 },
-    { url = "https://files.pythonhosted.org/packages/9f/62/60b3d8bc7f7f522b4ee9a69ec17e0c855fc294e9aac25687db2beb03396c/crosshair_tool-0.0.80-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:17c8274011ee8f10ccc5098f36716bcb1572957101b07a2c707c7f0152772ac3", size = 535125 },
-    { url = "https://files.pythonhosted.org/packages/6b/c3/a3edb977eb9d8a971f3f3ec797d66d47198fbc89f5ef035154df9d3ac8b6/crosshair_tool-0.0.80-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dcce47c55140cead13a1bc656fee437697069bf6b964f578477b8f5c4dcf360c", size = 536027 },
-    { url = "https://files.pythonhosted.org/packages/a1/13/21bd625d87cba4c4453cd1b2a494c442cb081956a20b3814b4dbffc83823/crosshair_tool-0.0.80-cp313-cp313-win32.whl", hash = "sha256:e4e244ccad6a4ca7f9423c6243a07555d198198f5eba2920b035dda231fdb873", size = 507938 },
-    { url = "https://files.pythonhosted.org/packages/0a/4b/f50136550e4c7c34cfcb7d405c31c3a7dd8b21bb34f364f3d9496815bf85/crosshair_tool-0.0.80-cp313-cp313-win_amd64.whl", hash = "sha256:27f6e74fd0688afdc17716028eff0b9c24a5650c61edbabed0319de47e9cda86", size = 509120 },
+    { url = "https://files.pythonhosted.org/packages/d3/6f/c9c5ea73982c306cbcd3af98e1c82c043ec247f05f9a1f294712bc3ffde0/crosshair_tool-0.0.81-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5f9a8fa5d5502919aa4de8e072cd7f95f592a7f6b94ed7c7208396950a1cbe3d", size = 510632 },
+    { url = "https://files.pythonhosted.org/packages/87/1a/f2b8e5b934076fdb7477306d4d17405d4821b0bc45cefa138fc453eb629a/crosshair_tool-0.0.81-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1b92607e8a3b7ee04b210e2e1d68278494e8b64b2577bf19900fc0f954104983", size = 502782 },
+    { url = "https://files.pythonhosted.org/packages/5f/0c/b850c10c01cccf0d44ffb46998032c551dd267af13b062ce5790f0cbf61e/crosshair_tool-0.0.81-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2de7c400454e2d6800f4d460175d59228bfaa08f23b2ecc87a1f60af2046fa2f", size = 503553 },
+    { url = "https://files.pythonhosted.org/packages/87/b6/6a63e29e1bd83a55c515e0aaf49ea2b2b36752750ea901c85f3366192497/crosshair_tool-0.0.81-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f8f0b47d7442927db48bcaf5f727e5c71ab1683e465e08b743dc8fcd179fa91a", size = 524692 },
+    { url = "https://files.pythonhosted.org/packages/5e/31/23149a0a7254784de60d90258e445f3448d7dcd3a52ebb579a4157939005/crosshair_tool-0.0.81-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05f0bd1b94c3c9f3d0d70c16d1a63f8e9071fe8f33a3e716d53f79f8094be742", size = 526933 },
+    { url = "https://files.pythonhosted.org/packages/3a/9e/440228032c5c8b9bd76267b3ae3b742e22347004427cca65b0efc8332bbd/crosshair_tool-0.0.81-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c7932be2f9a71c06dea12057274c1c433429a180a32905048600fd8eb4451949", size = 524502 },
+    { url = "https://files.pythonhosted.org/packages/99/4b/242dddbb347fb844c3c7924268584208e8ad14893e2e534f1bed6a960ebe/crosshair_tool-0.0.81-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:154dc0a8ca16efc353a9fe336b00e047c3edce3a715c954d15bd348f3a80f026", size = 526121 },
+    { url = "https://files.pythonhosted.org/packages/da/44/c5f62218badc5464fee126756818592a3f74e757dcdf5345c9b29230bd57/crosshair_tool-0.0.81-cp310-cp310-win32.whl", hash = "sha256:92aa6376fa765d6e7232871b560cb0b371fb1d05ff133c80a09dcd2e3f070b39", size = 505886 },
+    { url = "https://files.pythonhosted.org/packages/d3/25/860253ab3c756ff364fa1301df6c76668d9c8fec47e16972c7701b18fc44/crosshair_tool-0.0.81-cp310-cp310-win_amd64.whl", hash = "sha256:f634f7eb34794917c6a530696a58471923d81bcd155cfa3cce0dba8c2c341077", size = 506837 },
+    { url = "https://files.pythonhosted.org/packages/81/26/beb36ef40b1c6cf92b1f9f6a8e08208d6b326d3a8a497afa42ec433424fe/crosshair_tool-0.0.81-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2156308a15c80361e256e943253bd6ad76e6fde6981742535d7da86b135e3b4b", size = 510734 },
+    { url = "https://files.pythonhosted.org/packages/04/65/1645f716de735625e55d7a926a6c2f464a48d21b95b3de3071dc0094df68/crosshair_tool-0.0.81-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5e4f495a5cd5b41b78e5b563a71bc2b2a207fe600001a1699efb8fa862c8716a", size = 502828 },
+    { url = "https://files.pythonhosted.org/packages/9c/a7/7f9b6ec62e0da1a02310a54615e17032fb4df763aee8e13a1009dc94acf5/crosshair_tool-0.0.81-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:464159730044def21ce3150a7837b66c752f9a6e8c80d688cce10279a25a650a", size = 503619 },
+    { url = "https://files.pythonhosted.org/packages/19/a0/1f2f9f0a2b8a61cb1802b539346064d6db16625a0929598dc15eb4cb57d3/crosshair_tool-0.0.81-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c86dd1735ca9c0add9dcd401f0c63b91f6cfbf006b98f92265a70bdde788a9d5", size = 525301 },
+    { url = "https://files.pythonhosted.org/packages/05/b5/f27b9fa3fcc133429e798c83b6c4135ec94da1535d6adaa964665f787126/crosshair_tool-0.0.81-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebdb0c88c598e9b2d7fa3368e2ec245671e4ec3f9fc0cbe920659fd940944cdc", size = 527584 },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/3df578f61851de39619cd895854aa1614b7c34b9df52a99dba076d5d1b1d/crosshair_tool-0.0.81-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:258a52b4a616e8a5a3017dd2424ff1632dd051d0b1e93536ae120ab8873241fd", size = 525263 },
+    { url = "https://files.pythonhosted.org/packages/f8/ca/14ebbd2b38d07b4bb788289784286befdd17c65d02ee14aedf9da2d1fcd3/crosshair_tool-0.0.81-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0129505566ed0740b4ae9e33878613d0797fb8022be0fd62703bed9d5a05bfcc", size = 526905 },
+    { url = "https://files.pythonhosted.org/packages/5e/48/7478cb69719300497cbc8bc25000e6f50eec6b7c2ff2adcf69d9fa7591f3/crosshair_tool-0.0.81-cp311-cp311-win32.whl", hash = "sha256:5b8f5a7be6240a2afde2f612965fb298c109690a9782a0717f449dba72914045", size = 505915 },
+    { url = "https://files.pythonhosted.org/packages/43/be/c9c3533ffd6afbdb768521132727ee67134ef4910cc6e62b754b50a8a509/crosshair_tool-0.0.81-cp311-cp311-win_amd64.whl", hash = "sha256:ca400303a2e61763774cf401eef4fddea40ec0ece9b763340cfd4880f1411286", size = 506894 },
+    { url = "https://files.pythonhosted.org/packages/c0/7a/c5979569949bf276c8ae06ada6280a23299c26b80b318977e71e736fc083/crosshair_tool-0.0.81-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d587804175b10c7c14e5fdd529a615eb0ce8f9e587112e2200ef97decc83aa79", size = 516234 },
+    { url = "https://files.pythonhosted.org/packages/87/a5/a9d5cf839562fd2a1f1e7da5940b371f297ef78c071c958ef27499e04e31/crosshair_tool-0.0.81-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b9ce99be3a6a11cb7fcb338ab8cc75f96e59b0f309a1647c75b6f36700ffaef", size = 505544 },
+    { url = "https://files.pythonhosted.org/packages/43/9d/02ac3b40a839fbdb1e001e4321915d4c6536e03afae33e5ab2f2a0d8b9cb/crosshair_tool-0.0.81-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:01ffcac71a21f890d64f4b3f59df0e872854382e25d2e22f4c032be16ce5c609", size = 506125 },
+    { url = "https://files.pythonhosted.org/packages/1e/31/603a8ff08b3dab912951b4cd76588adf7ba78ab35448ea10ee79ed52715b/crosshair_tool-0.0.81-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a740b35ddfcef8b1f0650bd803d65d0fcee36794d0a694b209122aebc34252f9", size = 534232 },
+    { url = "https://files.pythonhosted.org/packages/00/02/3c45bb6693036184a3a06af8fb64f29dffee921c20c7787cd2b1eae317a5/crosshair_tool-0.0.81-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e824efd952d1d902cf04e974db69dfb7e671bae927776b829172fcb5c92f3db", size = 536911 },
+    { url = "https://files.pythonhosted.org/packages/0d/cc/31209083b38baa42edc7ed42e0c12069495318f2db0532645fc37457e92c/crosshair_tool-0.0.81-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f1f8b0ea5423a5ff78234590ad47b7264987221d07bc01c908e3ac3bfeab0990", size = 534754 },
+    { url = "https://files.pythonhosted.org/packages/aa/56/6e19f152b30fabcd01574434cc572e40c3880446e37eb6d90fbef967c645/crosshair_tool-0.0.81-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7c4b7028ef4a5ca9eb6d47450e22f967afcefb378db412f3eb92586a5fce64e9", size = 535786 },
+    { url = "https://files.pythonhosted.org/packages/3f/6f/f990e57e39643651bc5c7a9252d496f7b64bac7a68d64841128a3223ca55/crosshair_tool-0.0.81-cp312-cp312-win32.whl", hash = "sha256:08e77f0b6c24c6feb42b7d21d9e8dafdbc4d6a69d1ed4677bb7d7b3636aff8f7", size = 507934 },
+    { url = "https://files.pythonhosted.org/packages/e6/ea/934fd3ea42e7f4cb712c34336affea7b092ba6b183a62d57315968e61b81/crosshair_tool-0.0.81-cp312-cp312-win_amd64.whl", hash = "sha256:56370d8af6b5afc4847b413366ca64322f22596e1b74daea5d4813359bf99567", size = 509134 },
+    { url = "https://files.pythonhosted.org/packages/37/a2/e6cfc2c6eb3bab698756c8cec1f5e898bcd3d2f069bfb7b29ac32436ef86/crosshair_tool-0.0.81-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8dffc96bc4f0ac29c7de68dc18e2fc2ac6bd1b150e2ab5c8902b1275a7e7b4aa", size = 515171 },
+    { url = "https://files.pythonhosted.org/packages/db/90/7afb17c889fcc3a7b69c418c37fc63337c2ca2c7ac6c35698505a7a5834b/crosshair_tool-0.0.81-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b9746944b30dfdf0a911d691d70dd55e441307c771bb5cef94b8e1d2f0b5a1b2", size = 505551 },
+    { url = "https://files.pythonhosted.org/packages/e9/0e/1cd69cbdc2c04544de854aa6255a5a9cdd17568bcad5db6cf848e4556cfe/crosshair_tool-0.0.81-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b0a1b1813d567d07627e05c5794ae452da07f8c23f230b4952c5e9788ea33390", size = 506156 },
+    { url = "https://files.pythonhosted.org/packages/66/e8/a8ba0bdcbc1899925f83d25066ac1014363a213a65f8e6dd75fd61b835ff/crosshair_tool-0.0.81-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34d211bd615d7892828180333fa2af28305ae7709d5aa128731bcb02ccaac7", size = 534472 },
+    { url = "https://files.pythonhosted.org/packages/43/22/c17811b822f30cb73dd7e10f6c27387fb1c97a3bf627fd030499d23b8abd/crosshair_tool-0.0.81-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:494d32ed20ae5e065ae64297ac5a61f29220bf35cbba62be95eb87c08517bfdf", size = 537084 },
+    { url = "https://files.pythonhosted.org/packages/cd/62/bc703e799783cc523290eb7088deb1c6267fcd987114c12b8e17953dcc8a/crosshair_tool-0.0.81-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cd5b1752be1f8c76b656cee7822a1794b72fc1ec7df6b2f1fa8d9bf018d6312d", size = 535124 },
+    { url = "https://files.pythonhosted.org/packages/93/a7/11aa91cd72825f13dfeb822fc5bc43cbd02d6fbf2ad28f8d2f3451497a24/crosshair_tool-0.0.81-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:de7c69fc2035a9786fbb3a307a89a5ade46dd1f23d449ee83e61daf980ee211f", size = 536026 },
+    { url = "https://files.pythonhosted.org/packages/17/ae/787319fabc22ee0353df863a21587b20212881ac126ef72a2a41fab80872/crosshair_tool-0.0.81-cp313-cp313-win32.whl", hash = "sha256:d0b8fab0a08ccb43ffcc0414dd81aad19e81153c18e6f33eb7f0446c38fc91e9", size = 507938 },
+    { url = "https://files.pythonhosted.org/packages/d2/6c/967e98d9882895efbd77b98899b8c3e02e5b1b1a2365cf8a79c73ccde0f0/crosshair_tool-0.0.81-cp313-cp313-win_amd64.whl", hash = "sha256:8eebd589e27672dffe45c14cee776d5fc3c419a84630d6043116ed4407b4377b", size = 509121 },
 ]
 
 [[package]]
@@ -3927,6 +3935,7 @@ dependencies = [
     { name = "composio-core" },
     { name = "composio-langchain" },
     { name = "crewai" },
+    { name = "crosshair-tool" },
     { name = "dspy-ai" },
     { name = "duckduckgo-search" },
     { name = "elasticsearch" },
@@ -4067,7 +4076,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ag2" },
+    { name = "ag2", specifier = ">=0.1.0" },
     { name = "aiofile", specifier = ">=3.9.0,<4.0.0" },
     { name = "arize-phoenix-otel", specifier = ">=0.6.1" },
     { name = "assemblyai", specifier = "==0.35.1" },
@@ -4085,6 +4094,7 @@ requires-dist = [
     { name = "composio-langchain", specifier = "==0.6.7" },
     { name = "couchbase", marker = "extra == 'couchbase'", specifier = ">=4.2.1" },
     { name = "crewai", specifier = "~=0.86.0" },
+    { name = "crosshair-tool", specifier = "==0.0.81" },
     { name = "ctransformers", marker = "extra == 'local'", specifier = ">=0.2.10" },
     { name = "dspy-ai", specifier = "==2.5.41" },
     { name = "duckduckgo-search", specifier = "==6.3.7" },


### PR DESCRIPTION
This pull request makes changes to the `pyproject.toml` file, specifically updating and adding dependencies.

Dependency updates and additions:

* Updated the `ag2` dependency to require a minimum version of `0.1.0`.
* Added a new dependency, `crosshair-tool`, with a specific version `0.0.81`.