### PR TITLE
feat: add s3 uploader component

### DIFF
--- a/src/backend/base/langflow/components/data/s3_bucket_retriever.py
+++ b/src/backend/base/langflow/components/data/s3_bucket_retriever.py
@@ -1,0 +1,117 @@
+from loguru import logger
+import os
+import boto3
+import tempfile
+import fnmatch
+from typing import Any
+
+from langflow.base.data.utils import parse_text_file_to_data
+from langflow.custom import Component
+from langflow.io import (
+    SecretStrInput,
+    BoolInput,
+    DataInput,
+    DropdownInput,
+    FloatInput,
+    IntInput,
+    MessageTextInput,
+    MultilineInput,
+    Output,
+    StrInput,
+)
+from langflow.schema import Data
+
+class S3BucketRetrieverComponent(Component):
+    """A component for retrieving data from an S3 bucket.
+    Attributes:
+        display_name (str): The display name of the component.
+        description (str): A brief description of the component.
+        icon (str): The icon representing the component.
+        name (str): The name of the component.
+        inputs (list): A list of input configurations for the component.
+        outputs (list): A list of output configurations for the component.
+    Methods:
+        _s3_client() -> Any:
+            Downloads the specified object from the S3 bucket to a temporary file and returns the file path.
+        as_data() -> Data:
+            Converts the input value to a Data object by downloading the object from the S3 bucket and parsing it.
+    """
+    display_name = "S3 Bucket Retreiver"
+    description = "Reads from S3 bucket."
+    icon = "Globe"
+    name = "s3bucketretreiver"
+    
+    inputs = [
+        SecretStrInput(
+            name="aws_access_key_id",
+            display_name="AWS Access Key ID",
+            required=True,
+            password=True,
+            info="AWS Access key ID.",
+        ),
+        SecretStrInput(
+            name="aws_secret_access_key",
+            display_name="AWS Secret Key",
+            required=True,
+            password=True,
+            info="AWS Secret Key.",
+        ),
+        StrInput(
+            name="bucket_name",
+            display_name="Bucket Name",
+            info="Enter the name of the bucket.",
+            advanced=False,
+        ),
+        StrInput(
+            name="s3_prefix",
+            display_name="Prefix",
+            info="S3 Bucket Prefix.",
+            advanced=False,
+        ),
+        StrInput(
+            name="object_name",
+            display_name="Object Name",
+            info="Object name or wildcard for download.",
+            advanced=False,
+        ),
+    ]
+     
+    outputs = [
+        Output(display_name="Retrieve files from S3", name="data", method="retrieve_files"),
+    ]
+
+
+    def _s3_client(self) -> Any:
+        """
+        Creates and returns an S3 client using the provided AWS access key ID and secret access key.
+
+        Returns:
+            Any: A boto3 S3 client instance.
+        """
+        return boto3.client(
+            's3',
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+        )
+    
+    def retrieve_files(self) -> Data:
+
+        # List objects with the specified prefix
+        response = self._s3_client().list_objects_v2(Bucket=self.bucket_name, Prefix=self.s3_prefix)
+        if 'Contents' not in response:
+            self.log(f"No objects found with prefix {self.s3_prefix}")
+            return []
+
+        # Filter objects based on the wildcard pattern
+        matching_keys = [obj['Key'] for obj in response['Contents'] if fnmatch.fnmatch(obj['Key'], self.object_name)]
+        self.log(f"Found {len(matching_keys)} objects matching {self.object_name}")
+
+        # Download each matching object
+        data_list = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Download each matching object
+            for key in matching_keys:
+                file_name = os.path.join(temp_dir, os.path.basename(key))
+                self._s3_client().download_file(self.bucket_name, key, file_name)
+                data_list.append(parse_text_file_to_data(file_name, silent_errors=True))
+        return data_list

