### PR TITLE
Refactor: Simplify Vertex Queue Initialization by Removing is_input_vertex Dependency

### DIFF
--- a/src/backend/base/langflow/graph/schema.py
+++ b/src/backend/base/langflow/graph/schema.py
@@ -61,6 +61,7 @@ RECORDS_COMPONENTS = [InterfaceComponentTypes.DataOutput]
 INPUT_COMPONENTS = [
     InterfaceComponentTypes.ChatInput,
     InterfaceComponentTypes.WebhookInput,
+    InterfaceComponentTypes.TextInput,
 ]
 OUTPUT_COMPONENTS = [
     InterfaceComponentTypes.ChatOutput,

--- a/src/backend/base/langflow/graph/schema.py
+++ b/src/backend/base/langflow/graph/schema.py
@@ -61,7 +61,6 @@ RECORDS_COMPONENTS = [InterfaceComponentTypes.DataOutput]
 INPUT_COMPONENTS = [
     InterfaceComponentTypes.ChatInput,
     InterfaceComponentTypes.WebhookInput,
-    InterfaceComponentTypes.TextInput,
 ]
 OUTPUT_COMPONENTS = [
     InterfaceComponentTypes.ChatOutput,

--- a/src/backend/base/langflow/graph/vertex/vertex_types.py
+++ b/src/backend/base/langflow/graph/vertex/vertex_types.py
@@ -101,7 +101,6 @@ class ComponentVertex(Vertex):
             default_value: Any = UNDEFINED
             for edge in self.get_edge_with_target(requester.id):
                 # We need to check if the edge is a normal edge
-                # Get default value based on edge type
                 if edge.is_cycle and edge.target_param:
                     default_value = (None if edge.target_param in requester.output_names
                                     else requester.get_value_from_template_dict(edge.target_param))

--- a/src/backend/base/langflow/graph/vertex/vertex_types.py
+++ b/src/backend/base/langflow/graph/vertex/vertex_types.py
@@ -101,12 +101,11 @@ class ComponentVertex(Vertex):
             default_value: Any = UNDEFINED
             for edge in self.get_edge_with_target(requester.id):
                 # We need to check if the edge is a normal edge
-                # Get default value based on edge type
                 if edge.is_cycle and edge.target_param:
-                    default_value = (None if edge.target_param in requester.output_names
-                                    else requester.get_value_from_template_dict(edge.target_param))
-                else:
-                    default_value = requester.get_value_from_template_dict(target_handle_name)
+                    if edge.target_param in requester.output_names:
+                        default_value = None
+                    else:
+                        default_value = requester.get_value_from_template_dict(edge.target_param)
 
             if flow_id:
                 await self._log_transaction_async(source=self, target=requester, flow_id=str(flow_id), status="error")

--- a/src/backend/base/langflow/graph/vertex/vertex_types.py
+++ b/src/backend/base/langflow/graph/vertex/vertex_types.py
@@ -101,11 +101,12 @@ class ComponentVertex(Vertex):
             default_value: Any = UNDEFINED
             for edge in self.get_edge_with_target(requester.id):
                 # We need to check if the edge is a normal edge
+                # Get default value based on edge type
                 if edge.is_cycle and edge.target_param:
-                    if edge.target_param in requester.output_names:
-                        default_value = None
-                    else:
-                        default_value = requester.get_value_from_template_dict(edge.target_param)
+                    default_value = (None if edge.target_param in requester.output_names
+                                    else requester.get_value_from_template_dict(edge.target_param))
+                else:
+                    default_value = requester.get_value_from_template_dict(target_handle_name)
 
             if flow_id:
                 await self._log_transaction_async(source=self, target=requester, flow_id=str(flow_id), status="error")

--- a/src/backend/base/langflow/graph/vertex/vertex_types.py
+++ b/src/backend/base/langflow/graph/vertex/vertex_types.py
@@ -102,13 +102,10 @@ class ComponentVertex(Vertex):
             for edge in self.get_edge_with_target(requester.id):
                 # We need to check if the edge is a normal edge
                 if edge.is_cycle and edge.target_param:
-                    default_value = (
-                        None
-                        if edge.target_param in requester.output_names
-                        else requester.get_value_from_template_dict(edge.target_param)
-                    )
-                else:
-                    default_value = requester.get_value_from_template_dict(target_handle_name)
+                    if edge.target_param in requester.output_names:
+                        default_value = None
+                    else:
+                        default_value = requester.get_value_from_template_dict(edge.target_param)
 
             if flow_id:
                 await self._log_transaction_async(source=self, target=requester, flow_id=str(flow_id), status="error")


### PR DESCRIPTION
This pull request includes a small change to the `src/backend/base/langflow/graph/schema.py` file. The change removes the `InterfaceComponentTypes.TextInput` from the `INPUT_COMPONENTS` list.

* [`src/backend/base/langflow/graph/schema.py`](diffhunk://#diff-18ff9d04e38afcbd589463290cf6aa93e8faed272efcc544c59b71f9f8e86edaL64): Removed `InterfaceComponentTypes.TextInput` from the `INPUT_COMPONENTS` list.