### PR TITLE
fix: Problem checking Clickhouse connection when port is different from default

### DIFF
--- a/src/backend/base/langflow/components/vectorstores/clickhouse.py
+++ b/src/backend/base/langflow/components/vectorstores/clickhouse.py
@@ -75,8 +75,9 @@ class ClickhouseVectorStoreComponent(LCVectorStoreComponent):
             raise ImportError(msg) from e
 
         try:
-            client = clickhouse_connect.get_client(host=self.host, port=self.port,
-                                                   username=self.username, password=self.password)
+            client = clickhouse_connect.get_client(
+                host=self.host, port=self.port, username=self.username, password=self.password
+            )
             client.command("SELECT 1")
         except Exception as e:
             msg = f"Failed to connect to Clickhouse: {e}"

--- a/src/backend/base/langflow/components/vectorstores/clickhouse.py
+++ b/src/backend/base/langflow/components/vectorstores/clickhouse.py
@@ -49,7 +49,7 @@ class ClickhouseVectorStoreComponent(LCVectorStoreComponent):
             value=False,
             advanced=True,
         ),
-        StrInput(name="index_param", display_name="Param of the index", value="'L2Distance',100", advanced=True),
+        StrInput(name="index_param", display_name="Param of the index", value="100,'L2Distance'", advanced=True),
         DictInput(name="index_query_params", display_name="index query params", advanced=True),
         *LCVectorStoreComponent.inputs,
         HandleInput(name="embedding", display_name="Embedding", input_types=["Embeddings"]),
@@ -75,7 +75,8 @@ class ClickhouseVectorStoreComponent(LCVectorStoreComponent):
             raise ImportError(msg) from e
 
         try:
-            client = clickhouse_connect.get_client(host=self.host, username=self.username, password=self.password)
+            client = clickhouse_connect.get_client(host=self.host, port=self.port,
+                                                   username=self.username, password=self.password)
             client.command("SELECT 1")
         except Exception as e:
             msg = f"Failed to connect to Clickhouse: {e}"


### PR DESCRIPTION
A problem was reported regarding an unsuccessful connection attempt to clickhouse. After some analysis I found out that the problem was the lack of port information in the connection test, so the default port was used.

I also changed the advanced configuration of clickhouse as it was incorrect.

Issue: https://github.com/langflow-ai/langflow/issues/5954