### PR TITLE
fix: logout redirection on auto-login off

### DIFF
--- a/src/frontend/src/components/authorization/authGuard/index.tsx
+++ b/src/frontend/src/components/authorization/authGuard/index.tsx
@@ -18,8 +18,7 @@ export const ProtectedRoute = ({ children }) => {
   const shouldRedirect =
     !isAuthenticated &&
     autoLogin !== undefined &&
-    !autoLogin &&
-    !isAutoLoginEnv;
+    (!autoLogin || !isAutoLoginEnv);
 
   useEffect(() => {
     const envRefreshTime = LANGFLOW_ACCESS_TOKEN_EXPIRE_SECONDS_ENV;


### PR DESCRIPTION
This pull request includes a small change to the `ProtectedRoute` component in the `authGuard` module. The change simplifies the condition for the `shouldRedirect` variable by combining the `autoLogin` and `isAutoLoginEnv` checks into a single logical OR operation.

* [`src/frontend/src/components/authorization/authGuard/index.tsx`](diffhunk://#diff-18da52e5b642d1dcf06ad684c83caacf6a85ba9d10f63b5b299fb857b1d120e0L21-R21): Simplified the condition for `shouldRedirect` by combining the `autoLogin` and `isAutoLoginEnv` checks into a single logical OR operation.