### PR TITLE
chore: fix capitalization of "Open Playground" in default shortcuts

### DIFF
--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -819,8 +819,8 @@ export const defaultShortcuts = [
     shortcut: "backspace",
   },
   {
-    display_name: "Open playground",
-    name: "Open playground",
+    display_name: "Open Playground",
+    name: "Open Playground",
     shortcut: "mod+k",
   },
   {


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/src/constants/constants.ts` file. The change corrects the capitalization of the "Open Playground" display name and name in the `defaultShortcuts` array.

* [`src/frontend/src/constants/constants.ts`](diffhunk://#diff-3a3810648efc852f35a3780d6fe4ec65734c218f2281a175d9347a65db3fd360L822-R823): Corrected the capitalization of "Open Playground" in the `defaultShortcuts` array.