### PR TITLE
fix: add full width on Select files button

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
@@ -246,7 +246,7 @@ export default function InputFileComponent({
                   isList={isList}
                 >
                   {(selectedFiles.length === 0 || isList) && (
-                    <div data-testid="input-file-component">
+                    <div data-testid="input-file-component" className="w-full">
                       <Button
                         disabled={isDisabled}
                         variant={
@@ -256,7 +256,7 @@ export default function InputFileComponent({
                         className={cn(
                           selectedFiles.length !== 0 &&
                             "hit-area-icon absolute -top-8 right-0",
-                          "font-semibold",
+                          "w-full font-semibold",
                         )}
                         data-testid="button_open_file_management"
                       >


### PR DESCRIPTION
This pull request includes changes to the `InputFileComponent` in the `src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx` file to improve the layout and styling of the component.

Styling improvements:

* Added a `w-full` class to the `div` with `data-testid="input-file-component"` to ensure it takes the full width of its container.
* Modified the `Button` component's class list to include `w-full font-semibold` for better styling consistency and full-width display.