### PR TITLE
docs: add prerelease flag to nvidia ingest instructions

### DIFF
--- a/docs/docs/Integrations/Nvidia/integrations-nvidia-ingest.md
+++ b/docs/docs/Integrations/Nvidia/integrations-nvidia-ingest.md
@@ -25,7 +25,7 @@ The **NVIDIA Ingest** component imports the NVIDIA `Ingestor` client, ingests fi
   * If you are installing Langflow from the Python Package Index:
   ```bash
   source **YOUR_LANGFLOW_VENV**/bin/activate
-  uv pip install 'langflow[nv-ingest]'
+  uv pip install --prerelease=allow 'langflow[nv-ingest]'
   uv run langflow run
   ```
 


### PR DESCRIPTION
I'm not sure why this was now required, but if not added on my version of uv, uv will automatically downgrade langflow and other packages. 

```
uv --version             
uv 0.4.16 (e81ed8ec5 2024-09-24)
```