### PR TITLE
fix: update Google Analytics tracking ID in docusaurus configuration

### DIFF
--- a/docs/docs/Components/components-helpers.md
+++ b/docs/docs/Components/components-helpers.md
@@ -220,4 +220,3 @@ For example, the template `EBITDA: {EBITDA}  ,  Net Income: {NET_INCOME} , GROSS
 |------|--------------|------|
 | structured_output | Structured Output | The structured output is a Data object based on the defined schema. |
 | structured_output_dataframe | DataFrame | The structured output converted to a [DataFrame](/concepts-objects#dataframe-object) format. |
-

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -66,7 +66,7 @@ const config = {
           priority: null,
         },
         gtag: {
-          trackingID: "G-L8Y98PSEMQ",
+          trackingID: "G-SLQFLQ3KPT",
         },
         blog: false,
         theme: {


### PR DESCRIPTION
This pull request includes a small change to the `docs/docusaurus.config.js` file. The change updates the `trackingID` in the `gtag` configuration.

* [`docs/docusaurus.config.js`](diffhunk://#diff-28742c737e523f302e6de471b7fc27284dc8cf720be639e6afe4c17a550cd654L69-R69): Updated the `trackingID` from "G-L8Y98PSEMQ" to "G-SLQFLQ3KPT".
* 
<img width="278" alt="Screenshot 2025-04-09 at 2 31 51 PM" src="https://github.com/user-attachments/assets/d36043d1-7336-482a-aaa4-a833d05d187e" />
