### PR TITLE
feat: add SaveToFile component for DataFrame, Data and Message exports

### DIFF
--- a/src/backend/base/langflow/components/processing/save_to_file.py
+++ b/src/backend/base/langflow/components/processing/save_to_file.py
@@ -1,16 +1,18 @@
-from pathlib import Path
 import json
+from pathlib import Path
+
 import pandas as pd
+
 from langflow.custom import Component
 from langflow.io import (
-    DataInput,
-    MessageInput,
     DataFrameInput,
+    DataInput,
     DropdownInput,
-    StrInput,
+    MessageInput,
     Output,
+    StrInput,
 )
-from langflow.schema import Data, Message, DataFrame
+from langflow.schema import Data, DataFrame, Message
 
 
 class SaveToFileComponent(Component):
@@ -80,9 +82,9 @@ class SaveToFileComponent(Component):
     def update_build_config(self, build_config, field_value, field_name=None):
         # Hide/show dynamic fields based on the selected input type
         if field_name == "input_type":
-            build_config["df"]["show"] = (field_value == "DataFrame")
-            build_config["data"]["show"] = (field_value == "Data")
-            build_config["message"]["show"] = (field_value == "Message")
+            build_config["df"]["show"] = field_value == "DataFrame"
+            build_config["data"]["show"] = field_value == "Data"
+            build_config["message"]["show"] = field_value == "Message"
 
             if field_value in ["DataFrame", "Data"]:
                 build_config["file_format"]["options"] = self.DATA_FORMAT_CHOICES
@@ -103,14 +105,13 @@ class SaveToFileComponent(Component):
         if input_type == "DataFrame":
             df = self.df
             return self._save_dataframe(df, file_path, file_format)
-        elif input_type == "Data":
+        if input_type == "Data":
             data = self.data
             return self._save_data(data, file_path, file_format)
-        elif input_type == "Message":
+        if input_type == "Message":
             message = self.message
             return self._save_message(message, file_path, file_format)
-        else:
-            raise ValueError(f"Unsupported input type: {input_type}")
+        raise ValueError(f"Unsupported input type: {input_type}")
 
     def _save_dataframe(self, df: DataFrame, path: Path, fmt: str) -> str:
         if fmt == "csv":
@@ -159,5 +160,3 @@ class SaveToFileComponent(Component):
             raise ValueError(f"Unsupported Message format: {fmt}")
 
         return f"Message saved successfully as '{path}'"
-
-

--- a/src/backend/base/langflow/components/processing/save_to_file.py
+++ b/src/backend/base/langflow/components/processing/save_to_file.py
@@ -103,28 +103,30 @@ class SaveToFileComponent(Component):
             file_path.parent.mkdir(parents=True, exist_ok=True)
 
         if input_type == "DataFrame":
-            df = self.df
-            return self._save_dataframe(df, file_path, file_format)
+            dataframe = self.df
+            return self._save_dataframe(dataframe, file_path, file_format)
         if input_type == "Data":
             data = self.data
             return self._save_data(data, file_path, file_format)
         if input_type == "Message":
             message = self.message
             return self._save_message(message, file_path, file_format)
-        raise ValueError(f"Unsupported input type: {input_type}")
 
-    def _save_dataframe(self, df: DataFrame, path: Path, fmt: str) -> str:
+        error_msg = f"Unsupported input type: {input_type}"
+        raise ValueError(error_msg)
+
+    def _save_dataframe(self, dataframe: DataFrame, path: Path, fmt: str) -> str:
         if fmt == "csv":
-            df.to_csv(path, index=False)
+            dataframe.to_csv(path, index=False)
         elif fmt == "excel":
-            df.to_excel(path, index=False, engine="openpyxl")
+            dataframe.to_excel(path, index=False, engine="openpyxl")
         elif fmt == "json":
-            df.to_json(path, orient="records", indent=2)
+            dataframe.to_json(path, orient="records", indent=2)
         elif fmt == "markdown":
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(df.to_markdown(index=False))
+            path.write_text(dataframe.to_markdown(index=False), encoding="utf-8")
         else:
-            raise ValueError(f"Unsupported DataFrame format: {fmt}")
+            error_msg = f"Unsupported DataFrame format: {fmt}"
+            raise ValueError(error_msg)
 
         return f"DataFrame saved successfully as '{path}'"
 
