### PR TITLE
fix: refetch endpoints on backend startup (improvement for devs) 

### DIFF
--- a/src/frontend/src/pages/AppInitPage/index.tsx
+++ b/src/frontend/src/pages/AppInitPage/index.tsx
@@ -19,19 +19,25 @@ export function AppInitPage() {
 
   const { isFetched: isLoaded } = useCustomPrimaryLoading();
 
-  const { isFetched } = useGetAutoLogin({ enabled: isLoaded });
+  const { isFetched, refetch } = useGetAutoLogin({ enabled: isLoaded });
   useGetVersionQuery({ enabled: isFetched });
-  useGetConfig({ enabled: isFetched });
+  const { isFetched: isConfigFetched } = useGetConfig({ enabled: isFetched });
   useGetGlobalVariables({ enabled: isFetched });
   useGetTagsQuery({ enabled: isFetched });
   useGetFoldersQuery({ enabled: isFetched });
-  const { isFetched: isExamplesFetched } = useGetBasicExamplesQuery();
+  const { isFetched: isExamplesFetched, refetch: refetchExamples } =
+    useGetBasicExamplesQuery();
 
   useEffect(() => {
     if (isFetched) {
       refreshStars();
     }
-  }, [isFetched]);
+
+    if (isConfigFetched) {
+      refetch();
+      refetchExamples();
+    }
+  }, [isFetched, isConfigFetched]);
 
   return (
     //need parent component with width and height


### PR DESCRIPTION
This pull request includes changes to the `AppInitPage` component to improve the loading and refetching logic. The most important changes include adding refetch functionality and updating the useEffect dependencies.

Enhancements to loading and refetching logic:

* [`src/frontend/src/pages/AppInitPage/index.tsx`](diffhunk://#diff-3f47a6563af8bf59cd241de64d00738828c81574a70e287ac6b4cdbdefc99ef2L22-R40): Added `refetch` and `refetchExamples` functions to `useGetAutoLogin` and `useGetBasicExamplesQuery` hooks, respectively.
* [`src/frontend/src/pages/AppInitPage/index.tsx`](diffhunk://#diff-3f47a6563af8bf59cd241de64d00738828c81574a70e287ac6b4cdbdefc99ef2L22-R40): Updated the `useEffect` hook to include `isConfigFetched` in its dependency array and to call `refetch` and `refetchExamples` when `isConfigFetched` is true.