### PR TITLE
fix: prevent UnboundLocalError in MessageStoreComponent

### DIFF
--- a/src/backend/base/langflow/components/helpers/store_message.py
+++ b/src/backend/base/langflow/components/helpers/store_message.py
@@ -56,7 +56,7 @@ class MessageStoreComponent(Component):
         message.sender = self.sender or message.sender or MESSAGE_SENDER_AI
         message.sender_name = self.sender_name or message.sender_name or MESSAGE_SENDER_NAME_AI
 
-        stored_messages = []
+        stored_messages: list[Message] = []
 
         if self.memory:
             self.memory.session_id = message.session_id

--- a/src/backend/base/langflow/components/helpers/store_message.py
+++ b/src/backend/base/langflow/components/helpers/store_message.py
@@ -56,14 +56,14 @@ class MessageStoreComponent(Component):
         message.sender = self.sender or message.sender or MESSAGE_SENDER_AI
         message.sender_name = self.sender_name or message.sender_name or MESSAGE_SENDER_NAME_AI
 
-        stored_messages = []  
+        stored_messages = []
 
         if self.memory:
             self.memory.session_id = message.session_id
             lc_message = message.to_lc_message()
             await self.memory.aadd_messages([lc_message])
 
-            stored_messages = await self.memory.aget_messages() or [] 
+            stored_messages = await self.memory.aget_messages() or []
 
             stored_messages = [Message.from_lc_message(m) for m in stored_messages] if stored_messages else []
 
@@ -71,9 +71,12 @@ class MessageStoreComponent(Component):
                 stored_messages = [m for m in stored_messages if m.sender == message.sender]
         else:
             await astore_message(message, flow_id=self.graph.flow_id)
-            stored_messages = await aget_messages(
-                session_id=message.session_id, sender_name=message.sender_name, sender=message.sender
-            ) or [] 
+            stored_messages = (
+                await aget_messages(
+                    session_id=message.session_id, sender_name=message.sender_name, sender=message.sender
+                )
+                or []
+            )
 
         if not stored_messages:
             raise ValueError("No messages were stored. Please ensure that the session ID and sender are properly set.")

--- a/src/backend/base/langflow/components/helpers/store_message.py
+++ b/src/backend/base/langflow/components/helpers/store_message.py
@@ -79,7 +79,8 @@ class MessageStoreComponent(Component):
             )
 
         if not stored_messages:
-            raise ValueError("No messages were stored. Please ensure that the session ID and sender are properly set.")
+            msg = "No messages were stored. Please ensure that the session ID and sender are properly set."
+            raise ValueError(msg)
 
         stored_message = stored_messages[0]
         self.status = stored_message

--- a/src/backend/base/langflow/components/helpers/store_message.py
+++ b/src/backend/base/langflow/components/helpers/store_message.py
@@ -56,24 +56,28 @@ class MessageStoreComponent(Component):
         message.sender = self.sender or message.sender or MESSAGE_SENDER_AI
         message.sender_name = self.sender_name or message.sender_name or MESSAGE_SENDER_NAME_AI
 
+        stored_messages = []  
+
         if self.memory:
-            # override session_id
             self.memory.session_id = message.session_id
             lc_message = message.to_lc_message()
             await self.memory.aadd_messages([lc_message])
-            stored_messages = await self.memory.aget_messages()
-            stored_messages = [Message.from_lc_message(m) for m in stored_messages]
+
+            stored_messages = await self.memory.aget_messages() or [] 
+
+            stored_messages = [Message.from_lc_message(m) for m in stored_messages] if stored_messages else []
+
             if message.sender:
                 stored_messages = [m for m in stored_messages if m.sender == message.sender]
         else:
             await astore_message(message, flow_id=self.graph.flow_id)
             stored_messages = await aget_messages(
                 session_id=message.session_id, sender_name=message.sender_name, sender=message.sender
-            )
-        if not stored_messages:
-            msg = "No messages were stored. Please ensure that the session ID and sender are properly set."
-            raise ValueError(msg)
-        stored_message = stored_messages[0]
+            ) or [] 
 
+        if not stored_messages:
+            raise ValueError("No messages were stored. Please ensure that the session ID and sender are properly set.")
+
+        stored_message = stored_messages[0]
         self.status = stored_message
         return stored_message


### PR DESCRIPTION
## Summary
This PR fixes an UnboundLocalError in MessageStoreComponent when using external memory.

## Problem
When external memory is enabled, `stored_messages` was not properly initialized, leading to an error.

## Solution
- Ensure `stored_messages` is always initialized as an empty list.
- Use `stored_messages = await self.memory.aget_messages() or []` to prevent `None` assignment.
- Ensure transformation happens only if `stored_messages` is not empty.

## Testing
- Manually tested with and without external memory.
