### PR TITLE
fix: made node toolbar not appear when selecting multiple nodes

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -259,8 +259,12 @@ function GenericNode({
     return data.node?.description && data.node?.description !== "";
   }, [data.node?.description]);
 
+  const selectedNodes = useFlowStore((state) =>
+    state.nodes.filter((node) => node.selected),
+  );
+
   const memoizedNodeToolbarComponent = useMemo(() => {
-    return selected ? (
+    return selected && selectedNodes.length === 1 ? (
       <>
         <div
           className={cn(
@@ -341,6 +345,7 @@ function GenericNode({
     editNameDescription,
     hasChangedNodeDescription,
     toggleEditNameDescription,
+    selectedNodes,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
This pull request includes changes to the `GenericNode` component in the `src/frontend/src/CustomNodes/GenericNode/index.tsx` file. The changes primarily focus on enhancing the selection logic for nodes.

The most important changes include:

Enhancements to node selection logic:

* Added a new `selectedNodes` constant that filters the nodes to include only those that are selected. (`src/frontend/src/CustomNodes/GenericNode/index.tsx`)
* Updated the `memoizedNodeToolbarComponent` to display the toolbar only when a single node is selected. (`src/frontend/src/CustomNodes/GenericNode/index.tsx`)
* Included `selectedNodes` in the dependency array for the `useEffect` hook to ensure it reacts to changes in the selected nodes. (`src/frontend/src/CustomNodes/GenericNode/index.tsx`)