### PR TITLE
test: add test for AssistantsCreateThread component

### DIFF
--- a/src/backend/tests/unit/components/astra_assistants/test_create_thread_component.py
+++ b/src/backend/tests/unit/components/astra_assistants/test_create_thread_component.py
@@ -1,5 +1,4 @@
 import pytest
-
 from langflow.components.astra_assistants import AssistantsCreateThread
 from tests.base import ComponentTestBaseWithClient
 

--- a/src/backend/tests/unit/components/astra_assistants/test_create_thread_component.py
+++ b/src/backend/tests/unit/components/astra_assistants/test_create_thread_component.py
@@ -1,0 +1,34 @@
+import pytest
+
+from langflow.components.astra_assistants import AssistantsCreateThread
+from tests.base import ComponentTestBaseWithClient
+
+
+@pytest.mark.usefixtures("client")
+class TestAssistantsCreateThread(ComponentTestBaseWithClient):
+    @pytest.fixture
+    def component_class(self):
+        return AssistantsCreateThread
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {"env_set": "dummy_env"}
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return [
+            {"version": "1.0.0", "module": "assistants", "file_name": "AssistantsCreateThread"},
+        ]
+
+    def test_process_inputs_creates_thread(self, component_class, default_kwargs):
+        component = component_class(**default_kwargs)
+        result = component.process_inputs()
+        assert result is not None
+        assert isinstance(result, Message)
+        assert hasattr(result, "text")
+        assert result.text  # Ensure thread_id is not empty
+
+    async def test_latest_version(self, component_class, default_kwargs):
+        component_instance = await self.component_setup(component_class, default_kwargs)
+        result = await component_instance.run()
+        assert result is not None, "Component returned None for the latest version."


### PR DESCRIPTION
This PR adds a test for the AssistantsCreateThread component following the documentation proposed in PR #6288.