### PR TITLE
fix: Update useState default values in exportModal and flowSettingsModal

### DIFF
--- a/src/frontend/src/modals/exportModal/index.tsx
+++ b/src/frontend/src/modals/exportModal/index.tsx
@@ -22,11 +22,11 @@ const ExportModal = forwardRef(
     const [checked, setChecked] = useState(false);
     const currentFlow = useFlowStore((state) => state.currentFlow);
     useEffect(() => {
-      setName(currentFlow!.name);
-      setDescription(currentFlow!.description);
-    }, [currentFlow!.name, currentFlow!.description]);
-    const [name, setName] = useState(currentFlow!.name);
-    const [description, setDescription] = useState(currentFlow!.description);
+      setName(currentFlow?.name ?? "");
+      setDescription(currentFlow?.description ?? "");
+    }, [currentFlow?.name, currentFlow?.description]);
+    const [name, setName] = useState(currentFlow?.name ?? "");
+    const [description, setDescription] = useState(currentFlow?.description ?? "");
     const [open, setOpen] = useState(false);
 
     return (

--- a/src/frontend/src/modals/flowSettingsModal/index.tsx
+++ b/src/frontend/src/modals/flowSettingsModal/index.tsx
@@ -25,13 +25,13 @@ export default function FlowSettingsModal({
   const flows = useFlowsManagerStore((state) => state.flows);
   const flow = flowData ?? currentFlow;
   useEffect(() => {
-    setName(flow!.name);
-    setDescription(flow!.description);
+    setName(flow?.name ?? "");
+    setDescription(flow?.description ?? "");
   }, [flow?.name, flow?.description, open]);
 
-  const [name, setName] = useState(flow!.name);
-  const [description, setDescription] = useState(flow!.description);
-  const [endpoint_name, setEndpointName] = useState(flow!.endpoint_name ?? "");
+  const [name, setName] = useState(flow?.name ?? "");
+  const [description, setDescription] = useState(flow?.description ?? "");
+  const [endpoint_name, setEndpointName] = useState(flow?.endpoint_name ?? "");
   const [isSaving, setIsSaving] = useState(false);
   const [disableSave, setDisableSave] = useState(true);
   const autoSaving = useFlowsManagerStore((state) => state.autoSaving);


### PR DESCRIPTION
- Update the default values for the useState hooks in exportModal and flowSettingsModal to handle null values for currentFlow.
- Use the nullish coalescing operator (??) to set empty strings as default values for name and description.
- This ensures that the components do not throw errors when currentFlow is null or undefined.