### PR TITLE
chore: Update Docker build workflow for reliability improvements

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -302,8 +302,6 @@ jobs:
             file: ${{ matrix.dockerfile }}
             tags: ${{ matrix.tags }}
             provenance: false
-          attempt_limit: 3
-          attempt_delay: 5000
 
   restart-space:
     name: Restart HuggingFace Spaces

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -205,15 +205,17 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and Push to Docker Hub
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@master
         with:
-          context: .
-          push: true
-          file: ${{ needs.setup.outputs.file }}
-          tags: ${{ needs.setup.outputs.docker_tags }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          action: docker/build-push-action@v6
+          with: |
+            context: .
+            push: true
+            file: ${{ needs.setup.outputs.file }}
+            tags: ${{ needs.setup.outputs.docker_tags }}
+            platforms: linux/amd64,linux/arm64
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
 
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
@@ -223,15 +225,17 @@ jobs:
           password: ${{ secrets.TEMP_GHCR_TOKEN}}
 
       - name: Build and push to Github Container Registry
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@master
         with:
-          context: .
-          push: true
-          file: ${{ needs.setup.outputs.file }}
-          tags: ${{ needs.setup.outputs.ghcr_tags }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          action: docker/build-push-action@v6
+          with: |
+            context: .
+            push: true
+            file: ${{ needs.setup.outputs.file }}
+            tags: ${{ needs.setup.outputs.ghcr_tags }}
+            platforms: linux/amd64,linux/arm64
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
 
   build_components:
     if: ${{ inputs.release_type == 'main' }}
@@ -287,16 +291,19 @@ jobs:
         run: sleep 120
 
       - name: Build and push ${{ matrix.component }}
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@master
         with:
-          context: .
-          push: true
-          build-args: |
-            LANGFLOW_IMAGE=${{ matrix.langflow_image }}
-          file: ${{ matrix.dockerfile }}
-          tags: ${{ matrix.tags }}
-          # provenance: false will result in a single manifest for all platforms which makes the image pullable from arm64 machines via the emulation (e.g. Apple Silicon machines)
-          provenance: false
+          action: docker/build-push-action@v6
+          with: |
+            context: .
+            push: true
+            build-args: |
+              LANGFLOW_IMAGE=${{ matrix.langflow_image }}
+            file: ${{ matrix.dockerfile }}
+            tags: ${{ matrix.tags }}
+            provenance: false
+          attempt_limit: 3
+          attempt_delay: 5000
 
   restart-space:
     name: Restart HuggingFace Spaces

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -301,6 +301,7 @@ jobs:
               LANGFLOW_IMAGE=${{ matrix.langflow_image }}
             file: ${{ matrix.dockerfile }}
             tags: ${{ matrix.tags }}
+            # provenance: false will result in a single manifest for all platforms which makes the image pullable from arm64 machines via the emulation (e.g. Apple Silicon machines)
             provenance: false
 
   restart-space:


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/docker-build.yml` file to improve the reliability of Docker build and push actions by incorporating a retry mechanism.

Changes to Docker build and push actions:

* Replaced `docker/build-push-action@v6` with `Wandalen/wretry.action@master` to add retry capability for Docker Hub builds.
* Replaced `docker/build-push-action@v6` with `Wandalen/wretry.action@master` to add retry capability for GitHub Container Registry builds.
* Replaced `docker/build-push-action@v6` with `Wandalen/wretry.action@master` to add retry capability for matrix component builds.