### PR TITLE
feat: Add loading state and skeleton UI for FlowPage sidebar

### DIFF
--- a/src/frontend/src/components/ui/skeletonGroup.tsx
+++ b/src/frontend/src/components/ui/skeletonGroup.tsx
@@ -9,11 +9,11 @@ const SkeletonGroup = ({
   className?: string;
 }) => {
   return (
-    <div>
+    <>
       {Array.from({ length: count }, (_, i) => (
         <Skeleton key={i} className={cn("w-full", className)} />
       ))}
-    </div>
+    </>
   );
 };
 

--- a/src/frontend/src/components/ui/skeletonGroup.tsx
+++ b/src/frontend/src/components/ui/skeletonGroup.tsx
@@ -12,7 +12,7 @@ const SkeletonGroup = ({
       {Array(count)
         .fill(null)
         .map((_, i) => (
-          <Skeleton key={i} className="h-8 w-full" />
+          <Skeleton key={i} className="my-0.5 h-7 w-full" />
         ))}
     </div>
   );

--- a/src/frontend/src/components/ui/skeletonGroup.tsx
+++ b/src/frontend/src/components/ui/skeletonGroup.tsx
@@ -1,19 +1,18 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/utils/utils";
 
 const SkeletonGroup = ({
   count = 2,
-  containerClassName = "flex flex-col gap-3 px-4 pt-4",
+  className = "",
 }: {
   count?: number;
-  containerClassName?: string;
+  className?: string;
 }) => {
   return (
-    <div className={containerClassName}>
-      {Array(count)
-        .fill(null)
-        .map((_, i) => (
-          <Skeleton key={i} className="my-0.5 h-7 w-full" />
-        ))}
+    <div>
+      {Array.from({ length: count }, (_, i) => (
+        <Skeleton key={i} className={cn("w-full", className)} />
+      ))}
     </div>
   );
 };

--- a/src/frontend/src/components/ui/skeletonGroup.tsx
+++ b/src/frontend/src/components/ui/skeletonGroup.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+const SkeletonGroup = ({
+  count = 2,
+  containerClassName = "flex flex-col gap-3 px-4 pt-4",
+}: {
+  count?: number;
+  containerClassName?: string;
+}) => {
+  return (
+    <div className={containerClassName}>
+      {Array(count)
+        .fill(null)
+        .map((_, i) => (
+          <Skeleton key={i} className="h-8 w-full" />
+        ))}
+    </div>
+  );
+};
+
+export default SkeletonGroup;

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -79,7 +79,13 @@ const edgeTypes = {
   default: DefaultEdge,
 };
 
-export default function Page({ view }: { view?: boolean }): JSX.Element {
+export default function Page({
+  view,
+  setIsLoading,
+}: {
+  view?: boolean;
+  setIsLoading: (isLoading: boolean) => void;
+}): JSX.Element {
   const uploadFlow = useUploadFlow();
   const autoSaveFlow = useAutoSaveFlow();
   const types = useTypesStore((state) => state.types);
@@ -183,6 +189,10 @@ export default function Page({ view }: { view?: boolean }): JSX.Element {
     Object.keys(templates).length > 0 &&
     Object.keys(types).length > 0 &&
     !isFetching;
+
+  useEffect(() => {
+    setIsLoading(!showCanvas);
+  }, [showCanvas]);
 
   useEffect(() => {
     useFlowStore.setState({ autoSaveFlow });

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -648,7 +648,7 @@ export default function Page({
           ></div>
         </div>
       ) : (
-        <div className="z-50 flex h-full w-full items-center justify-center">
+        <div className="flex h-full w-full items-center justify-center">
           <CustomLoader remSize={30} />
         </div>
       )}

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -648,7 +648,7 @@ export default function Page({
           ></div>
         </div>
       ) : (
-        <div className="flex h-full w-full items-center justify-center">
+        <div className="z-50 flex h-full w-full items-center justify-center">
           <CustomLoader remSize={30} />
         </div>
       )}

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarFooterButtons/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarFooterButtons/index.tsx
@@ -3,19 +3,12 @@ import { Button } from "@/components/ui/button";
 import { SidebarMenuButton } from "@/components/ui/sidebar";
 import { CustomLink } from "@/customization/components/custom-link";
 
-interface SidebarMenuButtonsProps {
-  hasStore?: boolean;
-  customComponent?: string;
-  addComponent: (component: string, type: string) => void;
-  isLoading?: boolean;
-}
-
 const SidebarMenuButtons = ({
   hasStore = false,
   customComponent,
   addComponent,
-  isLoading,
-}: SidebarMenuButtonsProps) => {
+  isLoading = false,
+}) => {
   return (
     <>
       {hasStore && (

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarFooterButtons/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarFooterButtons/index.tsx
@@ -3,11 +3,19 @@ import { Button } from "@/components/ui/button";
 import { SidebarMenuButton } from "@/components/ui/sidebar";
 import { CustomLink } from "@/customization/components/custom-link";
 
+interface SidebarMenuButtonsProps {
+  hasStore?: boolean;
+  customComponent?: string;
+  addComponent: (component: string, type: string) => void;
+  isLoading?: boolean;
+}
+
 const SidebarMenuButtons = ({
   hasStore = false,
   customComponent,
   addComponent,
-}) => {
+  isLoading,
+}: SidebarMenuButtonsProps) => {
   return (
     <>
       {hasStore && (
@@ -37,6 +45,7 @@ const SidebarMenuButtons = ({
       <SidebarMenuButton asChild>
         <Button
           unstyled
+          disabled={isLoading}
           onClick={() => {
             if (customComponent) {
               addComponent(customComponent, "CustomComponent");

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
@@ -330,7 +330,7 @@ export function FlowSidebarComponent({ isLoading }: { isLoading?: boolean }) {
             <div className="flex flex-col gap-1 p-3">
               <SkeletonGroup count={13} className="my-0.5 h-7" />
             </div>
-            <div className="h-[32px]" />
+            <div className="h-8" />
             <div className="flex flex-col gap-1 px-3 pt-2">
               <SkeletonGroup count={21} className="my-0.5 h-7" />
             </div>

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
@@ -331,7 +331,7 @@ export function FlowSidebarComponent({ isLoading }: { isLoading?: boolean }) {
               <SkeletonGroup count={13} className="my-0.5 h-7" />
             </div>
             <div className="h-[32px]" />
-            <div className="flex flex-col gap-1 p-3">
+            <div className="flex flex-col gap-1 px-3 pt-2">
               <SkeletonGroup count={21} className="my-0.5 h-7" />
             </div>
           </div>

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
@@ -4,6 +4,7 @@ import {
   SidebarFooter,
   useSidebar,
 } from "@/components/ui/sidebar";
+import SkeletonGroup from "@/components/ui/skeletonGroup";
 import { useAddComponent } from "@/hooks/useAddComponent";
 import { useShortcutsStore } from "@/stores/shortcuts";
 import { useStoreStore } from "@/stores/storeStore";
@@ -44,7 +45,7 @@ interface FlowSidebarComponentProps {
   setShowLegacy: (value: boolean) => void;
 }
 
-export function FlowSidebarComponent() {
+export function FlowSidebarComponent({ isLoading }: { isLoading?: boolean }) {
   const { data, templates } = useTypesStore(
     useCallback(
       (state) => ({
@@ -322,39 +323,57 @@ export function FlowSidebarComponent() {
         setFilterData={setFilterData}
         data={data}
       />
+
       <SidebarContent>
-        {hasResults ? (
-          <>
-            <CategoryGroup
-              dataFilter={dataFilter}
-              sortedCategories={sortedCategories}
-              CATEGORIES={CATEGORIES}
-              openCategories={openCategories}
-              setOpenCategories={setOpenCategories}
-              search={search}
-              nodeColors={nodeColors}
-              chatInputAdded={chatInputAdded}
-              onDragStart={onDragStart}
-              sensitiveSort={sensitiveSort}
+        {isLoading ? (
+          <div className="flex flex-col gap-2">
+            <SkeletonGroup
+              count={13}
+              containerClassName="flex flex-col gap-1 p-3"
             />
-            {hasBundleItems && (
-              <MemoizedSidebarGroup
-                BUNDLES={BUNDLES}
-                search={search}
-                sortedCategories={sortedCategories}
-                dataFilter={dataFilter}
-                nodeColors={nodeColors}
-                chatInputAdded={chatInputAdded}
-                onDragStart={onDragStart}
-                sensitiveSort={sensitiveSort}
-                openCategories={openCategories}
-                setOpenCategories={setOpenCategories}
-                handleKeyDownInput={handleKeyDownInput}
-              />
+            <div className="h-[32px]" />
+            <SkeletonGroup
+              count={21}
+              containerClassName="flex flex-col gap-1 p-3"
+            />
+          </div>
+        ) : (
+          <>
+            {hasResults ? (
+              <>
+                <CategoryGroup
+                  dataFilter={dataFilter}
+                  sortedCategories={sortedCategories}
+                  CATEGORIES={CATEGORIES}
+                  openCategories={openCategories}
+                  setOpenCategories={setOpenCategories}
+                  search={search}
+                  nodeColors={nodeColors}
+                  chatInputAdded={chatInputAdded}
+                  onDragStart={onDragStart}
+                  sensitiveSort={sensitiveSort}
+                />
+
+                {hasBundleItems && (
+                  <MemoizedSidebarGroup
+                    BUNDLES={BUNDLES}
+                    search={search}
+                    sortedCategories={sortedCategories}
+                    dataFilter={dataFilter}
+                    nodeColors={nodeColors}
+                    chatInputAdded={chatInputAdded}
+                    onDragStart={onDragStart}
+                    sensitiveSort={sensitiveSort}
+                    openCategories={openCategories}
+                    setOpenCategories={setOpenCategories}
+                    handleKeyDownInput={handleKeyDownInput}
+                  />
+                )}
+              </>
+            ) : (
+              <NoResultsMessage onClearSearch={handleClearSearch} />
             )}
           </>
-        ) : (
-          <NoResultsMessage onClearSearch={handleClearSearch} />
         )}
       </SidebarContent>
       <SidebarFooter className="border-t p-4 py-3">
@@ -362,6 +381,7 @@ export function FlowSidebarComponent() {
           hasStore={hasStore}
           customComponent={customComponent}
           addComponent={addComponent}
+          isLoading={isLoading}
         />
       </SidebarFooter>
     </Sidebar>

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
@@ -327,15 +327,13 @@ export function FlowSidebarComponent({ isLoading }: { isLoading?: boolean }) {
       <SidebarContent>
         {isLoading ? (
           <div className="flex flex-col gap-2">
-            <SkeletonGroup
-              count={13}
-              containerClassName="flex flex-col gap-1 p-3"
-            />
+            <div className="flex flex-col gap-1 p-3">
+              <SkeletonGroup count={13} className="my-0.5 h-7" />
+            </div>
             <div className="h-[32px]" />
-            <SkeletonGroup
-              count={21}
-              containerClassName="flex flex-col gap-1 p-3"
-            />
+            <div className="flex flex-col gap-1 p-3">
+              <SkeletonGroup count={21} className="my-0.5 h-7" />
+            </div>
           </div>
         ) : (
           <>

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -6,7 +6,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { SaveChangesModal } from "@/modals/saveChangesModal";
 import useAlertStore from "@/stores/alertStore";
 import { customStringify } from "@/utils/reactflowUtils";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useBlocker, useParams } from "react-router-dom";
 import useFlowStore from "../../stores/flowStore";
 import useFlowsManagerStore from "../../stores/flowsManagerStore";
@@ -18,6 +18,7 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
   const currentFlow = useFlowStore((state) => state.currentFlow);
   const currentSavedFlow = useFlowsManagerStore((state) => state.currentFlow);
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
+  const [isLoading, setIsLoading] = useState(false);
 
   const changesNotSaved =
     customStringify(currentFlow) !== customStringify(currentSavedFlow) &&
@@ -154,10 +155,10 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
         {currentFlow && (
           <div className="flex h-full overflow-hidden">
             <SidebarProvider width="17.5rem" defaultOpen={!isMobile}>
-              {!view && <FlowSidebarComponent />}
+              {!view && <FlowSidebarComponent isLoading={isLoading} />}
               <main className="flex w-full overflow-hidden">
                 <div className="h-full w-full">
-                  <Page />
+                  <Page setIsLoading={setIsLoading} />
                 </div>
               </main>
             </SidebarProvider>


### PR DESCRIPTION
This pull request introduces several enhancements to the `FlowPage` component and its subcomponents to improve the loading state handling and user interface. The most important changes include adding a loading skeleton, refactoring components to accept a loading state, and updating the `FlowPage` to manage and pass down this state.

### Enhancements to Loading State and UI:

* [`src/frontend/src/components/ui/skeletonGroup.tsx`](diffhunk://#diff-2d79515cb4e2673652693ba1866fe3d47d52b041d318ea8ad02f9b27f67048efR1-R21): Added a new `SkeletonGroup` component to display loading skeletons.
* [`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eL82-R88): Updated the `Page` component to accept a `setIsLoading` function prop and use it to manage the loading state. [[1]](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eL82-R88) [[2]](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eR193-R196)
* [`src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarFooterButtons/index.tsx`](diffhunk://#diff-831a696f02718ecf01978a6440e41c88a8257d0f881f2d2472cbf9c578e26403R6-R18): Modified the `SidebarMenuButtons` component to accept an `isLoading` prop and disable buttons when loading. [[1]](diffhunk://#diff-831a696f02718ecf01978a6440e41c88a8257d0f881f2d2472cbf9c578e26403R6-R18) [[2]](diffhunk://#diff-831a696f02718ecf01978a6440e41c88a8257d0f881f2d2472cbf9c578e26403R48)

### Refactoring for Loading State:

* [`src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx`](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aR7): Updated the `FlowSidebarComponent` to accept an `isLoading` prop and display the `SkeletonGroup` when loading. [[1]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aR7) [[2]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL47-R48) [[3]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aR326-R341) [[4]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aR356) [[5]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aR376-R384)
* [`src/frontend/src/pages/FlowPage/index.tsx`](diffhunk://#diff-37a243d7fe9faf77fead8ea245d2884933fc5373bb9b4200371887aa989e21feL9-R9): Added a loading state to the `FlowPage` component and passed it down to `FlowSidebarComponent` and `Page` components. [[1]](diffhunk://#diff-37a243d7fe9faf77fead8ea245d2884933fc5373bb9b4200371887aa989e21feL9-R9) [[2]](diffhunk://#diff-37a243d7fe9faf77fead8ea245d2884933fc5373bb9b4200371887aa989e21feR21) [[3]](diffhunk://#diff-37a243d7fe9faf77fead8ea245d2884933fc5373bb9b4200371887aa989e21feL157-R161)


#### BUG (clicking bundles and categories will break the app)
![Screenshot 2025-02-20 at 2 34 08 PM](https://github.com/user-attachments/assets/9d989ed4-bd6e-4b33-a5b6-114e0e8eb0fd)

#### FIX (hides all clickable items in sidebar)
![Screenshot 2025-02-20 at 3 07 25 PM](https://github.com/user-attachments/assets/3933c0f0-948f-4a83-aee0-b775e1fe3b0f)


