### PR TITLE
fix: Add debouncing to handleOnNewValue and disable retries for usePostTemplateValue mutation

### DIFF
--- a/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
@@ -1,3 +1,4 @@
+import { DEBOUNCE_FIELD_LIST } from "@/constants/constants";
 import { usePostTemplateValue } from "@/controllers/API/queries/nodes/use-post-template-value";
 import { track } from "@/customization/utils/analytics";
 import useAlertStore from "@/stores/alertStore";
@@ -10,7 +11,7 @@ import { cloneDeep, debounce } from "lodash";
 import { useCallback, useMemo, useRef } from "react";
 import { mutateTemplate } from "../helpers/mutate-template";
 
-const DEBOUNCE_TIME_2_SECONDS = 2000;
+const DEBOUNCE_TIME_1_SECOND = 1000;
 
 export type handleOnNewValueType = (
   changes: Partial<InputFieldType>,
@@ -100,6 +101,10 @@ const useHandleOnNewValue = ({
         return;
       }
 
+      const shouldDebounce = DEBOUNCE_FIELD_LIST.includes(
+        parameter?._input_type,
+      );
+
       if (!options?.skipSnapshot) takeSnapshot();
 
       Object.entries(changes).forEach(([key, value]) => {
@@ -131,7 +136,7 @@ const useHandleOnNewValue = ({
                 setErrorDataFn,
               );
             },
-            DEBOUNCE_TIME_2_SECONDS,
+            shouldDebounce ? DEBOUNCE_TIME_1_SECOND : 0,
           );
         }
         debouncedMutateRef.current(

--- a/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
@@ -111,11 +111,7 @@ const useHandleOnNewValue = ({
         updateNodeState(newNodeClass);
       };
 
-      if (
-        shouldUpdate &&
-        changes.value !== undefined &&
-        changes.value?.length > 10
-      ) {
+      if (shouldUpdate && changes.value !== undefined) {
         if (!debouncedMutateRef.current) {
           debouncedMutateRef.current = debounce(
             async (

--- a/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
@@ -10,7 +10,7 @@ import { cloneDeep, debounce } from "lodash";
 import { useCallback, useMemo, useRef } from "react";
 import { mutateTemplate } from "../helpers/mutate-template";
 
-const DEBOUNCE_TIME_1_SECOND = 1000;
+const DEBOUNCE_TIME_2_SECONDS = 2000;
 
 export type handleOnNewValueType = (
   changes: Partial<InputFieldType>,
@@ -131,7 +131,7 @@ const useHandleOnNewValue = ({
                 setErrorDataFn,
               );
             },
-            DEBOUNCE_TIME_1_SECOND,
+            DEBOUNCE_TIME_2_SECONDS,
           );
         }
         debouncedMutateRef.current(

--- a/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
@@ -111,7 +111,11 @@ const useHandleOnNewValue = ({
         updateNodeState(newNodeClass);
       };
 
-      if (shouldUpdate && changes.value !== undefined) {
+      if (
+        shouldUpdate &&
+        changes.value !== undefined &&
+        changes.value?.length > 10
+      ) {
         if (!debouncedMutateRef.current) {
           debouncedMutateRef.current = debounce(
             async (

--- a/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
@@ -11,7 +11,7 @@ import { cloneDeep, debounce } from "lodash";
 import { useCallback, useMemo, useRef } from "react";
 import { mutateTemplate } from "../helpers/mutate-template";
 
-const DEBOUNCE_TIME_2_SECOND = 2000;
+const DEBOUNCE_TIME_1_SECOND = 1000;
 
 export type handleOnNewValueType = (
   changes: Partial<InputFieldType>,
@@ -136,7 +136,7 @@ const useHandleOnNewValue = ({
                 setErrorDataFn,
               );
             },
-            shouldDebounce ? DEBOUNCE_TIME_2_SECOND : 0,
+            shouldDebounce ? DEBOUNCE_TIME_1_SECOND : 0,
           );
         }
         debouncedMutateRef.current(

--- a/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
@@ -11,7 +11,7 @@ import { cloneDeep, debounce } from "lodash";
 import { useCallback, useMemo, useRef } from "react";
 import { mutateTemplate } from "../helpers/mutate-template";
 
-const DEBOUNCE_TIME_1_SECOND = 1000;
+const DEBOUNCE_TIME_2_SECOND = 2000;
 
 export type handleOnNewValueType = (
   changes: Partial<InputFieldType>,
@@ -136,7 +136,7 @@ const useHandleOnNewValue = ({
                 setErrorDataFn,
               );
             },
-            shouldDebounce ? DEBOUNCE_TIME_1_SECOND : 0,
+            shouldDebounce ? DEBOUNCE_TIME_2_SECOND : 0,
           );
         }
         debouncedMutateRef.current(

--- a/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
+++ b/src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts
@@ -10,6 +10,8 @@ import { cloneDeep, debounce } from "lodash";
 import { useCallback, useMemo, useRef } from "react";
 import { mutateTemplate } from "../helpers/mutate-template";
 
+const DEBOUNCE_TIME_1_SECOND = 1000;
+
 export type handleOnNewValueType = (
   changes: Partial<InputFieldType>,
   options?: {
@@ -129,7 +131,7 @@ const useHandleOnNewValue = ({
                 setErrorDataFn,
               );
             },
-            2000,
+            DEBOUNCE_TIME_1_SECOND,
           );
         }
         debouncedMutateRef.current(

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -1037,3 +1037,14 @@ export const ALL_LANGUAGES = [
   { value: "ar-SA", name: "Arabic" },
   { value: "hi-IN", name: "Hindi" },
 ];
+
+export const DEBOUNCE_FIELD_LIST = [
+  "SecretStrInput",
+  "MessageTextInput",
+  "TextInput",
+  "MultilineInput",
+  "SecretStrInput",
+  "IntInput",
+  "FloatInput",
+  "SliderInput",
+];

--- a/src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts
+++ b/src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts
@@ -54,7 +54,10 @@ export const usePostTemplateValue: useMutationFunctionType<
   > = mutate(
     ["usePostTemplateValue", { parameterId, nodeId }],
     postTemplateValueFn,
-    options,
+    {
+      ...options,
+      retry: 0,
+    },
   );
 
   return mutation;


### PR DESCRIPTION
This pull request includes several changes to improve the handling of new values and the mutation process in the frontend codebase. The most important changes involve adding debouncing to the `handleOnNewValue` function and modifying the retry behavior of the `usePostTemplateValue` mutation.

Enhancements to `handleOnNewValue` function:

* [`src/frontend/src/CustomNodes/hooks/use-handle-new-value.ts`](diffhunk://#diff-0e6f6b3f7ee5b77c22d6f3a6375292722443eb6d8bf0b90c92a03daf2d8f8693L9-R10): Added `debounce` from `lodash` and `useRef` from `react` to debounce the `mutateTemplate` function calls, reducing the frequency of updates and improving performance. [[1]](diffhunk://#diff-0e6f6b3f7ee5b77c22d6f3a6375292722443eb6d8bf0b90c92a03daf2d8f8693L9-R10) [[2]](diffhunk://#diff-0e6f6b3f7ee5b77c22d6f3a6375292722443eb6d8bf0b90c92a03daf2d8f8693L75-R76) [[3]](diffhunk://#diff-0e6f6b3f7ee5b77c22d6f3a6375292722443eb6d8bf0b90c92a03daf2d8f8693R115-R135)

Changes to mutation options:

* [`src/frontend/src/controllers/API/queries/nodes/use-post-template-value.ts`](diffhunk://#diff-086a525c817d0a6f1c036817a9062e885c210bab590879ac029ce9632f091d80L57-R60): Updated the `usePostTemplateValue` mutation to include a retry option set to 0, ensuring that failed mutation attempts are not retried automatically.