### PR TITLE
fix: make edit sticky notes mode occupy whole note

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx
@@ -153,7 +153,7 @@ export default function NodeDescription({
           <Textarea
             maxLength={charLimit}
             className={cn(
-              "nowheel h-full w-full focus:border-primary focus:ring-0",
+              "nowheel h-full w-full p-0 text-[13px] focus:border-primary focus:ring-0",
               inputClassName,
             )}
             autoFocus

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -151,7 +151,7 @@ function NoteNode({
             overflow: "hidden",
           }}
           className={cn(
-            "transition-all duration-200 ease-in-out",
+            "flex-1 transition-all duration-200 ease-in-out",
             !isResizing && "transition-[width,height]",
           )}
         >


### PR DESCRIPTION
This pull request includes updates to the styling of components in the `src/frontend/src/CustomNodes` directory. The changes focus on improving the layout and appearance of the `NodeDescription` and `NoteNode` components.

Styling updates:

* [`src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx`](diffhunk://#diff-29f29ad00a7a070d08356cd7caef9f3c7746207bd09b69e65551917943849002L156-R156): Added padding and adjusted text size for the `Textarea` component to enhance its appearance.
* [`src/frontend/src/CustomNodes/NoteNode/index.tsx`](diffhunk://#diff-f8b8ed9929042c70be90d199a6389270c4dde1e7ad261d8a5e5c560983220cdaL154-R154): Modified the className to include `flex-1` for better layout control and consistency during transitions.