### PR TITLE
fix: MCP SSE Model tool mode issue

### DIFF
--- a/src/backend/base/langflow/components/tools/mcp_component.py
+++ b/src/backend/base/langflow/components/tools/mcp_component.py
@@ -30,8 +30,6 @@ class MCPToolsComponent(Component):
     _tool_cache: dict = {}  # Cache for tool objects
     default_keys: list[str] = ["code", "_type", "mode", "command", "sse_url", "tool_placeholder", "tool_mode", "tool"]
 
-    sse_url: str | None = None
-
     display_name = "MCP Server"
     description = "Connect to an MCP server and expose tools."
     icon = "server"


### PR DESCRIPTION
This pull request includes a few changes to the `MCPToolsComponent` class in the `src/backend/base/langflow/components/tools/mcp_component.py` file. The most significant change is the removal of the `sse_url` attribute.

Codebase simplification:

* [`src/backend/base/langflow/components/tools/mcp_component.py`](diffhunk://#diff-8b368b159254d9a5a8ebef207dcb28d4790e3c6fcd01325b61d67bfd078b4177L33-L34): Removed the `sse_url` attribute from the `MCPToolsComponent` class.