### PR TITLE
feat: add legacy tag deprecated components

### DIFF
--- a/src/backend/base/langflow/components/processing/alter_metadata.py
+++ b/src/backend/base/langflow/components/processing/alter_metadata.py
@@ -9,6 +9,7 @@ class AlterMetadataComponent(Component):
     description = "Adds/Removes Metadata Dictionary on inputs"
     icon = "merge"
     name = "AlterMetadata"
+    legacy = True
 
     inputs = [
         HandleInput(

--- a/src/backend/base/langflow/components/processing/json_cleaner.py
+++ b/src/backend/base/langflow/components/processing/json_cleaner.py
@@ -14,7 +14,7 @@ class JSONCleaner(Component):
         "Cleans the messy and sometimes incorrect JSON strings produced by LLMs "
         "so that they are fully compliant with the JSON spec."
     )
-
+    legacy = True
     inputs = [
         MessageTextInput(
             name="json_str", display_name="JSON String", info="The JSON string to be cleaned.", required=True


### PR DESCRIPTION
This pull request includes updates to mark certain components as legacy in the `src/backend/base/langflow/components/processing` directory. 

The most important changes include:

* [`src/backend/base/langflow/components/processing/alter_metadata.py`](diffhunk://#diff-c4adf408d41d297e10550a57aa383137d04671df61d3364ce969b1db1370d885R12): Added the `legacy` attribute set to `True` in the `AlterMetadataComponent` class.
* [`src/backend/base/langflow/components/processing/json_cleaner.py`](diffhunk://#diff-fb7a201f70c86b2045ceccae73171258e8ddc4850e327166246ffd4f15ebdb9cL17-R17): Added the `legacy` attribute set to `True` in the `JSONCleaner` class.