### PR TITLE
fix: Streaming for anthropic models in Agents

### DIFF
--- a/src/backend/base/langflow/base/agents/events.py
+++ b/src/backend/base/langflow/base/agents/events.py
@@ -226,9 +226,10 @@ async def handle_on_chain_stream(
         agent_message = await send_message_method(message=agent_message)
         start_time = perf_counter()
     elif isinstance(data_chunk, AIMessageChunk):
-        agent_message.text += _extract_output_text(data_chunk.content)
-        agent_message.properties.state = "complete"
-        agent_message = await send_message_method(message=agent_message)
+        if output_text := _extract_output_text(data_chunk.content):
+            agent_message.text += output_text
+            agent_message.properties.state = "partial"
+            agent_message = await send_message_method(message=agent_message)
         start_time = perf_counter()
     return agent_message, start_time
 

--- a/src/backend/base/langflow/base/agents/events.py
+++ b/src/backend/base/langflow/base/agents/events.py
@@ -226,7 +226,8 @@ async def handle_on_chain_stream(
         agent_message = await send_message_method(message=agent_message)
         start_time = perf_counter()
     elif isinstance(data_chunk, AIMessageChunk):
-        if output_text := _extract_output_text(data_chunk.content):
+        output_text = _extract_output_text(data_chunk.content)
+        if output_text and isinstance(agent_message.text, str):
             agent_message.text += output_text
             agent_message.properties.state = "partial"
             agent_message = await send_message_method(message=agent_message)

--- a/src/backend/base/langflow/base/agents/events.py
+++ b/src/backend/base/langflow/base/agents/events.py
@@ -86,7 +86,7 @@ def _extract_output_text(output: str | list) -> str:
         return ""
     if not isinstance(output, list) or len(output) != 1:
         msg = f"Output is not a string or list of dictionaries with 'text' key: {output}"
-        raise ValueError(msg)
+        raise TypeError(msg)
 
     item = output[0]
     if isinstance(item, str):
@@ -99,7 +99,7 @@ def _extract_output_text(output: str | list) -> str:
         if item.get("type") == "tool_use":
             return ""
     msg = f"Output is not a string or list of dictionaries with 'text' key: {output}"
-    raise ValueError(msg)
+    raise TypeError(msg)
 
 
 async def handle_on_chain_end(

--- a/src/backend/base/langflow/base/agents/events.py
+++ b/src/backend/base/langflow/base/agents/events.py
@@ -81,13 +81,24 @@ async def handle_on_chain_start(
 
 def _extract_output_text(output: str | list) -> str:
     if isinstance(output, str):
-        text = output
-    elif isinstance(output, list) and len(output) == 1 and isinstance(output[0], dict) and "text" in output[0]:
-        text = output[0]["text"]
-    else:
+        return output
+    if isinstance(output, list) and len(output) == 0:
+        return ""
+    if not isinstance(output, list) or len(output) != 1:
         msg = f"Output is not a string or list of dictionaries with 'text' key: {output}"
         raise ValueError(msg)
-    return text
+
+    item = output[0]
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        if "text" in item:
+            return item["text"]
+        if item.get("type") == "tool_use":
+            return ""
+
+    msg = f"Output is not a string or list of dictionaries with 'text' key: {output}"
+    raise ValueError(msg)
 
 
 async def handle_on_chain_end(
@@ -214,7 +225,7 @@ async def handle_on_chain_stream(
         agent_message = await send_message_method(message=agent_message)
         start_time = perf_counter()
     elif isinstance(data_chunk, AIMessageChunk):
-        agent_message.text += data_chunk.content
+        agent_message.text += _extract_output_text(data_chunk.content)
         agent_message.properties.state = "complete"
         agent_message = await send_message_method(message=agent_message)
         start_time = perf_counter()

--- a/src/backend/base/langflow/base/agents/events.py
+++ b/src/backend/base/langflow/base/agents/events.py
@@ -94,9 +94,10 @@ def _extract_output_text(output: str | list) -> str:
     if isinstance(item, dict):
         if "text" in item:
             return item["text"]
+        # If the item's type is "tool_use", return an empty string.
+        # This likely indicates that "tool_use" outputs are not meant to be displayed as text.
         if item.get("type") == "tool_use":
             return ""
-
     msg = f"Output is not a string or list of dictionaries with 'text' key: {output}"
     raise ValueError(msg)
 


### PR DESCRIPTION
This pull request refactors the `_extract_output_text` function in `src/backend/base/langflow/base/agents/events.py` to improve its robustness and updates its usage in the `handle_on_chain_stream` function. The most important changes include restructuring the `_extract_output_text` function to handle additional edge cases and ensuring the `handle_on_chain_stream` function uses the updated logic.

### Refactoring `_extract_output_text` function:
* Enhanced `_extract_output_text` to handle edge cases where the input is an empty list, a list with non-dictionary items, or dictionaries without a "text" key. It now raises a `ValueError` with a descriptive message for unsupported formats.

### Updating `handle_on_chain_stream` function:
* Modified `handle_on_chain_stream` to use the updated `_extract_output_text` function for processing `data_chunk.content`, ensuring consistent and robust handling of output text.