### PR TITLE
fix: use greenlet_spawn to support sqlalchemy async driver

### DIFF
--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import re
 import sqlite3
 import time

--- a/src/backend/base/langflow/services/database/service.py
+++ b/src/backend/base/langflow/services/database/service.py
@@ -19,6 +19,7 @@ from sqlalchemy.dialects import sqlite as dialect_sqlite
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.util.concurrency import greenlet_spawn
 from sqlmodel import SQLModel, select, text
 from sqlmodel.ext.asyncio.session import AsyncSession
 from tenacity import retry, stop_after_attempt, wait_fixed
@@ -362,7 +363,7 @@ class DatabaseService(Service):
             except Exception:  # noqa: BLE001
                 logger.debug("Alembic not initialized")
                 should_initialize_alembic = True
-        await asyncio.to_thread(self._run_migrations, should_initialize_alembic, fix)
+        await greenlet_spawn(self._run_migrations, should_initialize_alembic, fix)
 
     @staticmethod
     def try_downgrade_upgrade_until_success(alembic_cfg, retries=5) -> None:


### PR DESCRIPTION
The async engine of sqlalchemy need to be executed in greenlet context, so change `asyncio.to_thread` to `greenlet_spawn`.  They do the same thing - run a sync func in async fashion.

Have been test on `aiomysql` client and `mariadb`:
 
`export LANGFLOW_DATABASE_URL='mysql+aiomysql://user:pass@localhost:3306/db'`

#5495 