### PR TITLE
feat: Add DataFrame color mapping and rose variables

### DIFF
--- a/src/frontend/src/style/index.css
+++ b/src/frontend/src/style/index.css
@@ -114,6 +114,9 @@
     --datatype-pink: 327.3 73.3% 97.1%;
     --datatype-pink-foreground: 333.3 71.4% 50.6%;
 
+    --datatype-rose: 346.8 77.2% 49.8%;
+    --datatype-rose-foreground: 355.6 100% 94.7%;
+
     --datatype-yellow: 40.6 96.1% 40.4%;
     --datatype-yellow-foreground: 54.9 96.7% 88%;
 
@@ -277,6 +280,9 @@
 
     --datatype-pink: 327.4 87.1% 81.8%;
     --datatype-pink-foreground: 333.3 71.4% 50.6%;
+
+    --datatype-rose: 352.6 95.7% 81.8%;
+    --datatype-rose-foreground: 346.8 77.2% 49.8%;
 
     --datatype-yellow: 50.4 97.8% 63.5%;
     --datatype-yellow-foreground: 40.6 96.1% 40.4%;

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -478,6 +478,7 @@ export const nodeColorsName: { [char: string]: string } = {
   BaseChatMemory: "cyan",
   BaseChatMessageHistory: "orange",
   Memory: "orange",
+  DataFrame: "rose",
 };
 
 export const SIDEBAR_CATEGORIES = [


### PR DESCRIPTION
This pull request includes changes to the color scheme in the CSS and updates to the color mappings in the `styleUtils.ts` file. The most important changes are the addition of new color variables and their corresponding foreground colors, as well as updating the color mappings for a new data type.

### CSS Color Scheme Updates:

* Added `--datatype-rose` and `--datatype-rose-foreground` variables to the CSS file `index.css` to define new color values. [[1]](diffhunk://#diff-90e2b07b21bd53ac0fe04b56353e8b37e8ba1f3034f51e66306a1ff010ab4437R117-R119) [[2]](diffhunk://#diff-90e2b07b21bd53ac0fe04b56353e8b37e8ba1f3034f51e66306a1ff010ab4437R284-R286)

### Color Mappings Update:

* Updated the `nodeColorsName` object in `styleUtils.ts` to include a new mapping for the `DataFrame` type with the color `rose`.


![image](https://github.com/user-attachments/assets/e87e2b34-f781-43c4-9efe-936c109105f9)
![image](https://github.com/user-attachments/assets/19731b36-2144-49a7-a2cc-078d81466b9d)


![image](https://github.com/user-attachments/assets/6a76f99e-786f-4f1a-8c39-5f6951531f8c)
![image](https://github.com/user-attachments/assets/c2353d38-045a-4268-bbc0-efd36511de85)
