### PR TITLE
ci: Automatically close existing PRs for test duration updates

### DIFF
--- a/.github/workflows/store_pytest_durations.yml
+++ b/.github/workflows/store_pytest_durations.yml
@@ -49,6 +49,28 @@ jobs:
       - name: Minimize uv cache
         run: uv cache prune --ci
 
+      - name: Close existing PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+
+            for (const pull of pulls) {
+              if (pull.title === "chore: update test durations") {
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pull.number,
+                  state: 'closed'
+                });
+              }
+            }
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
This pull request introduces a new step in the GitHub Actions workflow that automatically closes any open pull requests titled "chore: update test durations" before creating a new one. This enhancement ensures that only one pull request for updating test durations is active at a time, streamlining the workflow and minimizing potential merge conflicts.