### PR TITLE
chore: Update codeflash config to ignore components

### DIFF
--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -170,7 +170,7 @@ dev-dependencies = [
 module-root = "langflow"
 tests-root = "../tests/unit"
 test-framework = "pytest"
-ignore-paths = []
+ignore-paths = ["src/backend/base/langflow/components/"]
 formatter-cmds = ["ruff check --exit-zero --fix $file", "ruff format $file"]
 #disable plugins that might interfere with runtime measurement
 pytest-cmd = "pytest -p no:profiling -p no:sugar -p no:xdist -p no:cov -p no:split"


### PR DESCRIPTION
Modify the codeflash configuration to exclude the components directory from processing.

This is causing way too much spam PRs.