### PR TITLE
fix: add right padding to NodeStatus icon

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
@@ -211,7 +211,7 @@ export default function NodeStatus({
                   </span>
                 </div>
               ) : (
-                <div className="flex items-center self-center">
+                <div className="flex items-center self-center pr-1">
                   {iconStatus}
                 </div>
               )}


### PR DESCRIPTION
This pull request includes a small change to the `NodeStatus` component in the `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx` file. The change adds a right padding of 1 (`pr-1`) to the `div` containing `iconStatus` to improve the layout.