### PR TITLE
fix: Add optional chaining for getSelectedRows in TableComponent

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
@@ -223,7 +223,7 @@ const TableComponent = forwardRef<
           <TableOptions
             tableOptions={props.tableOptions}
             stateChange={columnStateChange}
-            hasSelection={realRef.current?.api?.getSelectedRows().length > 0}
+            hasSelection={realRef.current?.api?.getSelectedRows()?.length > 0}
             duplicateRow={props.onDuplicate ? props.onDuplicate : undefined}
             deleteRow={props.onDelete ? props.onDelete : undefined}
             addRow={props.addRow ? props.addRow : undefined}


### PR DESCRIPTION
This pull request includes a small change to the `TableComponent` in the `src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx` file. The change ensures that the `getSelectedRows` method is safely accessed using optional chaining.

* [`src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx`](diffhunk://#diff-f3fcb59cd5fd40bf313028ede0595abb9ebe326e02946ecaece08678d8ea212fL226-R226): Modified the `hasSelection` prop to use optional chaining for the `getSelectedRows` method.

#5447