### PR TITLE
fix: remove redundant description from Prompt modal

### DIFF
--- a/src/frontend/src/modals/promptModal/index.tsx
+++ b/src/frontend/src/modals/promptModal/index.tsx
@@ -16,7 +16,6 @@ import {
   EDIT_TEXT_PLACEHOLDER,
   INVALID_CHARACTERS,
   MAX_WORDS_HIGHLIGHT,
-  PROMPT_DIALOG_SUBTITLE,
   regexHighlight,
 } from "../../constants/constants";
 import useAlertStore from "../../stores/alertStore";
@@ -217,17 +216,17 @@ export default function PromptModal({
       <BaseModal.Trigger disable={disabled} asChild>
         {children}
       </BaseModal.Trigger>
-      <BaseModal.Header description={PROMPT_DIALOG_SUBTITLE}>
+      <BaseModal.Header>
         <div className="flex w-full items-start gap-3">
           <div className="flex">
-            <span className="pr-2" data-testid="modal-title">
-              Edit Prompt
-            </span>
             <IconComponent
               name="TerminalSquare"
-              className="h-6 w-6 pl-1 text-primary"
+              className="h-6 w-6 pr-1 text-primary"
               aria-hidden="true"
             />
+            <span className="pl-2" data-testid="modal-title">
+              Edit Prompt
+            </span>
           </div>
         </div>
       </BaseModal.Header>


### PR DESCRIPTION
This pull request includes changes to the `PromptModal` component in the `src/frontend/src/modals/promptModal/index.tsx` file. The changes involve the removal of an unused constant and adjustments to the modal header layout.

Key changes include:

* Removed the `PROMPT_DIALOG_SUBTITLE` constant from the import statement as it is no longer used in the component.
* Modified the `BaseModal.Header` to remove the `description` prop and adjusted the placement of the `Edit Prompt` text and `IconComponent` for better alignment.