### PR TITLE
fix: check if file management is on before getting files

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
@@ -143,7 +143,9 @@ export default function InputFileComponent({
 
   const isDisabled = disabled || isPending;
 
-  const { data: files } = useGetFilesV2();
+  const { data: files } = useGetFilesV2({
+    enabled: !!ENABLE_FILE_MANAGEMENT,
+  });
 
   const selectedFiles = (
     isList


### PR DESCRIPTION
This pull request includes an update to the `InputFileComponent` in the `src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx` file. The most important change involves conditionally enabling the `useGetFilesV2` hook based on the `ENABLE_FILE_MANAGEMENT` flag.

Enhancements to file management:

* [`src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx`](diffhunk://#diff-68cd26e922bccf5191323c0f9ed58160ce8528c3479e556151c1ce4d4258a6caL146-R148): Updated the `useGetFilesV2` hook to include an `enabled` option that is set based on the `ENABLE_FILE_MANAGEMENT` flag.