@@ -134,13 +136,15 @@ class SaveToFileComponent(Component):
         elif fmt == "excel":
             pd.DataFrame(data.data).to_excel(path, index=False, engine="openpyxl")
         elif fmt == "json":
-            with open(path, "w", encoding="utf-8") as f:
-                json.dump(data.data, f, indent=2)
+            path.write_text(json.dumps(data.data, indent=2), encoding="utf-8")
         elif fmt == "markdown":
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(pd.DataFrame(data.data).to_markdown(index=False))
+            path.write_text(
+                pd.DataFrame(data.data).to_markdown(index=False),
+                encoding="utf-8"
+            )
         else:
-            raise ValueError(f"Unsupported Data format: {fmt}")
+            error_msg = f"Unsupported Data format: {fmt}"
+            raise ValueError(error_msg)
 
         return f"Data saved successfully as '{path}'"
 
@@ -148,15 +152,16 @@ class SaveToFileComponent(Component):
         content = message.text
 
         if fmt == "txt":
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(content)
+            path.write_text(content, encoding="utf-8")
         elif fmt == "json":
-            with open(path, "w", encoding="utf-8") as f:
-                json.dump({"message": content}, f, indent=2)
+            path.write_text(
+                json.dumps({"message": content}, indent=2),
+                encoding="utf-8"
+            )
         elif fmt == "markdown":
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(f"**Message:**\n\n{content}")
+            path.write_text(f"**Message:**\n\n{content}", encoding="utf-8")
         else:
-            raise ValueError(f"Unsupported Message format: {fmt}")
+            error_msg = f"Unsupported Message format: {fmt}"
+            raise ValueError(error_msg)
 
         return f"Message saved successfully as '{path}'"

--- a/src/backend/base/langflow/components/processing/save_to_file.py
+++ b/src/backend/base/langflow/components/processing/save_to_file.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 
 import pandas as pd
@@ -146,7 +147,17 @@ class SaveToFileComponent(Component):
         return f"Data saved successfully as '{path}'"
 
     def _save_message(self, message: Message, path: Path, fmt: str) -> str:
-        content = message.text
+        if message.text is None:
+            content = ""
+        elif isinstance(message.text, AsyncIterator):
+            # AsyncIterator needs to be handled differently
+            error_msg = "AsyncIterator not supported"
+            raise ValueError(error_msg)
+        elif isinstance(message.text, Iterator):
+            # Convert iterator to string
+            content = " ".join(str(item) for item in message.text)
+        else:
+            content = str(message.text)
 
         if fmt == "txt":
             path.write_text(content, encoding="utf-8")

