### PR TITLE
fix: Add optional PostgreSQL dependencies for SQLAlchemy in langflow-base

### DIFF
--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -81,6 +81,7 @@ dependencies = [
     "mcp>=1.1.2",
     "aiosqlite>=0.20.0",
     "greenlet>=3.1.1",
+    "sqlalchemy[aiosqlite]>=2.0.38,<3.0.0",
 ]
 
 [dependency-groups]
@@ -120,6 +121,7 @@ dev = [
     "pytest-flakefinder>=1.1.0",
     "types-markdown>=3.7.0.20240822",
     "codeflash>=0.8.4"
+
 ]
 
 
@@ -221,6 +223,12 @@ Documentation = "https://docs.langflow.org"
 
 # Optional dependencies for uv
 [project.optional-dependencies]
+
+postgresql = [
+  "sqlalchemy[postgresql_psycopg2binary]",
+    "sqlalchemy[postgresql_psycopg]",
+
+]
 deploy = [
     "celery>=5.3.1",
     "redis>=4.6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4626,6 +4626,7 @@ dependencies = [
     { name = "sentry-sdk", extra = ["fastapi", "loguru"] },
     { name = "setuptools" },
     { name = "spider-client" },
+    { name = "sqlalchemy", extra = ["aiosqlite"] },
     { name = "sqlmodel" },
     { name = "typer" },
     { name = "uncurl" },
@@ -4651,6 +4652,9 @@ local = [
     { name = "ctransformers" },
     { name = "llama-cpp-python" },
     { name = "sentence-transformers" },
+]
+postgresql = [
+    { name = "sqlalchemy", extra = ["postgresql-psycopg", "postgresql-psycopg2binary"] },
 ]
 
 [package.dev-dependencies]
@@ -4764,6 +4768,9 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["fastapi", "loguru"], specifier = ">=2.5.1,<3.0.0" },
     { name = "setuptools", specifier = ">=70,<76.0.0" },
     { name = "spider-client", specifier = ">=0.0.27,<1.0.0" },
+    { name = "sqlalchemy", extras = ["aiosqlite"], specifier = ">=2.0.38,<3.0.0" },
+    { name = "sqlalchemy", extras = ["postgresql-psycopg"], marker = "extra == 'postgresql'" },
+    { name = "sqlalchemy", extras = ["postgresql-psycopg2binary"], marker = "extra == 'postgresql'" },
     { name = "sqlmodel", specifier = "==0.0.22" },
     { name = "typer", specifier = ">=0.13.0,<1.0.0" },
     { name = "uncurl", specifier = ">=0.0.11,<1.0.0" },


### PR DESCRIPTION
Introduce optional dependencies for PostgreSQL in the `pyproject.toml` and update the lock file to include SQLAlchemy with aiosqlite support.