### PR TITLE
fix: made global variables apply to fields not overwrite fields on refresh

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
@@ -41,7 +41,8 @@ export default function InputGlobalComponent({
     if (
       display_name &&
       unavailableFields &&
-      Object.keys(unavailableFields).includes(display_name)
+      Object.keys(unavailableFields).includes(display_name) &&
+      value === ""
     ) {
       return unavailableFields[display_name];
     }


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx` file. The change adds an additional condition to the `if` statement to check if the `value` is an empty string before returning `unavailableFields[display_name]`.

Change details:

* [`src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx`](diffhunk://#diff-caa2538c44f1fa4f2e83da3cb4ac7b060852e688dec0a7b6bc89cc18e2b5a58dL44-R45): Added a condition to check if `value` is an empty string in the `if` statement that verifies if `display_name` is included in `unavailableFields`.