--- a/src/backend/base/langflow/components/processing/save_to_file.py
+++ b/src/backend/base/langflow/components/processing/save_to_file.py
@@ -1,0 +1,163 @@
+from pathlib import Path
+import json
+import pandas as pd
+from langflow.custom import Component
+from langflow.io import (
+    DataInput,
+    MessageInput,
+    DataFrameInput,
+    DropdownInput,
+    StrInput,
+    Output,
+)
+from langflow.schema import Data, Message, DataFrame
+
+
+class SaveToFileComponent(Component):
+    display_name = "Save to File"
+    description = "Save DataFrames, Data, or Messages to various file formats."
+    icon = "save"
+    name = "SaveToFile"
+
+    # File format options for different types
+    DATA_FORMAT_CHOICES = ["csv", "excel", "json", "markdown"]
+    MESSAGE_FORMAT_CHOICES = ["txt", "json", "markdown"]
+
+    inputs = [
+        DropdownInput(
+            name="input_type",
+            display_name="Input Type",
+            options=["DataFrame", "Data", "Message"],
+            info="Select the type of input to save.",
+            value="DataFrame",
+            real_time_refresh=True,
+        ),
+        DataFrameInput(
+            name="df",
+            display_name="DataFrame",
+            info="The DataFrame to save.",
+            dynamic=True,
+            show=True,
+        ),
+        DataInput(
+            name="data",
+            display_name="Data",
+            info="The Data object to save.",
+            dynamic=True,
+            show=False,
+        ),
+        MessageInput(
+            name="message",
+            display_name="Message",
+            info="The Message to save.",
+            dynamic=True,
+            show=False,
+        ),
+        DropdownInput(
+            name="file_format",
+            display_name="File Format",
+            options=DATA_FORMAT_CHOICES,
+            info="Select the file format to save the input.",
+            real_time_refresh=True,
+        ),
+        StrInput(
+            name="file_path",
+            display_name="File Path (including filename)",
+            info="The full file path (including filename and extension).",
+            value="./output",
+        ),
+    ]
+
+    outputs = [
+        Output(
+            name="confirmation",
+            display_name="Confirmation",
+            method="save_to_file",
+            info="Confirmation message after saving the file.",
+        ),
+    ]
+
+    def update_build_config(self, build_config, field_value, field_name=None):
+        # Hide/show dynamic fields based on the selected input type
+        if field_name == "input_type":
+            build_config["df"]["show"] = (field_value == "DataFrame")
+            build_config["data"]["show"] = (field_value == "Data")
+            build_config["message"]["show"] = (field_value == "Message")
+
+            if field_value in ["DataFrame", "Data"]:
+                build_config["file_format"]["options"] = self.DATA_FORMAT_CHOICES
+            elif field_value == "Message":
+                build_config["file_format"]["options"] = self.MESSAGE_FORMAT_CHOICES
+
+        return build_config
+
+    def save_to_file(self) -> str:
+        input_type = self.input_type
+        file_format = self.file_format
+        file_path = Path(self.file_path).expanduser()
+
+        # Ensure the directory exists
+        if not file_path.parent.exists():
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if input_type == "DataFrame":
+            df = self.df
+            return self._save_dataframe(df, file_path, file_format)
+        elif input_type == "Data":
+            data = self.data
+            return self._save_data(data, file_path, file_format)
+        elif input_type == "Message":
+            message = self.message
+            return self._save_message(message, file_path, file_format)
+        else:
+            raise ValueError(f"Unsupported input type: {input_type}")
+
+    def _save_dataframe(self, df: DataFrame, path: Path, fmt: str) -> str:
+        if fmt == "csv":
+            df.to_csv(path, index=False)
+        elif fmt == "excel":
+            df.to_excel(path, index=False, engine="openpyxl")
+        elif fmt == "json":
+            df.to_json(path, orient="records", indent=2)
+        elif fmt == "markdown":
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(df.to_markdown(index=False))
+        else:
+            raise ValueError(f"Unsupported DataFrame format: {fmt}")
+
+        return f"DataFrame saved successfully as '{path}'"
+
+    def _save_data(self, data: Data, path: Path, fmt: str) -> str:
+        if fmt == "csv":
+            pd.DataFrame(data.data).to_csv(path, index=False)
+        elif fmt == "excel":
+            pd.DataFrame(data.data).to_excel(path, index=False, engine="openpyxl")
+        elif fmt == "json":
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(data.data, f, indent=2)
+        elif fmt == "markdown":
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(pd.DataFrame(data.data).to_markdown(index=False))
+        else:
+            raise ValueError(f"Unsupported Data format: {fmt}")
+
+        return f"Data saved successfully as '{path}'"
+
+    def _save_message(self, message: Message, path: Path, fmt: str) -> str:
+        content = message.text
+
+        if fmt == "txt":
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(content)
+        elif fmt == "json":
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump({"message": content}, f, indent=2)
+        elif fmt == "markdown":
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(f"**Message:**\n\n{content}")
+        else:
+            raise ValueError(f"Unsupported Message format: {fmt}")
+
+        return f"Message saved successfully as '{path}'"
+
+

--- a/src/backend/base/langflow/components/processing/save_to_file.py
+++ b/src/backend/base/langflow/components/processing/save_to_file.py
@@ -138,10 +138,7 @@ class SaveToFileComponent(Component):
         elif fmt == "json":
             path.write_text(json.dumps(data.data, indent=2), encoding="utf-8")
         elif fmt == "markdown":
-            path.write_text(
-                pd.DataFrame(data.data).to_markdown(index=False),
-                encoding="utf-8"
-            )
+            path.write_text(pd.DataFrame(data.data).to_markdown(index=False), encoding="utf-8")
         else:
             error_msg = f"Unsupported Data format: {fmt}"
             raise ValueError(error_msg)
@@ -154,10 +151,7 @@ class SaveToFileComponent(Component):
         if fmt == "txt":
             path.write_text(content, encoding="utf-8")
         elif fmt == "json":
-            path.write_text(
-                json.dumps({"message": content}, indent=2),
-                encoding="utf-8"
-            )
+            path.write_text(json.dumps({"message": content}, indent=2), encoding="utf-8")
         elif fmt == "markdown":
             path.write_text(f"**Message:**\n\n{content}", encoding="utf-8")
         else:

