### PR TITLE
fix: rollback package-lock.json file

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1005,14 +1005,14 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "optional": true,
       "os": [
-        "linux"
+        "darwin"
       ],
       "engines": {
         "node": ">=12"
@@ -2007,14 +2007,14 @@
     },
     "node_modules/@million/lint/node_modules/@esbuild/darwin-arm64": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "optional": true,
       "os": [
-        "linux"
+        "darwin"
       ],
       "engines": {
         "node": ">=12"
@@ -2415,14 +2415,14 @@
     },
     "node_modules/@napi-rs/nice-darwin-arm64": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-gnu/-/nice-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-XQAJs7DRN2GpLN6Fb+ZdGFeYZDdGl2Fn3TmFlqEL5JorgWKrQGRUrpGKbgZ25UeZPILuTKJ+OowG2avN8mThBA==",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-arm64/-/nice-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-91k3HEqUl2fsrz/sKkuEkscj6EAj3/eZNCLqzD2AA0TtVbkQi8nqxZCZDMkfklULmxLkMxuUdKe7RvG/T6s2AA==",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "optional": true,
       "os": [
-        "linux"
+        "darwin"
       ],
       "engines": {
         "node": ">= 10"
@@ -4122,11 +4122,11 @@
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.36.0.tgz",
       "integrity": "sha512-JQ1Jk5G4bGrD4pWJQzWsD8I1n1mgPXq33+/vP4sk8j/z/C2siRuxZtaUA7yMTf71TCZTZl/4e1bfzwUmFb3+rw==",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "optional": true,
       "os": [
-        "linux"
+        "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
@@ -4699,12 +4699,12 @@
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.11.tgz",
       "integrity": "sha512-vJcjGVDB8cZH7zyOkC0AfpFYI/7GHKG0NSsH3tpuKrmoAXJyCYspKPGid7FT53EAlWreN7+Pew+bukYf5j+Fmg==",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "dev": true,
       "optional": true,
       "os": [
-        "linux"
+        "darwin"
       ],
       "engines": {
         "node": ">=10"
@@ -8448,6 +8448,19 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "optional": true,
       "peer": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -15629,6 +15642,19 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/w3c-keyname": {


### PR DESCRIPTION
This pull request includes several updates to the `src/frontend/package-lock.json` file to change dependencies from Linux x64 to Darwin arm64 and to add new dependencies for fsevents.

Changes from Linux x64 to Darwin arm64:

* Updated `@esbuild/darwin-arm64` version 0.21.5 to use the correct Darwin arm64 package.
* Updated `@million/lint/node_modules/@esbuild/darwin-arm64` version 0.20.2 to use the correct Darwin arm64 package.
* Updated `@napi-rs/nice-darwin-arm64` version 1.0.1 to use the correct Darwin arm64 package.
* Updated `@rollup/rollup-darwin-arm64` to use the correct Darwin arm64 package.
* Updated `@swc/core-darwin-arm64` to use the correct Darwin arm64 package.

Addition of new dependencies:

* Added `fsevents` version 2.3.2 to support file system events on Darwin.
* Added `vite/node_modules/fsevents` version 2.3.3 to support file system events on Darwin.