### PR TITLE
fix(docker): add system-wide PostgreSQL dependencies and update uv usage

### DIFF
--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -10,12 +10,11 @@ RUN apt-get update \
     curl \
     npm \
     git \
+    libpq-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . /app
-
-# Install dependencies using uv
+# Install PostgreSQL dependencies and project dependencies
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=README.md,target=README.md \
@@ -23,7 +22,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=src/backend/base/README.md,target=src/backend/base/README.md \
     --mount=type=bind,source=src/backend/base/uv.lock,target=src/backend/base/uv.lock \
     --mount=type=bind,source=src/backend/base/pyproject.toml,target=src/backend/base/pyproject.toml \
+    uv pip install --system psycopg psycopg-binary sqlalchemy[postgresql] && \
     uv sync --frozen --no-install-project --no-dev --extra postgresql
+
+COPY . /app
 
 EXPOSE 7860
 EXPOSE 3000


### PR DESCRIPTION
### What  
This PR updates the `dev.Dockerfile` to fix build failures and improve system-wide dependency management:  

- Adds `libpq-dev` to support PostgreSQL compilation.  
- Ensures critical database packages (`psycopg`, `psycopg-binary`, and `sqlalchemy[postgresql]`) are explicitly installed via `uv pip install --system`.  
- Adds the `--system` flag to uv commands to support non-virtual environments inside containers.  
- Resolves recent `uv` version incompatibilities during Docker builds.  
- Keeps the development container aligned with production-like configurations.  

### Why  
- Without these adjustments, Docker builds fail due to uv's stricter handling of virtual environments, requiring system-wide installs.  Build error encountered: 
`=> ERROR [langflow stage-0 4/5] RUN --mount=type=cache,target=/root/.cache/uv     --mount=type=bind,source=uv.lock,target=uv.lock     --mount=type=bind,source=README.md,tar  12.1s`

- Additionally, explicit installation of PostgreSQL-related Python packages ensures consistent availability, regardless of changes in lockfiles or extras.  

### Test Results
- Docker build succeeded with no errors. 
- Success bringing `docker up` from /docker_example, application loads on browser, able to add flows, successfully restored backup to postgres - no visible issues.

### Impact  
- Fixes Docker build failures.  
- Ensures critical PostgreSQL packages and system libraries are present.  
- Improves maintainability for future uv updates. 