### PR TITLE
chore: Add aiofile dependency to langflow-base

### DIFF
--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -118,6 +118,7 @@ maintainers = [
 dependencies = [
     "fastapi>=0.115.2,<1.0.0",
     "httpx[http2]>=0.27,<1.0.0",
+    "aiofile>=3.9.0,<4.0.0",
     "uvicorn>=0.30.0,<1.0.0",
     "gunicorn>=22.0.0,<24.0.0",
     "langchain~=0.3.10",

--- a/uv.lock
+++ b/uv.lock
@@ -4033,7 +4033,7 @@ local = [
     { name = "sentence-transformers" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "asgi-lifespan" },
     { name = "blockbuster" },
@@ -4175,7 +4175,7 @@ requires-dist = [
     { name = "zep-python", specifier = "==2.0.2" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
     { name = "blockbuster", specifier = ">=1.5.8,<1.6" },
@@ -4220,6 +4220,7 @@ name = "langflow-base"
 version = "0.1.1"
 source = { editable = "src/backend/base" }
 dependencies = [
+    { name = "aiofile" },
     { name = "aiofiles" },
     { name = "alembic" },
     { name = "assemblyai" },
@@ -4332,7 +4333,7 @@ local = [
     { name = "sentence-transformers" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "asgi-lifespan" },
     { name = "pytest-codspeed" },
@@ -4342,6 +4343,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofile", specifier = ">=3.9.0,<4.0.0" },
     { name = "aiofiles", specifier = ">=24.1.0,<25.0.0" },
     { name = "alembic", specifier = ">=1.13.0,<2.0.0" },
     { name = "assemblyai", specifier = ">=0.33.0,<1.0.0" },
@@ -4444,7 +4446,7 @@ requires-dist = [
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.11" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
     { name = "pytest-codspeed", specifier = ">=3.0.0" },


### PR DESCRIPTION
This pull request introduces the `aiofile` package as a dependency in both `uv.lock` and `pyproject.toml`, ensuring it adheres to specified version constraints. Additionally, it refines the dependency management structure by renaming `[package.dependency-groups]` to `[package.dev-dependencies]` and updating `[package.metadata.dependency-groups]` to `[package.metadata.requires-dev]` in `uv.lock`, promoting consistency across configuration files.