### PR TITLE
fix: node minimize/expand functionality and regression tests

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -412,7 +412,7 @@ function GenericNode({
               {renderNodeIcon()}
               <div className="generic-node-tooltip-div">{renderNodeName()}</div>
             </div>
-            <div>
+            <div data-testid={`${showNode ? "show" : "hide"}-node-content`}>
               {!showNode && (
                 <>
                   {renderInputParameters()}

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -713,7 +713,6 @@ const NodeToolbarComponent = memo(
                       }
                       value={showNode ? "Minimize" : "Expand"}
                       icon={showNode ? "Minimize2" : "Maximize2"}
-                      dataTestId="minimize-button-modal"
                     />
                   </SelectItem>
                 )}

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -341,83 +341,104 @@ const NodeToolbarComponent = memo(
 
     const [selectedValue, setSelectedValue] = useState(null);
 
-    const handleSelectChange = useCallback((event) => {
-      setSelectedValue(event);
+    const handleSelectChange = useCallback(
+      (event) => {
+        setSelectedValue(event);
 
-      switch (event) {
-        case "save":
-          saveComponent();
-          break;
-        case "freeze":
-          freezeFunction();
-          break;
-        case "freezeAll":
-          FreezeAllVertices({ flowId: currentFlowId, stopNodeId: data.id });
-          break;
-        case "code":
-          setOpenModal(!openModal);
-          break;
-        case "advanced":
-          setShowModalAdvanced(true);
-          break;
-        case "show":
-          takeSnapshot();
-          handleMinimize();
-          break;
-        case "Share":
-          shareComponent();
-          break;
-        case "Download":
-          downloadNode(flowComponent!);
-          break;
-        case "SaveAll":
-          addFlow({
-            flow: flowComponent,
-            override: false,
-          });
-          break;
-        case "documentation":
-          openDocs();
-          break;
-        case "disabled":
-          break;
-        case "ungroup":
-          handleungroup();
-          break;
-        case "override":
-          setShowOverrideModal(true);
-          break;
-        case "delete":
-          deleteNode(data.id);
-          break;
-        case "update":
-          updateNode();
-          break;
-        case "copy":
-          const node = nodes.filter((node) => node.id === data.id);
-          setLastCopiedSelection({ nodes: _.cloneDeep(node), edges: [] });
-          break;
-        case "duplicate":
-          paste(
-            {
-              nodes: [nodes.find((node) => node.id === data.id)!],
-              edges: [],
-            },
-            {
-              x: 50,
-              y: 10,
-              paneX: nodes.find((node) => node.id === data.id)?.position.x,
-              paneY: nodes.find((node) => node.id === data.id)?.position.y,
-            },
-          );
-          break;
-        case "toolMode":
-          handleActivateToolMode();
-          break;
-      }
+        switch (event) {
+          case "save":
+            saveComponent();
+            break;
+          case "freeze":
+            freezeFunction();
+            break;
+          case "freezeAll":
+            FreezeAllVertices({ flowId: currentFlowId, stopNodeId: data.id });
+            break;
+          case "code":
+            setOpenModal(!openModal);
+            break;
+          case "advanced":
+            setShowModalAdvanced(true);
+            break;
+          case "show":
+            takeSnapshot();
+            handleMinimize();
+            break;
+          case "Share":
+            shareComponent();
+            break;
+          case "Download":
+            downloadNode(flowComponent!);
+            break;
+          case "SaveAll":
+            addFlow({
+              flow: flowComponent,
+              override: false,
+            });
+            break;
+          case "documentation":
+            openDocs();
+            break;
+          case "disabled":
+            break;
+          case "ungroup":
+            handleungroup();
+            break;
+          case "override":
+            setShowOverrideModal(true);
+            break;
+          case "delete":
+            deleteNode(data.id);
+            break;
+          case "update":
+            updateNode();
+            break;
+          case "copy":
+            const node = nodes.filter((node) => node.id === data.id);
+            setLastCopiedSelection({ nodes: _.cloneDeep(node), edges: [] });
+            break;
+          case "duplicate":
+            paste(
+              {
+                nodes: [nodes.find((node) => node.id === data.id)!],
+                edges: [],
+              },
+              {
+                x: 50,
+                y: 10,
+                paneX: nodes.find((node) => node.id === data.id)?.position.x,
+                paneY: nodes.find((node) => node.id === data.id)?.position.y,
+              },
+            );
+            break;
+          case "toolMode":
+            handleActivateToolMode();
+            break;
+        }
 
-      setSelectedValue(null);
-    }, []);
+        setSelectedValue(null);
+      },
+      [
+        saveComponent,
+        freezeFunction,
+        FreezeAllVertices,
+        setOpenModal,
+        setShowModalAdvanced,
+        handleMinimize,
+        shareComponent,
+        downloadNode,
+        addFlow,
+        openDocs,
+        handleungroup,
+        setShowOverrideModal,
+        deleteNode,
+        updateNode,
+        setLastCopiedSelection,
+        paste,
+        handleActivateToolMode,
+      ],
+    );
 
     const { handleOnNewValue: handleOnNewValueHook } = useHandleOnNewValue({
       node: data.node!,

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -784,7 +784,7 @@ export type toolbarSelectItemProps = {
   value: string;
   icon: string;
   style?: string;
-  dataTestId: string;
+  dataTestId?: string;
   ping?: boolean;
   shortcut: string;
 };

--- a/src/frontend/tests/extended/regression/general-bugs-minimize-state-error.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-minimize-state-error.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { extractAndCleanCode } from "../../utils/extract-and-clean-code";
+
+test(
+  "user must be able to minimize and expand a node how many times as they want",
+  { tag: ["@release", "@components"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page);
+
+    await page.getByTestId("blank-flow").click();
+
+    await page.waitForSelector('[data-testid="fit_view"]', {
+      timeout: 100000,
+    });
+    await page.getByTestId("sidebar-search-input").click();
+    await page.getByTestId("sidebar-search-input").fill("text output");
+
+    await page
+      .getByTestId("outputsText Output")
+      .hover()
+      .then(async () => {
+        await page.getByTestId("add-component-button-text-output").click();
+      });
+
+    await page.waitForSelector('[data-testid="title-Text Output"]', {
+      timeout: 3000,
+    });
+
+    expect(await page.getByText("Toolset", { exact: true }).count()).toBe(0);
+
+    await page.getByTestId("title-Text Output").click();
+
+    expect(await page.getByTestId("show-node-content").count()).toBe(1);
+
+    await page.getByTestId("more-options-modal").click();
+
+    await page.getByTestId("minimize-button-modal").click();
+
+    expect(await page.getByTestId("show-node-content").count()).toBe(0);
+
+    await page.getByTestId("more-options-modal").click();
+
+    await page.getByTestId("expand-button-modal").click();
+
+    expect(await page.getByTestId("show-node-content").count()).toBe(1);
+
+    await page.getByTestId("more-options-modal").click();
+
+    await page.getByTestId("minimize-button-modal").click();
+
+    expect(await page.getByTestId("show-node-content").count()).toBe(0);
+
+    await page.getByTestId("more-options-modal").click();
+
+    await page.getByTestId("expand-button-modal").click();
+
+    expect(await page.getByTestId("show-node-content").count()).toBe(1);
+
+    await page.getByTestId("more-options-modal").click();
+
+    await page.getByTestId("minimize-button-modal").click();
+
+    expect(await page.getByTestId("show-node-content").count()).toBe(0);
+
+    await page.getByTestId("more-options-modal").click();
+
+    await page.getByTestId("expand-button-modal").click();
+
+    expect(await page.getByTestId("show-node-content").count()).toBe(1);
+  },
+);


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and testing of node components in the frontend. The most important changes include adding data-testid attributes for better testability, updating the dependencies in `useCallback` hooks, making `dataTestId` optional in type definitions, and adding a new regression test.

Enhancements for testability:

* [`src/frontend/src/CustomNodes/GenericNode/index.tsx`](diffhunk://#diff-b6793e0279f94c374aae18db97958c0af6befc2b49b7ce30e0294f9c80ba0d0eL415-R415): Added `data-testid` attribute to the node content div for better testability.
* [`src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx`](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL695): Added `data-testid` attributes to the minimize and expand buttons for better testability.

Code improvements:

* [`src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx`](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL420-R441): Updated the dependencies in the `useCallback` hook to ensure proper functionality.

Type definitions:

* [`src/frontend/src/types/components/index.ts`](diffhunk://#diff-37f7198f6f1ca1cdf6cbcc98051772d333ae0835185f1a7ca99da54c90a0f3d6L787-R787): Made `dataTestId` optional in the `toolbarSelectItemProps` type definition.

Testing:

* [`src/frontend/tests/extended/regression/general-bugs-minimize-state-error.spec.ts`](diffhunk://#diff-84d87c00ffe089b67ea643656b3d1bbbdf93323e72ab51e302c6e53f72263e60R1-R72): Added a new regression test to ensure users can minimize and expand a node multiple times without errors.