### PR TITLE
refactor: replace StrInput with MultilineInput for URL fields

### DIFF
--- a/src/backend/base/langflow/components/firecrawl/firecrawl_crawl_api.py
+++ b/src/backend/base/langflow/components/firecrawl/firecrawl_crawl_api.py
@@ -6,7 +6,7 @@ from langflow.io import (
     IntInput,
     Output,
     SecretStrInput,
-    StrInput,
+    MultilineInput
 )
 from langflow.schema import Data
 
@@ -27,7 +27,7 @@ class FirecrawlCrawlApi(Component):
             password=True,
             info="The API key to use Firecrawl API.",
         ),
-        StrInput(
+        MultilineInput(
             name="url",
             display_name="URL",
             required=True,

--- a/src/backend/base/langflow/components/firecrawl/firecrawl_scrape_api.py
+++ b/src/backend/base/langflow/components/firecrawl/firecrawl_scrape_api.py
@@ -4,7 +4,7 @@ from langflow.io import (
     IntInput,
     Output,
     SecretStrInput,
-    StrInput,
+    MultilineInput,
 )
 from langflow.schema import Data
 
@@ -25,7 +25,7 @@ class FirecrawlScrapeApi(Component):
             password=True,
             info="The API key to use Firecrawl API.",
         ),
-        StrInput(
+        MultilineInput(
             name="url",
             display_name="URL",
             required=True,


### PR DESCRIPTION
This pull request includes changes to the `firecrawl_crawl_api.py` and `firecrawl_scrape_api.py` files to replace the `StrInput` component with the `MultilineInput` component for better handling of multi-line input fields.

Changes to input components:

* [`src/backend/base/langflow/components/firecrawl/firecrawl_crawl_api.py`](diffhunk://#diff-b3e62ebc8b9ddf3b83f34bf1677405767d0321ea754b69a69b4febfb1b40472aL9-R9): Replaced `StrInput` with `MultilineInput` in the imports and in the `FirecrawlCrawlApi` class for the `url` field. [[1]](diffhunk://#diff-b3e62ebc8b9ddf3b83f34bf1677405767d0321ea754b69a69b4febfb1b40472aL9-R9) [[2]](diffhunk://#diff-b3e62ebc8b9ddf3b83f34bf1677405767d0321ea754b69a69b4febfb1b40472aL30-R30)
* [`src/backend/base/langflow/components/firecrawl/firecrawl_scrape_api.py`](diffhunk://#diff-895b1f1235295c855c1e9ea2d073cc77c8ab1213f0b713ff1fad2f8cd1719908L7-R7): Replaced `StrInput` with `MultilineInput` in the imports and in the `FirecrawlScrapeApi` class for the `url` field. [[1]](diffhunk://#diff-895b1f1235295c855c1e9ea2d073cc77c8ab1213f0b713ff1fad2f8cd1719908L7-R7) [[2]](diffhunk://#diff-895b1f1235295c855c1e9ea2d073cc77c8ab1213f0b713ff1fad2f8cd1719908L28-R28)