### PR TITLE
fix: disable resizing in TextModal

### DIFF
--- a/src/frontend/src/modals/textModal/components/textEditorArea/index.tsx
+++ b/src/frontend/src/modals/textModal/components/textEditorArea/index.tsx
@@ -3,10 +3,12 @@ import { Textarea } from "../../../../components/ui/textarea";
 const TextEditorArea = ({
   left,
   value,
+  resizable = true,
   onChange,
   readonly,
 }: {
   left: boolean | undefined;
+  resizable?: boolean;
   value: any;
   onChange?: (string) => void;
   readonly: boolean;
@@ -17,7 +19,9 @@ const TextEditorArea = ({
   return (
     <Textarea
       readOnly={readonly}
-      className={`w-full custom-scroll ${left ? "min-h-32" : "h-full"}`}
+      className={`w-full custom-scroll ${left ? "min-h-32" : "h-full"} ${
+        resizable ? "resize-y" : "resize-none"
+      }`}
       placeholder={"Empty"}
       // update to real value on flowPool
       value={value}

--- a/src/frontend/src/modals/textModal/index.tsx
+++ b/src/frontend/src/modals/textModal/index.tsx
@@ -54,6 +54,7 @@ export default function TextModal({
               readonly={!editable}
               onChange={(text) => setInternalValue(text)}
               value={internalValue}
+              resizable={false}
               left={false}
             />
           </div>


### PR DESCRIPTION
This pull request introduces changes to the `TextEditorArea` component to add a new `resizable` property, allowing more control over the textarea's resizing behavior. Additionally, it updates the `TextModal` component to utilize this new property.

Enhancements to `TextEditorArea` component:

* Added an optional `resizable` property to the `TextEditorArea` component to enable or disable the textarea's resize functionality. (`src/frontend/src/modals/textModal/components/textEditorArea/index.tsx`)
* Updated the `Textarea` element within `TextEditorArea` to conditionally apply CSS classes based on the `resizable` property. (`src/frontend/src/modals/textModal/components/textEditorArea/index.tsx`)

Updates to `TextModal` component:

* Set the `resizable` property to `false` in the `TextModal` component to disable resizing by default. (`src/frontend/src/modals/textModal/index.tsx`)