### PR TITLE
feat: Add ModelScope API

### DIFF
--- a/docs/docs/Components/components-models.md
+++ b/docs/docs/Components/components-models.md
@@ -320,7 +320,7 @@ For more information, see [documentation](https://modelscope.cn/docs/model-servi
 
 | Name  | Type          | Description                                                      |
 |-------|---------------|------------------------------------------------------------------|
-| model | LanguageModel | An instance of Novita AI model configured with the specified parameters. |
+| model | LanguageModel | An instance of ModelScope model configured with the specified parameters. |
 
 ## Novita AI
 

--- a/docs/docs/Components/components-models.md
+++ b/docs/docs/Components/components-models.md
@@ -300,6 +300,28 @@ For more information, see [Mistral AI documentation](https://docs.mistral.ai/).
 |--------|---------------|-----------------------------------------------------|
 | model  | LanguageModel | An instance of ChatMistralAI configured with the specified parameters. |
 
+## ModelScope API
+
+This component generates text using ModelScope inference API.
+
+For more information, see [documentation](https://modelscope.cn/docs/model-service/API-Inference/intro).
+
+### Inputs
+
+| Name                | Type          | Description                                                      |
+|---------------------|---------------|------------------------------------------------------------------|
+| api_key             | SecretString   | Your ModelScope SDK token.                                             |
+| api_base            | String         | The base URL of the ModelScope API. Default: `https://api-inference.modelscope.cn/v1`. |
+| model_name               | String         | The name of the model to use.  |
+| temperature         | Float          | Controls randomness in the output. Range: [0.0, 1.0]. Default: 0.1. |
+
+
+### Outputs
+
+| Name  | Type          | Description                                                      |
+|-------|---------------|------------------------------------------------------------------|
+| model | LanguageModel | An instance of Novita AI model configured with the specified parameters. |
+
 ## Novita AI
 
 This component generates text using Novita AI's language models.

--- a/src/backend/base/langflow/components/models/__init__.py
+++ b/src/backend/base/langflow/components/models/__init__.py
@@ -11,6 +11,7 @@ from .huggingface import HuggingFaceEndpointsComponent
 from .lmstudiomodel import LMStudioModelComponent
 from .maritalk import MaritalkModelComponent
 from .mistral import MistralAIModelComponent
+from .modelscope import ModelScopeModelComponent
 from .novita import NovitaModelComponent
 from .nvidia import NVIDIAModelComponent
 from .ollama import ChatOllamaComponent
@@ -35,6 +36,7 @@ __all__ = [
     "LMStudioModelComponent",
     "MaritalkModelComponent",
     "MistralAIModelComponent",
+    "ModelScopeModelComponent",
     "NVIDIAModelComponent",
     "NovitaModelComponent",
     "OpenAIModelComponent",

--- a/src/backend/base/langflow/components/models/modelscope.py
+++ b/src/backend/base/langflow/components/models/modelscope.py
@@ -1,0 +1,151 @@
+import operator
+from functools import reduce
+
+from langchain_openai import ChatOpenAI
+from pydantic.v1 import SecretStr
+
+from langflow.base.models.model import LCModelComponent
+from langflow.field_typing import LanguageModel
+from langflow.field_typing.range_spec import RangeSpec
+from langflow.inputs import BoolInput, DictInput, DropdownInput, FloatInput, IntInput, SecretStrInput, StrInput
+from langflow.inputs.inputs import HandleInput
+
+MODELSCOPE_MODEL_NAMES = [
+    "Qwen/Qwen2.5-32B-Instruct",
+    "LLM-Research/Llama-3.3-70B-Instruct",
+    "Qwen/QVQ-72B-Preview",
+    "Qwen/QwQ-32B-Preview",
+    "Qwen/Qwen2.5-Coder-32B-Instruct",
+    "Qwen/Qwen2.5-Coder-14B-Instruct",
+    "Qwen/Qwen2.5-Coder-7B-Instruct",
+    "Qwen/Qwen2.5-72B-Instruct",
+    "Qwen/Qwen2.5-14B-Instruct",
+    "Qwen/Qwen2.5-7B-Instruct",
+]
+
+
+class ModelScopeModelComponent(LCModelComponent):
+    display_name = "ModelScope"
+    description = "Generate text using ModelScope Inference APIs"
+    icon = "ModelScope"
+    name = "ModelScopeModel"
+    inputs = [
+        *LCModelComponent._base_inputs,
+        IntInput(
+            name="max_tokens",
+            display_name="Max Tokens",
+            advanced=True,
+            info="The maximum number of tokens to generate. Set to 0 for unlimited tokens.",
+            range_spec=RangeSpec(min=0, max=128000),
+        ),
+        DictInput(
+            name="model_kwargs",
+            display_name="Model Kwargs",
+            advanced=True,
+            info="Additional keyword arguments to pass to the model.",
+        ),
+        BoolInput(
+            name="json_mode",
+            display_name="JSON Mode",
+            advanced=True,
+            info="If True, it will output JSON regardless of passing a schema.",
+        ),
+        DictInput(
+            name="output_schema",
+            is_list=True,
+            display_name="Schema",
+            advanced=True,
+            info="The schema for the Output of the model. "
+            "You must pass the word JSON in the prompt. "
+            "If left blank, JSON mode will be disabled. [DEPRECATED]",
+        ),
+        DropdownInput(
+            name="model_name",
+            display_name="Model Name",
+            advanced=False,
+            options=MODELSCOPE_MODEL_NAMES,
+            value=MODELSCOPE_MODEL_NAMES[0],
+            required=True,
+        ),
+        StrInput(
+            name="openai_api_base",
+            display_name="ModelScope Base URL",
+            advanced=True,
+            info="The base URL of the ModelScope. "
+            "Defaults to https://api-inference.modelscope.cn/v1. "
+            "You can change this to use other APIs like JinaChat, LocalAI and Prem.",
+            required=True,
+            value="https://api-inference.modelscope.cn/v1",
+        ),
+        SecretStrInput(
+            name="api_key",
+            display_name="ModelScope 访问令牌",
+            info="在 (ModelScope 首页 -> 访问令牌) 获取你的令牌然后填入",
+            advanced=False,
+            value="OPENAI_API_KEY",
+            required=True,
+        ),
+        FloatInput(name="temperature", display_name="Temperature", value=0.1),
+        IntInput(
+            name="seed",
+            display_name="Seed",
+            info="The seed controls the reproducibility of the job.",
+            advanced=True,
+            value=1,
+        ),
+        HandleInput(
+            name="output_parser",
+            display_name="Output Parser",
+            info="The parser to use to parse the output of the model",
+            advanced=True,
+            input_types=["OutputParser"],
+        ),
+    ]
+
+    def build_model(self) -> LanguageModel:  # type: ignore[type-var]
+        # self.output_schema is a list of dictionaries
+        # let's convert it to a dictionary
+        output_schema_dict: dict[str, str] = reduce(operator.ior, self.output_schema or {}, {})
+        openai_api_key = self.api_key
+        temperature = self.temperature
+        model_name: str = self.model_name
+        max_tokens = self.max_tokens
+        model_kwargs = self.model_kwargs or {}
+        openai_api_base = self.openai_api_base or "https://api-inference.modelscope.cn/v1"
+        json_mode = bool(output_schema_dict) or self.json_mode
+        seed = self.seed
+        api_key = SecretStr(openai_api_key).get_secret_value() if openai_api_key else None
+        output = ChatOpenAI(
+            max_tokens=max_tokens or None,
+            model_kwargs=model_kwargs,
+            model=model_name,
+            base_url=openai_api_base,
+            api_key=api_key,
+            temperature=temperature if temperature is not None else 0.1,
+            seed=seed,
+        )
+        if json_mode:
+            if output_schema_dict:
+                output = output.with_structured_output(schema=output_schema_dict, method="json_mode")
+            else:
+                output = output.bind(response_format={"type": "json_object"})
+        return output
+
+    def _get_exception_message(self, e: Exception):
+        """Get a message from an OpenAI exception.
+
+        Args:
+            e (Exception): The exception to get the message from.
+
+        Returns:
+            str: The message from the exception.
+        """
+        try:
+            from openai import BadRequestError
+        except ImportError:
+            return None
+        if isinstance(e, BadRequestError):
+            message = e.body.get("message")
+            if message:
+                return message
+        return None

--- a/src/frontend/src/icons/ModelScope/ModelScope.jsx
+++ b/src/frontend/src/icons/ModelScope/ModelScope.jsx
@@ -1,0 +1,29 @@
+const SvgModelScope = (props) => (
+  <svg
+    height="56"
+    style="flex:none;line-height:1"
+    viewBox="0 0 24 24"
+    width="56"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <title>ModelScope</title>
+    <path
+      d="M0 7.967h2.667v2.667H0zM8 10.633h2.667V13.3H8z"
+      fill="#36CED0"
+    ></path>
+    <path
+      d="M0 10.633h2.667V13.3H0zM2.667 13.3h2.666v2.667H8v2.666H2.667V13.3zM2.667 5.3H8v2.667H5.333v2.666H2.667V5.3zM10.667 13.3h2.667v2.667h-2.667z"
+      fill="#624AFF"
+    ></path>
+    <path
+      d="M24 7.967h-2.667v2.667H24zM16 10.633h-2.667V13.3H16z"
+      fill="#36CED0"
+    ></path>
+    <path
+      d="M24 10.633h-2.667V13.3H24zM21.333 13.3h-2.666v2.667H16v2.666h5.333V13.3zM21.333 5.3H16v2.667h2.667v2.666h2.666V5.3z"
+      fill="#624AFF"
+    ></path>
+  </svg>
+);
+export default SvgModelScope;

--- a/src/frontend/src/icons/ModelScope/index.tsx
+++ b/src/frontend/src/icons/ModelScope/index.tsx
@@ -1,0 +1,9 @@
+import React, { forwardRef } from "react";
+import SvgModelScope from "./ModelScope";
+
+export const ModelScopeIcon = forwardRef<
+  SVGSVGElement,
+  React.PropsWithChildren<{}>
+>((props, ref) => {
+  return <SvgModelScope ref={ref} {...props} />;
+});

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -279,6 +279,7 @@ import { MaritalkIcon } from "../icons/Maritalk";
 import { Mem0 } from "../icons/Mem0";
 import { MetaIcon } from "../icons/Meta";
 import { MidjourneyIcon } from "../icons/Midjorney";
+import { ModelScopeIcon } from "../icons/ModelScope";
 import { MongoDBIcon } from "../icons/MongoDB";
 import { NeedleIcon } from "../icons/Needle";
 import { NotDiamondIcon } from "../icons/NotDiamond";
@@ -668,6 +669,7 @@ export const nodeIconsLucide: iconsType = {
   Composio: ComposioIcon,
   Meta: MetaIcon,
   Midjorney: MidjourneyIcon,
+  ModelScope: ModelScopeIcon,
   MongoDBAtlasVectorSearch: MongoDBIcon,
   MongoDB: MongoDBIcon,
   MongoDBChatMessageHistory: MongoDBIcon,


### PR DESCRIPTION
**ModelScope** is the largest model community in China. It serves as a premier platform designed to bridge model checkpoints with model applications, offering the essential infrastructure to facilitate the sharing of open models and promote model-centric development. For more information, visit our GitHub page: [ModelScope](https://github.com/modelscope).

In this pull request, we have integrated the ModelScope Inference API as a model component. This addition aims to make it easier for more users to build applications using Langflow.