### PR TITLE
test: Update test selectors in frontend regression tests (nightly fix)

### DIFF
--- a/src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts
+++ b/src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts
@@ -95,7 +95,7 @@ AI:
 
     //connection 1
     const elementChatMemoryOutput = await page
-      .getByTestId("handle-memory-shownode-text-right")
+      .getByTestId("handle-memory-shownode-message-right")
       .first();
     await elementChatMemoryOutput.hover();
     await page.mouse.down();

--- a/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
@@ -109,7 +109,7 @@ test(
     await page.mouse.up();
 
     const elementsOpenAiOutput = await page
-      .locator('[data-testid="handle-openaimodel-shownode-text-right"]')
+      .locator('[data-testid="handle-openaimodel-shownode-message-right"]')
       .all();
 
     for (const element of elementsOpenAiOutput) {


### PR DESCRIPTION
This pull request includes changes to update test selectors in the frontend regression tests to ensure consistency and accuracy. The most important changes are as follows:

Test selector updates:

* [`src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts`](diffhunk://#diff-f52c0e7362d42e8988c86f3f0b14db1e98d9d096e879e7677b5d134c0fd22b8dL98-R98): Changed the test selector from `handle-memory-shownode-text-right` to `handle-memory-shownode-message-right` to match the updated element identifier.
* [`src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts`](diffhunk://#diff-c61d7345b8378427eeb622d524db04463e36b6e63e156b6f2e6d30b0b76ab473L112-R112): Updated the test selector from `handle-openaimodel-shownode-text-right` to `handle-openaimodel-shownode-message-right` to reflect the correct element identifier.