### PR TITLE
fix: change note toolbar wrong import that causes wrong padding

### DIFF
--- a/src/frontend/src/CustomNodes/NoteNode/components/select-items.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/components/select-items.tsx
@@ -1,6 +1,8 @@
 import { ForwardedIconComponent } from "@/components/common/genericIconComponent";
-import { SelectItem } from "@/components/ui/select";
-import { SelectContentWithoutPortal } from "@/components/ui/select-custom";
+import {
+  SelectContentWithoutPortal,
+  SelectItem,
+} from "@/components/ui/select-custom";
 import ToolbarSelectItem from "@/pages/FlowPage/components/nodeToolbarComponent/toolbarSelectItem";
 import { NoteDataType } from "@/types/flow";
 


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/src/CustomNodes/NoteNode/components/select-items.tsx` file. The change consolidates imports by grouping `SelectContentWithoutPortal` and `SelectItem` under the same module, `@/components/ui/select-custom`, improving code organization.