### PR TITLE
fix: Fix URL for alembic migrations

### DIFF
--- a/src/backend/base/langflow/alembic.ini
+++ b/src/backend/base/langflow/alembic.ini
@@ -61,9 +61,9 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # output_encoding = utf-8
 
 # This is the path to the db in the root of the project.
-# When the user runs the Langflow the database url will
-# be set dinamically.
-sqlalchemy.url = sqlite:///./langflow.db
+# When the user runs Langflow the database url will
+# be set dynamically.
+sqlalchemy.url = sqlite+aiosqlite:///./langflow.db
 
 
 [post_write_hooks]


### PR DESCRIPTION
Since https://github.com/langflow-ai/langflow/pull/6258 the command `make alembic-revision` doesn't work anymore with the default `alembic.ini`