### PR TITLE
fix: adjust edge position to not overlay handles on select

### DIFF
--- a/src/frontend/src/CustomEdges/index.tsx
+++ b/src/frontend/src/CustomEdges/index.tsx
@@ -21,8 +21,8 @@ export function DefaultEdge({
   const targetHandleObject = scapeJSONParse(targetHandleId!);
 
   const sourceXNew =
-    (sourceNode?.position.x ?? 0) + (sourceNode?.measured?.width ?? 0);
-  const targetXNew = targetNode?.position.x ?? 0;
+    (sourceNode?.position.x ?? 0) + (sourceNode?.measured?.width ?? 0) + 7;
+  const targetXNew = (targetNode?.position.x ?? 0) - 7;
 
   const distance = 200 + 0.1 * ((sourceXNew - targetXNew) / 2);
 
@@ -46,11 +46,11 @@ export function DefaultEdge({
 
   const [edgePath] = getBezierPath({
     sourceX: sourceXNew,
-    sourceY,
+    sourceY: sourceY + 1,
     sourcePosition: Position.Right,
     targetPosition: Position.Left,
     targetX: targetXNew,
-    targetY,
+    targetY: targetY + 1,
   });
 
   return (

--- a/src/frontend/src/CustomEdges/index.tsx
+++ b/src/frontend/src/CustomEdges/index.tsx
@@ -42,15 +42,18 @@ export function DefaultEdge({
     200 * (1 - zeroOnNegative) +
     0.3 * Math.abs(sourceY - targetY) * zeroOnNegative;
 
-  const edgePathLoop = `M ${sourceXNew} ${sourceY} C ${sourceXNew + distance} ${sourceY + sourceDistanceY}, ${targetXNew - distance} ${targetY + distanceY}, ${targetXNew} ${targetY}`;
+  const targetYNew = targetY + 1;
+  const sourceYNew = sourceY + 1;
+
+  const edgePathLoop = `M ${sourceXNew} ${sourceYNew} C ${sourceXNew + distance} ${sourceYNew + sourceDistanceY}, ${targetXNew - distance} ${targetYNew + distanceY}, ${targetXNew} ${targetYNew}`;
 
   const [edgePath] = getBezierPath({
     sourceX: sourceXNew,
-    sourceY: sourceY + 1,
+    sourceY: sourceYNew,
     sourcePosition: Position.Right,
     targetPosition: Position.Left,
     targetX: targetXNew,
-    targetY: targetY + 1,
+    targetY: targetYNew,
   });
 
   return (

--- a/src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx
@@ -52,7 +52,7 @@ const HandleContent = memo(function HandleContent({
       styleSheet.textContent = `
         @keyframes pulseNeon-${nodeId} {
           0% {
-            box-shadow: 0 0 0 2px hsl(var(--node-ring)),
+            box-shadow: 0 0 0 3px hsl(var(--node-ring)),
                         0 0 2px ${handleColor},
                         0 0 4px ${handleColor},
                         0 0 6px ${handleColor},
@@ -62,7 +62,7 @@ const HandleContent = memo(function HandleContent({
                         0 0 20px ${handleColor};
           }
           50% {
-            box-shadow: 0 0 0 2px hsl(var(--node-ring)),
+            box-shadow: 0 0 0 3px hsl(var(--node-ring)),
                         0 0 4px ${handleColor},
                         0 0 8px ${handleColor},
                         0 0 12px ${handleColor},
@@ -72,7 +72,7 @@ const HandleContent = memo(function HandleContent({
                         0 0 30px ${handleColor};
           }
           100% {
-            box-shadow: 0 0 0 2px hsl(var(--node-ring)),
+            box-shadow: 0 0 0 3px hsl(var(--node-ring)),
                         0 0 2px ${handleColor},
                         0 0 4px ${handleColor},
                         0 0 6px ${handleColor},


### PR DESCRIPTION
This pull request includes changes to the `src/frontend/src/CustomEdges/index.tsx` and `src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx` files to adjust the positioning and visual effects of custom edges and nodes. The most important changes include modifying the edge positioning calculations and updating the box-shadow properties for the node handles.

### Adjustments to Edge Positioning:
* [`src/frontend/src/CustomEdges/index.tsx`](diffhunk://#diff-d3f638b710d8dafb455ca26a7829b94b29a938ee7c5ef856e52b212b46eda05fL24-R25): Adjusted the `sourceXNew` and `targetXNew` calculations by adding/subtracting 7 pixels to improve the edge alignment.
* [`src/frontend/src/CustomEdges/index.tsx`](diffhunk://#diff-d3f638b710d8dafb455ca26a7829b94b29a938ee7c5ef856e52b212b46eda05fL45-R56): Updated the `edgePathLoop` and `getBezierPath` functions to use new `sourceYNew` and `targetYNew` variables, which are incremented by 1 pixel for better visual alignment.

### Updates to Node Handle Visual Effects:
* [`src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx`](diffhunk://#diff-6b00d330838431fd5fd114f3ed4159196f47f74d00a65bd4d5fa2ed70cf726fbL55-R55): Changed the `box-shadow` property in the `pulseNeon` keyframes from 2px to 3px to enhance the visual effect of the node handles. [[1]](diffhunk://#diff-6b00d330838431fd5fd114f3ed4159196f47f74d00a65bd4d5fa2ed70cf726fbL55-R55) [[2]](diffhunk://#diff-6b00d330838431fd5fd114f3ed4159196f47f74d00a65bd4d5fa2ed70cf726fbL65-R65) [[3]](diffhunk://#diff-6b00d330838431fd5fd114f3ed4159196f47f74d00a65bd4d5fa2ed70cf726fbL75-R75)