### PR TITLE
fix: Update default URL in URL component test

### DIFF
--- a/src/backend/tests/unit/components/data/test_url_component.py
+++ b/src/backend/tests/unit/components/data/test_url_component.py
@@ -19,7 +19,7 @@ class TestURLComponent(ComponentTestBaseWithoutClient):
     def default_kwargs(self):
         """Return the default kwargs for the component."""
         return {
-            "urls": ["https://example.com"],
+            "urls": ["https://google.com"],
             "format": "Text",
         }
 


### PR DESCRIPTION
Change the default URL in the URL component test from `https://example.com` to `https://google.com`.