### PR TITLE
fix: don't init langwatch if not configure

### DIFF
--- a/src/backend/base/langflow/services/tracing/langfuse.py
+++ b/src/backend/base/langflow/services/tracing/langfuse.py
@@ -133,7 +133,7 @@ class LangFuseTracer(BaseTracer):
     def get_langchain_callback(self) -> BaseCallbackHandler | None:
         if not self._ready:
             return None
-        return None  # self._callback
+        return self._callback
 
     @staticmethod
     def _get_config() -> dict:

--- a/src/backend/base/langflow/services/tracing/langwatch.py
+++ b/src/backend/base/langflow/services/tracing/langwatch.py
@@ -59,7 +59,7 @@ class LangWatchTracer(BaseTracer):
         return self._ready
 
     def setup_langwatch(self) -> bool:
-        if "LANGWATCH_API_KEY" not in os.environ
+        if "LANGWATCH_API_KEY" not in os.environ:
             return False
         try:
             import langwatch

--- a/src/backend/base/langflow/services/tracing/langwatch.py
+++ b/src/backend/base/langflow/services/tracing/langwatch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any, cast
 
 import nanoid
@@ -31,7 +32,7 @@ class LangWatchTracer(BaseTracer):
         self.flow_id = trace_name.split(" - ")[-1]
 
         try:
-            self._ready = self.setup_langwatch()
+            self._ready: bool = self.setup_langwatch() if "LANGWATCH_API_KEY" in os.environ else False
             if not self._ready:
                 return
 

--- a/src/backend/base/langflow/services/tracing/langwatch.py
+++ b/src/backend/base/langflow/services/tracing/langwatch.py
@@ -32,7 +32,7 @@ class LangWatchTracer(BaseTracer):
         self.flow_id = trace_name.split(" - ")[-1]
 
         try:
-            self._ready: bool = self.setup_langwatch() if "LANGWATCH_API_KEY" in os.environ else False
+            self._ready: bool = self.setup_langwatch()
             if not self._ready:
                 return
 
@@ -59,6 +59,8 @@ class LangWatchTracer(BaseTracer):
         return self._ready
 
     def setup_langwatch(self) -> bool:
+        if "LANGWATCH_API_KEY" not in os.environ
+            return False
         try:
             import langwatch
 


### PR DESCRIPTION
two tiny commit :
1. don't init langwatch if not configure
2. return langfuse callback for detail tracing