### PR TITLE
docs: Fix incorrect article form in French text Update README.FR.md

### DIFF
--- a/README.FR.md
+++ b/README.FR.md
@@ -1,5 +1,5 @@
 > [!WARNING]
-> Tout les liens externes sont susceptibles d'être en anglais.
+> Tous les liens externes sont susceptibles d'être en anglais.
 
 ![Langflow](./docs/static/img/hero.png)
 


### PR DESCRIPTION
I noticed that the word "Tout" was used incorrectly in the text. It should be "Tous" since "liens" is plural, and the article needs to match the plural form. 