### PR TITLE
feat: add deprecation warning for AUTO_LOGIN

### DIFF
--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -52,7 +52,7 @@ async def api_key_security(
             warnings.warn(
                 (
                     "In v1.5, the default behavior of AUTO_LOGIN authentication will change to require a valid API key"
-                    " or JWT. If you integrate with Langflow prior to v1.5, make sure to update your code to pass an "
+                    " or JWT. If you integrated with Langflow prior to v1.5, make sure to update your code to pass an "
                     "API key or JWT when authenticating with protected endpoints."
                 ),
                 DeprecationWarning,

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -49,8 +49,19 @@ async def api_key_security(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Missing first superuser credentials",
                 )
-
-            result = await get_user_by_username(db, settings_service.auth_settings.SUPERUSER)
+            warnings.warn(
+                (
+                    "In v1.5, the default behavior of AUTO_LOGIN authentication will change to require a valid API key"
+                    " or JWT. If you integrate with Langflow prior to v1.5, make sure to update your code to pass an "
+                    "API key or JWT when authenticating with protected endpoints."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if query_param or header_param:
+                result = await check_key(db, query_param or header_param)
+            else:
+                result = await get_user_by_username(db, settings_service.auth_settings.SUPERUSER)
 
         elif not query_param and not header_param:
             raise HTTPException(


### PR DESCRIPTION
This pull request introduces a deprecation warning and updates the authentication logic in the `api_key_security` function to prepare for upcoming changes in version 1.5. The most important change is the addition of a warning to inform users about the future requirement of an API key or JWT for authentication.

### Deprecation and Authentication Changes:

* `src/backend/base/langflow/services/auth/utils.py`:
  - Added a `DeprecationWarning` to notify users that starting from v1.5, the default behavior of AUTO_LOGIN authentication will require an API key or JWT. This ensures users are aware of the upcoming change and can update their integrations accordingly.
  - Updated the logic to check for `query_param` or `header_param` and validate them using the `check_key` function if present. This prepares the codebase for the new authentication requirements.