### PR TITLE
fix: changed badge to toggle on editable boolean fields on table component

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/TableNodeComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/TableNodeComponent/index.tsx
@@ -141,7 +141,8 @@ export default function TableNodeComponent({
       const isCustomEdit =
         column.formatter &&
         ((column.formatter === "text" && column.edit_mode === "modal") ||
-          column.formatter === "json");
+          column.formatter === "json" ||
+          column.formatter === "boolean");
       return {
         field: column.name,
         onUpdate: updateComponent,

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx
@@ -5,6 +5,8 @@ import DateReader from "@/components/core/dateReaderComponent";
 import { Badge } from "@/components/ui/badge";
 import { cn, isTimeStampString } from "@/utils/utils";
 import { CustomCellRendererProps } from "ag-grid-react";
+import { uniqueId } from "lodash";
+import ToggleShadComponent from "../../../toggleShadComponent";
 
 interface CustomCellRender extends CustomCellRendererProps {
   formatter?: "json" | "text" | "boolean" | "number" | "undefined" | "null";
@@ -81,7 +83,18 @@ export default function TableAutoCellRender({
           value === true
             ? true
             : false;
-        return (
+        return !!colDef?.onCellValueChanged ||
+          !!api.getGridOption("onCellValueChanged") ? (
+          <ToggleShadComponent
+            value={value}
+            handleOnNewValue={(data) => {
+              setValue?.(data.value);
+            }}
+            editNode={true}
+            id={"toggle" + colDef?.colId + uniqueId()}
+            disabled={false}
+          />
+        ) : (
           <Badge
             variant={value ? "successStatic" : "errorStatic"}
             size="sq"

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -1,6 +1,5 @@
 import TableAutoCellRender from "@/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender";
 import TableDropdownCellEditor from "@/components/core/parameterRenderComponent/components/tableComponent/components/tableDropdownCellEditor";
-import TableToggleCellEditor from "@/components/core/parameterRenderComponent/components/tableComponent/components/tableToggleCellEditor";
 import useAlertStore from "@/stores/alertStore";
 import { ColumnField, FormatterType } from "@/types/utils/functions";
 import { ColDef, ColGroupDef, ValueParserParams } from "ag-grid-community";
@@ -594,8 +593,7 @@ export function FormatColumns(columns: ColumnField[]): ColDef<any>[] {
           };
         } else if (col.formatter === FormatterType.boolean) {
           newCol.cellRenderer = TableAutoCellRender;
-          newCol.cellEditorPopup = false;
-          newCol.cellEditor = TableToggleCellEditor;
+          newCol.editable = false;
           newCol.autoHeight = false;
           newCol.cellClass = "no-border !py-2";
           newCol.type = "boolean";


### PR DESCRIPTION
This pull request includes changes to improve the handling of boolean formatters and the rendering of table cells in the frontend components. The most important changes include adding support for boolean formatters in the `TableNodeComponent`, integrating a new toggle component for cell rendering, and updating the utility functions accordingly.

Improvements to boolean formatter handling:

* [`src/frontend/src/components/core/parameterRenderComponent/components/TableNodeComponent/index.tsx`](diffhunk://#diff-0c62a57e27e05515113667234bff939fa464b255c228c92bc12c6ab9d61576a4L144-R145): Added support for `boolean` formatter in the `isCustomEdit` check.

Integration of new toggle component:

* [`src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx`](diffhunk://#diff-86977b55f6f3573ef83b6ec14ca59c0ae562383d4109c3006320324df35d261cR8-R9): Imported `ToggleShadComponent` and `uniqueId` from `lodash`, and added logic to render `ToggleShadComponent` based on the presence of `onCellValueChanged` in the column definition or grid options. [[1]](diffhunk://#diff-86977b55f6f3573ef83b6ec14ca59c0ae562383d4109c3006320324df35d261cR8-R9) [[2]](diffhunk://#diff-86977b55f6f3573ef83b6ec14ca59c0ae562383d4109c3006320324df35d261cL84-R97)

Updates to utility functions:

* [`src/frontend/src/utils/utils.ts`](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81L3): Removed the import of `TableToggleCellEditor` and updated the `FormatColumns` function to set `editable` to `false` for boolean formatters, instead of using `TableToggleCellEditor`. [[1]](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81L3) [[2]](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81L597-R596)