### PR TITLE
fix: mcp anyOf support

### DIFF
--- a/src/backend/base/langflow/base/mcp/util.py
+++ b/src/backend/base/langflow/base/mcp/util.py
@@ -116,14 +116,16 @@ def create_input_schema_from_json_schema(schema: dict[str, Any]) -> type[BaseMod
                 # Get the non-null type
                 non_null_type = next(t for t in subtypes if t != "null")
                 # Map it to Python type
-                return {
-                    "string": str,
-                    "integer": int,
-                    "number": float,
-                    "boolean": bool,
-                    "object": dict,
-                    "array": list,
-                }.get(non_null_type, Any)
+                if isinstance(non_null_type, str):
+                    return {
+                        "string": str,
+                        "integer": int,
+                        "number": float,
+                        "boolean": bool,
+                        "object": dict,
+                        "array": list,
+                    }.get(non_null_type, Any)
+                return Any
 
             # For other anyOf cases, use the first non-null type
             subtypes = [parse_type(sub) for sub in s["anyOf"]]
@@ -132,7 +134,7 @@ def create_input_schema_from_json_schema(schema: dict[str, Any]) -> type[BaseMod
                 return non_null_types[0]
             return str
 
-        t = s.get("type", Any)
+        t = s.get("type", "any")  # Use string "any" as default instead of Any type
         if t == "array":
             item_schema = s.get("items", {})
             schema_type: Any = parse_type(item_schema)


### PR DESCRIPTION
This pull request refines the `parse_type` function in `src/backend/base/langflow/base/mcp/util.py` to improve its handling of `anyOf` schemas.

Improvements to `anyOf` handling:

* Modified the `parse_type` function to simplify `anyOf` schemas by selecting the first non-null type from the subtypes. If no non-null type is found, it defaults to `str` instead of returning a tuple of types.

bug repros with this mcp server:

```
import asyncio
from fastapi import FastAPI
from fastmcp import FastMCP
from fastmcp.server.openapi import RouteMap, RouteType

api: FastAPI = FastAPI()

async def main():
    # Generate the MCP server
    mcp = FastMCP.from_fastapi(
        api,
        route_maps=[
            RouteMap(
                methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
                pattern=r".*",
                route_type=RouteType.TOOL,
            ),
        ],
    )
    # Run the MCP server in SSE mode
    await mcp.run_async(transport="sse")

@api.get("/items/{item_id}")
def read_item(item_id: int, query: str | None = None):
    return {"item_id": item_id, "query": query}

if __name__ == "__main__":
    asyncio.run(main())
```