### PR TITLE
fix: ensure string timestamps are converted to UTC in MessageTable model

### DIFF
--- a/src/backend/base/langflow/services/database/models/message/model.py
+++ b/src/backend/base/langflow/services/database/models/message/model.py
@@ -137,6 +137,10 @@ class MessageTable(MessageBase, table=True):  # type: ignore[call-arg]
             if value.tzinfo is None:
                 value = value.replace(tzinfo=timezone.utc)
             return value.strftime("%Y-%m-%d %H:%M:%S %Z")
+        if isinstance(value, str):
+            # Make sure the timestamp is in UTC
+            value = datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
+            return value.strftime("%Y-%m-%d %H:%M:%S %Z")
         return value
 
     @field_validator("flow_id", mode="before")


### PR DESCRIPTION
This pull request modifies the MessageTable model to ensure that string timestamps are correctly converted to UTC. A new check has been added to handle string inputs, ensuring they are parsed and adjusted to UTC before formatting. This change enhances the consistency and reliability of timestamp handling in the application.