### PR TITLE
fix: improve ref naming causing fallback error on icons + regression test

### DIFF
--- a/src/frontend/src/alerts/alertDropDown/index.tsx
+++ b/src/frontend/src/alerts/alertDropDown/index.tsx
@@ -1,6 +1,5 @@
 import { Cross2Icon } from "@radix-ui/react-icons";
 import { forwardRef, useEffect, useState } from "react";
-import ShortUniqueId from "short-unique-id";
 import IconComponent from "../../components/common/genericIconComponent";
 import {
   Popover,
@@ -31,9 +30,7 @@ const AlertDropdown = forwardRef<HTMLDivElement, AlertDropdownType>(
       if (!open) {
         onClose?.();
       }
-    }, [open, onClose]);
-
-    const uid = new ShortUniqueId();
+    }, [open]);
 
     return (
       <Popover
@@ -48,14 +45,11 @@ const AlertDropdown = forwardRef<HTMLDivElement, AlertDropdownType>(
       >
         <PopoverTrigger asChild>{children}</PopoverTrigger>
         <PopoverContent
-          ref={ref}
+          ref={notificationRef}
           data-testid="notification-dropdown-content"
           className="noflow nowheel nopan nodelete nodrag z-10 flex h-[500px] w-[500px] flex-col"
         >
-          <div
-            ref={notificationRef}
-            className="text-md flex flex-row justify-between pl-3 font-medium text-foreground"
-          >
+          <div className="text-md flex flex-row justify-between pl-3 font-medium text-foreground">
             Notifications
             <div className="flex gap-3 pr-3">
               <button
@@ -81,7 +75,7 @@ const AlertDropdown = forwardRef<HTMLDivElement, AlertDropdownType>(
             {notificationList.length !== 0 ? (
               notificationList.map((alertItem) => (
                 <SingleAlert
-                  key={uid.randomUUID(10)}
+                  key={alertItem.id}
                   dropItem={alertItem}
                   removeAlert={removeFromNotificationList}
                 />

--- a/src/frontend/src/components/ui/loading.tsx
+++ b/src/frontend/src/components/ui/loading.tsx
@@ -18,6 +18,7 @@ export const Loading = ({ size = 24, ...props }: LoadingProps) => (
     strokeLinejoin="round"
     className="feather feather-circle"
     {...props}
+    data-testid="loading-icon"
   >
     <circle cx={12} cy={12} r={10} strokeDasharray={63} strokeDashoffset={21}>
       <animateTransform

--- a/src/frontend/tests/extended/regression/general-bugs-icons-fallback.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-icons-fallback.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { extractAndCleanCode } from "../../utils/extract-and-clean-code";
+
+test(
+  "user must be able to see icons fallback if the icon is not found",
+  { tag: ["@release", "@components"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page);
+
+    await page.getByTestId("blank-flow").click();
+
+    await page.waitForSelector('[data-testid="fit_view"]', {
+      timeout: 100000,
+    });
+
+    await page.getByTestId("disclosure-data").click();
+    await page.waitForTimeout(500);
+    await page.getByTestId("disclosure-processing").click();
+    await page.waitForTimeout(500);
+    const loadingIcons = await page.getByTestId("loading-icon").count();
+    expect(loadingIcons).toBe(0);
+  },
+);


### PR DESCRIPTION
This pull request includes several important changes to the `AlertDropdown` component in the `src/frontend/src/alerts/alertDropDown/index.tsx` file. The changes focus on removing unnecessary dependencies and improving the code's readability and maintainability.

Improvements to the `AlertDropdown` component:

* Removed the import and usage of `ShortUniqueId` to simplify the code and reduce dependencies. [[1]](diffhunk://#diff-0543dd590276f022c89bfbef77b609cbf97fedc6d953222d2f9939a0b56367b4L3) [[2]](diffhunk://#diff-0543dd590276f022c89bfbef77b609cbf97fedc6d953222d2f9939a0b56367b4L34-R33) [[3]](diffhunk://#diff-0543dd590276f022c89bfbef77b609cbf97fedc6d953222d2f9939a0b56367b4L84-R78)
* Replaced the `ref` prop of the `PopoverContent` component with `notificationRef` to improve clarity and consistency.

![image](https://github.com/user-attachments/assets/71dff8ff-9a93-4d4a-8be6-852b58425df3)
