### PR TITLE
chore: Bump version to 1.1.5 for langflow and 0.1.5 for langflow-base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "langflow"
-version = "1.1.4.post1"
+version = "1.1.5"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.13"
 license = "MIT"
@@ -19,7 +19,7 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
-    "langflow-base==0.1.4.post1",
+    "langflow-base==0.1.5",
     "beautifulsoup4==4.12.3",
     "google-search-results>=2.4.1,<3.0.0",
     "google-api-python-client==2.154.0",
@@ -95,7 +95,7 @@ dependencies = [
     "langchain-google-community==2.0.3",
     "langchain-elasticsearch==0.3.0",
     "langchain-ollama==0.2.1",
-    "langchain-sambanova==0.1.0",   
+    "langchain-sambanova==0.1.0",
     "langchain-community~=0.3.10",
     "sqlalchemy[aiosqlite,postgresql_psycopg2binary,postgresql_psycopgbinary]>=2.0.36,<3.0.0",
     "atlassian-python-api==3.41.16",

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-base"
-version = "0.1.4.post1"
+version = "0.1.5"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.13"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -3804,7 +3804,7 @@ wheels = [
 
 [[package]]
 name = "langflow"
-version = "1.1.4.post1"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "ag2" },
@@ -3920,7 +3920,7 @@ local = [
     { name = "sentence-transformers" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "asgi-lifespan" },
     { name = "blockbuster" },
@@ -4065,7 +4065,7 @@ requires-dist = [
     { name = "zep-python", specifier = "==2.0.2" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
     { name = "blockbuster", specifier = ">=1.5.8,<1.6" },
@@ -4108,7 +4108,7 @@ dev = [
 
 [[package]]
 name = "langflow-base"
-version = "0.1.4.post1"
+version = "0.1.5"
 source = { editable = "src/backend/base" }
 dependencies = [
     { name = "aiofile" },
@@ -4229,7 +4229,7 @@ local = [
     { name = "sentence-transformers" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "asgi-lifespan" },
     { name = "pytest-codspeed" },
@@ -4347,7 +4347,7 @@ requires-dist = [
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.11" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
     { name = "pytest-codspeed", specifier = ">=3.0.0" },


### PR DESCRIPTION
Update version numbers for langflow and langflow-base in their respective configuration files.

This is so the Nightly Build finds a valid version. This also improves the nightly versions because now a nightly will reference a version that is not released yet.