### PR TITLE
tests: update selector to match new data-testid format in chat integration test (nightly fix)

### DIFF
--- a/src/frontend/tests/extended/integrations/chatInputOutputUser-shard-1.spec.ts
+++ b/src/frontend/tests/extended/integrations/chatInputOutputUser-shard-1.spec.ts
@@ -172,7 +172,7 @@ test(
     await page.waitForTimeout(600);
     await page.keyboard.press("o");
     await page.waitForSelector(
-      `[data-testid="${urlNodeId}-data-output-modal"]`,
+      `[data-testid="${urlNodeId}-dataframe-output-modal"]`,
       {
         timeout: 3000,
       },


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/tests/extended/integrations/chatInputOutputUser-shard-1.spec.ts` file. The change involves updating the test selector to match the new data-testid format.

* [`src/frontend/tests/extended/integrations/chatInputOutputUser-shard-1.spec.ts`](diffhunk://#diff-cb9b53bf3d01d702cb8d3bb07babf818a6a2aff482fdaf8fc7ad2bafeada850bL175-R175): Changed the test selector from `[data-testid="${urlNodeId}-data-output-modal"]` to `[data-testid="${urlNodeId}-dataframe-output-modal"]`.