### PR TITLE
bug: fix mcp_component _get_tools return always structure tools type

### DIFF
--- a/src/backend/base/langflow/components/tools/mcp_component.py
+++ b/src/backend/base/langflow/components/tools/mcp_component.py
@@ -397,6 +397,6 @@ class MCPToolsComponent(Component):
 
     async def _get_tools(self):
         """Get cached tools or update if necessary."""
-        if not self.tools:
+        if not self._tool_cache:
             return await self.update_tools()
         return list(self._tool_cache.values())

--- a/src/backend/base/langflow/components/tools/mcp_component.py
+++ b/src/backend/base/langflow/components/tools/mcp_component.py
@@ -399,4 +399,4 @@ class MCPToolsComponent(Component):
         """Get cached tools or update if necessary."""
         if not self.tools:
             return await self.update_tools()
-        return self.tools
+        return list(self._tool_cache.values())


### PR DESCRIPTION
This pull request includes a change to the `src/backend/base/langflow/components/tools/mcp_component.py` file, specifically in the `_get_tools` method. The change ensures that the method returns a list of tool cache values rather than the tools directly.

* [`src/backend/base/langflow/components/tools/mcp_component.py`](diffhunk://#diff-8b368b159254d9a5a8ebef207dcb28d4790e3c6fcd01325b61d67bfd078b4177L402-R402): Modified the `_get_tools` method to return a list of the `_tool_cache` values instead of `self.tools`.