### PR TITLE
test: add test for PassMessageComponent component

### DIFF
--- a/src/backend/tests/unit/components/logic/test_pass_message_component.py
+++ b/src/backend/tests/unit/components/logic/test_pass_message_component.py
@@ -1,0 +1,31 @@
+import pytest
+
+from langflow.components.logic import PassMessageComponent
+from tests.base import ComponentTestBaseWithClient
+
+
+@pytest.mark.usefixtures("client")
+class TestPassMessageComponent(ComponentTestBaseWithClient):
+    @pytest.fixture
+    def component_class(self):
+        return PassMessageComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {"input_message": "Hello, World!", "ignored_message": "This will be ignored."}
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_pass_message_functionality(self, component_class, default_kwargs):
+        component = component_class(**default_kwargs)
+        result = component.pass_message()
+        assert result == default_kwargs["input_message"], "The output message should match the input message."
+
+    async def test_latest_version(self, component_class, default_kwargs):
+        component_instance = await self.component_setup(component_class, default_kwargs)
+        result = await component_instance.run()
+        assert (
+            result == default_kwargs["input_message"]
+        ), "Component should return the input message for the latest version."

--- a/src/backend/tests/unit/components/logic/test_pass_message_component.py
+++ b/src/backend/tests/unit/components/logic/test_pass_message_component.py
@@ -1,6 +1,6 @@
 import pytest
-
 from langflow.components.logic import PassMessageComponent
+
 from tests.base import ComponentTestBaseWithClient
 
 
@@ -26,6 +26,6 @@ class TestPassMessageComponent(ComponentTestBaseWithClient):
     async def test_latest_version(self, component_class, default_kwargs):
         component_instance = await self.component_setup(component_class, default_kwargs)
         result = await component_instance.run()
-        assert (
-            result == default_kwargs["input_message"]
-        ), "Component should return the input message for the latest version."
+        assert result == default_kwargs["input_message"], (
+            "Component should return the input message for the latest version."
+        )


### PR DESCRIPTION
This PR adds a test for the PassMessageComponent component following the documentation proposed in PR #6288.