### PR TITLE
tests: fix tests by clearing service_manager services

### DIFF
--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -354,7 +354,11 @@ async def client_fixture(
                 )
                 monkeypatch.setenv("LANGFLOW_LOAD_FLOWS_PATH", load_flows_dir)
                 monkeypatch.setenv("LANGFLOW_AUTO_LOGIN", "true")
+            # Clear the services cache
+            from langflow.services.manager import service_manager
 
+            service_manager.factories.clear()
+            service_manager.services.clear()  # Clear the services cache
             app = create_app()
             db_service = get_db_service()
             db_service.database_url = f"sqlite:///{db_path}"

--- a/src/backend/tests/unit/api/v1/test_files.py
+++ b/src/backend/tests/unit/api/v1/test_files.py
@@ -134,6 +134,10 @@ async def files_client_fixture(
             db_path = Path(db_dir) / "test.db"
             monkeypatch.setenv("LANGFLOW_DATABASE_URL", f"sqlite:///{db_path}")
             monkeypatch.setenv("LANGFLOW_AUTO_LOGIN", "false")
+            from langflow.services.manager import service_manager
+
+            service_manager.factories.clear()
+            service_manager.services.clear()  # Clear the services cache
             app = create_app()
             return app, db_path
 

--- a/src/backend/tests/unit/api/v1/test_files.py
+++ b/src/backend/tests/unit/api/v1/test_files.py
@@ -1,20 +1,102 @@
 import asyncio
+import json
 import re
-import shutil
 import tempfile
 from contextlib import suppress
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock
 
+# we need to import tmpdir
 import anyio
 import pytest
 from asgi_lifespan import LifespanManager
 from httpx import ASGITransport, AsyncClient
 from langflow.main import create_app
-from langflow.services.deps import get_storage_service
+from langflow.services.auth.utils import get_password_hash
+from langflow.services.database.models.api_key.model import ApiKey
+from langflow.services.database.models.flow.model import Flow, FlowCreate
+from langflow.services.database.models.user.model import User, UserRead
+from langflow.services.database.utils import session_getter
+from langflow.services.deps import get_db_service, get_storage_service
 from langflow.services.storage.service import StorageService
-from sqlmodel import Session
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from tests.conftest import _delete_transactions_and_vertex_builds
+
+
+@pytest.fixture(name="files_created_api_key")
+async def files_created_api_key(files_client, files_active_user):  # noqa: ARG001
+    hashed = get_password_hash("random_key")
+    api_key = ApiKey(
+        name="files_created_api_key",
+        user_id=files_active_user.id,
+        api_key="random_key",
+        hashed_api_key=hashed,
+    )
+    db_manager = get_db_service()
+    async with session_getter(db_manager) as session:
+        stmt = select(ApiKey).where(ApiKey.api_key == api_key.api_key)
+        if existing_api_key := (await session.exec(stmt)).first():
+            yield existing_api_key
+            return
+        session.add(api_key)
+        await session.commit()
+        await session.refresh(api_key)
+        yield api_key
+        # Clean up
+        await session.delete(api_key)
+        await session.commit()
+
+
+@pytest.fixture(name="files_active_user")
+async def files_active_user(files_client):  # noqa: ARG001
+    db_manager = get_db_service()
+    async with db_manager.with_session() as session:
+        user = User(
+            username="files_active_user",
+            password=get_password_hash("testpassword"),
+            is_active=True,
+            is_superuser=False,
+        )
+        stmt = select(User).where(User.username == user.username)
+        if active_user := (await session.exec(stmt)).first():
+            user = active_user
+        else:
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+        user = UserRead.model_validate(user, from_attributes=True)
+    yield user
+    # Clean up
+    # Now cleanup transactions, vertex_build
+    async with db_manager.with_session() as session:
+        user = await session.get(User, user.id, options=[selectinload(User.flows)])
+        await _delete_transactions_and_vertex_builds(session, user.flows)
+        await session.delete(user)
+
+        await session.commit()
+
+
+@pytest.fixture(name="files_flow")
+async def files_flow(
+    files_client,  # noqa: ARG001
+    json_flow: str,
+    files_active_user,
+):
+    loaded_json = json.loads(json_flow)
+    flow_data = FlowCreate(name="test_flow", data=loaded_json.get("data"), user_id=files_active_user.id)
+    db_manager = get_db_service()
+    flow = Flow.model_validate(flow_data)
+    async with db_manager.with_session() as session:
+        session.add(flow)
+        await session.commit()
+        await session.refresh(flow)
+        yield flow
+        # Clean up
+        await session.delete(flow)
+        await session.commit()
 
 
 @pytest.fixture
@@ -38,10 +120,8 @@ def mock_storage_service():
 
 @pytest.fixture(name="files_client")
 async def files_client_fixture(
-    session: Session,  # noqa: ARG001
     monkeypatch,
     request,
-    load_flows_dir,
     mock_storage_service,
 ):
     # Set the database url to a test database
@@ -54,13 +134,6 @@ async def files_client_fixture(
             db_path = Path(db_dir) / "test.db"
             monkeypatch.setenv("LANGFLOW_DATABASE_URL", f"sqlite:///{db_path}")
             monkeypatch.setenv("LANGFLOW_AUTO_LOGIN", "false")
-            if "load_flows" in request.keywords:
-                shutil.copyfile(
-                    pytest.BASIC_EXAMPLE_PATH, Path(load_flows_dir) / "c54f9130-f2fa-4a3e-b22a-3856d946351b.json"
-                )
-                monkeypatch.setenv("LANGFLOW_LOAD_FLOWS_PATH", load_flows_dir)
-                monkeypatch.setenv("LANGFLOW_AUTO_LOGIN", "true")
-
             app = create_app()
             return app, db_path
 
@@ -93,54 +166,54 @@ def max_file_size_upload_10mb_fixture(monkeypatch):
     monkeypatch.undo()
 
 
-async def test_upload_file(files_client, created_api_key, flow):
-    headers = {"x-api-key": created_api_key.api_key}
+async def test_upload_file(files_client, files_created_api_key, files_flow):
+    headers = {"x-api-key": files_created_api_key.api_key}
 
     response = await files_client.post(
-        f"api/v1/files/upload/{flow.id}",
+        f"api/v1/files/upload/{files_flow.id}",
         files={"file": ("test.txt", b"test content")},
         headers=headers,
     )
-    assert response.status_code == 201
+    assert response.status_code == 201, f"Expected 201, got {response.status_code}: {response.json()}"
 
     response_json = response.json()
-    assert response_json["flowId"] == str(flow.id)
+    assert response_json["flowId"] == str(files_flow.id)
 
     # Check that the file_path matches the expected pattern
-    file_path_pattern = re.compile(rf"{flow.id}/\d{{4}}-\d{{2}}-\d{{2}}_\d{{2}}-\d{{2}}-\d{{2}}_test\.txt")
+    file_path_pattern = re.compile(rf"{files_flow.id}/\d{{4}}-\d{{2}}-\d{{2}}_\d{{2}}-\d{{2}}-\d{{2}}_test\.txt")
     assert file_path_pattern.match(response_json["file_path"])
 
 
-async def test_download_file(files_client, created_api_key, flow):
-    headers = {"x-api-key": created_api_key.api_key}
-    response = await files_client.get(f"api/v1/files/download/{flow.id}/test.txt", headers=headers)
+async def test_download_file(files_client, files_created_api_key, files_flow):
+    headers = {"x-api-key": files_created_api_key.api_key}
+    response = await files_client.get(f"api/v1/files/download/{files_flow.id}/test.txt", headers=headers)
     assert response.status_code == 200
     assert response.content == b"file content"
 
 
-async def test_list_files(files_client, created_api_key, flow):
-    headers = {"x-api-key": created_api_key.api_key}
-    response = await files_client.get(f"api/v1/files/list/{flow.id}", headers=headers)
+async def test_list_files(files_client, files_created_api_key, files_flow):
+    headers = {"x-api-key": files_created_api_key.api_key}
+    response = await files_client.get(f"api/v1/files/list/{files_flow.id}", headers=headers)
     assert response.status_code == 200
     assert response.json() == {"files": ["file1.txt", "file2.jpg"]}
 
 
-async def test_delete_file(files_client, created_api_key, flow):
-    headers = {"x-api-key": created_api_key.api_key}
+async def test_delete_file(files_client, files_created_api_key, files_flow):
+    headers = {"x-api-key": files_created_api_key.api_key}
 
-    response = await files_client.delete(f"api/v1/files/delete/{flow.id}/test.txt", headers=headers)
+    response = await files_client.delete(f"api/v1/files/delete/{files_flow.id}/test.txt", headers=headers)
     assert response.status_code == 200
     assert response.json() == {"message": "File test.txt deleted successfully"}
 
 
-async def test_file_operations(client, created_api_key, flow):
-    headers = {"x-api-key": created_api_key.api_key}
-    flow_id = flow.id
+async def test_file_operations(files_client, files_created_api_key, files_flow):
+    headers = {"x-api-key": files_created_api_key.api_key}
+    flow_id = files_flow.id
     file_name = "test.txt"
     file_content = b"Hello, world!"
 
     # Step 1: Upload the file
-    response = await client.post(
+    response = await files_client.post(
         f"api/v1/files/upload/{flow_id}",
         files={"file": (file_name, file_content)},
         headers=headers,
@@ -158,36 +231,36 @@ async def test_file_operations(client, created_api_key, flow):
     full_file_name = response_json["file_path"].split("/")[-1]
 
     # Step 2: List files in the folder
-    response = await client.get(f"api/v1/files/list/{flow_id}", headers=headers)
+    response = await files_client.get(f"api/v1/files/list/{files_flow.id}", headers=headers)
     assert response.status_code == 200
     assert full_file_name in response.json()["files"]
 
     # Step 3: Download the file and verify its content
-    response = await client.get(f"api/v1/files/download/{flow_id}/{full_file_name}", headers=headers)
+    response = await files_client.get(f"api/v1/files/download/{files_flow.id}/{full_file_name}", headers=headers)
     assert response.status_code == 200
     assert response.content == file_content
     assert response.headers["content-type"] == "application/octet-stream"
 
     # Step 4: Delete the file
-    response = await client.delete(f"api/v1/files/delete/{flow_id}/{full_file_name}", headers=headers)
+    response = await files_client.delete(f"api/v1/files/delete/{files_flow.id}/{full_file_name}", headers=headers)
     assert response.status_code == 200
     assert response.json() == {"message": f"File {full_file_name} deleted successfully"}
 
     # Verify that the file is indeed deleted
-    response = await client.get(f"api/v1/files/list/{flow_id}", headers=headers)
+    response = await files_client.get(f"api/v1/files/list/{files_flow.id}", headers=headers)
     assert full_file_name not in response.json()["files"]
 
 
 @pytest.mark.usefixtures("max_file_size_upload_fixture")
-async def test_upload_file_size_limit(files_client, created_api_key, flow):
-    headers = {"x-api-key": created_api_key.api_key}
+async def test_upload_file_size_limit(files_client, files_created_api_key, files_flow):
+    headers = {"x-api-key": files_created_api_key.api_key}
 
     # Test file under the limit (500KB)
     small_content = b"x" * (500 * 1024)
     small_file = ("small_file.txt", small_content, "application/octet-stream")
     headers["Content-Length"] = str(len(small_content))
     response = await files_client.post(
-        f"api/v1/files/upload/{flow.id}",
+        f"api/v1/files/upload/{files_flow.id}",
         files={"file": small_file},
         headers=headers,
     )
@@ -199,7 +272,7 @@ async def test_upload_file_size_limit(files_client, created_api_key, flow):
     bio = BytesIO(large_content)
     headers["Content-Length"] = str(len(large_content))
     response = await files_client.post(
-        f"api/v1/files/upload/{flow.id}",
+        f"api/v1/files/upload/{files_flow.id}",
         files={"file": ("large_file.txt", bio, "application/octet-stream")},
         headers=headers,
     )


### PR DESCRIPTION
This pull request includes several changes to the test files in the backend, primarily focusing on clearing the services cache, adding new fixtures, and refactoring test functions to use these new fixtures. The most important changes include the addition of new fixtures for API keys, users, and flows, and the refactoring of existing test functions to utilize these fixtures.

### Test Improvements:

* [`src/backend/tests/conftest.py`](diffhunk://#diff-2f574640999ddf5d1e3c1d4217f1d8d3018710f2801838edea87078a919ca77eR357-R361): Added code to clear the services cache by importing and clearing `service_manager.factories` and `service_manager.services` in the `init_app` function.

* [`src/backend/tests/unit/api/v1/test_files.py`](diffhunk://#diff-e2da636c00eddb3006c69cd63771801802cf918a292bef72ce967b318b94cff8R2-R99): Introduced new fixtures `files_created_api_key`, `files_active_user`, and `files_flow` to set up API keys, users, and flows for testing purposes.

### Refactoring:

* [`src/backend/tests/unit/api/v1/test_files.py`](diffhunk://#diff-e2da636c00eddb3006c69cd63771801802cf918a292bef72ce967b318b94cff8L96-R220): Refactored test functions to use the newly introduced fixtures `files_created_api_key`, `files_active_user`, and `files_flow`, replacing the previous parameters `created_api_key` and `flow`. [[1]](diffhunk://#diff-e2da636c00eddb3006c69cd63771801802cf918a292bef72ce967b318b94cff8L96-R220) [[2]](diffhunk://#diff-e2da636c00eddb3006c69cd63771801802cf918a292bef72ce967b318b94cff8L161-R267) [[3]](diffhunk://#diff-e2da636c00eddb3006c69cd63771801802cf918a292bef72ce967b318b94cff8L202-R279)

* [`src/backend/tests/unit/api/v1/test_files.py`](diffhunk://#diff-e2da636c00eddb3006c69cd63771801802cf918a292bef72ce967b318b94cff8L41-L44): Removed unnecessary imports and parameters, such as `shutil`, `session`, and `load_flows_dir`, to streamline the test setup. [[1]](diffhunk://#diff-e2da636c00eddb3006c69cd63771801802cf918a292bef72ce967b318b94cff8L41-L44) [[2]](diffhunk://#diff-e2da636c00eddb3006c69cd63771801802cf918a292bef72ce967b318b94cff8L57-R140)