### PR TITLE
fix: attempted to exit cancel scope in a different task (mcp)

### DIFF
--- a/src/backend/base/langflow/components/tools/mcp_component.py
+++ b/src/backend/base/langflow/components/tools/mcp_component.py
@@ -338,3 +338,19 @@ class MCPToolsComponent(Component):
         if not self.tools:
             return await self.update_tools()
         return self.tools
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self.stdio_client:
+            await self.stdio_client.cleanup()
+        if self.sse_client:
+            await self.sse_client.cleanup()
+
+    async def cleanup(self):
+        """Cleanup method to be called when the component is no longer needed."""
+        if self.stdio_client:
+            await self.stdio_client.cleanup()
+        if self.sse_client:
+            await self.sse_client.cleanup()


### PR DESCRIPTION
This pull request introduces several changes to improve the cleanup process and error handling in the `MCPStdioClient` and `MCPSseClient` classes in the `src/backend/base/langflow/base/mcp/util.py` file. Additionally, it adds context management methods to the `MCPComponent` class in the `src/backend/base/langflow/components/tools/mcp_component.py` file.

### Improvements to Cleanup Process and Error Handling:

* Added a `_cleanup_lock` and `_is_cleaning` flag to both `MCPStdioClient` and `MCPSseClient` classes to ensure that cleanup operations are not executed concurrently. [[1]](diffhunk://#diff-37c079efebed1e9da327c409abb8b1b6ec68d70c6a2a98885f0e1a11c087283cR121-R124) [[2]](diffhunk://#diff-37c079efebed1e9da327c409abb8b1b6ec68d70c6a2a98885f0e1a11c087283cR209-R211)
* Introduced a `cleanup` method in both `MCPStdioClient` and `MCPSseClient` classes to handle the cleanup of sessions and exit stacks. This method is called before establishing new connections and in case of exceptions during the connection process. [[1]](diffhunk://#diff-37c079efebed1e9da327c409abb8b1b6ec68d70c6a2a98885f0e1a11c087283cR133-R183) [[2]](diffhunk://#diff-37c079efebed1e9da327c409abb8b1b6ec68d70c6a2a98885f0e1a11c087283cL175-R248)
* Enhanced error handling in the `connect_to_server` methods by adding specific exception handling for `asyncio.CancelledError`, `GeneratorExit`, and general exceptions to ensure proper cleanup and provide informative error messages. [[1]](diffhunk://#diff-37c079efebed1e9da327c409abb8b1b6ec68d70c6a2a98885f0e1a11c087283cR133-R183) [[2]](diffhunk://#diff-37c079efebed1e9da327c409abb8b1b6ec68d70c6a2a98885f0e1a11c087283cL175-R248)

### Context Management:

* Added `__aenter__` and `__aexit__` methods to the `MCPComponent` class to support asynchronous context management, ensuring that cleanup operations are performed when the component is no longer needed.
* Introduced a `cleanup` method in the `MCPComponent` class to explicitly handle the cleanup of `stdio_client` and `sse_client` instances.

These changes enhance the stability and reliability of the MCP clients by ensuring that resources are properly managed and cleaned up, reducing the risk of resource leaks and improving error diagnostics.