### PR TITLE
fix: make dataframe output format identify and show truncation

### DIFF
--- a/src/frontend/src/components/core/dataOutputComponent/index.tsx
+++ b/src/frontend/src/components/core/dataOutputComponent/index.tsx
@@ -2,6 +2,7 @@ import TableComponent from "@/components/core/parameterRenderComponent/component
 import { ColDef, ColGroupDef } from "ag-grid-community";
 import "ag-grid-community/styles/ag-grid.css"; // Mandatory CSS required by the grid
 import "ag-grid-community/styles/ag-theme-balham.css"; // Optional Theme applied to the grid
+import { useEffect, useState } from "react";
 import { extractColumnsFromRows } from "../../../utils/utils";
 
 function DataOutputComponent({
@@ -13,12 +14,18 @@ function DataOutputComponent({
   rows: any[];
   columnMode?: "intersection" | "union";
 }) {
-  // If the rows are not an array of objects, convert them to an array of objects
-  if (rows.some((row) => typeof row !== "object")) {
-    rows = rows.map((row) => ({ data: row }));
-  }
+  const [rowsInternal, setRowsInternal] = useState(rows.slice(0, 1000));
 
-  const columns = extractColumnsFromRows(rows, columnMode);
+  useEffect(() => {
+    const rowsSliced = rows.slice(0, 1000);
+    if (rowsSliced.some((row) => typeof row !== "object")) {
+      setRowsInternal(rowsSliced.map((row) => ({ data: row })));
+    } else {
+      setRowsInternal(rowsSliced);
+    }
+  }, [rows]);
+
+  const columns = extractColumnsFromRows(rowsInternal, columnMode);
 
   const columnDefs = columns.map((col, idx) => ({
     ...col,
@@ -30,10 +37,11 @@ function DataOutputComponent({
       autoSizeStrategy={{ type: "fitGridWidth", defaultMinWidth: 100 }}
       key={"dataOutputComponent"}
       overlayNoRowsTemplate="No data available"
+      paginationInfo={rows.length > 1000 ? rows[1000] : undefined}
       suppressRowClickSelection={true}
       pagination={pagination}
       columnDefs={columnDefs}
-      rowData={rows}
+      rowData={rowsInternal}
     />
   );
 }

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/TableOptions/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/TableOptions/index.tsx
@@ -10,6 +10,7 @@ export default function TableOptions({
   deleteRow,
   hasSelection,
   stateChange,
+  paginationInfo,
   addRow,
   tableOptions,
 }: {
@@ -20,6 +21,7 @@ export default function TableOptions({
   hasSelection: boolean;
   stateChange: boolean;
   tableOptions?: TableOptionsTypeAPI;
+  paginationInfo?: string;
 }): JSX.Element {
   return (
     <div className={cn("absolute bottom-3 left-6")}>
@@ -119,6 +121,13 @@ export default function TableOptions({
             </Button>
           </ShadTooltip>
         </div>
+        {paginationInfo && (
+          <div className="ml-2 text-xs text-muted-foreground">
+            <ShadTooltip content="Pagination Info">
+              <span>{paginationInfo}</span>
+            </ShadTooltip>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
@@ -38,6 +38,7 @@ export interface TableComponentProps extends AgGridReactProps {
   onDuplicate?: () => void;
   addRow?: () => void;
   tableOptions?: TableOptionsTypeAPI;
+  paginationInfo?: string;
 }
 
 const TableComponent = forwardRef<
@@ -268,6 +269,7 @@ const TableComponent = forwardRef<
           <TableOptions
             tableOptions={props.tableOptions}
             stateChange={columnStateChange}
+            paginationInfo={props.paginationInfo}
             hasSelection={realRef.current?.api?.getSelectedRows()?.length > 0}
             duplicateRow={props.onDuplicate ? props.onDuplicate : undefined}
             deleteRow={props.onDelete ? props.onDelete : undefined}


### PR DESCRIPTION
This pull request includes several changes to the `DataOutputComponent` and `TableComponent` to improve pagination handling and update state management. The most important changes are as follows:

### State Management and Pagination:

* [`src/frontend/src/components/core/dataOutputComponent/index.tsx`](diffhunk://#diff-36efa9122816dc4e90f3d6d240c57b2e7899edb9d02ab98882dcfcff16d448bcL16-R28): Updated `DataOutputComponent` to use `useState` and `useEffect` for managing the internal state of rows, limiting the number of rows to 1000, and ensuring proper conversion of rows to objects if necessary.
* [`src/frontend/src/components/core/dataOutputComponent/index.tsx`](diffhunk://#diff-36efa9122816dc4e90f3d6d240c57b2e7899edb9d02ab98882dcfcff16d448bcR40-R44): Added `paginationInfo` prop to handle pagination information and updated the `rowData` prop to use the internal state of rows.

### Table Component Enhancements:

* [`src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/TableOptions/index.tsx`](diffhunk://#diff-fa2d379b3123e6c13c08b87e81a12cb29859ffa64575b111176e85b7f00eeb13R13): Added `paginationInfo` prop to `TableOptions` and updated the component to display pagination information if available. [[1]](diffhunk://#diff-fa2d379b3123e6c13c08b87e81a12cb29859ffa64575b111176e85b7f00eeb13R13) [[2]](diffhunk://#diff-fa2d379b3123e6c13c08b87e81a12cb29859ffa64575b111176e85b7f00eeb13R24) [[3]](diffhunk://#diff-fa2d379b3123e6c13c08b87e81a12cb29859ffa64575b111176e85b7f00eeb13R124-R130)
* [`src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx`](diffhunk://#diff-f3fcb59cd5fd40bf313028ede0595abb9ebe326e02946ecaece08678d8ea212fR41): Extended `TableComponentProps` to include the `paginationInfo` prop and passed it down to `TableOptions`. [[1]](diffhunk://#diff-f3fcb59cd5fd40bf313028ede0595abb9ebe326e02946ecaece08678d8ea212fR41) [[2]](diffhunk://#diff-f3fcb59cd5fd40bf313028ede0595abb9ebe326e02946ecaece08678d8ea212fR272)

### Import Adjustments:

* [`src/frontend/src/components/core/dataOutputComponent/index.tsx`](diffhunk://#diff-36efa9122816dc4e90f3d6d240c57b2e7899edb9d02ab98882dcfcff16d448bcR5): Added imports for `useEffect` and `useState` to manage state and side effects in `DataOutputComponent`.