### PR TITLE
chore: make codeflash config ignore-paths relative in langflow-base

### DIFF
--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -204,7 +204,7 @@ ignore = [
 module-root = "langflow"
 tests-root = "../tests/unit"
 test-framework = "pytest"
-ignore-paths = ["src/backend/base/langflow/components/"]
+ignore-paths = ["langflow/components/"]
 formatter-cmds = ["ruff check --exit-zero --fix $file", "ruff format $file"]
 #disable plugins that might interfere with runtime measurement
 pytest-cmd = "pytest -p no:profiling -p no:sugar -p no:xdist -p no:cov -p no:split"


### PR DESCRIPTION
currently codeflash does not work correctly in the GHA since it is using absolute paths for the ignore-paths field, codeflash relies on this being relative to the pyproject.toml, this fixes that.