### PR TITLE
tests: Skip tests that are failing during nightly build

### DIFF
--- a/src/frontend/tests/extended/features/files-page.spec.ts
+++ b/src/frontend/tests/extended/features/files-page.spec.ts
@@ -10,6 +10,8 @@ test(
   "should navigate to files page and show empty state",
   { tag: ["@release", "@files"] },
   async ({ page }) => {
+    test.skip(); //@TODO understand this behavior
+
     await awaitBootstrapTest(page, { skipModal: true });
 
     // Wait for the sidebar to be visible
@@ -44,6 +46,8 @@ test(
   "should upload file using upload button",
   { tag: ["@release", "@files"] },
   async ({ page }) => {
+    test.skip(); //@TODO understand this behavior
+
     const fileName = generateRandomFilename();
     const testFilePath = path.join(__dirname, "../../assets/test-file.txt");
     const fileContent = fs.readFileSync(testFilePath);
@@ -81,6 +85,8 @@ test(
   "should upload file using drag and drop",
   { tag: ["@release", "@files"] },
   async ({ page }) => {
+    test.skip(); //@TODO understand this behavior
+
     const fileName = generateRandomFilename();
 
     await awaitBootstrapTest(page, { skipModal: true });
@@ -195,6 +201,8 @@ test(
   "should search uploaded files",
   { tag: ["@release", "@files"] },
   async ({ page }) => {
+    test.skip(); //@TODO understand this behavior
+
     const fileNames = {
       txt: generateRandomFilename(),
       json: generateRandomFilename(),


### PR DESCRIPTION
This pull request includes changes to the `src/frontend/tests/extended/features/files-page.spec.ts` file, specifically focusing on temporarily skipping certain tests. The changes introduce a `test.skip()` statement to several test cases with a `@TODO` comment indicating the need to understand the behavior of these tests.

Key changes:

* `src/frontend/tests/extended/features/files-page.spec.ts`: Added `test.skip()` to the following test cases to temporarily skip them while investigating their behavior:
  * "should navigate to files page and show empty state"
  * "should upload file using upload button"
  * "should upload file using drag and drop"
  * "should search uploaded files"