### PR TITLE
feat: put Shareable Playground under ENABLE_PUBLISH feature flag and removed old publish

### DIFF
--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
@@ -10,7 +10,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { usePatchUpdateFlow } from "@/controllers/API/queries/flows/use-patch-update-flow";
 import { CustomLink } from "@/customization/components/custom-link";
-import { ENABLE_WIDGET } from "@/customization/feature-flags";
+import { ENABLE_PUBLISH, ENABLE_WIDGET } from "@/customization/feature-flags";
 import ApiModal from "@/modals/apiModal/new-api-modal";
 import EmbedModal from "@/modals/EmbedModal/embed-modal";
 import useAlertStore from "@/stores/alertStore";
@@ -130,63 +130,66 @@ export default function PublishDropdown() {
               </div>
             </DropdownMenuItem>
           )}
-          <ShadTooltipComponent
-            styleClasses="truncate"
-            side="left"
-            content={
-              hasIO
-                ? isPublished
-                  ? encodeURI(`${domain}/playground/${flowId}`)
-                  : "Activate to share a public version of this Playground"
-                : "Add a Chat Input or Chat Output to access your flow"
-            }
-          >
-            <div
-              className={cn(
-                !hasIO ? "cursor-not-allowed" : "",
-                "flex items-center",
-              )}
-              data-testid="shareable-playground"
+
+          {ENABLE_PUBLISH && (
+            <ShadTooltipComponent
+              styleClasses="truncate"
+              side="left"
+              content={
+                hasIO
+                  ? isPublished
+                    ? encodeURI(`${domain}/playground/${flowId}`)
+                    : "Activate to share a public version of this Playground"
+                  : "Add a Chat Input or Chat Output to access your flow"
+              }
             >
-              <CustomLink
+              <div
                 className={cn(
-                  "flex-1",
-                  !hasIO || !isPublished
-                    ? "pointer-events-none cursor-default"
-                    : "",
+                  !hasIO ? "cursor-not-allowed" : "",
+                  "flex items-center",
                 )}
-                to={`/playground/${flowId}`}
-                target="_blank"
+                data-testid="shareable-playground"
               >
-                <DropdownMenuItem
-                  disabled={!hasIO || !isPublished}
-                  className="deploy-dropdown-item group flex-1"
-                  onClick={() => {}}
+                <CustomLink
+                  className={cn(
+                    "flex-1",
+                    !hasIO || !isPublished
+                      ? "pointer-events-none cursor-default"
+                      : "",
+                  )}
+                  to={`/playground/${flowId}`}
+                  target="_blank"
                 >
-                  <div className="group-hover:bg-accent">
-                    <IconComponent
-                      name="Globe"
-                      className={`${groupStyle} icon-size mr-2`}
-                    />
-                    <span>Shareable Playground</span>
-                  </div>
-                </DropdownMenuItem>
-              </CustomLink>
-              <div className={`z-50 mr-2 text-foreground`}>
-                <Switch
-                  data-testid="publish-switch"
-                  className="scale-[85%]"
-                  checked={isPublished}
-                  disabled={!hasIO}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    handlePublishedSwitch(isPublished);
-                  }}
-                />
+                  <DropdownMenuItem
+                    disabled={!hasIO || !isPublished}
+                    className="deploy-dropdown-item group flex-1"
+                    onClick={() => {}}
+                  >
+                    <div className="group-hover:bg-accent">
+                      <IconComponent
+                        name="Globe"
+                        className={`${groupStyle} icon-size mr-2`}
+                      />
+                      <span>Shareable Playground</span>
+                    </div>
+                  </DropdownMenuItem>
+                </CustomLink>
+                <div className={`z-50 mr-2 text-foreground`}>
+                  <Switch
+                    data-testid="publish-switch"
+                    className="scale-[85%]"
+                    checked={isPublished}
+                    disabled={!hasIO}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handlePublishedSwitch(isPublished);
+                    }}
+                  />
+                </div>
               </div>
