### PR TITLE
test: Enhance MCP server test reliability with retry logic and improved interactions (nightly fix)

### DIFF
--- a/src/frontend/tests/extended/features/mcp-server.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server.spec.ts
@@ -4,7 +4,7 @@ import { zoomOut } from "../../utils/zoom-out";
 
 test(
   "user must be able to change mode of MCP server without any issues",
-  { tag: ["@release", "@workspace", "@components", "@development"] },
+  { tag: ["@release", "@workspace", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 

--- a/src/frontend/tests/extended/features/mcp-server.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server.spec.ts
@@ -31,16 +31,34 @@ test(
 
     await page.getByTestId("dropdown_str_tool").isDisabled();
 
-    await page.getByTestId("refresh-button-command").click();
+    let attempts = 0;
+    const maxAttempts = 3;
+    let dropdownEnabled = false;
 
-    await page.waitForTimeout(2000);
+    while (attempts < maxAttempts && !dropdownEnabled) {
+      await page.getByTestId("refresh-button-command").click();
+      await page.waitForTimeout(3000);
 
-    await page.waitForSelector(
-      '[data-testid="dropdown_str_tool"]:not([disabled])',
-      {
-        timeout: 30000,
-      },
-    );
+      try {
+        await page.waitForSelector(
+          '[data-testid="dropdown_str_tool"]:not([disabled])',
+          {
+            timeout: 10000,
+            state: "visible",
+          },
+        );
+        dropdownEnabled = true;
+      } catch (error) {
+        attempts++;
+        console.log(`Retry attempt ${attempts} for refresh button`);
+      }
+    }
+
+    if (!dropdownEnabled) {
+      throw new Error(
+        "Dropdown did not become enabled after multiple refresh attempts",
+      );
+    }
 
     await page.getByTestId("dropdown_str_tool").click();
 
@@ -92,16 +110,33 @@ test(
 
     await page.getByTestId("fit_view").click();
 
-    await page.getByTestId("refresh-button-command").click();
+    attempts = 0;
+    dropdownEnabled = false;
 
-    await page.waitForTimeout(2000);
+    while (attempts < maxAttempts && !dropdownEnabled) {
+      await page.getByTestId("refresh-button-command").click();
+      await page.waitForTimeout(3000);
 
-    await page.waitForSelector(
-      '[data-testid="dropdown_str_tool"]:not([disabled])',
-      {
-        timeout: 30000,
-      },
-    );
+      try {
+        await page.waitForSelector(
+          '[data-testid="dropdown_str_tool"]:not([disabled])',
+          {
+            timeout: 10000,
+            state: "visible",
+          },
+        );
+        dropdownEnabled = true;
+      } catch (error) {
+        attempts++;
+        console.log(`Retry attempt ${attempts} for second refresh button`);
+      }
+    }
+
+    if (!dropdownEnabled) {
+      throw new Error(
+        "Dropdown did not become enabled after multiple refresh attempts",
+      );
+    }
 
     await page.getByTestId("dropdown_str_tool").click();
 

--- a/src/frontend/tests/extended/features/mcp-server.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server.spec.ts
@@ -4,7 +4,7 @@ import { zoomOut } from "../../utils/zoom-out";
 
 test(
   "user must be able to change mode of MCP server without any issues",
-  { tag: ["@release", "@workspace", "@components"] },
+  { tag: ["@release", "@workspace", "@components", "@development"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
@@ -21,9 +21,8 @@ test(
 
     await page
       .getByTestId("toolsMCP Server")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-mcp-server").click();
+      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+        targetPosition: { x: 0, y: 0 },
       });
 
     await page.getByTestId("fit_view").click();
@@ -48,6 +47,10 @@ test(
     expect(fetchOptionCount).toBeGreaterThan(0);
 
     await page.getByTestId("fetch-0-option").click();
+
+    await page.waitForTimeout(2000);
+
+    await page.getByTestId("fit_view").click();
 
     await page.waitForSelector('[data-testid="int_int_max_length"]', {
       state: "visible",
@@ -83,6 +86,10 @@ test(
 
     await page.getByTestId("tab_0_stdio").click();
 
+    await page.waitForTimeout(2000);
+
+    await page.getByTestId("fit_view").click();
+
     await page.getByTestId("refresh-button-command").click();
 
     await page.waitForSelector(
@@ -97,6 +104,10 @@ test(
     fetchOptionCount = await page.getByTestId("fetch-0-option").count();
 
     await page.getByTestId("fetch-0-option").click();
+
+    await page.waitForTimeout(2000);
+
+    await page.getByTestId("fit_view").click();
 
     expect(fetchOptionCount).toBeGreaterThan(0);
 

--- a/src/frontend/tests/extended/features/mcp-server.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server.spec.ts
@@ -33,6 +33,8 @@ test(
 
     await page.getByTestId("refresh-button-command").click();
 
+    await page.waitForTimeout(2000);
+
     await page.waitForSelector(
       '[data-testid="dropdown_str_tool"]:not([disabled])',
       {
@@ -91,6 +93,8 @@ test(
     await page.getByTestId("fit_view").click();
 
     await page.getByTestId("refresh-button-command").click();
+
+    await page.waitForTimeout(2000);
 
     await page.waitForSelector(
       '[data-testid="dropdown_str_tool"]:not([disabled])',


### PR DESCRIPTION
This pull request updates the `mcp-server.spec.ts` test file to improve the robustness and functionality of the MCP server test suite. Key changes include adding retry logic for dropdown interactions, replacing a hover action with a drag-and-drop operation, and introducing additional wait times to enhance test reliability.

### Improvements to test reliability:
* Added retry logic with a maximum of three attempts to ensure the dropdown becomes enabled after clicking the refresh button. This includes logging retry attempts and throwing an error if the dropdown remains disabled. [[1]](diffhunk://#diff-37d0e42832061615b47a8d9aac2a99d55e565969f0e0e9311e1e536152013f9aR34-R61) [[2]](diffhunk://#diff-37d0e42832061615b47a8d9aac2a99d55e565969f0e0e9311e1e536152013f9aR109-R150)
* Introduced additional `waitForTimeout` calls to stabilize interactions and ensure elements are fully loaded before proceeding. [[1]](diffhunk://#diff-37d0e42832061615b47a8d9aac2a99d55e565969f0e0e9311e1e536152013f9aR71-R74) [[2]](diffhunk://#diff-37d0e42832061615b47a8d9aac2a99d55e565969f0e0e9311e1e536152013f9aR109-R150)

### Functional changes:
* Replaced the hover-and-click action for the "add-component-button-mcp-server" with a drag-and-drop operation to improve test accuracy and better simulate user behavior.

### Metadata updates:
* Added a new `@development` tag to the test metadata for better categorization and tracking.