### PR TITLE
fix: Adjust flow cascade deletion and improve flow delete message UI

### DIFF
--- a/src/backend/base/langflow/api/utils.py
+++ b/src/backend/base/langflow/api/utils.py
@@ -14,11 +14,11 @@ from langflow.graph.graph.base import Graph
 from langflow.services.auth.utils import get_current_active_user
 from langflow.services.database.models import User
 from langflow.services.database.models.flow import Flow
+from langflow.services.database.models.message import MessageTable
 from langflow.services.database.models.transactions.model import TransactionTable
 from langflow.services.database.models.vertex_builds.model import VertexBuildTable
 from langflow.services.deps import get_session, session_scope
 from langflow.services.store.utils import get_lf_version_from_pypi
-from langflow.services.database.models.message import MessageTable
 
 if TYPE_CHECKING:
     from langflow.services.chat.service import ChatService

--- a/src/frontend/src/pages/MainPage/components/grid/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/grid/index.tsx
@@ -64,7 +64,10 @@ const GridComponent = ({ flowData }: { flowData: FlowType }) => {
       });
   };
 
-  const descriptionModal = useDescriptionModal([flowData?.id], "flow");
+  const descriptionModal = useDescriptionModal(
+    [flowData?.id],
+    flowData.is_component ? "component" : "flow",
+  );
 
   const { onDragStart } = useDragStart(flowData);
 
@@ -145,6 +148,11 @@ const GridComponent = ({ flowData }: { flowData: FlowType }) => {
           setOpen={setOpenDelete}
           onConfirm={handleDelete}
           description={descriptionModal}
+          note={
+            !flowData.is_component
+              ? "Deleting the selected flow will remove all associated messages."
+              : ""
+          }
         >
           <></>
         </DeleteConfirmationModal>

--- a/src/frontend/src/pages/MainPage/components/list/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/list/index.tsx
@@ -64,7 +64,10 @@ const ListComponent = ({ flowData }: { flowData: FlowType }) => {
 
   const { onDragStart } = useDragStart(flowData);
 
-  const descriptionModal = useDescriptionModal([flowData?.id], "flow");
+  const descriptionModal = useDescriptionModal(
+    [flowData?.id],
+    flowData.is_component ? "component" : "flow",
+  );
 
   const swatchIndex =
     (flowData.gradient && !isNaN(parseInt(flowData.gradient))
@@ -164,6 +167,11 @@ const ListComponent = ({ flowData }: { flowData: FlowType }) => {
           setOpen={setOpenDelete}
           onConfirm={handleDelete}
           description={descriptionModal}
+          note={
+            !flowData.is_component
+              ? "Deleting the selected flow will remove all associated messages."
+              : ""
+          }
         >
           <></>
         </DeleteConfirmationModal>


### PR DESCRIPTION
This pull request includes changes to both the backend and frontend of the application to improve the handling and display of flow data. The most important changes include updating the cascade delete functionality, modifying modal behavior based on flow types, and ensuring proper deletion warnings are displayed.

### Backend changes:

* [`src/backend/base/langflow/api/utils.py`](diffhunk://#diff-a5536abdc36b706233e33dcb6ae402b9f9721ac540978b2e8da67f79ad09aabdR21): Added import for `MessageTable` and updated the `cascade_delete_flow` function to ensure messages are deleted when a flow is deleted. [[1]](diffhunk://#diff-a5536abdc36b706233e33dcb6ae402b9f9721ac540978b2e8da67f79ad09aabdR21) [[2]](diffhunk://#diff-a5536abdc36b706233e33dcb6ae402b9f9721ac540978b2e8da67f79ad09aabdL284-R294)

### Frontend changes:

* [`src/frontend/src/pages/MainPage/components/grid/index.tsx`](diffhunk://#diff-eae1f158ea4d00c00e54a9ab30123b91c8c51d2fbfbaac271bf6164e851e973fL67-R70): Modified `descriptionModal` to differentiate between components and flows, and added a note to the delete confirmation modal to warn users about message deletion when deleting a flow. [[1]](diffhunk://#diff-eae1f158ea4d00c00e54a9ab30123b91c8c51d2fbfbaac271bf6164e851e973fL67-R70) [[2]](diffhunk://#diff-eae1f158ea4d00c00e54a9ab30123b91c8c51d2fbfbaac271bf6164e851e973fR151-R155)
* [`src/frontend/src/pages/MainPage/components/list/index.tsx`](diffhunk://#diff-6b27a25ef98d4ca6530f4e77462e58711b64c6825f1e01f7eea648f9281d1a06L67-R70): Similar changes to the grid component, ensuring the `descriptionModal` differentiates between components and flows, and added a deletion warning note. [[1]](diffhunk://#diff-6b27a25ef98d4ca6530f4e77462e58711b64c6825f1e01f7eea648f9281d1a06L67-R70) [[2]](diffhunk://#diff-6b27a25ef98d4ca6530f4e77462e58711b64c6825f1e01f7eea648f9281d1a06R170-R174)

#5925

https://discord.com/channels/1116803230643527710/1338862961841799179