### PR TITLE
refactor: Comment out deprecated playground page

### DIFF
--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -41,7 +41,7 @@ const AdminPage = lazy(() => import("./pages/AdminPage"));
 const LoginAdminPage = lazy(() => import("./pages/AdminPage/LoginPage"));
 const DeleteAccountPage = lazy(() => import("./pages/DeleteAccountPage"));
 
-const PlaygroundPage = lazy(() => import("./pages/Playground"));
+// const PlaygroundPage = lazy(() => import("./pages/Playground"));
 
 const SignUp = lazy(() => import("./pages/SignUpPage"));
 const router = createBrowserRouter(
@@ -203,9 +203,9 @@ const router = createBrowserRouter(
                 </Route>
                 <Route path="view" element={<ViewPage />} />
               </Route>
-              <Route path="playground/:id/">
+              {/* <Route path="playground/:id/">
                 <Route path="" element={<PlaygroundPage />} />
-              </Route>
+              </Route> */}
             </Route>
           </Route>
           <Route


### PR DESCRIPTION
The deprecated playground page has been commented out in the code to prevent it from being used. This change ensures that the page is no longer accessible and avoids any potential issues related to its usage.