### PR TITLE
tests: allow tests to skip version tests if `file_names_mapping` is empty

### DIFF
--- a/src/backend/tests/base.py
+++ b/src/backend/tests/base.py
@@ -53,11 +53,8 @@ class ComponentTestBase:
     def test_all_versions_have_a_file_name_defined(self, file_names_mapping: list[VersionComponentMapping]) -> None:
         """Ensure all supported versions have a file name defined."""
         if not file_names_mapping:
-            msg = (
-                f"file_names_mapping is empty for {self.__class__.__name__}. "
-                "Please define the version mappings for your component."
-            )
-            raise AssertionError(msg)
+            msg = f"file_names_mapping is empty for {self.__class__.__name__}. Skipping versions test."
+            pytest.skip(msg)
 
         version_mappings = {mapping["version"]: mapping for mapping in file_names_mapping}
 
@@ -94,6 +91,8 @@ class ComponentTestBase:
         file_names_mapping: list[VersionComponentMapping],
     ) -> None:
         """Test if the component works across different versions."""
+        if not file_names_mapping:
+            pytest.skip("No file names mapping defined for this component.")
         version_mappings = {mapping["version"]: mapping for mapping in file_names_mapping}
 
         mapping = version_mappings[version]


### PR DESCRIPTION
This PR updates the `ComponentTestBase` class to skip tests when the `file_names_mapping` is empty, instead of raising an `AssertionError`. This change improves user feedback by providing a clear message indicating the reason for skipping the test, enhancing the overall testing experience.