### PR TITLE
chore: Bump version to 1.1.4 for langflow and 0.1.4 for langflow-base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "langflow"
-version = "1.1.3"
+version = "1.1.4"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.13"
 license = "MIT"
@@ -19,7 +19,7 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
-    "langflow-base==0.1.3",
+    "langflow-base==0.1.4",
     "beautifulsoup4==4.12.3",
     "google-search-results>=2.4.1,<3.0.0",
     "google-api-python-client==2.154.0",

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-base"
-version = "0.1.3"
+version = "0.1.4"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.13"
 license = "MIT"


### PR DESCRIPTION
Update the version numbers for both langflow and langflow-base to reflect the latest release.