### PR TITLE
feat: lmprove MCP angflow port search and error handling

### DIFF
--- a/src/backend/base/langflow/base/mcp/util.py
+++ b/src/backend/base/langflow/base/mcp/util.py
@@ -3,9 +3,11 @@ import os
 from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
 from typing import Any
+from urllib.parse import urlparse
 from uuid import UUID
 
 import httpx
+from loguru import logger
 from mcp import ClientSession, StdioServerParameters, stdio_client
 from mcp.client.sse import sse_client
 from pydantic import Field, create_model
@@ -13,6 +15,8 @@ from sqlmodel import select
 
 from langflow.helpers.base_model import BaseModel
 from langflow.services.database.models import Flow
+
+HTTP_ERROR_STATUS_CODE = 400  # HTTP status code for client errors
 
 
 def create_tool_coroutine(tool_name: str, arg_schema: type[BaseModel], session) -> Callable[..., Awaitable]:
@@ -139,40 +143,110 @@ class MCPSseClient:
         self.sse = None
         self.session: ClientSession | None = None
         self.exit_stack = AsyncExitStack()
+        self.max_retries = 3
+        self.retry_delay = 1.0  # seconds
 
-    async def pre_check_redirect(self, url: str):
-        async with httpx.AsyncClient(follow_redirects=False) as client:
-            response = await client.request("HEAD", url)
-            if response.status_code == httpx.codes.TEMPORARY_REDIRECT:
-                return response.headers.get("Location")
+    async def validate_url(self, url: str | None) -> tuple[bool, str]:
+        """Validate the SSE URL before attempting connection."""
+        try:
+            parsed = urlparse(url)
+            if not parsed.scheme or not parsed.netloc:
+                return False, "Invalid URL format. Must include scheme (http/https) and host."
+
+            async with httpx.AsyncClient() as client:
+                try:
+                    # First try a HEAD request to check if server is reachable
+                    response = await client.head(url, timeout=5.0)
+                    if response.status_code >= HTTP_ERROR_STATUS_CODE:
+                        return False, f"Server returned error status: {response.status_code}"
+
+                except httpx.TimeoutException:
+                    return False, "Connection timed out. Server may be down or unreachable."
+                except httpx.NetworkError:
+                    return False, "Network error. Could not reach the server."
+                else:
+                    return True, ""
+
+        except (httpx.HTTPError, ValueError, OSError) as e:
+            return False, f"URL validation error: {e!s}"
+
+    async def pre_check_redirect(self, url: str | None) -> str | None:
+        """Check for redirects and return the final URL."""
+        if url is None:
+            return url
+        try:
+            async with httpx.AsyncClient(follow_redirects=False) as client:
+                response = await client.request("HEAD", url)
+                if response.status_code == httpx.codes.TEMPORARY_REDIRECT:
+                    return response.headers.get("Location", url)
+        except (httpx.RequestError, httpx.HTTPError) as e:
+            logger.warning(f"Error checking redirects: {e}")
         return url
 
     async def _connect_with_timeout(
-        self, url: str, headers: dict[str, str] | None, timeout_seconds: int, sse_read_timeout_seconds: int
+        self, url: str | None, headers: dict[str, str] | None, timeout_seconds: int, sse_read_timeout_seconds: int
     ):
-        sse_transport = await self.exit_stack.enter_async_context(
-            sse_client(url, headers, timeout_seconds, sse_read_timeout_seconds)
-        )
-        self.sse, self.write = sse_transport
-        self.session = await self.exit_stack.enter_async_context(ClientSession(self.sse, self.write))
-        await self.session.initialize()
+        """Attempt to connect with timeout."""
+        try:
+            if url is None:
+                return
+            sse_transport = await self.exit_stack.enter_async_context(
+                sse_client(url, headers, timeout_seconds, sse_read_timeout_seconds)
+            )
+            self.sse, self.write = sse_transport
+            self.session = await self.exit_stack.enter_async_context(ClientSession(self.sse, self.write))
+            await self.session.initialize()
+        except Exception as e:
+            msg = f"Failed to establish SSE connection: {e!s}"
+            raise ConnectionError(msg) from e
 
     async def connect_to_server(
-        self, url: str, headers: dict[str, str] | None, timeout_seconds: int = 500, sse_read_timeout_seconds: int = 500
+        self,
+        url: str | None,
+        headers: dict[str, str] | None,
+        timeout_seconds: int = 30,
+        sse_read_timeout_seconds: int = 30,
     ):
+        """Connect to server with retries and improved error handling."""
         if headers is None:
             headers = {}
+
+        # First validate the URL
+        is_valid, error_msg = await self.validate_url(url)
+        if not is_valid:
+            msg = f"Invalid SSE URL ({url}): {error_msg}"
+            raise ValueError(msg)
+
         url = await self.pre_check_redirect(url)
