### PR TITLE
fix: wait on loguru to flush async logs from services

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -191,7 +191,10 @@ def get_lifespan(*, fix_migration=False, version=None):
                 sync_flows_from_fs_task.cancel()
                 await asyncio.wait([sync_flows_from_fs_task])
             await teardown_services()
+
+            await asyncio.sleep(0.1)  # let logger flush async logs
             await logger.complete()
+
             temp_dir_cleanups = [asyncio.to_thread(temp_dir.cleanup) for temp_dir in temp_dirs]
             await asyncio.gather(*temp_dir_cleanups)
             # Final message


### PR DESCRIPTION
Adds a wait to allow loguru to flush async logs. Avoids these logs on local build shutdown:
```
--- Logging error in Loguru Handler #-1 ---
Record was: {'elapsed': datetime.timedelta(seconds=95, microseconds=904420), 'exception': None, 'extra': {}, 'file': (name='manager.py', path='/Users/jordan.frazier/Documents/Langflow/langflow/src/backend/base/langflow/services/manager.py'), 'function': 'teardown', 'level': (name='DEBUG', no=10, icon='🐞'), 'line': 95, 'message': 'Teardown service storage_service', 'module': 'manager', 'name': 'langflow.services.manager', 'process': (id=12370, name='SpawnProcess-1'), 'thread': (id=8647473856, name='MainThread'), 'time': datetime(2025, 5, 5, 16, 50, 50, 397965, tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=61200), 'PDT'))}
Traceback (most recent call last):
  File "/Users/jordan.frazier/Documents/Langflow/langflow/src/backend/base/langflow/logging/logger.py", line 172, in write_async
    await asyncio.to_thread(self._sink.write, message)
  File "/Users/jordan.frazier/.pyenv/versions/3.11.2/lib/python3.11/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jordan.frazier/.pyenv/versions/3.11.2/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jordan.frazier/Documents/Langflow/langflow/.venv/lib/python3.11/site-packages/loguru/_file_sink.py", line 203, in write
    if self._rotation_function is not None and self._rotation_function(message, self._file):
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jordan.frazier/Documents/Langflow/langflow/.venv/lib/python3.11/site-packages/loguru/_file_sink.py", line 106, in rotation_size
    return file.tell() + len(message) > size_limit
           ^^^^^^^^^^^
ValueError: I/O operation on closed file
--- End of logging error ---

```


