### PR TITLE
fix: elevate edges on select

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -836,7 +836,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -551,6 +551,7 @@ export default function Page({ view }: { view?: boolean }): JSX.Element {
             onReconnectEnd={onEdgeUpdateEnd}
             onNodeDragStart={onNodeDragStart}
             onSelectionDragStart={onSelectionDragStart}
+            elevateEdgesOnSelect={true}
             onSelectionEnd={onSelectionEnd}
             onSelectionStart={onSelectionStart}
             connectionRadius={30}


### PR DESCRIPTION
This pull request includes a few changes to the `src/frontend` package. The changes involve a minor update to the `package-lock.json` file and an enhancement to the `PageComponent` in the `FlowPage` component.

Enhancements to `FlowPage` component:

* [`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eR554): Added the `elevateEdgesOnSelect` property set to `true` to enhance the user interaction experience with the flow page.

Minor update to package configuration:

* [`src/frontend/package-lock.json`](diffhunk://#diff-9eaa8c31e85b60ae25c139f2d6363cc9dcb6926125b5bf1d0cac092547e8cfcbL839): Removed the `extraneous` property from the `@clack/prompts/node_modules/is-unicode-supported` dependency.