### PR TITLE
fix: Improve tool metadata and dropdown state management

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -1166,7 +1166,7 @@ class Component(CustomComponent):
             {
                 "name": tool.name,
                 "description": tool.description,
-                "tags": tool.tags,
+                "tags": tool.tags if hasattr(tool, "tags") and tool.tags else [],
                 "status": True,  # Initialize all tools with status True
             }
             for tool in tools

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -1166,7 +1166,7 @@ class Component(CustomComponent):
             {
                 "name": tool.name,
                 "description": tool.description,
-                "tags": tool.tags if hasattr(tool, "tags") and tool.tags else [],
+                "tags": tool.tags if hasattr(tool, "tags") and tool.tags else [tool.name],
                 "status": True,  # Initialize all tools with status True
             }
             for tool in tools

--- a/src/frontend/src/components/core/dropdownComponent/index.tsx
+++ b/src/frontend/src/components/core/dropdownComponent/index.tsx
@@ -62,6 +62,12 @@ export default function Dropdown({
   const [refreshOptions, setRefreshOptions] = useState(false);
   const refButton = useRef<HTMLButtonElement>(null);
 
+  value = useMemo(() => {
+    if (!options.includes(value)) {
+      return null;
+    }
+    return value;
+  }, [value, options]);
   // Initialize utilities and constants
   const placeholderName = name
     ? formatPlaceholderName(name)


### PR DESCRIPTION
This pull request includes changes to improve the handling of tool metadata and the state management in a dropdown component. The most important changes are as follows:

Improvements to tool metadata handling:

* [`src/backend/base/langflow/custom/custom_component/component.py`](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169L1169-R1169): Updated the `_build_tools_metadata_input` method to ensure that the `tags` attribute is properly handled, assigning the tool's name as a default value if `tags` is not present or empty.

Enhancements to dropdown component state management:

* [`src/frontend/src/components/core/dropdownComponent/index.tsx`](diffhunk://#diff-98068ce778ac9a53f4733f9c370c5e54bd27c30b6545fa4241f10cba35518700R65-R70): Added a `useMemo` hook to the `Dropdown` component to ensure the `value` is set to `null` if it is not included in the `options`, thereby preventing potential issues with invalid selections.