### PR TITLE
feat: Add configurable polling interval for syncing flows from FS

### DIFF
--- a/src/backend/base/langflow/alembic/env.py
+++ b/src/backend/base/langflow/alembic/env.py
@@ -49,7 +49,7 @@ def run_migrations_offline() -> None:
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
         render_as_batch=True,
-        prepare_threshold=None
+        prepare_threshold=None,
     )
 
     with context.begin_transaction():
@@ -73,10 +73,7 @@ def _sqlite_do_begin(conn):
 
 def _do_run_migrations(connection):
     context.configure(
-        connection=connection,
-        target_metadata=target_metadata,
-        render_as_batch=True,
-        prepare_threshold=None
+        connection=connection, target_metadata=target_metadata, render_as_batch=True, prepare_threshold=None
     )
 
     with context.begin_transaction():

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -982,6 +982,7 @@ async def get_or_create_default_folder(session: AsyncSession, user_id: UUID) -> 
 
 async def sync_flows_from_fs():
     flow_mtimes = {}
+    fs_flows_polling_interval = get_settings_service().settings.fs_flows_polling_interval / 1000
     while True:
         try:
             async with session_scope() as session:
@@ -1010,4 +1011,4 @@ async def sync_flows_from_fs():
                         logger.exception(f"Error while handling flow file {path}")
         except Exception:  # noqa: BLE001
             logger.exception("Error while syncing flows from database")
-        await asyncio.sleep(10)
+        await asyncio.sleep(fs_flows_polling_interval)

--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -217,6 +217,8 @@ class Settings(BaseSettings):
     """The maximum number of builds to keep per vertex. Older builds will be deleted."""
     webhook_polling_interval: int = 5000
     """The polling interval for the webhook in ms."""
+    fs_flows_polling_interval: int = 10000
+    """The polling interval for synchronizing flows from the file system."""
 
     # MCP Server
     mcp_server_enabled: bool = True

--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -218,7 +218,7 @@ class Settings(BaseSettings):
     webhook_polling_interval: int = 5000
     """The polling interval for the webhook in ms."""
     fs_flows_polling_interval: int = 10000
-    """The polling interval for synchronizing flows from the file system."""
+    """The polling interval in milliseconds for synchronizing flows from the file system."""
 
     # MCP Server
     mcp_server_enabled: bool = True

--- a/src/backend/tests/unit/api/v1/test_flows.py
+++ b/src/backend/tests/unit/api/v1/test_flows.py
@@ -8,7 +8,7 @@ from langflow.services.database.models import Flow
 
 
 async def test_create_flow(client: AsyncClient, logged_in_headers):
-    flow_file = Path(tempfile.tempdir) / f"{uuid.uuid4()!s}.json"
+    flow_file = Path(tempfile.tempdir) / f"{uuid.uuid4()}.json"
     try:
         basic_case = {
             "name": "string",


### PR DESCRIPTION
This PR introduces a configurable polling interval for syncing flows from the file system by leveraging an environment variable and corresponding settings.

* Added a new environment variable fixture and test in test_initial_setup.py to verify polling updates.
* Modified the sync_flows_from_fs function in setup.py to use a configurable interval derived from settings.
* Updated settings and minor formatting improvements in test_flows.py and alembic/env.py.