### PR TITLE
test: improve element interactions in generalBugs shard 7 tests (nightly fix)

### DIFF
--- a/src/frontend/tests/extended/regression/generalBugs-shard-7.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-7.spec.ts
@@ -32,7 +32,12 @@ test(
 
     await page
       .getByTestId("embeddingsOllama Embeddings")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'));
+      .hover()
+      .then(async () => {
+        await page
+          .getByTestId("add-component-button-ollama-embeddings")
+          .click();
+      });
 
     await page.getByTestId("fit_view").click();
     await zoomOut(page, 3);
@@ -52,11 +57,11 @@ test(
 
     await page
       .getByPlaceholder("Type something...")
-      .nth(2)
+      .first()
       .fill("ollama_test_ctrl_a_first_input");
     let value = await page
       .getByPlaceholder("Type something...")
-      .nth(2)
+      .first()
       .inputValue();
     expect(value).toBe("ollama_test_ctrl_a_first_input");
 
@@ -76,7 +81,7 @@ test(
 
     await page.keyboard.press("ControlOrMeta+c");
 
-    await page.getByPlaceholder("Type something...").nth(2).click();
+    await page.getByPlaceholder("Type something...").first().click();
 
     await page.keyboard.press("ControlOrMeta+a");
 
@@ -84,7 +89,7 @@ test(
 
     value = await page
       .getByPlaceholder("Type something...")
-      .nth(2)
+      .first()
       .inputValue();
     expect(value).toBe("ollama_test_ctrl_a_second_input");
   },


### PR DESCRIPTION
This pull request includes changes to the `src/frontend/tests/extended/regression/generalBugs-shard-7.spec.ts` file to enhance the stability and reliability of the tests by modifying the way elements are interacted with.

Improvements to test stability:

* Replaced `dragTo` with `hover` and `click` for the "embeddingsOllama Embeddings" element to ensure the component is added correctly.

Enhancements to element selection:

* Changed the selection method from `.nth(2)` to `.first()` for elements with the placeholder "Type something..." to ensure the correct input field is targeted. [[1]](diffhunk://#diff-25a4b87a3b8c7c12b1fafa208c4efe861f17ece8643943057c7eda0348b70984L55-R64) [[2]](diffhunk://#diff-25a4b87a3b8c7c12b1fafa208c4efe861f17ece8643943057c7eda0348b70984L79-R92)