### PR TITLE
fix: bump frontend version to current version and add command to bump frontend version in Makefile

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "langflow",
-  "version": "0.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langflow",
-  "version": "0.1.2",
+  "version": "1.2.0",
   "private": true,
   "dependencies": {
     "@chakra-ui/number-input": "^2.1.2",


### PR DESCRIPTION
This pull request includes changes to update the versioning of the `langflow` project across various components. The most important changes are:

Version updates:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R42): Added a command to bump the version in the `src/frontend` directory using npm.
* [`src/frontend/package-lock.json`](diffhunk://#diff-9eaa8c31e85b60ae25c139f2d6363cc9dcb6926125b5bf1d0cac092547e8cfcbL3-R3): Updated the version from `0.1.2` to `1.2.0`.
* [`src/frontend/package.json`](diffhunk://#diff-12ee508ecc1901fe1a1d71ed459dba8454f3160983ee18b2c51b76ade45235d3L3-R3): Updated the version from `0.1.2` to `1.2.0`.