### PR TITLE
ci: Update Python version defaults in CI workflows

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -13,7 +13,7 @@ on:
         description: "(Optional) Python versions to test"
         required: true
         type: string
-        default: "['3.10', '3.11', '3.12', '3.13']"
+        default: "['3.10', '3.11', '3.12']"
       ref:
         description: "(Optional) ref to checkout"
         required: false

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -7,7 +7,7 @@ on:
         description: "(Optional) Python versions to test"
         required: true
         type: string
-        default: "['3.10', '3.11', '3.12', '3.13']"
+        default: "['3.10', '3.11', '3.12']"
       ref:
         description: "(Optional) ref to checkout"
         required: false
@@ -23,7 +23,7 @@ on:
         description: "(Optional) Python versions to test"
         required: true
         type: string
-        default: "['3.10', '3.11', '3.12', '3.13']"
+        default: "['3.10', '3.11', '3.12']"
 env:
   POETRY_VERSION: "1.8.2"
   NODE_VERSION: "21"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     name: CI
     uses: ./.github/workflows/ci.yml
     with:
-      python-versions: "['3.10', '3.11', '3.12', '3.13']"
+      python-versions: "['3.10', '3.11', '3.12']"
       frontend-tests-folder: "tests"
       release: true
 


### PR DESCRIPTION
This pull request updates the default Python versions in the CI workflows by removing Python 3.13 from the integration_tests.yml, python_test.yml, and release.yml files. This change ensures compatibility and reduces testing overhead, streamlining the CI process.