### PR TITLE
fix: add validation on build request to prevent output glitch

### DIFF
--- a/src/frontend/src/controllers/API/queries/_builds/use-get-builds-polling-mutation.ts
+++ b/src/frontend/src/controllers/API/queries/_builds/use-get-builds-polling-mutation.ts
@@ -99,7 +99,7 @@ export const useGetBuildsMutation: useMutationFunctionType<
 
   const getBuildsFn = async (
     payload: IGetBuilds,
-  ): Promise<{ vertex_builds: FlowPoolType }> => {
+  ): Promise<{ vertex_builds: FlowPoolType } | undefined> => {
     if (requestInProgressRef.current[payload.flowId]) {
       return Promise.reject("Request already in progress");
     }
@@ -112,7 +112,10 @@ export const useGetBuildsMutation: useMutationFunctionType<
 
       if (currentFlow) {
         const flowPool = res?.data?.vertex_builds;
-        setFlowPool(flowPool);
+        if (Object.keys(flowPool).length > 0) {
+          setFlowPool(flowPool);
+        }
+        return;
       }
 
       return res.data;

--- a/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
@@ -1,6 +1,7 @@
 import useAuthStore from "@/stores/authStore";
 import { useMutationFunctionType } from "@/types/api";
 
+import { Cookies } from "react-cookie";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
@@ -9,10 +10,14 @@ export const useLogout: useMutationFunctionType<undefined, void> = (
   options?,
 ) => {
   const { mutate } = UseRequestProcessor();
+  const cookies = new Cookies();
   const logout = useAuthStore((state) => state.logout);
 
   async function logoutUser(): Promise<any> {
-    const autoLogin = useAuthStore.getState().autoLogin;
+    const autoLogin =
+      useAuthStore.getState().autoLogin ||
+      cookies.get("auto_login_lf") === "auto";
+
     if (autoLogin) {
       return {};
     }

--- a/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-logout.ts
@@ -1,6 +1,10 @@
 import useAuthStore from "@/stores/authStore";
 import { useMutationFunctionType } from "@/types/api";
 
+import {
+  IS_AUTO_LOGIN,
+  LANGFLOW_AUTO_LOGIN_OPTION,
+} from "@/constants/constants";
 import { Cookies } from "react-cookie";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
@@ -12,11 +16,13 @@ export const useLogout: useMutationFunctionType<undefined, void> = (
   const { mutate } = UseRequestProcessor();
   const cookies = new Cookies();
   const logout = useAuthStore((state) => state.logout);
+  const isAutoLoginEnv = IS_AUTO_LOGIN;
 
   async function logoutUser(): Promise<any> {
     const autoLogin =
       useAuthStore.getState().autoLogin ||
-      cookies.get("auto_login_lf") === "auto";
+      cookies.get(LANGFLOW_AUTO_LOGIN_OPTION) === "auto" ||
+      isAutoLoginEnv;
 
     if (autoLogin) {
       return {};


### PR DESCRIPTION
This pull request includes updates to the `use-get-builds-polling-mutation.ts` and `use-post-logout.ts` files to handle edge cases and improve functionality. The most important changes include modifying the return type of `getBuildsFn`, adding a condition to set `flowPool`, and enhancing the logout functionality with additional checks.

Improvements to `use-get-builds-polling-mutation.ts`:

* Modified the return type of `getBuildsFn` to include `undefined` to handle cases where the request is already in progress.
* Added a condition to check if `flowPool` has keys before setting it, ensuring only valid data is processed.

Enhancements to `use-post-logout.ts`:

* Imported necessary constants and `Cookies` to manage auto-login state.
* Updated the `logoutUser` function to include checks for `LANGFLOW_AUTO_LOGIN_OPTION` and environment variable `IS_AUTO_LOGIN` to determine the auto-login state.