### PR TITLE
refactor: Implement LimitedBackgroundTasks for controlled vertex build logging

### DIFF
--- a/src/backend/base/langflow/api/limited_background_tasks.py
+++ b/src/backend/base/langflow/api/limited_background_tasks.py
@@ -1,0 +1,29 @@
+from fastapi import BackgroundTasks
+
+from langflow.graph.utils import log_vertex_build
+from langflow.services.deps import get_settings_service
+
+
+class LimitedBackgroundTasks(BackgroundTasks):
+    """A subclass of FastAPI BackgroundTasks that limits the number of tasks added per vertex_id.
+
+    If more than max_vertex_builds_per_vertex tasks are added for a given vertex_id,
+    the oldest task is removed so that only the most recent remain.
+    This only applies to log_vertex_build tasks.
+    """
+
+    def add_task(self, func, *args, **kwargs):
+        # Only apply limiting logic to log_vertex_build tasks
+        if func == log_vertex_build:
+            vertex_id = kwargs.get("vertex_id")
+            if vertex_id is not None:
+                # Filter tasks that are log_vertex_build calls with the same vertex_id
+                relevant_tasks = [
+                    t for t in self.tasks if t.func == log_vertex_build and t.kwargs.get("vertex_id") == vertex_id
+                ]
+                if len(relevant_tasks) >= get_settings_service().settings.max_vertex_builds_per_vertex:
+                    # Remove the oldest task for this vertex_id
+                    oldest_task = relevant_tasks[0]
+                    self.tasks.remove(oldest_task)
+
+        super().add_task(func, *args, **kwargs)

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -13,6 +13,7 @@ from langflow.api.build import (
     get_flow_events_response,
     start_flow_build,
 )
+from langflow.api.limited_background_tasks import LimitedBackgroundTasks
 from langflow.api.utils import (
     CurrentActiveUser,
     DbSession,
@@ -129,7 +130,7 @@ async def retrieve_vertices_order(
 async def build_flow(
     *,
     flow_id: uuid.UUID,
-    background_tasks: BackgroundTasks,
+    background_tasks: LimitedBackgroundTasks,
     inputs: Annotated[InputValueRequest | None, Body(embed=True)] = None,
     data: Annotated[FlowDataRequest | None, Body(embed=True)] = None,
     files: list[str] | None = None,


### PR DESCRIPTION
Introduce LimitedBackgroundTasks to manage the number of logging tasks per vertex, ensuring only the most recent tasks are retained. Refactor the build_flow endpoint to utilize this new class for improved task management.

This is necessary because in Flows with Loop there maybe tens or hundreds of `log_vertex_build` calls that will run after the flow finishes building.