### PR TITLE
chore: add missing semicolon after `cluster: ecs.Cluster`

### DIFF
--- a/scripts/aws/lib/construct/frontend.ts
+++ b/scripts/aws/lib/construct/frontend.ts
@@ -16,7 +16,7 @@ import { CfnDistribution, Distribution } from 'aws-cdk-lib/aws-cloudfront';
 import { NodejsBuild } from 'deploy-time-build';
 
 interface WebProps {
-  cluster:ecs.Cluster
+  cluster:ecs.Cluster;
   alb:elb.IApplicationLoadBalancer;
   albSG:ec2.SecurityGroup;
 }


### PR DESCRIPTION
noticed a missing semicolon after `cluster: ecs.Cluster`, which could cause syntax errors or unexpected behavior.
added it to fix the issue.