### PR TITLE
fix:agent execution time in streaming mode

### DIFF
--- a/src/backend/base/langflow/base/agents/events.py
+++ b/src/backend/base/langflow/base/agents/events.py
@@ -217,7 +217,6 @@ async def handle_on_chain_stream(
         agent_message.text += data_chunk.content
         agent_message.properties.state = "complete"
         agent_message = await send_message_method(message=agent_message)
-        start_time = perf_counter()
     return agent_message, start_time
 
 


### PR DESCRIPTION
Start_timer is 0 for streaming hence removing it for streaming, so the final timer in UI of playground is consistent.
This pull request includes a minor change to the `handle_on_chain_stream` function in `src/backend/base/langflow/base/agents/events.py`. The change removes an unused `start_time` variable assignment, likely as part of a cleanup to improve code clarity and maintainability.