### PR TITLE
ci: Update nightly build workflow to delete existing main tags before generating new ones

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -41,19 +41,16 @@ jobs:
           echo "main_tag=$MAIN_TAG" >> $GITHUB_OUTPUT
           echo "main_tag=$MAIN_TAG"
 
-      - name: Check if main tag already exists
+      - name: Delete existing tag if it exists
         id: check_main_tag
         run: |
           git fetch --tags
-          if git rev-parse -q --verify "refs/tags/${{ steps.generate_main_tag.outputs.main_tag }}" >/dev/null; then
-            echo "main_tag_exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "main_tag_exists=false" >> $GITHUB_OUTPUT
-          fi
+          git tag -d ${{ steps.generate_main_tag.outputs.main_tag }} || true
+          git push --delete origin ${{ steps.generate_main_tag.outputs.main_tag }} || true
+          echo "main_tag_exists=false" >> $GITHUB_OUTPUT
 
       - name: Generate base nightly tag
         id: generate_base_tag
-        if: ${{ steps.check_main_tag.outputs.main_tag_exists == 'false' }}
         run: |
           # NOTE: This outputs the tag with the `v` prefix.
           BASE_TAG="$(uv run ./scripts/ci/pypi_nightly_tag.py base)"
@@ -62,7 +59,6 @@ jobs:
 
       - name: Commit tag
         id: commit_tag
-        if: ${{ steps.check_main_tag.outputs.main_tag_exists == 'false' }}
         run: |
           # If the main tag does not exist in GH, we create the base tag from the existing codebase.
 
@@ -95,13 +91,11 @@ jobs:
 
       - name: Checkout main nightly tag
         uses: actions/checkout@v4
-        if: ${{ steps.check_main_tag.outputs.main_tag_exists == 'true' }}
         with:
           ref: ${{ steps.generate_main_tag.outputs.main_tag }}
 
       - name: Retrieve Base Tag
         id: retrieve_base_tag
-        if: ${{ steps.check_main_tag.outputs.main_tag_exists == 'true' }}
         working-directory: src/backend/base
         run: |
           # If the main tag already exists, we need to retrieve the base version from the main tag codebase.


### PR DESCRIPTION
This PR modifies the nightly build workflow to ensure that any existing main tags are deleted before new ones are generated. An existing tag causes the build to be stuck in time.