### PR TITLE
fix: pass props to SvgAnthropicBox component

### DIFF
--- a/src/frontend/src/icons/Anthropic/Anthropic.jsx
+++ b/src/frontend/src/icons/Anthropic/Anthropic.jsx
@@ -6,6 +6,7 @@ const SvgAnthropicBox = (props) => {
       viewBox="0 0 280 196"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <path d="M201.88 0H159.04L237.16 196H280L201.88 0Z" fill="#FAFAF8" />
       <path

--- a/src/frontend/src/icons/Anthropic/Anthropic.jsx
+++ b/src/frontend/src/icons/Anthropic/Anthropic.jsx
@@ -21,6 +21,7 @@ const SvgAnthropicBox = (props) => {
       viewBox="0 0 280 196"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <path d="M201.88 0H159.04L237.16 196H280L201.88 0Z" fill="#1F1F1E" />
       <path


### PR DESCRIPTION
Anthropic icon was inconsistent, made it consistent by passing the necessary props.

previously:
<img width="283" alt="Screenshot 2025-03-12 at 8 41 03 PM" src="https://github.com/user-attachments/assets/6b2b3215-eb48-4464-8428-4f0fbbdc742e" />

after fix:
<img width="295" alt="Screenshot 2025-03-12 at 8 41 23 PM" src="https://github.com/user-attachments/assets/6e5d24c6-58ba-4df2-95e3-948cafc20b9e" />
