### PR TITLE
fix: remove subscribe call and add unsubscribe method in StateService

### DIFF
--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -644,10 +644,7 @@ class Graph:
         if run_id is None:
             run_id = uuid.uuid4()
 
-        run_id_str = str(run_id)
-        for vertex in self.vertices:
-            self.state_manager.subscribe(run_id_str, vertex.update_graph_state)
-        self._run_id = run_id_str
+        self._run_id = str(run_id)
         if self.tracing_service:
             self.tracing_service.set_run_id(run_id)
 
@@ -1430,6 +1427,7 @@ class Graph:
                         vertex.results = cached_vertex_dict["results"]
                         try:
                             vertex.finalize_build()
+
                             if vertex.result is not None:
                                 vertex.result.used_frozen_result = True
                         except Exception:  # noqa: BLE001

--- a/src/backend/base/langflow/graph/graph/state_manager.py
+++ b/src/backend/base/langflow/graph/graph/state_manager.py
@@ -33,3 +33,6 @@ class GraphStateManager:
 
     def subscribe(self, key, observer: Callable) -> None:
         self.state_service.subscribe(key, observer)
+
+    def unsubscribe(self, key, observer: Callable) -> None:
+        self.state_service.unsubscribe(key, observer)


### PR DESCRIPTION
This PR removes erroneous subscribe call in `Graph.set_run_id`.

Fixes #5275