### PR TITLE
fix: changed naming from freeze path to freeze

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -460,7 +460,7 @@ const NodeToolbarComponent = memo(
           {!hasToolMode && (
             <ToolbarButton
               icon="FreezeAll"
-              label="Freeze Path"
+              label="Freeze"
               onClick={() => {
                 takeSnapshot();
                 FreezeAllVertices({

--- a/src/frontend/tests/core/features/freeze.spec.ts
+++ b/src/frontend/tests/core/features/freeze.spec.ts
@@ -272,7 +272,7 @@ test(
       timeout: 1000,
     });
 
-    await page.getByText("Freeze", { exact: true }).click();
+    await page.getByText("Freeze", { exact: true }).first().click();
 
     await page.waitForTimeout(3000);
 

--- a/src/frontend/tests/extended/regression/generalBugs-shard-10.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-10.spec.ts
@@ -66,9 +66,7 @@ test(
 
     await page.getByText("Prompt", { exact: true }).last().click();
 
-    await page.getByTestId("more-options-modal").click();
-
-    await page.getByText("Freeze", { exact: true }).last().click();
+    await page.getByText("Freeze", { exact: true }).first().click();
 
     await page.waitForSelector(".border-ring-frozen", { timeout: 3000 });
 

--- a/src/frontend/tests/extended/regression/generalBugs-shard-10.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-10.spec.ts
@@ -66,6 +66,8 @@ test(
 
     await page.getByText("Prompt", { exact: true }).last().click();
 
+    await page.getByTestId("more-options-modal").click();
+
     await page.getByText("Freeze", { exact: true }).first().click();
 
     await page.waitForSelector(".border-ring-frozen", { timeout: 3000 });


### PR DESCRIPTION
This pull request includes a minor change to the `src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx` file. The change updates the label of a toolbar button from "Freeze Path" to "Freeze".

* [`src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx`](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL463-R463): Updated the label of the "Freeze Path" button to "Freeze".