### PR TITLE
fix: Fix langchain tool calling agent component toolkit

### DIFF
--- a/src/backend/base/langflow/components/langchain_utilities/tool_calling.py
+++ b/src/backend/base/langflow/components/langchain_utilities/tool_calling.py
@@ -56,11 +56,10 @@ class ToolCallingAgentComponent(LCToolsAgentComponent):
         except NotImplementedError as e:
             message = f"{self.display_name} does not support tool calling. Please try using a compatible model."
             raise NotImplementedError(message) from e
+
     async def to_toolkit(self) -> list[Tool]:
         component_toolkit = _get_component_toolkit()
-        # TODO: Agent Description Depreciated Feature to be removed
-        tools = component_toolkit(component=self).get_tools(callbacks=self.get_langchain_callbacks()
-        )
+        tools = component_toolkit(component=self).get_tools(callbacks=self.get_langchain_callbacks())
         if hasattr(self, "tools_metadata"):
             tools = component_toolkit(component=self, metadata=self.tools_metadata).update_tools_metadata(tools=tools)
         return tools

--- a/src/backend/base/langflow/components/langchain_utilities/tool_calling.py
+++ b/src/backend/base/langflow/components/langchain_utilities/tool_calling.py
@@ -2,6 +2,8 @@ from langchain.agents import create_tool_calling_agent
 from langchain_core.prompts import ChatPromptTemplate
 
 from langflow.base.agents.agent import LCToolsAgentComponent
+from langflow.custom.custom_component.component import _get_component_toolkit
+from langflow.field_typing import Tool
 from langflow.inputs import MessageTextInput
 from langflow.inputs.inputs import DataInput, HandleInput
 from langflow.schema import Data
@@ -54,3 +56,11 @@ class ToolCallingAgentComponent(LCToolsAgentComponent):
         except NotImplementedError as e:
             message = f"{self.display_name} does not support tool calling. Please try using a compatible model."
             raise NotImplementedError(message) from e
+    async def to_toolkit(self) -> list[Tool]:
+        component_toolkit = _get_component_toolkit()
+        # TODO: Agent Description Depreciated Feature to be removed
+        tools = component_toolkit(component=self).get_tools(callbacks=self.get_langchain_callbacks()
+        )
+        if hasattr(self, "tools_metadata"):
+            tools = component_toolkit(component=self, metadata=self.tools_metadata).update_tools_metadata(tools=tools)
+        return tools

--- a/src/backend/tests/unit/mock_language_model.py
+++ b/src/backend/tests/unit/mock_language_model.py
@@ -1,8 +1,9 @@
 from unittest.mock import MagicMock
 
 from langchain_core.language_models import BaseLanguageModel
-from pydantic import BaseModel, Field
 from typing_extensions import override
+
+from pydantic import BaseModel, Field
 
 
 class MockLanguageModel(BaseLanguageModel, BaseModel):

--- a/src/backend/tests/unit/test_schema.py
+++ b/src/backend/tests/unit/test_schema.py
@@ -7,6 +7,7 @@ from langflow.schema.data import Data
 from langflow.template import Input, Output
 from langflow.template.field.base import UNDEFINED
 from langflow.type_extraction.type_extraction import post_process_type
+
 from pydantic import ValidationError
 
 


### PR DESCRIPTION
This pull request includes several changes to the `src/backend` directory, focusing on improving the functionality and organization of the `langflow` components and tests. The most important changes include adding a new method to convert components to toolkits, importing necessary modules, and reorganizing imports in test files.

Improvements to `langflow` components:

* [`src/backend/base/langflow/components/langchain_utilities/tool_calling.py`](diffhunk://#diff-f471df7dd024398b17f74cb674546607197d5286ca9afead2570b9a1d11f6e40R5-R6): Added imports for `_get_component_toolkit` and `Tool` to support the new `to_toolkit` method.
* [`src/backend/base/langflow/components/langchain_utilities/tool_calling.py`](diffhunk://#diff-f471df7dd024398b17f74cb674546607197d5286ca9afead2570b9a1d11f6e40R59-R65): Added the `to_toolkit` method to convert components to toolkits, allowing for metadata updates and tool retrieval.

Reorganization of imports in test files:

* [`src/backend/tests/unit/mock_language_model.py`](diffhunk://#diff-d787d779739c27e8faf20b188a502bab23c059f6bde36d792de4ca3fb3d7cdafL4-R7): Reorganized imports by moving `pydantic` imports to the correct location to improve code readability.
* [`src/backend/tests/unit/test_schema.py`](diffhunk://#diff-8a50c216442c34aa342fce856e8a7bea5631335145293184a5283bfa95aa4c11R10): Added a newline for better separation of imports, enhancing code readability.