### PR TITLE
chore: Use expose instead of ports in docker compose example

### DIFF
--- a/docker_example/docker-compose.yml
+++ b/docker_example/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       POSTGRES_USER: langflow
       POSTGRES_PASSWORD: langflow
       POSTGRES_DB: langflow
-    ports:
-      - "5432:5432"
+    expose:
+      - 5432
     volumes:
       - langflow-postgres:/var/lib/postgresql/data
 


### PR DESCRIPTION
This makes the postgres instance only reachable from the langflow container and allows it to spin up even if another process (e.g. another postgres instance) is running on the host and binds to the same port.