### PR TITLE
fix: Improve dropdown component with null option filtering

### DIFF
--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -765,3 +765,8 @@ export const isStringArray = (value: unknown): value is string[] => {
 };
 
 export const stringToBool = (str) => (str === "false" ? false : true);
+
+// Filter out null/undefined options
+export const filterNullOptions = (opts: any[]): any[] => {
+  return opts.filter((opt) => opt !== null && opt !== undefined);
+};


### PR DESCRIPTION
This pull request focuses on improving the `Dropdown` component by filtering out null or undefined options to ensure the component works with valid data. The changes include the introduction of a new utility function and updates to the component to use this function.

Key changes:

### Dropdown Component Enhancements:

* Added `filterNullOptions` utility function to filter out null or undefined options in `src/frontend/src/utils/utils.ts`.
* Updated import statements in `src/frontend/src/components/core/dropdownComponent/index.tsx` to include `useMemo` and `filterNullOptions`.
* Introduced `validOptions` using `useMemo` to filter out null or undefined options and replaced occurrences of `options` with `validOptions` in the `Dropdown` component. [[1]](diffhunk://#diff-98068ce778ac9a53f4733f9c370c5e54bd27c30b6545fa4241f10cba35518700R51-R57) [[2]](diffhunk://#diff-98068ce778ac9a53f4733f9c370c5e54bd27c30b6545fa4241f10cba35518700L59-R66) [[3]](diffhunk://#diff-98068ce778ac9a53f4733f9c370c5e54bd27c30b6545fa4241f10cba35518700L87-R94) [[4]](diffhunk://#diff-98068ce778ac9a53f4733f9c370c5e54bd27c30b6545fa4241f10cba35518700L136-R143) [[5]](diffhunk://#diff-98068ce778ac9a53f4733f9c370c5e54bd27c30b6545fa4241f10cba35518700L162-R169) [[6]](diffhunk://#diff-98068ce778ac9a53f4733f9c370c5e54bd27c30b6545fa4241f10cba35518700L400-R407)\


#### BUG
https://github.com/user-attachments/assets/05417092-fdfa-443e-b4d8-3ab4293c2751



#### FIX
https://github.com/user-attachments/assets/a0479559-4632-480f-9c9b-de4a0afa54bf

