### PR TITLE
refactor: migrate chat lock state to useFlowStore

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chat-view-wrapper.tsx
+++ b/src/frontend/src/modals/IOModal/components/chat-view-wrapper.tsx
@@ -19,8 +19,6 @@ export const ChatViewWrapper = ({
   messagesFetched,
   sessionId,
   sendMessage,
-  lockChat,
-  setLockChat,
   canvasOpen,
   setOpen,
 }: ChatViewWrapperProps) => {
@@ -93,8 +91,6 @@ export const ChatViewWrapper = ({
           <ChatView
             focusChat={sessionId}
             sendMessage={sendMessage}
-            lockChat={lockChat}
-            setLockChat={setLockChat}
             visibleSession={visibleSession}
             closeChat={
               !canvasOpen

--- a/src/frontend/src/modals/IOModal/components/chatView/chat-view.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chat-view.tsx
@@ -30,8 +30,6 @@ const MemoizedChatMessage = memo(ChatMessage, (prevProps, nextProps) => {
 
 export default function ChatView({
   sendMessage,
-  lockChat,
-  setLockChat,
   visibleSession,
   focusChat,
   closeChat,
@@ -50,6 +48,8 @@ export default function ChatView({
   const displayLoadingMessage = useMessagesStore(
     (state) => state.displayLoadingMessage,
   );
+
+  const lockChat = useFlowStore((state) => state.lockChat);
 
   const inputTypes = inputs.map((obj) => obj.type);
   const updateFlowPool = useFlowStore((state) => state.updateFlowPool);
@@ -168,8 +168,6 @@ export default function ChatView({
             <>
               {chatHistory?.map((chat, index) => (
                 <MemoizedChatMessage
-                  setLockChat={setLockChat}
-                  lockChat={lockChat}
                   chat={chat}
                   lastMessage={chatHistory.length - 1 === index}
                   key={`${chat.id}-${index}`}

--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/chat-message.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/chat-message.tsx
@@ -6,6 +6,7 @@ import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import useFlowStore from "@/stores/flowStore";
 import { useUtilityStore } from "@/stores/utilityStore";
+import { ChatMessageType } from "@/types/chat";
 import Convert from "ansi-to-html";
 import { useEffect, useRef, useState } from "react";
 import Robot from "../../../../../assets/robot.png";
@@ -27,12 +28,13 @@ import { convertFiles } from "./helpers/convert-files";
 
 export default function ChatMessage({
   chat,
-  lockChat,
   lastMessage,
   updateChat,
-  setLockChat,
   closeChat,
 }: chatMessagePropsType): JSX.Element {
+  const setLockChat = useFlowStore((state) => state.setLockChat);
+  const lockChat = useFlowStore((state) => state.lockChat);
+
   const convert = new Convert({ newline: true });
   const [hidden, setHidden] = useState(true);
   const [streamUrl, setStreamUrl] = useState(chat.stream_url);
@@ -53,7 +55,10 @@ export default function ChatMessage({
   useEffect(() => {
     const chatMessageString = chat.message ? chat.message.toString() : "";
     setChatMessage(chatMessageString);
-  }, [chat]);
+    chatMessageRef.current = chatMessage;
+  }, [chat, setLockChat]);
+
+  console.log(lockChat);
 
   const playgroundScrollBehaves = useUtilityStore(
     (state) => state.playgroundScrollBehaves,
@@ -61,10 +66,6 @@ export default function ChatMessage({
   const setPlaygroundScrollBehaves = useUtilityStore(
     (state) => state.setPlaygroundScrollBehaves,
   );
-  // Sync ref with state
-  useEffect(() => {
-    chatMessageRef.current = chatMessage;
-  }, [chatMessage]);
 
   // The idea now is that chat.stream_url MAY be a URL if we should stream the output of the chat
   // probably the message is empty when we have a stream_url
@@ -360,7 +361,7 @@ export default function ChatMessage({
                         }
                         className="flex w-full flex-col"
                       >
-                        {chatMessage === "" && lockChat ? (
+                        {chatMessage === "" && lockChat && lastMessage ? (
                           <IconComponent
                             name="MoreHorizontal"
                             className="h-8 w-8 animate-pulse"

--- a/src/frontend/src/modals/IOModal/new-modal.tsx
+++ b/src/frontend/src/modals/IOModal/new-modal.tsx
@@ -113,8 +113,8 @@ export default function IOModal({
 
   const buildFlow = useFlowStore((state) => state.buildFlow);
   const setIsBuilding = useFlowStore((state) => state.setIsBuilding);
-  const lockChat = useFlowStore((state) => state.lockChat);
   const setLockChat = useFlowStore((state) => state.setLockChat);
+
   const isBuilding = useFlowStore((state) => state.isBuilding);
   const messages = useMessagesStore((state) => state.messages);
   const [sessions, setSessions] = useState<string[]>(
@@ -147,8 +147,6 @@ export default function IOModal({
       files?: string[];
     }): Promise<void> => {
       if (isBuilding) return;
-      setIsBuilding(true);
-      setLockChat(true);
       setChatValue("");
       for (let i = 0; i < repeat; i++) {
         await buildFlow({
@@ -163,7 +161,6 @@ export default function IOModal({
           setLockChat(false);
         });
       }
-      // refetch();
       setLockChat(false);
     },
     [
@@ -331,8 +328,6 @@ export default function IOModal({
                 messagesFetched={messagesFetched}
                 sessionId={sessionId}
                 sendMessage={sendMessage}
-                lockChat={lockChat}
-                setLockChat={setLockChat}
                 canvasOpen={canvasOpen}
                 setOpen={setOpen}
               />

--- a/src/frontend/src/modals/IOModal/types/chat-view-wrapper.ts
+++ b/src/frontend/src/modals/IOModal/types/chat-view-wrapper.ts
@@ -14,8 +14,6 @@ export type ChatViewWrapperProps = {
   messagesFetched: boolean;
   sessionId: string;
   sendMessage: (options: { repeat: number; files?: string[] }) => Promise<void>;
-  lockChat: boolean;
-  setLockChat: (locked: boolean) => void;
   canvasOpen: boolean | undefined;
   setOpen: (open: boolean) => void;
 };

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -593,9 +593,7 @@ export type codeAreaModalPropsType = {
 
 export type chatMessagePropsType = {
   chat: ChatMessageType;
-  lockChat: boolean;
   lastMessage: boolean;
-  setLockChat: (lock: boolean) => void;
   updateChat: (
     chat: ChatMessageType,
     message: string,
@@ -772,8 +770,6 @@ export type chatViewProps = {
     repeat: number;
     files?: string[];
   }) => void;
-  lockChat: boolean;
-  setLockChat: (lock: boolean) => void;
   visibleSession?: string;
   focusChat?: string;
   closeChat?: () => void;


### PR DESCRIPTION
This pull request focuses on refactoring the chat locking mechanism in the `IOModal` component and its related subcomponents. The changes primarily involve removing the `lockChat` and `setLockChat` props and replacing them with state management using the `useFlowStore` hook.

Refactoring of chat locking mechanism:

* Removed `lockChat` and `setLockChat` props from `ChatViewWrapper` and `ChatView` components and their respective type definitions. [[1]](diffhunk://#diff-52d471cf733cb05b6f50c8d666222a28e007f00cb811d925e37b01b697d3fc9aL22-L23) [[2]](diffhunk://#diff-52d471cf733cb05b6f50c8d666222a28e007f00cb811d925e37b01b697d3fc9aL96-L97) [[3]](diffhunk://#diff-5ab3fdad30cd6db1da8bb1d0febd32f1e422bd8efbc4085bd89c4e617eeefaf5L33-L34) [[4]](diffhunk://#diff-5ab3fdad30cd6db1da8bb1d0febd32f1e422bd8efbc4085bd89c4e617eeefaf5R52-R53) [[5]](diffhunk://#diff-c954eff206b8544cf185efa26c7881aa14c328628f5d662ddb5c854db4a192a8L17-L18) [[6]](diffhunk://#diff-37f7198f6f1ca1cdf6cbcc98051772d333ae0835185f1a7ca99da54c90a0f3d6L596-L598) [[7]](diffhunk://#diff-37f7198f6f1ca1cdf6cbcc98051772d333ae0835185f1a7ca99da54c90a0f3d6L775-L776)
* Added `lockChat` and `setLockChat` state management using `useFlowStore` in `ChatView` and `ChatMessage` components. [[1]](diffhunk://#diff-5ab3fdad30cd6db1da8bb1d0febd32f1e422bd8efbc4085bd89c4e617eeefaf5R52-R53) [[2]](diffhunk://#diff-32094af3aa7e49cc56ea2fd2b832c2bf540ead37267d7d68792cfd533d1716d9L30-R37)
* Updated `ChatMessage` component to use the new state management for `lockChat` and `setLockChat`, and adjusted the conditional rendering logic based on the new state. [[1]](diffhunk://#diff-32094af3aa7e49cc56ea2fd2b832c2bf540ead37267d7d68792cfd533d1716d9L56-L67) [[2]](diffhunk://#diff-32094af3aa7e49cc56ea2fd2b832c2bf540ead37267d7d68792cfd533d1716d9L363-R364)
* Removed `lockChat` and `setLockChat` from the `IOModal` component and its related logic. [[1]](diffhunk://#diff-35a8d953d616582d1e2933848c04ac2cbda55ee7939d22620d60374f0df61815L116-R117) [[2]](diffhunk://#diff-35a8d953d616582d1e2933848c04ac2cbda55ee7939d22620d60374f0df61815L150-L151) [[3]](diffhunk://#diff-35a8d953d616582d1e2933848c04ac2cbda55ee7939d22620d60374f0df61815L166) [[4]](diffhunk://#diff-35a8d953d616582d1e2933848c04ac2cbda55ee7939d22620d60374f0df61815L334-L335)