### PR TITLE
fix: adjust GenericNode width to fit component wrapper

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -19,7 +19,7 @@ body {
 }
 
 .react-flow__node {
-  width: auto;
+  width: fit-content !important;
   height: auto;
   border-radius: auto;
   min-width: inherit;

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -358,14 +358,6 @@ function GenericNode({
     );
   }, [data, types, isToolMode, showNode, shownOutputs, showHiddenOutputs]);
 
-  useEffect(() => {
-    // Find and update ReactFlow node element to fit the component wrapper
-    const reactFlowNode = document.querySelector(`[data-id="${data.id}"]`);
-    if (reactFlowNode) {
-      (reactFlowNode as HTMLElement).style.width = "fit-content";
-    }
-  }, [data.id]);
-
   return (
     <div className={cn(isOutdated && !isUserEdited ? "relative -mt-10" : "")}>
       <div

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -358,6 +358,14 @@ function GenericNode({
     );
   }, [data, types, isToolMode, showNode, shownOutputs, showHiddenOutputs]);
 
+  useEffect(() => {
+    // Find and update ReactFlow node element to fit the component wrapper
+    const reactFlowNode = document.querySelector(`[data-id="${data.id}"]`);
+    if (reactFlowNode) {
+      (reactFlowNode as HTMLElement).style.width = "fit-content";
+    }
+  }, [data.id]);
+
   return (
     <div className={cn(isOutdated && !isUserEdited ? "relative -mt-10" : "")}>
       <div


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/src/App.css` file. The change modifies the width property of `.react-flow__node` to use `fit-content` with an `!important` flag, ensuring that the width fits the content within the node.

* [`src/frontend/src/App.css`](diffhunk://#diff-3e7904848c381eb53375a14db869438235df15b6e439845f23d09b12382c0d47L22-R22): Changed the `.react-flow__node` width property from `auto` to `fit-content !important`.