### PR TITLE
feat: make NvidiaRerankComponent work with search_results

### DIFF
--- a/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
@@ -13,7 +13,6 @@ class NvidiaRerankComponent(LCVectorStoreComponent):
     display_name = "NVIDIA Rerank"
     description = "Rerank documents using the NVIDIA API and a retriever."
     icon = "NVIDIA"
-    legacy: bool = True
 
     inputs = [
         MultilineInput(

--- a/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
@@ -61,7 +61,7 @@ class NvidiaRerankComponent(LCVectorStoreComponent):
                 raise ValueError(msg) from e
         return build_config
 
-    def build_model(self):
+    def build_reranker(self):
         try:
             from langchain_nvidia_ai_endpoints import NVIDIARerank
         except ImportError as e:

--- a/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
@@ -18,6 +18,7 @@ class NvidiaRerankComponent(LCVectorStoreComponent):
         MultilineInput(
             name="search_query",
             display_name="Search Query",
+            tool_mode=True,
         ),
         StrInput(
             name="base_url",

--- a/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
@@ -44,11 +44,6 @@ class NvidiaRerankComponent(LCVectorStoreComponent):
 
     outputs = [
         Output(
-            display_name="Retriever",
-            name="base_retriever",
-            method="build_base_retriever",
-        ),
-        Output(
             display_name="Search Results",
             name="search_results",
             method="search_documents",

--- a/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from langchain.schema import Document
-
 from langflow.base.vectorstores.model import LCVectorStoreComponent, check_cached_vector_store
 from langflow.field_typing import VectorStore
 from langflow.inputs.inputs import DataInput
@@ -80,7 +78,8 @@ class NvidiaRerankComponent(LCVectorStoreComponent):
     async def rerank_documents(self) -> list[Data]:  # type: ignore[override]
         reranker = self.build_reranker()
         documents = reranker.compress_documents(
-            query=self.search_query, documents=[Document(page_content=passage.text) for passage in self.search_results]
+            query=self.search_query,
+            documents=[passage.to_lc_document() for passage in self.search_results if isinstance(passage, Data)],
         )
         data = self.to_data(documents)
         self.status = data

--- a/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
@@ -44,9 +44,9 @@ class NvidiaRerankComponent(LCVectorStoreComponent):
 
     outputs = [
         Output(
-            display_name="Search Results",
-            name="search_results",
-            method="search_documents",
+            display_name="Reranked Documents",
+            name="reranked_documents",
+            method="rerank_documents",
         ),
     ]
 


### PR DESCRIPTION
This pull request refactors the NvidiaRerankComponent by removing an unused legacy flag, renaming the output from 'search_results' to 'reranked_documents', and eliminating the base_retriever output. Additionally, it updates the document handling to utilize the new Data model, ensuring type safety and consistency. These changes enhance the clarity, maintainability, and functionality of the component.

Fixes #5734 

Thanks @brian-ogrady!

Co-authored-by: @brian-ogrady