### PR TITLE
fix: restore template tags and correct names (nightly fix)

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -3161,8 +3161,15 @@
   },
   "description": " Create engaging Instagram posts with AI-generated content and image prompts, streamlining social media content creation.",
   "endpoint_name": null,
-  "id": "b20d6b1d-ecf0-4fea-bc75-73067dfb272f",
+  "gradient": "0",
+  "icon": "InstagramIcon",
+  "id": "4bb309e6-42b4-4565-b960-8bd0f7e431f2",
   "is_component": false,
-  "last_tested_version": "1.1.1",
-  "name": "Instagram Copywriter (1)"
+  "last_tested_version": "1.0.19.post2",
+  "name": "Instagram Copywriter",
+  "tags": [
+    "content-generation",
+    "chatbots",
+    "agents"
+  ]
 }

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -2553,8 +2553,14 @@
   },
   "description": "Researches companies, extracts key business data, and presents structured information for efficient analysis. ",
   "endpoint_name": null,
-  "id": "2b5680e5-a393-42d1-9e5e-1602c95a6468",
+  "gradient": "1",
+  "icon": "PieChart",
+  "id": "153a05e5-86bd-4de8-b159-2cb4f9f94de5",
   "is_component": false,
-  "last_tested_version": "1.1.1",
-  "name": "Market Research"
+  "last_tested_version": "1.0.19.post2",
+  "name": "Market Research",
+  "tags": [
+    "assistants",
+    "agents"
+  ]
 }

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -2557,7 +2557,7 @@
   "icon": "PieChart",
   "id": "153a05e5-86bd-4de8-b159-2cb4f9f94de5",
   "is_component": false,
-  "last_tested_version": "1.0.19.post2",
+  "last_tested_version": "1.1.1",
   "name": "Market Research",
   "tags": [
     "assistants",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -1436,7 +1436,7 @@
   "icon": "calculator",
   "id": "9357f72e-2121-4541-8e7d-74b7ba2ada2b",
   "is_component": false,
-  "last_tested_version": "1.0.19.post2",
+  "last_tested_version": "1.1.1",
   "name": "SaaS Pricing",
   "tags": [
     "agents",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -1752,7 +1752,7 @@
   "endpoint_name": null,
   "id": "263070d6-3560-4f4d-a6c4-003f4a586e6e",
   "is_component": false,
-  "last_tested_version": "1.1.0",
+  "last_tested_version": "1.1.1",
   "name": "Simple Agent",
   "tags": [
     "assistants",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -3193,15 +3193,17 @@
                 "dynamic": false,
                 "info": "Name of the new collection to create.",
                 "list": false,
+                "list_add_label": "Add More",
                 "load_from_db": false,
                 "name": "collection_name_new",
                 "placeholder": "",
                 "required": true,
                 "show": true,
                 "title_case": false,
+                "tool_mode": false,
                 "trace_as_metadata": true,
                 "type": "str",
-                "value": "vector_store_rag_demo"
+                "value": ""
               },
               "content_field": {
                 "_input_type": "StrInput",
@@ -3624,15 +3626,17 @@
                 "dynamic": false,
                 "info": "Name of the new collection to create.",
                 "list": false,
+                "list_add_label": "Add More",
                 "load_from_db": false,
                 "name": "collection_name_new",
                 "placeholder": "",
                 "required": true,
                 "show": true,
                 "title_case": false,
+                "tool_mode": false,
                 "trace_as_metadata": true,
                 "type": "str",
-                "value": "vector_store_rag_demo"
+                "value": ""
               },
               "content_field": {
                 "_input_type": "StrInput",


### PR DESCRIPTION
This pull request includes updates to several starter project JSON files in the `src/backend/base/langflow/initial_setup/starter_projects` directory. The changes primarily involve updating metadata and adding new fields to improve the configuration of these projects.

Metadata updates:

* [`src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json`](diffhunk://#diff-5d6ded6e79298fe0d8d3e046b0fa85a89fec1f78154eb80b39acc5bdd1bb42baL3164-R3174): Updated the `id`, `last_tested_version`, `name`, and added `gradient`, `icon`, and `tags` fields.
* [`src/backend/base/langflow/initial_setup/starter_projects/Market Research.json`](diffhunk://#diff-633ea36314515f61aad893da1d70ebba0cecf77783d084343b43ca94c0e1849aL2556-R2565): Updated the `id`, `last_tested_version`, `name`, and added `gradient`, `icon`, and `tags` fields.

Configuration improvements:

* [`src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json`](diffhunk://#diff-10837b87e2da91a231aa3ec84c3b6317cd239066c0c8979d2ce127f6408cf67dR3196-R3206): Added `list_add_label` and `tool_mode` fields to the `collection_name_new` configuration. [[1]](diffhunk://#diff-10837b87e2da91a231aa3ec84c3b6317cd239066c0c8979d2ce127f6408cf67dR3196-R3206) [[2]](diffhunk://#diff-10837b87e2da91a231aa3ec84c3b6317cd239066c0c8979d2ce127f6408cf67dR3629-R3639)