### PR TITLE
docs: Update GCP deployment documentation to clarify pricing details

### DIFF
--- a/docs/docs/Deployment/deployment-gcp.md
+++ b/docs/docs/Deployment/deployment-gcp.md
@@ -26,17 +26,6 @@ The script will guide you through setting up a Debian-based VM with the Langflow
 
 When running a [spot (preemptible) instance](https://cloud.google.com/compute/docs/instances/preemptible), the code and VM will behave the same way as in a regular instance, executing the startup script to configure the environment, install necessary dependencies, and run the Langflow application. However, **due to the nature of spot instances, the VM may be terminated at any time if Google Cloud needs to reclaim the resources**. This makes spot instances suitable for fault-tolerant, stateless, or interruptible workloads that can handle unexpected terminations and restarts.
 
-## Pricing (approximate)
-
-:::info
+## Pricing
 
 For more information, see the [GCP Pricing Calculator](https://cloud.google.com/products/calculator?hl=en).
-
-:::
-
-
-| Component          | Regular Cost (Hourly) | Regular Cost (Monthly) | Spot/Preemptible Cost (Hourly) | Spot/Preemptible Cost (Monthly) | Notes                                                                      |
-| ------------------ | --------------------- | ---------------------- | ------------------------------ | ------------------------------- | -------------------------------------------------------------------------- |
-| 100 GB Disk        | -                     | $10/month              | -                              | $10/month                       | Disk cost remains the same for both regular and Spot/Preemptible VMs       |
-| VM (n1-standard-4) | $0.15/hr              | ~$108/month            | ~$0.04/hr                      | ~$29/month                      | The VM cost can be significantly reduced using a Spot/Preemptible instance |
-| **Total**          | **$0.15/hr**          | **~$118/month**        | **~$0.04/hr**                  | **~$39/month**                  | Total costs for running the VM and disk 24/7 for an entire month           |

--- a/docs/docs/Deployment/deployment-gcp.md
+++ b/docs/docs/Deployment/deployment-gcp.md
@@ -28,4 +28,4 @@ When running a [spot (preemptible) instance](https://cloud.google.com/compute/do
 
 ## Pricing
 
-For more information, see the [GCP Pricing Calculator](https://cloud.google.com/products/calculator?hl=en).
+For more information, see the [GCP pricing calculator](https://cloud.google.com/products/calculator?hl=en).


### PR DESCRIPTION
This pull request includes a change to the `docs/docs/Deployment/deployment-gcp.md` file, which simplifies the pricing section by removing the detailed cost table and associated notes.

Also, the deployment script still works.