### PR TITLE
fix: updates color of inactive buttons on table component

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/TableOptions/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/TableOptions/index.tsx
@@ -57,7 +57,9 @@ export default function TableOptions({
                   name="Copy"
                   className={cn(
                     "h-5 w-5 transition-all",
-                    hasSelection ? "text-primary" : "text-muted-foreground",
+                    hasSelection
+                      ? "text-primary"
+                      : "cursor-not-allowed text-placeholder-foreground",
                   )}
                 />
               </Button>
@@ -86,7 +88,7 @@ export default function TableOptions({
                   className={cn(
                     "h-5 w-5 transition-all",
                     !hasSelection
-                      ? "text-muted-foreground"
+                      ? "cursor-not-allowed text-placeholder-foreground"
                       : "text-primary hover:text-status-red",
                   )}
                 />
@@ -109,7 +111,9 @@ export default function TableOptions({
                 strokeWidth={2}
                 className={cn(
                   "h-5 w-5 transition-all",
-                  !stateChange ? "text-muted-foreground" : "text-primary",
+                  !stateChange
+                    ? "cursor-not-allowed text-placeholder-foreground"
+                    : "text-primary",
                 )}
               />
             </Button>


### PR DESCRIPTION
This pull request includes several changes to the `TableOptions` component in the `index.tsx` file to improve the user interface by updating the styles and behavior of buttons based on their state.

Changes to button styles and behavior:

* Updated the button styles to show a "not allowed" cursor and a placeholder foreground color when there is no selection (`hasSelection`) in the table. (`src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/TableOptions/index.tsx`)
* Modified the button styles to display a "not allowed" cursor and a placeholder foreground color when there is no selection (`hasSelection`) in the table, and to show a primary color with a hover effect when there is a selection. (`src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/TableOptions/index.tsx`)
* Changed the button styles to display a "not allowed" cursor and a placeholder foreground color when there is no state change (`stateChange`), and to show a primary color when there is a state change. (`src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/TableOptions/index.tsx`)