### PR TITLE
fix: Improve TracingService initialization logic around `deactivated`

### DIFF
--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -77,7 +77,7 @@ class TracingService(Service):
                 self.logs_queue.task_done()
 
     async def start(self) -> None:
-        if self.running or self.deactivated:
+        if self.running:
             return
         try:
             self.running = True
@@ -112,8 +112,11 @@ class TracingService(Service):
         self.outputs_metadata = defaultdict(dict)
 
     async def initialize_tracers(self) -> None:
+        if self.deactivated:
+            return
         try:
             await self.start()
+
             self._initialize_langsmith_tracer()
             self._initialize_langwatch_tracer()
             self._initialize_langfuse_tracer()

--- a/src/backend/tests/unit/components/agents/test_agent_component.py
+++ b/src/backend/tests/unit/components/agents/test_agent_component.py
@@ -78,9 +78,9 @@ class TestAgentComponent(ComponentTestBaseWithoutClient):
         assert all(provider in updated_config["agent_llm"]["options"] for provider in MODEL_PROVIDERS_DICT)
         assert "Anthropic" in updated_config["agent_llm"]["options"]
         assert updated_config["agent_llm"]["input_types"] == []
-        assert any(
-            "sonnet" in option.lower() for option in updated_config["model_name"]["options"]
-        ), f"Options: {updated_config['model_name']['options']}"
+        assert any("sonnet" in option.lower() for option in updated_config["model_name"]["options"]), (
+            f"Options: {updated_config['model_name']['options']}"
+        )
 
         # Test updating build config for Custom
         updated_config = await component.update_build_config(build_config, "Custom", "agent_llm")


### PR DESCRIPTION
This pull request enhances the initialization logic of the TracingService by modifying the `start` method to allow the service to start even when deactivated. Additionally, it introduces an early return in the `initialize_tracers` method if the service is deactivated, which prevents unnecessary initialization calls. These changes streamline the service's startup process and ensure that the deactivated state is respected during tracer initialization.