### PR TITLE
fix: improved the huggingface emdeddings component, to handle local inference and serverless inference  

### DIFF
--- a/src/backend/base/langflow/components/embeddings/huggingface_inference_api.py
+++ b/src/backend/base/langflow/components/embeddings/huggingface_inference_api.py
@@ -2,6 +2,8 @@ from urllib.parse import urlparse
 
 import requests
 from langchain_community.embeddings.huggingface import HuggingFaceInferenceAPIEmbeddings
+
+# Next update: use langchain_huggingface
 from pydantic import SecretStr
 from tenacity import retry, stop_after_attempt, wait_fixed
 
@@ -21,7 +23,7 @@ class HuggingFaceInferenceAPIEmbeddingsComponent(LCEmbeddingsModel):
         SecretStrInput(
             name="api_key",
             display_name="API Key",
-            advanced=True,
+            advanced=False,
             info="Required for non-local inference endpoints. Local inference does not require an API Key.",
         ),
         MessageTextInput(
@@ -83,11 +85,14 @@ class HuggingFaceInferenceAPIEmbeddingsComponent(LCEmbeddingsModel):
     def build_embeddings(self) -> Embeddings:
         api_url = self.get_api_url()
 
-        is_local_url = api_url.startswith(("http://localhost", "http://127.0.0.1"))
+        is_local_url = (
+            api_url.startswith(("http://localhost", "http://127.0.0.1", "http://0.0.0.0", "http://docker"))
+            or "huggingface.co" not in api_url.lower()
+        )
 
         if not self.api_key and is_local_url:
             self.validate_inference_endpoint(api_url)
-            api_key = SecretStr("DummyAPIKeyForLocalDeployment")
+            api_key = SecretStr("APIKeyForLocalDeployment")
         elif not self.api_key:
             msg = "API Key is required for non-local inference endpoints"
             raise ValueError(msg)


### PR DESCRIPTION
This pull request includes several updates to the `src/backend/base/langflow/components/embeddings/huggingface_inference_api.py` file, focusing on improving the handling of API keys and local URLs for HuggingFace embeddings. The most important changes include updating the advanced setting for the API key input, expanding the list of local URLs, and modifying the default API key for local deployment.

Improvements to API key handling:

* [`class HuggingFaceInferenceAPIEmbeddingsComponent(LCEmbeddingsModel)`](diffhunk://#diff-541c702f2347658d1a1cb6bca6a4321a8c385512105750aec884c84a10b19113L24-R26): Changed the `advanced` setting for the `api_key` input from `True` to `False` to make it more accessible.

Enhancements to local URL handling:

* [`def create_huggingface_embeddings(`](diffhunk://#diff-541c702f2347658d1a1cb6bca6a4321a8c385512105750aec884c84a10b19113L86-R95): Expanded the list of local URLs to include `http://0.0.0.0` and `http://docker`, and added a check to ensure `huggingface.co` is not in the URL for local deployment.
* [`def create_huggingface_embeddings(`](diffhunk://#diff-541c702f2347658d1a1cb6bca6a4321a8c385512105750aec884c84a10b19113L86-R95): Modified the default API key for local deployment from `DummyAPIKeyForLocalDeployment` to `APIKeyForLocalDeployment` for better clarity.

Additional comments:

* Added a comment to use `langchain_huggingface` in the next update.



https://www.loom.com/share/1e6885358434465a94ef72ea38ec4eec?sid=d2a8c171-fb05-499f-8364-7fb51350828d