### PR TITLE
fix: transaction logging of pandas dataframes

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -266,7 +266,7 @@ async def run_flow_generator(
         await event_manager.queue.put((None, None, time.time))
 
 
-@router.post("/run/{flow_id_or_name}", response_model=RunResponse, response_model_exclude_none=True)
+@router.post("/run/{flow_id_or_name}", response_model=None, response_model_exclude_none=True)
 async def simplified_run_flow(
     *,
     background_tasks: BackgroundTasks,

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -56,22 +56,6 @@ if TYPE_CHECKING:
 
 router = APIRouter(tags=["Base"])
 
-# def serialize_response(obj):
-#     if isinstance(obj, pd.DataFrame):
-#         return obj.to_dict(orient='records')
-#     return jsonable_encoder(obj)
-
-
-# class CustomRunResponse(RunResponse):
-#     @classmethod
-#     def model_validate(cls, obj):
-#         if isinstance(obj, dict):
-#             for key, value in obj.items():
-#                 if isinstance(value, pd.DataFrame):
-#                     obj[key] = value.to_dict(orient='records')
-#         return super().model_validate(obj)
-
-
 @router.get("/all", dependencies=[Depends(get_current_active_user)])
 async def get_all():
     """Retrieve all component types with compression for better performance.

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -4,7 +4,7 @@ import asyncio
 import time
 from collections.abc import AsyncGenerator
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -13,7 +13,6 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
 from loguru import logger
 from sqlmodel import select
-import pandas as pd
 
 from langflow.api.utils import CurrentActiveUser, DbSession, parse_value
 from langflow.api.v1.schemas import (
@@ -71,7 +70,6 @@ router = APIRouter(tags=["Base"])
 #                 if isinstance(value, pd.DataFrame):
 #                     obj[key] = value.to_dict(orient='records')
 #         return super().model_validate(obj)
-
 
 
 @router.get("/all", dependencies=[Depends(get_current_active_user)])
@@ -773,5 +771,3 @@ async def get_config():
         }
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -57,20 +57,20 @@ if TYPE_CHECKING:
 
 router = APIRouter(tags=["Base"])
 
-def serialize_response(obj):
-    if isinstance(obj, pd.DataFrame):
-        return obj.to_dict(orient='records')
-    return jsonable_encoder(obj)
+# def serialize_response(obj):
+#     if isinstance(obj, pd.DataFrame):
+#         return obj.to_dict(orient='records')
+#     return jsonable_encoder(obj)
 
 
-class CustomRunResponse(RunResponse):
-    @classmethod
-    def model_validate(cls, obj):
-        if isinstance(obj, dict):
-            for key, value in obj.items():
-                if isinstance(value, pd.DataFrame):
-                    obj[key] = value.to_dict(orient='records')
-        return super().model_validate(obj)
+# class CustomRunResponse(RunResponse):
+#     @classmethod
+#     def model_validate(cls, obj):
+#         if isinstance(obj, dict):
+#             for key, value in obj.items():
+#                 if isinstance(value, pd.DataFrame):
+#                     obj[key] = value.to_dict(orient='records')
+#         return super().model_validate(obj)
 
 
 
@@ -284,7 +284,7 @@ async def run_flow_generator(
         await event_manager.queue.put((None, None, time.time))
 
 
-@router.post("/run/{flow_id_or_name}", response_model=CustomRunResponse, response_model_exclude_none=True)
+@router.post("/run/{flow_id_or_name}", response_model=RunResponse, response_model_exclude_none=True)
 async def simplified_run_flow(
     *,
     background_tasks: BackgroundTasks,

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
 
 router = APIRouter(tags=["Base"])
 
+
 @router.get("/all", dependencies=[Depends(get_current_active_user)])
 async def get_all():
     """Retrieve all component types with compression for better performance.

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import json
+import pandas as pd
 from collections.abc import Generator
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from loguru import logger
-import pandas as pd
 
 from langflow.interface.utils import extract_input_variables_from_prompt
 from langflow.schema.data import Data
@@ -125,18 +125,17 @@ async def log_transaction(
             else:
                 return
         inputs = _vertex_to_primitive_dict(source)
-        
+
         # Convert the result to a serializable format
         if source.result:
             try:
                 result_dict = json.loads(source.result.model_dump_json())
-                # Check for DataFrame in the result and convert to dict
                 for key, value in result_dict.items():
                     if isinstance(value, pd.DataFrame):
                         result_dict[key] = value.to_dict()
                 outputs = result_dict
-            except Exception as e:
-                logger.warning(f"Error serializing result: {str(e)}")
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"Error serializing result: {e!s}")
                 outputs = None
         else:
             outputs = None

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import json
-import pandas as pd
 from collections.abc import Generator
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
+import json
+
+import pandas as pd
 
 from loguru import logger
 
@@ -155,7 +156,7 @@ async def log_transaction(
                 if inserted:
                     logger.debug(f"Logged transaction: {inserted.id}")
     except Exception as exc:  # noqa: BLE001
-        logger.error(f"Error logging transaction: {str(exc)}")
+        logger.error(f"Error logging transaction: {exc!s}")
 
 
 async def log_vertex_build(

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Generator
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
-import json
 
 import pandas as pd
-
 from loguru import logger
 
 from langflow.interface.utils import extract_input_variables_from_prompt

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from loguru import logger
+import pandas as pd
 
 from langflow.interface.utils import extract_input_variables_from_prompt
 from langflow.schema.data import Data
@@ -131,7 +132,7 @@ async def log_transaction(
                 result_dict = json.loads(source.result.model_dump_json())
                 # Check for DataFrame in the result and convert to dict
                 for key, value in result_dict.items():
-                    if hasattr(value, '__class__') and value.__class__.__name__ == 'DataFrame':
+                    if isinstance(value, pd.DataFrame):
                         result_dict[key] = value.to_dict()
                 outputs = result_dict
             except Exception as e:

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Generator
 from enum import Enum
 from typing import TYPE_CHECKING, Any

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -129,7 +129,7 @@ async def log_transaction(
         # Convert the result to a serializable format
         if source.result:
             try:
-                result_dict = json.loads(source.result.model_dump_json())
+                result_dict = source.result.model_dump()
                 for key, value in result_dict.items():
                     if isinstance(value, pd.DataFrame):
                         result_dict[key] = value.to_dict()

--- a/src/backend/base/langflow/serialization/serialization.py
+++ b/src/backend/base/langflow/serialization/serialization.py
@@ -144,7 +144,7 @@ def _serialize_numpy_type(obj: Any, max_length: int | None, max_items: int | Non
         # For single-element arrays
         if obj.size == 1 and hasattr(obj, "item"):
             return obj.item()
-            
+
         # For multi-element arrays
         if np.issubdtype(obj.dtype, np.number):
             return obj.tolist()  # Convert to Python list

--- a/src/backend/base/langflow/serialization/serialization.py
+++ b/src/backend/base/langflow/serialization/serialization.py
@@ -140,18 +140,27 @@ def _is_numpy_type(obj: Any) -> bool:
 
 def _serialize_numpy_type(obj: Any, max_length: int | None, max_items: int | None) -> Any:
     """Serialize numpy types."""
-    if np.issubdtype(obj.dtype, np.number) and hasattr(obj, "item"):
-        return obj.item()
-    if np.issubdtype(obj.dtype, np.bool_):
-        return bool(obj)
-    if np.issubdtype(obj.dtype, np.complexfloating):
-        return complex(cast("complex", obj))
-    if np.issubdtype(obj.dtype, np.str_):
-        return _serialize_str(str(obj), max_length, max_items)
-    if np.issubdtype(obj.dtype, np.bytes_) and hasattr(obj, "tobytes"):
-        return _serialize_bytes(obj.tobytes(), max_length, max_items)
-    if np.issubdtype(obj.dtype, np.object_) and hasattr(obj, "item"):
-        return _serialize_instance(obj.item(), max_length, max_items)
+    try:
+        # For single-element arrays
+        if obj.size == 1 and hasattr(obj, "item"):
+            return obj.item()
+            
+        # For multi-element arrays
+        if np.issubdtype(obj.dtype, np.number):
+            return obj.tolist()  # Convert to Python list
+        if np.issubdtype(obj.dtype, np.bool_):
+            return bool(obj)
+        if np.issubdtype(obj.dtype, np.complexfloating):
+            return complex(cast("complex", obj))
+        if np.issubdtype(obj.dtype, np.str_):
+            return _serialize_str(str(obj), max_length, max_items)
+        if np.issubdtype(obj.dtype, np.bytes_) and hasattr(obj, "tobytes"):
+            return _serialize_bytes(obj.tobytes(), max_length, max_items)
+        if np.issubdtype(obj.dtype, np.object_) and hasattr(obj, "item"):
+            return _serialize_instance(obj.item(), max_length, max_items)
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"Cannot serialize numpy array: {e!s}")
+        return UNSERIALIZABLE_SENTINEL
     return UNSERIALIZABLE_SENTINEL
 
 


### PR DESCRIPTION
Seeing transaction failure logs (with some additional print statements):
```
                    ERROR    2025-04-19 13:33:11 - ERROR    - utils - Exception details: PydanticSerializationError                                            utils.py:144
                    ERROR    2025-04-19 13:33:11 - ERROR    - utils - Error logging transaction: Unable to serialize unknown type: <class                      utils.py:143
                             'pandas.core.frame.DataFrame'>   
```

Not sure if a recent change to process dataframes occurred, but this fixes it by checking if the value is a dataframe and converting it to json first

I ran some benchmarks to verify this doesn't _add_ serialization time. We have performance issues serializing dataframes now, but this change is unrelated.