### PR TITLE
fix: ensure end_all_traces is called at the end of all flow build events

### DIFF
--- a/src/backend/base/langflow/api/build.py
+++ b/src/backend/base/langflow/api/build.py
@@ -424,7 +424,9 @@ async def generate_flow_events(
         )
         event_manager.on_error(data=error_message.data)
         raise
+
     event_manager.on_end(data={})
+    await graph.end_all_traces()
     await event_manager.queue.put((None, None, time.time()))
 
 


### PR DESCRIPTION
Ensures that end_all_traces is called at the end of all flow build events, ensuring proper trace finalization.

Fixes #6880