### PR TITLE
fix: run flow multiple execution in tool mode

### DIFF
--- a/src/backend/base/langflow/base/tools/run_flow.py
+++ b/src/backend/base/langflow/base/tools/run_flow.py
@@ -47,9 +47,19 @@ class RunFlowBaseComponent(Component):
         ),
     ]
     _base_outputs: list[Output] = [
-        Output(name="flow_outputs_data", display_name="Flow Data Output", method="data_output", hidden=True),
         Output(
-            name="flow_outputs_dataframe", display_name="Flow Dataframe Output", method="dataframe_output", hidden=True
+            name="flow_outputs_data",
+            display_name="Flow Data Output",
+            method="data_output",
+            hidden=True,
+            tool_mode=False,
+        ),
+        Output(
+            name="flow_outputs_dataframe",
+            display_name="Flow Dataframe Output",
+            method="dataframe_output",
+            hidden=True,
+            tool_mode=False,
         ),
         Output(name="flow_outputs_message", display_name="Flow Message Output", method="message_output"),
     ]

--- a/src/backend/base/langflow/base/tools/run_flow.py
+++ b/src/backend/base/langflow/base/tools/run_flow.py
@@ -52,14 +52,14 @@ class RunFlowBaseComponent(Component):
             display_name="Flow Data Output",
             method="data_output",
             hidden=True,
-            tool_mode=False,
+            tool_mode=False,  # This output is not intended to be used as a tool, so tool_mode is disabled.
         ),
         Output(
             name="flow_outputs_dataframe",
             display_name="Flow Dataframe Output",
             method="dataframe_output",
             hidden=True,
-            tool_mode=False,
+            tool_mode=False,  # This output is not intended to be used as a tool, so tool_mode is disabled.
         ),
         Output(name="flow_outputs_message", display_name="Flow Message Output", method="message_output"),
     ]


### PR DESCRIPTION
Hotfix to enable only single execution for the runflow in tool mode.

All three outputs give similar responses in various formats, whereas in tool mode, the result must only be in message format.
________________
This pull request updates the `_base_outputs` list in the `src/backend/base/langflow/base/tools/run_flow.py` file to enhance the configuration of `Output` objects. The most notable change is the addition of the `tool_mode` attribute to two `Output` definitions, improving their configurability.

### Changes to `_base_outputs` list:

* Added the `tool_mode` attribute (set to `False`) to the `flow_outputs_data` and `flow_outputs_dataframe` `Output` objects for enhanced configurability.