### PR TITLE
tests: add tests for streaming calls on api/v1/run

### DIFF
--- a/src/backend/base/langflow/services/database/models/api_key/crud.py
+++ b/src/backend/base/langflow/services/database/models/api_key/crud.py
@@ -10,8 +10,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from langflow.services.database.models import User
 from langflow.services.database.models.api_key import ApiKey, ApiKeyCreate, ApiKeyRead, UnmaskedApiKeyRead
-from langflow.services.database.utils import session_getter
-from langflow.services.deps import get_db_service
+from langflow.services.deps import session_scope
 
 if TYPE_CHECKING:
     from sqlmodel.sql.expression import SelectOfScalar
@@ -68,7 +67,7 @@ async def check_key(session: AsyncSession, api_key: str) -> User | None:
 
 async def update_total_uses(api_key_id: UUID):
     """Update the total uses and last used at."""
-    async with session_getter(get_db_service()) as session:
+    async with session_scope() as session:
         new_api_key = await session.get(ApiKey, api_key_id)
         if new_api_key is None:
             msg = "API Key not found"

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -415,9 +415,9 @@ async def test_successful_run_with_input_type_text(client, simple_api_test, crea
     assert len(text_input_outputs) == 1
     # Now we check if the input_value is correct
     # We get text key twice because the output is now a Message
-    assert all(
-        output.get("results").get("text").get("text") == "value1" for output in text_input_outputs
-    ), text_input_outputs
+    assert all(output.get("results").get("text").get("text") == "value1" for output in text_input_outputs), (
+        text_input_outputs
+    )
 
 
 @pytest.mark.api_key_required
@@ -449,9 +449,9 @@ async def test_successful_run_with_input_type_chat(client: AsyncClient, simple_a
     chat_input_outputs = [output for output in outputs_dict.get("outputs") if "ChatInput" in output.get("component_id")]
     assert len(chat_input_outputs) == 1
     # Now we check if the input_value is correct
-    assert all(
-        output.get("results").get("message").get("text") == "value1" for output in chat_input_outputs
-    ), chat_input_outputs
+    assert all(output.get("results").get("message").get("text") == "value1" for output in chat_input_outputs), (
+        chat_input_outputs
+    )
 
 
 @pytest.mark.benchmark
@@ -505,9 +505,9 @@ async def test_successful_run_with_input_type_any(client, simple_api_test, creat
     all_message_or_text_dicts = [
         result_dict.get("message", result_dict.get("text")) for result_dict in all_result_dicts
     ]
-    assert all(
-        message_or_text_dict.get("text") == "value1" for message_or_text_dict in all_message_or_text_dicts
-    ), any_input_outputs
+    assert all(message_or_text_dict.get("text") == "value1" for message_or_text_dict in all_message_or_text_dicts), (
+        any_input_outputs
+    )
 
 
 async def test_invalid_flow_id(client, created_api_key):
@@ -536,12 +536,12 @@ async def _run_single_stream_test(client: AsyncClient, flow_id: str, headers: di
     final_result = None
 
     async with client.stream("POST", f"/api/v1/run/{flow_id}?stream=true", headers=headers, json=payload) as response:
-        assert (
-            response.status_code == status.HTTP_200_OK
-        ), f"Request failed with status {response.status_code}: {response.text}"
-        assert response.headers["content-type"].startswith(
-            "text/event-stream"
-        ), f"Expected event stream content type, got: {response.headers['content-type']}"
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Request failed with status {response.status_code}: {response.text}"
+        )
+        assert response.headers["content-type"].startswith("text/event-stream"), (
+            f"Expected event stream content type, got: {response.headers['content-type']}"
+        )
 
         async for line in response.aiter_lines():
             if not line or line.strip() == "":
@@ -585,12 +585,12 @@ async def _run_single_stream_test(client: AsyncClient, flow_id: str, headers: di
 
     # Verify we got at least one message or token event before end
     assert len(received_events) > 2, f"Should receive multiple events before the end event. Got: {received_events}"
-    assert any(
-        event == "add_message" for event in received_events
-    ), f"Should receive at least one add_message event. Received events: {received_events}"
-    assert any(
-        event == "token" for event in received_events
-    ), f"Should receive at least one token event. Received events: {received_events}"
+    assert any(event == "add_message" for event in received_events), (
+        f"Should receive at least one add_message event. Received events: {received_events}"
+    )
+    assert any(event == "token" for event in received_events), (
+        f"Should receive at least one token event. Received events: {received_events}"
+    )
 
     # Verify the final result structure in the end event
     assert final_result is not None, "Final result should not be None"
@@ -603,17 +603,17 @@ async def _run_single_stream_test(client: AsyncClient, flow_id: str, headers: di
     # Verify the debug outputs in final result
     assert "inputs" in outputs_dict, f"Missing 'inputs' in outputs_dict: {outputs_dict}"
     assert "outputs" in outputs_dict, f"Missing 'outputs' in outputs_dict: {outputs_dict}"
-    assert outputs_dict["inputs"] == {
-        "input_value": payload["input_value"]
-    }, f"Input value mismatch. Expected: {{'input_value': {payload['input_value']}}}, Got: {outputs_dict['inputs']}"
-    assert isinstance(
-        outputs_dict.get("outputs"), list
-    ), f"Expected outputs to be a list, got: {type(outputs_dict.get('outputs'))}"
+    assert outputs_dict["inputs"] == {"input_value": payload["input_value"]}, (
+        f"Input value mismatch. Expected: {{'input_value': {payload['input_value']}}}, Got: {outputs_dict['inputs']}"
+    )
+    assert isinstance(outputs_dict.get("outputs"), list), (
+        f"Expected outputs to be a list, got: {type(outputs_dict.get('outputs'))}"
+    )
 
     chat_input_outputs = [output for output in outputs_dict.get("outputs") if "ChatInput" in output.get("component_id")]
-    assert (
-        len(chat_input_outputs) == 1
-    ), f"Expected 1 ChatInput output, got {len(chat_input_outputs)}: {chat_input_outputs}"
+    assert len(chat_input_outputs) == 1, (
+        f"Expected 1 ChatInput output, got {len(chat_input_outputs)}: {chat_input_outputs}"
+    )
     assert all(
         output.get("results").get("message").get("text") == payload["input_value"] for output in chat_input_outputs
     ), f"Message text mismatch. Expected: {payload['input_value']}, Got: {chat_input_outputs}"

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -536,82 +536,99 @@ async def _run_single_stream_test(client: AsyncClient, flow_id: str, headers: di
     final_result = None
 
     async with client.stream("POST", f"/api/v1/run/{flow_id}?stream=true", headers=headers, json=payload) as response:
-        assert response.status_code == status.HTTP_200_OK, response.text
-        assert response.headers["content-type"].startswith("text/event-stream")
+        assert (
+            response.status_code == status.HTTP_200_OK
+        ), f"Request failed with status {response.status_code}: {response.text}"
+        assert response.headers["content-type"].startswith(
+            "text/event-stream"
+        ), f"Expected event stream content type, got: {response.headers['content-type']}"
 
         async for line in response.aiter_lines():
             if not line or line.strip() == "":
                 continue
 
-            event_data = json.loads(line)
+            try:
+                event_data = json.loads(line)
+            except json.JSONDecodeError:
+                pytest.fail(f"Failed to parse JSON from stream line: {line}")
+
             assert "event" in event_data, f"Event type missing in response line: {line}"
             event_type = event_data["event"]
             received_events.append(event_type)
 
             if event_type == "add_message":
                 message_data = event_data["data"]
-                assert "sender_name" in message_data
-                assert "sender" in message_data
-                assert "session_id" in message_data
-                assert "text" in message_data
+                assert "sender_name" in message_data, f"Missing 'sender_name' in add_message event: {message_data}"
+                assert "sender" in message_data, f"Missing 'sender' in add_message event: {message_data}"
+                assert "session_id" in message_data, f"Missing 'session_id' in add_message event: {message_data}"
+                assert "text" in message_data, f"Missing 'text' in add_message event: {message_data}"
 
             elif event_type == "token":
                 token_data = event_data["data"]
-                assert "chunk" in token_data
+                assert "chunk" in token_data, f"Missing 'chunk' in token event: {token_data}"
 
             elif event_type == "end":
                 got_end_event = True
                 final_result = event_data["data"].get("result")
-                assert final_result is not None, "End event should contain result data"
+                assert final_result is not None, "End event should contain result data but was None"
                 break  # Exit loop after end event
 
             elif event_type == "error":
-                pytest.fail(f"Received unexpected error event: {event_data['data']}")
+                pytest.fail(f"Received error event in stream: {event_data['data']}")
 
     # Assert we got the end event
-    assert got_end_event, "Stream did not receive an end event"
+    assert got_end_event, f"Stream did not receive an end event. Received events: {received_events}"
 
     # Verify event sequence
-    assert "end" in received_events, "End event missing from event sequence"
-    assert received_events[-1] == "end", "Last event should be 'end'"
+    assert "end" in received_events, f"End event missing from event sequence. Received: {received_events}"
+    assert received_events[-1] == "end", f"Last event should be 'end', but was '{received_events[-1]}'"
 
     # Verify we got at least one message or token event before end
-    assert len(received_events) > 1, "Should receive events before the end event"
+    assert len(received_events) > 2, f"Should receive multiple events before the end event. Got: {received_events}"
     assert any(
-        event in ["add_message", "token"] for event in received_events
-    ), "Should receive at least one message or token event"
+        event == "add_message" for event in received_events
+    ), f"Should receive at least one add_message event. Received events: {received_events}"
+    assert any(
+        event == "token" for event in received_events
+    ), f"Should receive at least one token event. Received events: {received_events}"
 
     # Verify the final result structure in the end event
-    assert final_result is not None
-    assert "outputs" in final_result
-    assert "session_id" in final_result
+    assert final_result is not None, "Final result should not be None"
+    assert "outputs" in final_result, f"Missing 'outputs' in final result: {final_result}"
+    assert "session_id" in final_result, f"Missing 'session_id' in final result: {final_result}"
     outputs = final_result["outputs"]
-    assert len(outputs) == 1
+    assert len(outputs) == 1, f"Expected 1 output, got {len(outputs)}: {outputs}"
     outputs_dict = outputs[0]
 
     # Verify the debug outputs in final result
-    assert "inputs" in outputs_dict
-    assert "outputs" in outputs_dict
-    assert outputs_dict["inputs"] == {"input_value": payload["input_value"]}
-    assert isinstance(outputs_dict.get("outputs"), list)
+    assert "inputs" in outputs_dict, f"Missing 'inputs' in outputs_dict: {outputs_dict}"
+    assert "outputs" in outputs_dict, f"Missing 'outputs' in outputs_dict: {outputs_dict}"
+    assert outputs_dict["inputs"] == {
+        "input_value": payload["input_value"]
+    }, f"Input value mismatch. Expected: {{'input_value': {payload['input_value']}}}, Got: {outputs_dict['inputs']}"
+    assert isinstance(
+        outputs_dict.get("outputs"), list
+    ), f"Expected outputs to be a list, got: {type(outputs_dict.get('outputs'))}"
 
     chat_input_outputs = [output for output in outputs_dict.get("outputs") if "ChatInput" in output.get("component_id")]
-    assert len(chat_input_outputs) == 1
+    assert (
+        len(chat_input_outputs) == 1
+    ), f"Expected 1 ChatInput output, got {len(chat_input_outputs)}: {chat_input_outputs}"
     assert all(
         output.get("results").get("message").get("text") == payload["input_value"] for output in chat_input_outputs
-    ), chat_input_outputs
+    ), f"Message text mismatch. Expected: {payload['input_value']}, Got: {chat_input_outputs}"
 
 
 @pytest.mark.api_key_required
 @pytest.mark.benchmark
-async def test_concurrent_stream_run_with_input_type_chat(client: AsyncClient, simple_api_test, created_api_key):
+async def test_concurrent_stream_run_with_input_type_chat(client: AsyncClient, starter_project, created_api_key):
     """Test concurrent streaming requests to the run endpoint with chat input type."""
     headers = {"x-api-key": created_api_key.api_key, "Accept": "text/event-stream", "Content-Type": "application/json"}
-    flow_id = simple_api_test["id"]
+    flow_id = starter_project["id"]
     payload = {
         "input_type": "chat",
         "output_type": "debug",
-        "input_value": "test concurrent streaming message",
+        "input_value": "How are you?",
     }
     num_concurrent_requests = 5  # Number of concurrent requests to test
 


### PR DESCRIPTION
Add tests for concurrent requests with chat input type with `stream=True`.