### PR TITLE
fix: Playground messages sometimes appearing in wrong order because of new messages missing the UTC identifier in the `timestamp` field (#3146)

### DIFF
--- a/src/backend/base/langflow/services/database/models/message/model.py
+++ b/src/backend/base/langflow/services/database/models/message/model.py
@@ -45,6 +45,18 @@ class MessageBase(SQLModel):
         if not value:
             value = []
         return value
+    
+    @field_serializer("timestamp")
+    def serialize_timestamp(self, value, _info):
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            return value.strftime("%Y-%m-%d %H:%M:%S %Z")
+        if isinstance(value, str):
+            # Make sure the timestamp is in UTC
+            value = datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
+            return value.strftime("%Y-%m-%d %H:%M:%S %Z")
+        return value
 
     @classmethod
     def from_message(cls, message: "Message", flow_id: str | UUID | None = None):

--- a/src/backend/base/langflow/services/database/models/message/model.py
+++ b/src/backend/base/langflow/services/database/models/message/model.py
@@ -45,7 +45,7 @@ class MessageBase(SQLModel):
         if not value:
             value = []
         return value
-    
+
     @field_serializer("timestamp")
     def serialize_timestamp(self, value, _info):
         if isinstance(value, datetime):


### PR DESCRIPTION
fix: Playground messages sometimes appearing in wrong order because of new messages missing the UTC identifier in the `timestamp` field (Fixes #3146)

When the user opens the playground, messages are fetched from `/api/v1/monitor/messages?flow_id=[flow_id]` and the `timestamp` fields have the UTC marker.

When the user sends a new message, it is timestamped by the server when sent through `/api/v1/build/[flow_id]/flow` and the `timestamp` fields in the base64 blob of concatenated JSON objects in the response are missing the UTC marker. These are merged into the existing message history from the `messages` endpoint, without re-fetching the messages.

This means that the frontend `ChatView` component sorts the messages to `const finalChatHistory` wrongly unless the user's system is set to `GMT+00:00`, and the messages end up out of order if continuing a Playground conversation after closing the Playground and re-opening it.

The correct behaviour is the server returning `timestamp` fields with the UTC marker in the build endpoint response, which is achieved by this commit.

It can also be fixed by modifying `src/backend/base/langflow/schema/encoders.py` to modify `encode_datetime` and also register it as a `ENCODERS_BY_TYPE` entry for `datetime` objects, but this is not as clean a solution as the one implemented here.

It also seems unnecessary to sort the messages in the `ChatView` component, as the messages seem to be given in the correct order anyway. Therefore, removing this `sort` also alleviates the UTC marker issue by sweeping it under the rug.