### PR TITLE
fix: Avoid unnecessary field resets in the API Request component

### DIFF
--- a/src/backend/base/langflow/components/data/api_request.py
+++ b/src/backend/base/langflow/components/data/api_request.py
@@ -281,6 +281,10 @@ class APIRequestComponent(Component):
         if field_name == "use_curl":
             build_config = self._update_curl_mode(build_config, use_curl=field_value)
 
+            # If curl is not used, we don't need to reset the fields
+            if not self.use_curl:
+                return {}
+
             # Fields that should not be reset
             preserve_fields = {"timeout", "follow_redirects", "save_to_file", "include_httpx_metadata", "use_curl"}
 

--- a/src/backend/base/langflow/components/data/api_request.py
+++ b/src/backend/base/langflow/components/data/api_request.py
@@ -368,8 +368,6 @@ class APIRequestComponent(Component):
                     field_config["advanced"] = method not in {"POST", "PUT", "PATCH"}
                 elif field_name in always_advanced_fields:
                     field_config["advanced"] = True
-                else:
-                    field_config["advanced"] = True
             else:
                 self.log(f"Expected dict for build_config[{field_name}], got {type(field_config).__name__}")
 

--- a/src/backend/base/langflow/components/data/api_request.py
+++ b/src/backend/base/langflow/components/data/api_request.py
@@ -368,8 +368,6 @@ class APIRequestComponent(Component):
                     field_config["advanced"] = method not in {"POST", "PUT", "PATCH"}
                 elif field_name in always_advanced_fields:
                     field_config["advanced"] = True
-                else:
-                    field_config["advanced"] = self.use_curl or field_config.get("advanced")
             else:
                 self.log(f"Expected dict for build_config[{field_name}], got {type(field_config).__name__}")
 

--- a/src/backend/base/langflow/components/data/api_request.py
+++ b/src/backend/base/langflow/components/data/api_request.py
@@ -330,7 +330,7 @@ class APIRequestComponent(Component):
                 elif field_name in {"body", "headers"}:
                     field_config["advanced"] = True  # Always keep body and headers in advanced when use_curl is False
                 else:
-                    field_config["advanced"] = use_curl
+                    field_config["advanced"] = True if use_curl else field_config.get("advanced")
             else:
                 self.log(f"Expected dict for build_config[{field_name}], got {type(field_config).__name__}")
 

--- a/src/backend/base/langflow/components/data/api_request.py
+++ b/src/backend/base/langflow/components/data/api_request.py
@@ -330,7 +330,7 @@ class APIRequestComponent(Component):
                 elif field_name in {"body", "headers"}:
                     field_config["advanced"] = True  # Always keep body and headers in advanced when use_curl is False
                 else:
-                    field_config["advanced"] = True if use_curl else field_config.get("advanced")
+                    field_config["advanced"] = use_curl or field_config.get("advanced")
             else:
                 self.log(f"Expected dict for build_config[{field_name}], got {type(field_config).__name__}")
 
@@ -368,6 +368,8 @@ class APIRequestComponent(Component):
                     field_config["advanced"] = method not in {"POST", "PUT", "PATCH"}
                 elif field_name in always_advanced_fields:
                     field_config["advanced"] = True
+                else:
+                    field_config["advanced"] = self.use_curl or field_config.get("advanced")
             else:
                 self.log(f"Expected dict for build_config[{field_name}], got {type(field_config).__name__}")
 

--- a/src/backend/base/langflow/components/data/api_request.py
+++ b/src/backend/base/langflow/components/data/api_request.py
@@ -283,7 +283,7 @@ class APIRequestComponent(Component):
 
             # If curl is not used, we don't need to reset the fields
             if not self.use_curl:
-                return {}
+                return dotdict()
 
             # Fields that should not be reset
             preserve_fields = {"timeout", "follow_redirects", "save_to_file", "include_httpx_metadata", "use_curl"}


### PR DESCRIPTION
This PR fixes some issues related to field reset in the API Request components:

- Fixes https://github.com/langflow-ai/langflow/issues/7382 by adding a condition to ensure the use_curl property is active before proceeding with the field reset.
- Fixes an issue where fields are set back to `advanced` when `update_build_config` is triggered

### Test Evidence 1

Before ⬇️

![url_reset_smal](https://github.com/user-attachments/assets/955fdef1-432b-48c6-bc64-40d74d559f0a)

After ⬇️

![url_reset_fix_small](https://github.com/user-attachments/assets/5e68e4f8-3094-4e6a-9af3-dd70b523456e)

### Test Evidence 2

Before ⬇️

![advanced_bug](https://github.com/user-attachments/assets/8764cae0-ba11-497a-aedd-1f8a7b362d08)

After ⬇️

![advanced_fix](https://github.com/user-attachments/assets/e059fd7d-2208-4ecb-9a6f-361d99fb0b56)

