### PR TITLE
fix: fixed scroll to outer layer on json viewer

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -66,8 +66,6 @@ body {
 }
 
 .jv-indent {
-  overflow-y: auto !important;
-  max-height: 310px !important;
   border-radius: 10px;
 }
 

--- a/src/frontend/src/style/classes.css
+++ b/src/frontend/src/style/classes.css
@@ -174,6 +174,7 @@ textarea[class^="ag-"]:focus {
 
 .json-view {
   height: 370px !important;
+  overflow-y: auto !important;
   border-radius: 10px !important;
   padding: 10px !important;
 }


### PR DESCRIPTION
This pull request includes changes to the CSS files to improve the styling of certain elements. The most important changes include the removal of the `overflow-y` and `max-height` properties from the `.jv-indent` class and the addition of the `overflow-y` property to the `.json-view` class.

Styling changes:

* [`src/frontend/src/App.css`](diffhunk://#diff-3e7904848c381eb53375a14db869438235df15b6e439845f23d09b12382c0d47L69-L70): Removed the `overflow-y` and `max-height` properties from the `.jv-indent` class to potentially address layout or scrolling issues.
* [`src/frontend/src/style/classes.css`](diffhunk://#diff-20389fa3f9c927b863b7941b7a81e87d4d6d8f53f049354aaf1863fa1a3ac5ebR177): Added the `overflow-y` property to the `.json-view` class to enable vertical scrolling within the element.