### PR TITLE
fix: changed edge position on minimized and not updated node

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -490,8 +490,8 @@ function GenericNode({
         <div
           data-testid={`${data.id}-main-node`}
           className={cn(
-            "grid gap-3 truncate text-wrap p-4 leading-5",
-            showNode && "border-b",
+            "grid gap-3 text-wrap p-4 leading-5",
+            showNode ? "border-b" : "relative",
           )}
         >
           <div
@@ -507,7 +507,9 @@ function GenericNode({
               data-testid="generic-node-title-arrangement"
             >
               {renderNodeIcon()}
-              <div className="generic-node-tooltip-div">{renderNodeName()}</div>
+              <div className="generic-node-tooltip-div truncate">
+                {renderNodeName()}
+              </div>
             </div>
             <div data-testid={`${showNode ? "show" : "hide"}-node-content`}>
               {!showNode && (


### PR DESCRIPTION
This pull request includes changes to the `GenericNode` component to improve the layout and styling. The most important changes include adjustments to the class names for better handling of the node's display and the addition of truncation to the node name tooltip.

Styling improvements:

* [`src/frontend/src/CustomNodes/GenericNode/index.tsx`](diffhunk://#diff-b6793e0279f94c374aae18db97958c0af6befc2b49b7ce30e0294f9c80ba0d0eL493-R494): Modified the class names in the main node container to conditionally apply "border-b" or "relative" based on the `showNode` state.
* [`src/frontend/src/CustomNodes/GenericNode/index.tsx`](diffhunk://#diff-b6793e0279f94c374aae18db97958c0af6befc2b49b7ce30e0294f9c80ba0d0eL510-R512): Added the "truncate" class to the node name tooltip to ensure the node name is truncated appropriately.