### PR TITLE
feat: update API code generation to use Langflow client

### DIFF
--- a/src/frontend/src/modals/apiModal/utils/get-js-api-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-js-api-code.tsx
@@ -18,29 +18,35 @@ export default function getJsApiCode({
 }: GetCodeType): string {
   let tweaksString = "{}";
   if (tweaksBuildedObject)
-    tweaksString = JSON.stringify(tweaksBuildedObject, null, 8);
+    tweaksString = JSON.stringify(tweaksBuildedObject, null, 2).replace(/^ {2}/gm, "    ").replace(/}$/, "  }");
   const inputs = useFlowStore.getState().inputs;
   const outputs = useFlowStore.getState().outputs;
   const hasChatInput = inputs.some((input) => input.type === "ChatInput");
   const hasChatOutput = outputs.some((output) => output.type === "ChatOutput");
 
-  return `${activeTweaks ? "" : 'let inputValue = ""; // Insert input value here\n\n'}fetch(
-  "${window.location.protocol}//${window.location.host}/api/v1/run/${endpointName || flowId}?stream=false",
-  {
-    method: "POST",
-    headers: {
-      "Authorization": "Bearer <TOKEN>",
-      "Content-Type": "application/json",${isAuth ? '\n\t\t\t"x-api-key": <your api key>' : ""}
-    },
-    body: JSON.stringify({${activeTweaks ? "" : "\n\t\t\tinput_value: inputValue, "}
-      output_type: ${hasChatOutput ? '"chat"' : '"text"'},
-      input_type: ${hasChatInput ? '"chat"' : '"text"'},
-      tweaks: ${tweaksString}
-    }),
-  },
-)
-  .then(res => res.json())
-  .then(data => console.log(data))
-  .catch(error => console.error('Error:', error));
-`;
+  return `# Install the Langflow client
+# npm install @datastax/langflow-client
+
+import { LangflowClient } from "@datastax/langflow-client";
+
+const client = new LangflowClient({
+  baseUrl: "${window.location.protocol}//${window.location.host}"${isAuth ? ",\n  apiKey: <your api key>" : ""}
+})
+const flow = client.flow("${endpointName || flowId}");
+
+let inputValue = ""; // Insert input value here
+
+flow.run(inputValue, {
+  output_type: ${hasChatOutput ? '"chat"' : '"text"'},
+  input_type: ${hasChatInput ? '"chat"' : '"text"'},
+  session_id: "user_1",
+  tweaks: ${tweaksString}
+}).then(response => {
+  // get the text of the first chat response
+  console.log(response.chatOutputText());
+  // Or get all the outputs
+  console.log(response.outputs);
+}.catch(error => {
+  console.error(error);
+});`;
 }


### PR DESCRIPTION
This is a suggestion to use this [Langflow client](https://www.npmjs.com/package/@datastax/langflow-client) package as the JavaScript code example instead of a raw `fetch`.

This simplifies the code as developers don't have to worry about headers, how to set the API key (as it is different between self-hosted and DataStax-hosted Langflow), or stringifying objects. It also shows that you can use `response.chatOutputText()` to retrieve just the chat response from the full API response.

You can see a rendered output example in this screenshot:

![langflow-client-example](https://github.com/user-attachments/assets/4dcb15fe-370c-4602-afc8-940d23c34edb)

The only thing I couldn't work out from the code base was how to show DataStax-hosted specific information, like including the `langflowId` in the URL.

Let me know what you think.