### PR TITLE
fix: add missing Needle component icon

### DIFF
--- a/src/backend/base/langflow/components/needle/needle.py
+++ b/src/backend/base/langflow/components/needle/needle.py
@@ -12,7 +12,7 @@ class NeedleComponent(Component):
     display_name = "Needle Retriever"
     description = "A retriever that uses the Needle API to search collections and generates responses using OpenAI."
     documentation = "https://docs.needle-ai.com"
-    icon = "search"
+    icon = "Needle"
     name = "needle"
 
     inputs = [


### PR DESCRIPTION


- Replaced the generic 'search' icon with a dedicated 'Needle' icon to properly represent the Needle component in the UI, addressing the missing icon issue.
