### PR TITLE
clean duplicate call _cleanup_inputs

### DIFF
--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -243,7 +243,7 @@ class TracingService(Service):
             trace_id,
             trace_name,
             trace_type,
-            self._cleanup_inputs(inputs),
+            inputs,
             metadata,
             component._vertex,
         )


### PR DESCRIPTION
duplicate, _cleanup_inputs have been call in _start_traces, no need call twice