### PR TITLE
feat: Data field required in UpdateDataComponent

### DIFF
--- a/src/backend/base/langflow/components/processing/update_data.py
+++ b/src/backend/base/langflow/components/processing/update_data.py
@@ -27,6 +27,7 @@ class UpdateDataComponent(Component):
             display_name="Data",
             info="The record to update.",
             is_list=True,  # Changed to True to handle list of Data objects
+            required=True,
         ),
         IntInput(
             name="number_of_fields",

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
@@ -211,7 +211,7 @@ export default function NodeStatus({
                   </span>
                 </div>
               ) : (
-                <div className="flex items-center self-center">
+                <div className="flex items-center self-center pr-1">
                   {iconStatus}
                 </div>
               )}

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
@@ -211,7 +211,7 @@ export default function NodeStatus({
                   </span>
                 </div>
               ) : (
-                <div className="flex items-center self-center pr-1">
+                <div className="flex items-center self-center">
                   {iconStatus}
                 </div>
               )}


### PR DESCRIPTION
This pull request includes a change to the `UpdateDataComponent` class in `src/backend/base/langflow/components/processing/update_data.py`. The change ensures that the `Data` field is marked as required.

* [`src/backend/base/langflow/components/processing/update_data.py`](diffhunk://#diff-050cb4102347879d1fece343bacd8b4dd1e3afcb0038fc38deb6588f7e34055dR30): Added the `required=True` attribute to the `Data` field in the `UpdateDataComponent` class to ensure that data is mandatory.

![image](https://github.com/user-attachments/assets/56e26143-31d1-4a1f-a7ac-cfea365db650)

This component needs a data component connected to him to run.

![image](https://github.com/user-attachments/assets/d46bfae2-df7d-4ac8-9110-4108c745d352)

