### PR TITLE
tests: update DuckDuckGo test selectors

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -836,7 +836,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/frontend/tests/extended/integrations/duckduckgo.spec.ts
+++ b/src/frontend/tests/extended/integrations/duckduckgo.spec.ts
@@ -11,15 +11,19 @@ test(
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("duck");
 
-    await page.waitForSelector('//*[@id="toolsDuckDuckGo Search"]', {
+    await page.waitForSelector('[data-testid="toolsDuckDuckGo Search"]', {
       timeout: 3000,
     });
 
     await page
-      .locator('//*[@id="toolsDuckDuckGo Search"]')
-      .dragTo(page.locator('//*[@id="react-flow-id"]'));
-    await page.mouse.up();
-    await page.mouse.down();
+      .getByTestId("toolsDuckDuckGo Search")
+      .hover()
+      .then(async () => {
+        await page
+          .getByTestId("add-component-button-duckduckgo-search")
+          .click();
+      });
+
     await page.getByTestId("fit_view").click();
 
     await page
@@ -42,7 +46,7 @@ test(
         ) ?? false;
 
       await page
-        .getByTestId("output-inspection-data-duckduckgosearch")
+        .getByTestId("output-inspection-data-duckduckgosearchcomponent")
         .first()
         .click();
 


### PR DESCRIPTION
This pull request includes several changes to the `src/frontend` directory, focusing on updating dependencies and improving the test suite for DuckDuckGo integration. Below are the most important changes:

Dependency updates:

* [`src/frontend/package-lock.json`](diffhunk://#diff-9eaa8c31e85b60ae25c139f2d6363cc9dcb6926125b5bf1d0cac092547e8cfcbL839): Removed the "extraneous" flag from the `@clack/prompts` package to ensure proper dependency management.

Improvements to DuckDuckGo integration tests:

* [`src/frontend/tests/extended/integrations/duckduckgo.spec.ts`](diffhunk://#diff-4adeafe8432cd447af72a709cfd02bf951cabc4df1e40abb0ca6b725b98e9ae8L14-R26): Updated the selector for waiting for the DuckDuckGo search tool to use `data-testid` instead of an XPath expression, improving test reliability.
* [`src/frontend/tests/extended/integrations/duckduckgo.spec.ts`](diffhunk://#diff-4adeafe8432cd447af72a709cfd02bf951cabc4df1e40abb0ca6b725b98e9ae8L14-R26): Modified the test to use `getByTestId` for interacting with the DuckDuckGo search tool and added a hover action followed by a click on the "add component" button.
* [`src/frontend/tests/extended/integrations/duckduckgo.spec.ts`](diffhunk://#diff-4adeafe8432cd447af72a709cfd02bf951cabc4df1e40abb0ca6b725b98e9ae8L45-R49): Updated the test to use the `data-testid` for the output inspection data component, ensuring consistency with other test modifications.