### PR TITLE
feat: option to hide a column in frontend when defining a Table Input, hides Tool identifier from table display

### DIFF
--- a/src/backend/base/langflow/base/tools/constants.py
+++ b/src/backend/base/langflow/base/tools/constants.py
@@ -12,6 +12,7 @@ TOOL_TABLE_SCHEMA = [
         "sortable": False,
         "filterable": False,
         "edit_mode": EditMode.INLINE,
+        "hidden": False,
     },
     {
         "name": "description",
@@ -21,6 +22,7 @@ TOOL_TABLE_SCHEMA = [
         "sortable": False,
         "filterable": False,
         "edit_mode": EditMode.POPOVER,
+        "hidden": False,
     },
     {
         "name": "tags",
@@ -31,6 +33,7 @@ TOOL_TABLE_SCHEMA = [
         "sortable": False,
         "filterable": False,
         "edit_mode": EditMode.INLINE,
+        "hidden": True,
     },
 ]
 

--- a/src/backend/base/langflow/schema/table.py
+++ b/src/backend/base/langflow/schema/table.py
@@ -30,6 +30,7 @@ class Column(BaseModel):
     default: str | None = None
     disable_edit: bool = Field(default=False)
     edit_mode: EditMode | None = Field(default=EditMode.MODAL)
+    hidden: bool = Field(default=False)
 
     @model_validator(mode="after")
     def set_display_name(self):

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
@@ -53,65 +53,67 @@ const TableComponent = forwardRef<
     },
     ref,
   ) => {
-    let colDef = props.columnDefs.map((col, index) => {
-      let newCol = {
-        ...col,
-      };
-      // Filter out hidden columns
-      if (col.hidden) {
-        return null;
-      }
-      if (props.rowSelection && props.onSelectionChanged && index === 0) {
-        newCol = {
-          ...newCol,
-          checkboxSelection: true,
-          headerCheckboxSelection: true,
-          headerCheckboxSelectionFilteredOnly: true,
+    let colDef = props.columnDefs
+      .map((col, index) => {
+        let newCol = {
+          ...col,
         };
-      }
-      if (
-        (typeof props.tableOptions?.block_hide === "boolean" &&
-          props.tableOptions?.block_hide) ||
-        (Array.isArray(props.tableOptions?.block_hide) &&
-          props.tableOptions?.block_hide.includes(newCol.field ?? ""))
-      ) {
-        newCol = {
-          ...newCol,
-          lockVisible: true,
-        };
-      }
-      if (
-        (typeof props.editable === "boolean" && props.editable) ||
-        (Array.isArray(props.editable) &&
-          props.editable.every((field) => typeof field === "string") &&
-          (props.editable as Array<string>).includes(newCol.field ?? ""))
-      ) {
-        newCol = {
-          ...newCol,
-          editable: true,
-        };
-      }
-      if (
-        Array.isArray(props.editable) &&
-        props.editable.every((field) => typeof field === "object")
-      ) {
-        const field = (
-          props.editable as Array<{
-            field: string;
-            onUpdate: (value: any) => void;
-            editableCell: boolean;
-          }>
-        ).find((field) => field.field === newCol.field);
-        if (field) {
+        // Filter out hidden columns
+        if (col.hidden) {
+          return null;
+        }
+        if (props.rowSelection && props.onSelectionChanged && index === 0) {
           newCol = {
             ...newCol,
-            editable: field.editableCell,
-            onCellValueChanged: (e) => field.onUpdate(e),
+            checkboxSelection: true,
+            headerCheckboxSelection: true,
+            headerCheckboxSelectionFilteredOnly: true,
           };
         }
-      }
-      return newCol;
-    }).filter(Boolean); // Filter out null values from hidden columns
+        if (
+          (typeof props.tableOptions?.block_hide === "boolean" &&
+            props.tableOptions?.block_hide) ||
+          (Array.isArray(props.tableOptions?.block_hide) &&
+            props.tableOptions?.block_hide.includes(newCol.field ?? ""))
+        ) {
+          newCol = {
+            ...newCol,
+            lockVisible: true,
+          };
+        }
+        if (
+          (typeof props.editable === "boolean" && props.editable) ||
+          (Array.isArray(props.editable) &&
+            props.editable.every((field) => typeof field === "string") &&
+            (props.editable as Array<string>).includes(newCol.field ?? ""))
+        ) {
+          newCol = {
+            ...newCol,
+            editable: true,
+          };
+        }
+        if (
+          Array.isArray(props.editable) &&
+          props.editable.every((field) => typeof field === "object")
+        ) {
+          const field = (
+            props.editable as Array<{
+              field: string;
+              onUpdate: (value: any) => void;
+              editableCell: boolean;
+            }>
+          ).find((field) => field.field === newCol.field);
+          if (field) {
+            newCol = {
+              ...newCol,
+              editable: field.editableCell,
+              onCellValueChanged: (e) => field.onUpdate(e),
+            };
+          }
+        }
+        return newCol;
+      })
+      .filter(Boolean); // Filter out null values from hidden columns
     // @ts-ignore
     const realRef: React.MutableRefObject<AgGridReact> =
       useRef<AgGridReact | null>(null);

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
@@ -57,6 +57,10 @@ const TableComponent = forwardRef<
       let newCol = {
         ...col,
       };
+      // Filter out hidden columns
+      if (col.hidden) {
+        return null;
+      }
       if (props.rowSelection && props.onSelectionChanged && index === 0) {
         newCol = {
           ...newCol,
@@ -107,7 +111,7 @@ const TableComponent = forwardRef<
         }
       }
       return newCol;
-    });
+    }).filter(Boolean); // Filter out null values from hidden columns
     // @ts-ignore
     const realRef: React.MutableRefObject<AgGridReact> =
       useRef<AgGridReact | null>(null);

