### PR TITLE
chore: bump langflow and langflow-base for 1.3.2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "langflow"
-version = "1.3.1"
+version = "1.3.2"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.14"
 license = "MIT"
@@ -19,7 +19,7 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
-    "langflow-base==0.3.1",
+    "langflow-base==0.3.2",
     "beautifulsoup4==4.12.3",
     "google-search-results>=2.4.1,<3.0.0",
     "google-api-python-client==2.154.0",

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-base"
-version = "0.3.1"
+version = "0.3.2"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.14"
 license = "MIT"

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langflow",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langflow",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@chakra-ui/number-input": "^2.1.2",
         "@headlessui/react": "^2.0.4",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langflow",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "dependencies": {
     "@chakra-ui/number-input": "^2.1.2",

--- a/uv.lock
+++ b/uv.lock
@@ -4517,7 +4517,7 @@ wheels = [
 
 [[package]]
 name = "langflow"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "ag2" },
@@ -4875,7 +4875,7 @@ dev = [
 
 [[package]]
 name = "langflow-base"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "src/backend/base" }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
This pull request includes version updates for the `langflow` project and its dependencies. The most important changes involve updating the version numbers in several configuration files to ensure consistency across the project.

Version updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L4-R4): Updated the project version from `1.3.1` to `1.3.2` and the `langflow-base` dependency from `0.3.1` to `0.3.2`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L4-R4) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L22-R22)
* [`src/backend/base/pyproject.toml`](diffhunk://#diff-791e429538b782db78051d7dc01bf66022b585810db3f20b644e26ce5d1cce48L3-R3): Updated the `langflow-base` project version from `0.3.1` to `0.3.2`.
* [`src/frontend/package-lock.json`](diffhunk://#diff-9eaa8c31e85b60ae25c139f2d6363cc9dcb6926125b5bf1d0cac092547e8cfcbL3-R9): Updated the project version from `1.3.1` to `1.3.2`.
* [`src/frontend/package.json`](diffhunk://#diff-12ee508ecc1901fe1a1d71ed459dba8454f3160983ee18b2c51b76ade45235d3L3-R3): Updated the project version from `1.3.1` to `1.3.2`.