### PR TITLE
fix: add correct size properties to novitaAI icon

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -836,6 +836,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/frontend/src/icons/Novita/index.tsx
+++ b/src/frontend/src/icons/Novita/index.tsx
@@ -1,3 +1,4 @@
+import { useDarkStore } from "@/stores/darkStore";
 import React, { forwardRef } from "react";
 import SvgNovita from "./novita";
 
@@ -5,5 +6,7 @@ export const NovitaIcon = forwardRef<
   SVGSVGElement,
   React.PropsWithChildren<{}>
 >((props, ref) => {
-  return <SvgNovita ref={ref} {...props} />;
+  const isdark = useDarkStore((state) => state.dark).toString();
+
+  return <SvgNovita ref={ref} {...props} isdark={isdark} />;
 });

--- a/src/frontend/src/icons/Novita/novita.jsx
+++ b/src/frontend/src/icons/Novita/novita.jsx
@@ -1,28 +1,17 @@
 const SvgNovita = (props) => (
   <svg
-    width="188"
-    height="188"
-    viewBox="0 0 188 188"
-    fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    width="30px"
+    height="30px"
+    fill="currentColor"
+    fillRule="evenodd"
+    style={{ flex: "none", lineHeight: "1" }}
+    viewBox="0 0 24 24"
   >
-    <rect width="188" height="188" fill="white" />
-    <g clip-path="url(#clip0_1987_17498)">
-      <path
-        d="M71.8103 36V80.3795L0 152.19H71.8103V107.808L116.194 152.19H188L71.8103 36Z"
-        fill="black"
-      />
-    </g>
-    <defs>
-      <clipPath id="clip0_1987_17498">
-        <rect
-          width="188"
-          height="116.19"
-          fill="white"
-          transform="translate(0 36)"
-        />
-      </clipPath>
-    </defs>
+    <path
+      d="M9.167 4.17v5.665L0 19.003h9.167v-5.666l5.666 5.666H24z"
+      clipRule="evenodd"
+    ></path>
   </svg>
 );
 export default SvgNovita;

--- a/src/frontend/src/icons/Novita/novita.svg
+++ b/src/frontend/src/icons/Novita/novita.svg
@@ -1,11 +1,1 @@
-<svg width="188" height="188" viewBox="0 0 188 188" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="188" height="188" fill="white"/>
-<g clip-path="url(#clip0_1987_17498)">
-<path d="M71.8103 36V80.3795L0 152.19H71.8103V107.808L116.194 152.19H188L71.8103 36Z" fill="black"/>
-</g>
-<defs>
-<clipPath id="clip0_1987_17498">
-<rect width="188" height="116.19" fill="white" transform="translate(0 36)"/>
-</clipPath>
-</defs>
-</svg>
+<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>Novita AI</title><path clip-rule="evenodd" d="M9.167 4.17v5.665L0 19.003h9.167v-5.666l5.666 5.666H24L9.167 4.17z"></path></svg>


### PR DESCRIPTION
This pull request includes updates to the `Novita` icon component and its associated SVG file, as well as a minor change to the `package-lock.json` file. The most important changes involve adding dark mode support to the `NovitaIcon` component and modifying the SVG properties for better scalability and styling.

Changes to `Novita` icon component:

* [`src/frontend/src/icons/Novita/index.tsx`](diffhunk://#diff-4da4fd3af5c922d4126bf08d3a3957f27b1b16422d84b3241666a4ad7338ae98R1-R11): Added import of `useDarkStore` and updated the `NovitaIcon` component to pass the `isdark` prop to `SvgNovita`.

Changes to `Novita` SVG file:

* [`src/frontend/src/icons/Novita/novita.jsx`](diffhunk://#diff-92312211df0f2ae70ecdf1cae8751d8c8c1d06139f2efb936dfe23997552f00cL3-R14): Updated the SVG properties including width, height, fill color, and viewBox to make the icon more flexible and styled according to the current theme.

Other changes:

* [`src/frontend/package-lock.json`](diffhunk://#diff-9eaa8c31e85b60ae25c139f2d6363cc9dcb6926125b5bf1d0cac092547e8cfcbR839): Marked `is-unicode-supported` as extraneous.

![image](https://github.com/user-attachments/assets/d0f68259-f8f8-4372-8f8a-7fc7e3975dcd)

![image](https://github.com/user-attachments/assets/b9e799ab-62ba-4107-8a71-a4e0fead80bb)

![image](https://github.com/user-attachments/assets/b724b300-c82a-4b03-b036-b3e1385d1c4e)
