### PR TITLE
feat: display the color itself instead of gray if there's only one color in the handle

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx
@@ -278,11 +278,17 @@ const HandleRenderComponent = memo(function HandleRenderComponent({
     const isNullHandle =
       filterPresent && !(openHandle || ownDraggingHandle || ownFilterHandle);
 
+    // Create a Set from colorName to remove duplicates
+    const colorNameSet = new Set(colorName || []);
+    const uniqueColorCount = colorNameSet.size;
+    const firstUniqueColor =
+      colorName && colorName.length > 0 ? colorName[0] : "";
+
     const handleColorName = connectedEdge
       ? connectedColor
-      : colorName!.length > 1
+      : uniqueColorCount > 1
         ? "secondary-foreground"
-        : "datatype-" + colorName![0];
+        : "datatype-" + firstUniqueColor;
 
     const handleColor = isNullHandle
       ? dark
@@ -290,15 +296,15 @@ const HandleRenderComponent = memo(function HandleRenderComponent({
         : "hsl(var(--accent-gray-foreground)"
       : connectedEdge
         ? "hsl(var(--datatype-" + connectedColor + "))"
-        : colorName!.length > 1
+        : uniqueColorCount > 1
           ? "hsl(var(--secondary-foreground))"
-          : "hsl(var(--datatype-" + colorName![0] + "))";
+          : "hsl(var(--datatype-" + firstUniqueColor + "))";
 
     const accentForegroundColorName = connectedEdge
       ? "hsl(var(--datatype-" + connectedColor + "-foreground))"
-      : colorName!.length > 1
+      : uniqueColorCount > 1
         ? "hsl(var(--input))"
-        : "hsl(var(--datatype-" + colorName![0] + "-foreground))";
+        : "hsl(var(--datatype-" + firstUniqueColor + "-foreground))";
 
     const currentFilter = left
       ? {


### PR DESCRIPTION
This pull request includes a change to the `HandleRenderComponent` in the `index.tsx` file to improve the handling of color names by removing duplicates and simplifying the logic.

Improvements to color name handling:

* [`src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx`](diffhunk://#diff-6b00d330838431fd5fd114f3ed4159196f47f74d00a65bd4d5fa2ed70cf726fbR281-R307): Created a `Set` from `colorName` to remove duplicates, calculated the unique color count, and used the first unique color in the logic for determining `handleColorName`, `handleColor`, and `accentForegroundColorName`.