### PR TITLE
fix: add the git binary to the final step of the container images

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -69,6 +69,7 @@ FROM python:3.12.3-slim AS runtime
 
 RUN apt-get update \
     && apt-get upgrade -y \
+    && apt-get install git -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -73,6 +73,7 @@ FROM python:3.12.3-slim AS runtime
 
 RUN apt-get update \
     && apt-get upgrade -y \
+    && apt-get install git -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -68,7 +68,7 @@ FROM python:3.12.3-slim AS runtime
 
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y curl \
+    && apt-get install -y curl git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data \

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     build-essential \
     curl \
     npm \
+    git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
We were having issues with the `GitLoader` component, throwing following error:

```
Could not import git python package. Please install it with `pip install GitPython`.
```

Looking into this, it was due to the missing Git binary.

I noticed that the git binary was added in https://github.com/langflow-ai/langflow/pull/5040, but only in the builder step, not in the runtime step.

This PR adds the binary in the runtime step so it can be used by e.g. the `GitLoader` component