### PR TITLE
feat: Add Support for validating  Tool Mode Models in NVIDIA LLM Component

### DIFF
--- a/src/backend/base/langflow/components/models/nvidia.py
+++ b/src/backend/base/langflow/components/models/nvidia.py
@@ -37,8 +37,7 @@ class NVIDIAModelComponent(LCModelComponent):
             name="tool_model_enabled",
             display_name="Enable Tool Models",
             info=(
-                "Select if you want to use models that can work with tools. "
-                "If yes, only those models will be shown."
+                "Select if you want to use models that can work with tools. If yes, only those models will be shown."
             ),
             advanced=False,
             value=True,


### PR DESCRIPTION
This pull request includes updates to the NVIDIA model component in the `langflow` project to add support for tool models. The changes introduce a new input type and refactor the method for retrieving available models.

Enhancements to NVIDIA model component:

* [`src/backend/base/langflow/components/models/nvidia.py`](diffhunk://#diff-9497a9d3010368c344c0dad0b1b04a8b84f2be1617da122437b70fc227d821a0R36-R45): Added `BoolInput` to allow users to enable or disable tool models.
* [`src/backend/base/langflow/components/models/nvidia.py`](diffhunk://#diff-9497a9d3010368c344c0dad0b1b04a8b84f2be1617da122437b70fc227d821a0R63-R73): Refactored the `update_build_config` method to use the new `get_models` method, which filters models based on the `tool_model_enabled` flag.

Refactoring and code improvements:

* [`src/backend/base/langflow/components/models/nvidia.py`](diffhunk://#diff-9497a9d3010368c344c0dad0b1b04a8b84f2be1617da122437b70fc227d821a0L5-R5): Added import for `BoolInput` to support the new input type.