### PR TITLE
test: add test for MultiQueryRetrieverComponent component

### DIFF
--- a/src/backend/tests/unit/components/retrievers/test_multi_query_component.py
+++ b/src/backend/tests/unit/components/retrievers/test_multi_query_component.py
@@ -1,5 +1,4 @@
 import pytest
-
 from langflow.components.retrievers import MultiQueryRetrieverComponent
 from tests.base import ComponentTestBaseWithClient
 

--- a/src/backend/tests/unit/components/retrievers/test_multi_query_component.py
+++ b/src/backend/tests/unit/components/retrievers/test_multi_query_component.py
@@ -1,0 +1,35 @@
+import pytest
+
+from langflow.components.retrievers import MultiQueryRetrieverComponent
+from tests.base import ComponentTestBaseWithClient
+
+
+@pytest.mark.usefixtures("client")
+class TestMultiQueryRetrieverComponent(ComponentTestBaseWithClient):
+    @pytest.fixture
+    def component_class(self):
+        return MultiQueryRetrieverComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {"llm": "mock_llm", "retriever": "mock_retriever", "prompt": None, "parser_key": "lines"}
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return [
+            {"version": "1.0.0", "module": "retrievers", "file_name": "MultiQueryRetriever"},
+        ]
+
+    def test_build_with_default_prompt(self, component_class, default_kwargs):
+        component = component_class(**default_kwargs)
+        result = component.build(**default_kwargs)
+        assert result is not None
+        assert isinstance(result, MultiQueryRetriever)
+
+    def test_build_with_custom_prompt(self, component_class, default_kwargs):
+        default_kwargs["prompt"] = "What are the benefits of AI?"
+        component = component_class(**default_kwargs)
+        result = component.build(**default_kwargs)
+        assert result is not None
+        assert isinstance(result, MultiQueryRetriever)
+        assert result.prompt.template == "What are the benefits of AI?"


### PR DESCRIPTION
This PR adds a test for the MultiQueryRetrieverComponent component following the documentation proposed in PR #6288.