### PR TITLE
chore: Update Makefile to include PostgreSQL in backend installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ reinstall_backend: ## forces reinstall all dependencies (no caching)
 
 install_backend: ## install the backend dependencies
 	@echo 'Installing backend dependencies'
-	@uv sync --frozen $(EXTRA_ARGS)
+	@uv sync --frozen --extra "postgresql" $(EXTRA_ARGS)
 
 install_frontend: ## install the frontend dependencies
 	@echo 'Installing frontend dependencies'


### PR DESCRIPTION
Modify the backend installation command in the Makefile to include PostgreSQL as an extra dependency.