### PR TITLE
fix: Fix tool mode retrieval in frontend node template update

### DIFF
--- a/src/backend/base/langflow/template/utils.py
+++ b/src/backend/base/langflow/template/utils.py
@@ -82,7 +82,7 @@ def update_frontend_node_with_template_values(frontend_node, raw_frontend_node):
     # Compute tool modes from template
     tool_modes = [
         value.get("tool_mode")
-        for key, value in raw_frontend_node["template"].items()
+        for key, value in frontend_node["template"].items()
         if key != "_type" and isinstance(value, dict)
     ]
 


### PR DESCRIPTION
This PR corrects the retrieval of tool modes in the `update_frontend_node_with_template_values` function by ensuring that the tool modes are computed from the `frontend_node` instead of the `raw_frontend_node`. This change improves the accuracy of the template updates in the frontend.