### PR TITLE
feat: Change default event delivery method to polling

### DIFF
--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -222,7 +222,7 @@ class Settings(BaseSettings):
     mcp_server_enable_progress_notifications: bool = False
     """If set to False, Langflow will not send progress notifications in the MCP server."""
 
-    event_delivery: Literal["polling", "streaming"] = "streaming"
+    event_delivery: Literal["polling", "streaming"] = "polling"
     """How to deliver build events to the frontend. Can be 'polling' or 'streaming'."""
 
     @field_validator("dev")


### PR DESCRIPTION
Update the default method for event delivery from streaming to polling in the settings configuration.