### PR TITLE
fix: made tool_mode components minimizable

### DIFF
--- a/src/frontend/src/CustomNodes/helpers/count-handles.ts
+++ b/src/frontend/src/CustomNodes/helpers/count-handles.ts
@@ -9,8 +9,10 @@ export function countHandlesFn(data: NodeDataType): number {
     )
     .map((templateCamp) => {
       const { template } = data.node!;
-      if (template[templateCamp]?.input_types) return true;
+      if (template[templateCamp]?.tool_mode && data.node?.tool_mode)
+        return false;
       if (!template[templateCamp]?.show) return false;
+      if (template[templateCamp]?.input_types) return true;
       switch (template[templateCamp]?.type) {
         case "str":
         case "bool":
@@ -18,8 +20,10 @@ export function countHandlesFn(data: NodeDataType): number {
         case "code":
         case "prompt":
         case "file":
+        case "table":
         case "int":
           return false;
+
         default:
           return true;
       }


### PR DESCRIPTION
This pull request includes changes to the `countHandlesFn` function in `count-handles.ts` to improve the logic for determining handle counts based on node data. The most important changes include adding a condition to check for `tool_mode`, reordering the checks for `input_types`, and adding a new case for the `table` type.

Improvements to handle count logic:

* Added a condition to check for `tool_mode` to determine if the handle should be counted as false.
* Reordered the check for `input_types` to occur after the `show` check.
* Added a new case for the `table` type to return false in the switch statement.