### PR TITLE
fix: get backend url dynamically for mcp

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
@@ -3,6 +3,7 @@ import ShadTooltip from "@/components/common/shadTooltipComponent";
 import ToolsComponent from "@/components/core/parameterRenderComponent/components/ToolsComponent";
 import { Button } from "@/components/ui/button";
 import { createApiKey } from "@/controllers/API";
+import { api } from "@/controllers/API/api";
 import {
   useGetFlowsMCP,
   usePatchFlowsMCP,
@@ -61,7 +62,9 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
     },
   };
 
-  const apiUrl = `${PROXY_TARGET}/api/v1/mcp/project/${projectId}/sse`;
+  const apiHost = api.defaults.baseURL || window.location.origin;
+
+  const apiUrl = `${apiHost}/api/v1/mcp/project/${projectId}/sse`;
 
   const MCP_SERVER_JSON = `{
   "mcpServers": {


### PR DESCRIPTION
This pull request introduces a change to the `McpServerTab` component in `McpServerTab.tsx` to improve how the API base URL is determined. The most important updates include importing the `api` module and using its `baseURL` property as a fallback for constructing the `apiUrl`.

### Updates to API URL construction:

* [`src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx`](diffhunk://#diff-da4edd139a58d412a5bba68a4e4e84c77cf40f53711bceee9c9a12da4ea2eda8R6): Added an import for the `api` module from `@/controllers/API/api` to access the default `baseURL`.
* [`src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx`](diffhunk://#diff-da4edd139a58d412a5bba68a4e4e84c77cf40f53711bceee9c9a12da4ea2eda8L64-R67): Modified the `apiUrl` to dynamically use `api.defaults.baseURL` or fall back to `window.location.origin` if `baseURL` is not set. This ensures greater flexibility and adaptability for different environments.