### PR TITLE
fix: Removes embedding model input from GraphRAG component

### DIFF
--- a/src/backend/base/langflow/components/vectorstores/graph_rag.py
+++ b/src/backend/base/langflow/components/vectorstores/graph_rag.py
@@ -49,13 +49,6 @@ class GraphRAGComponent(LCVectorStoreComponent):
 
     inputs = [
         HandleInput(
-            name="embedding_model",
-            display_name="Embedding Model",
-            input_types=["Embeddings"],
-            info="Specify the Embedding Model. Not required for Astra Vectorize collections.",
-            required=False,
-        ),
-        HandleInput(
             name="vector_store",
             display_name="Vector Store Connection",
             input_types=["VectorStore"],


### PR DESCRIPTION
The Graph RAG component relies on vector store connection injection, meaning it does not need direct access to the embedding model. Whether the embedding is client-side (via a passed model) or server-side (handled transparently), the Graph RAG component remains unaffected. This PR removes the redundant embedding_model input from the Graph RAG component to simplify the interface and reflect this decoupling.