### PR TITLE
fix: Enhance Folder Sidebar Readability - increase Font Sizes and Adjust Layout Dimensions

### DIFF
--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
@@ -82,7 +82,7 @@ export const GetStartedProgress: FC<{
   };
 
   return (
-    <div className="mt-3 h-[168px] w-full">
+    <div className="mt-3 h-[180px] w-full">
       <div className="mb-2 flex items-center justify-between">
         <span className="text-sm font-semibold">
           {percentageGetStarted >= 100 ? (
@@ -110,7 +110,7 @@ export const GetStartedProgress: FC<{
           />
         </div>
         <span
-          className="text-xs text-muted-foreground"
+          className="text-sm text-muted-foreground"
           data-testid="get_started_progress_percentage"
         >
           {percentageGetStarted}%
@@ -151,7 +151,7 @@ export const GetStartedProgress: FC<{
             )}
             <span
               className={cn(
-                "text-xs",
+                "text-sm",
                 isGithubStarredChild && "text-muted-foreground line-through",
               )}
             >
@@ -193,7 +193,7 @@ export const GetStartedProgress: FC<{
             )}
             <span
               className={cn(
-                "text-xs",
+                "text-sm",
                 isDiscordJoinedChild && "text-muted-foreground line-through",
               )}
             >
@@ -223,7 +223,7 @@ export const GetStartedProgress: FC<{
                 )}
               />
             </span>
-            <span className={cn("text-xs", hasFlows && "line-through")}>
+            <span className={cn("text-sm", hasFlows && "line-through")}>
               Create a flow
             </span>
           </div>

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -413,7 +413,7 @@ const SideBarFoldersButtonsComponent = ({
                                   handleKeyDown={handleKeyDown}
                                 />
                               ) : (
-                                <span className="block w-0 grow truncate text-xs opacity-100">
+                                <span className="text-smopacity-100 block w-0 grow truncate">
                                   {item.name}
                                 </span>
                               )}
@@ -459,7 +459,7 @@ const SideBarFoldersButtonsComponent = ({
               >
                 <SidebarMenuButton
                   size="md"
-                  className="text-xs"
+                  className="text-sm"
                   onClick={() => {
                     window.open("/store", "_blank");
                   }}
@@ -473,7 +473,7 @@ const SideBarFoldersButtonsComponent = ({
               isActive={checkPathFiles}
               onClick={() => handleFilesClick?.()}
               size="md"
-              className="text-xs"
+              className="text-sm"
             >
               <ForwardedIconComponent name="File" className="h-4 w-4" />
               My Files


### PR DESCRIPTION
This pull request focuses on improving the visual consistency and readability of text elements in the folder sidebar components by adjusting font sizes and layout dimensions. The most important changes involve increasing font sizes from `text-xs` to `text-sm` and slightly modifying the height of a container to accommodate these changes.

### Font size adjustments for readability:

* Increased the font size from `text-xs` to `text-sm` for various text elements in the `GetStartedProgress` component, including progress percentage, child items, and the "Create a flow" label. (`src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx`) [[1]](diffhunk://#diff-8d321fde6165c43e414eab942a430830c848898375d8ab3c1edc2e6acdcfe423L113-R113) [[2]](diffhunk://#diff-8d321fde6165c43e414eab942a430830c848898375d8ab3c1edc2e6acdcfe423L154-R154) [[3]](diffhunk://#diff-8d321fde6165c43e414eab942a430830c848898375d8ab3c1edc2e6acdcfe423L196-R196) [[4]](diffhunk://#diff-8d321fde6165c43e414eab942a430830c848898375d8ab3c1edc2e6acdcfe423L226-R226)

* Updated font sizes from `text-xs` to `text-sm` in the `SideBarFoldersButtonsComponent` for folder names, menu buttons, and "My Files" button to improve consistency. (`src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx`) [[1]](diffhunk://#diff-c555da19c21570f424bb71bd92a075b37bbe7be3fbc75387b03b37728a8dc9cfL462-R462) [[2]](diffhunk://#diff-c555da19c21570f424bb71bd92a075b37bbe7be3fbc75387b03b37728a8dc9cfL476-R476)

### Layout adjustments:

* Adjusted the height of the container in the `GetStartedProgress` component from `h-[168px]` to `h-[180px]` to better fit the updated font sizes. (`src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx`)