### PR TITLE
fix: suppress migration warnings on flow table

### DIFF
--- a/src/backend/base/langflow/services/database/models/flow/model.py
+++ b/src/backend/base/langflow/services/database/models/flow/model.py
@@ -35,6 +35,9 @@ class AccessTypeEnum(str, Enum):
 
 
 class FlowBase(SQLModel):
+    # Supresses warnings during migrations
+    __mapper_args__ = {"confirm_deleted_rows": False}
+
     name: str = Field(index=True)
     description: str | None = Field(default=None, sa_column=Column(Text, index=True, nullable=True))
     icon: str | None = Field(default=None, nullable=True)


### PR DESCRIPTION
suppress warnings from migrations on the `flow` table, such as in the following:

Closes https://github.com/langflow-ai/langflow/issues/6016
Closes https://github.com/langflow-ai/langflow/issues/6944

Note that this will suppress all instances of this warning, which can be beneficial if we have a bug in the flow deletion logic where we attempt to delete a flow that doesn't exist, but as this is not business-critical logic for langflow, I believe it to be fine. 