### PR TITLE
fix: Standardize flow name handling with snake_case conversion in MCP API

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp.py
+++ b/src/backend/base/langflow/api/v1/mcp.py
@@ -21,7 +21,7 @@ from starlette.background import BackgroundTasks
 
 from langflow.api.v1.chat import build_flow_and_stream
 from langflow.api.v1.schemas import InputValueRequest
-from langflow.base.mcp.util import get_flow
+from langflow.base.mcp.util import get_flow_snake_case
 from langflow.helpers.flow import json_schema_from_flow
 from langflow.services.auth.utils import get_current_active_user
 from langflow.services.database.models import Flow, User
@@ -186,11 +186,12 @@ async def handle_list_tools():
                 if flow.user_id is None:
                     continue
 
+                flow_name = "_".join(flow.name.lower().split())
                 tool = types.Tool(
-                    name=flow.name,
+                    name=flow_name,
                     description=f"{flow.id}: {flow.description}"
                     if flow.description
-                    else f"Tool generated from flow: {flow.name}",
+                    else f"Tool generated from flow: {flow_name}",
                     inputSchema=json_schema_from_flow(flow),
                 )
                 tools.append(tool)
@@ -215,7 +216,7 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
 
     async def execute_tool(session):
         # get flow id from name
-        flow = await get_flow(name, current_user.id, session)
+        flow = await get_flow_snake_case(name, current_user.id, session)
         if not flow:
             msg = f"Flow with name '{name}' not found"
             raise ValueError(msg)

--- a/src/backend/base/langflow/base/mcp/util.py
+++ b/src/backend/base/langflow/base/mcp/util.py
@@ -60,13 +60,14 @@ def create_tool_func(tool_name: str, arg_schema: type[BaseModel], session) -> Ca
     return tool_func
 
 
-async def get_flow(flow_name: str, user_id: str, session) -> Flow | None:
+async def get_flow_snake_case(flow_name: str, user_id: str, session) -> Flow | None:
     uuid_user_id = UUID(user_id) if isinstance(user_id, str) else user_id
     stmt = select(Flow).where(Flow.user_id == uuid_user_id).where(Flow.is_component == False)  # noqa: E712
     flows = (await session.exec(stmt)).all()
 
     for flow in flows:
-        if flow.to_data().name == flow_name:
+        this_flow_name = "_".join(flow.name.lower().split())
+        if this_flow_name == flow_name:
             return flow
     return None
 

--- a/src/backend/tests/unit/components/data/test_api_request_component.py
+++ b/src/backend/tests/unit/components/data/test_api_request_component.py
@@ -8,7 +8,7 @@ import pytest
 import respx
 from httpx import Response
 from langflow.components.data import APIRequestComponent
-from langflow.schema import Data, DataFrame, Message
+from langflow.schema import Data, DataFrame
 
 from tests.base import ComponentTestBaseWithoutClient
 
@@ -145,7 +145,6 @@ class TestAPIRequestComponent(ComponentTestBaseWithoutClient):
 
         assert isinstance(result, Data)
         assert result.data["source"] == url
-
 
     @respx.mock
     async def test_make_request_timeout(self, component):


### PR DESCRIPTION
This pull request introduces changes to the `src/backend/base/langflow/api/v1/mcp.py` file to ensure flow names are consistently handled in snake_case format. The changes include updating function calls and modifying the flow name processing logic.

Key changes include:

* Updated import statement to use `get_flow_snake_case` instead of `get_flow` in `src/backend/base/langflow/api/v1/mcp.py`.

* Modified `handle_list_tools` function to convert flow names to snake_case before using them.

* Updated `handle_call_tool` function to use `get_flow_snake_case` for retrieving flows.

* Renamed `get_flow` to `get_flow_snake_case` and adjusted the flow name comparison logic in `src/backend/base/langflow/base/mcp/util.py`.