### PR TITLE
refactor: Allow using MySQL as a database

### DIFF
--- a/src/backend/base/langflow/alembic/versions/260dbcc8b680_adds_tables.py
+++ b/src/backend/base/langflow/alembic/versions/260dbcc8b680_adds_tables.py
@@ -112,7 +112,10 @@ def upgrade() -> None:
         if "user.id" not in existing_fks_flow:
             batch_op.create_foreign_key("fk_flow_user_id", "user", ["user_id"], ["id"])
         if "ix_flow_description" not in existing_indices_flow:
-            batch_op.create_index(batch_op.f("ix_flow_description"), ["description"], unique=False)
+            if "mysql" in str(conn.engine.url):
+                batch_op.create_index(batch_op.f("ix_flow_description"), ["description"], unique=False, mysql_length=255)
+            else:
+                batch_op.create_index(batch_op.f("ix_flow_description"), ["description"], unique=False)
         if "ix_flow_name" not in existing_indices_flow:
             batch_op.create_index(batch_op.f("ix_flow_name"), ["name"], unique=False)
     with op.batch_alter_table("flow", schema=None) as batch_op:

--- a/src/backend/base/langflow/services/database/models/transactions/crud.py
+++ b/src/backend/base/langflow/services/database/models/transactions/crud.py
@@ -51,20 +51,22 @@ async def log_transaction(db: AsyncSession, transaction: TransactionBase) -> Tra
     try:
         # Get max entries setting
         max_entries = get_settings_service().settings.max_transactions_to_keep
-
-        # Delete older entries in a single transaction
+        subquery = select(TransactionTable.id).where(
+            TransactionTable.flow_id == transaction.flow_id
+        ).order_by(
+            col(TransactionTable.timestamp).desc()
+        ).limit(
+            max_entries - 1
+        ).subquery()
+        select_subquery = select(subquery.c.id)
         delete_older = delete(TransactionTable).where(
             TransactionTable.flow_id == transaction.flow_id,
-            col(TransactionTable.id).in_(
-                select(TransactionTable.id)
-                .where(TransactionTable.flow_id == transaction.flow_id)
-                .order_by(col(TransactionTable.timestamp).desc())
-                .offset(max_entries - 1)  # Keep newest max_entries-1 plus the one we're adding
-            ),
+            col(TransactionTable.id).in_(select_subquery) # Keep newest max_entries-1 plus the one we're adding
         )
 
         # Add new entry and execute delete in same transaction
         db.add(table)
+        await db.commit()
         await db.exec(delete_older)
         await db.commit()
 

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -180,14 +180,21 @@ async def clean_transactions(settings_service: SettingsService, session: AsyncSe
     """
     try:
         # Delete transactions using bulk delete
-        delete_stmt = delete(TransactionTable).where(
-            col(TransactionTable.id).in_(
-                select(TransactionTable.id)
-                .order_by(col(TransactionTable.timestamp).desc())
-                .offset(settings_service.settings.max_transactions_to_keep)
-            )
-        )
+        # delete_stmt = delete(TransactionTable).where(
+        #     col(TransactionTable.id).in_(
+        #         select(TransactionTable.id)
+        #         .order_by(col(TransactionTable.timestamp).desc())
+        #         .offset(settings_service.settings.max_transactions_to_keep)
+        #     )
+        # )
+        subquery = select(VertexBuildTable.id).order_by(
+            col(VertexBuildTable.timestamp).desc()
+        ).limit(settings_service.settings.max_vertex_builds_to_keep).subquery()
 
+        # 构建删除查询，通过 NOT IN 排除需要保留的记录
+        delete_stmt = delete(VertexBuildTable).where(
+            col(VertexBuildTable.id).in_(subquery)
+        )
         await session.exec(delete_stmt)
         await session.commit()
         logger.debug("Successfully cleaned up old transactions")
@@ -208,15 +215,17 @@ async def clean_vertex_builds(settings_service: SettingsService, session: AsyncS
         session: The database session to use for the deletion
     """
     try:
-        # Delete vertex builds using bulk delete
+        subquery = select(VertexBuildTable.id).order_by(
+            col(VertexBuildTable.timestamp).desc()
+        ).limit(settings_service.settings.max_vertex_builds_to_keep).subquery()
+
+        # 构建删除查询，通过 NOT IN 排除需要保留的记录
         delete_stmt = delete(VertexBuildTable).where(
-            col(VertexBuildTable.id).in_(
-                select(VertexBuildTable.id)
-                .order_by(col(VertexBuildTable.timestamp).desc())
-                .offset(settings_service.settings.max_vertex_builds_to_keep)
-            )
+            col(VertexBuildTable.id).in_(subquery)
         )
 
+        # 构建删除查询
+        #delete_query = VertexBuildTable.delete().where(col(VertexBuildTable.id).in_(subquery))
         await session.exec(delete_stmt)
         await session.commit()
         logger.debug("Successfully cleaned up old vertex builds")


### PR DESCRIPTION
1. if use mysql, the index description length is 255.
2. Using subquery to adapt to MySQL syntax, to avoid the error:
```This version of MySQL doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery' ```
