### PR TITLE
fix: update hide outputs behavior to show current state, update disabled button UI

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
@@ -73,10 +73,15 @@ const HideShowButton = memo(
       unstyled
       onClick={onClick}
       data-testid={`input-inspection-${title.toLowerCase()}`}
-      className="cursor-pointer"
     >
       <ShadTooltip
-        content={disabled ? null : hidden ? "Show output" : "Hide output"}
+        content={
+          disabled
+            ? "Cannot hide output"
+            : hidden
+              ? "Show output"
+              : "Hide output"
+        }
       >
         <div>
           <EyeIcon
@@ -84,9 +89,7 @@ const HideShowButton = memo(
             className={cn(
               "icon-size",
               disabled
-                ? isToolMode
-                  ? "text-placeholder-foreground opacity-60"
-                  : "text-placeholder-foreground hover:text-foreground"
+                ? "text-placeholder-foreground opacity-60"
                 : isToolMode
                   ? "text-background hover:text-secondary-hover"
                   : "text-placeholder-foreground hover:text-primary-hover",

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
@@ -77,7 +77,7 @@ const HideShowButton = memo(
       <ShadTooltip
         content={
           disabled
-            ? "Cannot hide output"
+            ? "Connected outputs can't be hidden."
             : hidden
               ? "Show output"
               : "Hide output"

--- a/src/frontend/src/CustomNodes/GenericNode/components/RenderInputParameters/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/RenderInputParameters/index.tsx
@@ -28,6 +28,17 @@ const RenderInputParameters = ({
       );
   }, [data.node?.template, data.node?.field_order, isToolMode]);
 
+  const shownTemplateFields = useMemo(() => {
+    return templateFields.filter((templateField) => {
+      const template = data.node?.template[templateField];
+      return (
+        template?.show &&
+        !template?.advanced &&
+        !(template?.tool_mode && isToolMode)
+      );
+    });
+  }, [templateFields, data.node?.template, isToolMode]);
+
   const memoizedColors = useMemo(() => {
     const colorMap = new Map();
 
@@ -74,24 +85,19 @@ const RenderInputParameters = ({
     return keyMap;
   }, [templateFields, data.id, data.node?.template]);
 
-  const renderInputParameter = templateFields.map(
-    (templateField: string, idx) => {
+  const renderInputParameter = shownTemplateFields.map(
+    (templateField: string, idx: number) => {
       const template = data.node?.template[templateField];
-
-      if (
-        !template?.show ||
-        template?.advanced ||
-        (template?.tool_mode && isToolMode)
-      ) {
-        return null;
-      }
 
       const memoizedColor = memoizedColors.get(templateField);
       const memoizedKey = memoizedKeys.get(templateField);
 
       return (
         <NodeInputField
-          lastInput={!(shownOutputs.length > 0 || showHiddenOutputs)}
+          lastInput={
+            !(shownOutputs.length > 0 || showHiddenOutputs) &&
+            idx === shownTemplateFields.length - 1
+          }
           key={memoizedKey}
           data={data}
           colors={memoizedColor.colors}

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -233,7 +233,13 @@ function GenericNode({
           showNode={showNode}
           isToolMode={isToolMode}
           showHiddenOutputs={showHiddenOutputs}
-          hidden={key === "hidden" ? output.hidden : false}
+          hidden={
+            key === "hidden"
+              ? showHiddenOutputs
+                ? output.hidden
+                : true
+              : false
+          }
         />
       ));
     },

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -233,7 +233,7 @@ function GenericNode({
           showNode={showNode}
           isToolMode={isToolMode}
           showHiddenOutputs={showHiddenOutputs}
-          hidden={output.hidden}
+          hidden={key === "hidden" ? output.hidden : false}
         />
       ));
     },

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -233,7 +233,7 @@ function GenericNode({
           showNode={showNode}
           isToolMode={isToolMode}
           showHiddenOutputs={showHiddenOutputs}
-          hidden={key === "hidden"}
+          hidden={output.hidden}
         />
       ));
     },


### PR DESCRIPTION
This pull request focuses on improving the behavior and rendering logic of input and output fields in the `GenericNode` component. The key changes include refining the tooltip messages for output visibility, introducing a filtered list of template fields for rendering, and improving the logic for determining the visibility of outputs.

### Enhancements to Output Visibility and Tooltips:

* Updated the tooltip logic in `NodeOutputfield` to display more accurate messages based on the `disabled` and `hidden` states. The tooltip now shows "Cannot hide output" when disabled, enhancing clarity for users. (`src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx`, [src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsxL76-L89](diffhunk://#diff-4742b353430022eb88d35ab987d50925c592f35702319e1d476e2d53818cd795L76-L89))

### Improvements to Input Parameter Rendering:

* Introduced a `shownTemplateFields` variable using `useMemo` to filter template fields based on their `show`, `advanced`, and `tool_mode` properties. This ensures only relevant fields are processed for rendering. (`src/frontend/src/CustomNodes/GenericNode/components/RenderInputParameters/index.tsx`, [src/frontend/src/CustomNodes/GenericNode/components/RenderInputParameters/index.tsxR31-R41](diffhunk://#diff-4698b7d1c55e61a64837ac9e2588c7e8e91ca6cb599aec866a6e6f296b36d4b3R31-R41))
* Updated the `renderInputParameter` logic to use `shownTemplateFields` instead of `templateFields`, improving performance and readability. Removed redundant checks for field visibility within the map function. (`src/frontend/src/CustomNodes/GenericNode/components/RenderInputParameters/index.tsx`, [src/frontend/src/CustomNodes/GenericNode/components/RenderInputParameters/index.tsxL77-R100](diffhunk://#diff-4698b7d1c55e61a64837ac9e2588c7e8e91ca6cb599aec866a6e6f296b36d4b3L77-R100))

### Refinements to Output Handling:

* Adjusted the `hidden` property assignment in the `GenericNode` component to directly use the `hidden` attribute of the `output` object, ensuring consistent behavior. (`src/frontend/src/CustomNodes/GenericNode/index.tsx`, [src/frontend/src/CustomNodes/GenericNode/index.tsxL236-R236](diffhunk://#diff-b6793e0279f94c374aae18db97958c0af6befc2b49b7ce30e0294f9c80ba0d0eL236-R236))