### PR TITLE
ci: Stop using uv to catch dependency timeouts in nightly workflow

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -102,8 +102,8 @@ jobs:
           # TODO: Unsure why the whl is not built in src/backend/base/dist
           mkdir src/backend/base/dist
           mv dist/*.whl src/backend/base/dist/
-          uv pip install src/backend/base/dist/*.whl
-          uv run python -m langflow run --host 127.0.0.1 --port 7860 --backend-only &
+          python -m pip install src/backend/base/dist/*.whl
+          python -m langflow run --host 127.0.0.1 --port 7860 --backend-only &
           SERVER_PID=$!
           # Wait for the server to start
           timeout 120 bash -c 'until curl -f http://127.0.0.1:7860/api/v1/auto_login; do sleep 2; done' || (echo "Server did not start in time" && kill $SERVER_PID && exit 1)


### PR DESCRIPTION
This pull request replaces the use of `uv` for installing dependencies and running the application in the CI workflow with standard Python commands. This change aims to improve reliability and reduce potential issues related to dependency timeouts.