### PR TITLE
feat: add url parameter to playground modal

### DIFF
--- a/src/frontend/src/components/core/flowToolbarComponent/index.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/index.tsx
@@ -17,21 +17,30 @@ import { useStoreStore } from "../../../stores/storeStore";
 import { classNames, cn, isThereModal } from "../../../utils/utils";
 import ForwardedIconComponent from "../../common/genericIconComponent";
 import FlowToolbarOptions from "./components/flow-toolbar-options";
+import { useSearchParams } from "react-router-dom";
 
 export default function FlowToolbar(): JSX.Element {
   const preventDefault = true;
-  const [open, setOpen] = useState<boolean>(false);
+  
+
+  const [searchParams, setSearchParams] = useSearchParams();
   const [openCodeModal, setOpenCodeModal] = useState<boolean>(false);
   const [openShareModal, setOpenShareModal] = useState<boolean>(false);
   function handleAPIWShortcut(e: KeyboardEvent) {
     if (isThereModal() && !openCodeModal) return;
     setOpenCodeModal((oldOpen) => !oldOpen);
   }
+  
+  const open = searchParams.get("playground") === "true";
+
+  function setOpen (isOpen: boolean) {
+    setSearchParams({playground: isOpen ? 'true':'false'})
+   }
 
   function handleChatWShortcut(e: KeyboardEvent) {
     if (isThereModal() && !open) return;
     if (useFlowStore.getState().hasIO) {
-      setOpen((oldState) => !oldState);
+      setOpen(!open);
     }
   }
 

--- a/src/frontend/src/components/core/flowToolbarComponent/index.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/index.tsx
@@ -9,6 +9,7 @@ import { track } from "@/customization/utils/analytics";
 import { Panel } from "@xyflow/react";
 import { useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { useSearchParams } from "react-router-dom";
 import ApiModal from "../../../modals/apiModal";
 import ShareModal from "../../../modals/shareModal";
 import useFlowStore from "../../../stores/flowStore";
@@ -17,11 +18,9 @@ import { useStoreStore } from "../../../stores/storeStore";
 import { classNames, cn, isThereModal } from "../../../utils/utils";
 import ForwardedIconComponent from "../../common/genericIconComponent";
 import FlowToolbarOptions from "./components/flow-toolbar-options";
-import { useSearchParams } from "react-router-dom";
 
 export default function FlowToolbar(): JSX.Element {
   const preventDefault = true;
-  
 
   const [searchParams, setSearchParams] = useSearchParams();
   const [openCodeModal, setOpenCodeModal] = useState<boolean>(false);
@@ -30,12 +29,12 @@ export default function FlowToolbar(): JSX.Element {
     if (isThereModal() && !openCodeModal) return;
     setOpenCodeModal((oldOpen) => !oldOpen);
   }
-  
+
   const open = searchParams.get("playground") === "true";
 
-  function setOpen (isOpen: boolean) {
-    setSearchParams({playground: isOpen ? 'true':'false'})
-   }
+  function setOpen(isOpen: boolean) {
+    setSearchParams({ playground: isOpen ? "true" : "false" });
+  }
 
   function handleChatWShortcut(e: KeyboardEvent) {
     if (isThereModal() && !open) return;

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -33,8 +33,11 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
     (currentFlow?.data?.nodes?.length ?? 0) > 0;
 
   const isBuilding = useFlowStore((state) => state.isBuilding);
-  const blocker = useBlocker(({currentLocation, nextLocation}) => (changesNotSaved || isBuilding) && 
-    !checkIsPlaygroundModalNavigation(currentLocation, nextLocation));
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      (changesNotSaved || isBuilding) &&
+      !checkIsPlaygroundModalNavigation(currentLocation, nextLocation),
+  );
 
   const setOnFlowPage = useFlowStore((state) => state.setOnFlowPage);
   const { id } = useParams();
@@ -86,8 +89,10 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
   };
 
   const checkIsPlaygroundModalNavigation = (currentLocation, nextLocation) => {
-    return nextLocation.search.includes('playground') && 
-          currentLocation.pathname === nextLocation.pathname;
+    return (
+      nextLocation.search.includes("playground") &&
+      currentLocation.pathname === nextLocation.pathname
+    );
   };
 
   useEffect(() => {

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -33,7 +33,8 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
     (currentFlow?.data?.nodes?.length ?? 0) > 0;
 
   const isBuilding = useFlowStore((state) => state.isBuilding);
-  const blocker = useBlocker(changesNotSaved || isBuilding);
+  const blocker = useBlocker(({currentLocation, nextLocation}) => (changesNotSaved || isBuilding) && 
+    !checkIsPlaygroundModalNavigation(currentLocation, nextLocation));
 
   const setOnFlowPage = useFlowStore((state) => state.setOnFlowPage);
   const { id } = useParams();
@@ -82,6 +83,11 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
     } else {
       navigate("/all");
     }
+  };
+
+  const checkIsPlaygroundModalNavigation = (currentLocation, nextLocation) => {
+    return nextLocation.search.includes('playground') && 
+          currentLocation.pathname === nextLocation.pathname;
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Description

This PR adds URL parameters to the Playground modal, allowing users to directly open and share the Playground state via URLs. Previously, the Playground state was only managed internally, which made sharing specific states or opening directly to a state impossible.

### Changes Made
- [src/frontend/src/components/core/flowToolbarComponent/index.tsx](https://github.com/langflow-ai/langflow/compare/main...suwonthugger:langflow:feat-add-url-parameter-to-playground-modal?expand=1#diff-fa085ba4e24214d10978e8e8d929242633c9a698956b79309d546e27b0b72272)
  - Integrated React Router's useSearchParams to synchronize the Playground modal state with the URL parameter (playground=true).
  
  - Updated state management logic to toggle the modal state based on URL parameters, ensuring consistency between UI and URL. Modified keyboard shortcuts handling to respect the new URL-based modal state. Adjusted the analytics tracking to properly reflect modal state changes based on URL parameters.

- [src/frontend/src/pages/FlowPage/index.tsx](https://github.com/langflow-ai/langflow/compare/main...suwonthugger:langflow:feat-add-url-parameter-to-playground-modal?expand=1#diff-37a243d7fe9faf77fead8ea245d2884933fc5373bb9b4200371887aa989e21fe)
  - Enhanced the navigation blocking logic (useBlocker) to prevent unintended navigation away from the Playground modal when changes are unsaved or building is in progress.
  - Implemented a new function checkIsPlaygroundModalNavigation to specifically handle navigation checks related to the Playground modal, ensuring navigation is allowed when switching between modal states without leaving the page.