### PR TITLE
feat: Startup DO_NOT_TRACK message hiding

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -401,10 +401,10 @@ def print_banner(host: str, port: int) -> None:
     access_link = f"Access [link=http://{host}:{port}]http://{host}:{port}[/link]"
 
     panel_content_array = [title, *styled_notices, info_text]
-    if os.environ.get('DO_NOT_TRACK', "") != "true":
+    if os.environ.get("DO_NOT_TRACK", "") != "true":
         panel_content_array.append(telemetry_text)
     panel_content_array.append(access_link)
-    
+
     panel_content = "\n\n".join(panel_content_array)
     panel = Panel(panel_content, box=box.ROUNDED, border_style="blue", expand=False)
     rprint(panel)

--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -400,7 +400,12 @@ def print_banner(host: str, port: int) -> None:
     )
     access_link = f"Access [link=http://{host}:{port}]http://{host}:{port}[/link]"
 
-    panel_content = "\n\n".join([title, *styled_notices, info_text, telemetry_text, access_link])
+    panel_content_array = [title, *styled_notices, info_text]
+    if os.environ.get('DO_NOT_TRACK', "") != "true":
+        panel_content_array.append(telemetry_text)
+    panel_content_array.append(access_link)
+    
+    panel_content = "\n\n".join(panel_content_array)
     panel = Panel(panel_content, box=box.ROUNDED, border_style="blue", expand=False)
     rprint(panel)
 


### PR DESCRIPTION
I noticed that setting `DO_NOT_TRACK=true` did not remove the DO_NOT_TRACK message from the startup output.

I made this change so that when this option is set, it properly reflects on the command line by removing the message.