### PR TITLE
feat: adds Wikipedia Component and deprecates the wikipedia API tool component

### DIFF
--- a/src/backend/base/langflow/components/tools/__init__.py
+++ b/src/backend/base/langflow/components/tools/__init__.py
@@ -25,6 +25,7 @@ from .serp_api import SerpAPIComponent
 from .tavily import TavilySearchComponent
 from .tavily_search import TavilySearchToolComponent
 from .wikidata_api import WikidataAPIComponent
+from .wikipedia import WikipediaComponent
 from .wikipedia_api import WikipediaAPIComponent
 from .wolfram_alpha_api import WolframAlphaAPIComponent
 from .yahoo import YfinanceComponent
@@ -62,6 +63,7 @@ __all__ = [
     "TavilySearchToolComponent",
     "WikidataAPIComponent",
     "WikipediaAPIComponent",
+    "WikipediaComponent",
     "WolframAlphaAPIComponent",
     "YfinanceComponent",
     "YfinanceToolComponent",

--- a/src/backend/base/langflow/components/tools/wikipedia.py
+++ b/src/backend/base/langflow/components/tools/wikipedia.py
@@ -10,7 +10,6 @@ from langflow.schema.message import Message
 class WikipediaComponent(Component):
     display_name = "Wikipedia"
     description = "Call Wikipedia API."
-    name = "Wikipedia"
     icon = "Wikipedia"
 
     inputs = [

--- a/src/backend/base/langflow/components/tools/wikipedia.py
+++ b/src/backend/base/langflow/components/tools/wikipedia.py
@@ -1,25 +1,23 @@
-from typing import cast
-
-from langchain_community.tools import WikipediaQueryRun
 from langchain_community.utilities.wikipedia import WikipediaAPIWrapper
 
-from langflow.base.langchain_utilities.model import LCToolComponent
-from langflow.field_typing import Tool
+from langflow.custom import Component
 from langflow.inputs import BoolInput, IntInput, MessageTextInput, MultilineInput
+from langflow.io import Output
 from langflow.schema import Data
+from langflow.schema.message import Message
 
 
-class WikipediaAPIComponent(LCToolComponent):
-    display_name = "Wikipedia API [Deprecated]"
+class WikipediaComponent(Component):
+    display_name = "Wikipedia"
     description = "Call Wikipedia API."
-    name = "WikipediaAPI"
+    name = "Wikipedia"
     icon = "Wikipedia"
-    legacy=True
 
     inputs = [
         MultilineInput(
             name="input_value",
             display_name="Input",
+            tool_mode=True,
         ),
         MessageTextInput(name="lang", display_name="Language", value="en"),
         IntInput(name="k", display_name="Number of results", value=4, required=True),
@@ -29,16 +27,25 @@ class WikipediaAPIComponent(LCToolComponent):
         ),
     ]
 
-    def run_model(self) -> list[Data]:
+    outputs = [
+        Output(display_name="Data", name="data", method="fetch_content"),
+        Output(display_name="Text", name="text", method="fetch_content_text"),
+    ]
+
+    def fetch_content(self) -> list[Data]:
         wrapper = self._build_wrapper()
         docs = wrapper.load(self.input_value)
         data = [Data.from_document(doc) for doc in docs]
         self.status = data
         return data
 
-    def build_tool(self) -> Tool:
-        wrapper = self._build_wrapper()
-        return cast("Tool", WikipediaQueryRun(api_wrapper=wrapper))
+    def fetch_content_text(self) -> Message:
+        data = self.fetch_content()
+        result_string = ""
+        for item in data:
+            result_string += item.text + "\n"
+        self.status = result_string
+        return Message(text=result_string)
 
     def _build_wrapper(self) -> WikipediaAPIWrapper:
         return WikipediaAPIWrapper(

--- a/src/backend/base/langflow/components/tools/wikipedia_api.py
+++ b/src/backend/base/langflow/components/tools/wikipedia_api.py
@@ -14,7 +14,7 @@ class WikipediaAPIComponent(LCToolComponent):
     description = "Call Wikipedia API."
     name = "WikipediaAPI"
     icon = "Wikipedia"
-    legacy=True
+    legacy = True
 
     inputs = [
         MultilineInput(

--- a/src/backend/tests/unit/components/tools/test_wikipedia_api.py
+++ b/src/backend/tests/unit/components/tools/test_wikipedia_api.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from langflow.components.tools import WikipediaAPIComponent
+from langflow.components.tools import WikipediaComponent
 from langflow.custom import Component
 from langflow.custom.utils import build_custom_component_template
 from langflow.schema import Data
@@ -9,14 +9,14 @@ from langflow.schema.message import Message
 
 
 def test_wikipedia_initialization():
-    component = WikipediaAPIComponent()
+    component = WikipediaComponent()
     assert component.display_name == "Wikipedia API"
     assert component.description == "Call Wikipedia API."
     assert component.icon == "Wikipedia"
 
 
 def test_wikipedia_template():
-    wikipedia = WikipediaAPIComponent()
+    wikipedia = WikipediaComponent()
     component = Component(_code=wikipedia._code)
     frontend_node, _ = build_custom_component_template(component)
 
@@ -39,7 +39,7 @@ def mock_wikipedia_wrapper(mocker):
 
 
 def test_fetch_content(mock_wikipedia_wrapper):
-    component = WikipediaAPIComponent()
+    component = WikipediaComponent()
     component.input_value = "test query"
     component.k = 3
     component.lang = "en"
@@ -66,7 +66,7 @@ def test_fetch_content(mock_wikipedia_wrapper):
 
 
 def test_fetch_content_text():
-    component = WikipediaAPIComponent()
+    component = WikipediaComponent()
     component.fetch_content = MagicMock(return_value=[Data(text="First result"), Data(text="Second result")])
 
     result = component.fetch_content_text()
@@ -76,7 +76,7 @@ def test_fetch_content_text():
 
 
 def test_wikipedia_error_handling():
-    component = WikipediaAPIComponent()
+    component = WikipediaComponent()
 
     # Mock _build_wrapper to raise exception
     component._build_wrapper = MagicMock(side_effect=Exception("API Error"))

--- a/src/backend/tests/unit/components/tools/test_wikipedia_api.py
+++ b/src/backend/tests/unit/components/tools/test_wikipedia_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from langflow.components.tools import WikipediaComponent
@@ -7,79 +7,96 @@ from langflow.custom.utils import build_custom_component_template
 from langflow.schema import Data
 from langflow.schema.message import Message
 
-
-def test_wikipedia_initialization():
-    component = WikipediaComponent()
-    assert component.display_name == "Wikipedia"
-    assert component.description == "Call Wikipedia API."
-    assert component.icon == "Wikipedia"
+# Import the base test class
+from tests.base import ComponentTestBaseWithoutClient
 
 
-def test_wikipedia_template():
-    wikipedia = WikipediaComponent()
-    component = Component(_code=wikipedia._code)
-    frontend_node, _ = build_custom_component_template(component)
+class TestWikipediaComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        """Fixture to create a WikipediaComponent instance."""
+        return WikipediaComponent
 
-    # Verify basic structure
-    assert isinstance(frontend_node, dict)
+    @pytest.fixture
+    def default_kwargs(self):
+        """Return the default kwargs for the component."""
+        return {
+            "input_value": "test query",
+            "lang": "en",
+            "k": 3,
+        }
 
-    # Verify inputs
-    assert "template" in frontend_node
-    input_names = [input_["name"] for input_ in frontend_node["template"].values() if isinstance(input_, dict)]
-
-    expected_inputs = ["input_value", "lang", "k", "load_all_available_meta", "doc_content_chars_max"]
-
-    for input_name in expected_inputs:
-        assert input_name in input_names
-
-
-@pytest.fixture
-def mock_wikipedia_wrapper(mocker):
-    return mocker.patch("langchain_community.utilities.wikipedia.WikipediaAPIWrapper")
+    @pytest.fixture
+    def file_names_mapping(self):
+        """Return an empty list since this component doesn't have version-specific files."""
+        return []
 
 
-def test_fetch_content(mock_wikipedia_wrapper):
-    component = WikipediaComponent()
-    component.input_value = "test query"
-    component.k = 3
-    component.lang = "en"
+    def test_wikipedia_initialization(self, component_class):
+        component = component_class()
+        assert component.display_name == "Wikipedia"
+        assert component.description == "Call Wikipedia API."
+        assert component.icon == "Wikipedia"
 
-    # Mock the WikipediaAPIWrapper and its load method
-    mock_instance = MagicMock()
-    mock_wikipedia_wrapper.return_value = mock_instance
-    mock_doc = MagicMock()
-    mock_doc.page_content = "Test content"
-    mock_doc.metadata = {"source": "wikipedia", "title": "Test Page"}
-    mock_instance.load.return_value = [mock_doc]
+    def test_wikipedia_template(self, component_class):
+        component = component_class()
+        frontend_node, _ = build_custom_component_template(Component(_code=component._code))
 
-    # Mock the _build_wrapper method to return our mock instance
-    component._build_wrapper = MagicMock(return_value=mock_instance)
+        # Verify basic structure
+        assert isinstance(frontend_node, dict)
 
-    result = component.fetch_content()
+        # Verify inputs
+        assert "template" in frontend_node
+        input_names = [input_["name"] for input_ in frontend_node["template"].values() if isinstance(input_, dict)]
 
-    # Verify wrapper was built with correct params
-    component._build_wrapper.assert_called_once()
-    mock_instance.load.assert_called_once_with("test query")
-    assert isinstance(result, list)
-    assert len(result) == 1
-    assert result[0].text == "Test content"
+        expected_inputs = ["input_value", "lang", "k", "load_all_available_meta", "doc_content_chars_max"]
 
+        for input_name in expected_inputs:
+            assert input_name in input_names
 
-def test_fetch_content_text():
-    component = WikipediaComponent()
-    component.fetch_content = MagicMock(return_value=[Data(text="First result"), Data(text="Second result")])
+    @pytest.fixture
+    def mock_wikipedia_wrapper(self, mocker):
+        return mocker.patch("langchain_community.utilities.wikipedia.WikipediaAPIWrapper")
 
-    result = component.fetch_content_text()
+    def test_fetch_content(self, component_class, mock_wikipedia_wrapper):
+        component = component_class()
+        component.input_value = "test query"
+        component.k = 3
+        component.lang = "en"
 
-    assert isinstance(result, Message)
-    assert result.text == "First result\nSecond result\n"
+        # Mock the WikipediaAPIWrapper and its load method
+        mock_instance = MagicMock()
+        mock_wikipedia_wrapper.return_value = mock_instance
+        mock_doc = MagicMock()
+        mock_doc.page_content = "Test content"
+        mock_doc.metadata = {"source": "wikipedia", "title": "Test Page"}
+        mock_instance.load.return_value = [mock_doc]
 
+        # Mock the _build_wrapper method to return our mock instance
+        component._build_wrapper = MagicMock(return_value=mock_instance)
 
-def test_wikipedia_error_handling():
-    component = WikipediaComponent()
+        result = component.fetch_content()
 
-    # Mock _build_wrapper to raise exception
-    component._build_wrapper = MagicMock(side_effect=Exception("API Error"))
+        # Verify wrapper was built with correct params
+        component._build_wrapper.assert_called_once()
+        mock_instance.load.assert_called_once_with("test query")
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].text == "Test content"
 
-    with pytest.raises(Exception, match="API Error"):
-        component.fetch_content()
+    def test_fetch_content_text(self, component_class):
+        component = component_class()
+        component.fetch_content = MagicMock(return_value=[Data(text="First result"), Data(text="Second result")])
+
+        result = component.fetch_content_text()
+
+        assert isinstance(result, Message)
+        assert result.text == "First result\nSecond result\n"
+
+    def test_wikipedia_error_handling(self, component_class):
+        component = component_class()
+        # Mock _build_wrapper to raise exception
+        component._build_wrapper = MagicMock(side_effect=Exception("API Error"))
+
+        with pytest.raises(Exception, match="API Error"):
+            component.fetch_content()

--- a/src/backend/tests/unit/components/tools/test_wikipedia_api.py
+++ b/src/backend/tests/unit/components/tools/test_wikipedia_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from langflow.components.tools import WikipediaComponent
@@ -30,7 +30,6 @@ class TestWikipediaComponent(ComponentTestBaseWithoutClient):
     def file_names_mapping(self):
         """Return an empty list since this component doesn't have version-specific files."""
         return []
-
 
     def test_wikipedia_initialization(self, component_class):
         component = component_class()

--- a/src/backend/tests/unit/components/tools/test_wikipedia_api.py
+++ b/src/backend/tests/unit/components/tools/test_wikipedia_api.py
@@ -10,7 +10,7 @@ from langflow.schema.message import Message
 
 def test_wikipedia_initialization():
     component = WikipediaComponent()
-    assert component.display_name == "Wikipedia API"
+    assert component.display_name == "Wikipedia"
     assert component.description == "Call Wikipedia API."
     assert component.icon == "Wikipedia"
 


### PR DESCRIPTION
fixes depreciation in: https://github.com/langflow-ai/langflow/pull/5432

This pull request introduces a new `WikipediaComponent` and deprecates the existing `WikipediaAPIComponent`. The changes include adding the new component, updating the initialization and usage of the components, and modifying the test cases to reflect these updates.

New Component Addition:

* Added `WikipediaComponent` to `src/backend/base/langflow/components/tools/__init__.py` and included it in the list of components. [[1]](diffhunk://#diff-978762db35f605246f0bf595f91cfb0ff502fa74a15603d70ea3f6902f009175R28) [[2]](diffhunk://#diff-978762db35f605246f0bf595f91cfb0ff502fa74a15603d70ea3f6902f009175R66)
* Implemented `WikipediaComponent` in `src/backend/base/langflow/components/tools/wikipedia.py`, including methods for fetching content and text, and building the API wrapper.

Deprecation of Existing Component:

* Modified `WikipediaAPIComponent` in `src/backend/base/langflow/components/tools/wikipedia_api.py` to mark it as deprecated and updated its methods to align with the new component structure. [[1]](diffhunk://#diff-1796428da0345138390a38ea027289c228abad790392f4b5d4efdad8a3dfa89eR1-L20) [[2]](diffhunk://#diff-1796428da0345138390a38ea027289c228abad790392f4b5d4efdad8a3dfa89eL30-R41)

Test Case Updates:

* Updated test cases in `src/backend/tests/unit/components/tools/test_wikipedia_api.py` to use `WikipediaComponent` instead of `WikipediaAPIComponent`. [[1]](diffhunk://#diff-82b15b10e02b7c38359c8b7af80bcc1f7f7eb3f95baf07c68ba181a4a649a9c5L4-R19) [[2]](diffhunk://#diff-82b15b10e02b7c38359c8b7af80bcc1f7f7eb3f95baf07c68ba181a4a649a9c5L42-R42) [[3]](diffhunk://#diff-82b15b10e02b7c38359c8b7af80bcc1f7f7eb3f95baf07c68ba181a4a649a9c5L69-R69) [[4]](diffhunk://#diff-82b15b10e02b7c38359c8b7af80bcc1f7f7eb3f95baf07c68ba181a4a649a9c5L79-R79)