### PR TITLE
fix(cache): resolve event loop conflict in redis connection check

### DIFF
--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -219,16 +219,14 @@ class RedisCache(AsyncBaseCacheService, Generic[LockType]):
         self.expiration_time = expiration_time
 
     # check connection
-    def is_connected(self) -> bool:
-        """Check if the Redis client is connected."""
+    # change to keep async safe
+    async def is_connected(self) -> bool:
         import redis
-
         try:
-            asyncio.run(self._client.ping())
-        except redis.exceptions.ConnectionError:
-            logger.exception("RedisCache could not connect to the Redis server")
+            await self._client.ping()  # 直接使用await
+            return True
+        except (redis.ConnectionError, redis.TimeoutError):
             return False
-        return True
 
     @override
     async def get(self, key, lock=None):

--- a/src/backend/base/langflow/services/cache/service.py
+++ b/src/backend/base/langflow/services/cache/service.py
@@ -222,6 +222,7 @@ class RedisCache(AsyncBaseCacheService, Generic[LockType]):
     # change to keep async safe
     async def is_connected(self) -> bool:
         import redis
+
         try:
             await self._client.ping()  # 直接使用await
             return True


### PR DESCRIPTION
- Replace asyncio.run() with await for async compatibility
![error](https://github.com/user-attachments/assets/2f9231a2-fb64-42e0-bcc8-a699387fe7c8)
