### PR TITLE
fix: add conditional authorization header for dslf in curl commands

### DIFF
--- a/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
@@ -1,3 +1,4 @@
+import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
 import useFlowStore from "@/stores/flowStore";
 import { GetCodeType } from "@/types/tweaks";
 
@@ -62,8 +63,12 @@ export function getCurlWebhookCode({
 
   return `curl -X POST \\
   "${baseUrl}" \\
-  -H 'Content-Type: application/json'\\${
-    !isAuth ? `\n  -H 'x-api-key: <your api key>'\\` : ""
+  -H 'Content-Type: application/json' \\${
+    !isAuth ? `\n  -H 'x-api-key: <your api key>' \\` : ""
+  }${
+    ENABLE_DATASTAX_LANGFLOW
+      ? `\n  -H 'Authorization: Bearer <YOUR_APPLICATION_TOKEN>' \\`
+      : ""
   }
   -d '{"any": "data"}'
   `.trim();

--- a/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
@@ -64,7 +64,7 @@ export function getCurlWebhookCode({
   return `curl -X POST \\
   "${baseUrl}" \\
   -H 'Content-Type: application/json' \\${
-    !isAuth ? `\n  -H 'x-api-key: <your api key>' \\` : ""
+    isAuth ? `\n  -H 'x-api-key: <your api key>' \\` : ""
   }${
     ENABLE_DATASTAX_LANGFLOW
       ? `\n  -H 'Authorization: Bearer <YOUR_APPLICATION_TOKEN>' \\`


### PR DESCRIPTION
This pull request includes changes to the `src/frontend/src/modals/apiModal/utils/get-curl-code.tsx` file to add a new feature flag for Datastax Langflow. The most important changes include importing the new feature flag and conditionally adding an authorization header to the curl command based on this flag.

Feature flag implementation:

* [`src/frontend/src/modals/apiModal/utils/get-curl-code.tsx`](diffhunk://#diff-8189eec096566608e569bd4a44fa4aaa7a17a2b048682b9388f52bfedddedf51R1): Imported the `ENABLE_DATASTAX_LANGFLOW` feature flag.
* [`src/frontend/src/modals/apiModal/utils/get-curl-code.tsx`](diffhunk://#diff-8189eec096566608e569bd4a44fa4aaa7a17a2b048682b9388f52bfedddedf51R68-R71): Updated the `getCurlWebhookCode` function to conditionally include an authorization header if the `ENABLE_DATASTAX_LANGFLOW` feature flag is enabled.