### PR TITLE
fix: publish button not redirecting to right path

### DIFF
--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
@@ -19,9 +19,11 @@ import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import useFlowStore from "@/stores/flowStore";
 import { cn } from "@/utils/utils";
 import { useState } from "react";
+import { useHref } from "react-router-dom";
 
 export default function PublishDropdown() {
-  const domain = window.location.origin;
+  const location = useHref("/");
+  const domain = window.location.origin + location;
   const [openEmbedModal, setOpenEmbedModal] = useState(false);
   const currentFlow = useFlowsManagerStore((state) => state.currentFlow);
   const flowId = currentFlow?.id;

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
@@ -137,7 +137,7 @@ export default function PublishDropdown() {
               hasIO
                 ? isPublished
                   ? encodeURI(`${domain}/playground/${flowId}`)
-                  : "Active to share a public version of this Playground"
+                  : "Activate to share a public version of this Playground"
                 : "Add a Chat Input or Chat Output to access your flow"
             }
           >

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
 import { usePatchUpdateFlow } from "@/controllers/API/queries/flows/use-patch-update-flow";
+import { CustomLink } from "@/customization/components/custom-link";
 import { ENABLE_WIDGET } from "@/customization/feature-flags";
 import ApiModal from "@/modals/apiModal/new-api-modal";
 import EmbedModal from "@/modals/EmbedModal/embed-modal";
@@ -145,25 +146,30 @@ export default function PublishDropdown() {
               )}
               data-testid="shareable-playground"
             >
-              <DropdownMenuItem
-                disabled={!hasIO || !isPublished}
-                className="deploy-dropdown-item group flex-1"
-                onClick={() => {
-                  if (hasIO) {
-                    if (isPublished) {
-                      window.open(`${domain}/playground/${flowId}`, "_blank");
-                    }
-                  }
-                }}
+              <CustomLink
+                className={cn(
+                  "flex-1",
+                  !hasIO || !isPublished
+                    ? "pointer-events-none cursor-default"
+                    : "",
+                )}
+                to={`/playground/${flowId}`}
+                target="_blank"
               >
-                <div className="group-hover:bg-accent">
-                  <IconComponent
-                    name="Globe"
-                    className={`${groupStyle} icon-size mr-2`}
-                  />
-                  <span>Shareable Playground</span>
-                </div>
-              </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={!hasIO || !isPublished}
+                  className="deploy-dropdown-item group flex-1"
+                  onClick={() => {}}
+                >
+                  <div className="group-hover:bg-accent">
+                    <IconComponent
+                      name="Globe"
+                      className={`${groupStyle} icon-size mr-2`}
+                    />
+                    <span>Shareable Playground</span>
+                  </div>
+                </DropdownMenuItem>
+              </CustomLink>
               <div className={`z-50 mr-2 text-foreground`}>
                 <Switch
                   data-testid="publish-switch"


### PR DESCRIPTION
This pull request includes several changes to the `deploy-dropdown.tsx` file to enhance the functionality and maintainability of the PublishDropdown component. The most important changes include the addition of a `CustomLink` component and the use of `useHref` from `react-router-dom` to construct URLs dynamically.

Enhancements to the PublishDropdown component:

* [`src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx`](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489R150-R164): Added the `CustomLink` component to replace the previous `window.open` method for opening the playground link in a new tab. This improves the readability and maintainability of the code. [[1]](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489R150-R164) [[2]](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489R174)
* [`src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx`](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489R12): Imported `CustomLink` from `@/customization/components/custom-link` to support the new link functionality.

Dynamic URL construction:

* [`src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx`](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489R22-R26): Added `useHref` from `react-router-dom` to dynamically construct the domain URL, ensuring it adapts to different environments.