### PR TITLE
fix: removed handle from sortableinput and connectinput

### DIFF
--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -655,6 +655,8 @@ export const LANGFLOW_SUPPORTED_TYPES = new Set([
   "link",
   "slider",
   "tab",
+  "sortableList",
+  "connect",
 ]);
 
 export const FLEX_VIEW_TYPES = ["bool"];


### PR DESCRIPTION
This pull request includes an update to the `LANGFLOW_SUPPORTED_TYPES` constant in the `src/frontend/src/constants/constants.ts` file. The change adds new supported types to the set.

* [`src/frontend/src/constants/constants.ts`](diffhunk://#diff-3a3810648efc852f35a3780d6fe4ec65734c218f2281a175d9347a65db3fd360R658-R659): Added "sortableList" and "connect" to the `LANGFLOW_SUPPORTED_TYPES` set.