### PR TITLE
fix: move home assistants to bundle

### DIFF
--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -596,6 +596,7 @@ export const SIDEBAR_BUNDLES = [
   { display_name: "Mem0", name: "mem0", icon: "Mem0" },
   { display_name: "Youtube", name: "youtube", icon: "YouTube" },
   { display_name: "ScrapeGraph AI", name: "scrapegraph", icon: "ScrapeGraph" },
+  { display_name: "Home Assistant", name: "homeassistant", icon: "HomeAssistant" },
 ];
 
 export const categoryIcons = {

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -596,7 +596,11 @@ export const SIDEBAR_BUNDLES = [
   { display_name: "Mem0", name: "mem0", icon: "Mem0" },
   { display_name: "Youtube", name: "youtube", icon: "YouTube" },
   { display_name: "ScrapeGraph AI", name: "scrapegraph", icon: "ScrapeGraph" },
-  { display_name: "Home Assistant", name: "homeassistant", icon: "HomeAssistant" },
+  {
+    display_name: "Home Assistant",
+    name: "homeassistant",
+    icon: "HomeAssistant",
+  },
 ];
 
 export const categoryIcons = {


### PR DESCRIPTION
Moves the home assistants components to a bundle

<img width="292" alt="Screenshot 2025-04-03 at 12 39 19 PM" src="https://github.com/user-attachments/assets/8e1116fe-9589-4dd8-abec-e7c52445228e" />
