### PR TITLE
fix: typo in Alembic enum type declaration

### DIFF
--- a/src/backend/base/langflow/alembic/versions/f3b2d1f1002d_add_column_access_type_to_flow.py
+++ b/src/backend/base/langflow/alembic/versions/f3b2d1f1002d_add_column_access_type_to_flow.py
@@ -33,5 +33,5 @@ def downgrade() -> None:
         if migration.column_exists(table_name='flow', column_name='access_type', conn=conn):
             batch_op.drop_column('access_type')
 
-    access_type_enum = sa.EnuM('PRIVATE', 'PUBLIC', name='access_type_enum')
+    access_type_enum = sa.Enum('PRIVATE', 'PUBLIC', name='access_type_enum')
     access_type_enum.drop(conn, checkfirst=True)


### PR DESCRIPTION
This PR fixes a small typo in the Alembic migration script where sa.EnuM was mistakenly used instead of sa.Enum for the access_type_enum.
The issue did not cause a runtime error immediately, which made it harder to spot during review