### PR TITLE
fix: make sure tool mode is not lost on component validation

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -667,6 +667,13 @@ async def custom_component(
     if raw_code.frontend_node is not None:
         built_frontend_node = await component_instance.update_frontend_node(built_frontend_node, raw_code.frontend_node)
 
+    tool_mode: bool = built_frontend_node.get("tool_mode", False)
+    if isinstance(component_instance, Component):
+        await component_instance.run_and_validate_update_outputs(
+            frontend_node=built_frontend_node,
+            field_name="tool_mode",
+            field_value=tool_mode,
+        )
     type_ = get_instance_name(component_instance)
     return CustomComponentResponse(data=built_frontend_node, type=type_)
 

--- a/src/backend/base/langflow/template/utils.py
+++ b/src/backend/base/langflow/template/utils.py
@@ -67,7 +67,7 @@ def update_frontend_node_with_template_values(frontend_node, raw_frontend_node):
     """Updates the given frontend node with values from the raw template data.
 
     :param frontend_node: A dict representing a built frontend node.
-    :param raw_template_data: A dict representing raw template data.
+    :param raw_frontend_node: A dict representing raw template data.
     :return: Updated frontend node.
     """
     if not is_valid_data(frontend_node, raw_frontend_node):
@@ -77,29 +77,22 @@ def update_frontend_node_with_template_values(frontend_node, raw_frontend_node):
 
     old_code = raw_frontend_node["template"]["code"]["value"]
     new_code = frontend_node["template"]["code"]["value"]
-    frontend_node["edited"] = raw_frontend_node["edited"] or (old_code != new_code)
-    frontend_node["tool_mode"] = raw_frontend_node.get("tool_mode", False)
+    frontend_node["edited"] = raw_frontend_node.get("edited", False) or (old_code != new_code)
 
-    if not any(extract_tool_modes(raw_frontend_node["template"])):
+    # Compute tool modes from template
+    tool_modes = [
+        value.get("tool_mode")
+        for key, value in raw_frontend_node["template"].items()
+        if key != "_type" and isinstance(value, dict)
+    ]
+
+    if any(tool_modes):
+        frontend_node["tool_mode"] = raw_frontend_node.get("tool_mode", False)
+    else:
         frontend_node["tool_mode"] = False
 
     if not frontend_node.get("edited", False):
-        frontend_node["display_name"] = raw_frontend_node["display_name"]
-        frontend_node["description"] = raw_frontend_node["description"]
+        frontend_node["display_name"] = raw_frontend_node.get("display_name", frontend_node.get("display_name", ""))
+        frontend_node["description"] = raw_frontend_node.get("description", frontend_node.get("description", ""))
 
     return frontend_node
-
-
-def extract_tool_modes(data: dict | list) -> list[bool | None]:
-    tool_models = []
-    if isinstance(data, dict):
-        for key, value in data.items():
-            if key == "tool_mode":
-                tool_models.append(value)
-            else:
-                tool_models.extend(extract_tool_modes(value))
-    elif isinstance(data, list):
-        for item in data:
-            tool_models.extend(extract_tool_modes(item))
-
-    return tool_models

--- a/src/backend/base/langflow/template/utils.py
+++ b/src/backend/base/langflow/template/utils.py
@@ -80,7 +80,7 @@ def update_frontend_node_with_template_values(frontend_node, raw_frontend_node):
     frontend_node["edited"] = raw_frontend_node["edited"] or (old_code != new_code)
     frontend_node["tool_mode"] = raw_frontend_node.get("tool_mode", False)
 
-    if any(extract_tool_modes(raw_frontend_node["template"])):
+    if not any(extract_tool_modes(raw_frontend_node["template"])):
         frontend_node["tool_mode"] = False
 
     if not frontend_node.get("edited", False):


### PR DESCRIPTION
This pull request addresses issues with the tool mode handling in the frontend node updates. It corrects the parameter name in the `update_frontend_node_with_template_values` function and enhances the logic to ensure that the tool mode is accurately retrieved and validated. Additionally, the conditions for setting the tool mode have been refined to improve its accuracy based on the template values provided. These changes collectively enhance the functionality and reliability of the custom component endpoint.