### PR TITLE
feat: use all available time zone names in CurrentDateComponent

### DIFF
--- a/src/backend/base/langflow/components/helpers/current_date.py
+++ b/src/backend/base/langflow/components/helpers/current_date.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, available_timezones
 
 from loguru import logger
 
@@ -18,41 +18,7 @@ class CurrentDateComponent(Component):
         DropdownInput(
             name="timezone",
             display_name="Timezone",
-            options=[
-                "UTC",
-                "US/Eastern",
-                "US/Central",
-                "US/Mountain",
-                "US/Pacific",
-                "Europe/London",
-                "Europe/Paris",
-                "Europe/Berlin",
-                "Europe/Moscow",
-                "Asia/Tokyo",
-                "Asia/Shanghai",
-                "Asia/Singapore",
-                "Asia/Dubai",
-                "Australia/Sydney",
-                "Australia/Melbourne",
-                "Pacific/Auckland",
-                "America/Sao_Paulo",
-                "America/Mexico_City",
-                "America/Toronto",
-                "America/Vancouver",
-                "Africa/Cairo",
-                "Africa/Johannesburg",
-                "Atlantic/Reykjavik",
-                "Indian/Maldives",
-                "America/Bogota",
-                "America/Lima",
-                "America/Santiago",
-                "America/Buenos_Aires",
-                "America/Caracas",
-                "America/La_Paz",
-                "America/Montevideo",
-                "America/Asuncion",
-                "America/Cuiaba",
-            ],
+            options=list(available_timezones()),
             value="UTC",
             info="Select the timezone for the current date and time.",
             tool_mode=True,


### PR DESCRIPTION
This component is used as a default tool in the agent component. Since the agent was able to select the time zone it desired, if you asked about a location that wasn't in this list the agent would error out.

Python includes access to the tzdb database through zoneinfo and that has a full list of available zones.