### PR TITLE
chore: update Google AI models list

### DIFF
--- a/src/backend/base/langflow/base/models/google_generative_ai_constants.py
+++ b/src/backend/base/langflow/base/models/google_generative_ai_constants.py
@@ -1,18 +1,15 @@
 GOOGLE_GENERATIVE_AI_MODELS = [
+    # GEMINI 1.5
     "gemini-1.5-pro",
     "gemini-1.5-flash",
     "gemini-1.5-flash-8b",
-    "gemini-1.0-pro",
-    "gemini-1.0-pro-vision",
-    "gemini-1.5-pro-001",
-    "gemini-1.5-pro-002",
-    "gemini-1.5-flash-001",
-    "gemini-1.5-flash-002",
-    "gemini-1.5-pro-exp-0827",
-    "gemini-1.5-flash-exp-0827",
-    "gemini-1.5-flash-8b-exp-0827",
-    "gemini-1.5-flash-8b-exp-0924",
-    "gemini-exp-1114",
+    # PREVIEW
     "gemini-2.0-flash-exp",
     "gemini-exp-1206",
+    "gemini-2.0-flash-thinking-exp-01-21",
+    "learnlm-1.5-pro-experimental",
+    # GEMMA
+    "gemma-2-2b",
+    "gemma-2-9b",
+    "gemma-2-27b"
 ]


### PR DESCRIPTION
This pull request updates the Google AI models list to reflect the current available models. It adds the new Gemini 2.0 Preview models, GEMMA models, and removes deprecated models that are no longer available in the platform.