### PR TITLE
feat: Add truncation notification for large outputs

### DIFF
--- a/src/frontend/src/shared/components/textOutputView/index.tsx
+++ b/src/frontend/src/shared/components/textOutputView/index.tsx
@@ -10,14 +10,25 @@ const TextOutputView = ({
   if (typeof value === "object" && Object.keys(value).includes("text")) {
     value = value.text;
   }
+
+  const isTruncated = value?.length > 20000;
+
   return (
-    <Textarea
-      className={`w-full custom-scroll ${left ? "min-h-32" : "h-full"}`}
-      placeholder={"Empty"}
-      readOnly
-      // update to real value on flowPool
-      value={value}
-    />
+    <>
+      {" "}
+      <Textarea
+        className={`w-full custom-scroll ${left ? "min-h-32" : "h-full"}`}
+        placeholder={"Empty"}
+        readOnly
+        // update to real value on flowPool
+        value={value}
+      />
+      {isTruncated && (
+        <div className="mt-2 text-xs text-muted-foreground">
+          This output has been truncated due to its size.
+        </div>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
This pull request includes an enhancement to the `TextOutputView` component in the `src/frontend/src/shared/components/textOutputView/index.tsx` file. The most important change is the addition of a feature to handle and notify users when the text output is truncated.

Enhancement to `TextOutputView` component:

* Added a check to determine if the `value` length exceeds 20,000 characters and display a notification if the output has been truncated.

![image](https://github.com/user-attachments/assets/0f054c2c-c910-4844-8386-134617e8832b)