-            </div>
-          </ShadTooltipComponent>
+            </ShadTooltipComponent>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
       <ApiModal open={openApiModal} setOpen={setOpenApiModal}>

--- a/src/frontend/src/components/core/flowToolbarComponent/components/playground-button.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/playground-button.tsx
@@ -1,7 +1,6 @@
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
 import { PLAYGROUND_BUTTON_NAME } from "@/constants/constants";
-import { ENABLE_PUBLISH } from "@/customization/feature-flags";
 import IOModal from "@/modals/IOModal/new-modal";
 
 const PlaygroundButton = ({ hasIO, open, setOpen, canvasOpen }) => {
@@ -9,7 +8,7 @@ const PlaygroundButton = ({ hasIO, open, setOpen, canvasOpen }) => {
     <ForwardedIconComponent
       name="Play"
       className="h-4 w-4 transition-all"
-      strokeWidth={ENABLE_PUBLISH ? 2 : 1.5}
+      strokeWidth={2}
     />
   );
 

--- a/src/frontend/src/components/core/flowToolbarComponent/index.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/index.tsx
@@ -1,15 +1,8 @@
 import ShadTooltip from "@/components/common/shadTooltipComponent";
-import PlaygroundButton from "@/components/core/flowToolbarComponent/components/playground-button";
-import {
-  ENABLE_API,
-  ENABLE_LANGFLOW_STORE,
-  ENABLE_PUBLISH,
-} from "@/customization/feature-flags";
 import { track } from "@/customization/utils/analytics";
 import { Panel } from "@xyflow/react";
 import { useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-import ApiModal from "../../../modals/apiModal";
 import ShareModal from "../../../modals/shareModal";
 import useFlowStore from "../../../stores/flowStore";
 import { useShortcutsStore } from "../../../stores/shortcuts";
@@ -122,66 +115,10 @@ export default function FlowToolbar(): JSX.Element {
       <Panel className="!m-2" position="top-right">
         <div
           className={cn(
-            "hover:shadow-round-btn-shadow flex items-center justify-center gap-7 rounded-md border bg-background px-1.5 shadow transition-all",
-            ENABLE_PUBLISH ? "h-11" : "",
+            "hover:shadow-round-btn-shadow flex h-11 items-center justify-center gap-7 rounded-md border bg-background px-1.5 shadow transition-all",
           )}
         >
-          {ENABLE_PUBLISH ? (
-            <FlowToolbarOptions />
-          ) : (
-            <div className="flex gap-1.5">
-              <div className="flex h-full w-full gap-1.5 rounded-sm transition-all">
-                <PlaygroundButton
-                  hasIO={hasIO}
-                  open={open}
-                  setOpen={setOpen}
-                  canvasOpen
-                />
-              </div>
-              {ENABLE_API && (
-                <>
-                  <div
-                    className="flex cursor-pointer items-center gap-2"
-                    data-testid="api_button_modal"
-                    id="api_button_modal"
-                  >
-                    {currentFlow && currentFlow.data && (
-                      <ApiModal
-                        flow={currentFlow}
-                        open={openCodeModal}
-                        setOpen={setOpenCodeModal}
-                      >
-                        <div
-                          className={classNames(
-                            "relative inline-flex h-8 w-full items-center justify-center gap-1.5 rounded px-3 py-1.5 text-sm font-semibold text-foreground transition-all duration-150 ease-in-out hover:bg-accent",
-                          )}
-                        >
-                          <ForwardedIconComponent
-                            name="Code2"
-                            className={"h-4 w-4"}
-                          />
-                          <span className="hidden md:block">API</span>
-                        </div>
-                      </ApiModal>
-                    )}
-                  </div>
-                </>
-              )}
-              {ENABLE_LANGFLOW_STORE && (
-                <div className="flex items-center gap-2">
-                  <div
-                    className={`side-bar-button ${
-                      !hasApiKey || !validApiKey || !hasStore
-                        ? "cursor-not-allowed"
-                        : "cursor-pointer"
-                    }`}
-                  >
-                    {ModalMemo}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
+          <FlowToolbarOptions />
         </div>
       </Panel>
     </>

--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/chat-message.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/chat-message.tsx
@@ -2,10 +2,7 @@ import { ProfileIcon } from "@/components/core/appHeaderComponent/components/Pro
 import { ContentBlockDisplay } from "@/components/core/chatComponents/ContentBlockDisplay";
 import { useUpdateMessage } from "@/controllers/API/queries/messages";
 import { CustomProfileIcon } from "@/customization/components/custom-profile-icon";
-import {
-  ENABLE_DATASTAX_LANGFLOW,
-  ENABLE_PUBLISH,
-} from "@/customization/feature-flags";
+import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import useFlowStore from "@/stores/flowStore";
 import { useUtilityStore } from "@/stores/utilityStore";

--- a/src/frontend/src/modals/IOModal/new-modal.tsx
+++ b/src/frontend/src/modals/IOModal/new-modal.tsx
@@ -75,8 +75,7 @@ export default function IOModal({
     currentFlowId,
   );
   const flowName = useFlowStore((state) => state.currentFlow?.name);
-  const PlaygroundTitle =
-    playgroundPage && ENABLE_PUBLISH && flowName ? flowName : "Playground";
+  const PlaygroundTitle = playgroundPage && flowName ? flowName : "Playground";
 
   useEffect(() => {
     setIOModalOpen(open);


### PR DESCRIPTION
This pull request includes changes to the `flowToolbarComponent` and related components to conditionally enable the "Publish" feature based on the `ENABLE_PUBLISH` feature flag. The most important changes involve adding the `ENABLE_PUBLISH` import, updating the `PublishDropdown` component, and modifying the `FlowToolbar` component to handle the new feature flag.

Feature flag integration:

* [`src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx`](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489L13-R13): Added `ENABLE_PUBLISH` import and modified the `PublishDropdown` component to conditionally render based on the `ENABLE_PUBLISH` flag. [[1]](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489L13-R13) [[2]](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489R133-R134) [[3]](diffhunk://#diff-ed7af519b4da90e7f9693659b6f59be8a2f47bc173e59fde2ea6c3e49b522489R192)
* [`src/frontend/src/components/core/flowToolbarComponent/index.tsx`](diffhunk://#diff-fa085ba4e24214d10978e8e8d929242633c9a698956b79309d546e27b0b72272L2-L12): Removed conditional rendering logic for the `FlowToolbar` component based on the `ENABLE_PUBLISH` flag. Simplified the component structure and removed unused imports. [[1]](diffhunk://#diff-fa085ba4e24214d10978e8e8d929242633c9a698956b79309d546e27b0b72272L2-L12) [[2]](diffhunk://#diff-fa085ba4e24214d10978e8e8d929242633c9a698956b79309d546e27b0b72272L125-L184)

Code cleanup:

* [`src/frontend/src/components/core/flowToolbarComponent/components/playground-button.tsx`](diffhunk://#diff-e9c3f79bfabbe88366d921c465b428bbf8e5f48a774067246aba7fd170b70c7bL4-R11): Removed the `ENABLE_PUBLISH` import and updated the `PlayIcon` component to always use a stroke width of 2.
* [`src/frontend/src/modals/IOModal/components/chatView/chatMessage/chat-message.tsx`](diffhunk://#diff-32094af3aa7e49cc56ea2fd2b832c2bf540ead37267d7d68792cfd533d1716d9L5-R5): Removed the `ENABLE_PUBLISH` import as it is no longer needed.
* [`src/frontend/src/modals/IOModal/new-modal.tsx`](diffhunk://#diff-35a8d953d616582d1e2933848c04ac2cbda55ee7939d22620d60374f0df61815L78-R78): Updated the `PlaygroundTitle` logic to remove the dependency on the `ENABLE_PUBLISH` flag.