### PR TITLE
fix: path for aws ecr bootstrap script

### DIFF
--- a/scripts/aws/lib/construct/ecr.ts
+++ b/scripts/aws/lib/construct/ecr.ts
@@ -19,7 +19,7 @@ export class EcrRepository extends Construct {
     super(scope, id)
 
     const imagePlatform = props.arch == ecs.CpuArchitecture.ARM64 ? Platform.LINUX_ARM64 : Platform.LINUX_AMD64
-    const backendPath = path.join(__dirname, "../../../../../", "langflow")
+    const backendPath = path.join(__dirname, "../../../../", "langflow")
     const excludeDir = ['node_modules','.git', 'cdk.out']
     const LifecycleRule = {
       tagStatus: ecr.TagStatus.ANY,


### PR DESCRIPTION
Fixes path for aws ecr bootstrap script.

Closes #3440