### PR TITLE
fix: prevent logout when auto-login is true

### DIFF
--- a/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
@@ -1,6 +1,7 @@
 import useAuthStore from "@/stores/authStore";
 import { useMutationFunctionType } from "@/types/api";
 
+import { Cookies } from "react-cookie";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
@@ -9,10 +10,14 @@ export const useLogout: useMutationFunctionType<undefined, void> = (
   options?,
 ) => {
   const { mutate } = UseRequestProcessor();
+  const cookies = new Cookies();
   const logout = useAuthStore((state) => state.logout);
 
   async function logoutUser(): Promise<any> {
-    const autoLogin = useAuthStore.getState().autoLogin;
+    const autoLogin =
+      useAuthStore.getState().autoLogin ||
+      cookies.get("auto_login_lf") === "auto";
+
     if (autoLogin) {
       return {};
     }

--- a/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
@@ -1,6 +1,10 @@
 import useAuthStore from "@/stores/authStore";
 import { useMutationFunctionType } from "@/types/api";
 
+import {
+  IS_AUTO_LOGIN,
+  LANGFLOW_AUTO_LOGIN_OPTION,
+} from "@/constants/constants";
 import { Cookies } from "react-cookie";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
@@ -12,11 +16,13 @@ export const useLogout: useMutationFunctionType<undefined, void> = (
   const { mutate } = UseRequestProcessor();
   const cookies = new Cookies();
   const logout = useAuthStore((state) => state.logout);
+  const isAutoLoginEnv = IS_AUTO_LOGIN;
 
   async function logoutUser(): Promise<any> {
     const autoLogin =
       useAuthStore.getState().autoLogin ||
-      cookies.get("auto_login_lf") === "auto";
+      cookies.get(LANGFLOW_AUTO_LOGIN_OPTION) === "auto" ||
+      isAutoLoginEnv;
 
     if (autoLogin) {
       return {};


### PR DESCRIPTION
This pull request includes changes to the `use-post-logout.ts` file to enhance the logout functionality by incorporating cookie handling. The most important changes include importing the `Cookies` library and modifying the `logoutUser` function to check for an `auto_login_lf` cookie.

Enhancements to logout functionality:

* [`src/frontend/src/controllers/API/queries/auth/use-post-logout.ts`](diffhunk://#diff-b82440cdb42aa9d4e70abe54789c41e27dc4f2962bf729061686728c095895b8R4): Imported the `Cookies` library to manage cookies.
* [`src/frontend/src/controllers/API/queries/auth/use-post-logout.ts`](diffhunk://#diff-b82440cdb42aa9d4e70abe54789c41e27dc4f2962bf729061686728c095895b8R13-R20): Modified the `logoutUser` function to check for the `auto_login_lf` cookie in addition to the `autoLogin` state.