### PR TITLE
ci: adds verbosity to the backend unit tests output

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           timeout_minutes: 12
           max_attempts: 2
-          command: make unit_tests async=false args="-x --splits ${{ matrix.splitCount }} --group ${{ matrix.group }}"
+          command: make unit_tests async=false args="-x -vv --splits ${{ matrix.splitCount }} --group ${{ matrix.group }}"
       - name: Minimize uv cache
         run: uv cache prune --ci
   integration-tests:


### PR DESCRIPTION
This PR increases the verbosity of the backend unit tests output by adding the -vv parameter. This change provides more detailed information during test execution, making it easier to debug and analyze test results.