### PR TITLE
fix: add tool_mode to query input on gleanSearchComponent

### DIFF
--- a/src/backend/base/langflow/components/tools/glean_search_api.py
+++ b/src/backend/base/langflow/components/tools/glean_search_api.py
@@ -109,11 +109,7 @@ class GleanSearchAPIComponent(LCToolComponent):
     ]
 
     inputs = [
-        StrInput(
-            name="glean_api_url",
-            display_name="Glean API URL",
-            required=True
-        ),
+        StrInput(name="glean_api_url", display_name="Glean API URL", required=True),
         SecretStrInput(name="glean_access_token", display_name="Glean Access Token", required=True),
         MultilineInput(name="query", display_name="Query", required=True, tool_mode=True),
         IntInput(name="page_size", display_name="Page Size", value=10),

--- a/src/backend/base/langflow/components/tools/glean_search_api.py
+++ b/src/backend/base/langflow/components/tools/glean_search_api.py
@@ -112,10 +112,10 @@ class GleanSearchAPIComponent(LCToolComponent):
         StrInput(
             name="glean_api_url",
             display_name="Glean API URL",
-            required=True,
+            required=True
         ),
         SecretStrInput(name="glean_access_token", display_name="Glean Access Token", required=True),
-        MultilineInput(name="query", display_name="Query", required=True),
+        MultilineInput(name="query", display_name="Query", required=True, tool_mode=True),
         IntInput(name="page_size", display_name="Page Size", value=10),
         NestedDictInput(name="request_options", display_name="Request Options", required=False),
     ]


### PR DESCRIPTION
This pull request includes a small change to the `src/backend/base/langflow/components/tools/glean_search_api.py` file. The change adds the `tool_mode` attribute to the `MultilineInput` for the `query` field in the `GleanSearchAPIComponent` class to enhance its functionality.

* [`src/backend/base/langflow/components/tools/glean_search_api.py`](diffhunk://#diff-7482c741b055e68a32e49981de3cd0da48aa1cb3d674d8aab69bdc1c291ab6d5L115-R118): Added `tool_mode=True` to the `MultilineInput` for the `query` field in the `GleanSearchAPIComponent` class.