### PR TITLE
fix: Update folder progress component sizing and correct analytics event name

### DIFF
--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
@@ -82,7 +82,7 @@ export const GetStartedProgress: FC<{
   };
 
   return (
-    <div className="mt-3 h-[180px] w-full">
+    <div className="mt-3 h-[10.8rem] w-full">
       <div className="mb-2 flex items-center justify-between">
         <span className="text-sm font-semibold">
           {percentageGetStarted >= 100 ? (

--- a/src/frontend/src/pages/MainPage/pages/empty-page.tsx
+++ b/src/frontend/src/pages/MainPage/pages/empty-page.tsx
@@ -136,7 +136,7 @@ export const EmptyPageCommunity = ({
                 unstyled
                 className="group mx-3 h-[84px] sm:mx-0"
                 onClick={() => {
-                  handleUserTrack("discord_joined")();
+                  handleUserTrack("discord_clicked")();
                   window.open(DISCORD_URL, "_blank", "noopener,noreferrer");
                 }}
                 data-testid="empty_page_discord_button"


### PR DESCRIPTION
This pull request includes two changes to the frontend components, focusing on improving UI consistency and analytics tracking.

### UI Improvements:
* [`src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx`](diffhunk://#diff-8d321fde6165c43e414eab942a430830c848898375d8ab3c1edc2e6acdcfe423L85-R85): Updated the height of the progress container to use `rem` units for better scalability and consistency (`h-[180px]` → `h-[10.8rem]`).

### Analytics Tracking:
* [`src/frontend/src/pages/MainPage/pages/empty-page.tsx`](diffhunk://#diff-0bca997a243edf751074da90447661915fa2b3cfac4814efbcd5305cac4c42dbL139-R139): Updated the event name in the `handleUserTrack` function to reflect a more accurate user action (`discord_joined` → `discord_clicked`).