### PR TITLE
test: add test for GetEnvVar component

### DIFF
--- a/src/backend/tests/unit/components/astra_assistants/test_getenvvar_component.py
+++ b/src/backend/tests/unit/components/astra_assistants/test_getenvvar_component.py
@@ -1,0 +1,34 @@
+import os
+
+import pytest
+
+from langflow.components.astra_assistants import GetEnvVar
+from tests.base import ComponentTestBaseWithClient
+
+
+@pytest.mark.usefixtures("client")
+class TestGetEnvVarComponent(ComponentTestBaseWithClient):
+    @pytest.fixture
+    def component_class(self):
+        return GetEnvVar
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {"env_var_name": "TEST_ENV_VAR"}
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_process_inputs_env_var_set(self, component_class, default_kwargs):
+        os.environ["TEST_ENV_VAR"] = "test_value"
+        component = component_class(**default_kwargs)
+        result = component.process_inputs()
+        assert result.text == "test_value"
+
+    def test_process_inputs_env_var_not_set(self, component_class, default_kwargs):
+        if "TEST_ENV_VAR" in os.environ:
+            del os.environ["TEST_ENV_VAR"]
+        component = component_class(**default_kwargs)
+        with pytest.raises(ValueError, match="Environment variable TEST_ENV_VAR not set"):
+            component.process_inputs()

--- a/src/backend/tests/unit/components/astra_assistants/test_getenvvar_component.py
+++ b/src/backend/tests/unit/components/astra_assistants/test_getenvvar_component.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-
 from langflow.components.astra_assistants import GetEnvVar
 from tests.base import ComponentTestBaseWithClient
 


### PR DESCRIPTION
This PR adds a test for the GetEnvVar component following the documentation proposed in PR #6288.