### PR TITLE
fix: remove search and adjust color and height of json viewer

### DIFF
--- a/src/frontend/src/components/core/jsonEditor/index.tsx
+++ b/src/frontend/src/components/core/jsonEditor/index.tsx
@@ -1,6 +1,4 @@
 import { jsonquery } from "@jsonquerylang/jsonquery";
-import { edit } from "ace-builds";
-import { Check } from "lucide-react";
 import { KeyboardEvent, useEffect, useRef, useState } from "react";
 import {
   Content,
@@ -9,8 +7,6 @@ import {
 } from "vanilla-jsoneditor";
 import useAlertStore from "../../../stores/alertStore";
 import { cn } from "../../../utils/utils";
-import { Button } from "../../ui/button";
-import { Input } from "../../ui/input";
 
 interface JsonEditorProps {
   data?: Content;
@@ -371,7 +367,7 @@ const JsonEditor = ({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {allowFilter && (
+      {/* {allowFilter && (
         <div className="mb-2 flex shrink-0 gap-2">
           <Input
             placeholder="Enter path (e.g. users[0].name) or JSONQuery (e.g. .users | filter(.age > 25))"
@@ -406,9 +402,9 @@ const JsonEditor = ({
             Clear
           </Button>
         </div>
-      )}
-      <div className="relative min-h-0 flex-1">
-        <div ref={containerRef} className={cn("absolute inset-0", className)} />
+      )} */}
+      <div className="relative h-full min-h-0 flex-1">
+        <div ref={containerRef} className={cn("!h-full w-full", className)} />
       </div>
     </div>
   );

--- a/src/frontend/src/style/index.css
+++ b/src/frontend/src/style/index.css
@@ -44,7 +44,7 @@
     --tooltip: 0 0% 0%; /* hsl(0, 0%, 0%) */
     --tooltip-foreground: 0 0% 100%; /* hsl(0, 0%, 100%) */
 
-    --jse-theme-color: hsl(0, 0%, 100%);
+    --jse-theme-color: hsl(240, 5%, 96%);
     --jse-theme-color-highlight: hsl(240, 6%, 90%);
     --jse-menu-color: hsl(0, 0%, 0%);
     --jse-main-border: hsl(240, 6%, 90%);


### PR DESCRIPTION
This pull request includes several changes to the `jsonEditor` component and the overall styling of the application. The most important changes involve the removal of unused imports, commenting out a filter section in the `jsonEditor` component, and updating the theme color in the CSS file.

Changes to `jsonEditor` component:

* [`src/frontend/src/components/core/jsonEditor/index.tsx`](diffhunk://#diff-4b6b60993db97e3919d4d6f05e83dd8910f24be729ef65ac2d6cad75173b0b88L2-L3): Removed unused imports (`edit`, `Check`, `Button`, `Input`) to clean up the code. [[1]](diffhunk://#diff-4b6b60993db97e3919d4d6f05e83dd8910f24be729ef65ac2d6cad75173b0b88L2-L3) [[2]](diffhunk://#diff-4b6b60993db97e3919d4d6f05e83dd8910f24be729ef65ac2d6cad75173b0b88L12-L13)
* [`src/frontend/src/components/core/jsonEditor/index.tsx`](diffhunk://#diff-4b6b60993db97e3919d4d6f05e83dd8910f24be729ef65ac2d6cad75173b0b88L374-R370): Commented out the filter input section to temporarily disable it. [[1]](diffhunk://#diff-4b6b60993db97e3919d4d6f05e83dd8910f24be729ef65ac2d6cad75173b0b88L374-R370) [[2]](diffhunk://#diff-4b6b60993db97e3919d4d6f05e83dd8910f24be729ef65ac2d6cad75173b0b88L409-R407)

Styling updates:

* [`src/frontend/src/style/index.css`](diffhunk://#diff-90e2b07b21bd53ac0fe04b56353e8b37e8ba1f3034f51e66306a1ff010ab4437L47-R47): Updated the `--jse-theme-color` to a lighter shade for better visual appearance.