### PR TITLE
docs: Allow setting baseUrl configuration via ENV variable

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -12,7 +12,7 @@ const config = {
     "Langflow is a low-code app builder for RAG and multi-agent AI applications.",
   favicon: "img/favicon.ico",
   url: "https://docs.langflow.org",
-  baseUrl: "/",
+  baseUrl: process.env.BASE_URL ? process.env.BASE_URL : "/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   onBrokenAnchors: "warn",


### PR DESCRIPTION
Allow setting docusaurus `baseUrl` configuration at build time using ENV variable.