### PR TITLE
fix: made truncate gradient appear just in the end of the truncated component

### DIFF
--- a/src/frontend/tailwind.config.mjs
+++ b/src/frontend/tailwind.config.mjs
@@ -421,7 +421,7 @@ const config = {
                 content: '""',
                 position: "absolute",
                 inset: "0 0 0 0",
-                background: `linear-gradient(to right, transparent, 75%, ${colorValue})`,
+                background: `linear-gradient(to right, transparent 80%, ${colorValue})`,
               },
             };
           } else if (typeof colorValue === "object") {
@@ -434,7 +434,7 @@ const config = {
                   content: '""',
                   position: "absolute",
                   inset: "0 0 0 0",
-                  background: `linear-gradient(to right, transparent, ${colorValue.DEFAULT})`,
+                  background: `linear-gradient(to right, transparent 80%, ${colorValue.DEFAULT})`,
                 },
               };
             }


### PR DESCRIPTION
This pull request includes changes to the `src/frontend/tailwind.config.mjs` file to adjust the gradient background in the configuration. The changes ensure a smoother transition in gradient backgrounds by modifying the transparency percentage.

Gradient background adjustments:

* Changed the transparency percentage in the gradient background from 75% to 80% for a more gradual transition.
* Updated the transparency percentage in the gradient background from the default value to 80% for consistency.