### PR TITLE
fix: tool name in component toolkit if the name of the component is None

### DIFF
--- a/src/backend/base/langflow/base/tools/component_tool.py
+++ b/src/backend/base/langflow/base/tools/component_tool.py
@@ -221,7 +221,7 @@ class ComponentToolkit:
             else:
                 args_schema = create_input_schema(self.component.inputs)
 
-            name = f"{self.component.name or self.component.display_name or ''}.{output.method}".strip(".")
+            name = f"{self.component.name or self.component.__class__.__name__ or ''}.{output.method}".strip(".")
             formatted_name = _format_tool_name(name)
             event_manager = self.component._event_manager
             if asyncio.iscoroutinefunction(output_method):

--- a/src/backend/base/langflow/base/tools/component_tool.py
+++ b/src/backend/base/langflow/base/tools/component_tool.py
@@ -221,7 +221,7 @@ class ComponentToolkit:
             else:
                 args_schema = create_input_schema(self.component.inputs)
 
-            name = f"{self.component.name or self.component.display_name or ''}.{output.method}".strip('.')
+            name = f"{self.component.name or self.component.display_name or ''}.{output.method}".strip(".")
             formatted_name = _format_tool_name(name)
             event_manager = self.component._event_manager
             if asyncio.iscoroutinefunction(output_method):

--- a/src/backend/base/langflow/base/tools/component_tool.py
+++ b/src/backend/base/langflow/base/tools/component_tool.py
@@ -220,7 +220,8 @@ class ComponentToolkit:
                 args_schema = create_input_schema(tool_mode_inputs)
             else:
                 args_schema = create_input_schema(self.component.inputs)
-            name = f"{self.component.name}.{output.method}"
+
+            name = f"{self.component.name or self.component.display_name or ''}.{output.method}".strip('.')
             formatted_name = _format_tool_name(name)
             event_manager = self.component._event_manager
             if asyncio.iscoroutinefunction(output_method):


### PR DESCRIPTION
This pull request includes a change to the `get_tools` method in the `src/backend/base/langflow/base/tools/component_tool.py` file. The change ensures that a component's name is properly formatted by using either `component.name` or `component.display_name` if available, and then stripping any trailing period.

* [`src/backend/base/langflow/base/tools/component_tool.py`](diffhunk://#diff-e6b607a8c5e404d2d308314cf694b33701ebcd21f8d564b6932c522d3a5e02cbL213-R214): Updated the `name` variable assignment to use `component.name` or `component.display_name` and strip any trailing period.


This was noted as bug. Leading to cause None in Tool name