### PR TITLE
fix: Use relative paths for data files in unit tests

### DIFF
--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+from pathlib import Path
 from typing import Any
 
 from aiofile import async_open
@@ -34,7 +35,8 @@ async def test_get_config(client: AsyncClient):
 
 
 async def test_update_component_outputs(client: AsyncClient, logged_in_headers: dict):
-    async with async_open("src/backend/tests/data/dynamic_output_component.py", encoding="utf-8") as f:
+    path = Path(__file__).parent.parent.parent.parent / "data" / "dynamic_output_component.py"
+    async with async_open(path, encoding="utf-8") as f:
         code = await f.read()
     frontend_node: dict[str, Any] = {"outputs": []}
     request = UpdateCustomComponentRequest(

--- a/src/backend/tests/unit/test_custom_component.py
+++ b/src/backend/tests/unit/test_custom_component.py
@@ -13,7 +13,8 @@ from langflow.custom.utils import build_custom_component_template
 
 @pytest.fixture
 def code_component_with_multiple_outputs():
-    code = Path("src/backend/tests/data/component_multiple_outputs.py").read_text(encoding="utf-8")
+    path = Path(__file__).parent.parent / "data" / "component_multiple_outputs.py"
+    code = path.read_text(encoding="utf-8")
     return Component(_code=code)
 
 


### PR DESCRIPTION
With this, the concerned tests can be launched from PyCharm's editor.