--- a/src/backend/tests/unit/components/processing/test_save_to_file_component.py
+++ b/src/backend/tests/unit/components/processing/test_save_to_file_component.py
@@ -4,9 +4,9 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
-
 from langflow.components.processing.save_to_file import SaveToFileComponent
 from langflow.schema import Data, Message
+
 from tests.base import ComponentTestBaseWithoutClient
 
 
@@ -39,12 +39,7 @@ class TestSaveToFileComponent(ComponentTestBaseWithoutClient):
     def default_kwargs(self):
         """Return the default kwargs for the component."""
         sample_df = pd.DataFrame([{"col1": 1, "col2": "a"}, {"col1": 2, "col2": "b"}])
-        return {
-            "input_type": "DataFrame",
-            "df": sample_df,
-            "file_format": "csv",
-            "file_path": "./test_output.csv"
-        }
+        return {"input_type": "DataFrame", "df": sample_df, "file_format": "csv", "file_path": "./test_output.csv"}
 
     @pytest.fixture
     def file_names_mapping(self):
@@ -96,12 +91,14 @@ class TestSaveToFileComponent(ComponentTestBaseWithoutClient):
                 mock_path.return_value = mock_file
 
                 component = component_class()
-                component.set_attributes({
-                    "input_type": "Message",
-                    "message": Message(text="Test message"),
-                    "file_format": fmt,
-                    "file_path": f"./test_output.{fmt}"
-                })
+                component.set_attributes(
+                    {
+                        "input_type": "Message",
+                        "message": Message(text="Test message"),
+                        "file_format": fmt,
+                        "file_path": f"./test_output.{fmt}",
+                    }
+                )
 
                 result = component.save_to_file()
 
@@ -122,12 +119,14 @@ class TestSaveToFileComponent(ComponentTestBaseWithoutClient):
             mock_path.return_value = mock_file
 
             component = component_class()
-            component.set_attributes({
-                "input_type": "Data",
-                "data": Data(data=test_data),
-                "file_format": "json",
-                "file_path": "./test_output.json"
-            })
+            component.set_attributes(
+                {
+                    "input_type": "Data",
+                    "data": Data(data=test_data),
+                    "file_format": "json",
+                    "file_path": "./test_output.json",
+                }
+            )
 
             result = component.save_to_file()
 

