### PR TITLE
refactor: move API key input into Cohere and NVIDIA rerank components

### DIFF
--- a/src/backend/base/langflow/base/compressors/model.py
+++ b/src/backend/base/langflow/base/compressors/model.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 
 from langflow.custom import Component
 from langflow.field_typing import BaseDocumentCompressor
-from langflow.io import DataInput, IntInput, MultilineInput, SecretStrInput
+from langflow.io import DataInput, IntInput, MultilineInput
 from langflow.schema import Data
 from langflow.schema.dataframe import DataFrame
 from langflow.template.field.base import Output
@@ -14,10 +14,6 @@ class LCCompressorComponent(Component):
             name="search_query",
             display_name="Search Query",
             tool_mode=True,
-        ),
-        SecretStrInput(
-            name="api_key",
-            display_name="API Key",
         ),
         DataInput(
             name="search_results",

--- a/src/backend/base/langflow/components/cohere/cohere_rerank.py
+++ b/src/backend/base/langflow/components/cohere/cohere_rerank.py
@@ -1,5 +1,6 @@
 from langflow.base.compressors.model import LCCompressorComponent
 from langflow.field_typing import BaseDocumentCompressor
+from langflow.inputs.inputs import SecretStrInput
 from langflow.io import DropdownInput
 from langflow.template.field.base import Output
 
@@ -12,6 +13,10 @@ class CohereRerankComponent(LCCompressorComponent):
 
     inputs = [
         *LCCompressorComponent.inputs,
+        SecretStrInput(
+            name="api_key",
+            display_name="Cohere API Key",
+        ),
         DropdownInput(
             name="model",
             display_name="Model",

--- a/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia_rerank.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from langflow.base.compressors.model import LCCompressorComponent
 from langflow.field_typing import BaseDocumentCompressor
+from langflow.inputs.inputs import SecretStrInput
 from langflow.io import DropdownInput, StrInput
 from langflow.schema.dotdict import dotdict
 from langflow.template.field.base import Output
@@ -14,6 +15,10 @@ class NvidiaRerankComponent(LCCompressorComponent):
 
     inputs = [
         *LCCompressorComponent.inputs,
+        SecretStrInput(
+            name="api_key",
+            display_name="NVIDIA API Key",
+        ),
         StrInput(
             name="base_url",
             display_name="Base URL",


### PR DESCRIPTION
Move the API key input from the base compressor model to the specific Cohere and NVIDIA Rerank components, enhancing clarity and specificity in the input handling.