### PR TITLE
fix: disable images on playground

### DIFF
--- a/src/frontend/src/customization/feature-flags.ts
+++ b/src/frontend/src/customization/feature-flags.ts
@@ -12,6 +12,6 @@ export const ENABLE_FILE_MANAGEMENT = true;
 export const ENABLE_PUBLISH = true;
 export const ENABLE_WIDGET = true;
 export const ENABLE_VOICE_ASSISTANT = true;
-export const ENABLE_IMAGE_ON_PLAYGROUND = true;
+export const ENABLE_IMAGE_ON_PLAYGROUND = false;
 export const ENABLE_MCP = true;
 export const ENABLE_MCP_NOTICE = true;

--- a/src/frontend/src/modals/IOModal/components/chatView/components/chat-view.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/components/chat-view.tsx
@@ -38,7 +38,6 @@ export default function ChatView({
   playgroundPage,
   sidebarOpen,
 }: chatViewProps): JSX.Element {
-  const flowPool = useFlowStore((state) => state.flowPool);
   const inputs = useFlowStore((state) => state.inputs);
   const clientId = useUtilityStore((state) => state.clientId);
   let realFlowId = useFlowsManagerStore((state) => state.currentFlowId);
@@ -145,7 +144,7 @@ export default function ChatView({
       });
   }
 
-  const { files, setFiles, handleFiles } = useFileHandler(currentFlowId);
+  const { files, setFiles, handleFiles } = useFileHandler(realFlowId);
   const [isDragging, setIsDragging] = useState(false);
 
   const { dragOver, dragEnter, dragLeave } = useDragAndDrop(


### PR DESCRIPTION
This fix disables images on playground since there is no way of handling public images by now.

### Feature flag updates:
* [`src/frontend/src/customization/feature-flags.ts`](diffhunk://#diff-5475ebe578c52e406769df95401c19b8e8316917f09835449aff30824262b6baL15-R15): Disabled the `ENABLE_IMAGE_ON_PLAYGROUND` feature flag by setting it to `false`. This change likely reflects a decision to temporarily or permanently turn off this feature.