### PR TITLE
fix: job id should be returned only if event_delivery is not direct

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -199,7 +199,7 @@ async def build_flow(
     )
 
     # This is required to support FE tests - we need to be able to set the event delivery to direct
-    if event_delivery == EventDeliveryType.DIRECT:
+    if event_delivery != EventDeliveryType.DIRECT:
         return {"job_id": job_id}
     return await get_flow_events_response(
         job_id=job_id,

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -149,6 +149,7 @@ async def test_build_flow_polling(client, json_memory_chatbot_no_llm, logged_in_
 
     # Start the build and get job_id
     build_response = await build_flow(client, flow_id, logged_in_headers)
+    assert "job_id" in build_response, f"Expected job_id in build_response, got {build_response}"
     job_id = build_response["job_id"]
     assert job_id is not None
 
@@ -166,7 +167,7 @@ async def test_build_flow_polling(client, json_memory_chatbot_no_llm, logged_in_
                 max_sleeps = 100
                 while True:
                     response = await self.client.get(
-                        f"api/v1/build/{self.job_id}/events?stream=false", headers=self.headers
+                        f"api/v1/build/{self.job_id}/events?event_delivery=polling", headers=self.headers
                     )
                     assert response.status_code == codes.OK
                     data = response.json()


### PR DESCRIPTION
Update the event delivery condition in the build_flow function to ensure proper handling of non-DIRECT types, enhancing the robustness of event delivery. Additionally, improve test assertions for job_id presence in responses.