### PR TITLE
fix: update handle display logic and improve popover layout in node components

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
@@ -68,6 +68,10 @@ export default function NodeInputField({
     name,
   });
 
+  const hasRefreshButton = useMemo(() => {
+    return data.node?.template[name].refresh_button;
+  }, [data.node?.template, name]);
+
   const nodeInformationMetadata: NodeInfoType = useMemo(() => {
     return {
       flowId: currentFlow?.id ?? "",
@@ -89,7 +93,8 @@ export default function NodeInputField({
   const displayHandle =
     (!LANGFLOW_SUPPORTED_TYPES.has(type ?? "") ||
       (optionalHandle && optionalHandle.length > 0)) &&
-    !isToolMode;
+    !isToolMode &&
+    !hasRefreshButton;
 
   const isFlexView = FLEX_VIEW_TYPES.includes(type ?? "");
 

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
@@ -69,7 +69,7 @@ export default function NodeInputField({
   });
 
   const hasRefreshButton = useMemo(() => {
-    return data.node?.template[name].refresh_button;
+    return data.node?.template[name]?.refresh_button;
   }, [data.node?.template, name]);
 
   const nodeInformationMetadata: NodeInfoType = useMemo(() => {

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
@@ -185,6 +185,7 @@ const CustomInputPopover = ({
   popoverWidth,
   commandWidth,
   blockAddNewGlobalVariable,
+  hasRefreshButton,
 }) => {
   const [isFocused, setIsFocused] = useState(false);
   const memoizedOptions = useMemo(() => new Set<string>(options), [options]);
@@ -254,8 +255,9 @@ const CustomInputPopover = ({
                   className={cn(
                     editNode && "text-xs",
                     nodeStyle
-                      ? "max-w-48 rounded-[3px] px-1 font-mono"
+                      ? "max-w-56 rounded-[3px] px-1 font-mono"
                       : "bg-muted",
+                    hasRefreshButton && "max-w-48",
                   )}
                 />
               </div>

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx
@@ -254,7 +254,7 @@ const CustomInputPopover = ({
                   className={cn(
                     editNode && "text-xs",
                     nodeStyle
-                      ? "max-w-60 rounded-[3px] px-1 font-mono"
+                      ? "max-w-48 rounded-[3px] px-1 font-mono"
                       : "bg-muted",
                   )}
                 />

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx
@@ -42,6 +42,7 @@ export default function InputComponent({
   popoverWidth,
   commandWidth,
   blockAddNewGlobalVariable = false,
+  hasRefreshButton = false,
 }: InputComponentType): JSX.Element {
   const [pwdVisible, setPwdVisible] = useState(false);
   const refInput = useRef<HTMLInputElement>(null);
@@ -155,6 +156,7 @@ export default function InputComponent({
               popoverWidth={popoverWidth}
               commandWidth={commandWidth}
               blockAddNewGlobalVariable={blockAddNewGlobalVariable}
+              hasRefreshButton={hasRefreshButton}
             />
           )}
         </>

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
@@ -5,7 +5,7 @@ import {
 import GeneralDeleteConfirmationModal from "@/shared/components/delete-confirmation-modal";
 import GeneralGlobalVariableModal from "@/shared/components/global-variable-modal";
 import { useGlobalVariablesStore } from "@/stores/globalVariablesStore/globalVariables";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import DeleteConfirmationModal from "../../../../../modals/deleteConfirmationModal";
 import useAlertStore from "../../../../../stores/alertStore";
 import { cn } from "../../../../../utils/utils";
@@ -27,6 +27,7 @@ export default function InputGlobalComponent({
   editNode = false,
   placeholder,
   isToolMode = false,
+  hasRefreshButton = false,
 }: InputProps<string, InputGlobalComponentType>): JSX.Element {
   const { data: globalVariables } = useGetGlobalVariables();
   const unavailableFields = useGlobalVariablesStore(
@@ -115,6 +116,7 @@ export default function InputGlobalComponent({
         );
       }}
       isToolMode={isToolMode}
+      hasRefreshButton={hasRefreshButton}
     />
   );
 }

--- a/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx
@@ -66,7 +66,7 @@ export function StrRenderComponent({
       <DropdownComponent
         {...baseInputProps}
         dialogInputs={templateData.dialog_inputs}
-        options={templateData.options}
+        options={templateData.options ?? []}
         optionsMetaData={templateData.options_metadata}
         combobox={templateData.combobox}
         name={templateData?.name!}

--- a/src/frontend/src/components/core/parameterRenderComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/index.tsx
@@ -72,6 +72,7 @@ export function ParameterRenderComponent({
       isToolMode,
       nodeId,
       nodeInformationMetadata,
+      hasRefreshButton: templateData.refresh_button,
     };
 
     if (TEXT_FIELD_TYPES.includes(templateData.type ?? "")) {

--- a/src/frontend/src/components/core/parameterRenderComponent/types.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/types.ts
@@ -20,6 +20,7 @@ export type BaseInputProps<valueType = any> = {
   metadata?: any;
   nodeId?: string;
   nodeInformationMetadata?: NodeInfoType;
+  hasRefreshButton?: boolean;
 };
 
 // Generic type for composing input props

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -49,6 +49,7 @@ export type InputComponentType = {
   popoverWidth?: string;
   commandWidth?: string;
   blockAddNewGlobalVariable?: boolean;
+  hasRefreshButton?: boolean;
 };
 export type DropDownComponent = {
   disabled?: boolean;


### PR DESCRIPTION
This pull request includes changes to the `NodeInputField` and `CustomInputPopover` components to enhance functionality and improve the user interface. The most important changes are as follows:

Enhancements to `NodeInputField` component:

* Added a `hasRefreshButton` memoized value to determine if a refresh button should be displayed based on the node's template. (`src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx`, [src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsxR71-R74](diffhunk://#diff-b68d4cff4ce636f41882b2e6c2fb46ce2e134bdf292e38bcf6df9c6c5807d518R71-R74))
* Updated the `displayHandle` logic to hide the handle if a refresh button is present. (`src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx`, [src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsxL92-R97](diffhunk://#diff-b68d4cff4ce636f41882b2e6c2fb46ce2e134bdf292e38bcf6df9c6c5807d518L92-R97))

Improvements to `CustomInputPopover` component:

* Adjusted the maximum width of the popover when `nodeStyle` is applied to improve the layout. (`src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsx`, [src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/components/popover/index.tsxL257-R257](diffhunk://#diff-6dd2f8aa520258e6efb0482b5419536b2eb345b1cccdcf29c1b4562971c4f0e4L257-R257))