### PR TITLE
feat(groq): add missing llama-3.3 models

### DIFF
--- a/src/backend/base/langflow/base/models/groq_constants.py
+++ b/src/backend/base/langflow/base/models/groq_constants.py
@@ -10,6 +10,8 @@ GROQ_MODELS = [
     "llama-3.2-3b-preview",  # Meta
     "llama-3.2-11b-vision-preview",  # Meta
     "llama-3.2-90b-vision-preview",  # Meta
+    "llama-3.3-70b-versatile",  # Meta
+    "llama-3.3-70b-specdec",  # Meta
     "llama-guard-3-8b",  # Meta
     "llama3-70b-8192",  # Meta
     "llama3-8b-8192",  # Meta


### PR DESCRIPTION
This pull request updates the GROQ_MODELS list to include the latest Meta Llama 3.3 models:
- Added llama-3.3-70b-versatile (Production model)
- Added llama-3.3-70b-specdec (Preview model)