### PR TITLE
fix: Disable retries in usePostValidateComponentCode mutation

### DIFF
--- a/src/frontend/src/controllers/API/queries/nodes/use-post-validate-component-code.ts
+++ b/src/frontend/src/controllers/API/queries/nodes/use-post-validate-component-code.ts
@@ -40,11 +40,11 @@ export const usePostValidateComponentCode: useMutationFunctionType<
     CustomComponentRequest,
     ResponseErrorTypeAPI,
     IPostValidateComponentCode
-  > = mutate(
-    ["usePostValidateComponentCode"],
-    postValidateComponentCodeFn,
-    options,
-  );
+  > = mutate(["usePostValidateComponentCode"], postValidateComponentCodeFn, {
+    ...options,
+    retry: 0,
+    retryDelay: 0,
+  });
 
   return mutation;
 };


### PR DESCRIPTION
This pull request includes a change to the `usePostValidateComponentCode` mutation function in the `src/frontend/src/controllers/API/queries/nodes/use-post-validate-component-code.ts` file. The change modifies the mutation options to disable retries and retry delays.

* [`src/frontend/src/controllers/API/queries/nodes/use-post-validate-component-code.ts`](diffhunk://#diff-9f8270699c193619ca23967a57577064faca1578b651d94c821f9285a72af9d3L43-R47): Updated the mutation options to include `retry: 0` and `retryDelay: 0`, ensuring that the mutation does not retry in case of failure.