### PR TITLE
fix: change access_type to fit new ENUM

### DIFF
--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
@@ -30,7 +30,7 @@ export default function PublishDropdown() {
   const flows = useFlowsManagerStore((state) => state.flows);
   const setFlows = useFlowsManagerStore((state) => state.setFlows);
   const setCurrentFlow = useFlowStore((state) => state.setCurrentFlow);
-  const isPublished = currentFlow?.access_type === "public";
+  const isPublished = currentFlow?.access_type === "PUBLIC";
   const hasIO = useFlowStore((state) => state.hasIO);
   const isAuth = useAuthStore((state) => !!state.autoLogin);
   const [openApiModal, setOpenApiModal] = useState(false);
@@ -39,7 +39,7 @@ export default function PublishDropdown() {
     mutateAsync(
       {
         id: flowId ?? "",
-        access_type: checked ? "private" : "public",
+        access_type: checked ? "PRIVATE" : "PUBLIC",
       },
       {
         onSuccess: (updatedFlow) => {
@@ -179,19 +179,6 @@ export default function PublishDropdown() {
               </div>
             </div>
           </ShadTooltipComponent>
-          {/* <DropdownMenuItem className="deploy-dropdown-item group">
-            <div className="group-hover:bg-accent">
-              <IconComponent
-                name="FileCode2"
-                className={`${groupStyle} icon-size mr-2`}
-              />
-              <span>Langflow SDK</span>
-              <IconComponent
-                name="ExternalLink"
-                className={`icon-size ml-auto mr-3 ${externalUrlStyle} text-foreground`}
-              />
-            </div>
-          </DropdownMenuItem> */}
         </DropdownMenuContent>
       </DropdownMenu>
       <ApiModal open={openApiModal} setOpen={setOpenApiModal}>

--- a/src/frontend/src/controllers/API/queries/flows/use-patch-update-flow.ts
+++ b/src/frontend/src/controllers/API/queries/flows/use-patch-update-flow.ts
@@ -13,7 +13,7 @@ interface IPatchUpdateFlow {
   folder_id?: string | null | undefined;
   endpoint_name?: string | null | undefined;
   locked?: boolean | null | undefined;
-  access_type?: "public" | "private" | "protected";
+  access_type?: "PUBLIC" | "PRIVATE" | "PROTECTED";
 }
 
 export const usePatchUpdateFlow: useMutationFunctionType<

--- a/src/frontend/src/pages/Playground/index.tsx
+++ b/src/frontend/src/pages/Playground/index.tsx
@@ -66,7 +66,7 @@ export default function PlaygroundPage() {
       );
       if (
         (inputs.length === 0 && outputs.length === 0) ||
-        currentSavedFlow?.access_type !== "public"
+        currentSavedFlow?.access_type !== "PUBLIC"
       ) {
         // redirect to the home page
         navigate("/");

--- a/src/frontend/src/types/flow/index.ts
+++ b/src/frontend/src/types/flow/index.ts
@@ -32,7 +32,7 @@ export type FlowType = {
   webhook?: boolean;
   locked?: boolean | null;
   public?: boolean;
-  access_type?: "public" | "private" | "protected";
+  access_type?: "PUBLIC" | "PRIVATE" | "PROTECTED";
 };
 
 export type GenericNodeType = Node<NodeDataType, "genericNode">;

--- a/src/frontend/tests/core/features/publish-flow.spec.ts
+++ b/src/frontend/tests/core/features/publish-flow.spec.ts
@@ -11,12 +11,11 @@ test(
     await page.waitForSelector('[data-testid="blank-flow"]', {
       timeout: 3000,
     });
-    await page.getByTestId("blank-flow").click();
-
     const flowId = page.url().split("/").pop();
     expect(flowId).toBeDefined();
     expect(flowId).not.toBeNull();
     expect(flowId!.length).toBeGreaterThan(0);
+    await page.getByTestId("blank-flow").click();
     await page.waitForSelector('[data-testid="sidebar-search-input"]', {
       timeout: 3000,
     });

--- a/src/frontend/tests/core/features/publish-flow.spec.ts
+++ b/src/frontend/tests/core/features/publish-flow.spec.ts
@@ -11,11 +11,12 @@ test(
     await page.waitForSelector('[data-testid="blank-flow"]', {
       timeout: 3000,
     });
+    await page.getByTestId("blank-flow").click();
+
     const flowId = page.url().split("/").pop();
     expect(flowId).toBeDefined();
     expect(flowId).not.toBeNull();
     expect(flowId!.length).toBeGreaterThan(0);
-    await page.getByTestId("blank-flow").click();
     await page.waitForSelector('[data-testid="sidebar-search-input"]', {
       timeout: 3000,
     });

--- a/src/frontend/tests/core/features/publish-flow.spec.ts
+++ b/src/frontend/tests/core/features/publish-flow.spec.ts
@@ -60,8 +60,11 @@ test(
     await newPage.close();
     await page.bringToFront();
     // check if deactivate the publishworks
+    await page.waitForTimeout(500);
     await page.getByTestId("publish-button").click();
+    await page.waitForTimeout(500);
     await page.getByTestId("publish-switch").click();
+    await page.waitForTimeout(500);
     await expect(page.getByTestId("rf__wrapper")).toBeVisible();
     await expect(page.getByTestId("publish-switch")).toBeChecked({
       checked: false,

--- a/src/frontend/tests/core/unit/floatComponent.spec.ts
+++ b/src/frontend/tests/core/unit/floatComponent.spec.ts
@@ -33,6 +33,8 @@ test(
 
     await page.getByText("Close").last().click();
 
+    await page.getByTestId("fit_view").click();
+
     await page.locator('//*[@id="int_int_seed"]').click();
     await page.locator('//*[@id="int_int_seed"]').fill("");
     await page.locator('//*[@id="int_int_seed"]').fill("3");


### PR DESCRIPTION
This pull request includes several changes to standardize the `access_type` field values and remove commented-out code. The changes ensure consistency in the `access_type` field values across the codebase by using uppercase strings. Additionally, an unnecessary commented-out section in the `deploy-dropdown.tsx` file has been removed.

Standardization of `access_type` field values:

* [`src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx`](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489L33-R33): Updated `access_type` field values to use uppercase strings. [[1]](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489L33-R33) [[2]](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489L42-R42) [[3]](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489L182-L194)
* [`src/frontend/src/controllers/API/queries/flows/use-patch-update-flow.ts`](diffhunk://#diff-4db6da1e4a55fca23f49479288ddea59624745ffd2bdbc7b50d8dbe040281de4L16-R16): Modified `access_type` field values to use uppercase strings in the `IPatchUpdateFlow` interface.
* [`src/frontend/src/pages/Playground/index.tsx`](diffhunk://#diff-bd24bb9b69edf42441c5214fe478f8623638fae6f233c35d57710fe0709155daL69-R69): Updated `access_type` field value check to use uppercase strings.
* [`src/frontend/src/types/flow/index.ts`](diffhunk://#diff-11a4bb5ffa692f3179510a801baca460e214f368eb6fe5ee9fd2ebf39535ceb0L35-R35): Changed `access_type` field values to use uppercase strings in the `FlowType` type.

Removal of commented-out code:

* [`src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx`](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489L182-L194): Removed an unnecessary commented-out section related to `Langflow SDK`.