### PR TITLE
feat: Disable inspect button for empty node outputs

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
@@ -213,6 +213,12 @@ function NodeOutputField({
     [flowPool, flowPoolId, flowPoolNode?.data, internalOutputName],
   );
 
+  const emptyOutput = useMemo(() => {
+    return Object.keys(flowPoolNode?.data?.outputs ?? {})?.every(
+      (key) => flowPoolNode?.data?.outputs[key]?.message?.length === 0,
+    );
+  }, [flowPoolNode?.data?.outputs]);
+
   const disabledOutput = useMemo(
     () => edges.some((edge) => edge.sourceHandle === scapedJSONStringfy(id)),
     [edges, id],
@@ -369,6 +375,9 @@ function NodeOutputField({
     ],
   );
 
+  const disabledInspectButton =
+    !displayOutputPreview || unknownOutput || emptyOutput;
+
   if (!showNode) return <>{Handle}</>;
 
   return (
@@ -424,7 +433,7 @@ function NodeOutputField({
           <ShadTooltip
             content={
               displayOutputPreview
-                ? unknownOutput
+                ? unknownOutput || emptyOutput
                   ? "Output can't be displayed"
                   : "Inspect output"
                 : "Please build the component first"
@@ -435,12 +444,12 @@ function NodeOutputField({
               <OutputModal
                 open={openOutputModal}
                 setOpen={setOpenOutputModal}
-                disabled={!displayOutputPreview || unknownOutput}
+                disabled={disabledInspectButton}
                 nodeId={flowPoolId}
                 outputName={internalOutputName}
               >
                 <InspectButton
-                  disabled={!displayOutputPreview || unknownOutput}
+                  disabled={disabledInspectButton}
                   displayOutputPreview={displayOutputPreview}
                   unknownOutput={unknownOutput ?? false}
                   errorOutput={errorOutput ?? false}


### PR DESCRIPTION
This pull request includes changes to the `NodeOutputField` component in `src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx` to improve the handling of empty outputs. The most important changes include the addition of a new `emptyOutput` state, the creation of a `disabledInspectButton` state, and updates to the `ShadTooltip` and `OutputModal` components to use these new states.

Improvements to handling empty outputs:

* Added a new `emptyOutput` state to check if all output messages are empty.
* Created a new `disabledInspectButton` state to disable the inspect button when outputs are empty or other conditions are met.

Updates to component behavior:

* Updated the `ShadTooltip` component to display a message when outputs are empty.
* Updated the `OutputModal` and `InspectButton` components to use the new `disabledInspectButton` state for their disabled conditions.


![image](https://github.com/user-attachments/assets/1a2c45e0-3bb6-4171-9a7a-f2369c05b4d5)
