### PR TITLE
fix: update datetime serialization to include timezone information

### DIFF
--- a/src/backend/base/langflow/schema/data.py
+++ b/src/backend/base/langflow/schema/data.py
@@ -230,8 +230,8 @@ class Data(BaseModel):
 
 def custom_serializer(obj):
     if isinstance(obj, datetime):
-        date = obj.replace(tzinfo=timezone.utc)
-        return date.strftime("%Y-%m-%d %H:%M:%S %Z")
+        utc_date = obj.replace(tzinfo=timezone.utc)
+        return utc_date.strftime("%Y-%m-%d %H:%M:%S %Z")
     if isinstance(obj, Decimal):
         return float(obj)
     if isinstance(obj, UUID):

--- a/src/backend/base/langflow/schema/data.py
+++ b/src/backend/base/langflow/schema/data.py
@@ -1,6 +1,6 @@
 import copy
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import cast
 from uuid import UUID
@@ -230,7 +230,8 @@ class Data(BaseModel):
 
 def custom_serializer(obj):
     if isinstance(obj, datetime):
-        return obj.astimezone().isoformat()
+        date = obj.replace(tzinfo=timezone.utc)
+        return date.strftime("%Y-%m-%d %H:%M:%S %Z")
     if isinstance(obj, Decimal):
         return float(obj)
     if isinstance(obj, UUID):


### PR DESCRIPTION
This pull request enhances the datetime serialization process by ensuring that timezone information is included. The custom serializer now converts datetime objects to UTC before formatting them, providing a more accurate representation of date and time.