### PR TITLE
fix: make sure graph build errors bubble up to the frontend

### DIFF
--- a/src/backend/base/langflow/schema/properties.py
+++ b/src/backend/base/langflow/schema/properties.py
@@ -28,6 +28,8 @@ class Properties(BaseModel):
     def validate_source(cls, v):
         if isinstance(v, str):
             return Source(id=v, display_name=v, source=v)
+        if v is None:
+            return Source()
         return v
 
     @field_serializer("source")


### PR DESCRIPTION
This pull request adds handling for None values in the `validate_source` method, ensuring it returns a default `Source` instance when no value is provided. Additionally, the `build_flow` function has been refactored to enhance session handling and error logging, improving overall reliability and maintainability of the code.