### PR TITLE
test: add pokedex agent and social media agent integration tests

### DIFF
--- a/src/frontend/tests/core/integrations/Pokedex Agent.spec.ts
+++ b/src/frontend/tests/core/integrations/Pokedex Agent.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+import * as dotenv from "dotenv";
+import path from "path";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { initialGPTsetup } from "../../utils/initialGPTsetup";
+import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
+
+withEventDeliveryModes(
+  "Pokedex Agent",
+  { tag: ["@release", "@starter-projects"] },
+  async ({ page }) => {
+    test.skip(
+      !process?.env?.OPENAI_API_KEY,
+      "OPENAI_API_KEY required to run this test",
+    );
+
+    if (!process.env.CI) {
+      dotenv.config({ path: path.resolve(__dirname, "../../.env") });
+    }
+
+    await awaitBootstrapTest(page);
+
+    await page.getByTestId("side_nav_options_all-templates").click();
+    await page.getByRole("heading", { name: "Pokédex Agent" }).click();
+
+    await initialGPTsetup(page);
+
+    await page.getByTestId("playground-btn-flow-io").click();
+
+    await page
+      .getByTestId("input-chat-playground")
+      .last()
+      .fill("Can I catch a Charizard in Pokemon Yellow?");
+
+    await page.getByTestId("button-send").last().click();
+
+    const stopButton = page.getByRole("button", { name: "Stop" });
+    await stopButton.waitFor({ state: "visible", timeout: 30000 });
+
+    if (await stopButton.isVisible()) {
+      await expect(stopButton).toBeHidden({ timeout: 120000 });
+    }
+
+    const output = await page
+      .getByTestId("div-chat-message")
+      .last()
+      .innerText();
+    expect(output).toContain("Charmander");
+    expect(output).toContain("Route 24");
+    expect(output.length).toBeGreaterThan(100);
+  },
+);

--- a/src/frontend/tests/core/integrations/Social Media Agent.spec.ts
+++ b/src/frontend/tests/core/integrations/Social Media Agent.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+import * as dotenv from "dotenv";
+import path from "path";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { initialGPTsetup } from "../../utils/initialGPTsetup";
+import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
+
+withEventDeliveryModes(
+  "Social Media Agent",
+  { tag: ["@release", "@starter-projects"] },
+  async ({ page }) => {
+    test.skip(
+      !process?.env?.APIFY_API_TOKEN,
+      "APIFY_API_TOKEN required to run this test",
+    );
+
+    if (!process.env.CI) {
+      dotenv.config({ path: path.resolve(__dirname, "../../.env") });
+    }
+
+    await awaitBootstrapTest(page);
+
+    await page.getByTestId("side_nav_options_all-templates").click();
+    await page.getByRole("heading", { name: "Social Media Agent" }).click();
+
+    await initialGPTsetup(page);
+
+    const apifyApiTokenInputCount = await page
+      .getByTestId("popover-anchor-input-apify_token")
+      .count();
+
+    for (let i = 0; i < apifyApiTokenInputCount; i++) {
+      await page
+        .getByTestId("popover-anchor-input-apify_token")
+        .nth(i)
+        .fill(process.env.APIFY_API_TOKEN ?? "");
+    }
+
+    await page
+      .getByTestId("popover-anchor-input-apify_token")
+      .nth(apifyApiTokenInputCount - 1)
+      .fill(process.env.APIFY_API_TOKEN ?? "");
+
+    await page.getByTestId("playground-btn-flow-io").click();
+
+    await page
+      .getByTestId("input-chat-playground")
+      .last()
+      .fill(
+        "Find the TikTok profile of the company OpenAI using Google search, then show me the profile bio and their latest video.",
+      );
+
+    await page.getByTestId("button-send").last().click();
+
+    const stopButton = page.getByRole("button", { name: "Stop" });
+    await stopButton.waitFor({ state: "visible", timeout: 30000 });
+
+    if (await stopButton.isVisible()) {
+      await expect(stopButton).toBeHidden({ timeout: 120000 });
+    }
+
+    const output = await page
+      .getByTestId("div-chat-message")
+      .last()
+      .innerText();
+    expect(output).toContain("TikTok");
+    expect(output.length).toBeGreaterThan(300);
+  },
+);


### PR DESCRIPTION
This pull request introduces new integration tests for the Pokedex Agent and Social Media Agent. These tests ensure that the respective agents function correctly by simulating user interactions and verifying the outputs.

New integration tests:

* [`src/frontend/tests/core/integrations/Pokedex Agent.spec.ts`](diffhunk://#diff-91c904e5906cc34cdd85c6ad5ef96b80428732380e3adf5fd05c73cb3cb9067eR1-R52): Added a test to verify the functionality of the Pokedex Agent, including setting up the environment, simulating user interactions, and checking the output for specific content.
* [`src/frontend/tests/core/integrations/Social Media Agent.spec.ts`](diffhunk://#diff-df04d8e025e2cadfbc68695ca3c1cd59bdc3c6c2e4876aff080b150ada752abfR1-R69): Added a test to verify the functionality of the Social Media Agent, including setting up the environment, simulating user interactions, and checking the output for specific content.