### PR TITLE
feat: Add desktop flag to VersionPayload schema

### DIFF
--- a/src/backend/base/langflow/services/telemetry/schema.py
+++ b/src/backend/base/langflow/services/telemetry/schema.py
@@ -21,6 +21,7 @@ class VersionPayload(BaseModel):
     auto_login: bool = Field(serialization_alias="autoLogin")
     cache_type: str = Field(serialization_alias="cacheType")
     backend_only: bool = Field(serialization_alias="backendOnly")
+    desktop: bool = False
 
 
 class PlaygroundPayload(BaseModel):


### PR DESCRIPTION
Introduce a new `desktop` flag to the `VersionPayload` schema to enhance telemetry data.