### PR TITLE
Fix: Issue with the timestamp in the message table on PostgreSQL

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -105,7 +105,6 @@ class DatabaseService(Service):
         url = self.settings_service.settings.database_url
         if not url:
             return {}
-
         connect_args = {}
         if url.startswith("postgresql://"):
             connect_args = {"options": "-c timezone=UTC"}

--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -102,15 +102,18 @@ class DatabaseService(Service):
         )
 
     def _get_connect_args(self):
-        if self.settings_service.settings.database_url and self.settings_service.settings.database_url.startswith(
-            "sqlite"
-        ):
+        url = self.settings_service.settings.database_url
+        if not url:
+            return {}
+
+        connect_args = {}
+        if url.startswith("postgresql://"):
+            connect_args = {"options": "-c timezone=UTC"}
+        elif url.startswith("sqlite://"):
             connect_args = {
                 "check_same_thread": False,
                 "timeout": self.settings_service.settings.db_connect_timeout,
             }
-        else:
-            connect_args = {}
         return connect_args
 
     def on_connection(self, dbapi_connection, _connection_record) -> None:


### PR DESCRIPTION
The issue:
The application uses timestamps with the UTC timezone. When saving data to the database, the timestamp is converted to the timezone of the environment where the application is running. However, there is no reverse correction when reading data from the database.

As a result, during each read-write cycle, the time shifts by the difference between UTC and the current timezone.

For example:
If the application is in a +3 timezone and we save a message with a timestamp of 12:00:00, the database stores 15:00:00. If the message is updated and saved again, the time becomes 18:00:00, and so on.

This issue occurs due to the behavior of psycopg and the application enforcing the UTC timezone with |replace(tzinfo=timezone.utc).

The problem can be resolved by specifying that the database operates in UTC in the database connection string.