### PR TITLE
fix: MCP Tool mode issue

### DIFF
--- a/src/backend/base/langflow/components/tools/mcp_component.py
+++ b/src/backend/base/langflow/components/tools/mcp_component.py
@@ -499,7 +499,7 @@ class MCPToolsComponent(Component):
                         func=create_tool_func(tool.name, args_schema, client.session),
                         coroutine=create_tool_coroutine(tool.name, args_schema, client.session),
                         tags=[tool.name],
-                        metadata={}
+                        metadata={},
                     )
                     tool_list.append(tool_obj)
                     self._tool_cache[tool.name] = tool_obj

--- a/src/backend/base/langflow/components/tools/mcp_component.py
+++ b/src/backend/base/langflow/components/tools/mcp_component.py
@@ -499,6 +499,7 @@ class MCPToolsComponent(Component):
                         func=create_tool_func(tool.name, args_schema, client.session),
                         coroutine=create_tool_coroutine(tool.name, args_schema, client.session),
                         tags=[tool.name],
+                        metadata={}
                     )
                     tool_list.append(tool_obj)
                     self._tool_cache[tool.name] = tool_obj
@@ -526,4 +527,3 @@ class MCPToolsComponent(Component):
             msg = "SSE URL is not set"
             raise ValueError(msg)
         return await self.update_tools()
-        # return self.tools

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -1162,20 +1162,21 @@ class Component(CustomComponent):
         # Create a mapping of tool names to their status
         tool_status = {item["name"]: item.get("status", True) for item in metadata_dict}
         return [tool for tool in tools if tool_status.get(tool.name, True)]
-    def _build_tool_data(self, tool:Tool) -> dict:
+
+    def _build_tool_data(self, tool: Tool) -> dict:
         if tool.metadata is None:
             tool.metadata = {}
         return {
-                "name": tool.name,
-                "description": tool.description,
-                "tags": tool.tags if hasattr(tool, "tags") and tool.tags else [tool.name],
-                "status": True,  # Initialize all tools with status True
-                "display_name": tool.metadata.get("display_name", tool.name),
-                "display_description": tool.metadata.get("display_description", tool.description),
-                "readonly": tool.metadata.get("readonly", False),
-                "args": tool.args,
-                # "args_schema": tool.args_schema,
-            }
+            "name": tool.name,
+            "description": tool.description,
+            "tags": tool.tags if hasattr(tool, "tags") and tool.tags else [tool.name],
+            "status": True,  # Initialize all tools with status True
+            "display_name": tool.metadata.get("display_name", tool.name),
+            "display_description": tool.metadata.get("display_description", tool.description),
+            "readonly": tool.metadata.get("readonly", False),
+            "args": tool.args,
+            # "args_schema": tool.args_schema,
+        }
 
     async def _build_tools_metadata_input(self):
         tools = await self._get_tools()

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -1140,7 +1140,7 @@ class Component(CustomComponent):
             list[Tool]: Filtered list of tools.
         """
         # Convert metadata to a list of dicts if it's a DataFrame
-        metadata_dict = None
+        metadata_dict = None  # Initialize as None to avoid lint issues with empty dict
         if isinstance(metadata, pd.DataFrame):
             metadata_dict = metadata.to_dict(orient="records")
 

--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -1140,7 +1140,7 @@ class Component(CustomComponent):
             list[Tool]: Filtered list of tools.
         """
         # Convert metadata to a list of dicts if it's a DataFrame
-        metadata_dict = {}
+        metadata_dict = None
         if isinstance(metadata, pd.DataFrame):
             metadata_dict = metadata.to_dict(orient="records")
 


### PR DESCRIPTION
Ensure the proper initialisation of Tool mode variables.
______________________
This pull request introduces changes to improve tool metadata handling, refactor tool-related methods, and enhance code clarity in `mcp_component.py` and `custom_component.py`. The key updates include adding metadata initialization, simplifying metadata filtering, and refactoring the tool data construction logic.

### Improvements to Tool Metadata Handling:
* [`src/backend/base/langflow/components/tools/mcp_component.py`](diffhunk://#diff-8b368b159254d9a5a8ebef207dcb28d4790e3c6fcd01325b61d67bfd078b4177R502): Added an empty `metadata` dictionary to tool objects during their creation in the `update_tools` method to ensure consistent metadata initialization.

### Refactoring and Simplification:
* [`src/backend/base/langflow/custom/custom_component/component.py`](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169L1143-R1143): Changed the default value of `metadata_dict` to an empty dictionary in `_filter_tools_by_status`, simplifying the handling of metadata when it is not provided.
* [`src/backend/base/langflow/custom/custom_component/component.py`](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169L1165-R1168): Refactored `_build_tools_metadata_input` by extracting tool data construction into a new `_build_tool_data` method, improving modularity and reusability. [[1]](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169L1165-R1168) [[2]](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169L1182-R1183)

### Code Cleanup:
* [`src/backend/base/langflow/components/tools/mcp_component.py`](diffhunk://#diff-8b368b159254d9a5a8ebef207dcb28d4790e3c6fcd01325b61d67bfd078b4177L529): Removed a commented-out return statement in `_get_tools` for cleaner and more maintainable code.