### PR TITLE
fix: make extension check case-insensitive in BaseFileComponent

### DIFF
--- a/src/backend/base/langflow/base/data/base_file.py
+++ b/src/backend/base/langflow/base/data/base_file.py
@@ -492,7 +492,7 @@ class BaseFileComponent(Component, ABC):
                 self.log(f"Not a file: {file.path.name}")
                 continue
 
-            if file.path.suffix[1:] not in self.valid_extensions:
+            if file.path.suffix[1:].lower() not in self.valid_extensions:
                 if self.ignore_unsupported_extensions:
                     ignored_files.append(file.path.name)
                     continue


### PR DESCRIPTION
Modify file extension validation to ensure consistent handling of extensions by using lowercase comparison.