### PR TITLE
fix: Return empty list when not ingesting data

### DIFF
--- a/src/backend/base/langflow/base/vectorstores/model.py
+++ b/src/backend/base/langflow/base/vectorstores/model.py
@@ -105,7 +105,7 @@ class LCVectorStoreComponent(Component):
         """Prepares ingest_data by converting DataFrame to Data if needed."""
         ingest_data: list | Data | DataFrame = self.ingest_data
         if not ingest_data:
-            return [ingest_data]
+            return []
 
         if not isinstance(ingest_data, list):
             ingest_data = [ingest_data]


### PR DESCRIPTION
This pull request updates the new `_prepare_ingest_data` function to return an empty list, rather than a list of a null like attribute, when no ingestion connection is made to vector store components.