### PR TITLE
fix: reposition and disable shareable playground toggle on empty flow

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -706,7 +706,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/frontend/src/components/core/dropdownComponent/index.tsx
+++ b/src/frontend/src/components/core/dropdownComponent/index.tsx
@@ -203,7 +203,9 @@ export default function Dropdown({
                 className="h-4 w-4"
               />
             )}
-            {value && filteredOptions.includes(value) ? value : placeholderName}{" "}
+            {value && filteredOptions.includes(value)
+              ? value
+              : placeholderName}{" "}
           </span>
           <ForwardedIconComponent
             name="ChevronsUpDown"

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
@@ -16,6 +16,7 @@ import useAlertStore from "@/stores/alertStore";
 import useAuthStore from "@/stores/authStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import useFlowStore from "@/stores/flowStore";
+import { cn } from "@/utils/utils";
 import { useState } from "react";
 
 export default function PublishDropdown() {
@@ -138,9 +139,10 @@ export default function PublishDropdown() {
             }
           >
             <div
-              className={
-                !hasIO ? "cursor-not-allowed" : "" + "flex items-center"
-              }
+              className={cn(
+                !hasIO ? "cursor-not-allowed" : "",
+                "flex items-center",
+              )}
             >
               <DropdownMenuItem
                 data-testid="shareable-playground"
@@ -167,6 +169,7 @@ export default function PublishDropdown() {
                   data-testid="publish-switch"
                   className="scale-[85%]"
                   checked={isPublished}
+                  disabled={!hasIO}
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();


### PR DESCRIPTION
This pull request includes several changes to the `src/frontend` directory, focusing on improving the `deploy-dropdown.tsx` component and updating the `package-lock.json` file. The most important changes include the addition of a utility function for class names, refactoring the class name assignment, and updating the `package-lock.json` file.

Improvements to `deploy-dropdown.tsx` component:

* Added the `cn` utility function from `@/utils/utils` to manage class names more efficiently.
* Refactored the class name assignment for the dropdown item to use the `cn` function, improving readability and maintainability.
* Disabled the publish switch when `hasIO` is false, ensuring better control over the component's behavior.

Updates to `package-lock.json` file:

* Removed the `extraneous` field from the `@clack/prompts/node_modules/is-unicode-supported` package entry, aligning with the latest dependency management practices.