### PR TITLE
feat: make AWS credentials required in bedrock component

### DIFF
--- a/src/backend/base/langflow/components/models/amazon_bedrock.py
+++ b/src/backend/base/langflow/components/models/amazon_bedrock.py
@@ -26,6 +26,7 @@ class AmazonBedrockComponent(LCModelComponent):
             info="The access key for your AWS account."
             "Usually set in Python code as the environment variable 'AWS_ACCESS_KEY_ID'.",
             value="AWS_ACCESS_KEY_ID",
+            required=True,
         ),
         SecretStrInput(
             name="aws_secret_access_key",
@@ -33,6 +34,7 @@ class AmazonBedrockComponent(LCModelComponent):
             info="The secret key for your AWS account. "
             "Usually set in Python code as the environment variable 'AWS_SECRET_ACCESS_KEY'.",
             value="AWS_SECRET_ACCESS_KEY",
+            required=True,
         ),
         SecretStrInput(
             name="aws_session_token",


### PR DESCRIPTION
- Make aws_access_key_id field required
- Make aws_secret_access_key field required