### PR TITLE
fix: Correct widget code URL

### DIFF
--- a/src/frontend/src/modals/apiModal/utils/get-widget-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-widget-code.tsx
@@ -10,7 +10,7 @@ export default function getWidgetCode({
   flowName,
   isAuth,
 }: GetCodeType): string {
-  return `<script src="https://cdn.jsdelivr.net/gh/logspace-ai/langflow-embedded-chat@v1.0.7/dist/build/static/js/bundle.min.js""></script>
+  return `<script src="https://cdn.jsdelivr.net/gh/logspace-ai/langflow-embedded-chat@v1.0.7/dist/build/static/js/bundle.min.js"></script>
 
   <langflow-chat
     window_title="${flowName}"


### PR DESCRIPTION
src attribute has extra double quotes