### PR TITLE
fix: update currentflow to be fetched from Flow Store for icon to be rendered correctly

### DIFF
--- a/src/frontend/src/modals/IOModal/new-modal.tsx
+++ b/src/frontend/src/modals/IOModal/new-modal.tsx
@@ -69,8 +69,6 @@ export default function IOModal({
     : realFlowId;
   const currentFlow = useFlowStore((state) => state.currentFlow);
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const setPlaygroundPage = useFlowStore((state) => state.setPlaygroundPage);
-  setPlaygroundPage(!!playgroundPage);
 
   const { mutate: deleteSessionFunction } = useDeleteMessages();
   const [visibleSession, setvisibleSession] = useState<string | undefined>(

--- a/src/frontend/src/modals/IOModal/new-modal.tsx
+++ b/src/frontend/src/modals/IOModal/new-modal.tsx
@@ -67,7 +67,7 @@ export default function IOModal({
   const currentFlowId = playgroundPage
     ? uuidv5(`${clientId}_${realFlowId}`, uuidv5.DNS)
     : realFlowId;
-  const currentFlow = useFlowsManagerStore((state) => state.currentFlow);
+  const currentFlow = useFlowStore((state) => state.currentFlow);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const setPlaygroundPage = useFlowStore((state) => state.setPlaygroundPage);
   setPlaygroundPage(!!playgroundPage);

--- a/src/frontend/src/pages/Playground/index.tsx
+++ b/src/frontend/src/pages/Playground/index.tsx
@@ -3,17 +3,13 @@ import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import { track } from "@/customization/utils/analytics";
 import IOModal from "@/modals/IOModal/new-modal";
 import useFlowStore from "@/stores/flowStore";
-import { useStoreStore } from "@/stores/storeStore";
 import { useUtilityStore } from "@/stores/utilityStore";
 import { CookieOptions, getCookie, setCookie } from "@/utils/utils";
 import { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { v4 as uuid } from "uuid";
-import { getComponent } from "../../controllers/API";
 import useFlowsManagerStore from "../../stores/flowsManagerStore";
-import cloneFLowWithParent, {
-  getInputsAndOutputs,
-} from "../../utils/storeUtils";
+import { getInputsAndOutputs } from "../../utils/storeUtils";
 export default function PlaygroundPage() {
   const setCurrentFlow = useFlowsManagerStore((state) => state.setCurrentFlow);
   const currentSavedFlow = useFlowsManagerStore((state) => state.currentFlow);
@@ -26,6 +22,7 @@ export default function PlaygroundPage() {
 
   const currentFlowId = useFlowsManagerStore((state) => state.currentFlowId);
   const setIsLoading = useFlowsManagerStore((state) => state.setIsLoading);
+  const setPlaygroundPage = useFlowStore((state) => state.setPlaygroundPage);
 
   async function getFlowData() {
     try {
@@ -56,6 +53,7 @@ export default function PlaygroundPage() {
 
   useEffect(() => {
     if (id) track("Playground Page Loaded", { flowId: id });
+    setPlaygroundPage(true);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
This pull request includes a small yet significant change to the `IOModal` component in the `new-modal.tsx` file. The change involves updating the state management hook used to retrieve the `currentFlow` state.

* [`src/frontend/src/modals/IOModal/new-modal.tsx`](diffhunk://#diff-35a8d953d616582d1e2933848c04ac2cbda55ee7939d22620d60374f0df61815L70-R70): Replaced the `useFlowsManagerStore` hook with the `useFlowStore` hook for fetching the `currentFlow` state.