### PR TITLE
feat: add validation for node js for npx based mcp command

### DIFF
--- a/src/backend/base/langflow/components/tools/mcp_component.py
+++ b/src/backend/base/langflow/components/tools/mcp_component.py
@@ -1,4 +1,5 @@
 import re
+import shutil
 from typing import Any
 
 from langchain_core.tools import StructuredTool
@@ -175,6 +176,13 @@ class MCPToolsComponent(Component):
         if mode == "SSE" and not url:
             msg = "URL is required for SSE mode"
             raise ValueError(msg)
+        
+    def validate_npx_command(self, command: str) -> str:
+        """Validate the npx command."""
+        if "npx" in command and not shutil.which("node"):
+            msg = "Node.js is not installed. Please install Node.js to use npx commands."
+            raise ValueError(msg)
+        return command
 
     def _process_headers(self, headers: Any) -> dict:
         """Process the headers input into a valid dictionary.
@@ -435,6 +443,7 @@ class MCPToolsComponent(Component):
                 mode = self.mode
             if command is None:
                 command = self.command
+                self.validate_npx_command(command)
             if env is None:
                 env = self.env
             if url is None:


### PR DESCRIPTION
This pull request introduces a new method to validate `npx` commands and ensures that the validation is integrated into the tool update process. The changes enhance error handling and provide clearer feedback when Node.js is not installed, which is required for `npx` commands.

### Enhancements to `npx` command validation:

* **New method for validation**: Added the `validate_npx_command` method to check if Node.js is installed when using `npx` commands. If Node.js is not found, a `ValueError` is raised with an appropriate message. (`src/backend/base/langflow/components/tools/mcp_component.py`, [src/backend/base/langflow/components/tools/mcp_component.pyR180-R186](diffhunk://#diff-8b368b159254d9a5a8ebef207dcb28d4790e3c6fcd01325b61d67bfd078b4177R180-R186))

* **Integration into tool update process**: Incorporated the `validate_npx_command` method into the `update_tools` function to ensure `npx` commands are validated whenever tools are updated. (`src/backend/base/langflow/components/tools/mcp_component.py`, [src/backend/base/langflow/components/tools/mcp_component.pyR446](diffhunk://#diff-8b368b159254d9a5a8ebef207dcb28d4790e3c6fcd01325b61d67bfd078b4177R446))

### Codebase improvements:

* **Import addition**: Added the `shutil` module to support the `which` function used for validating the presence of Node.js. (`src/backend/base/langflow/components/tools/mcp_component.py`, [src/backend/base/langflow/components/tools/mcp_component.pyR2](diffhunk://#diff-8b368b159254d9a5a8ebef207dcb28d4790e3c6fcd01325b61d67bfd078b4177R2))