### PR TITLE
fix: env-file loading

### DIFF
--- a/src/backend/base/langflow/api/router.py
+++ b/src/backend/base/langflow/api/router.py
@@ -9,7 +9,6 @@ from langflow.api.v1 import (
     flows_router,
     folders_router,
     login_router,
-    mcp_router,
     monitor_router,
     starter_projects_router,
     store_router,
@@ -17,7 +16,6 @@ from langflow.api.v1 import (
     validate_router,
     variables_router,
 )
-from langflow.services.deps import get_settings_service
 
 router = APIRouter(
     prefix="/api/v1",
@@ -35,6 +33,3 @@ router.include_router(files_router)
 router.include_router(monitor_router)
 router.include_router(folders_router)
 router.include_router(starter_projects_router)
-
-if get_settings_service().settings.mcp_server_enabled:
-    router.include_router(mcp_router)

--- a/src/backend/base/langflow/api/v1/mcp.py
+++ b/src/backend/base/langflow/api/v1/mcp.py
@@ -57,7 +57,7 @@ current_user_ctx: ContextVar[User] = ContextVar("current_user_ctx")
 MAX_RETRIES = 2
 
 
-def get_enable_progress_notifications():
+def get_enable_progress_notifications() -> bool:
     return get_settings_service().settings.mcp_server_enable_progress_notifications
 
 
@@ -179,7 +179,7 @@ async def handle_list_tools():
 
 @server.call_tool()
 async def handle_call_tool(
-    name: str, arguments: dict, enable_progress_notifications: Depends(get_enable_progress_notifications)
+    name: str, arguments: dict, *, enable_progress_notifications: bool = Depends(get_enable_progress_notifications)
 ) -> list[types.TextContent]:
     """Handle tool execution requests."""
     try:

--- a/src/backend/base/langflow/api/v1/mcp.py
+++ b/src/backend/base/langflow/api/v1/mcp.py
@@ -45,7 +45,6 @@ if False:
 
     logger.debug("MCP module loaded - debug logging enabled")
 
-enable_progress_notifications = get_settings_service().settings.mcp_server_enable_progress_notifications
 
 router = APIRouter(prefix="/mcp", tags=["mcp"])
 
@@ -56,6 +55,10 @@ current_user_ctx: ContextVar[User] = ContextVar("current_user_ctx")
 
 # Define constants
 MAX_RETRIES = 2
+
+
+def get_enable_progress_notifications():
+    return get_settings_service().settings.mcp_server_enable_progress_notifications
 
 
 @server.list_prompts()
@@ -175,7 +178,9 @@ async def handle_list_tools():
 
 
 @server.call_tool()
-async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+async def handle_call_tool(
+    name: str, arguments: dict, enable_progress_notifications: Depends(get_enable_progress_notifications)
+) -> list[types.TextContent]:
     """Handle tool execution requests."""
     try:
         session = await anext(get_session())

--- a/src/backend/base/langflow/components/logic/run_flow.py
+++ b/src/backend/base/langflow/components/logic/run_flow.py
@@ -56,7 +56,7 @@ class RunFlowComponent(RunFlowBaseComponent):
                     if node not in tweaks:
                         tweaks[node] = {}
                     tweaks[node][name] = self._attributes[field]
-        # import pdb; pdb.set_trace()
+
         return await run_flow(
             inputs=None,
             output_type="all",

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -24,6 +24,7 @@ from rich import print as rprint
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
 from langflow.api import health_check_router, log_router, router
+from langflow.api.v1 import mcp_router
 from langflow.initial_setup.setup import (
     create_or_update_starter_projects,
     initialize_super_user_if_needed,
@@ -232,6 +233,9 @@ def create_app():
         from prometheus_client import start_http_server
 
         start_http_server(settings.prometheus_port)
+
+    if settings.mcp_server_enabled:
+        router.include_router(mcp_router)
 
     app.include_router(router)
     app.include_router(health_check_router)

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -24,7 +24,6 @@ from rich import print as rprint
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
 from langflow.api import health_check_router, log_router, router
-from langflow.api.v1 import mcp_router
 from langflow.initial_setup.setup import (
     create_or_update_starter_projects,
     initialize_super_user_if_needed,
@@ -235,6 +234,8 @@ def create_app():
         start_http_server(settings.prometheus_port)
 
     if settings.mcp_server_enabled:
+        from langflow.api.v1 import mcp_router
+
         router.include_router(mcp_router)
 
     app.include_router(router)


### PR DESCRIPTION
This PR removes the inclusion of mcp_router from the global context in router.py. The previous implementation caused issues by executing code before the settings service was fully initialized.