### PR TITLE
tests: Remove unnecessary benchmark markers from server init tests

### DIFF
--- a/src/backend/tests/performance/test_server_init.py
+++ b/src/backend/tests/performance/test_server_init.py
@@ -23,7 +23,6 @@ def setup_database_url(tmp_path, monkeypatch):
         monkeypatch.delenv("LANGFLOW_DATABASE_URL", raising=False)
 
 
-@pytest.mark.benchmark
 async def test_initialize_services():
     """Benchmark the initialization of services."""
     from langflow.services.utils import initialize_services
@@ -33,7 +32,6 @@ async def test_initialize_services():
     assert "test_performance.db" in settings_service.settings.database_url
 
 
-@pytest.mark.benchmark
 def test_setup_llm_caching():
     """Benchmark LLM caching setup."""
     from langflow.interface.utils import setup_llm_caching
@@ -43,7 +41,6 @@ def test_setup_llm_caching():
     assert "test_performance.db" in settings_service.settings.database_url
 
 
-@pytest.mark.benchmark
 async def test_initialize_super_user():
     """Benchmark super user initialization."""
     from langflow.initial_setup.setup import initialize_super_user_if_needed
@@ -55,7 +52,6 @@ async def test_initialize_super_user():
     assert "test_performance.db" in settings_service.settings.database_url
 
 
-@pytest.mark.benchmark
 async def test_get_and_cache_all_types_dict():
     """Benchmark get_and_cache_all_types_dict function."""
     from langflow.interface.components import get_and_cache_all_types_dict
@@ -66,7 +62,6 @@ async def test_get_and_cache_all_types_dict():
     assert "test_performance.db" in settings_service.settings.database_url
 
 
-@pytest.mark.benchmark
 async def test_create_starter_projects():
     """Benchmark creation of starter projects."""
     from langflow.initial_setup.setup import create_or_update_starter_projects
@@ -80,7 +75,6 @@ async def test_create_starter_projects():
     assert "test_performance.db" in settings_service.settings.database_url
 
 
-@pytest.mark.benchmark
 async def test_load_flows():
     """Benchmark loading flows from directory."""
     from langflow.initial_setup.setup import load_flows_from_directory


### PR DESCRIPTION
This pull request removes redundant `@pytest.mark.benchmark` decorators from several performance test functions in `test_server_init.py`. This streamlines the test suite while ensuring that the integrity of the tests is maintained. The changes enhance readability and maintainability of the test code.