### PR TITLE
fix: update value conversion logic in convertValuesToNumbers function

### DIFF
--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -931,12 +931,12 @@ export function convertValuesToNumbers(arr) {
     for (const key in obj) {
       if (obj.hasOwnProperty(key)) {
         let value = obj[key];
-        if (/^\d+$/.test(value)) {
+        if (/^-?\d*\.?\d+$/.test(value) && value !== "") {
           value = value?.toString().trim();
+          newObj[key] = Number(value);
+        } else {
+          newObj[key] = value.toString();
         }
-        newObj[key] =
-          value === "" || isNaN(value) ? value.toString() : Number(value);
-      }
     }
     return newObj;
   });

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -937,6 +937,7 @@ export function convertValuesToNumbers(arr) {
         } else {
           newObj[key] = value.toString();
         }
+      }
     }
     return newObj;
   });


### PR DESCRIPTION
There's a bug in the `keypairListComponent`, for instance, typing "0.8" results in "08" because the `convertValuesToNumbers` function incorrectly processes "0." as a number and removes the decimal point.  

To fix this, I updated the logic so that any input matching the pattern `"(any number)."` is treated as a string rather than a number. If the input follows the pattern `"(any number).(any number)"`, it will be correctly converted to a number.  

This ensures that decimal values are preserved during input.