### PR TITLE
revert: update components filter and build artifact logic

### DIFF
--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -45,6 +45,7 @@ components:
   - "src/frontend/tests/extended/integrations/**"
   - "src/frontend/tests/extended/features/**"
   - "src/frontend/tests/extended/regression/**"
+  - "src/backend/base/langflow/custom/**"
 
 workspace:
   - "src/backend/base/langflow/inputs/**"

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -957,19 +957,19 @@ class Component(CustomComponent):
             custom_repr = str(custom_repr)
 
         raw = self._process_raw_result(result)
-        artifact_type = get_artifact_type(raw or self.status, result)
+        artifact_type = get_artifact_type(self.status or raw, result)
         raw, artifact_type = post_process_raw(raw, artifact_type)
         return {"repr": custom_repr, "raw": raw, "type": artifact_type}
 
     def _process_raw_result(self, result):
-        if hasattr(result, "data"):
+        if self.status:
+            raw = self.status
+        elif hasattr(result, "data"):
             raw = result.data
         elif hasattr(result, "model_dump"):
             raw = result.model_dump()
         elif isinstance(result, dict | Data | str):
             raw = result.data if isinstance(result, Data) else result
-        elif self.status:
-            raw = self.status
         else:
             raw = result
         return raw


### PR DESCRIPTION
This pull request includes changes to the `components` section in the `.github/changes-filter.yaml` file and modifications to the `_build_artifact` method in the `component.py` file. The changes focus on adding a new directory to the components list and improving the logic for processing raw results and determining artifact types in the backend.

### Components Update:

* [`.github/changes-filter.yaml`](diffhunk://#diff-1b2ef07bf2b24cfe900fb2d2b36e0ca604e96b38cd48e00c82d21d64a9c06697R48): Added the `src/backend/base/langflow/custom/**` directory to the `components` section to ensure changes in this directory are tracked appropriately.

### Backend Logic Improvements:

* [`src/backend/base/langflow/custom/custom_component/component.py`](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169L960-L972): Modified the `_build_artifact` method to use `self.status` before `raw` when determining the artifact type and improved the `_process_raw_result` method to prioritize `self.status` over other attributes when processing the raw result.