### PR TITLE
fix: improve modal z-index and keyboard event handling

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
@@ -378,6 +378,7 @@ function NodeOutputField({
                   : "Inspect output"
                 : "Please build the component first"
             }
+            styleClasses="z-40"
           >
             <div className="flex items-center gap-2">
               <OutputModal

--- a/src/frontend/src/CustomNodes/GenericNode/components/outputModal/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/outputModal/index.tsx
@@ -11,7 +11,7 @@ export default function OutputModal({
 }): JSX.Element {
   const [activeTab, setActiveTab] = useState<"Outputs" | "Logs">("Outputs");
   return (
-    <BaseModal disable={disabled} size="large">
+    <BaseModal disable={disabled} size="large" className="z-50">
       <BaseModal.Header description="Inspect the output of the component below.">
         <div className="flex items-center">
           <span className="pr-2">Component Output</span>

--- a/src/frontend/src/modals/textModal/index.tsx
+++ b/src/frontend/src/modals/textModal/index.tsx
@@ -26,8 +26,18 @@ export default function TextModal({
   const [open, setOpen] = useState(false);
   const [internalValue, setInternalValue] = useState(value);
 
+  const handleEscapeKeyDown = (event: KeyboardEvent) => {
+    setOpen(false);
+    event.stopPropagation();
+  };
+
   return (
-    <BaseModal size="medium-h-full" open={open} setOpen={setOpen}>
+    <BaseModal
+      size="medium-h-full"
+      open={open}
+      setOpen={setOpen}
+      onEscapeKeyDown={handleEscapeKeyDown}
+    >
       <BaseModal.Trigger className="h-full">{children}</BaseModal.Trigger>
       <BaseModal.Header description={""}>
         <span className="pr-2">View Text</span>


### PR DESCRIPTION
This pull request includes several updates to the modal components in the frontend codebase. The changes primarily involve adding new styles and handling keyboard events more effectively.

Styling improvements:

* [`src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx`](diffhunk://#diff-4742b353430022eb88d35ab987d50925c592f35702319e1d476e2d53818cd795R381): Added `styleClasses="z-40"` to the component for better z-index management.
* [`src/frontend/src/CustomNodes/GenericNode/components/outputModal/index.tsx`](diffhunk://#diff-688de3020304c7a9f88dc79691f7abcb54c98e93b3e5293dcccf75d3facc1a38L14-R14): Added `className="z-50"` to the `BaseModal` for improved z-index handling.

Event handling improvements:

* [`src/frontend/src/modals/textModal/index.tsx`](diffhunk://#diff-dbe0454633656d75881af87ec2350cc46035b2119c3de2cdeeadb790e2ce9138R29-R40): Introduced `handleEscapeKeyDown` function to close the modal and stop event propagation when the Escape key is pressed.