### PR TITLE
fix: Hides agent executor output in components

### DIFF
--- a/src/backend/base/langflow/base/agents/agent.py
+++ b/src/backend/base/langflow/base/agents/agent.py
@@ -69,7 +69,7 @@ class LCAgentComponent(Component):
     ]
 
     outputs = [
-        Output(display_name="Agent", name="agent", method="build_agent"),
+        Output(display_name="Agent", name="agent", method="build_agent", hidden=True),
         Output(display_name="Response", name="response", method="message_response"),
     ]
 

--- a/src/backend/base/langflow/components/langchain_utilities/csv_agent.py
+++ b/src/backend/base/langflow/components/langchain_utilities/csv_agent.py
@@ -56,7 +56,7 @@ class CSVAgentComponent(LCAgentComponent):
 
     outputs = [
         Output(display_name="Response", name="response", method="build_agent_response"),
-        Output(display_name="Agent", name="agent", method="build_agent"),
+        Output(display_name="Agent", name="agent", method="build_agent", hidden=True),
     ]
 
     def _path(self) -> str:


### PR DESCRIPTION
This pull request includes changes to the `Output` configuration in the `LCAgentComponent` and `CSVAgentComponent` classes to improve the visibility settings of the `Agent` output.

Visibility settings update:

* [`src/backend/base/langflow/base/agents/agent.py`](diffhunk://#diff-87ba96f91b4bbce3350ae83d5d4c7dfa3a7c800deeed21a60857dff1caaefe04L72-R72): Modified the `Output` for `Agent` in `LCAgentComponent` to include `hidden=True`.
* [`src/backend/base/langflow/components/langchain_utilities/csv_agent.py`](diffhunk://#diff-c168846face60946ac035d0572d1f85c58c8e1e7fdd66ab6629df235adc22304L59-R59): Modified the `Output` for `Agent` in `CSVAgentComponent` to include `hidden=True`.

<img width="1098" alt="Screenshot 2025-01-23 at 2 35 47 PM" src="https://github.com/user-attachments/assets/fe6f9fc0-3970-460b-a11a-5bfdcc95cfac" />
