### PR TITLE
fix: use correct json load method when loading flow from file

### DIFF
--- a/src/backend/base/langflow/load/load.py
+++ b/src/backend/base/langflow/load/load.py
@@ -58,7 +58,7 @@ async def aload_flow_from_json(
     if isinstance(flow, str | Path):
         async with async_open(Path(flow).name, encoding="utf-8") as f:
             content = await f.read()
-            flow_graph = json.load(content)
+            flow_graph = json.loads(content)
     # If input is a dictionary, assume it's a JSON object
     elif isinstance(flow, dict):
         flow_graph = flow


### PR DESCRIPTION
In https://github.com/langflow-ai/langflow/pull/5057 `load_flow_from_json` was made async, and the needed logic changes were added.
One of the changes is that the file is now loaded as string, instead of being a file object.

Therefore the way of loading also needs to change, from [`json.load`](https://docs.python.org/3/library/json.html#json.load) to [`json.loads`](https://docs.python.org/3/library/json.html#json.loads)
This is not the case, and an error is thrown.

```
  File "/app/.venv/lib/python3.12/site-packages/langflow/load/load.py", line 61, in aload_flow_from_json
    flow_graph = json.load(content)
                 ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/__init__.py", line 293, in load
    return loads(fp.read(),
                 ^^^^^^^
AttributeError: 'str' object has no attribute 'read'
```
This PR addresses this.