### PR TITLE
refactor: update DataFrame color to pink

### DIFF
--- a/src/frontend/src/style/index.css
+++ b/src/frontend/src/style/index.css
@@ -111,8 +111,8 @@
     --smooth-red: 0 93.3% 94.1%;
     --radius: 0.5rem;
 
-    --datatype-pink: 327.3 73.3% 97.1%;
-    --datatype-pink-foreground: 333.3 71.4% 50.6%;
+    --datatype-pink: 333.3 71.4% 50.6%;
+    --datatype-pink-foreground: 325.7 77.8% 94.7%;
 
     --datatype-rose: 346.8 77.2% 49.8%;
     --datatype-rose-foreground: 355.6 100% 94.7%;

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -452,13 +452,13 @@ export const nodeColorsName: { [char: string]: string } = {
   vectorsearch: "yellow",
   textsplitters: "fuchsia",
   toolkits: "red",
-  wrappers: "pink",
+  wrappers: "rose",
   notion: "slate",
   Notion: "slate",
   AssemblyAI: "blue",
   assemblyai: "blue",
   helpers: "cyan",
-  prototypes: "pink",
+  prototypes: "rose",
   astra_assistants: "indigo",
   langchain_utilities: "sky",
   output_parsers: "yellow",
@@ -479,7 +479,7 @@ export const nodeColorsName: { [char: string]: string } = {
   BaseChatMemory: "cyan",
   BaseChatMessageHistory: "orange",
   Memory: "orange",
-  DataFrame: "rose",
+  DataFrame: "pink",
 };
 
 export const SIDEBAR_CATEGORIES = [


### PR DESCRIPTION
This pull request includes changes to the color scheme used in the frontend. The changes focus on updating color values in the CSS file and modifying the color assignments in the `styleUtils.ts` file.

Color scheme updates:

* [`src/frontend/src/style/index.css`](diffhunk://#diff-90e2b07b21bd53ac0fe04b56353e8b37e8ba1f3034f51e66306a1ff010ab4437L114-R115): Updated the `--datatype-pink` and `--datatype-pink-foreground` color values.

Color assignments in `styleUtils.ts`:

* [`src/frontend/src/utils/styleUtils.ts`](diffhunk://#diff-ce70511ff4131ac5078d799cd2295f98874bad89bcde4732f33c967c1bbc71f2L455-R461): Changed the color assignment for `wrappers` and `prototypes` from "pink" to "rose".
* [`src/frontend/src/utils/styleUtils.ts`](diffhunk://#diff-ce70511ff4131ac5078d799cd2295f98874bad89bcde4732f33c967c1bbc71f2L482-R482): Changed the color assignment for `DataFrame` from "rose" to "pink".

<img width="378" alt="image" src="https://github.com/user-attachments/assets/a0a0809a-8a21-4749-9f0e-7a66938a4f3a" />