-        try:
-            await asyncio.wait_for(
-                self._connect_with_timeout(url, headers, timeout_seconds, sse_read_timeout_seconds),
-                timeout=timeout_seconds,
-            )
-            if self.session is None:
-                msg = "Session not initialized"
-                raise ValueError(msg)
-            response = await self.session.list_tools()
-        except asyncio.TimeoutError as err:
-            msg = f"Connection to {url} timed out after {timeout_seconds} seconds"
-            raise TimeoutError(msg) from err
-        return response.tools
+        last_error = None
+
+        for attempt in range(self.max_retries):
+            try:
+                await asyncio.wait_for(
+                    self._connect_with_timeout(url, headers, timeout_seconds, sse_read_timeout_seconds),
+                    timeout=timeout_seconds,
+                )
+
+                if self.session is None:
+                    msg = "Session not initialized"
+                    raise ValueError(msg)
+
+                response = await self.session.list_tools()
+
+            except asyncio.TimeoutError:
+                last_error = f"Connection to {url} timed out after {timeout_seconds} seconds"
+                logger.warning(f"Connection attempt {attempt + 1} failed: {last_error}")
+            except ConnectionError as err:
+                last_error = str(err)
+                logger.warning(f"Connection attempt {attempt + 1} failed: {last_error}")
+            except (ValueError, httpx.HTTPError, OSError) as err:
+                last_error = f"Connection error: {err!s}"
+                logger.warning(f"Connection attempt {attempt + 1} failed: {last_error}")
+            else:
+                return response.tools
+
+            if attempt < self.max_retries - 1:
+                await asyncio.sleep(self.retry_delay * (attempt + 1))
+
+        msg = f"Failed to connect after {self.max_retries} attempts. Last error: {last_error}"
+        raise ConnectionError(msg)

--- a/src/backend/tests/unit/api/v1/test_api_schemas.py
+++ b/src/backend/tests/unit/api/v1/test_api_schemas.py
@@ -6,6 +6,7 @@ from langflow.api.v1.schemas import ResultDataResponse, VertexBuildResponse
 from langflow.schema.schema import OutputValue
 from langflow.serialization import serialize
 from langflow.services.tracing.schema import Log
+
 from pydantic import BaseModel
 
 # Use a smaller test size for hypothesis

--- a/src/backend/tests/unit/base/tools/test_component_toolkit.py
+++ b/src/backend/tests/unit/base/tools/test_component_toolkit.py
@@ -8,6 +8,7 @@ from langflow.components.outputs.chat import ChatOutput
 from langflow.components.tools.calculator import CalculatorToolComponent
 from langflow.graph import Graph
 from langflow.schema.data import Data
+
 from pydantic import BaseModel
 
 

--- a/src/backend/tests/unit/base/tools/test_toolmodemixin.py
+++ b/src/backend/tests/unit/base/tools/test_toolmodemixin.py
@@ -21,6 +21,7 @@ from langflow.io import (
     TableInput,
 )
 from langflow.schema import Data
+
 from pydantic import BaseModel
 
 

--- a/src/backend/tests/unit/components/helpers/test_structured_output_component.py
+++ b/src/backend/tests/unit/components/helpers/test_structured_output_component.py
@@ -5,8 +5,8 @@ import pytest
 from langflow.components.helpers.structured_output import StructuredOutputComponent
 from langflow.helpers.base_model import build_model_from_schema
 from langflow.inputs.inputs import TableInput
-from pydantic import BaseModel
 
+from pydantic import BaseModel
 from tests.base import ComponentTestBaseWithoutClient
 from tests.unit.mock_language_model import MockLanguageModel
 

--- a/src/backend/tests/unit/graph/graph/state/test_state_model.py
+++ b/src/backend/tests/unit/graph/graph/state/test_state_model.py
@@ -5,6 +5,7 @@ from langflow.graph import Graph
 from langflow.graph.graph.constants import Finish
 from langflow.graph.state.model import create_state_model
 from langflow.template.field.base import UNDEFINED
+
 from pydantic import Field
 
 

--- a/src/backend/tests/unit/helpers/test_base_model_from_schema.py
+++ b/src/backend/tests/unit/helpers/test_base_model_from_schema.py
@@ -4,8 +4,9 @@ from typing import Any
 
 import pytest
 from langflow.helpers.base_model import build_model_from_schema
-from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
+
+from pydantic import BaseModel
 
 
 class TestBuildModelFromSchema:

--- a/src/backend/tests/unit/inputs/test_inputs.py
+++ b/src/backend/tests/unit/inputs/test_inputs.py
@@ -24,6 +24,7 @@ from langflow.inputs.inputs import (
 )
 from langflow.inputs.utils import instantiate_input
 from langflow.schema.message import Message
+
 from pydantic import ValidationError
 
 

