### PR TITLE
fix: update YouTube icon name in sidebar bundles

### DIFF
--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -535,7 +535,7 @@ export const SIDEBAR_BUNDLES = [
   { display_name: "Git", name: "git", icon: "GitLoader" },
   { display_name: "Confluence", name: "confluence", icon: "Confluence" },
   { display_name: "Mem0", name: "mem0", icon: "Mem0" },
-  { display_name: "Youtube", name: "youtube", icon: "Youtube" },
+  { display_name: "Youtube", name: "youtube", icon: "YouTube" },
 ];
 
 export const categoryIcons = {


### PR DESCRIPTION
Correct capitalization of YouTube icon name in sidebar bundles