### PR TITLE
ci: Update pytest durations workflow schedule to run weekly on Monday

### DIFF
--- a/.github/workflows/store_pytest_durations.yml
+++ b/.github/workflows/store_pytest_durations.yml
@@ -3,8 +3,8 @@ name: Store pytest durations
 on:
   workflow_dispatch:
   schedule:
-    # Run job at 6:30 UTC, 10.30pm PST, or 11.30pm PDT
-    - cron: "30 6 * * *"
+    # Run job at 6:30 UTC every Monday (10.30pm PST/11.30pm PDT Sunday night)
+    - cron: "30 6 * * 1"
 
 env:
   PYTEST_RUN_PATH: "src/backend/tests"


### PR DESCRIPTION
Change the schedule for the pytest durations workflow to execute every Monday at 6:30 UTC.