### PR TITLE
fix: add memo hook to handle filter to prevent excessive renders (icons loading error)

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -259,12 +259,12 @@ function GenericNode({
     return data.node?.description && data.node?.description !== "";
   }, [data.node?.description]);
 
-  const selectedNodes = useFlowStore((state) =>
-    state.nodes.filter((node) => node.selected),
-  );
+  const selectedNodesCount = useMemo(() => {
+    return useFlowStore.getState().nodes.filter((node) => node.selected).length;
+  }, [selected]);
 
   const memoizedNodeToolbarComponent = useMemo(() => {
-    return selected && selectedNodes.length === 1 ? (
+    return selected && selectedNodesCount === 1 ? (
       <>
         <div
           className={cn(
@@ -345,7 +345,7 @@ function GenericNode({
     editNameDescription,
     hasChangedNodeDescription,
     toggleEditNameDescription,
-    selectedNodes,
+    selectedNodesCount,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
This pull request includes changes to the `src/frontend/src/CustomNodes/GenericNode/index.tsx` file to improve performance and readability by optimizing the way selected nodes are counted. The most important changes include replacing the `selectedNodes` array with a memoized count of selected nodes.

Performance and readability improvements:

* Replaced the `selectedNodes` array with a memoized `selectedNodesCount` to reduce the number of times the nodes are filtered. (`src/frontend/src/CustomNodes/GenericNode/index.tsx`)
* Updated the `memoizedNodeToolbarComponent` to use `selectedNodesCount` instead of `selectedNodes.length` for checking if exactly one node is selected. (`src/frontend/src/CustomNodes/GenericNode/index.tsx`)
* Updated the dependencies list in the `useEffect` hook to use `selectedNodesCount` instead of `selectedNodes`. (`src/frontend/src/CustomNodes/GenericNode/index.tsx`)