### PR TITLE
docs: fix syntax errors at build

### DIFF
--- a/docs/docs/API-Reference/api-reference-api-examples.md
+++ b/docs/docs/API-Reference/api-reference-api-examples.md
@@ -19,13 +19,13 @@ The examples in this guide use environment variables for these values.
 
 * Export your Langflow URL in your terminal.
 Langflow starts by default at `http://127.0.0.1:7860`.
-```plain
+```bash
 export LANGFLOW_URL="http://127.0.0.1:7860"
 ```
 
 * Export the `flow-id` in your terminal.
 The `flow-id` is found in the [API pane](/concepts-api) or in the flow's URL.
-```plain
+```bash
 export FLOW_ID="359cd752-07ea-46f2-9d3b-a4407ef618da"
 ```
 
@@ -33,14 +33,14 @@ export FLOW_ID="359cd752-07ea-46f2-9d3b-a4407ef618da"
 To find your folder ID, call the Langflow [/api/v1/folders/](#read-folders) endpoint for a list of folders.
 <Tabs>
   <TabItem value="curl" label="curl" default>
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/folders/" \
   -H "accept: application/json"
 ```
   </TabItem>
   <TabItem value="result" label="Result">
-```plain
+```json
 [
   {
     "name": "My Projects",
@@ -53,7 +53,7 @@ curl -X GET \
   </TabItem>
 </Tabs>
 Export the `folder-id` as an environment variable.
-```plain
+```bash
 export FOLDER_ID="1415de42-8f01-4f36-bf34-539f23e47466"
 ```
 
@@ -61,19 +61,19 @@ export FOLDER_ID="1415de42-8f01-4f36-bf34-539f23e47466"
 To create a Langflow API key, run the following command in the Langflow CLI.
 <Tabs>
   <TabItem value="curl" label="curl" default>
-```plain
+```text
 langflow api-key
 ```
   </TabItem>
   <TabItem value="result" label="Result">
-```plain
+```text
 API Key Created Successfully:
 sk-...
 ```
   </TabItem>
 </Tabs>
 Export the generated API key as an environment variable.
-```plain
+```text
 export LANGFLOW_API_KEY="sk-..."
 ```
 
@@ -88,7 +88,7 @@ This operation returns a dictionary of all Langflow components.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/all" \
   -H "accept: application/json"
@@ -96,7 +96,7 @@ curl -X GET \
 
   </TabItem>
   <TabItem value="result" label="Result">
-```result
+```text
 A dictionary of all Langflow components.
 ```
   </TabItem>
@@ -111,7 +111,7 @@ For more configuration options when building your flow, use the [`/build` endpoi
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/run/$FLOW_ID?stream=false" \
   -H "accept: application/json" \
@@ -122,7 +122,7 @@ curl -X POST \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```result
+```text
 {"session_id":"947eaf64-bc35-4431-ae52-8b30d819915b","outputs":[{"inputs":{},"outputs":[{"results":{"message":{"text_key":"text","data":{"timestamp":"2025-02-04T21:44:02+00:00","sender":"Machine","sender_name":"AI","session_id":"947eaf64-bc35-4431-ae52-8b30d819915b","text":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","files":[],"error":false,"edit":false,"properties":{"text_color":"","background_color":"","edited":false,"source":{"id":"OpenAIModel-g7uMN","display_name":"OpenAI","source":"gpt-4o-mini"},"icon":"OpenAI","allow_markdown":false,"positive_feedback":null,"state":"complete","targets":[]},"category":"message","content_blocks":[],"id":"dcb15280-a16c-489a-9818-bec697fd123e","flow_id":"947eaf64-bc35-4431-ae52-8b30d819915b"},"default_value":"","text":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","sender":"Machine","sender_name":"AI","files":[],"session_id":"947eaf64-bc35-4431-ae52-8b30d819915b","timestamp":"2025-02-04T21:44:02+00:00","flow_id":"947eaf64-bc35-4431-ae52-8b30d819915b","error":false,"edit":false,"properties":{"text_color":"","background_color":"","edited":false,"source":{"id":"OpenAIModel-g7uMN","display_name":"OpenAI","source":"gpt-4o-mini"},"icon":"OpenAI","allow_markdown":false,"positive_feedback":null,"state":"complete","targets":[]},"category":"message","content_blocks":[]}},"artifacts":{"message":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","sender":"Machine","sender_name":"AI","files":[],"type":"object"},"outputs":{"message":{"message":{"timestamp":"2025-02-04T21:44:02","sender":"Machine","sender_name":"AI","session_id":"947eaf64-bc35-4431-ae52-8b30d819915b","text":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","files":[],"error":false,"edit":false,"properties":{"text_color":"","background_color":"","edited":false,"source":{"id":"OpenAIModel-g7uMN","display_name":"OpenAI","source":"gpt-4o-mini"},"icon":"OpenAI","allow_markdown":false,"positive_feedback":null,"state":"complete","targets":[]},"category":"message","content_blocks":[],"id":"dcb15280-a16c-489a-9818-bec697fd123e","flow_id":"947eaf64-bc35-4431-ae52-8b30d819915b"},"type":"message"}},"logs":{"message":[]},"messages":[{"message":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","sender":"Machine","sender_name":"AI","session_id":"947eaf64-bc35-4431-ae52-8b30d819915b","stream_url":null,"component_id":"ChatOutput-HnFx1","files":[],"type":"message"}],"timedelta":null,"duration":null,"component_display_name":"Chat Output","component_id":"ChatOutput-HnFx1","used_frozen_result":false}]}]}
 ```
 
@@ -134,7 +134,7 @@ To stream LLM token responses, append the `?stream=true` query parameter to the 
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/run/$FLOW_ID?stream=true" \
   -H "accept: application/json" \
@@ -146,7 +146,7 @@ curl -X POST \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```result
+```text
 {"event": "add_message", "data": {"timestamp": "2025-02-05T14:46:24", "sender": "User", "sender_name": "User", "session_id": "947eaf64-bc35-4431-ae52-8b30d819915b", "text": "Hello", "files": [], "error": false, "edit": false, "properties": {"text_color": "", "background_color": "", "edited": false, "source": {"id": null, "display_name": null, "source": null}, "icon": "", "allow_markdown": false, "positive_feedback": null, "state": "complete", "targets": []}, "category": "message", "content_blocks": [], "id": "1d6044d6-332c-431a-a50c-dcea5deee4ab", "flow_id": "947eaf64-bc35-4431-ae52-8b30d819915b"}}
 
 {"event": "add_message", "data": {"timestamp": "2025-02-05T14:46:24", "sender": "Machine", "sender_name": "AI", "session_id": "947eaf64-bc35-4431-ae52-8b30d819915b", "text": "", "files": [], "error": false, "edit": false, "properties": {"text_color": "", "background_color": "", "edited": false, "source": {"id": "OpenAIModel-g7uMN", "display_name": "OpenAI", "source": "gpt-4o-mini"}, "icon": "OpenAI", "allow_markdown": false, "positive_feedback": null, "state": "complete", "targets": []}, "category": "message", "content_blocks": [], "id": "be9db128-eaac-49db-bfd7-ed63406ebbcf", "flow_id": "947eaf64-bc35-4431-ae52-8b30d819915b"}}
@@ -178,7 +178,7 @@ To test the **Webhook** component in your flow, see the [Webhook component](/com
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/webhook/$FLOW_ID" \
   -H "Content-Type: application/json" \
@@ -188,7 +188,7 @@ curl -X POST \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```result
+```text
 {
   {"message":"Task started in the background","status":"in progress"}
 }
@@ -216,7 +216,7 @@ Get the status of a task.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/task/TASK_ID" \
   -H "accept: application/json"
@@ -225,7 +225,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```result
+```text
 {
   "status": "Task status",
   "result": "Task result if completed"
@@ -248,7 +248,7 @@ Get the version of the Langflow API.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/version" \
   -H "accept: application/json"
@@ -257,7 +257,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```result
+```text
 {
     "version": "1.1.1",
     "main_version": "1.1.1",
@@ -275,7 +275,7 @@ Retrieve the Langflow configuration information.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/config" \
   -H "accept: application/json"
@@ -284,7 +284,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```json
 {
     "feature_flags": {
         "mvp_components": false
@@ -316,7 +316,7 @@ This example builds a flow with a given `flow_id`.
 <Tabs>
    <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/build/$FLOW_ID/flow" \
   -H "accept: application/json" \
@@ -328,7 +328,7 @@ curl -X POST \
    </TabItem>
    <TabItem value="result" label="Result">
 
-```plain
+```json
 {"event": "vertices_sorted", "data": {"ids": ["ChatInput-TAEvF"], "to_run": ["Prompt-2gtLN", "ChatInput-TAEvF", "ChatOutput-HnFx1", "OpenAIModel-g7uMN"]}}
 
 {"event": "add_message", "data": {"timestamp": "2025-02-05T14:45:33", "sender": "User", "sender_name": "User", "session_id": "947eaf64-bc35-4431-ae52-8b30d819915b", "text": "Hello", "files": [], "error": false, "edit": false, "properties": {"text_color": "", "background_color": "", "edited": false, "source": {"id": null, "display_name": null, "source": null}, "icon": "", "allow_markdown": false, "positive_feedback": null, "state": "complete", "targets": []}, "category": "message", "content_blocks": [], "id": "12be981b-9816-4361-b0f9-ce65d0ba6cc1", "flow_id": "947eaf64-bc35-4431-ae52-8b30d819915b"}}
@@ -368,7 +368,7 @@ The `/build` endpoint accepts values for `start_component_id` and `stop_componen
 Setting `stop_component_id` for a component triggers the same behavior as clicking the **Play** button on that component, where all dependent components leading up to that component are also run.
 For example, to stop flow execution at the Open AI model component, run the following command:
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/build/$FLOW_ID/flow" \
   -H "accept: application/json" \
@@ -383,7 +383,7 @@ This is useful for running flows without having to pass custom values through th
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/build/$FLOW_ID/flow" \
   -H "accept: application/json" \
@@ -425,7 +425,7 @@ This example uploads `the_oscar_award.csv`.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/files/upload/$FLOW_ID" \
   -H "accept: application/json" \
@@ -455,7 +455,7 @@ For more information, see [Supported environment variables](/environment-variabl
 
 1. To send an image to your flow with the API, POST the image file to the `v1/files/upload/<YOUR-FLOW-ID>` endpoint of your flow.
 
-```curl
+```bash
 curl -X POST "$LANGFLOW_URL/api/v1/files/upload/a430cc57-06bb-4c11-be39-d3d4de68d2c4" \
   -H "Content-Type: multipart/form-data" \
   -F "file=@image-file.png"
@@ -470,7 +470,7 @@ The API returns the image file path in the format `"file_path":"<YOUR-FLOW-ID>/<
 2. Post the image file to the **Chat Input** component of a **Basic prompting** flow.
 Pass the file path value as an input in the **Tweaks** section of the curl call to Langflow.
 
-```curl
+```bash
 curl -X POST \
     "$LANGFLOW_URL/api/v1/run/a430cc57-06bb-4c11-be39-d3d4de68d2c4?stream=false" \
     -H 'Content-Type: application/json'\
@@ -487,7 +487,7 @@ curl -X POST \
 
 Your chatbot describes the image file you sent.
 
-```plain
+```text
 "text": "This flowchart appears to represent a complex system for processing financial inquiries using various AI agents and tools. Here's a breakdown of its components and how they might work together..."
 ```
 
@@ -499,7 +499,7 @@ List all files associated with a specific flow.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/files/list/$FLOW_ID" \
   -H "accept: application/json"
@@ -532,7 +532,7 @@ The `--output` flag is optional.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/files/download/$FLOW_ID/2024-12-30_15-19-43_the_oscar_award.csv" \
   -H "accept: application/json" \
@@ -542,7 +542,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```text
 The file contents.
 ```
 
@@ -562,7 +562,7 @@ The `--output` flag is optional.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/files/images/$FLOW_ID/2024-12-30_15-42-44_image-file.png" \
   -H "accept: application/json" \
@@ -572,7 +572,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```text
 Image file content.
 ```
 
@@ -589,7 +589,7 @@ This example deletes the `2024-12-30_15-42-44_image-file.png` file from Langflow
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X DELETE \
   "$LANGFLOW_URL/api/v1/files/delete/$FLOW_ID/2024-12-30_15-42-44_image-file.png" \
   -H "accept: application/json"
@@ -598,7 +598,7 @@ curl -X DELETE \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```json
 {
   "message": "File 2024-12-30_15-42-44_image-file.png deleted successfully"
 }
@@ -618,7 +618,7 @@ Create a new flow.
 <Tabs>
    <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/flows/" \
   -H "accept: application/json" \
@@ -642,7 +642,7 @@ curl -X POST \
    </TabItem>
    <TabItem value="result" label="Result">
 
-```plain
+```json
 {"name":"string2","description":"string","icon":"string","icon_bg_color":"#FF0000","gradient":"string","data":{},"is_component":false,"updated_at":"2025-02-04T21:07:36+00:00","webhook":false,"endpoint_name":"string","tags":["string"],"locked":false,"id":"e8d81c37-714b-49ae-ba82-e61141f020ee","user_id":"f58396d4-a387-4bb8-b749-f40825c3d9f3","folder_id":"1415de42-8f01-4f36-bf34-539f23e47466"}
 ```
 
@@ -666,7 +666,7 @@ curl -X GET \
 
 <TabItem value="result" label="Result">
 
-```plain
+```text
 A JSON object containing a list of flows.
 ```
    </TabItem>
@@ -688,7 +688,7 @@ curl -X GET \
 
 <TabItem value="result" label="Result">
 
-```plain
+```text
 A JSON object containing a list of flows.
 ```
 
@@ -813,7 +813,7 @@ Create multiple new flows.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/flows/batch/" \
   -H "accept: application/json" \
@@ -883,7 +883,7 @@ This example uploads a local file named `agent-with-astra-db-tool.json`.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/flows/upload/?folder_id=$FOLDER_ID" \
   -H "accept: application/json" \
@@ -913,7 +913,7 @@ curl -X POST \
 To specify a target folder for the flow, include the query parameter `folder_id`.
 The target `folder_id` must already exist before uploading a flow. Call the [/api/v1/folders/](#read-folders) endpoint for a list of available folders.
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/flows/upload/?folder_id=$FOLDER_ID" \
   -H "accept: application/json" \
@@ -930,7 +930,7 @@ This endpoint downloads a ZIP file containing flows for all `flow-id` values lis
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/flows/download/" \
   -H "accept: application/json" \
@@ -945,7 +945,7 @@ curl -X POST \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```text
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100 76437    0 76353  100    84  4516k   5088 --:--:-- --:--:-- --:--:-- 4665k
@@ -960,7 +960,7 @@ Retrieve a list of basic example flows.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/flows/basic_examples/" \
   -H "accept: application/json"
@@ -969,7 +969,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```text
 A list of example flows.
 ```
 
@@ -990,7 +990,7 @@ Get a list of Langflow folders.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/folders/" \
   -H "accept: application/json"
@@ -999,7 +999,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```json
 [
   {
     "name": "My Projects",
@@ -1020,7 +1020,7 @@ Create a new folder.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/folders/" \
   -H "accept: application/json" \
@@ -1036,7 +1036,7 @@ curl -X POST \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```json
 {
   "name": "new_folder_name",
   "description": "string",
@@ -1052,7 +1052,7 @@ To add flows and components at folder creation, retrieve the `components_list` a
 
 Adding a flow to a folder moves the flow from its previous location. The flow is not copied.
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/folders/" \
   -H "accept: application/json" \
@@ -1078,7 +1078,7 @@ To find the UUID of your folder, call the [read folders](#read-folders) endpoint
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/folders/$FOLDER_ID" \
   -H "accept: application/json"
@@ -1087,7 +1087,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```json
 [
     {
         "name": "My Projects",
@@ -1112,7 +1112,7 @@ If you send the same values multiple times, the update is still processed, even 
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X PATCH \
   "$LANGFLOW_URL/api/v1/folders/b408ddb9-6266-4431-9be8-e04a62758331" \
   -H "accept: application/json" \
@@ -1133,7 +1133,7 @@ curl -X PATCH \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```json
 {
   "name": "string",
   "description": "string",
@@ -1152,7 +1152,7 @@ Delete a specific folder.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X DELETE \
   "$LANGFLOW_URL/api/v1/folders/$FOLDER_ID" \
   -H "accept: */*"
@@ -1161,7 +1161,7 @@ curl -X DELETE \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```text
 204 No Content
 ```
 
@@ -1177,7 +1177,7 @@ The `--output` flag is optional.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/folders/download/b408ddb9-6266-4431-9be8-e04a62758331" \
   -H "accept: application/json" \
@@ -1187,7 +1187,7 @@ curl -X GET \
   </TabItem>
     <TabItem value="result" label="Result">
 
-```plain
+```text
 The folder contents.
 ```
 
@@ -1201,7 +1201,7 @@ Upload a folder to Langflow.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X POST \
   "$LANGFLOW_URL/api/v1/folders/upload/" \
   -H "accept: application/json" \
@@ -1213,7 +1213,7 @@ curl -X POST \
 
   <TabItem value="result" label="Result">
 
-```plain
+```text
 The folder contents are uploaded to Langflow.
 ```
 
@@ -1229,7 +1229,7 @@ This endpoint requires log retrieval to be enabled in your Langflow application.
 
 To enable log retrieval, include these values in your `.env` file:
 
-```plain
+```text
 LANGFLOW_ENABLE_LOG_RETRIEVAL=true
 LANGFLOW_LOG_RETRIEVER_BUFFER_SIZE=10000
 LANGFLOW_LOG_LEVEL=DEBUG
@@ -1239,7 +1239,7 @@ For log retrieval to function, `LANGFLOW_LOG_RETRIEVER_BUFFER_SIZE` needs to be 
 
 Start Langflow with this `.env`:
 
-```plain
+```text
 uv run langflow run --env-file .env
 ```
 
@@ -1250,7 +1250,7 @@ Stream logs in real-time using Server-Sent Events (SSE).
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/logs-stream" \
   -H "accept: text/event-stream"
@@ -1259,7 +1259,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```text
 keepalive
 
 {"1736355791151": "2025-01-08T12:03:11.151218-0500 DEBUG Building Chat Input\n"}
@@ -1296,7 +1296,7 @@ With these values, the endpoint returns the last 10 lines of logs.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/logs?lines_before=0&lines_after=0&timestamp=0" \
   -H "accept: application/json"
@@ -1305,7 +1305,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```text
 {
   "1736354770500": "2025-01-08T11:46:10.500363-0500 DEBUG Creating starter project Document Q&A\n",
   "1736354770511": "2025-01-08T11:46:10.511146-0500 DEBUG Creating starter project Image Sentiment Analysis\n",
@@ -1334,7 +1334,7 @@ Retrieve Vertex builds for a specific flow.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/monitor/builds?flow_id=$FLOW_ID" \
   -H "accept: application/json"
@@ -1343,7 +1343,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```json
 {"vertex_builds":{"ChatInput-NCmix":[{"data":{"results":{"message":{"text_key":"text","data":{"timestamp":"2024-12-23 19:10:57","sender":"User","sender_name":"User","session_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a","text":"Hello","files":[],"error":"False","edit":"False","properties":{"text_color":"","background_color":"","edited":"False","source":{"id":"None","display_name":"None","source":"None"},"icon":"","allow_markdown":"False","positive_feedback":"None","state":"complete","targets":[]},"category":"message","content_blocks":[],"id":"c95bed34-f906-4aa6-84e4-68553f6db772","flow_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a"},"default_value":"","text":"Hello","sender":"User","sender_name":"User","files":[],"session_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a","timestamp":"2024-12-23 19:10:57+00:00","flow_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a","error":"False","edit":"False","properties":{"text_color":"","background_color":"","edited":"False","source":{"id":"None","display_name":"None","source":"None"},"icon":"","allow_markdown":"False","positive_feedback":"None","state":"complete","targets":[]},"category":"message","content_blocks":[]}},"outputs":{"message":{"message":{"timestamp":"2024-12-23T19:10:57","sender":"User","sender_name":"User","session_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a","text":"Hello","files":[],"error":false,"edit":false,"properties":{"text_color":"","background_color":"","edited":false,"source":{"id":null,"display_name":null,"source":null},"icon":"","allow_markdown":false,"positive_feedback":null,"state":"complete","targets":[]},"category":"message","content_blocks":[],"id":"c95bed34-f906-4aa6-84e4-68553f6db772","flow_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a"},"type":"object"}},"logs":{"message":[]},"message":{"message":"Hello","sender":"User","sender_name":"User","files":[],"type":"object"},"artifacts":{"message":"Hello","sender":"User","sender_name":"User","files":[],"type":"object"},"timedelta":0.015060124918818474,"duration":"15 ms","used_frozen_result":false},"artifacts":{"message":"Hello","sender":"User","sender_name":"User","files":[],"type":"object"},"params":"- Files: []\n  Message: Hello\n  Sender: User\n  Sender Name: User\n  Type: object\n","valid":true,"build_id":"40aa200e-74db-4651-b698-f80301d2b26b","id":"ChatInput-NCmix","timestamp":"2024-12-23T19:10:58.772766Z","flow_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a"}],"Prompt-BEn9c":[{"data":{"results":{},"outputs":{"prompt":{"message":"Answer the user as if you were a GenAI expert, enthusiastic about helping them get started building something fresh.","type":"text"}},"logs":{"prompt":[]},"message":{"prompt":{"repr":"Answer the user as if you were a GenAI expert, enthusiastic about helping them get started building something fresh.","raw":"Answer the user as if you were a GenAI expert, enthusiastic about helping them get started building something fresh.","type":"text"}},"artifacts":{"prompt":{"repr":"Answer the user as if you were a GenAI expert, enthusiastic about helping them get started building something fresh.","raw":"Answer the user as if you were a GenAI expert, enthusiastic about helping them get started building something fresh.","type":"text"}},"timedelta":0.0057758750626817346,"duration":"6 ms","used_frozen_result":false},"artifacts":{"prompt":{"repr":"Answer the user as if you were a GenAI expert, enthusiastic about helping them get started building something fresh.","raw":"Answer the user as if you were a GenAI expert, enthusiastic about helping them get started building something fresh.","type":"text"}},"params":"None","valid":true,"build_id":"39bbbfde-97fd-42a5-a9ed-d42a5c5d532b","id":"Prompt-BEn9c","timestamp":"2024-12-23T19:10:58.781019Z","flow_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a"}],"OpenAIModel-7AjrN":[{"data":{"results":{},"outputs":{"text_output":{"message":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","type":"text"},"model_output":{"message":"","type":"unknown"}},"logs":{"text_output":[]},"message":{"text_output":{"repr":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","raw":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","type":"text"}},"artifacts":{"text_output":{"repr":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","raw":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","type":"text"}},"timedelta":1.034765167045407,"duration":"1.03 seconds","used_frozen_result":false},"artifacts":{"text_output":{"repr":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","raw":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","type":"text"}},"params":"None","valid":true,"build_id":"4f0ae730-a266-4d35-b89f-7b825c620a0f","id":"OpenAIModel-7AjrN","timestamp":"2024-12-23T19:10:58.790484Z","flow_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a"}],"ChatOutput-sfUhT":[{"data":{"results":{"message":{"text_key":"text","data":{"timestamp":"2024-12-23 19:10:58","sender":"Machine","sender_name":"AI","session_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a","text":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","files":[],"error":"False","edit":"False","properties":{"text_color":"","background_color":"","edited":"False","source":{"id":"OpenAIModel-7AjrN","display_name":"OpenAI","source":"gpt-4o-mini"},"icon":"OpenAI","allow_markdown":"False","positive_feedback":"None","state":"complete","targets":[]},"category":"message","content_blocks":[],"id":"5688356d-9f30-40ca-9907-79a7a2fc16fd","flow_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a"},"default_value":"","text":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","sender":"Machine","sender_name":"AI","files":[],"session_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a","timestamp":"2024-12-23 19:10:58+00:00","flow_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a","error":"False","edit":"False","properties":{"text_color":"","background_color":"","edited":"False","source":{"id":"OpenAIModel-7AjrN","display_name":"OpenAI","source":"gpt-4o-mini"},"icon":"OpenAI","allow_markdown":"False","positive_feedback":"None","state":"complete","targets":[]},"category":"message","content_blocks":[]}},"outputs":{"message":{"message":{"timestamp":"2024-12-23T19:10:58","sender":"Machine","sender_name":"AI","session_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a","text":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","files":[],"error":false,"edit":false,"properties":{"text_color":"","background_color":"","edited":false,"source":{"id":"OpenAIModel-7AjrN","display_name":"OpenAI","source":"gpt-4o-mini"},"icon":"OpenAI","allow_markdown":false,"positive_feedback":null,"state":"complete","targets":[]},"category":"message","content_blocks":[],"id":"5688356d-9f30-40ca-9907-79a7a2fc16fd","flow_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a"},"type":"object"}},"logs":{"message":[]},"message":{"message":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","sender":"Machine","sender_name":"AI","files":[],"type":"object"},"artifacts":{"message":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","sender":"Machine","sender_name":"AI","files":[],"type":"object"},"timedelta":0.017838125000707805,"duration":"18 ms","used_frozen_result":false},"artifacts":{"message":"Hello! 🌟 I'm excited to help you get started on your journey to building something fresh! What do you have in mind? Whether it's a project, an idea, or a concept, let's dive in and make it happen!","sender":"Machine","sender_name":"AI","files":[],"type":"object"},"params":"- Files: []\n  Message: Hello! 🌟 I'm excited to help you get started on your journey to building\n    something fresh! What do you have in mind? Whether it's a project, an idea, or\n    a concept, let's dive in and make it happen!\n  Sender: Machine\n  Sender Name: AI\n  Type: object\n","valid":true,"build_id":"1e8b908b-aba7-403b-9e9b-eca92bb78668","id":"ChatOutput-sfUhT","timestamp":"2024-12-23T19:10:58.813268Z","flow_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a"}]}}
 ```
 
@@ -1357,7 +1357,7 @@ Delete Vertex builds for a specific flow.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X DELETE \
   "$LANGFLOW_URL/api/v1/monitor/builds?flow_id=$FLOW_ID" \
   -H "accept: */*"
@@ -1366,7 +1366,7 @@ curl -X DELETE \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```text
 204 No Content
 ```
 
@@ -1380,7 +1380,7 @@ Retrieve messages with optional filters.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/monitor/messages" \
   -H "accept: application/json"
@@ -1389,7 +1389,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```text
 A list of all messages.
 ```
 
@@ -1404,7 +1404,7 @@ This example retrieves messages sent by `Machine` and `AI` in a given chat sessi
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/monitor/messages?flow_id=$FLOW_ID&session_id=01ce083d-748b-4b8d-97b6-33adbb6a528a&sender=Machine&sender_name=AI&order_by=timestamp" \
   -H "accept: application/json"
@@ -1413,7 +1413,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```json
 [
   {
     "id": "1c1d6134-9b8b-4079-931c-84dcaddf19ba",
@@ -1458,7 +1458,7 @@ This example deletes the message retrieved in the previous Get messages example.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -v -X DELETE \
   "$LANGFLOW_URL/api/v1/monitor/messages" \
   -H "accept: */*" \
@@ -1468,7 +1468,7 @@ curl -v -X DELETE \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```text
 204 No Content
 ```
 
@@ -1484,7 +1484,7 @@ This example updates the `text` value of message `3ab66cc6-c048-48f8-ab07-570f5a
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X PUT \
   "$LANGFLOW_URL/api/v1/monitor/messages/3ab66cc6-c048-48f8-ab07-570f5af7b160" \
   -H "accept: application/json" \
@@ -1497,7 +1497,7 @@ curl -X PUT \
 </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```json
 {"timestamp":"2024-12-23T18:49:06","sender":"string","sender_name":"string","session_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a","text":"testing 1234","files":["string"],"error":true,"edit":true,"properties":{"text_color":"string","background_color":"string","edited":false,"source":{"id":"string","display_name":"string","source":"string"},"icon":"string","allow_markdown":false,"positive_feedback":true,"state":"complete","targets":[]},"category":"message","content_blocks":[],"id":"3ab66cc6-c048-48f8-ab07-570f5af7b160","flow_id":"01ce083d-748b-4b8d-97b6-33adbb6a528a"}
 ```
 
@@ -1514,7 +1514,7 @@ This example updates the `session_ID` value `01ce083d-748b-4b8d-97b6-33adbb6a528
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X PATCH \
   "$LANGFLOW_URL/api/v1/monitor/messages/session/01ce083d-748b-4b8d-97b6-33adbb6a528a?new_session_id=different_session_id" \
   -H "accept: application/json"
@@ -1523,7 +1523,7 @@ curl -X PATCH \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```json
 [
   {
     "id": "8dd7f064-e63a-4773-b472-ca0475249dfd",
@@ -1566,7 +1566,7 @@ Delete all messages for a specific session.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X DELETE \
   "$LANGFLOW_URL/api/v1/monitor/messages/session/different_session_id_2" \
   -H "accept: */*"
@@ -1575,7 +1575,7 @@ curl -X DELETE \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```text
 HTTP/1.1 204 No Content
 ```
 
@@ -1589,7 +1589,7 @@ Retrieve all transactions (interactions between components) for a specific flow.
 <Tabs>
   <TabItem value="curl" label="curl" default>
 
-```curl
+```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/monitor/transactions?flow_id=$FLOW_ID&page=1&size=50" \
   -H "accept: application/json"
@@ -1598,7 +1598,7 @@ curl -X GET \
   </TabItem>
   <TabItem value="result" label="Result">
 
-```plain
+```json
 {
   "items": [
     {

--- a/docs/docs/Deployment/deployment-docker.md
+++ b/docs/docs/Deployment/deployment-docker.md
@@ -121,5 +121,5 @@ docker build -t myuser/langflow-hello-world:1.0.0 .
 docker push myuser/langflow-hello-world:1.0.0
 ```
 
-To deploy the image with Helm, see [Langflow runtime deployment](/deployment-kubernetes#langflow-runtime-deployment).
+To deploy the image with Helm, see [Langflow runtime deployment](/deployment-kubernetes#deploy-the-langflow-runtime).
 

--- a/docs/docs/Deployment/deployment-kubernetes.md
+++ b/docs/docs/Deployment/deployment-kubernetes.md
@@ -10,8 +10,8 @@ This guide demonstrates deploying Langflow on a Kubernetes cluster.
 
 Two charts are available at the [Langflow Helm Charts repository](https://github.com/langflow-ai/langflow-helm-charts):
 
-- Deploy the [Langflow IDE](deployment-kubernetes#langflow-ide-deployment) for the complete Langflow development environment.
-- Deploy the [Langflow runtime](/deployment-kubernetes#langflow-runtime-deployment) to deploy a standalone Langflow application in a more secure and stable environment.
+- Deploy the [Langflow IDE](#deploy-the-langflow-ide) for the complete Langflow development environment.
+- Deploy the [Langflow runtime](#deploy-the-langflow-runtime) to deploy a standalone Langflow application in a more secure and stable environment.
 
 ## Deploy the Langflow IDE
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "langflow-docs",
   "version": "0.0.0",
+  "license": "MIT",
   "private": false,
   "scripts": {
     "clear-docs": "rimraf ./docs/",

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -1,0 +1,17 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx,md,mdx}",
+    "./docs/**/*.{js,jsx,ts,tsx,md,mdx}",
+    "./blog/**/*.{js,jsx,ts,tsx,md,mdx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+  // Docusaurus specific configuration
+  corePlugins: {
+    preflight: false, // This is important to prevent Tailwind from conflicting with Docusaurus styles
+  },
+  darkMode: ['class', '[data-theme="dark"]'], // This helps with Docusaurus dark mode
+}


### PR DESCRIPTION
Remove docs-related build errors:
* Replace unsupported code block syntaxes
* Add a tailwind-config.js file 
* Add MIT to the license field of package.json 
* Fix linking errors

Result:
```
yarn build
yarn run v1.22.18
$ docusaurus build
[INFO] [en] Creating an optimized production build...

✔ Client
  Compiled successfully in 4.08s

✔ Server
  


● Client █████████████████████████ cache (99%) shutdown IdleFileCachePlugin
 stored

✔ Server
  

[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
✨  Done in 9.96s.
➜  docs git:(docs-fix-syntax-errors) ✗ yarn serve
yarn run v1.22.18
$ docusaurus serve
[SUCCESS] Serving "build" directory at: http://localhost:3000/
^C
➜  docs git:(docs-fix-syntax-errors) ✗ yarn start
yarn run v1.22.18
$ docusaurus start
[INFO] Starting the development server...
[SUCCESS] Docusaurus website is running at: http://localhost:3000/

✔ Client
  Compiled successfully in 5.29s

client (webpack 5.98.0) compiled successfully
```