### PR TITLE
ffix: Update Gmail test to assert direct result_field return instead of full data dictionary (nightly fix)

### DIFF
--- a/src/backend/tests/unit/components/bundles/composio/test_gmail.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_gmail.py
@@ -113,8 +113,8 @@ class TestGmailComponent(ComponentTestBaseWithoutClient):
         # Patch the _build_wrapper method
         with patch.object(component, "_build_wrapper", return_value=mock_toolset):
             result = component.execute_action()
-            # Based on the component's actual behavior, it returns the entire data dict
-            assert result == {"messages": "mocked response"}
+            # Based on the component's actual behavior, it returns the result_field directly
+            assert result == "mocked response"
 
     def test_execute_action_get_profile(self, component_class, default_kwargs, monkeypatch):
         # Mock Action enum


### PR DESCRIPTION
This pull request updates a unit test in `test_gmail.py` to reflect a change in the behavior of the `execute_action` method. Specifically, the test now asserts that the method returns the `result_field` directly instead of the entire data dictionary.

* **Unit test update:**
  * [`src/backend/tests/unit/components/bundles/composio/test_gmail.py`](diffhunk://#diff-a5119444f0339aa3609d5219850cf6aa2603f5d8f6dd2af71f4083fa32df0b56L116-R117): Modified the `test_execute_action_fetch_emails` test to assert that `execute_action` returns the `result_field` directly, aligning with the updated behavior of the method.