--- a/src/backend/base/langflow/components/data/s3_bucket_uploader.py
+++ b/src/backend/base/langflow/components/data/s3_bucket_uploader.py
@@ -1,0 +1,195 @@
+import os
+from typing import Any
+
+import boto3
+
+from langflow.custom import Component
+from langflow.io import (
+    BoolInput,
+    DropdownInput,
+    HandleInput,
+    Output,
+    SecretStrInput,
+    StrInput,
+)
+
+class S3BucketUploaderComponent(Component):
+    """S3BucketUploaderComponent is a component responsible for uploading files to an S3 bucket.
+
+    It provides two strategies for file upload: "By Data" and "By File Name". The component
+    requires AWS credentials and bucket details as inputs and processes files accordingly.
+
+    Attributes:
+        display_name (str): The display name of the component.
+        description (str): A brief description of the components functionality.
+        icon (str): The icon representing the component.
+        name (str): The internal name of the component.
+        inputs (list): A list of input configurations required by the component.
+        outputs (list): A list of output configurations provided by the component.
+
+    Methods:
+        process_files() -> None:
+            Processes files based on the selected strategy. Calls the appropriate method
+            based on the strategy attribute.
+        process_files_by_data() -> None:
+            Processes and uploads files to an S3 bucket based on the data inputs. Iterates
+            over the data inputs, logs the file path and text content, and uploads each file
+            to the specified S3 bucket if both file path and text content are available.
+        process_files_by_name() -> None:
+            Processes and uploads files to an S3 bucket based on their names. Iterates through
+            the list of data inputs, retrieves the file path from each data item, and uploads
+            the file to the specified S3 bucket if the file path is available. Logs the file
+            path being uploaded.
+        _s3_client() -> Any:
+            Creates and returns an S3 client using the provided AWS access key ID and secret
+            access key.
+
+        Please note that this component requires the boto3 library to be installed. It is designed to work with File and Director components as inputs
+    """
+    display_name = "S3 Bucket Uploader"
+    description = "Uploads files to S3 bucket."
+    icon = "Globe"
+    name = "s3bucketuploader"
+
+    inputs = [
+        SecretStrInput(
+            name="aws_access_key_id",
+            display_name="AWS Access Key ID",
+            required=True,
+            password=True,
+            info="AWS Access key ID.",
+        ),
+        SecretStrInput(
+            name="aws_secret_access_key",
+            display_name="AWS Secret Key",
+            required=True,
+            password=True,
+            info="AWS Secret Key.",
+        ),
+        StrInput(
+            name="bucket_name",
+            display_name="Bucket Name",
+            info="Enter the name of the bucket.",
+            advanced=False,
+        ),
+        DropdownInput(
+            name="strategy",
+            display_name="Strategy for file upload",
+            options=["Store Data", "Store Original File"],
+            value="By Data",
+            info="Choose the strategy to upload the file. By Data means that the source file is parsed and stored as LangFlow data. By File Name means that the source file is uploaded as is.",
+        ),
+        HandleInput(
+            name="data_inputs",
+            display_name="Data Inputs",
+            info="The data to split.",
+            input_types=["Data"],
+            is_list=True,
+            required=True,
+        ),
+        StrInput(
+            name="s3_prefix",
+            display_name="S3 Prefix",
+            info="Prefix for all files.",
+        ),
+        BoolInput (
+            name="strip_path",
+            display_name="Strip Path",
+            info="Removes path from file path.",
+            value=True,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Upload files to S3", name="data", method="upload_files"),
+    ]
+
+    def upload_files(self) -> None:
+        """
+        Process files based on the selected strategy.
+        This method uses a strategy pattern to process files. The strategy is determined
+        by the `self.strategy` attribute, which can be either "By Data" or "By File Name".
+        Depending on the strategy, the corresponding method (`process_files_by_data` or
+        `process_files_by_name`) is called. If an invalid strategy is provided, an error
+        is logged.
+
+        Returns:
+            None
+
+        """
+        strategy_methods = {
+            "Store Data": self._process_files_by_data,
+            "Store Original File": self._process_files_by_name,
+        }
+        strategy_methods.get(self.strategy, lambda: self.log("Invalid strategy"))()
+
+    def _process_files_by_data(self) -> None:
+        """Processes and uploads files to an S3 bucket based on the data inputs.
+        This method iterates over the data inputs, logs the file path and text content,
+        and uploads each file to the specified S3 bucket if both file path and text content
+        are available.
+
+        Args:
+            None
+        Returns:
+            None
+        """
+        for data_item in self.data_inputs:
+
+            file_path = data_item.data.get("file_path")
+            text_content = data_item.data.get("text")
+
+            if file_path and text_content:
+                self._s3_client().put_object(Bucket=self.bucket_name, Key=self._normalize_path(file_path), Body=text_content)
+
+    def _process_files_by_name(self) -> None:
+        """Processes and uploads files to an S3 bucket based on their names.
+        Iterates through the list of data inputs, retrieves the file path from each data item,
+        and uploads the file to the specified S3 bucket if the file path is available.
+        Logs the file path being uploaded.
+
+        Returns:
+            None
+        """
+        for data_item in self.data_inputs:
+            file_path = data_item.data.get("file_path")
+            self.log(f"Uploading file: {file_path}")
+            if file_path:
+                self._s3_client().upload_file(file_path, Bucket=self.bucket_name, Key=self._normalize_path(file_path))
+
+    def _s3_client(self) -> Any:
+        """Creates and returns an S3 client using the provided AWS access key ID and secret access key.
+
+        Returns:
+            Any: A boto3 S3 client instance.
+        """
+        return boto3.client(
+            "s3",
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+        )
+
+    def _normalize_path(self, file_path) -> str:
+        """Process the file path based on the s3_prefix and path_as_prefix.
+        
+        Args:
+            file_path (str): The original file path.
+            s3_prefix (str): The S3 prefix to use.
+            path_as_prefix (bool): Whether to use the file path as the S3 prefix.
+        
+        Returns:
+            str: The processed file path.
+        """
+        prefix = self.s3_prefix
+        strip_path = self.strip_path
+        processed_path: str = file_path
+
+        if strip_path:
+            # Filename only
+            processed_path = os.path.basename(file_path)
+
+        # Concatenate the s3_prefix if it exists
+        if prefix:
+           processed_path = os.path.join(prefix, processed_path)
+
+        return processed_path

--- a/src/backend/tests/unit/components/data/test_s3_retriever_component.py
+++ b/src/backend/tests/unit/components/data/test_s3_retriever_component.py
@@ -1,0 +1,120 @@
+import pytest
+import tempfile
+import uuid
+import boto3
+import os
+
+from tests.base import ComponentTestBaseWithoutClient
+
+from langflow.schema.data import Data
+from langflow.components.data.s3_bucket_uploader import S3BucketUploaderComponent
+from langflow.components.data.s3_bucket_retriever import S3BucketRetrieverComponent
+
+class TestS3RetrieverComponent(ComponentTestBaseWithoutClient):
+    
+    @pytest.fixture
+    def component_class(self):
+        """Return the component class to test."""
+        return S3BucketUploaderComponent
+
+    @pytest.fixture
+    def retriever_component_class(self):
+        """Return the component class to test."""
+        return S3BucketRetrieverComponent
+    
+    @pytest.fixture
+    def file_names_mapping(self):
+        """Return an empty list since this component doesn't have version-specific files."""
+        return [
+        ]
+
+    @pytest.fixture
+    def temp_files(self):
+        # Setup: Create three temporary files
+        temp_files = []
+        contents = [
+            b"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            b"Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+            b"Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+        ]
+
+        for content in contents:
+            with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as temp_file:
+                temp_file.write(content)
+                temp_file.flush()
+                temp_file.close()
+                temp_files.append(temp_file.name)
+    
+        data = [
+            Data(data={"file_path": file_path, "text": open(file_path, 'r').read()})
+            for file_path in temp_files
+        ]
+
+        yield data
+    
+        # Teardown: Explicitly delete the files
+        for temp_file in temp_files:
+            os.unlink(temp_file)
+            
+            
+    @pytest.fixture
+    def s3_bucket(self) -> str:
+        # Generate a unique bucket name (AWS requires globally unique names)
+        bucket_name = f"graphrag-test-bucket-{uuid.uuid4().hex[:8]}"
+
+        # Initialize S3 client using environment variables for credentials. Assumes key and secret are set via environment variables
+        s3 = boto3.client(
+            's3'
+        )   
+
+        try:
+            # Create an S3 bucket in your default region
+            s3.create_bucket(Bucket=bucket_name)
+            
+            yield bucket_name
+
+        finally:
+            # Teardown: Delete the bucket and its contents
+            try:
+                # List and delete all objects in the bucket
+                objects = s3.list_objects_v2(Bucket=bucket_name).get('Contents', [])
+                for obj in objects:
+                    s3.delete_object(Bucket=bucket_name, Key=obj['Key'])
+                
+                # Delete the bucket
+                s3.delete_bucket(Bucket=bucket_name)
+            except Exception as e:
+                print(f"Error during teardown: {e}")
+
+    def test_upload_download(self, temp_files, s3_bucket):
+        """Test uploading files to an S3 bucket."""
+        upload = S3BucketUploaderComponent()
+        download = S3BucketRetrieverComponent()
+        
+        # Set AWS credentials from environment variables
+        aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID')
+        aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
+        upload.set_attributes({
+            "aws_access_key_id": aws_access_key_id,
+            "aws_secret_access_key": aws_secret_access_key,
+            "bucket_name": s3_bucket,
+            "strategy": "Store Original File",
+            "data_inputs": temp_files,
+            "s3_prefix": "test",
+            "strip_path": True
+        })
+        upload.upload_files()
+        
+        download = S3BucketRetrieverComponent()
+        download.set_attributes({
+            "aws_access_key_id": aws_access_key_id,
+            "aws_secret_access_key": aws_secret_access_key,
+            "bucket_name": s3_bucket,
+            "strategy": "Store Original File",
+            "s3_prefix": "test",
+            "object_name": "*.txt"
+        })
+        
+        data = download.retrieve_files()
+        assert len(data) == len(temp_files)
+        

--- a/src/backend/tests/unit/components/data/test_s3_uploader_component.py
+++ b/src/backend/tests/unit/components/data/test_s3_uploader_component.py
@@ -1,0 +1,123 @@
+import pytest
+import tempfile
+import uuid
+import boto3
+import os
+
+from tests.base import ComponentTestBaseWithoutClient
+
+from langflow.schema.data import Data
+from langflow.components.data.s3_bucket_uploader import S3BucketUploaderComponent
+
+class TestS3UploaderComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        """Return the component class to test."""
+        return S3BucketUploaderComponent
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        """Return an empty list since this component doesn't have version-specific files."""
+        return [
+        ]
+
+    @pytest.fixture
+    def temp_files(self):
+        # Setup: Create three temporary files
+        temp_files = []
+        contents = [
+            b"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            b"Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+            b"Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+        ]
+
+        for content in contents:
+            with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as temp_file:
+                temp_file.write(content)
+                temp_file.flush()
+                temp_file.close()
+                temp_files.append(temp_file.name)
+    
+        data = [
+            Data(data={"file_path": file_path, "text": open(file_path, 'r').read()})
+            for file_path in temp_files
+        ]
+
+        yield data
+    
+        # Teardown: Explicitly delete the files
+        for temp_file in temp_files:
+            os.unlink(temp_file)
+            
+            
+    @pytest.fixture
+    def s3_bucket(self) -> str:
+        # Get credentials from environment variables
+        session = boto3.Session()
+        credentials = session.get_credentials()
+
+        
+        # Generate a unique bucket name (AWS requires globally unique names)
+        bucket_name = f"graphrag-test-bucket-{uuid.uuid4().hex[:8]}"
+
+        # Initialize S3 client using environment variables for credentials. Assumes key and secret are set via environment variables
+        s3 = boto3.client(
+            's3'
+        )   
+
+        try:
+            # Create an S3 bucket in your default region
+            s3.create_bucket(Bucket=bucket_name)
+            
+            yield bucket_name
+
+        finally:
+            pass
+            # Teardown: Delete the bucket and its contents
+            try:
+                # List and delete all objects in the bucket
+                objects = s3.list_objects_v2(Bucket=bucket_name).get('Contents', [])
+                for obj in objects:
+                    s3.delete_object(Bucket=bucket_name, Key=obj['Key'])
+                
+                # Delete the bucket
+                s3.delete_bucket(Bucket=bucket_name)
+            except Exception as e:
+                print(f"Error during teardown: {e}")
+
+    def test_upload(self, temp_files, s3_bucket):
+        """Test uploading files to an S3 bucket."""
+ 
+         # Set AWS credentials from environment variables
+        aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID')
+        aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
+        
+        component = S3BucketUploaderComponent()
+        component.set_attributes({
+            "aws_access_key_id": aws_access_key_id,
+            "aws_secret_access_key": aws_secret_access_key,
+            "bucket_name": s3_bucket,
+            "strategy": "Store Original File",
+            "data_inputs": temp_files,
+            "s3_prefix": "test",
+            "strip_path": True
+        })
+        
+        component.upload_files()
+
+        # Check if the files were uploaded. Assumes key and secret are set via environment variables 
+        s3 = boto3.client(
+            's3'
+        )   
+
+        for temp_file in temp_files:
+            key = f"test/{os.path.basename(temp_file.file_path)}"
+            response = s3.get_object(Bucket=s3_bucket, Key=key)
+            assert response['Body'].read() == open(temp_file.file_path, 'rb').read()
+        
+        
+        
+        
+        
+        
+


### PR DESCRIPTION
Notes:

This PR replaces https://github.com/langflow-ai/langflow/pull/6146. It now includes both the s3 uploader and the retriever because of a dependency on unit testing. 

New Feature:
Uploader allows users to take input from File and Directory components and saves the file in an s3 bucket. Retriever allows users to download files from an s3 bucket into "data". 

Note to testing - UT requires a public s3 bucket with key/secret access set as environment variables

