### PR TITLE
fix: made plus button on file component not occupy full width

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
@@ -254,9 +254,10 @@ export default function InputFileComponent({
                         }
                         size={selectedFiles.length !== 0 ? "iconMd" : "default"}
                         className={cn(
-                          selectedFiles.length !== 0 &&
-                            "hit-area-icon absolute -top-8 right-0",
-                          "w-full font-semibold",
+                          selectedFiles.length !== 0
+                            ? "hit-area-icon absolute -top-8 right-0"
+                            : "w-full",
+                          "font-semibold",
                         )}
                         data-testid="button_open_file_management"
                       >


### PR DESCRIPTION
This pull request includes a small change to the `InputFileComponent` in the `src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx` file. The change simplifies the conditional class assignment for the `className` property of a button element. 

* [`src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx`](diffhunk://#diff-68cd26e922bccf5191323c0f9ed58160ce8528c3479e556151c1ce4d4258a6caL257-R260): Simplified the conditional class assignment for the `className` property by using a ternary operator.