### PR TITLE
fix: Add webrtcvad dependency to backend base requirements

### DIFF
--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -84,6 +84,7 @@ dependencies = [
     "jsonquerylang>=1.1.1",
     "sqlalchemy[aiosqlite]>=2.0.38,<3.0.0",
     "elevenlabs>=1.54.0",
+    "webrtcvad>=2.0.10",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -4824,6 +4824,7 @@ dependencies = [
     { name = "uncurl" },
     { name = "uvicorn" },
     { name = "validators" },
+    { name = "webrtcvad" },
 ]
 
 [package.optional-dependencies]
@@ -4970,6 +4971,7 @@ requires-dist = [
     { name = "uncurl", specifier = ">=0.0.11,<1.0.0" },
     { name = "uvicorn", specifier = ">=0.30.0,<1.0.0" },
     { name = "validators", specifier = ">=0.34.0" },
+    { name = "webrtcvad", specifier = ">=2.0.10" },
 ]
 provides-extras = ["postgresql", "deploy", "local", "all"]
 


### PR DESCRIPTION
This pull request includes a small change to the `src/backend/base/pyproject.toml` file. The change adds the `webrtcvad` dependency to the list of dependencies.

* [`src/backend/base/pyproject.toml`](diffhunk://#diff-791e429538b782db78051d7dc01bf66022b585810db3f20b644e26ce5d1cce48R87): Added `webrtcvad>=2.0.10` to the dependencies list.