### PR TITLE
fix: removed gradient from icon when component is tool mode

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/nodeIcon/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/nodeIcon/index.tsx
@@ -1,10 +1,5 @@
 import { useTypesStore } from "@/stores/typesStore";
-import {
-  BG_NOISE,
-  iconExists,
-  nodeColors,
-  toolModeGradient,
-} from "@/utils/styleUtils";
+import { iconExists, nodeColors } from "@/utils/styleUtils";
 import emojiRegex from "emoji-regex";
 import { useEffect, useState } from "react";
 
@@ -18,13 +13,11 @@ export function NodeIcon({
   dataType,
   showNode,
   isGroup,
-  hasToolMode,
 }: {
   icon?: string;
   dataType: string;
   showNode: boolean;
   isGroup?: boolean;
-  hasToolMode: boolean;
 }) {
   const types = useTypesStore((state) => state.types);
   const [name, setName] = useState(types[dataType]);
@@ -46,8 +39,6 @@ export function NodeIcon({
     isLucideIcon ? "lucide-icon" : "integration-icon",
   );
 
-  const bgToolMode = BG_NOISE + "," + toolModeGradient;
-
   const renderIcon = () => {
     if (icon && isEmoji) {
       return <span className="text-lg">{icon}</span>;
@@ -57,13 +48,10 @@ export function NodeIcon({
       return (
         <div
           className={cn(
-            hasToolMode ? "text-white" : "text-foreground",
+            "text-white",
             !showNode && "flex min-h-8 min-w-8 items-center justify-center",
             "bg-lucide-icon",
           )}
-          style={{
-            backgroundImage: hasToolMode ? bgToolMode : "",
-          }}
         >
           <IconComponent
             strokeWidth={ICON_STROKE_WIDTH}

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -361,10 +361,9 @@ function GenericNode({
         showNode={showNode}
         icon={data.node?.icon}
         isGroup={!!data.node?.flow}
-        hasToolMode={hasToolMode ?? false}
       />
     );
-  }, [data.type, showNode, data.node?.icon, data.node?.flow, hasToolMode]);
+  }, [data.type, showNode, data.node?.icon, data.node?.flow]);
 
   const renderNodeName = useCallback(() => {
     return (


### PR DESCRIPTION
This pull request simplifies the `NodeIcon` component in the `GenericNode` feature by removing the `hasToolMode` property and its associated logic. The changes improve maintainability by eliminating unused code and unnecessary complexity.

### Simplification of `NodeIcon` component:

* Removed the `hasToolMode` property from the `NodeIcon` component's props and its usage throughout the component. This includes removing the conditional logic for `hasToolMode` in class names and styles. (`src/frontend/src/CustomNodes/GenericNode/components/nodeIcon/index.tsx`) [[1]](diffhunk://#diff-108b8898385719cca096f06d0b63e5ff9ab30ab55a020f819400c01fe2123abfL21-L27) [[2]](diffhunk://#diff-108b8898385719cca096f06d0b63e5ff9ab30ab55a020f819400c01fe2123abfL60-L66)
* Removed unused imports `BG_NOISE` and `toolModeGradient` from `styleUtils`, as they were only used in the now-deleted `hasToolMode` logic. (`src/frontend/src/CustomNodes/GenericNode/components/nodeIcon/index.tsx`)

### Updates in `GenericNode` usage:

* Removed the `hasToolMode` property from the `GenericNode` component's `NodeIcon` usage, along with its dependency in the `useCallback` hook. (`src/frontend/src/CustomNodes/GenericNode/index.tsx`)