### PR TITLE
refactor: Remove "commands" field from TOOL_TABLE_SCHEMA

### DIFF
--- a/src/backend/base/langflow/base/tools/constants.py
+++ b/src/backend/base/langflow/base/tools/constants.py
@@ -32,19 +32,6 @@ TOOL_TABLE_SCHEMA = [
         "filterable": False,
         "edit_mode": EditMode.INLINE,
     },
-    {
-        "name": "commands",
-        "display_name": "Commands",
-        "type": "str",
-        "description": (
-            "Add commands to the tool. These commands will be used to run the tool. Start all commands with a `/`. "
-            "You can add multiple commands separated by a comma.\n"
-            "Example: `/command1`, `/command2`, `/command3`"
-        ),
-        "sortable": False,
-        "filterable": False,
-        "edit_mode": EditMode.INLINE,
-    },
 ]
 
 TOOLS_METADATA_INFO = "Modify tool names and descriptions to help agents understand when to use each tool."


### PR DESCRIPTION
This pull request removes the "commands" field from the TOOL_TABLE_SCHEMA. The "commands" field was previously used to add commands to the tool, but it is no longer needed. This change simplifies the TOOL_TABLE_SCHEMA and improves the overall code structure.