### PR TITLE
feat: adds dropdown to toggle and shows only text and icon if dropdown has one single option

### DIFF
--- a/src/backend/base/langflow/inputs/input_mixin.py
+++ b/src/backend/base/langflow/inputs/input_mixin.py
@@ -202,6 +202,18 @@ class DropDownMixin(BaseModel):
     """Variable that defines if the user can insert custom values in the dropdown."""
     dialog_inputs: dict[str, Any] | None = None
     """Dictionary of dialog inputs for the field. Default is an empty object."""
+    toggle: bool = False
+    """Variable that defines if a toggle button is shown."""
+    toggle_value: bool | None = None
+    """Variable that defines the value of the toggle button. Defaults to None."""
+
+    @field_validator("toggle_value")
+    @classmethod
+    def validate_toggle_value(cls, v):
+        if v is not None and not isinstance(v, bool):
+            msg = "toggle_value must be a boolean or None"
+            raise ValueError(msg)
+        return v
 
 
 class SortableListMixin(BaseModel):

--- a/src/backend/base/langflow/inputs/inputs.py
+++ b/src/backend/base/langflow/inputs/inputs.py
@@ -459,6 +459,8 @@ class DropdownInput(BaseInputMixin, DropDownMixin, MetadataTraceMixin, ToolModeM
         options_metadata (Optional[list[dict[str, str]]): List of dictionaries with metadata for each option.
             Default is None.
         combobox (CoalesceBool): Variable that defines if the user can insert custom values in the dropdown.
+        toggle (CoalesceBool): Variable that defines if a toggle button is shown.
+        toggle_value (CoalesceBool | None): Variable that defines the value of the toggle button. Defaults to None.
     """
 
     field_type: SerializableFieldTypes = FieldTypes.TEXT
@@ -466,6 +468,8 @@ class DropdownInput(BaseInputMixin, DropDownMixin, MetadataTraceMixin, ToolModeM
     options_metadata: list[dict[str, Any]] = Field(default_factory=list)
     combobox: CoalesceBool = False
     dialog_inputs: dict[str, Any] = Field(default_factory=dict)
+    toggle: bool = False
+    toggle_value: bool | None = None
 
 
 class ConnectionInput(BaseInputMixin, ConnectionMixin, MetadataTraceMixin, ToolModeMixin):

--- a/src/frontend/src/components/core/dropdownComponent/index.tsx
+++ b/src/frontend/src/components/core/dropdownComponent/index.tsx
@@ -482,6 +482,18 @@ export default function Dropdown({
         <PopoverAnchor>{children}</PopoverAnchor>
       ) : refreshOptions || isLoading ? (
         renderLoadingButton()
+      ) : validOptions.length === 1 &&
+        !combobox &&
+        value === validOptions[0] ? (
+        <div className="flex w-full items-center gap-2 truncate">
+          {optionsMetaData?.[0]?.icon && (
+            <ForwardedIconComponent
+              name={optionsMetaData?.[0]?.icon}
+              className="h-4 w-4 flex-shrink-0"
+            />
+          )}
+          <span className="truncate text-sm">{value}</span>
+        </div>
       ) : (
         <div className="w-full truncate">{renderTriggerButton()}</div>
       )}

--- a/src/frontend/src/components/core/parameterRenderComponent/components/dropdownComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/dropdownComponent/index.tsx
@@ -1,5 +1,6 @@
 import Dropdown from "../../../dropdownComponent";
 import { DropDownComponentType, InputProps } from "../../types";
+import ToggleShadComponent from "../toggleShadComponent";
 
 export default function DropdownComponent({
   id,
@@ -15,6 +16,8 @@ export default function DropdownComponent({
   nodeClass,
   nodeId,
   handleNodeClass,
+  toggle,
+  toggleValue,
   ...baseInputProps
 }: InputProps<string, DropDownComponentType>) {
   const onChange = (value: any, dbValue?: boolean, skipSnapshot?: boolean) => {
@@ -22,22 +25,35 @@ export default function DropdownComponent({
   };
 
   return (
-    <Dropdown
-      disabled={disabled}
-      editNode={editNode}
-      options={options}
-      nodeId={nodeId}
-      nodeClass={nodeClass}
-      handleNodeClass={handleNodeClass}
-      optionsMetaData={optionsMetaData}
-      onSelect={onChange}
-      combobox={combobox}
-      value={value || ""}
-      id={`dropdown_${id}`}
-      name={name}
-      dialogInputs={dialogInputs}
-      handleOnNewValue={handleOnNewValue}
-      {...baseInputProps}
-    />
+    <div className="flex w-full items-center gap-4">
+      <Dropdown
+        disabled={disabled}
+        editNode={editNode}
+        options={options}
+        nodeId={nodeId}
+        nodeClass={nodeClass}
+        handleNodeClass={handleNodeClass}
+        optionsMetaData={optionsMetaData}
+        onSelect={onChange}
+        combobox={combobox}
+        value={value || ""}
+        id={`dropdown_${id}`}
+        name={name}
+        dialogInputs={dialogInputs}
+        handleOnNewValue={handleOnNewValue}
+        {...baseInputProps}
+      />
+      {toggle && (
+        <ToggleShadComponent
+          value={toggleValue ?? false}
+          handleOnNewValue={(data) => {
+            handleOnNewValue({ toggle_value: data.value });
+          }}
+          editNode={editNode}
+          id={`toggle_dropdown_${id}`}
+          disabled={disabled}
+        />
+      )}
+    </div>
   );
 }

--- a/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx
@@ -76,6 +76,8 @@ export function StrRenderComponent({
         optionsMetaData={templateData.options_metadata}
         combobox={templateData.combobox}
         name={templateData?.name!}
+        toggle={templateData.toggle}
+        toggleValue={templateData.toggle_value}
       />
     );
   }

--- a/src/frontend/src/components/core/parameterRenderComponent/types.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/types.ts
@@ -97,6 +97,8 @@ export type DropDownComponentType = {
   nodeId: string;
   nodeClass: APIClassType;
   handleNodeClass: (value: any, code?: string, type?: string) => void;
+  toggle?: boolean;
+  toggleValue?: boolean;
 };
 
 export type TextAreaComponentType = {


### PR DESCRIPTION
This pull request introduces a new feature that adds toggle functionality to dropdown components in both the backend and frontend. The most important changes include updating the backend models to support the toggle feature, modifying the frontend components to render the toggle button, and ensuring the toggle state is properly handled.

### Backend changes:
* [`src/backend/base/langflow/inputs/input_mixin.py`](diffhunk://#diff-837adde4354a1111797f603eeae73ff0370b299b0e15ad55ce14ffa227e4fd3cR205-R216): Added `toggle` and `toggle_value` fields to `DropDownMixin` class along with a validator for `toggle_value`.
* [`src/backend/base/langflow/inputs/inputs.py`](diffhunk://#diff-f12c9ca218a67d203869442cb70537349ad1f026a3c20c88c8f1e15ae71bdbc8R462-R472): Added `toggle` and `toggle_value` fields to `DropdownInput` class.

### Frontend changes:
* [`src/frontend/src/components/core/dropdownComponent/index.tsx`](diffhunk://#diff-98068ce778ac9a53f4733f9c370c5e54bd27c30b6545fa4241f10cba35518700R485-R496): Updated `Dropdown` component to handle cases where there is only one valid option and the value matches that option.
* [`src/frontend/src/components/core/parameterRenderComponent/components/dropdownComponent/index.tsx`](diffhunk://#diff-c7d658b8a7075d6c09f1c5b0f7cc3ce6d36c6490edcf745352f2d21edc272b31R3): Integrated `ToggleShadComponent` to render the toggle button alongside the dropdown. [[1]](diffhunk://#diff-c7d658b8a7075d6c09f1c5b0f7cc3ce6d36c6490edcf745352f2d21edc272b31R3) [[2]](diffhunk://#diff-c7d658b8a7075d6c09f1c5b0f7cc3ce6d36c6490edcf745352f2d21edc272b31R19-R28) [[3]](diffhunk://#diff-c7d658b8a7075d6c09f1c5b0f7cc3ce6d36c6490edcf745352f2d21edc272b31R46-R57)
* [`src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx`](diffhunk://#diff-35f7590f9986bab61631e0de5aa2bf8970fec7eb16aa130c5a58f751aa203014R79-R80): Passed `toggle` and `toggleValue` props to the dropdown component.
* [`src/frontend/src/components/core/parameterRenderComponent/types.ts`](diffhunk://#diff-ca7e6ae1952b367e4db8fcad88a1d65c961a8fe99cc604c32bc243597a2dcbd7R100-R101): Added `toggle` and `toggleValue` properties to `DropDownComponentType`.