### PR TITLE
docs: add hardware requirements to installation prerequisites

### DIFF
--- a/docs/docs/Get-Started/get-started-installation.md
+++ b/docs/docs/Get-Started/get-started-installation.md
@@ -19,6 +19,7 @@ Before you install and run Langflow OSS, be sure you have the following items.
 - [Python 3.10 to 3.13](https://www.python.org/downloads/release/python-3100/)
 - [uv](https://docs.astral.sh/uv/getting-started/installation/) or [pip](https://pypi.org/project/pip/)
 - A virtual environment created with [uv](https://docs.astral.sh/uv/pip/environments) or [venv](https://docs.python.org/3/library/venv.html)
+- A dual-core CPU and at least 2 GB of RAM. More intensive use requires a multi-core CPU and at least 4 GB of RAM.
 
 Install and run Langflow OSS with [uv (recommended)](https://docs.astral.sh/uv/getting-started/installation/) or [pip](https://pypi.org/project/pip/).
 


### PR DESCRIPTION
This pull request updates the installation prerequisites in the `Get Started` documentation for Langflow OSS by adding hardware requirements:
`- A dual-core CPU and at least 2 GB of RAM. More intensive use requires a multi-core CPU and at least 4 GB of RAM.`