### PR TITLE
Fix: error handling in data_to_text_list function

### DIFF
--- a/src/backend/base/langflow/helpers/data.py
+++ b/src/backend/base/langflow/helpers/data.py
@@ -83,7 +83,7 @@ def data_to_text_list(template: str, data: Data | list[Data]) -> tuple[list[str]
             if isinstance(data_obj.data.get("data"), dict):
                 format_dict.update(data_obj.data["data"])
 
-            elif "error" in format_dict:
+            elif "error" in format_dict and format_dict["error"]:
                 format_dict["text"] = format_dict["error"]
 
         format_dict["data"] = data_obj.data

--- a/src/backend/base/langflow/helpers/data.py
+++ b/src/backend/base/langflow/helpers/data.py
@@ -83,7 +83,7 @@ def data_to_text_list(template: str, data: Data | list[Data]) -> tuple[list[str]
             if isinstance(data_obj.data.get("data"), dict):
                 format_dict.update(data_obj.data["data"])
 
-            elif "error" in format_dict and format_dict["error"]:
+            elif format_dict.get("error"):
                 format_dict["text"] = format_dict["error"]
 
         format_dict["data"] = data_obj.data


### PR DESCRIPTION
This pull request includes a small but important change to the `data_to_text_list` function in the `src/backend/base/langflow/helpers/data.py` file. The change ensures that the `error` key in the `format_dict` is checked for a truthy value before assigning it to the `text` key.

* [`src/backend/base/langflow/helpers/data.py`](diffhunk://#diff-4e2e18fb4871befde95e9c1207b7554a7c4437fc3f06c0075dffd3cdb842896fL86-R86): Modified the `data_to_text_list` function to check if the `error` key in `format_dict` is truthy before assigning it to the `text` key.