### PR TITLE
fix: Improve token refresh logic and API interceptor handling

### DIFF
--- a/src/frontend/src/controllers/API/queries/auth/use-get-autologin.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-get-autologin.ts
@@ -31,6 +31,7 @@ export const useGetAutoLogin: useQueryFunctionType<undefined, undefined> = (
   const isLoginPage = location.pathname.includes("login");
   const navigate = useCustomNavigate();
   const { mutateAsync: mutationLogout } = useLogout();
+  const autoLogin = useAuthStore((state) => state.autoLogin);
 
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -67,8 +68,13 @@ export const useGetAutoLogin: useQueryFunctionType<undefined, undefined> = (
   };
 
   const handleAutoLoginError = async () => {
-    const manualLoginNotAuthenticated = !isAuthenticated && !IS_AUTO_LOGIN;
-    const autoLoginNotAuthenticated = !isAuthenticated && IS_AUTO_LOGIN;
+    const manualLoginNotAuthenticated =
+      (!isAuthenticated && !IS_AUTO_LOGIN) ||
+      (!isAuthenticated && autoLogin !== undefined && !autoLogin);
+
+    const autoLoginNotAuthenticated =
+      (!isAuthenticated && IS_AUTO_LOGIN) ||
+      (!isAuthenticated && autoLogin !== undefined && autoLogin);
 
     if (manualLoginNotAuthenticated) {
       await mutationLogout();

--- a/src/frontend/src/controllers/API/queries/auth/use-post-refresh-access.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-refresh-access.ts
@@ -1,4 +1,5 @@
 import { IS_AUTO_LOGIN, LANGFLOW_REFRESH_TOKEN } from "@/constants/constants";
+import useAuthStore from "@/stores/authStore";
 import { useMutationFunctionType } from "@/types/api";
 import { Cookies } from "react-cookie";
 import { api } from "../../api";
@@ -17,6 +18,7 @@ export const useRefreshAccessToken: useMutationFunctionType<
 > = (options?) => {
   const { mutate } = UseRequestProcessor();
   const cookies = new Cookies();
+  const autoLogin = useAuthStore((state) => state.autoLogin);
 
   async function refreshAccess(): Promise<IRefreshAccessToken> {
     const res = await api.post<IRefreshAccessToken>(`${getURL("REFRESH")}`);
@@ -27,7 +29,7 @@ export const useRefreshAccessToken: useMutationFunctionType<
 
   const mutation = mutate(["useRefreshAccessToken"], refreshAccess, {
     ...options,
-    retry: 0,
+    retry: IS_AUTO_LOGIN || autoLogin ? 0 : 2,
   });
 
   return mutation;

--- a/src/frontend/src/controllers/API/queries/auth/use-post-refresh-access.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-refresh-access.ts
@@ -27,7 +27,7 @@ export const useRefreshAccessToken: useMutationFunctionType<
 
   const mutation = mutate(["useRefreshAccessToken"], refreshAccess, {
     ...options,
-    retry: IS_AUTO_LOGIN ? 0 : 3,
+    retry: 0,
   });
 
   return mutation;


### PR DESCRIPTION
This pull request includes changes to the API interceptor and the use of the refresh access token mutation in the frontend codebase. The most important changes include modifying the logic for retrying refresh tokens and updating the retry configuration for access token refresh.

Changes to API interceptor logic:

* [`src/frontend/src/controllers/API/api.tsx`](diffhunk://#diff-40877b80b2243cdac1ce21fa28ef5d9e9ab22eaf0051893e4c3236c3ec273150L68-R72): Modified the logic to determine when to retry refreshing tokens by introducing a new variable `shouldRetryRefresh`. This change simplifies the conditions under which a refresh is attempted.

* [`src/frontend/src/controllers/API/api.tsx`](diffhunk://#diff-40877b80b2243cdac1ce21fa28ef5d9e9ab22eaf0051893e4c3236c3ec273150L88): Removed an unnecessary closing bracket to clean up the code structure.

Changes to refresh access token mutation:

* [`src/frontend/src/controllers/API/queries/auth/use-post-refresh-access.ts`](diffhunk://#diff-c50b21a853224366318d6aa7b966ac24b277d79d95722d76fa79a638cabe966cL30-R30): Updated the retry configuration for the `useRefreshAccessToken` mutation to always set the retry count to 0, removing the conditional logic based on `IS_AUTO_LOGIN`.