### PR TITLE
fix: composio gmail output maps

### DIFF
--- a/src/backend/base/langflow/components/composio/gmail_composio.py
+++ b/src/backend/base/langflow/components/composio/gmail_composio.py
@@ -386,11 +386,7 @@ class ComposioGmailAPIComponent(ComposioBaseComponent):
             # using 'result_field'. Otherwise, fall back to the entire 'data' field in the response.
             if actions_data.get("get_result_field") and actions_data.get("result_field"):
                 result_data = result_data.get(actions_data.get("result_field"), result.get("data", []))
-            if (
-                len(result_data) != 1
-                and not self._actions_data.get(action_key, {}).get("result_field")
-                and self._actions_data.get(action_key, {}).get("get_result_field")
-            ):
+            if len(result_data) != 1 and not actions_data.get("result_field") and actions_data.get("get_result_field"):
                 msg = f"Expected a dict with a single key, got {len(result_data)} keys: {result_data.keys()}"
                 raise ValueError(msg)
             return result_data  # noqa: TRY300

--- a/src/backend/base/langflow/components/composio/gmail_composio.py
+++ b/src/backend/base/langflow/components/composio/gmail_composio.py
@@ -80,6 +80,8 @@ class ComposioGmailAPIComponent(ComposioBaseComponent):
         "GMAIL_LIST_THREADS": {
             "display_name": "List Email Threads",
             "action_fields": ["max_results", "query", "gmail_user_id", "page_token"],
+            "get_result_field": True,
+            "result_field": "threads"
         },
         "GMAIL_REPLY_TO_THREAD": {
             "display_name": "Reply To Thread",
@@ -88,6 +90,8 @@ class ComposioGmailAPIComponent(ComposioBaseComponent):
         "GMAIL_LIST_LABELS": {
             "display_name": "List Email Labels",
             "action_fields": ["gmail_user_id"],
+            "get_result_field": True,
+            "result_field": "labels"
         },
         "GMAIL_CREATE_LABEL": {
             "display_name": "Create Email Label",
@@ -96,6 +100,8 @@ class ComposioGmailAPIComponent(ComposioBaseComponent):
         "GMAIL_GET_PEOPLE": {
             "display_name": "Get Contacts",
             "action_fields": ["resource_name", "person_fields"],
+            "get_result_field": True,
+            "result_field": "people_data"
         },
         "GMAIL_REMOVE_LABEL": {
             "display_name": "Delete Email Label",
@@ -374,7 +380,10 @@ class ComposioGmailAPIComponent(ComposioBaseComponent):
                     "status": error_data.get("status"),
                 }
 
-            result_data = result.get("data", [])
+            result_data = result.get("data", {})
+            actions_data = self._actions_data.get(action_key, {})
+            if actions_data.get("get_result_field") and actions_data.get("result_field"):
+                result_data = result_data.get(actions_data.get("result_field"), result.get("data", []))
             if (
                 len(result_data) != 1
                 and not self._actions_data.get(action_key, {}).get("result_field")

--- a/src/backend/base/langflow/components/composio/gmail_composio.py
+++ b/src/backend/base/langflow/components/composio/gmail_composio.py
@@ -81,7 +81,7 @@ class ComposioGmailAPIComponent(ComposioBaseComponent):
             "display_name": "List Email Threads",
             "action_fields": ["max_results", "query", "gmail_user_id", "page_token"],
             "get_result_field": True,
-            "result_field": "threads"
+            "result_field": "threads",
         },
         "GMAIL_REPLY_TO_THREAD": {
             "display_name": "Reply To Thread",
@@ -91,7 +91,7 @@ class ComposioGmailAPIComponent(ComposioBaseComponent):
             "display_name": "List Email Labels",
             "action_fields": ["gmail_user_id"],
             "get_result_field": True,
-            "result_field": "labels"
+            "result_field": "labels",
         },
         "GMAIL_CREATE_LABEL": {
             "display_name": "Create Email Label",
@@ -101,7 +101,7 @@ class ComposioGmailAPIComponent(ComposioBaseComponent):
             "display_name": "Get Contacts",
             "action_fields": ["resource_name", "person_fields"],
             "get_result_field": True,
-            "result_field": "people_data"
+            "result_field": "people_data",
         },
         "GMAIL_REMOVE_LABEL": {
             "display_name": "Delete Email Label",

--- a/src/backend/base/langflow/components/composio/gmail_composio.py
+++ b/src/backend/base/langflow/components/composio/gmail_composio.py
@@ -382,6 +382,8 @@ class ComposioGmailAPIComponent(ComposioBaseComponent):
 
             result_data = result.get("data", {})
             actions_data = self._actions_data.get(action_key, {})
+            # If 'get_result_field' is True and 'result_field' is specified, extract the data
+            # using 'result_field'. Otherwise, fall back to the entire 'data' field in the response.
             if actions_data.get("get_result_field") and actions_data.get("result_field"):
                 result_data = result_data.get(actions_data.get("result_field"), result.get("data", []))
             if (

--- a/src/frontend/src/pages/MainPage/pages/empty-page.tsx
+++ b/src/frontend/src/pages/MainPage/pages/empty-page.tsx
@@ -164,7 +164,7 @@ export const EmptyPageCommunity = ({
 
               <Button
                 variant="default"
-                className="z-10 m-auto mt-3 h-10 w-full max-w-[155px] rounded-lg font-bold transition-all duration-300"
+                className="z-10 m-auto mt-3 h-10 w-full max-w-[10rem] rounded-lg font-bold transition-all duration-300"
                 onClick={() => setOpenModal(true)}
                 id="new-project-btn"
                 data-testid="new_project_btn_empty_page"
@@ -172,7 +172,7 @@ export const EmptyPageCommunity = ({
                 <ForwardedIconComponent
                   name="Plus"
                   aria-hidden="true"
-                  className="relative left-1 h-4 w-4"
+                  className="h-4 w-4"
                 />
                 <span>{EMPTY_PAGE_CREATE_FIRST_FLOW_BUTTON_TEXT}</span>
               </Button>


### PR DESCRIPTION
This pull request enhances the `ComposioGmailAPIComponent` to support extracting specific fields from API responses for various Gmail actions. The changes include adding metadata to define result fields for actions and updating the execution logic to utilize this metadata.

### Enhancements to Gmail action metadata:
* Added `get_result_field` and `result_field` attributes to the following Gmail actions to specify which field in the API response should be extracted:
  - [`GMAIL_LIST_THREADS`](diffhunk://#diff-4f363eaaeb0d748c11cfb4d083b044d4de6d1da648f3e7c09ebc4d14d4688a9aR83-R84): Extracts the `threads` field.
  - [`GMAIL_LIST_LABELS`](diffhunk://#diff-4f363eaaeb0d748c11cfb4d083b044d4de6d1da648f3e7c09ebc4d14d4688a9aR93-R94): Extracts the `labels` field.
  - [`GMAIL_GET_PEOPLE`](diffhunk://#diff-4f363eaaeb0d748c11cfb4d083b044d4de6d1da648f3e7c09ebc4d14d4688a9aR103-R104): Extracts the `people_data` field.

### Updates to action execution logic:
* Modified the `execute_action` method to check for the `get_result_field` attribute and extract the specified `result_field` from the API response. If the field is not found, it defaults to the original `data` field.