### PR TITLE
chore: Add @components tag to auto-save-off test configuration

### DIFF
--- a/src/frontend/tests/extended/features/auto-save-off.spec.ts
+++ b/src/frontend/tests/extended/features/auto-save-off.spec.ts
@@ -3,7 +3,7 @@ import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 
 test(
   "user should be able to manually save a flow when the auto_save is off",
-  { tag: ["@release", "@api", "@database"] },
+  { tag: ["@release", "@api", "@database", "@components"] },
   async ({ page }) => {
     await page.route("**/api/v1/config", (route) => {
       route.fulfill({


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/tests/extended/features/auto-save-off.spec.ts` file. The change adds a new tag to the test configuration to include `@components`.

* [`src/frontend/tests/extended/features/auto-save-off.spec.ts`](diffhunk://#diff-5cc384d4f74ef4a7fe667ddd0faf5cef8c6e55f8043eb80509b08d93df45cb18L6-R6): Added the `@components` tag to the test configuration.