### PR TITLE
fix: handle null and boolean correctly on table parameter

### DIFF
--- a/src/backend/base/langflow/schema/table.py
+++ b/src/backend/base/langflow/schema/table.py
@@ -39,7 +39,7 @@ class Column(BaseModel):
     formatter: FormatterType | str | None = Field(default=None)
     type: FormatterType | str | None = Field(default=None)
     description: str | None = None
-    default: str | None = None
+    default: str | bool | int | float | None = None
     disable_edit: bool = Field(default=False)
     edit_mode: EditMode | None = Field(default=EditMode.POPOVER)
     hidden: bool = Field(default=False)
@@ -54,6 +54,19 @@ class Column(BaseModel):
     def set_formatter_from_type(self):
         if self.type and not self.formatter:
             self.formatter = self.validate_formatter(self.type)
+        if self.formatter in {"boolean", "bool"}:
+            valid_trues = ["True", "true", "1", "yes"]
+            valid_falses = ["False", "false", "0", "no"]
+            if self.default in valid_trues:
+                self.default = True
+            if self.default in valid_falses:
+                self.default = False
+        elif self.formatter in {"integer", "int"}:
+            self.default = int(self.default)
+        elif self.formatter in {"float"}:
+            self.default = float(self.default)
+        else:
+            self.default = str(self.default)
         return self
 
     @field_validator("formatter", mode="before")

--- a/src/backend/base/langflow/schema/table.py
+++ b/src/backend/base/langflow/schema/table.py
@@ -2,7 +2,18 @@ from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-VALID_TYPES = ["date", "number", "text", "json", "integer", "int", "float", "str", "string", "boolean"]
+VALID_TYPES = [
+    "date",
+    "number",
+    "text",
+    "json",
+    "integer",
+    "int",
+    "float",
+    "str",
+    "string",
+    "boolean",
+]
 
 
 class FormatterType(str, Enum):
@@ -25,11 +36,12 @@ class Column(BaseModel):
     display_name: str = Field(default="")
     sortable: bool = Field(default=True)
     filterable: bool = Field(default=True)
-    formatter: FormatterType | str | None = Field(default=None, alias="type")
+    formatter: FormatterType | str | None = Field(default=None)
+    type: FormatterType | str | None = Field(default=None)
     description: str | None = None
     default: str | None = None
     disable_edit: bool = Field(default=False)
-    edit_mode: EditMode | None = Field(default=EditMode.MODAL)
+    edit_mode: EditMode | None = Field(default=EditMode.POPOVER)
     hidden: bool = Field(default=False)
 
     @model_validator(mode="after")
@@ -38,15 +50,25 @@ class Column(BaseModel):
             self.display_name = self.name
         return self
 
+    @model_validator(mode="after")
+    def set_formatter_from_type(self):
+        if self.type and not self.formatter:
+            self.formatter = self.validate_formatter(self.type)
+        return self
+
     @field_validator("formatter", mode="before")
     @classmethod
     def validate_formatter(cls, value):
+        if value in {"boolean", "bool"}:
+            value = FormatterType.boolean
         if value in {"integer", "int", "float"}:
             value = FormatterType.number
         if value in {"str", "string"}:
             value = FormatterType.text
         if value == "dict":
             value = FormatterType.json
+        if value == "date":
+            value = FormatterType.date
         if isinstance(value, str):
             return FormatterType(value)
         if isinstance(value, FormatterType):
@@ -99,6 +121,10 @@ class TableOptions(BaseModel):
     block_hide: bool | list[str] = Field(default=False)
     block_select: bool = Field(default=False)
     hide_options: bool = Field(default=False)
-    field_validators: dict[str, list[FieldValidatorType] | FieldValidatorType] | None = Field(default=None)
-    field_parsers: dict[str, list[FieldParserType] | FieldParserType] | None = Field(default=None)
+    field_validators: (
+        dict[str, list[FieldValidatorType] | FieldValidatorType] | None
+    ) = Field(default=None)
+    field_parsers: dict[str, list[FieldParserType] | FieldParserType] | None = Field(
+        default=None
+    )
     description: str | None = Field(default=None)

--- a/src/backend/base/langflow/schema/table.py
+++ b/src/backend/base/langflow/schema/table.py
@@ -134,10 +134,6 @@ class TableOptions(BaseModel):
     block_hide: bool | list[str] = Field(default=False)
     block_select: bool = Field(default=False)
     hide_options: bool = Field(default=False)
-    field_validators: (
-        dict[str, list[FieldValidatorType] | FieldValidatorType] | None
-    ) = Field(default=None)
-    field_parsers: dict[str, list[FieldParserType] | FieldParserType] | None = Field(
-        default=None
-    )
+    field_validators: dict[str, list[FieldValidatorType] | FieldValidatorType] | None = Field(default=None)
+    field_parsers: dict[str, list[FieldParserType] | FieldParserType] | None = Field(default=None)
     description: str | None = Field(default=None)

