### PR TITLE
fix: change telemetry logging level from exception to error

### DIFF
--- a/src/backend/base/langflow/services/telemetry/service.py
+++ b/src/backend/base/langflow/services/telemetry/service.py
@@ -52,7 +52,7 @@ class TelemetryService(Service):
             try:
                 await func(payload, path)
             except Exception:  # noqa: BLE001
-                logger.exception("Error sending telemetry data")
+                logger.error("Error sending telemetry data")
             finally:
                 self.telemetry_queue.task_done()
 


### PR DESCRIPTION
Logging this as exception causes a huge error message when running Langflow offline.