### PR TITLE
chore: Mark internal vertex-related endpoints as deprecated

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -69,7 +69,7 @@ async def try_running_celery_task(vertex, user_id):
     return vertex
 
 
-@router.post("/build/{flow_id}/vertices")
+@router.post("/build/{flow_id}/vertices", deprecated=True)
 async def retrieve_vertices_order(
     *,
     flow_id: uuid.UUID,
@@ -471,7 +471,7 @@ class DisconnectHandlerStreamingResponse(StreamingResponse):
                 break
 
 
-@router.post("/build/{flow_id}/vertices/{vertex_id}")
+@router.post("/build/{flow_id}/vertices/{vertex_id}", deprecated=True)
 async def build_vertex(
     *,
     flow_id: uuid.UUID,
@@ -713,7 +713,7 @@ async def _stream_vertex(flow_id: str, vertex_id: str, chat_service: ChatService
         yield str(StreamData(event="close", data={"message": "Stream closed"}))
 
 
-@router.get("/build/{flow_id}/{vertex_id}/stream", response_class=StreamingResponse)
+@router.get("/build/{flow_id}/{vertex_id}/stream", response_class=StreamingResponse, deprecated=True)
 async def build_vertex_stream(
     flow_id: uuid.UUID,
     vertex_id: str,


### PR DESCRIPTION
This pull request marks several vertex-related endpoints in the API as deprecated. This change is intended to signal to users that these endpoints will be phased out in future releases, allowing for a smoother transition to alternative solutions. The affected endpoints include those for retrieving vertices order, building a vertex, and streaming vertex data.