### PR TITLE
fix: replace hasattr with dictionary key check for flow_data nodes (nightly fix)

### DIFF
--- a/src/backend/base/langflow/services/database/models/flow/utils.py
+++ b/src/backend/base/langflow/services/database/models/flow/utils.py
@@ -5,7 +5,7 @@ from .model import Flow
 
 def get_webhook_component_in_flow(flow_data: dict):
     """Get webhook component in flow data."""
-    if hasattr(flow_data, "nodes"):
+    if "nodes" in flow_data:
         for node in flow_data.get("nodes", []):
             if "Webhook" in node.get("id"):
                 return node


### PR DESCRIPTION
This pull request includes a small change to the `src/backend/base/langflow/services/database/models/flow/utils.py` file. The change improves the method for checking the presence of "nodes" in the `flow_data` dictionary by using key access instead of the `hasattr` function.

* [`src/backend/base/langflow/services/database/models/flow/utils.py`](diffhunk://#diff-67749e1b270b011305729740ad79f6db329bc584ccacec838597956e75d42b1bL8-R8): Changed the method for checking the presence of "nodes" in `flow_data` from `hasattr` to key access.