### PR TITLE
feat: allow support for a root path

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -151,10 +151,17 @@ def create_app():
     from langflow.utils.version import get_version_info
 
     __version__ = get_version_info()["version"]
+    root_path = os.environ.get("LANGFLOW_ROOT_PATH", "")
 
     configure()
     lifespan = get_lifespan(version=__version__)
-    app = FastAPI(lifespan=lifespan, title="Langflow", version=__version__)
+    app = FastAPI(
+        lifespan=lifespan,
+        title="Langflow",
+        version=__version__,
+        root_path=root_path
+    )
+
     app.add_middleware(
         ContentSizeLimitMiddleware,
     )

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -44,6 +44,7 @@ const DeleteAccountPage = lazy(() => import("./pages/DeleteAccountPage"));
 // const PlaygroundPage = lazy(() => import("./pages/Playground"));
 
 const SignUp = lazy(() => import("./pages/SignUpPage"));
+const rootPath = process.env.LANGFLOW_ROOT_PATH || "";
 const router = createBrowserRouter(
   createRoutesFromElements([
     <Route
@@ -237,7 +238,7 @@ const router = createBrowserRouter(
       <Route path="*" element={<CustomNavigate replace to="/" />} />
     </Route>,
   ]),
-  { basename: BASENAME || undefined },
+  { basename: rootPath || BASENAME },
 );
 
 export default router;

--- a/src/frontend/vite.config.mts
+++ b/src/frontend/vite.config.mts
@@ -30,7 +30,7 @@ export default defineConfig(({ mode }) => {
   }, {});
 
   return {
-    base: BASENAME || "",
+    base: env.LANGFLOW_ROOT_PATH || BASENAME || "",
     build: {
       outDir: "build",
     },
@@ -40,6 +40,7 @@ export default defineConfig(({ mode }) => {
         env.ACCESS_TOKEN_EXPIRE_SECONDS,
       ),
       "process.env.CI": JSON.stringify(env.CI),
+      "process.env.LANGFLOW_ROOT_PATH": JSON.stringify(env.LANGFLOW_ROOT_PATH),
     },
     plugins: [react(), svgr(), tsconfigPaths()],
     server: {


### PR DESCRIPTION
Adds support for adding a root_path, so users can execute on a relative path. 

TODO
* Noticed that curls without the root path still work. Unsure why