### PR TITLE
fix: playground page allowing image upload even if feature flag is disabled

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/chat-input.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/chat-input.tsx
@@ -1,4 +1,5 @@
 import { usePostUploadFile } from "@/controllers/API/queries/files/use-post-upload-file";
+import { ENABLE_IMAGE_ON_PLAYGROUND } from "@/customization/feature-flags";
 import useFileSizeValidator from "@/shared/hooks/use-file-size-validator";
 import useAlertStore from "@/stores/alertStore";
 import useFlowStore from "@/stores/flowStore";
@@ -64,7 +65,7 @@ export default function ChatInput({
   const handleFileChange = async (
     event: React.ChangeEvent<HTMLInputElement> | ClipboardEvent,
   ) => {
-    if (playgroundPage) {
+    if (playgroundPage && !ENABLE_IMAGE_ON_PLAYGROUND) {
       return;
     }
 

--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/input-wrapper.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/input-wrapper.tsx
@@ -84,7 +84,8 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
         </div>
         <div className="flex w-full items-end justify-between">
           <div className={isBuilding ? "cursor-not-allowed" : ""}>
-            {!playgroundPage && ENABLE_IMAGE_ON_PLAYGROUND && (
+            {(!playgroundPage ||
+              (playgroundPage && ENABLE_IMAGE_ON_PLAYGROUND)) && (
               <UploadFileButton
                 isBuilding={isBuilding}
                 fileInputRef={fileInputRef}

--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/hooks/use-drag-and-drop.ts
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/hooks/use-drag-and-drop.ts
@@ -1,8 +1,11 @@
 import { ENABLE_IMAGE_ON_PLAYGROUND } from "@/customization/feature-flags";
 
-const useDragAndDrop = (setIsDragging: (value: boolean) => void) => {
+const useDragAndDrop = (
+  setIsDragging: (value: boolean) => void,
+  playgroundPage: boolean,
+) => {
   const dragOver = (e) => {
-    if (!ENABLE_IMAGE_ON_PLAYGROUND) return;
+    if (!ENABLE_IMAGE_ON_PLAYGROUND && playgroundPage) return;
     e.preventDefault();
     if (e.dataTransfer.types.some((type) => type === "Files")) {
       setIsDragging(true);
@@ -10,7 +13,7 @@ const useDragAndDrop = (setIsDragging: (value: boolean) => void) => {
   };
 
   const dragEnter = (e) => {
-    if (!ENABLE_IMAGE_ON_PLAYGROUND) return;
+    if (!ENABLE_IMAGE_ON_PLAYGROUND && playgroundPage) return;
     if (e.dataTransfer.types.some((type) => type === "Files")) {
       setIsDragging(true);
     }
@@ -18,6 +21,7 @@ const useDragAndDrop = (setIsDragging: (value: boolean) => void) => {
   };
 
   const dragLeave = (e) => {
+    if (!ENABLE_IMAGE_ON_PLAYGROUND && playgroundPage) return;
     e.preventDefault();
     setIsDragging(false);
   };

--- a/src/frontend/src/modals/IOModal/components/chatView/components/chat-view.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/components/chat-view.tsx
@@ -148,10 +148,13 @@ export default function ChatView({
   const { files, setFiles, handleFiles } = useFileHandler(currentFlowId);
   const [isDragging, setIsDragging] = useState(false);
 
-  const { dragOver, dragEnter, dragLeave } = useDragAndDrop(setIsDragging);
+  const { dragOver, dragEnter, dragLeave } = useDragAndDrop(
+    setIsDragging,
+    !!playgroundPage,
+  );
 
   const onDrop = (e) => {
-    if (!ENABLE_IMAGE_ON_PLAYGROUND) {
+    if (!ENABLE_IMAGE_ON_PLAYGROUND && playgroundPage) {
       e.stopPropagation();
       return;
     }


### PR DESCRIPTION
This pull request introduces changes to enhance feature flag handling for enabling or disabling image uploads in the Playground page. The updates ensure that the behavior of file uploads, drag-and-drop functionality, and UI components is consistent with the `ENABLE_IMAGE_ON_PLAYGROUND` flag.

### Feature flag integration (`ENABLE_IMAGE_ON_PLAYGROUND`):

* **Conditional file upload handling**: Updated the `handleFileChange` function in `chat-input.tsx` to block file uploads on the Playground page when the `ENABLE_IMAGE_ON_PLAYGROUND` flag is disabled.

* **Input wrapper logic adjustment**: Modified the conditional rendering logic in `input-wrapper.tsx` to ensure that the `UploadFileButton` is displayed only when the Playground page is enabled for image uploads.

* **Drag-and-drop enhancements**: Updated the `useDragAndDrop` hook in `use-drag-and-drop.ts` to conditionally handle drag-and-drop events based on the `ENABLE_IMAGE_ON_PLAYGROUND` flag and the `playgroundPage` parameter.

* **Drag-and-drop integration in `ChatView`**: Adjusted the `ChatView` component in `chat-view.tsx` to pass the `playgroundPage` flag to the `useDragAndDrop` hook and enforce the feature flag during the `onDrop` event.

* **Feature flag import**: Added the `ENABLE_IMAGE_ON_PLAYGROUND` import in `chat-input.tsx` to enable feature flag checks.