### PR TITLE
fix: remove unnecessary lockChat condition in ChatMessage loading state

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/chat-message.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/chat-message.tsx
@@ -313,7 +313,6 @@ export default function ChatMessage({
                 contentBlocks={chat.content_blocks}
                 isLoading={
                   chatMessage === "" &&
-                  lockChat &&
                   chat.properties?.state === "partial" &&
                   isBuilding &&
                   lastMessage


### PR DESCRIPTION
Eliminate the redundant lockChat condition when determining the loading state of ChatMessage.