### PR TITLE
chore: mark zep componente as deprecated

### DIFF
--- a/src/backend/base/langflow/components/memories/zep.py
+++ b/src/backend/base/langflow/components/memories/zep.py
@@ -8,6 +8,7 @@ class ZepChatMemory(LCChatMemoryComponent):
     description = "Retrieves and store chat messages from Zep."
     name = "ZepChatMemory"
     icon = "ZepMemory"
+    legacy = True
 
     inputs = [
         MessageTextInput(name="url", display_name="Zep URL", info="URL of the Zep instance."),


### PR DESCRIPTION
For the reasons mentioned in issues #4266 and #5993, this PR deprecates the component