### PR TITLE
docs: change new-user-is-active value

### DIFF
--- a/docs/docs/Configuration/configuration-authentication.md
+++ b/docs/docs/Configuration/configuration-authentication.md
@@ -21,7 +21,7 @@ LANGFLOW_AUTO_LOGIN=False
 LANGFLOW_SUPERUSER=admin
 LANGFLOW_SUPERUSER_PASSWORD=securepassword
 LANGFLOW_SECRET_KEY=randomly_generated_secure_key
-LANGFLOW_NEW_USER_IS_ACTIVE=False
+LANGFLOW_NEW_USER_IS_ACTIVE=true
 ```
 
 For more information, see [Authentication configuration values](#values).

--- a/docs/docs/Configuration/configuration-authentication.md
+++ b/docs/docs/Configuration/configuration-authentication.md
@@ -21,7 +21,7 @@ LANGFLOW_AUTO_LOGIN=False
 LANGFLOW_SUPERUSER=admin
 LANGFLOW_SUPERUSER_PASSWORD=securepassword
 LANGFLOW_SECRET_KEY=randomly_generated_secure_key
-LANGFLOW_NEW_USER_IS_ACTIVE=true
+LANGFLOW_NEW_USER_IS_ACTIVE=True
 ```
 
 For more information, see [Authentication configuration values](#values).


### PR DESCRIPTION
If `LANGFLOW_NEW_USER_IS_ACTIVE=False`, the superuser is created with `is_active=False`. 

This blocks the superuser from seeing their flows.

[Code](https://github.com/langflow-ai/langflow/blob/main/src/backend/base/langflow/services/auth/utils.py#L331)

This is a quick fix so this doesn't to any other users, but with followon work required.