### PR TITLE
fix: update NestedDictInput value type to remove unnecessary Data option

### DIFF
--- a/src/backend/base/langflow/inputs/inputs.py
+++ b/src/backend/base/langflow/inputs/inputs.py
@@ -426,7 +426,7 @@ class NestedDictInput(
     """
 
     field_type: SerializableFieldTypes = FieldTypes.NESTED_DICT
-    value: dict | Data | None = {}
+    value: dict | None = {}
 
 
 class DictInput(BaseInputMixin, ListableInputMixin, InputTraceMixin, ToolModeMixin):


### PR DESCRIPTION
This pull request includes a small change to the `NestedDictInput` class in the `src/backend/base/langflow/inputs/inputs.py` file. The change modifies the type annotation for the `value` attribute to remove the `Data` type and default it to an empty dictionary.

* [`src/backend/base/langflow/inputs/inputs.py`](diffhunk://#diff-f12c9ca218a67d203869442cb70537349ad1f026a3c20c88c8f1e15ae71bdbc8L429-R429): Modified the `value` attribute type annotation in the `NestedDictInput` class to `dict | None` and set its default to an empty dictionary.