### PR TITLE
fix: add tab to supported types to not show input handles

### DIFF
--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -654,6 +654,7 @@ export const LANGFLOW_SUPPORTED_TYPES = new Set([
   "table",
   "link",
   "slider",
+  "tab",
 ]);
 
 export const FLEX_VIEW_TYPES = ["bool"];


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/src/constants/constants.ts` file. The change adds a new supported type, "tab", to the `LANGFLOW_SUPPORTED_TYPES` set.

* [`src/frontend/src/constants/constants.ts`](diffhunk://#diff-3a3810648efc852f35a3780d6fe4ec65734c218f2281a175d9347a65db3fd360R657): Added "tab" to the `LANGFLOW_SUPPORTED_TYPES` set.