### PR TITLE
fix: allow float to be typed in float input

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/floatComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/floatComponent/index.tsx
@@ -23,6 +23,9 @@ export default function FloatComponent({
   const min = rangeSpec?.min ?? -2;
   const max = rangeSpec?.max ?? 2;
 
+  // Local state for input value
+  const [localValue, setLocalValue] = useState<string>(value.toString());
+
   // Clear component state
   useEffect(() => {
     if (disabled && value !== 0) {
@@ -30,20 +33,29 @@ export default function FloatComponent({
     }
   }, [disabled, handleOnNewValue]);
 
+  // Update local value when prop changes
+  useEffect(() => {
+    setLocalValue(value.toString());
+  }, [value]);
+
   const [cursor, setCursor] = useState<number | null>(null);
   const ref = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     ref.current?.setSelectionRange(cursor, cursor);
-  }, [ref, cursor, value]);
+  }, [ref, cursor, localValue]);
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setCursor(e.target.selectionStart);
-    handleOnNewValue({ value: Number(e.target.value) });
+    setLocalValue(e.target.value);
+  };
+
+  const handleBlur = () => {
+    handleOnNewValue({ value: Number(localValue) });
   };
 
   const handleNumberChange = (newValue) => {
-    handleOnNewValue({ value: Number(newValue) });
+    setLocalValue(newValue);
   };
 
   const handleInputChange = (event) => {
@@ -79,17 +91,19 @@ export default function FloatComponent({
         min={min}
         max={max}
         onChange={handleNumberChange}
-        value={value ?? ""}
+        value={localValue ?? ""}
+        onBlur={handleBlur}
       >
         <NumberInputField
           className={getInputClassName()}
           onChange={handleChangeInput}
-          onKeyDown={(event) => handleKeyDown(event, value, "")}
+          onKeyDown={(event) => handleKeyDown(event, localValue, "")}
           onInput={handleInputChange}
           disabled={disabled}
           placeholder={editNode ? "Float number" : "Type a float number"}
           data-testid={id}
           ref={inputRef}
+          onBlur={handleBlur}
         />
         <NumberInputStepper className={stepperClassName}>
           <NumberIncrementStepper className={incrementStepperClassName}>


### PR DESCRIPTION
This pull request includes updates to the `FloatComponent` in the `src/frontend/src/components/core/parameterRenderComponent/components/floatComponent/index.tsx` file to enhance the handling of input values and improve the user experience. The most important changes include adding local state management for the input value, updating the local value when the prop changes, and modifying event handlers to use the new local state.

Enhancements to input value handling:

* Added local state `localValue` to manage the input value independently of the prop value.
* Implemented an `useEffect` hook to update `localValue` whenever the prop `value` changes.

Event handler modifications:

* Updated the `handleChangeInput` function to set the `localValue` instead of calling `handleOnNewValue` directly.
* Added a `handleBlur` function to update the prop value from `localValue` when the input field loses focus.
* Modified the `value` and `onKeyDown` props of the `NumberInput` and `NumberInputField` components to use `localValue` and added the `onBlur` event handler to both components.