### PR TITLE
fix: correct typo in pretty-logs property

### DIFF
--- a/src/backend/base/langflow/logging/logger.py
+++ b/src/backend/base/langflow/logging/logger.py
@@ -233,7 +233,7 @@ def configure(
             log_format = DEFAULT_LOG_FORMAT
         # pretty print to rich stdout development-friendly but poor performance, It's better for debugger.
         # suggest directly print to stdout in production
-        log_stdout_pretty = os.getenv("LAGFLOW_PRETTY_LOGS", "true").lower() == "true"
+        log_stdout_pretty = os.getenv("LANGFLOW_PRETTY_LOGS", "true").lower() == "true"
         if log_stdout_pretty:
             logger.configure(
                 handlers=[


### PR DESCRIPTION
Typo property fix

LAGFLOW_PRETTY_LOGS -> LANGFLOW_PRETTY_LOGS