### PR TITLE
fix: changed naming for download button on sidebar nav context menu

### DIFF
--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx
@@ -66,7 +66,7 @@ export const SelectOptions = ({
             </SelectItem>
           )}
           <SelectItem value="download" data-testid="btn-download-folder">
-            <FolderSelectItem name="Download Content" iconName="Download" />
+            <FolderSelectItem name="Download" iconName="Download" />
           </SelectItem>
           {index > 0 && (
             <SelectItem value="delete" data-testid="btn-delete-folder">


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx` file. The change updates the `FolderSelectItem` component's `name` property from "Download Content" to "Download".

* [`src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/select-options.tsx`](diffhunk://#diff-d5ce5da31ecc0209d1b295e4cf9f4a3eadd9af8c2511a85567c9fb706e6cc033L69-R69): Updated `FolderSelectItem` component's `name` property from "Download Content" to "Download".