### PR TITLE
feat: Slack Conversation History Component

### DIFF
--- a/src/backend/base/langflow/components/slack/__init__.py
+++ b/src/backend/base/langflow/components/slack/__init__.py
@@ -1,0 +1,5 @@
+from .conversation_history import SlackConversationsHistoryComponent
+
+__all__ = [
+    "SlackConversationsHistoryComponent",
+]

--- a/src/backend/base/langflow/components/slack/conversation_history.py
+++ b/src/backend/base/langflow/components/slack/conversation_history.py
@@ -1,0 +1,128 @@
+import requests
+
+from langflow.custom import Component
+from langflow.io import BoolInput, IntInput, MessageTextInput, Output, SecretStrInput
+from langflow.schema import Data, DataFrame
+
+
+class SlackConversationsHistoryComponent(Component):
+    display_name = "Fetch Slack Messages"
+    description = "Fetches a conversation's history of messages and events."
+    icon = "SlackDirectoryLoader"
+    name = "SlackConversationsHistoryComponent"
+
+    inputs = [
+        MessageTextInput(
+            name="channel",
+            display_name="Channel",
+            info="Conversation ID to fetch history for.",
+            required=True,
+        ),
+        SecretStrInput(
+            name="token",
+            display_name="Token",
+            info="Authentication token bearing required scopes.",
+            required=True,
+        ),
+        MessageTextInput(
+            name="cursor",
+            display_name="Cursor",
+            info="Paginate through collections of data by setting the cursor parameter to a next_cursor attribute returned by a previous request's response_metadata.",
+            advanced=True,
+            value="",
+        ),
+        BoolInput(
+            name="include_all_metadata",
+            display_name="Include all metadata",
+            info="Return all metadata associated with this message.",
+            advanced=True,
+            value=False,
+        ),
+        BoolInput(
+            name="inclusive",
+            display_name="Inclusive",
+            info="Include messages with oldest or latest timestamps in results. Ignored unless either timestamp is specified.",
+            advanced=True,
+            value=False,
+        ),
+        MessageTextInput(
+            name="latest",
+            display_name="Latest Timestamp",
+            info="Only messages before this Unix timestamp will be included in results.",
+            advanced=True,
+            value="",
+        ),
+        MessageTextInput(
+            name="oldest",
+            display_name="Oldest Timestamp",
+            info="Only messages after this Unix timestamp will be included in results.",
+            advanced=True,
+            value="",
+        ),
+        IntInput(
+            name="limit",
+            display_name="Limit",
+            info="The maximum number of items to return. Maximum of 999.",
+            advanced=True,
+            value=100,
+        ),
+    ]
+
+    outputs = [
+        Output(
+            display_name="Slack Response",
+            name="response",
+            method="build_slack_response",
+        ),
+        Output(display_name="Messages", name="messages", method="build_messages"),
+    ]
+
+    def fetch_messages(self) -> list[dict]:
+        """Retrive messages using [conversations.history](https://api.slack.com/methods/conversations.history) from Slack API.
+        """
+        url = "https://slack.com/api/conversations.history"
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.token}",
+        }
+
+        payload = {
+            "channel": self.channel,
+            "cursor": self.cursor,
+            "include_all_metadata": self.include_all_metadata,
+            "inclusive": self.inclusive,
+            "latest": self.latest,
+            "oldest": self.oldest,
+            "limit": self.limit,
+        }
+
+        http_response = requests.request("POST", url, json=payload, headers=headers)
+        json_response = http_response.json()
+
+        if not json_response.get("ok"):
+            error_message = json_response.get("error")
+            raise ValueError(f"Slack Error: {error_message}")
+
+        return json_response
+
+    def build_slack_response(self) -> Data:
+        """Build the output object containing the Slack API response.
+        """
+        data = Data(
+            data=self.fetch_messages(),
+            text_key="messages",
+            default_value="No content available",
+        )
+
+        return data
+
+    def build_messages(self) -> DataFrame:
+        """Build the output object containing messages returned from the Slack API.
+        """
+        data = [
+            Data(data=message, text_key="text")
+            for message in self.response.value.messages
+        ]
+
+        return DataFrame(data)

