### PR TITLE
fix: restored save on change, simplified tool_mode attribution to make it work between updates

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
@@ -49,7 +49,6 @@ export default function NodeInputField({
     node: data.node!,
     nodeId: data.id,
     parameterId: name,
-    tool_mode: data.node!.tool_mode ?? false,
   });
   const setFilterEdge = useFlowStore((state) => state.setFilterEdge);
   const { handleNodeClass } = useHandleNodeClass(data.id);

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -181,8 +181,10 @@ function GenericNode({
     () =>
       data.node?.outputs?.some(
         (output) => output.name === "component_as_tool",
-      ) ?? false,
-    [data.node?.outputs],
+      ) ??
+      data.node?.tool_mode ??
+      false,
+    [data.node?.outputs, data.node?.tool_mode],
   );
 
   const hasToolMode = useMemo(

--- a/src/frontend/src/CustomNodes/helpers/mutate-template.ts
+++ b/src/frontend/src/CustomNodes/helpers/mutate-template.ts
@@ -20,16 +20,19 @@ export const mutateTemplate = debounce(
     setErrorData,
     parameterName?: string,
     callback?: () => void,
+    toolMode?: boolean,
   ) => {
     try {
       const newNode = cloneDeep(node);
       const newTemplate = await postTemplateValue.mutateAsync({
         value: newValue,
         field_name: parameterName,
+        tool_mode: toolMode ?? node.tool_mode,
       });
       if (newTemplate) {
         newNode.template = newTemplate.template;
         newNode.outputs = newTemplate.outputs;
+        newNode.tool_mode = toolMode;
       }
       setNodeClass(newNode);
       callback?.();

--- a/src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts
+++ b/src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts
@@ -17,7 +17,6 @@ interface IPostTemplateValueParams {
   node: APIClassType;
   nodeId: string;
   parameterId: string;
-  tool_mode: boolean;
 }
 
 export const usePostTemplateValue: useMutationFunctionType<
@@ -25,7 +24,7 @@ export const usePostTemplateValue: useMutationFunctionType<
   IPostTemplateValue,
   APIClassType,
   ResponseErrorDetailAPI
-> = ({ parameterId, nodeId, node, tool_mode }, options?) => {
+> = ({ parameterId, nodeId, node }, options?) => {
   const { mutate } = UseRequestProcessor();
 
   const postTemplateValueFn = async (
@@ -41,7 +40,7 @@ export const usePostTemplateValue: useMutationFunctionType<
         template: template,
         field: parameterId,
         field_value: payload.value,
-        tool_mode: tool_mode,
+        tool_mode: payload.tool_mode,
       },
     );
 

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -185,7 +185,7 @@ export default function Page({ view }: { view?: boolean }): JSX.Element {
 
   useEffect(() => {
     useFlowStore.setState({ autoSaveFlow });
-  });
+  }, [autoSaveFlow]);
 
   function handleUndo(e: KeyboardEvent) {
     if (!isWrappedWithClass(e, "noflow")) {

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -5,7 +5,6 @@ import useHandleNodeClass from "@/CustomNodes/hooks/use-handle-node-class";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
 import ToggleShadComponent from "@/components/core/parameterRenderComponent/components/toggleShadComponent";
 import { Button } from "@/components/ui/button";
-import { usePatchUpdateFlow } from "@/controllers/API/queries/flows/use-patch-update-flow";
 import { usePostTemplateValue } from "@/controllers/API/queries/nodes/use-post-template-value";
 import { usePostRetrieveVertexOrder } from "@/controllers/API/queries/vertex";
 import useAddFlow from "@/hooks/flows/use-add-flow";
@@ -93,7 +92,6 @@ const NodeToolbarComponent = memo(
         });
       },
     });
-    const updateToolMode = useFlowStore((state) => state.updateToolMode);
 
     const flowDataNodes = useMemo(
       () => currentFlow?.data?.nodes,
@@ -114,7 +112,6 @@ const NodeToolbarComponent = memo(
       node: data.node!,
       nodeId: data.id,
       parameterId: "tool_mode",
-      tool_mode: data.node!.tool_mode ?? false,
     });
 
     const isSaved = flows?.some((flow) =>
@@ -140,8 +137,6 @@ const NodeToolbarComponent = memo(
       [data.node?.template, isGroup],
     );
     const addFlow = useAddFlow();
-
-    const { mutate: patchUpdateFlow } = usePatchUpdateFlow();
 
     const isMinimal = useMemo(
       () => countHandlesFn(data) <= 1 && numberOfOutputHandles <= 1,
@@ -172,13 +167,8 @@ const NodeToolbarComponent = memo(
     };
 
     const handleActivateToolMode = () => {
-      const newValue = !flowDataNodes![index]!.data.node.tool_mode;
-
-      updateToolMode(data.id, newValue);
-      data.node!.tool_mode = newValue;
-
+      const newValue = !toolMode;
       setToolMode(newValue);
-
       mutateTemplate(
         newValue,
         data.node!,
@@ -186,21 +176,9 @@ const NodeToolbarComponent = memo(
         postToolModeValue,
         setErrorData,
         "tool_mode",
-        () => {
-          currentFlow!.data!.nodes[index]!.data.node.tool_mode = newValue;
-          patchUpdateFlow({
-            id: currentFlow?.id!,
-            name: currentFlow?.name!,
-            data: currentFlow?.data!,
-            description: currentFlow?.description!,
-            folder_id: currentFlow?.folder_id!,
-            endpoint_name: currentFlow?.endpoint_name!,
-          });
-        },
+        () => updateNodeInternals(data.id),
+        newValue,
       );
-
-      updateNodeInternals(data.id);
-      return newValue;
     };
 
     const handleMinimize = useCallback(() => {
@@ -437,6 +415,7 @@ const NodeToolbarComponent = memo(
         setLastCopiedSelection,
         paste,
         handleActivateToolMode,
+        toolMode,
       ],
     );
 

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -279,32 +279,35 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
         ? change(get().nodes.find((node) => node.id === id)!)
         : change;
 
-    set((state) => {
-      const newNodes = state.nodes.map((node) => {
-        if (node.id === id) {
-          if (isUserChange) {
-            if ((node.data as NodeDataType).node?.frozen) {
-              (newChange.data as NodeDataType).node!.frozen = false;
-            }
+    const newNodes = get().nodes.map((node) => {
+      if (node.id === id) {
+        if (isUserChange) {
+          if ((node.data as NodeDataType).node?.frozen) {
+            (newChange.data as NodeDataType).node!.frozen = false;
           }
-          return newChange;
         }
-        return node;
-      });
+        return newChange;
+      }
+      return node;
+    });
 
-      const newEdges = cleanEdges(newNodes, get().edges);
+    const newEdges = cleanEdges(newNodes, get().edges);
 
+    set((state) => {
       if (callback) {
         // Defer the callback execution to ensure it runs after state updates are fully applied.
         queueMicrotask(callback);
       }
-
       return {
         ...state,
         nodes: newNodes,
         edges: newEdges,
       };
     });
+    get().updateCurrentFlow({ nodes: newNodes, edges: newEdges });
+    if (get().autoSaveFlow) {
+      get().autoSaveFlow!();
+    }
   },
   getNode: (id: string) => {
     return get().nodes.find((node) => node.id === id);


### PR DESCRIPTION
This pull request includes several changes to handle the `tool_mode` parameter more effectively in the frontend components and to improve state management in the `useFlowStore` function. The most important changes include modifying the `NodeInputField`, `GenericNode`, and `mutateTemplate` functions to account for the `tool_mode` parameter, and refactoring the `useFlowStore` function to ensure state updates and auto-save functionality are handled correctly.

### Handling `tool_mode` parameter:

* [`src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx`](diffhunk://#diff-b68d4cff4ce636f41882b2e6c2fb46ce2e134bdf292e38bcf6df9c6c5807d518L52): Removed the `tool_mode` parameter from the `NodeInputField` function.
* [`src/frontend/src/CustomNodes/GenericNode/index.tsx`](diffhunk://#diff-b6793e0279f94c374aae18db97958c0af6befc2b49b7ce30e0294f9c80ba0d0eL184-R187): Updated the `GenericNode` function to include `tool_mode` in the dependency array and use it as a fallback value.
* [`src/frontend/src/CustomNodes/helpers/mutate-template.ts`](diffhunk://#diff-a65752801640d4acb83ee2c8787c474b31940dec9357cec061f4db81634b65cdR23-R35): Added `toolMode` parameter to `mutateTemplate` function and ensured it is passed correctly to the `postTemplateValue` mutation.

### State management improvements:

* [`src/frontend/src/stores/flowStore.ts`](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357L282-R282): Refactored the `useFlowStore` function to handle state updates and auto-save functionality more effectively. [[1]](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357L282-R282) [[2]](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357R296-R310)

### Other minor changes:

* [`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eL188-R188): Added `autoSaveFlow` to the dependency array of the `useEffect` hook.
* [`src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx`](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL8): Removed unused imports and refactored the `handleActivateToolMode` function to simplify the code. [[1]](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL8) [[2]](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL96) [[3]](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL117) [[4]](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL144-L145) [[5]](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL175-L203) [[6]](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaR418)