### PR TITLE
build: add event-delivery polling for cloud image

### DIFF
--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -99,6 +99,7 @@ WORKDIR /app
 
 ENV LANGFLOW_HOST=0.0.0.0
 ENV LANGFLOW_PORT=7860
+ENV LANGFLOW_EVENT_DELIVERY=polling
 
 USER 1000
 CMD ["python", "-m", "langflow", "run", "--host", "0.0.0.0", "--backend-only"]


### PR DESCRIPTION
Now that the default is swapped to `streaming`, we must set this env back to `polling` for DSLFv1 to operate. 