--- a/src/frontend/src/types/utils/functions.ts
+++ b/src/frontend/src/types/utils/functions.ts
@@ -26,6 +26,7 @@ export interface ColumnField {
   formatter?: FormatterType;
   description?: string;
   disable_edit?: boolean;
-  default?: any; // Add this line
+  default?: any;
   edit_mode?: "modal" | "inline" | "popover";
+  hidden?: boolean;
 }

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -524,7 +524,7 @@ export function brokenEdgeMessage({
 export function FormatColumns(columns: ColumnField[]): ColDef<any>[] {
   if (!columns) return [];
   const basic_types = new Set(["date", "number"]);
-  const colDefs = columns.map((col, index) => {
+  const colDefs = columns.map((col) => {
     let newCol: ColDef = {
       headerName: col.display_name,
       field: col.name,
@@ -532,6 +532,7 @@ export function FormatColumns(columns: ColumnField[]): ColDef<any>[] {
       filter: col.filterable,
       context: col.description ? { info: col.description } : {},
       cellClass: col.disable_edit ? "cell-disable-edit" : "",
+      hide: col.hidden,
       valueParser: (params: ValueParserParams) => {
         const { context, newValue, colDef, oldValue } = params;
         if (
@@ -595,6 +596,7 @@ export function generateBackendColumnsFromValue(
       sortable: !tableOptions?.block_sort,
       filterable: !tableOptions?.block_filter,
       default: null, // Initialize default to null or appropriate value
+      hidden: false,
     };
 
     // Attempt to infer the default value from the data, if possible


### PR DESCRIPTION
This pull request introduces a new feature to handle hidden columns in the table components. The changes span across backend and frontend files to ensure proper handling and rendering of hidden columns.

### Backend changes:
* [`src/backend/base/langflow/base/tools/constants.py`](diffhunk://#diff-c60ffce8614e539a6fa7c3e47ac11aa7b89f15b9e09d9549c907ef15a7d33894R15): Added the `hidden` attribute to the column definitions with appropriate boolean values. [[1]](diffhunk://#diff-c60ffce8614e539a6fa7c3e47ac11aa7b89f15b9e09d9549c907ef15a7d33894R15) [[2]](diffhunk://#diff-c60ffce8614e539a6fa7c3e47ac11aa7b89f15b9e09d9549c907ef15a7d33894R25) [[3]](diffhunk://#diff-c60ffce8614e539a6fa7c3e47ac11aa7b89f15b9e09d9549c907ef15a7d33894R36)
* [`src/backend/base/langflow/schema/table.py`](diffhunk://#diff-66bd9e20d21689c7321905c0c2e5b0e4e5cedb2e92c2f6c00c092a4714f597baR33): Added the `hidden` attribute to the `Column` class with a default value of `False`.

### Frontend changes:
* [`src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx`](diffhunk://#diff-f3fcb59cd5fd40bf313028ede0595abb9ebe326e02946ecaece08678d8ea212fR60-R63): Updated the `TableComponent` to filter out hidden columns. [[1]](diffhunk://#diff-f3fcb59cd5fd40bf313028ede0595abb9ebe326e02946ecaece08678d8ea212fR60-R63) [[2]](diffhunk://#diff-f3fcb59cd5fd40bf313028ede0595abb9ebe326e02946ecaece08678d8ea212fL110-R114)
* [`src/frontend/src/types/utils/functions.ts`](diffhunk://#diff-33d96254db9b4d7cd0985c1b2abdfa748415b86e975b2752aca358bcbdb57a2aL29-R31): Added the `hidden` attribute to the `ColumnField` interface.
* [`src/frontend/src/utils/utils.ts`](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81L527-R535): Updated the `FormatColumns` and `generateBackendColumnsFromValue` functions to handle the `hidden` attribute. [[1]](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81L527-R535) [[2]](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81R599)