### PR TITLE
test: Update API key requirements and test configurations for frontend tests (fix nightly)

### DIFF
--- a/src/frontend/tests/core/integrations/Custom Component Generator.spec.ts
+++ b/src/frontend/tests/core/integrations/Custom Component Generator.spec.ts
@@ -1,14 +1,8 @@
 import { expect, test } from "@playwright/test";
 import * as dotenv from "dotenv";
 import path from "path";
-import { addNewApiKeys } from "../../utils/add-new-api-keys";
-import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { getAllResponseMessage } from "../../utils/get-all-response-message";
-import { initialGPTsetup } from "../../utils/initialGPTsetup";
-import { removeOldApiKeys } from "../../utils/remove-old-api-keys";
-import { selectGptModel } from "../../utils/select-gpt-model";
-import { updateOldComponents } from "../../utils/update-old-components";
 import { waitForOpenModalWithChatInput } from "../../utils/wait-for-open-modal";
 
 test(
@@ -17,7 +11,7 @@ test(
   async ({ page }) => {
     test.skip(
       !process?.env?.ANTHROPIC_API_KEY,
-      "OPENAI_API_KEY required to run this test",
+      "ANTHROPIC_API_KEY required to run this test",
     );
 
     if (!process.env.CI) {
@@ -35,16 +29,18 @@ test(
       timeout: 100000,
     });
 
-    await initialGPTsetup(page);
+    await page
+      .getByTestId("popover-anchor-input-api_key")
+      .last()
+      .fill(process.env.ANTHROPIC_API_KEY ?? "");
 
-    const apiKeyInput = page.getByTestId(
-      "popover-anchor-input-anthropic_api_key",
-    );
-    const isApiKeyInputVisible = await apiKeyInput.isVisible();
+    await page.waitForSelector('[data-testid="dropdown_str_model_name"]', {
+      timeout: 5000,
+    });
 
-    if (isApiKeyInputVisible) {
-      await apiKeyInput.fill(process.env.ANTHROPIC_API_KEY ?? "");
-    }
+    await page.getByTestId("dropdown_str_model_name").click();
+
+    await page.keyboard.press("Enter");
 
     await page.getByTestId("button_run_chat output").click();
     await page.waitForSelector("text=built successfully", { timeout: 30000 });
@@ -63,7 +59,9 @@ test(
 
     const textContents = await getAllResponseMessage(page);
     expect(textContents.length).toBeGreaterThan(100);
-    expect(await page.getByTestId("chat-code-tab").isVisible()).toBe(true);
+    expect(await page.getByTestId("chat-code-tab").last().isVisible()).toBe(
+      true,
+    );
     expect(textContents).toContain("langflow");
   },
 );

--- a/src/frontend/tests/core/unit/sliderComponent.spec.ts
+++ b/src/frontend/tests/core/unit/sliderComponent.spec.ts
@@ -39,7 +39,8 @@ test(
     cleanCode = cleanCode.replace("FloatInput(", "SliderInput(");
     cleanCode = cleanCode.replace(
       "from langflow.io import BoolInput, DictInput, DropdownInput, FloatInput, IntInput, StrInput",
-      "from langflow.io import BoolInput, DictInput, DropdownInput, FloatInput, IntInput, StrInput, SliderInput",
+      "from langflow.io import BoolInput, DictInput, DropdownInput, FloatInput, IntInput, StrInput, SliderInput\n" +
+        "from langflow.field_typing.range_spec import RangeSpec",
     );
 
     cleanCode = cleanCode.replace(


### PR DESCRIPTION
This pull request includes several changes to the integration and unit tests in the frontend codebase. The changes focus on updating the API key requirements, modifying the test setup, and ensuring the tests run correctly with the new configurations.

### Updates to integration tests:

* [`src/frontend/tests/core/integrations/Custom Component Generator.spec.ts`](diffhunk://#diff-d914f41b7bd3fca12fd73e47e07d28542a0c70076f89767d5fbb600eed61e726L4-L11): Removed unused utility imports to clean up the code.
* [`src/frontend/tests/core/integrations/Custom Component Generator.spec.ts`](diffhunk://#diff-d914f41b7bd3fca12fd73e47e07d28542a0c70076f89767d5fbb600eed61e726L20-R14): Updated the API key requirement message to reflect the use of `ANTHROPIC_API_KEY` instead of `OPENAI_API_KEY`.
* [`src/frontend/tests/core/integrations/Custom Component Generator.spec.ts`](diffhunk://#diff-d914f41b7bd3fca12fd73e47e07d28542a0c70076f89767d5fbb600eed61e726L38-R43): Replaced the `initialGPTsetup` function with direct interaction commands to input the API key and select the model name. This change simplifies the test setup process.
* [`src/frontend/tests/core/integrations/Custom Component Generator.spec.ts`](diffhunk://#diff-d914f41b7bd3fca12fd73e47e07d28542a0c70076f89767d5fbb600eed61e726L66-R64): Ensured the visibility check for the "chat-code-tab" element targets the last element in the list.

### Updates to unit tests:

* [`src/frontend/tests/core/unit/sliderComponent.spec.ts`](diffhunk://#diff-2a9d4fa3ff5a5a515de881cf9634631aefc464e81129dd30bca9781478204a83L42-R43): Added import for `RangeSpec` from `langflow.field_typing.range_spec` to accommodate changes in the `SliderInput` component.