### PR TITLE
Fix: Reset Edge Update Tracking Before Success Message in UpdateAllComponents

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -32,4 +32,4 @@ Dockerfile text
 *.mp4 binary
 *.svg binary
 *.csv binary
-
+*.wav binary

--- a/src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx
@@ -51,24 +51,19 @@ export default function UpdateAllComponents({}: {}) {
         title: ERROR_MESSAGE_EDGES_LOST,
       });
 
-      edgesUpdateRef.current = {
-        numberOfEdgesBeforeUpdate: 0,
-        updateComponent: false,
-      };
+      resetEdgesUpdateRef();
     }
   }, [edges]);
 
   const getSuccessTitle = (updatedCount: number) => {
+    resetEdgesUpdateRef();
     return `Successfully updated ${updatedCount} component${
       updatedCount > 1 ? "s" : ""
     }`;
   };
 
   const handleUpdateAllComponents = () => {
-    edgesUpdateRef.current = {
-      numberOfEdgesBeforeUpdate: edges.length,
-      updateComponent: true,
-    };
+    startEdgesUpdateRef();
 
     setLoadingUpdate(true);
     takeSnapshot();
@@ -133,6 +128,20 @@ export default function UpdateAllComponents({}: {}) {
       .finally(() => {
         setLoadingUpdate(false);
       });
+  };
+
+  const resetEdgesUpdateRef = () => {
+    edgesUpdateRef.current = {
+      numberOfEdgesBeforeUpdate: 0,
+      updateComponent: false,
+    };
+  };
+
+  const startEdgesUpdateRef = () => {
+    edgesUpdateRef.current = {
+      numberOfEdgesBeforeUpdate: edges.length,
+      updateComponent: true,
+    };
   };
 
   if (componentsToUpdate.length === 0) return null;


### PR DESCRIPTION
This pull request includes a change to the `UpdateAllComponents` function in the `FlowPage` component. The change introduces a reset of the `edgesUpdateRef` object within the `getSuccessTitle` function to ensure the tracking of the number of edges and update status is reset before the success message is generated.

* [`src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx`](diffhunk://#diff-1fa6c72d078cb9d7b501ddccdfdf2babb7ed1c958eca52d03d718ac420deb751R62-R66): Added code to reset `edgesUpdateRef` within the `getSuccessTitle` function.