### PR TITLE
fix: make sure tests run async 

### DIFF
--- a/src/backend/tests/base.py
+++ b/src/backend/tests/base.py
@@ -66,6 +66,8 @@ class ComponentTestBase:
         """Test that the component works with the latest version."""
         component_instance = await self.component_setup(component_class, default_kwargs)
         result = component_instance()
+        if inspect.iscoroutinefunction(result):
+            result = await result
         assert result is not None, "Component returned None for the latest version."
 
     def test_all_versions_have_a_file_name_defined(self, file_names_mapping: list[VersionComponentMapping]) -> None:

--- a/src/backend/tests/base.py
+++ b/src/backend/tests/base.py
@@ -59,15 +59,14 @@ class ComponentTestBase:
         mock_vertex.graph.flow_id = str(uuid4())
         source_code = await asyncio.to_thread(inspect.getsource, component_class)
         component_instance = component_class(_code=source_code, **default_kwargs)
+        component_instance._should_process_output = Mock(return_value=False)
         component_instance._vertex = mock_vertex
         return component_instance
 
     async def test_latest_version(self, component_class: type[Any], default_kwargs: dict[str, Any]) -> None:
         """Test that the component works with the latest version."""
         component_instance = await self.component_setup(component_class, default_kwargs)
-        result = component_instance()
-        if inspect.iscoroutinefunction(result):
-            result = await result
+        result = await component_instance.run()
         assert result is not None, "Component returned None for the latest version."
 
     def test_all_versions_have_a_file_name_defined(self, file_names_mapping: list[VersionComponentMapping]) -> None:

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 from typing import Any
 
@@ -65,7 +66,7 @@ async def test_update_component_model_name_options(client: AsyncClient, logged_i
     # load the code from the file at langflow.components.agents.agent.py asynchronously
     # we are at str/backend/tests/unit/api/v1/test_endpoints.py
     # find the file by using the class AgentComponent
-    agent_component_file = inspect.getsourcefile(AgentComponent)
+    agent_component_file = await asyncio.to_thread(inspect.getsourcefile, AgentComponent)
     async with async_open(agent_component_file, encoding="utf-8") as f:
         code = await f.read()
 
@@ -87,12 +88,12 @@ async def test_update_component_model_name_options(client: AsyncClient, logged_i
     assert "template" in result
     assert "model_name" in result["template"]
     assert isinstance(result["template"]["model_name"]["options"], list)
-    assert len(result["template"]["model_name"]["options"]) > 0, (
-        f"Model names: {result['template']['model_name']['options']}"
-    )
-    assert current_model_names != result["template"]["model_name"]["options"], (
-        f"Current model names: {current_model_names}, New model names: {result['template']['model_name']['options']}"
-    )
+    assert (
+        len(result["template"]["model_name"]["options"]) > 0
+    ), f"Model names: {result['template']['model_name']['options']}"
+    assert (
+        current_model_names != result["template"]["model_name"]["options"]
+    ), f"Current model names: {current_model_names}, New model names: {result['template']['model_name']['options']}"
     # Now test with Custom provider
     template["agent_llm"]["value"] = "Custom"
     request.field_value = "Custom"

--- a/src/backend/tests/unit/test_messages.py
+++ b/src/backend/tests/unit/test_messages.py
@@ -12,7 +12,6 @@ from langflow.memory import (
     aupdate_messages,
     delete_messages,
     get_messages,
-    store_message,
 )
 from langflow.schema.content_block import ContentBlock
 from langflow.schema.content_types import TextContent, ToolContent
@@ -125,11 +124,11 @@ async def test_adelete_messages():
 
 
 @pytest.mark.usefixtures("client")
-def test_store_message():
+async def test_store_message():
     session_id = "stored_session_id"
     message = Message(text="Stored message", sender="User", sender_name="User", session_id=session_id)
-    store_message(message)
-    stored_messages = get_messages(sender="User", session_id=session_id)
+    await astore_message(message)
+    stored_messages = await aget_messages(sender="User", session_id=session_id)
     assert len(stored_messages) == 1
     assert stored_messages[0].text == "Stored message"
 


### PR DESCRIPTION
This pull request updates the test suite to utilize asynchronous methods, enhancing reliability and performance. Key changes include modifying the `ComponentTestBase` to manage output processing during tests, updating various test methods to await asynchronous calls, and streamlining the structure for better clarity. These improvements ensure that tests handle message storage and retrieval correctly while maintaining a clean and efficient codebase.