### PR TITLE
fix: enhance log message handling with optional text property

### DIFF
--- a/src/frontend/src/types/api/index.ts
+++ b/src/frontend/src/types/api/index.ts
@@ -203,6 +203,7 @@ export type ErrorLogType = {
 export type OutputLogType = {
   message: any | ErrorLogType;
   type: string;
+  text?: string;
 };
 export type LogsLogType = {
   name: string;

--- a/src/frontend/src/types/api/index.ts
+++ b/src/frontend/src/types/api/index.ts
@@ -203,7 +203,6 @@ export type ErrorLogType = {
 export type OutputLogType = {
   message: any | ErrorLogType;
   type: string;
-  text?: string;
 };
 export type LogsLogType = {
   name: string;

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -465,9 +465,13 @@ export const logHasMessage = (
   if (!outputs) return false;
 
   if (Array.isArray(outputs) && outputs.length > 0) {
-    return outputs.some((outputLog) => outputLog?.message);
+    return outputs.some(
+      (outputLog) =>
+        outputLog?.message ||
+        (typeof outputLog === "object" && outputLog?.text),
+    );
   }
-  return outputs?.message;
+  return outputs?.message || (typeof outputs === "object" && outputs?.text);
 };
 
 export const logTypeIsUnknown = (

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -465,13 +465,23 @@ export const logHasMessage = (
   if (!outputs) return false;
 
   if (Array.isArray(outputs) && outputs.length > 0) {
-    return outputs.some(
-      (outputLog) =>
-        outputLog?.message ||
-        (typeof outputLog === "object" && outputLog?.text),
-    );
+    return outputs.some((outputLog) => {
+      if (!outputLog) return false;
+      if (typeof outputLog === "string") return true;
+      if (typeof outputLog === "object") {
+        if ("message" in outputLog && outputLog.message) return true;
+        if ("text" in outputLog && outputLog.text) return true;
+      }
+      return false;
+    });
   }
-  return outputs?.message || (typeof outputs === "object" && outputs?.text);
+
+  if (typeof outputs === "string") return true;
+  if (typeof outputs === "object" && outputs) {
+    if ("message" in outputs && outputs.message) return true;
+    if ("text" in outputs && outputs.text) return true;
+  }
+  return false;
 };
 
 export const logTypeIsUnknown = (


### PR DESCRIPTION
This pull request includes changes to enhance the handling of log messages in the frontend codebase. The most important changes include adding a new optional `text` property to the `OutputLogType` and updating the `logHasMessage` utility function to account for this new property.

Enhancements to log handling:

* [`src/frontend/src/types/api/index.ts`](diffhunk://#diff-ba4d437895345b850ffebdd55488b1502a4fa3bb2b9f57bc1cd74a22fd718421R206): Added an optional `text` property to the `OutputLogType` to allow for more flexible log messages.
* [`src/frontend/src/utils/utils.ts`](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81L468-R474): Updated the `logHasMessage` function to check for the presence of the `text` property in addition to the `message` property, ensuring that logs with only a `text` property are correctly identified as having a message.