### PR TITLE
feat: make YouTube Transcripts URL field required

### DIFF
--- a/src/backend/base/langflow/components/tools/youtube_transcripts.py
+++ b/src/backend/base/langflow/components/tools/youtube_transcripts.py
@@ -21,6 +21,7 @@ class YouTubeTranscriptsComponent(Component):
             display_name="Video URL",
             info="Enter the YouTube video URL to get transcripts from.",
             tool_mode=True,
+            required=True,
         ),
         DropdownInput(
             name="transcript_format",


### PR DESCRIPTION
This change ensures that users provide a video URL before using the YouTube Transcripts component, preventing potential runtime errors due to missing video source.