--- a/src/backend/tests/unit/mock_language_model.py
+++ b/src/backend/tests/unit/mock_language_model.py
@@ -1,8 +1,9 @@
 from unittest.mock import MagicMock
 
 from langchain_core.language_models import BaseLanguageModel
-from pydantic import BaseModel, Field
 from typing_extensions import override
+
+from pydantic import BaseModel, Field
 
 
 class MockLanguageModel(BaseLanguageModel, BaseModel):

--- a/src/backend/tests/unit/serialization/test_serialization.py
+++ b/src/backend/tests/unit/serialization/test_serialization.py
@@ -9,6 +9,7 @@ from hypothesis import strategies as st
 from langchain_core.documents import Document
 from langflow.serialization.constants import MAX_ITEMS_LENGTH, MAX_TEXT_LENGTH
 from langflow.serialization.serialization import serialize, serialize_or_str
+
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic.v1 import BaseModel as PydanticV1BaseModel
 

--- a/src/backend/tests/unit/test_schema.py
+++ b/src/backend/tests/unit/test_schema.py
@@ -9,6 +9,7 @@ from langflow.schema.data import Data
 from langflow.template import Input, Output
 from langflow.template.field.base import UNDEFINED
 from langflow.type_extraction.type_extraction import post_process_type
+
 from pydantic import BaseModel, Field, ValidationError
 
 

--- a/src/backend/tests/unit/test_template.py
+++ b/src/backend/tests/unit/test_template.py
@@ -2,6 +2,7 @@ import importlib
 
 import pytest
 from langflow.utils.util import build_template_from_function, get_base_classes, get_default_factory
+
 from pydantic import BaseModel
 
 


### PR DESCRIPTION
This pull request includes several changes to enhance error handling, improve URL validation, and add retry mechanisms for server connections. Additionally, it includes minor import adjustments across multiple test files.

Improvements to error handling and URL validation:

* [`src/backend/base/langflow/base/mcp/util.py`](diffhunk://#diff-37c079efebed1e9da327c409abb8b1b6ec68d70c6a2a98885f0e1a11c087283cR146-R252): Added URL validation and retry mechanisms for server connections, including detailed error messages and logging. [[1]](diffhunk://#diff-37c079efebed1e9da327c409abb8b1b6ec68d70c6a2a98885f0e1a11c087283cR146-R252) [[2]](diffhunk://#diff-37c079efebed1e9da327c409abb8b1b6ec68d70c6a2a98885f0e1a11c087283cR19-R20)
* [`src/backend/base/langflow/components/tools/mcp_component.py`](diffhunk://#diff-8b368b159254d9a5a8ebef207dcb28d4790e3c6fcd01325b61d67bfd078b4177R90-R118): Implemented a method to find Langflow instances by checking environment variables and common ports, and improved error handling for tool updates. [[1]](diffhunk://#diff-8b368b159254d9a5a8ebef207dcb28d4790e3c6fcd01325b61d67bfd078b4177R90-R118) [[2]](diffhunk://#diff-8b368b159254d9a5a8ebef207dcb28d4790e3c6fcd01325b61d67bfd078b4177R339-R360)

Minor import adjustments:

* Various test files: Added or adjusted import statements for `pydantic.BaseModel` and other modules to ensure consistency and avoid import errors. [[1]](diffhunk://#diff-ce8fb305757f76c8971bf191a9cd12023ad77feca0b237f6c29ca9b5bfec5ca5R9) [[2]](diffhunk://#diff-7bbd0eef6ac48ffcadb0cc8f0297d139de1322e4e2eb0f516d14ae1d22926d8dR11) [[3]](diffhunk://#diff-4bb13e8576b092869e429fedfa15488162f5a42b37f45d65f8eaf71617133f36R24) [[4]](diffhunk://#diff-8896f16f82913e7b94630df33d317f9ba7f15fbaaee95983306d53e97e02ec95L8-R9) [[5]](diffhunk://#diff-e9713db49fc3c16e99f6b878e1bf6a1dda721d924919041a30de2d8d39ce3e1bR8) [[6]](diffhunk://#diff-96ff92b710b470403be164e043232105d9e91322c5cf31420e1559a3524957dfL7-R10) [[7]](diffhunk://#diff-f7a9ec5751cf4f699a4e7ea08dfa7c67e5cb6fdb84353263c5951c18a96c28d9R27) [[8]](diffhunk://#diff-d787d779739c27e8faf20b188a502bab23c059f6bde36d792de4ca3fb3d7cdafL4-R7) [[9]](diffhunk://#diff-07ba5bd911a56b57a5bb0e7210dbe2d25ee813c663f45e343d1fe919fd694d6fR12) [[10]](diffhunk://#diff-8a50c216442c34aa342fce856e8a7bea5631335145293184a5283bfa95aa4c11R12) [[11]](diffhunk://#diff-531ba64b027e7ac774af95dcda190563a6be57eb705f80f66f992e80c3aa30e2R5)