### PR TITLE
feat: change Text to MessageTextInput type with backend and frontend support

### DIFF
--- a/src/backend/base/langflow/inputs/inputs.py
+++ b/src/backend/base/langflow/inputs/inputs.py
@@ -483,7 +483,7 @@ class SliderInput(BaseInputMixin, RangeMixin, SliderMixin, ToolModeMixin):
     field_type: SerializableFieldTypes = FieldTypes.SLIDER
 
 
-DEFAULT_PROMPT_INTUT_TYPES = ["Message", "Text"]
+DEFAULT_PROMPT_INTUT_TYPES = ["Message", "MessageTextInput"]
 
 
 class DefaultPromptField(Input):

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -428,6 +428,7 @@ export const nodeColors: { [char: string]: string } = {
   LanguageModel: "#c026d3",
   Agent: "#903BBE",
   Tool: "#00fbfc",
+  MessageTextInput: "#4F46E5",
 };
 
 export const nodeColorsName: { [char: string]: string } = {
@@ -480,6 +481,7 @@ export const nodeColorsName: { [char: string]: string } = {
   BaseChatMessageHistory: "orange",
   Memory: "orange",
   DataFrame: "pink",
+  MessageTextInput: "indigo",
 };
 
 export const SIDEBAR_CATEGORIES = [


### PR DESCRIPTION
This pull request includes changes to both the backend and frontend components of the project to support a new input type, `MessageTextInput`. The most important changes include updating the default prompt input types and adding color definitions for the new input type.

Backend updates:

* [`src/backend/base/langflow/inputs/inputs.py`](diffhunk://#diff-f12c9ca218a67d203869442cb70537349ad1f026a3c20c88c8f1e15ae71bdbc8L486-R486): Updated `DEFAULT_PROMPT_INTUT_TYPES` to include `MessageTextInput`.

Frontend updates:

* [`src/frontend/src/utils/styleUtils.ts`](diffhunk://#diff-ce70511ff4131ac5078d799cd2295f98874bad89bcde4732f33c967c1bbc71f2R431): Added `MessageTextInput` color definitions to `nodeColors` and `nodeColorsName`. [[1]](diffhunk://#diff-ce70511ff4131ac5078d799cd2295f98874bad89bcde4732f33c967c1bbc71f2R431) [[2]](diffhunk://#diff-ce70511ff4131ac5078d799cd2295f98874bad89bcde4732f33c967c1bbc71f2R484)


![image](https://github.com/user-attachments/assets/5f304cd2-13d8-4715-9af5-4e9026921f68)
