### PR TITLE
refactor: reduce menu bar rerenders

### DIFF
--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -1,10 +1,9 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import useAddFlow from "@/hooks/flows/use-add-flow";
 import useSaveFlow from "@/hooks/flows/use-save-flow";
 import useUploadFlow from "@/hooks/flows/use-upload-flow";
-import { customStringify } from "@/utils/reactflowUtils";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import IconComponent from "@/components/common/genericIconComponent";

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -21,6 +21,7 @@ import { UPLOAD_ERROR_ALERT } from "@/constants/alerts_constants";
 import { SAVED_HOVER } from "@/constants/constants";
 import { useGetRefreshFlowsQuery } from "@/controllers/API/queries/flows/use-get-refresh-flows-query";
 import { useGetFoldersQuery } from "@/controllers/API/queries/folders/use-get-folders";
+import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import ExportModal from "@/modals/exportModal";
 import FlowLogsModal from "@/modals/flowLogsModal";
 import FlowSettingsModal from "@/modals/flowSettingsModal";
@@ -32,8 +33,7 @@ import { useShortcutsStore } from "@/stores/shortcuts";
 import { swatchColors } from "@/utils/styleUtils";
 import { cn, getNumberFromString } from "@/utils/utils";
 import { useQueryClient } from "@tanstack/react-query";
-import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
-import { useShallow } from 'zustand/react/shallow';
+import { useShallow } from "zustand/react/shallow";
 
 export const MenuBar = ({}: {}): JSX.Element => {
   const shortcuts = useShortcutsStore((state) => state.shortcuts);
@@ -51,19 +51,25 @@ export const MenuBar = ({}: {}): JSX.Element => {
   const saveFlow = useSaveFlow();
   const queryClient = useQueryClient();
   const autoSaving = useFlowsManagerStore((state) => state.autoSaving);
-  const { currentFlowName, currentFlowId, currentFlowFolderId, currentFlowIcon, currentFlowGradient } = useFlowStore(
+  const {
+    currentFlowName,
+    currentFlowId,
+    currentFlowFolderId,
+    currentFlowIcon,
+    currentFlowGradient,
+  } = useFlowStore(
     useShallow((state) => ({
       currentFlowName: state.currentFlow?.name,
       currentFlowId: state.currentFlow?.id,
       currentFlowFolderId: state.currentFlow?.folder_id,
       currentFlowIcon: state.currentFlow?.icon,
       currentFlowGradient: state.currentFlow?.gradient,
-    }))
+    })),
   );
   const { updated_at: updatedAt } = useFlowsManagerStore(
     useShallow((state) => ({
-      updated_at: state.currentFlow?.updated_at
-    }))
+      updated_at: state.currentFlow?.updated_at,
+    })),
   );
   const onFlowPage = useFlowStore((state) => state.onFlowPage);
   const setCurrentFlow = useFlowsManagerStore((state) => state.setCurrentFlow);
@@ -184,10 +190,14 @@ export const MenuBar = ({}: {}): JSX.Element => {
   );
 
   const handleNameSubmit = useCallback(() => {
-    if (flowName.trim() !== "" && flowName !== currentFlowName && !isInvalidName) {
+    if (
+      flowName.trim() !== "" &&
+      flowName !== currentFlowName &&
+      !isInvalidName
+    ) {
       // Get a one-time snapshot of currentFlow using get()
       const currentFlowSnapshot = useFlowStore.getState().currentFlow;
-      
+
       const newFlow = {
         ...currentFlowSnapshot!,
         name: flowName,

--- a/src/frontend/src/hooks/useUnsavedChanges.ts
+++ b/src/frontend/src/hooks/useUnsavedChanges.ts
@@ -1,6 +1,6 @@
-import useFlowStore from '../stores/flowStore';
-import useFlowsManagerStore from '../stores/flowsManagerStore';
-import { customStringify } from '../utils/reactflowUtils';
+import useFlowStore from "../stores/flowStore";
+import useFlowsManagerStore from "../stores/flowsManagerStore";
+import { customStringify } from "../utils/reactflowUtils";
 
 export function useUnsavedChanges() {
   const currentFlow = useFlowStore((state) => state.currentFlow);

--- a/src/frontend/src/hooks/useUnsavedChanges.ts
+++ b/src/frontend/src/hooks/useUnsavedChanges.ts
@@ -1,0 +1,18 @@
+import useFlowStore from '../stores/flowStore';
+import useFlowsManagerStore from '../stores/flowsManagerStore';
+import { customStringify } from '../utils/reactflowUtils';
+
+export function useUnsavedChanges() {
+  const currentFlow = useFlowStore((state) => state.currentFlow);
+  const savedFlow = useFlowsManagerStore((state) => state.currentFlow);
+
+  if (!currentFlow || !savedFlow) {
+    return false;
+  }
+
+  if ((currentFlow?.data?.nodes?.length ?? 0) > 0) {
+    return false;
+  }
+
+  return customStringify(currentFlow) !== customStringify(savedFlow);
+}

--- a/src/frontend/src/modals/flowSettingsModal/index.tsx
+++ b/src/frontend/src/modals/flowSettingsModal/index.tsx
@@ -18,8 +18,10 @@ export default function FlowSettingsModal({
   flowData,
   details,
 }: FlowSettingsPropsType): JSX.Element {
+  if (!open) return <></>;
+
   const saveFlow = useSaveFlow();
-  const currentFlow = useFlowStore((state) => state.currentFlow);
+  const currentFlow = useFlowStore((state) => flowData ? undefined : state.currentFlow);
   const setCurrentFlow = useFlowStore((state) => state.setCurrentFlow);
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const flows = useFlowsManagerStore((state) => state.flows);

--- a/src/frontend/src/modals/flowSettingsModal/index.tsx
+++ b/src/frontend/src/modals/flowSettingsModal/index.tsx
@@ -21,7 +21,9 @@ export default function FlowSettingsModal({
   if (!open) return <></>;
 
   const saveFlow = useSaveFlow();
-  const currentFlow = useFlowStore((state) => flowData ? undefined : state.currentFlow);
+  const currentFlow = useFlowStore((state) =>
+    flowData ? undefined : state.currentFlow,
+  );
   const setCurrentFlow = useFlowStore((state) => state.setCurrentFlow);
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const flows = useFlowsManagerStore((state) => state.flows);


### PR DESCRIPTION
When doing something as simple as moving a node around the header (menubar, and flowsettingsmodal) rerender on each move. This is unnecessary and this PR addresses by removing the dependency on `useFlowStore` and `useFlowsManagerStore` currentFlow state

Before:

![Screenshot 2025-04-11 at 9 29 40 AM](https://github.com/user-attachments/assets/edb200e0-5959-4cd8-a0f9-cb3ea24dba8c)

After: (note found in the list)

![Screenshot 2025-04-11 at 9 35 44 AM](https://github.com/user-attachments/assets/92f899dc-48f0-4871-b2a7-9c8f1a60c4b8)
