### PR TITLE
feat: add Table type to be a replacement of DataFrame in a future version

### DIFF
--- a/src/backend/base/langflow/custom/utils.py
+++ b/src/backend/base/langflow/custom/utils.py
@@ -23,7 +23,7 @@ from langflow.custom.schema import MissingDefault
 from langflow.field_typing.range_spec import RangeSpec
 from langflow.helpers.custom import format_type
 from langflow.schema import dotdict
-from langflow.template.field.base import Input
+from langflow.template.field.base import Input, Output
 from langflow.template.frontend_node.custom_components import ComponentFrontendNode, CustomComponentFrontendNode
 from langflow.type_extraction.type_extraction import extract_inner_type
 from langflow.utils import validate
@@ -363,6 +363,11 @@ def add_code_field(frontend_node: CustomComponentFrontendNode, raw_code):
     return frontend_node
 
 
+def add_new_types_to_output(output: Output):
+    if "Data" in output.types and "JSON" not in output.types:
+        output.types.append("JSON")
+
+
 def build_custom_component_template_from_inputs(
     custom_component: Component | CustomComponent, user_id: str | UUID | None = None
 ):
@@ -374,6 +379,7 @@ def build_custom_component_template_from_inputs(
     # But we now need to calculate the return_type of the methods in the outputs
     for output in frontend_node.outputs:
         if output.types:
+            add_new_types_to_output(output)
             continue
         return_types = cc_instance.get_method_return_type(output.method)
         return_types = [format_type(return_type) for return_type in return_types]

--- a/src/backend/base/langflow/custom/utils.py
+++ b/src/backend/base/langflow/custom/utils.py
@@ -366,6 +366,8 @@ def add_code_field(frontend_node: CustomComponentFrontendNode, raw_code):
 def add_new_types_to_output(output: Output):
     if "Data" in output.types and "JSON" not in output.types:
         output.types.append("JSON")
+    if "DataFrame" in output.types and "Table" not in output.types:
+        output.types.append("Table")
 
 
 def build_custom_component_template_from_inputs(

--- a/src/backend/base/langflow/inputs/inputs.py
+++ b/src/backend/base/langflow/inputs/inputs.py
@@ -33,6 +33,7 @@ from .input_mixin import (
 class TableInput(BaseInputMixin, MetadataTraceMixin, TableMixin, ListableInputMixin, ToolModeMixin):
     field_type: SerializableFieldTypes = FieldTypes.TABLE
     is_list: bool = True
+    input_types: list[str] = ["DataFrame", "Table"]
 
     @field_validator("value")
     @classmethod
@@ -93,7 +94,7 @@ class DataInput(HandleInput, InputTraceMixin, ListableInputMixin, ToolModeMixin)
 
 
 class DataFrameInput(HandleInput, InputTraceMixin, ListableInputMixin, ToolModeMixin):
-    input_types: list[str] = ["DataFrame"]
+    input_types: list[str] = ["DataFrame", "Table"]
 
 
 class PromptInput(BaseInputMixin, ListableInputMixin, InputTraceMixin, ToolModeMixin):

--- a/src/backend/base/langflow/schema/dataframe.py
+++ b/src/backend/base/langflow/schema/dataframe.py
@@ -168,3 +168,11 @@ class DataFrame(pandas_DataFrame):
             DataFrame: A new DataFrame with the converted Documents
         """
         return DataFrame(docs)
+
+
+class Table(DataFrame):
+    """A pandas DataFrame subclass specialized for handling collections of Data objects.
+
+    This class extends pandas.DataFrame to provide seamless integration between
+    Langflow's JSON objects and pandas' powerful data manipulation capabilities.
+    """


### PR DESCRIPTION
Improve flexibility in custom component outputs by automatically adding 'JSON' and 'Table' types based on existing types. Extend input type support for Table and DataFrame inputs to enhance data handling capabilities.