### PR TITLE
fix: handle undefined data.outputs and outputName params in log utility functions

### DIFF
--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -460,39 +460,42 @@ export const logHasMessage = (
   data: VertexDataTypeAPI,
   outputName: string | undefined,
 ) => {
-  if (!outputName) return;
-  const outputs = data?.outputs[outputName];
-  if (Array.isArray(outputs) && outputs.length > 1) {
-    return outputs.some((outputLog) => outputLog.message);
-  } else {
-    return outputs?.message;
+  if (!outputName || !data?.outputs) return false;
+  const outputs = data.outputs[outputName];
+  if (!outputs) return false;
+
+  if (Array.isArray(outputs) && outputs.length > 0) {
+    return outputs.some((outputLog) => outputLog?.message);
   }
+  return outputs?.message;
 };
 
 export const logTypeIsUnknown = (
   data: VertexDataTypeAPI,
   outputName: string | undefined,
 ) => {
-  if (!outputName) return;
-  const outputs = data?.outputs[outputName];
-  if (Array.isArray(outputs) && outputs.length > 1) {
-    return outputs.some((outputLog) => outputLog.type === "unknown");
-  } else {
-    return outputs?.type === "unknown";
+  if (!outputName || !data?.outputs) return false;
+  const outputs = data.outputs[outputName];
+  if (!outputs) return false;
+
+  if (Array.isArray(outputs) && outputs.length > 0) {
+    return outputs.some((outputLog) => outputLog?.type === "unknown");
   }
+  return outputs?.type === "unknown";
 };
 
 export const logTypeIsError = (
   data: VertexDataTypeAPI,
   outputName: string | undefined,
 ) => {
-  if (!outputName) return;
-  const outputs = data?.outputs[outputName];
-  if (Array.isArray(outputs) && outputs.length > 1) {
+  if (!outputName || !data?.outputs) return false;
+  const outputs = data.outputs[outputName];
+  if (!outputs) return false;
+
+  if (Array.isArray(outputs) && outputs.length > 0) {
     return outputs.some((log) => isErrorLog(log));
-  } else {
-    return isErrorLog(outputs);
   }
+  return isErrorLog(outputs);
 };
 
 export function isEndpointNameValid(name: string, maxLength: number): boolean {


### PR DESCRIPTION
This pull request includes changes to improve the robustness and reliability of utility functions in `src/frontend/src/utils/utils.ts`. The modifications focus on enhancing the handling of edge cases and ensuring that the functions return consistent boolean values.

Improvements to utility functions:

* [`logHasMessage`](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81L463-R498): Enhanced the function to handle cases where `outputName` is not provided or `data.outputs` is undefined, ensuring it returns `false` in these scenarios. Improved the logic to check for the presence of messages more reliably.
* [`logTypeIsUnknown`](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81L463-R498): Updated the function to return `false` if `outputName` is not provided or `data.outputs` is undefined, and refined the logic to check for the "unknown" type more consistently.
* [`logTypeIsError`](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81L463-R498): Modified the function to handle cases where `outputName` is not provided or `data.outputs` is undefined, ensuring it returns `false` in these scenarios. Improved the logic to check for error logs more reliably.