### PR TITLE
fix: remove reference to a non-existent method in NvidiaRerankComponent

### DIFF
--- a/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
@@ -53,7 +53,7 @@ class NvidiaRerankComponent(LCVectorStoreComponent):
     def update_build_config(self, build_config: dotdict, field_value: Any, field_name: str | None = None):
         if field_name == "base_url" and field_value:
             try:
-                build_model = self.build_model()
+                build_model = self.build_reranker()
                 ids = [model.id for model in build_model.available_models]
                 build_config["model"]["options"] = ids
                 build_config["model"]["value"] = ids[0]


### PR DESCRIPTION
Fixes #5934