### PR TITLE
fix: initial hidden state for shadow-box component

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -631,6 +631,7 @@ export default function Page({ view }: { view?: boolean }): JSX.Element {
               backgroundColor: `${shadowBoxBackgroundColor}`,
               opacity: 0.7,
               pointerEvents: "none",
+              display: "none",
             }}
           ></div>
         </div>


### PR DESCRIPTION
This pull request addresses the issue where the `shadow-box` component could unpredictably display during initial renders. 
An example of the bug can be reproduced by opening the `Edit Prompt` interface within the `Prompt` component, pressing the enter key, and then closing the window. The `shadow-box`, which is supposed to be hidden, may appear in the bottom left corner, as shown in the image below.
![image](https://github.com/user-attachments/assets/38c28816-8925-481f-af99-17d4ea5985e3)
By setting 'display: none' in the initial style, the shadow-box is now guaranteed to remain hidden unless explicitly changed. 