### PR TITLE
feat: deprecate Google Components

### DIFF
--- a/src/backend/base/langflow/components/google/google_drive.py
+++ b/src/backend/base/langflow/components/google/google_drive.py
@@ -17,6 +17,7 @@ class GoogleDriveComponent(Component):
     display_name = "Google Drive Loader"
     description = "Loads documents from Google Drive using provided credentials."
     icon = "Google"
+    legacy: bool = True
 
     inputs = [
         SecretStrInput(

--- a/src/backend/base/langflow/components/google/google_drive_search.py
+++ b/src/backend/base/langflow/components/google/google_drive_search.py
@@ -14,6 +14,7 @@ class GoogleDriveSearchComponent(Component):
     display_name = "Google Drive Search"
     description = "Searches Google Drive files using provided credentials and query parameters."
     icon = "Google"
+    legacy: bool = True
 
     inputs = [
         SecretStrInput(

--- a/src/backend/base/langflow/components/google/google_oauth_token.py
+++ b/src/backend/base/langflow/components/google/google_oauth_token.py
@@ -17,7 +17,7 @@ class GoogleOAuthToken(Component):
     documentation: str = "https://developers.google.com/identity/protocols/oauth2/web-server?hl=pt-br#python_1"
     icon = "Google"
     name = "GoogleOAuthToken"
-
+    legacy: bool = True
     inputs = [
         MultilineInput(
             name="scopes",


### PR DESCRIPTION
These components are not fully functional, hence moving to legacy.
_______________
This pull request introduces a new `legacy` attribute to several Google-related components in the codebase. This attribute is likely being added to indicate whether these components are considered legacy or deprecated.

### Addition of `legacy` attribute:

* [`src/backend/base/langflow/components/google/google_drive.py`](diffhunk://#diff-f31bbe70e174383dda327c5f37c17271993ecf7e23c8acbf8ad0468fd126b474R20): Added a `legacy` attribute with a value of `True` to the `GoogleDriveComponent` class.
* [`src/backend/base/langflow/components/google/google_drive_search.py`](diffhunk://#diff-70e7a2be779f29384e01e371c0d84e0fe20802cb5c0e2e8167b365cd1e5ef7ebR17): Added a `legacy` attribute with a value of `True` to the `GoogleDriveSearchComponent` class.
* [`src/backend/base/langflow/components/google/google_oauth_token.py`](diffhunk://#diff-3bfdc7d50a7959e881cf6aed3d7d97a93e3302047f9200200e3d0a87edf50408L20-R20): Added a `legacy` attribute with a value of `True` to the `GoogleOAuthToken` class.