### PR TITLE
fix: added overflow on dataframe output

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/edit-message.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/edit-message.tsx
@@ -57,8 +57,10 @@ export const MarkdownField = ({
           },
           table: ({ node, ...props }) => {
             return (
-              <div className="max-h-[600px] w-full overflow-auto rounded-md border bg-muted p-4">
-                <table className="!my-0 w-full">{props.children}</table>
+              <div className="max-w-full overflow-hidden rounded-md border bg-muted">
+                <div className="max-h-[600px] w-full overflow-auto p-4">
+                  <table className="!my-0 w-full">{props.children}</table>
+                </div>
               </div>
             );
           },

--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/edit-message.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/edit-message.tsx
@@ -55,6 +55,13 @@ export const MarkdownField = ({
           pre({ node, ...props }) {
             return <>{props.children}</>;
           },
+          table: ({ node, ...props }) => {
+            return (
+              <div className="max-h-[600px] w-full overflow-auto rounded-md border bg-muted p-4">
+                <table className="!my-0 w-full">{props.children}</table>
+              </div>
+            );
+          },
           code: ({ node, inline, className, children, ...props }) => {
             let content = children as string;
             if (

--- a/src/frontend/src/style/classes.css
+++ b/src/frontend/src/style/classes.css
@@ -18,8 +18,8 @@ body {
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 pre {
   font-family: inherit;
@@ -288,7 +288,7 @@ input[type="search"]::-webkit-search-cancel-button {
 }
 
 .markdown td {
-  min-width: 78px;
+  min-width: 100px;
 }
 
 .jse-group-button.jse-last,


### PR DESCRIPTION
This pull request includes changes to improve the rendering of markdown tables in the chat message editor and adjusts some CSS styles for better consistency and appearance. The most important changes include adding a new rendering method for tables in the `MarkdownField` component and modifying the minimum width of table cells in the CSS.

Improvements to markdown table rendering:

* [`src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/edit-message.tsx`](diffhunk://#diff-cbaba4957b1340b9e7f4cdb92ba3da08bc88e40b1b5fbbc390e613ddc82701e1R58-R66): Added a new method to render tables with a max width, overflow handling, and border styling in the `MarkdownField` component.

CSS adjustments:

* [`src/frontend/src/style/classes.css`](diffhunk://#diff-20389fa3f9c927b863b7941b7a81e87d4d6d8f53f049354aaf1863fa1a3ac5ebL21-R22): Adjusted the `font-family` property for the `code` element to improve readability.
* [`src/frontend/src/style/classes.css`](diffhunk://#diff-20389fa3f9c927b863b7941b7a81e87d4d6d8f53f049354aaf1863fa1a3ac5ebL291-R291): Increased the minimum width of table cells from 78px to 100px for better layout consistency.