### PR TITLE
feat: Display flow logs timestamps in local time zone

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -59,6 +59,7 @@
         "lucide-react": "^0.469.0",
         "million": "^3.1.11",
         "moment": "^2.30.1",
+        "moment-timezone": "^0.5.48",
         "openseadragon": "^4.1.1",
         "p-debounce": "^4.0.0",
         "pako": "^2.1.0",
@@ -11757,6 +11758,17 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
       "engines": {
         "node": "*"
       }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -54,6 +54,7 @@
     "lucide-react": "^0.469.0",
     "million": "^3.1.11",
     "moment": "^2.30.1",
+    "moment-timezone": "^0.5.48",
     "openseadragon": "^4.1.1",
     "p-debounce": "^4.0.0",
     "pako": "^2.1.0",

--- a/src/frontend/src/modals/flowLogsModal/index.tsx
+++ b/src/frontend/src/modals/flowLogsModal/index.tsx
@@ -4,6 +4,7 @@ import TableComponent from "@/components/core/parameterRenderComponent/component
 import { useGetTransactionsQuery } from "@/controllers/API/queries/transactions";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { FlowSettingsPropsType } from "@/types/components";
+import { convertUTCToLocalTimezone } from "@/utils/utils";
 import { ColDef, ColGroupDef } from "ag-grid-community";
 import { useCallback, useEffect, useState } from "react";
 import BaseModal from "../baseModal";
@@ -31,6 +32,13 @@ export default function FlowLogsModal({
   useEffect(() => {
     if (data) {
       const { columns, rows } = data;
+
+      if (data?.rows?.length > 0) {
+        data.rows.map((row: any) => {
+          row.timestamp = convertUTCToLocalTimezone(row.timestamp);
+        });
+      }
+
       setColumns(columns.map((col) => ({ ...col, editable: true })));
       setRows(rows);
     }

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -4,6 +4,8 @@ import useAlertStore from "@/stores/alertStore";
 import { ColumnField, FormatterType } from "@/types/utils/functions";
 import { ColDef, ColGroupDef, ValueParserParams } from "ag-grid-community";
 import clsx, { ClassValue } from "clsx";
+import moment from "moment";
+import "moment-timezone";
 import { twMerge } from "tailwind-merge";
 import {
   DRAG_EVENTS_CUSTOM_TYPESS,
@@ -865,3 +867,8 @@ export function setCookie(
 export function testIdCase(str: string): string {
   return str.toLowerCase().replace(/\s+/g, "_");
 }
+
+export const convertUTCToLocalTimezone = (timestamp: string) => {
+  const localTimezone = moment.tz.guess();
+  return moment.utc(timestamp).tz(localTimezone).format("MM/DD/YYYY HH:mm:ss");
+};


### PR DESCRIPTION
This pull request includes several changes to the frontend package and utility functions. The most notable changes involve adding a new dependency for time zone handling and updating the flow logs modal to display timestamps in the local time zone.

### Dependency Updates:
* Added `moment-timezone` version `0.5.48` to `package.json` and `package-lock.json` to handle time zone conversions. [[1]](diffhunk://#diff-9eaa8c31e85b60ae25c139f2d6363cc9dcb6926125b5bf1d0cac092547e8cfcbR62) [[2]](diffhunk://#diff-9eaa8c31e85b60ae25c139f2d6363cc9dcb6926125b5bf1d0cac092547e8cfcbR11765-R11775) [[3]](diffhunk://#diff-12ee508ecc1901fe1a1d71ed459dba8454f3160983ee18b2c51b76ade45235d3R57)

### Utility Functions:
* Introduced a new utility function `convertUTCToLocalTimezone` in `utils.ts` to convert UTC timestamps to the local time zone. [[1]](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81R7-R8) [[2]](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81R870-R874)

### Flow Logs Modal:
* Updated the `FlowLogsModal` component to use the new `convertUTCToLocalTimezone` function, ensuring that timestamps are displayed in the local time zone. [[1]](diffhunk://#diff-148c241771f73d834f354690e291ec99be7faaa23deaed2e2328b288ea593d82R7) [[2]](diffhunk://#diff-148c241771f73d834f354690e291ec99be7faaa23deaed2e2328b288ea593d82R35-R41)

`Now it's automatically detecting the timezone and formatting the timestamps in the Logs table for a better UX.`

![image](https://github.com/user-attachments/assets/e211a683-2ae1-4631-844e-94b05345d72a)
