### PR TITLE
fix: add correct amber colors and button design

### DIFF
--- a/src/frontend/src/components/ui/button.tsx
+++ b/src/frontend/src/components/ui/button.tsx
@@ -14,7 +14,8 @@ const buttonVariants = cva(
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
           "border border-input hover:bg-input hover:text-accent-foreground ",
-        outlineAmber: "border border-accent-amber-foreground",
+        outlineAmber:
+          "border border-accent-amber-foreground hover:bg-accent-amber",
         primary:
           "border bg-background text-secondary-foreground hover:bg-muted hover:shadow-sm",
         warning:

--- a/src/frontend/src/components/ui/button.tsx
+++ b/src/frontend/src/components/ui/button.tsx
@@ -14,8 +14,7 @@ const buttonVariants = cva(
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
           "border border-input hover:bg-input hover:text-accent-foreground ",
-        outlineAmber:
-          "border border-accent-amber-foreground hover:border-accent-amber",
+        outlineAmber: "border border-accent-amber-foreground",
         primary:
           "border bg-background text-secondary-foreground hover:bg-muted hover:shadow-sm",
         warning:

--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx
@@ -457,7 +457,7 @@ export function VoiceAssistant({
                     variant={"outlineAmber"}
                     size={"icon"}
                     data-testid="voice-assistant-settings-icon-without-openai"
-                    className="group h-8 w-8 hover:bg-accent-amber"
+                    className="h-8 w-8"
                   >
                     <IconComponent
                       name="Key"

--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx
@@ -457,14 +457,12 @@ export function VoiceAssistant({
                     variant={"outlineAmber"}
                     size={"icon"}
                     data-testid="voice-assistant-settings-icon-without-openai"
-                    className="group h-8 w-8"
+                    className="group h-8 w-8 hover:bg-accent-amber"
                   >
                     <IconComponent
-                      name="Settings"
+                      name="Key"
                       strokeWidth={ICON_STROKE_WIDTH}
-                      className={cn(
-                        "h-4 w-4 text-accent-amber-foreground group-hover:text-accent-amber",
-                      )}
+                      className={cn("h-4 w-4 text-accent-amber-foreground")}
                     />
                   </Button>
                 </>

--- a/src/frontend/src/style/index.css
+++ b/src/frontend/src/style/index.css
@@ -191,7 +191,7 @@
 
     --zinc-foreground: 240 5.9% 90%;
 
-    --accent-amber: 21.7 77.8% 26.5%;
+    --accent-amber: 48, 96%, 89%;
     --accent-amber-foreground: 26 90.5% 37.1%;
     --red-foreground: 0 90.6% 70.8%;
   }
@@ -447,7 +447,7 @@
 
     --zinc-foreground: 240 5.2% 33.9%;
 
-    --accent-amber: 48 96.5% 88.8%;
+    --accent-amber: 22, 78%, 26%;
     --accent-amber-foreground: 45.9 96.7% 64.5%;
     --red-foreground: 0 72.2% 50.6%;
   }


### PR DESCRIPTION
This pull request includes changes to the styling and behavior of the `outlineAmber` button variant and updates to the `accent-amber` color values in the CSS. The most important changes include modifying the `outlineAmber` button variant, updating the hover behavior of the voice assistant settings icon, and adjusting the `accent-amber` color values in the CSS.

Styling changes:

* [`src/frontend/src/components/ui/button.tsx`](diffhunk://#diff-563c249a9783eb98b2bf8f32f082aee8a2746e243b2bb7d59974f4455c0a2121L17-R17): Modified the `outlineAmber` button variant to remove the hover border effect.

Behavioral changes:

* [`src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx`](diffhunk://#diff-fa0c14eb69379a58b00c257854ca8efb8b00fd1355beda2e3c7433ff014d337fL460-R465): Updated the hover behavior of the voice assistant settings icon and changed the icon from "Settings" to "Key".

Color adjustments:

* [`src/frontend/src/style/index.css`](diffhunk://#diff-90e2b07b21bd53ac0fe04b56353e8b37e8ba1f3034f51e66306a1ff010ab4437L194-R194): Adjusted the `accent-amber` color values to ensure consistency across the application. [[1]](diffhunk://#diff-90e2b07b21bd53ac0fe04b56353e8b37e8ba1f3034f51e66306a1ff010ab4437L194-R194) [[2]](diffhunk://#diff-90e2b07b21bd53ac0fe04b56353e8b37e8ba1f3034f51e66306a1ff010ab4437L450-R450)