### PR TITLE
Fix: Prevent Error Popups When Session Expires During Logout

### DIFF
--- a/src/frontend/src/controllers/API/queries/flows/use-get-refresh-flows-query.ts
+++ b/src/frontend/src/controllers/API/queries/flows/use-get-refresh-flows-query.ts
@@ -9,6 +9,7 @@ import {
   processFlows,
 } from "@/utils/reactflowUtils";
 import { UseQueryOptions } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
@@ -74,9 +75,11 @@ export const useGetRefreshFlowsQuery: useQueryFunctionType<
 
       return [];
     } catch (e) {
-      setErrorData({
-        title: "Could not load flows from database",
-      });
+      if (e instanceof AxiosError && e.status !== 403) {
+        setErrorData({
+          title: "Could not load flows from database",
+        });
+      }
       throw e;
     }
   };

--- a/src/frontend/src/controllers/API/queries/flows/use-get-refresh-flows.ts
+++ b/src/frontend/src/controllers/API/queries/flows/use-get-refresh-flows.ts
@@ -9,6 +9,7 @@ import {
   processFlows,
 } from "@/utils/reactflowUtils";
 import { UseMutationOptions } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
@@ -77,9 +78,11 @@ export const useGetRefreshFlows: useMutationFunctionType<
 
       return [];
     } catch (e) {
-      setErrorData({
-        title: "Could not load flows from database",
-      });
+      if (e instanceof AxiosError && e.status !== 403) {
+        setErrorData({
+          title: "Could not load flows from database",
+        });
+      }
       throw e;
     }
   };


### PR DESCRIPTION
This pull request includes updates to error handling in two query functions within the `src/frontend/src/controllers/API/queries/flows` directory. The primary changes involve importing `AxiosError` and adding conditional checks for this error type in the catch blocks.

Error handling improvements:

* [`src/frontend/src/controllers/API/queries/flows/use-get-refresh-flows-query.ts`](diffhunk://#diff-c70b5e2e0695512c8ec4c67ea960b49e6a4be89aa8af4f2ac81563b6990fa750R12): Imported `AxiosError` from `axios` and added a conditional check for `AxiosError` with a status other than 403 in the `useGetRefreshFlowsQuery` function. [[1]](diffhunk://#diff-c70b5e2e0695512c8ec4c67ea960b49e6a4be89aa8af4f2ac81563b6990fa750R12) [[2]](diffhunk://#diff-c70b5e2e0695512c8ec4c67ea960b49e6a4be89aa8af4f2ac81563b6990fa750R78-R82)
* [`src/frontend/src/controllers/API/queries/flows/use-get-refresh-flows.ts`](diffhunk://#diff-e4eadf0fc02e7ec7d4de85bd3d05deac7d05d931c169c9e3238c6fa48a6472a3R12): Imported `AxiosError` from `axios` and added a conditional check for `AxiosError` with a status other than 403 in the `useGetRefreshFlows` function. [[1]](diffhunk://#diff-e4eadf0fc02e7ec7d4de85bd3d05deac7d05d931c169c9e3238c6fa48a6472a3R12) [[2]](diffhunk://#diff-e4eadf0fc02e7ec7d4de85bd3d05deac7d05d931c169c9e3238c6fa48a6472a3R81-R85)

![image](https://github.com/user-attachments/assets/abcb348d-40b2-407d-82ac-45714493ff3e)
