### PR TITLE
fix: make chat input handle overflow

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -493,7 +493,7 @@ function GenericNode({
         <div
           data-testid={`${data.id}-main-node`}
           className={cn(
-            "grid truncate text-wrap p-4 leading-5",
+            "grid text-wrap p-4 leading-5",
             showNode ? "border-b" : "relative",
             hasDescription && "gap-3",
           )}


### PR DESCRIPTION
This pull request includes a change to the `GenericNode` component in the `src/frontend/src/CustomNodes/GenericNode/index.tsx` file. The change simplifies the CSS class list by removing the `truncate` class from the main node's `div` element.

Changes in `GenericNode` component:

* [`src/frontend/src/CustomNodes/GenericNode/index.tsx`](diffhunk://#diff-b6793e0279f94c374aae18db97958c0af6befc2b49b7ce30e0294f9c80ba0d0eL496-R496): Removed the `truncate` class from the `div` element's class list to potentially improve the display of text within the node.