--- a/src/frontend/src/components/core/parameterRenderComponent/components/TableNodeComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/TableNodeComponent/index.tsx
@@ -179,6 +179,10 @@ export default function TableNodeComponent({
           pagination={!table_options?.hide_options}
           addRow={addRow}
           onDelete={deleteRow}
+          gridOptions={{
+            ensureDomOrder: true,
+            suppressRowClickSelection: true,
+          }}
           onDuplicate={duplicateRow}
           displayEmptyAlert={false}
           className="h-full w-full"

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx
@@ -7,7 +7,7 @@ import { cn, isTimeStampString } from "@/utils/utils";
 import { CustomCellRendererProps } from "ag-grid-react";
 
 interface CustomCellRender extends CustomCellRendererProps {
-  formatter?: "json" | "text";
+  formatter?: "json" | "text" | "boolean" | "number" | "undefined" | "null";
 }
 
 export default function TableAutoCellRender({
@@ -76,13 +76,18 @@ export default function TableAutoCellRender({
       case "null":
         return "";
       case "boolean":
-        return value ? (
-          <Badge variant="successStatic" size="sq" className="h-[18px]">
-            {String(value)}
-          </Badge>
-        ) : (
-          <Badge variant="errorStatic" size="sq" className="h-[18px]">
-            {String(value)}
+        value =
+          (typeof value === "string" && value.toLowerCase() === "true") ||
+          value === true
+            ? true
+            : false;
+        return (
+          <Badge
+            variant={value ? "successStatic" : "errorStatic"}
+            size="sq"
+            className="h-[18px]"
+          >
+            {String(value).toLowerCase()}
           </Badge>
         );
       default:
@@ -91,7 +96,7 @@ export default function TableAutoCellRender({
   }
 
   return (
-    <div className="group flex h-full w-full truncate text-align-last-left">
+    <div className="group flex h-full w-full items-center truncate text-align-last-left">
       {getCellType()}
     </div>
   );

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx
@@ -71,6 +71,20 @@ export default function TableAutoCellRender({
         }
       case "number":
         return <NumberReader number={value} />;
+      case "undefined":
+        return "";
+      case "null":
+        return "";
+      case "boolean":
+        return value ? (
+          <Badge variant="successStatic" size="sq" className="h-[18px]">
+            {String(value)}
+          </Badge>
+        ) : (
+          <Badge variant="errorStatic" size="sq" className="h-[18px]">
+            {String(value)}
+          </Badge>
+        );
       default:
         return String(value);
     }

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableToggleCellEditor/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableToggleCellEditor/index.tsx
@@ -1,0 +1,28 @@
+import { CustomCellEditorProps } from "ag-grid-react";
+import { uniqueId } from "lodash";
+import ToggleShadComponent from "../../../toggleShadComponent";
+
+export default function TableToggleCellEditor({
+  value,
+  onValueChange,
+  colDef,
+}: CustomCellEditorProps) {
+  value =
+    (typeof value === "string" && value.toLowerCase() === "true") ||
+    value === true
+      ? true
+      : false;
+  return (
+    <div className="flex h-full items-center px-2">
+      <ToggleShadComponent
+        value={value}
+        handleOnNewValue={(data) => {
+          onValueChange?.(data.value);
+        }}
+        editNode={true}
+        id={"toggle" + colDef?.colId + uniqueId()}
+        disabled={false}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/types/utils/functions.ts
+++ b/src/frontend/src/types/utils/functions.ts
@@ -14,6 +14,7 @@ export enum FormatterType {
   text = "text",
   number = "number",
   json = "json",
+  boolean = "boolean",
 }
 
 export interface ColumnField {

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import TableAutoCellRender from "@/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender";
+import TableToggleCellEditor from "@/components/core/parameterRenderComponent/components/tableComponent/components/tableToggleCellEditor";
 import useAlertStore from "@/stores/alertStore";
 import { ColumnField, FormatterType } from "@/types/utils/functions";
 import { ColDef, ColGroupDef, ValueParserParams } from "ag-grid-community";
@@ -566,7 +567,10 @@ export function FormatColumns(columns: ColumnField[]): ColDef<any>[] {
         formatter: col.formatter,
       };
       if (col.formatter !== FormatterType.text || col.edit_mode !== "inline") {
-        if (col.edit_mode === "popover") {
+        if (
+          col.edit_mode === "popover" &&
+          col.formatter === FormatterType.text
+        ) {
           newCol.wrapText = false;
           newCol.autoHeight = false;
           newCol.cellEditor = "agLargeTextCellEditor";
@@ -574,6 +578,13 @@ export function FormatColumns(columns: ColumnField[]): ColDef<any>[] {
           newCol.cellEditorParams = {
             maxLength: 100000000,
           };
+        } else if (col.formatter === FormatterType.boolean) {
+          newCol.cellRenderer = TableAutoCellRender;
+          newCol.cellEditorPopup = false;
+          newCol.cellEditor = TableToggleCellEditor;
+          newCol.autoHeight = false;
+          newCol.cellClass = "no-border !py-2";
+          newCol.type = "boolean";
         } else {
           newCol.cellRenderer = TableAutoCellRender;
         }

--- a/src/frontend/tests/core/unit/tableInputComponent.spec.ts
+++ b/src/frontend/tests/core/unit/tableInputComponent.spec.ts
@@ -113,32 +113,26 @@ class CustomComponent(Component):
       await expect(page.getByText(text).last()).toBeVisible();
     }
 
-    await page.locator(".ag-cell-value").first().click();
-
-    await page.getByPlaceholder("Empty").fill(randomText);
-    await page.getByText("Save").last().click();
-    await expect(page.getByTestId("icon-Type")).toBeHidden({
-      timeout: 2000,
-    });
-    await page.locator(".ag-cell-value").nth(12).click();
-
-    await page.getByPlaceholder("Empty").fill(secondRandomText);
-    await page.getByText("Save").last().click();
-    await expect(page.getByTestId("icon-Type")).toBeHidden({
-      timeout: 2000,
+    await page.locator(".ag-cell-value").first().dblclick({
+      force: true,
     });
 
-    await page.locator(".ag-cell-value").nth(24).click();
-    await expect(page.getByTestId("icon-Type")).toBeVisible({
-      timeout: 2000,
+    await page.getByLabel("Input Editor").fill(randomText);
+    await page.keyboard.press("Enter");
+
+    await page.locator(".ag-cell-value").nth(12).dblclick({
+      force: true,
     });
 
-    await page.getByPlaceholder("Empty").fill(thirdRandomText);
-    await page.getByText("Save").last().click();
+    await page.getByLabel("Input Editor").fill(secondRandomText);
+    await page.keyboard.press("Enter");
 
-    await expect(page.getByTestId("icon-Type")).toBeHidden({
-      timeout: 2000,
+    await page.locator(".ag-cell-value").nth(24).dblclick({
+      force: true,
     });
+
+    await page.getByLabel("Input Editor").fill(thirdRandomText);
+    await page.keyboard.press("Enter");
 
     expect(page.getByText(randomText)).toBeVisible();
     expect(page.getByText(secondRandomText)).toBeVisible();


### PR DESCRIPTION
This pull request includes significant changes to the backend and frontend code to improve the handling of table schemas and rendering components. The most important changes include updates to the `Column` class to support new data types, enhancements to the table rendering logic, and the addition of a new toggle cell editor component.

### Backend Changes:
* [`src/backend/base/langflow/schema/table.py`](diffhunk://#diff-66bd9e20d21689c7321905c0c2e5b0e4e5cedb2e92c2f6c00c092a4714f597baL28-R44): Updated the `Column` class to support new data types (`bool`, `int`, `float`) for the `default` field and added a new `type` field. Implemented a `set_formatter_from_type` method to set the formatter based on the type and convert default values accordingly. [[1]](diffhunk://#diff-66bd9e20d21689c7321905c0c2e5b0e4e5cedb2e92c2f6c00c092a4714f597baL28-R44) [[2]](diffhunk://#diff-66bd9e20d21689c7321905c0c2e5b0e4e5cedb2e92c2f6c00c092a4714f597baR53-R84)

### Frontend Changes:
* [`src/frontend/src/components/core/parameterRenderComponent/components/TableNodeComponent/index.tsx`](diffhunk://#diff-0c62a57e27e05515113667234bff939fa464b255c228c92bc12c6ab9d61576a4R182-R185): Added grid options to ensure DOM order and suppress row click selection.
* [`src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx`](diffhunk://#diff-86977b55f6f3573ef83b6ec14ca59c0ae562383d4109c3006320324df35d261cL10-R10): Extended the `formatter` options to include `boolean`, `number`, `undefined`, and `null`. Added rendering logic for these new types. [[1]](diffhunk://#diff-86977b55f6f3573ef83b6ec14ca59c0ae562383d4109c3006320324df35d261cL10-R10) [[2]](diffhunk://#diff-86977b55f6f3573ef83b6ec14ca59c0ae562383d4109c3006320324df35d261cR74-R99)
* [`src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableToggleCellEditor/index.tsx`](diffhunk://#diff-6b818d253856e946f32e9785a66771d7b33f19dc995e6e0bfb5db085b89d197bR1-R28): Introduced a new `TableToggleCellEditor` component to handle boolean values with a toggle switch.
* [`src/frontend/src/utils/utils.ts`](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81L569-R587): Updated the `FormatColumns` function to handle the new `boolean` formatter and configure the appropriate cell renderer and editor.