### PR TITLE
fix: return a standard tool for each Astra DB Tool component

### DIFF
--- a/src/backend/base/langflow/components/tools/astradb.py
+++ b/src/backend/base/langflow/components/tools/astradb.py
@@ -111,7 +111,7 @@ class AstraDBToolComponent(LCToolComponent):
         model = create_model("ToolInput", **args, __base__=BaseModel)
         return {"ToolInput": model}
 
-    def build_tool(self) -> StructuredTool:
+    def build_tool(self) -> Tool:
         """Builds an Astra DB Collection tool.
 
         Returns:

--- a/src/backend/base/langflow/components/tools/astradb.py
+++ b/src/backend/base/langflow/components/tools/astradb.py
@@ -119,7 +119,7 @@ class AstraDBToolComponent(LCToolComponent):
         """
         schema_dict = self.create_args_schema()
 
-        structured_tool = StructuredTool.from_function(
+        tool = StructuredTool.from_function(
             name=self.tool_name,
             args_schema=schema_dict["ToolInput"],
             description=self.tool_description,
@@ -128,12 +128,7 @@ class AstraDBToolComponent(LCToolComponent):
         )
         self.status = "Astra DB Tool created"
 
-        # Convert the StructuredTool to a regular Tool
-        return Tool(
-            name=structured_tool.name,
-            func=structured_tool.func,
-            description=structured_tool.description,
-        )
+        return tool
 
     def projection_args(self, input_str: str) -> dict:
         elements = input_str.split(",")

--- a/src/backend/base/langflow/components/tools/astradb.py
+++ b/src/backend/base/langflow/components/tools/astradb.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from astrapy import Collection, DataAPIClient, Database
 from langchain.pydantic_v1 import BaseModel, Field, create_model
-from langchain_core.tools import StructuredTool
+from langchain_core.tools import StructuredTool, Tool
 
 from langflow.base.langchain_utilities.model import LCToolComponent
 from langflow.io import DictInput, IntInput, SecretStrInput, StrInput
@@ -119,7 +119,7 @@ class AstraDBToolComponent(LCToolComponent):
         """
         schema_dict = self.create_args_schema()
 
-        tool = StructuredTool.from_function(
+        structured_tool = StructuredTool.from_function(
             name=self.tool_name,
             args_schema=schema_dict["ToolInput"],
             description=self.tool_description,
@@ -128,7 +128,12 @@ class AstraDBToolComponent(LCToolComponent):
         )
         self.status = "Astra DB Tool created"
 
-        return tool
+        # Convert the StructuredTool to a regular Tool
+        return Tool(
+            name=structured_tool.name,
+            func=structured_tool.func,
+            description=structured_tool.description,
+        )
 
     def projection_args(self, input_str: str) -> dict:
         elements = input_str.split(",")

--- a/src/backend/base/langflow/components/tools/astradb_cql.py
+++ b/src/backend/base/langflow/components/tools/astradb_cql.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import requests
 from langchain.pydantic_v1 import BaseModel, Field, create_model
-from langchain_core.tools import StructuredTool
+from langchain_core.tools import StructuredTool, Tool
 
 from langflow.base.langchain_utilities.model import LCToolComponent
 from langflow.io import DictInput, IntInput, SecretStrInput, StrInput
@@ -140,7 +140,7 @@ class AstraDBCQLToolComponent(LCToolComponent):
         model = create_model("ToolInput", **args, __base__=BaseModel)
         return {"ToolInput": model}
 
-    def build_tool(self) -> StructuredTool:
+    def build_tool(self) -> Tool:
         """Builds a Astra DB CQL Table tool.
 
         Args:
@@ -150,12 +150,19 @@ class AstraDBCQLToolComponent(LCToolComponent):
             Tool: The built AstraDB tool.
         """
         schema_dict = self.create_args_schema()
-        return StructuredTool.from_function(
+        structured_tool = StructuredTool.from_function(
             name=self.tool_name,
             args_schema=schema_dict["ToolInput"],
             description=self.tool_description,
             func=self.run_model,
             return_direct=False,
+        )
+
+        # Convert the StructuredTool to a regular Tool
+        return Tool(
+            name=structured_tool.name,
+            func=structured_tool.func,
+            description=structured_tool.description,
         )
 
     def projection_args(self, input_str: str) -> dict:

--- a/src/backend/base/langflow/components/tools/astradb_cql.py
+++ b/src/backend/base/langflow/components/tools/astradb_cql.py
@@ -150,19 +150,12 @@ class AstraDBCQLToolComponent(LCToolComponent):
             Tool: The built AstraDB tool.
         """
         schema_dict = self.create_args_schema()
-        structured_tool = StructuredTool.from_function(
+        return StructuredTool.from_function(
             name=self.tool_name,
             args_schema=schema_dict["ToolInput"],
             description=self.tool_description,
             func=self.run_model,
             return_direct=False,
-        )
-
-        # Convert the StructuredTool to a regular Tool
-        return Tool(
-            name=structured_tool.name,
-            func=structured_tool.func,
-            description=structured_tool.description,
         )
 
     def projection_args(self, input_str: str) -> dict:


### PR DESCRIPTION
This pull request updates the return format of the Astra DB Tool and CQL Tool components to return a Tool object, making them compatible with other Langflow components.