### PR TITLE
feat: Change default event delivery method to streaming

### DIFF
--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -242,7 +242,7 @@ class Settings(BaseSettings):
     public_flow_expiration: int = Field(default=86400, gt=600)
     """The time in seconds after which a public temporary flow will be considered expired and eligible for cleanup.
     Default is 24 hours (86400 seconds). Minimum is 600 seconds (10 minutes)."""
-    event_delivery: Literal["polling", "streaming", "direct"] = "polling"
+    event_delivery: Literal["polling", "streaming", "direct"] = "streaming"
     """How to deliver build events to the frontend. Can be 'polling', 'streaming' or 'direct'."""
     lazy_load_components: bool = False
     """If set to True, Langflow will only partially load components at startup and fully load them on demand.


### PR DESCRIPTION
Update the default method for event delivery from polling to streaming to enhance performance.