### PR TITLE
fix: removed file uploaded successfully message when no file is picked, fixed nvidia ingest message

### DIFF
--- a/src/backend/base/langflow/components/nvidia/nvidia_ingest.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia_ingest.py
@@ -24,7 +24,7 @@ class NvidiaIngestComponent(Component):
             "NVIDIA Ingest dependencies missing. "
             "Please install them using your package manager. (e.g. uv pip install langflow[nv-ingest])"
         )
-        file_types = [msg]
+        file_types = []
         supported_file_types_info = msg
 
     inputs = [

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -1066,3 +1066,4 @@ export const OPENAI_VOICES = [
 
 export const DEFAULT_POLLING_INTERVAL = 5000;
 export const DEFAULT_TIMEOUT = 30000;
+export const DEFAULT_FILE_PICKER_TIMEOUT = 60000;

--- a/src/frontend/src/helpers/create-file-upload.ts
+++ b/src/frontend/src/helpers/create-file-upload.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_FILE_PICKER_TIMEOUT } from "@/constants/constants";
+
 export function createFileUpload(props?: {
   accept?: string;
   multiple?: boolean;
@@ -64,6 +66,6 @@ export function createFileUpload(props?: {
         cleanup();
         resolve([]);
       }
-    }, 30000);
+    }, DEFAULT_FILE_PICKER_TIMEOUT);
   });
 }

--- a/src/frontend/src/modals/fileManagerModal/components/dragFilesComponent/index.tsx
+++ b/src/frontend/src/modals/fileManagerModal/components/dragFilesComponent/index.tsx
@@ -53,10 +53,12 @@ export default function DragFilesComponent({
         const filesIds = await uploadFile({
           files: droppedFiles,
         });
-        onUpload(filesIds);
-        setSuccessData({
-          title: `File${filesIds.length > 1 ? "s" : ""} uploaded successfully`,
-        });
+        if (filesIds.length > 0) {
+          onUpload(filesIds);
+          setSuccessData({
+            title: `File${filesIds.length > 1 ? "s" : ""} uploaded successfully`,
+          });
+        }
       } catch (error: any) {
         setErrorData({
           title: "Error uploading file",
@@ -69,10 +71,12 @@ export default function DragFilesComponent({
   const handleClick = async () => {
     try {
       const filesIds = await uploadFile({});
-      onUpload(filesIds);
-      setSuccessData({
-        title: `File${filesIds.length > 1 ? "s" : ""} uploaded successfully`,
-      });
+      if (filesIds.length > 0) {
+        onUpload(filesIds);
+        setSuccessData({
+          title: `File${filesIds.length > 1 ? "s" : ""} uploaded successfully`,
+        });
+      }
     } catch (error: any) {
       setErrorData({
         title: "Error uploading file",


### PR DESCRIPTION
This pull request includes changes to both the backend and frontend components to improve functionality and user experience. The most important changes include modifying file handling and upload mechanisms, as well as updating constants for better configuration.

Backend changes:

* [`src/backend/base/langflow/components/nvidia/nvidia_ingest.py`](diffhunk://#diff-e2345c6cd9d86c7275148ba76f6c8c94e8955f48453af3aaa3409a51347571adL27-R27): Removed the assignment of `msg` to `file_types`, leaving `file_types` as an empty list.

Frontend changes:

* [`src/frontend/src/constants/constants.ts`](diffhunk://#diff-3a3810648efc852f35a3780d6fe4ec65734c218f2281a175d9347a65db3fd360R1069): Added a new constant `DEFAULT_FILE_PICKER_TIMEOUT` set to 60000.
* [`src/frontend/src/helpers/create-file-upload.ts`](diffhunk://#diff-c511a429fb4ac6cfab2241a362fca3a40c6755a83c4c1297e8bfde6deaaae519R1-R2): Imported `DEFAULT_FILE_PICKER_TIMEOUT` and replaced the hardcoded timeout value with this constant in the `createFileUpload` function. [[1]](diffhunk://#diff-c511a429fb4ac6cfab2241a362fca3a40c6755a83c4c1297e8bfde6deaaae519R1-R2) [[2]](diffhunk://#diff-c511a429fb4ac6cfab2241a362fca3a40c6755a83c4c1297e8bfde6deaaae519L67-R69)
* [`src/frontend/src/modals/fileManagerModal/components/dragFilesComponent/index.tsx`](diffhunk://#diff-f2cb30bb7a9794fd5c9da30b1fd637168152166b3c02de8f4677cd6cfeb0e7d5R56-R61): Added checks to ensure `onUpload` and `setSuccessData` are only called if `filesIds` is not empty. [[1]](diffhunk://#diff-f2cb30bb7a9794fd5c9da30b1fd637168152166b3c02de8f4677cd6cfeb0e7d5R56-R61) [[2]](diffhunk://#diff-f2cb30bb7a9794fd5c9da30b1fd637168152166b3c02de8f4677cd6cfeb0e7d5R74-R79)