### PR TITLE
fix: fixes AgentExecutor handle greyed out 

### DIFF
--- a/src/frontend/src/style/index.css
+++ b/src/frontend/src/style/index.css
@@ -307,9 +307,9 @@
 
     --datatype-fuchsia: 291.1 93.1% 82.9%;
     --datatype-fuchsia-foreground: 293.4 69.5% 48.8%;
-
-    --datatype-purple: 269.2 97.4% 85.1%;
-    --datatype-purple-foreground: 293.4 69.5% 48.8%;
+    
+    --datatype-purple: 268.6 100% 91.8%;
+    --datatype-purple-foreground: 272.1 71.7% 47.1%;
 
     --datatype-cyan: 187 92.4% 69%;
     --datatype-cyan-foreground: 191.6 91.4% 36.5%;

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -432,6 +432,7 @@ export const nodeColors: { [char: string]: string } = {
   BaseLanguageModel: "#c026d3",
   LanguageModel: "#c026d3",
   Agent: "#903BBE",
+  AgentExecutor: "#903BBE",
   Tool: "#00fbfc",
 };
 
@@ -480,6 +481,7 @@ export const nodeColorsName: { [char: string]: string } = {
   BaseLanguageModel: "fuchsia",
   LanguageModel: "fuchsia",
   Agent: "purple",
+  AgentExecutor: "purple",
   Tool: "cyan",
   BaseChatMemory: "cyan",
   BaseChatMessageHistory: "orange",


### PR DESCRIPTION
This pull request includes updates to the `src/frontend/src/utils/styleUtils.ts` file to add color mappings for the `AgentExecutor` node.

Changes to color mappings:

* [`src/frontend/src/utils/styleUtils.ts`](diffhunk://#diff-ce70511ff4131ac5078d799cd2295f98874bad89bcde4732f33c967c1bbc71f2R435): Added `AgentExecutor` to the `nodeColors` object with the color `#903BBE`.
* [`src/frontend/src/utils/styleUtils.ts`](diffhunk://#diff-ce70511ff4131ac5078d799cd2295f98874bad89bcde4732f33c967c1bbc71f2R484): Added `AgentExecutor` to the `nodeColorsName` object with the color name `purple`.

