### PR TITLE
fix: override modality for elevenlabs on response.create

### DIFF
--- a/src/backend/base/langflow/api/v1/voice_mode.py
+++ b/src/backend/base/langflow/api/v1/voice_mode.py
@@ -613,6 +613,11 @@ async def flow_as_tool_websocket(
                             log_event(event, "↑")
                             if voice_config.barge_in_enabled:
                                 await vad_queue.put(base64_data)
+                        elif msg.get("type") == "response.create":
+                            if voice_config.use_elevenlabs:
+                                response = msg.setdefault("response", {})
+                                response["modalities"] = ["text"]
+                            await openai_ws.send(json.dumps(msg))
                         elif msg.get("type") == "input_audio_buffer.commit":
                             if num_audio_samples > AUDIO_SAMPLE_THRESHOLD:
                                 await openai_ws.send(message_text)


### PR DESCRIPTION
This pull request includes an enhancement to the `forward_to_openai` function in the `voice_mode.py` file. The change adds handling for a new message type and integrates with ElevenLabs if configured.

Enhancements to `forward_to_openai` function:

* [`src/backend/base/langflow/api/v1/voice_mode.py`](diffhunk://#diff-41b04dcf95abc28892d4a8e3b2e674a8c014706c6f49c95cadb76b6efaef59b4R616-R620): Added handling for the `response.create` message type, including setting the response modalities to "text" if ElevenLabs is used, and sending the modified message to the OpenAI WebSocket.