### PR TITLE
fix: Improve disabled state handling in CustomInputPopover and InputGlobalComponent

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
@@ -229,7 +229,7 @@ const CustomInputPopover = ({
           className={getAnchorClassName(editNode, disabled, isFocused)}
           onClick={() => !nodeStyle && !disabled && setShowOptions(true)}
         >
-          {selectedOptions?.length > 0 ? (
+          {!disabled && selectedOptions?.length > 0 ? (
             <div className="mr-5 flex flex-wrap gap-2">
               {selectedOptions.map((option) => (
                 <OptionBadge
@@ -240,7 +240,7 @@ const CustomInputPopover = ({
                 />
               ))}
             </div>
-          ) : selectedOption?.length > 0 ? (
+          ) : !disabled && selectedOption?.length > 0 ? (
             <ShadTooltip content={selectedOption} side="left">
               <div
                 style={{
@@ -262,7 +262,7 @@ const CustomInputPopover = ({
             </ShadTooltip>
           ) : null}
 
-          {!selectedOption?.length && !selectedOptions?.length && (
+          {(!selectedOption?.length && !selectedOptions?.length) || disabled ? (
             <input
               autoComplete="off"
               onFocus={() => setIsFocused(true)}
@@ -274,7 +274,7 @@ const CustomInputPopover = ({
                 onInputLostFocus?.();
                 setIsFocused(false);
               }}
-              value={value || ""}
+              value={disabled ? "" : value || ""}
               disabled={disabled}
               required={required}
               className={getInputClassName(
@@ -285,7 +285,9 @@ const CustomInputPopover = ({
                 blockAddNewGlobalVariable,
               )}
               placeholder={
-                selectedOptions?.length > 0 || selectedOption ? "" : placeholder
+                !disabled && (selectedOptions?.length > 0 || selectedOption)
+                  ? ""
+                  : placeholder
               }
               onChange={(e) => onChange?.(e.target.value)}
               onKeyDown={(e) => {
@@ -294,7 +296,7 @@ const CustomInputPopover = ({
               }}
               data-testid={editNode ? id + "-edit" : id}
             />
-          )}
+          ) : null}
         </div>
       </PopoverAnchor>
 

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
@@ -34,7 +34,7 @@ export default function InputGlobalComponent({
   );
 
   useEffect(() => {
-    if (globalVariables) {
+    if (globalVariables && !disabled) {
       if (
         load_from_db &&
         !globalVariables.find((variable) => variable.name === value)
@@ -56,7 +56,7 @@ export default function InputGlobalComponent({
         );
       }
     }
-  }, [globalVariables, unavailableFields]);
+  }, [globalVariables, unavailableFields, disabled]);
 
   function handleDelete(key: string) {
     if (value === key && load_from_db) {


### PR DESCRIPTION
This pull request includes changes to improve the handling of the `disabled` state in the `CustomInputPopover` and `InputGlobalComponent` components. The main changes ensure that the components behave correctly when they are disabled.

Improvements to handling the `disabled` state:

* [`src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx`](diffhunk://#diff-6dd2f8aa520258e6efb0482b5419536b2eb345b1cccdcf29c1b4562971c4f0e4L232-R232): Modified the `CustomInputPopover` component to account for the `disabled` state in various conditions, including when displaying selected options, input value, and placeholder text. [[1]](diffhunk://#diff-6dd2f8aa520258e6efb0482b5419536b2eb345b1cccdcf29c1b4562971c4f0e4L232-R232) [[2]](diffhunk://#diff-6dd2f8aa520258e6efb0482b5419536b2eb345b1cccdcf29c1b4562971c4f0e4L243-R243) [[3]](diffhunk://#diff-6dd2f8aa520258e6efb0482b5419536b2eb345b1cccdcf29c1b4562971c4f0e4L265-R265) [[4]](diffhunk://#diff-6dd2f8aa520258e6efb0482b5419536b2eb345b1cccdcf29c1b4562971c4f0e4L277-R277) [[5]](diffhunk://#diff-6dd2f8aa520258e6efb0482b5419536b2eb345b1cccdcf29c1b4562971c4f0e4L288-R290) [[6]](diffhunk://#diff-6dd2f8aa520258e6efb0482b5419536b2eb345b1cccdcf29c1b4562971c4f0e4L297-R299)
* [`src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx`](diffhunk://#diff-caa2538c44f1fa4f2e83da3cb4ac7b060852e688dec0a7b6bc89cc18e2b5a58dL37-R37): Updated the `InputGlobalComponent` component to check the `disabled` state when handling global variables and added `disabled` to the dependency array of the `useEffect` hook. [[1]](diffhunk://#diff-caa2538c44f1fa4f2e83da3cb4ac7b060852e688dec0a7b6bc89cc18e2b5a58dL37-R37) [[2]](diffhunk://#diff-caa2538c44f1fa4f2e83da3cb4ac7b060852e688dec0a7b6bc89cc18e2b5a58dL59-R59)

![image](https://github.com/user-attachments/assets/81184b17-71e9-4dc5-97ca-101436dc1e79)
