### PR TITLE
fix: Prevent API key banner from displaying when key is unavailable

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -591,7 +591,8 @@ def api_key(
 
     unmasked_api_key = asyncio.run(aapi_key())
     # Create a banner to display the API key and tell the user it won't be shown again
-    api_key_banner(unmasked_api_key)
+    if unmasked_api_key:
+        api_key_banner(unmasked_api_key)
 
 
 def show_version(*, value: bool):


### PR DESCRIPTION
Add a conditional check to display the API key banner only when a valid API key is retrieved, enhancing the user experience by avoiding unnecessary prompts.