### PR TITLE
chore: Bump frontend package version and enhance test reliability

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "langflow",
-      "version": "0.1.2",
+      "version": "1.2.0",
       "dependencies": {
         "@chakra-ui/number-input": "^2.1.2",
         "@headlessui/react": "^2.0.4",

--- a/src/frontend/tests/extended/regression/generalBugs-shard-6.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-6.spec.ts
@@ -61,8 +61,20 @@ class CustomComponent(Component):
 
     await page.getByText("Check & Save").last().click();
 
-    //wait for the animation to propagate
-    await page.waitForTimeout(1000);
+    // Wait for the error message to appear and have sufficient length
+    await page.waitForFunction(
+      () => {
+        const errorElement = document.querySelector(
+          '[data-testid="title_error_code_modal"]',
+        );
+        return (
+          errorElement &&
+          errorElement.textContent &&
+          errorElement.textContent.length > 20
+        );
+      },
+      { timeout: 10000 }, // 5 second timeout
+    );
 
     const error = await page
       .getByTestId("title_error_code_modal")


### PR DESCRIPTION
Update the frontend package version to 1.2.0 and improve the error message wait condition in the test to dynamically check for a minimum length, enhancing test robustness.