### PR TITLE
docs: fix localhost address for NIM docs

### DIFF
--- a/docs/docs/Integrations/Nvidia/integrations-nvidia-nim-wsl2.md
+++ b/docs/docs/Integrations/Nvidia/integrations-nvidia-nim-wsl2.md
@@ -24,7 +24,7 @@ To connect the NIM you've deployed with Langflow, add the **NVIDIA** model compo
 
 1. Create a [basic prompting flow](/get-started-quickstart).
 2. Replace the **OpenAI** model component with the **NVIDIA** component.
-3. In the **NVIDIA** component's **Base URL** field, add the URL where your NIM is accessible. If you followed your model's [deployment instructions](https://build.nvidia.com/nv-mistralai/mistral-nemo-12b-instruct/deploy?environment=wsl2.md), the value is `http://0.0.0.0:8000/v1`.
+3. In the **NVIDIA** component's **Base URL** field, add the URL where your NIM is accessible. If you followed your model's [deployment instructions](https://build.nvidia.com/nv-mistralai/mistral-nemo-12b-instruct/deploy?environment=wsl2.md), the value is `http://localhost:8000/v1`.
 4. In the **NVIDIA** component's **NVIDIA API Key** field, add your NVIDIA API Key.
 5. Select your model from the **Model Name** dropdown.
 6. Open the **Playground** and chat with your **NIM** model.


### PR DESCRIPTION
https://superuser.com/questions/949428/whats-the-difference-between-127-0-0-1-and-0-0-0-0

It works locally in the WSL2 environment due to implicit redirection, but from windows host -> WSL2 it needs `localhost` or the `WSL2` address. 