--- a/src/backend/tests/unit/components/processing/test_save_to_file_component.py
+++ b/src/backend/tests/unit/components/processing/test_save_to_file_component.py
@@ -1,0 +1,164 @@
+import json
+from pathlib import Path
+from langflow.components.processing.save_to_file import SaveToFileComponent
+import pytest
+import pandas as pd
+from unittest.mock import Mock, patch, MagicMock
+from langflow.schema import Data, DataFrame, Message
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestSaveToFileComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        """Setup and teardown for each test"""
+        # Setup
+        test_files = [
+            "./test_output.csv",
+            "./test_output.xlsx",
+            "./test_output.json",
+            "./test_output.md",
+            "./test_output.txt"
+        ]
+        # Teardown
+        yield
+        # Delete test files after each test
+        for file_path in test_files:
+            path = Path(file_path)
+            if path.exists():
+                path.unlink()
+
+    @pytest.fixture
+    def component_class(self):
+        """Return the component class to test."""
+        return SaveToFileComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        """Return the default kwargs for the component."""
+        df = pd.DataFrame([{"col1": 1, "col2": "a"}, {"col1": 2, "col2": "b"}])
+        return {
+            "input_type": "DataFrame",
+            "df": DataFrame(df),
+            "file_format": "csv",
+            "file_path": "./test_output.csv"
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        """Return the file names mapping for different versions."""
+        return []  # New component
+
+    def test_basic_setup(self, component_class, default_kwargs):
+        """Test basic component initialization."""
+        component = component_class()
+        component.set_attributes(default_kwargs)
+        assert component.input_type == "DataFrame"
+        assert component.file_format == "csv"
+        assert component.file_path == "./test_output.csv"
+
+    def test_update_build_config_dataframe(self, component_class):
+        """Test build config update for DataFrame input type."""
+        component = component_class()
+        build_config = {
+            "df": {"show": False},
+            "data": {"show": False},
+            "message": {"show": False},
+            "file_format": {"options": []}
+        }
+        
+        updated_config = component.update_build_config(build_config, "DataFrame", "input_type")
+        
+        assert updated_config["df"]["show"] is True
+        assert updated_config["data"]["show"] is False
+        assert updated_config["message"]["show"] is False
+        assert set(updated_config["file_format"]["options"]) == set(component.DATA_FORMAT_CHOICES)
+
+    def test_save_message(self, component_class):
+        """Test saving Message to different formats."""
+        test_cases = [
+            ("txt", "Test message"),
+            ("json", json.dumps({"message": "Test message"}, indent=2)),
+            ("markdown", "**Message:**\n\nTest message")
+        ]
+        
+        for fmt, expected_content in test_cases:
+            mock_file = MagicMock()
+            mock_parent = MagicMock()
+            mock_parent.exists.return_value = True
+            mock_file.parent = mock_parent
+            mock_file.expanduser.return_value = mock_file
+
+            # Mock Path at the module level where it's imported
+            with patch('langflow.components.processing.save_to_file.Path') as MockPath:
+                MockPath.return_value = mock_file
+                
+                component = component_class()
+                component.set_attributes({
+                    "input_type": "Message",
+                    "message": Message(text="Test message"),
+                    "file_format": fmt,
+                    "file_path": f"./test_output.{fmt}"
+                })
+                
+                result = component.save_to_file()
+                
+                mock_file.write_text.assert_called_once_with(expected_content, encoding="utf-8")
+                assert "saved successfully" in result
+
+    def test_save_data(self, component_class):
+        """Test saving Data object to JSON."""
+        test_data = {"col1": ["value1"], "col2": ["value2"]}
+        
+        mock_file = MagicMock()
+        mock_parent = MagicMock()
+        mock_parent.exists.return_value = True
+        mock_file.parent = mock_parent
+        mock_file.expanduser.return_value = mock_file
+
+        with patch('langflow.components.processing.save_to_file.Path') as MockPath:
+            MockPath.return_value = mock_file
+            
+            component = component_class()
+            component.set_attributes({
+                "input_type": "Data",
+                "data": Data(data=test_data),
+                "file_format": "json",
+                "file_path": "./test_output.json"
+            })
+            
+            result = component.save_to_file()
+            
+            expected_json = json.dumps(test_data, indent=2)
+            mock_file.write_text.assert_called_once_with(expected_json, encoding="utf-8")
+            assert "saved successfully" in result
+
+    def test_directory_creation(self, component_class, default_kwargs):
+        """Test directory creation if it doesn't exist."""
+        mock_file = MagicMock()
+        mock_parent = MagicMock()
+        mock_parent.exists.return_value = False
+        mock_file.parent = mock_parent
+        mock_file.expanduser.return_value = mock_file
+
+        with patch('langflow.components.processing.save_to_file.Path') as MockPath:
+            MockPath.return_value = mock_file
+            with patch.object(pd.DataFrame, 'to_csv') as mock_to_csv:
+                component = component_class()
+                component.set_attributes(default_kwargs)
+                
+                result = component.save_to_file()
+                
+                mock_parent.mkdir.assert_called_once_with(parents=True, exist_ok=True)
+                assert mock_to_csv.called
+                assert "saved successfully" in result
+
+    def test_invalid_input_type(self, component_class, default_kwargs):
+        """Test handling of invalid input type."""
+        default_kwargs["input_type"] = "InvalidType"
+        component = component_class()
+        component.set_attributes(default_kwargs)
+        
+        with pytest.raises(ValueError) as exc_info:
+            component.save_to_file()
+        assert "Unsupported input type" in str(exc_info.value)


### PR DESCRIPTION
This pull request introduces a new component for saving various types of data to files in different formats. The `SaveToFileComponent` class has been added to handle DataFrames, Data, and Messages, providing options for saving them in formats such as CSV, Excel, JSON, and Markdown.

Key changes include:

### New Component Addition:
* [`src/backend/base/langflow/components/processing/save_to_file.py`](diffhunk://#diff-9d7ce72a176300ab240d49aacccf3915cf78f288dcbb472bb60e6514e078229eR1-R163): Added the `SaveToFileComponent` class, which allows saving DataFrames, Data, or Messages to various file formats. This includes defining inputs for selecting the data type and format, and outputs for confirmation messages.

### Methods for Saving Data:
* Implemented methods `_save_dataframe`, `_save_data`, and `_save_message` to handle the saving process for each data type, supporting multiple file formats.


![image](https://github.com/user-attachments/assets/6aa6e003-d1f1-4bb0-8d85-a1bb0d0cba05)
