### PR TITLE
fix: remove lexical search from astra db hybrid search

### DIFF
--- a/src/backend/base/langflow/base/vectorstores/model.py
+++ b/src/backend/base/langflow/base/vectorstores/model.py
@@ -65,7 +65,7 @@ class LCVectorStoreComponent(Component):
         QueryInput(
             name="search_query",
             display_name="Search Query",
-            info="Enter a query to run a combined similarity and lexical terms search.",
+            info="Enter a query to run a similarity search.",
             placeholder="Enter a query...",
             tool_mode=True,
         ),

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -1898,7 +1898,7 @@
                 "advanced": false,
                 "display_name": "Search Query",
                 "dynamic": false,
-                "info": "Enter a query to run a combined similarity and lexical terms search.",
+                "info": "Enter a query to run a similarity search.",
                 "input_types": [
                   "Message"
                 ],

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -3964,7 +3964,7 @@
                 "advanced": false,
                 "display_name": "Search Query",
                 "dynamic": false,
-                "info": "Enter a query to run a combined similarity and lexical terms search.",
+                "info": "Enter a query to run a similarity search.",
                 "input_types": [
                   "Message"
                 ],
@@ -4727,7 +4727,7 @@
                 "advanced": false,
                 "display_name": "Search Query",
                 "dynamic": false,
-                "info": "Enter a query to run a combined similarity and lexical terms search.",
+                "info": "Enter a query to run a similarity search.",
                 "input_types": [
                   "Message"
                 ],


### PR DESCRIPTION
This pull request includes changes to the `src/backend/base/langflow/base/vectorstores/model.py` file to update the `QueryInput` parameters. The most important change is the modification of the `info` attribute to provide a more accurate description of the search functionality.

* [`src/backend/base/langflow/base/vectorstores/model.py`](diffhunk://#diff-2393357b05f6ba626e42103c089e1769b136251439604f0e5f2147677769998dL68-R68): Updated the `info` attribute of `QueryInput` to describe the search as a "similarity search" instead of a "combined similarity and lexical terms search."