--- a/src/backend/tests/unit/components/slack/test_conversation_history.py
+++ b/src/backend/tests/unit/components/slack/test_conversation_history.py
@@ -1,0 +1,94 @@
+import pytest
+from langflow.components.slack.conversation_history import (
+    SlackConversationsHistoryComponent,
+)
+from langflow.schema.data import Data
+from langflow.schema.dataframe import DataFrame
+
+
+@pytest.fixture
+def slack_conversation_history():
+    return SlackConversationsHistoryComponent()
+
+
+def test_deepseek_initialization(slack_conversation_history):
+    assert slack_conversation_history.display_name == "Fetch Slack Messages"
+    assert (
+        slack_conversation_history.description
+        == "Fetches a conversation's history of messages and events."
+    )
+    assert slack_conversation_history.icon == "SlackDirectoryLoader"
+
+
+def test_get_message_successful_execution(mocker, slack_conversation_history):
+    mock_response = {
+        "ok": True,
+        "messages": [{"text": "Test message 1"}, {"text": "Test message 2"}],
+    }
+
+    mock_requests = mocker.patch("requests.request")
+    mock_requests.return_value.json.return_value = mock_response
+
+    slack_conversation_history.fetch_messages()
+
+    mock_requests.assert_called_once_with(
+        "POST",
+        "https://slack.com/api/conversations.history",
+        json=mocker.ANY,
+        headers=mocker.ANY,
+    )
+
+
+def test_get_message_channel_slack_error_exception(mocker, slack_conversation_history):
+    mock_response = {
+        "ok": False,
+        "error": "some_slack_error",
+    }
+
+    mock_requests = mocker.patch("requests.request")
+    mock_requests.return_value.json.return_value = mock_response
+
+    with pytest.raises(ValueError) as err:
+        slack_conversation_history.fetch_messages()
+
+    assert str(err.value) == f"Slack Error: {mock_response['error']}"
+
+    mock_requests.assert_called_once_with(
+        "POST",
+        "https://slack.com/api/conversations.history",
+        json=mocker.ANY,
+        headers=mocker.ANY,
+    )
+
+
+def test_build_slack_response_successful_execution(mocker, slack_conversation_history):
+    mock_fetch_messages_response = {
+        "ok": True,
+        "messages": [{"text": "Test message 1"}, {"text": "Test message 2"}],
+    }
+
+    mocker.patch.object(
+        slack_conversation_history,
+        "fetch_messages",
+        return_value=mock_fetch_messages_response,
+    )
+
+    slack_response_output = slack_conversation_history.build_slack_response()
+
+    slack_conversation_history.fetch_messages.assert_called_once()
+
+    assert isinstance(slack_response_output, Data)
+
+
+def test_build_messages_successful_execution(mocker, slack_conversation_history):
+    mock_messages = [
+        Data(data={"text": "Test message 1"}),
+        Data(data={"text": "Test message 2"}),
+    ]
+
+    mock_response = mocker.patch.object(slack_conversation_history, "response")
+    mock_response.return_value.value.return_value.messages = mock_messages
+
+    slack_response_output = slack_conversation_history.build_messages()
+
+    assert isinstance(slack_response_output, DataFrame)

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -589,6 +589,7 @@ export const SIDEBAR_BUNDLES = [
   { display_name: "Mem0", name: "mem0", icon: "Mem0" },
   { display_name: "Youtube", name: "youtube", icon: "YouTube" },
   { display_name: "ScrapeGraph AI", name: "scrapegraph", icon: "ScrapeGraph" },
+  { display_name: "Slack", name: "slack", icon: "SlackDirectoryLoader" },
 ];
 
 export const categoryIcons = {


### PR DESCRIPTION
This pull request adds a new connector for Slack's [conversations history API](https://api.slack.com/methods/conversations.history)

**Changelog:**
- Add a new `SlackConversationsHistoryComponent` component
- Add Unit Tests
- Add Slack as a sidebar Bundle