### PR TITLE
fix: make sure public flow endpoint is correctly identified

### DIFF
--- a/src/frontend/src/controllers/API/helpers/constants.ts
+++ b/src/frontend/src/controllers/API/helpers/constants.ts
@@ -25,7 +25,7 @@ export const URLs = {
   SIDEBAR_CATEGORIES: `sidebar_categories`,
   ALL: `all`,
   VOICE: `voice`,
-  PUBLIC_FLOW: `/flows/public_flow`,
+  PUBLIC_FLOW: `flows/public_flow`,
 } as const;
 
 export function getURL(


### PR DESCRIPTION
This pull request includes a minor change to the `src/frontend/src/controllers/API/helpers/constants.ts` file. The change corrects the `PUBLIC_FLOW` URL by removing the leading slash.

* [`src/frontend/src/controllers/API/helpers/constants.ts`](diffhunk://#diff-de99daefacebca7e0f392df2dad151bd9c9d51078b51c7c5112c6ccda15f6b20L28-R28): Corrected the `PUBLIC_FLOW` URL by removing the leading slash.