### PR TITLE
fix: add optional chaining and improve code robustness

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/outputModal/components/switchOutputView/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/outputModal/components/switchOutputView/index.tsx
@@ -25,13 +25,15 @@ const SwitchOutputView: React.FC<SwitchOutputViewProps> = ({
   type,
 }) => {
   const flowPool = useFlowStore((state) => state.flowPool);
+
   const flowPoolNode = (flowPool[nodeId] ?? [])[
     (flowPool[nodeId]?.length ?? 1) - 1
   ];
+
   let results: OutputLogType | LogsLogType =
     (type === "Outputs"
-      ? flowPoolNode?.data?.outputs[outputName]
-      : flowPoolNode?.data?.logs[outputName]) ?? {};
+      ? flowPoolNode?.data?.outputs?.[outputName]
+      : flowPoolNode?.data?.logs?.[outputName]) ?? {};
   const resultType = results?.type;
   let resultMessage = results?.message ?? {};
   const RECORD_TYPES = ["data", "object", "array", "message"];
@@ -40,18 +42,20 @@ const SwitchOutputView: React.FC<SwitchOutputViewProps> = ({
   }
 
   const resultMessageMemoized = useMemo(() => {
+    if (!resultMessage) return "";
+
     if (
       typeof resultMessage === "string" &&
       resultMessage.length > MAX_TEXT_LENGTH
     ) {
-      resultMessage = `${resultMessage.substring(0, MAX_TEXT_LENGTH)}...`;
+      return `${resultMessage.substring(0, MAX_TEXT_LENGTH)}...`;
     }
 
     if (Array.isArray(resultMessage)) {
-      resultMessage = resultMessage.map((item) => {
-        if (item && typeof item.data === "object") {
+      return resultMessage.map((item) => {
+        if (item?.data && typeof item?.data === "object") {
           const truncatedData = Object.fromEntries(
-            Object.entries(item.data).map(([key, value]) => {
+            Object.entries(item?.data).map(([key, value]) => {
               if (typeof value === "string" && value.length > MAX_TEXT_LENGTH) {
                 return [key, `${value.substring(0, MAX_TEXT_LENGTH)}...`];
               }
@@ -74,8 +78,8 @@ const SwitchOutputView: React.FC<SwitchOutputViewProps> = ({
       </Case>
       <Case condition={resultType === "error" || resultType === "ValueError"}>
         <ErrorOutput
-          value={`${resultMessageMemoized.errorMessage}\n\n${resultMessageMemoized.stackTrace}`}
-        ></ErrorOutput>
+          value={`${resultMessageMemoized?.errorMessage}\n\n${resultMessageMemoized?.stackTrace}`}
+        />
       </Case>
 
       <Case condition={resultType === "text"}>
@@ -86,10 +90,14 @@ const SwitchOutputView: React.FC<SwitchOutputViewProps> = ({
         <DataOutputComponent
           rows={
             Array.isArray(resultMessageMemoized)
-              ? (resultMessageMemoized as Array<any>).every((item) => item.data)
-                ? (resultMessageMemoized as Array<any>).map((item) => item.data)
+              ? (resultMessageMemoized as Array<any>).every(
+                  (item) => item?.data,
+                )
+                ? (resultMessageMemoized as Array<any>).map(
+                    (item) => item?.data,
+                  )
                 : resultMessageMemoized
-              : Object.keys(resultMessageMemoized).length > 0
+              : Object.keys(resultMessageMemoized)?.length > 0
                 ? [resultMessageMemoized]
                 : []
           }
@@ -119,10 +127,10 @@ const SwitchOutputView: React.FC<SwitchOutputViewProps> = ({
     <DataOutputComponent
       rows={
         Array.isArray(results)
-          ? (results as Array<any>).every((item) => item.data)
-            ? (results as Array<any>).map((item) => item.data)
+          ? (results as Array<any>).every((item) => item?.data)
+            ? (results as Array<any>).map((item) => item?.data)
             : results
-          : Object.keys(results).length > 0
+          : Object.keys(results)?.length > 0
             ? [results]
             : []
       }


### PR DESCRIPTION
This pull request includes several improvements to the `SwitchOutputView` component in the `src/frontend/src/CustomNodes/GenericNode/components/outputModal/components/switchOutputView/index.tsx` file. The changes primarily focus on improving code robustness and readability by adding optional chaining and refactoring some logic.

Key improvements:

* Added optional chaining to access properties safely, reducing the risk of runtime errors. [[1]](diffhunk://#diff-e47fc1140ed84f01cd2346d6240b9055eccda2f254b53f08643b9ca7c18e2a4fR28-R36) [[2]](diffhunk://#diff-e47fc1140ed84f01cd2346d6240b9055eccda2f254b53f08643b9ca7c18e2a4fR45-R58) [[3]](diffhunk://#diff-e47fc1140ed84f01cd2346d6240b9055eccda2f254b53f08643b9ca7c18e2a4fL77-R82) [[4]](diffhunk://#diff-e47fc1140ed84f01cd2346d6240b9055eccda2f254b53f08643b9ca7c18e2a4fL89-R100) [[5]](diffhunk://#diff-e47fc1140ed84f01cd2346d6240b9055eccda2f254b53f08643b9ca7c18e2a4fL122-R133)
* Refactored the `resultMessageMemoized` logic to improve readability and maintainability.