### PR TITLE
fix: add search functionality to code modal on desktop and cli langflow

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -34,7 +34,7 @@
         "@types/axios": "^0.14.0",
         "@types/react-syntax-highlighter": "^15.5.13",
         "@xyflow/react": "^12.3.6",
-        "ace-builds": "^1.35.0",
+        "ace-builds": "^1.41.0",
         "ag-grid-community": "^32.0.2",
         "ag-grid-react": "^32.0.2",
         "ansi-to-html": "^0.7.2",
@@ -5794,9 +5794,10 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.40.1.tgz",
-      "integrity": "sha512-32uwJNwmhqpnYtr6oq8RoO1D6F6tnxisv5f9w2XPX3vi4QruuHNikadHUiHvnxLAV1n5Azv4LFtpItQ5dD1eRw=="
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.41.0.tgz",
+      "integrity": "sha512-tiEUfw7V/FpHuI4tG7KS+muOTMIuPh6zReBAD2Uqhe9t00tLeyVGxjXu0tSqz5OIPWy7/wvuJBVXAsNWx0rYvQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.14.1",
@@ -12852,6 +12853,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-11.0.1.tgz",
       "integrity": "sha512-ulk2851Fx2j59AAahZHTe7rmQ5bITW1xytskAt11F8dv3rPLtdwBXCyT2qSbRnJvOq8UpuAhWO4/JhKGqQBEDA==",
+      "license": "MIT",
       "dependencies": {
         "ace-builds": "^1.32.8",
         "diff-match-patch": "^1.0.5",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -29,7 +29,7 @@
     "@types/axios": "^0.14.0",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@xyflow/react": "^12.3.6",
-    "ace-builds": "^1.35.0",
+    "ace-builds": "^1.41.0",
     "ag-grid-community": "^32.0.2",
     "ag-grid-react": "^32.0.2",
     "ansi-to-html": "^0.7.2",

--- a/src/frontend/src/modals/codeAreaModal/index.tsx
+++ b/src/frontend/src/modals/codeAreaModal/index.tsx
@@ -54,13 +54,12 @@ export default function CodeAreaModal({
   const setErrorData = useAlertStore((state) => state.setErrorData);
   const [openConfirmation, setOpenConfirmation] = useState(false);
   const codeRef = useRef<ReactAce | null>(null);
-  const { mutate, isPending } = usePostValidateCode();
+  const { mutate } = usePostValidateCode();
   const [error, setError] = useState<{
     detail: CodeErrorDataTypeAPI;
   } | null>(null);
 
   const { mutate: validateComponentCode } = usePostValidateComponentCode();
-  const setNode = useFlowStore((state) => state.setNode);
 
   useEffect(() => {
     // if nodeClass.template has more fields other than code and dynamic is true
@@ -177,6 +176,8 @@ export default function CodeAreaModal({
         } else {
           if (
             !(
+              codeRef.current?.editor.completer &&
+              "popup" in codeRef.current?.editor.completer &&
               codeRef.current?.editor.completer.popup &&
               codeRef.current?.editor.completer.popup.isOpen
             )

--- a/src/frontend/src/modals/codeAreaModal/index.tsx
+++ b/src/frontend/src/modals/codeAreaModal/index.tsx
@@ -1,12 +1,12 @@
-import "ace-builds/src-noconflict/ace";
-import "ace-builds/src-noconflict/ext-language_tools";
-import "ace-builds/src-noconflict/mode-python";
-import "ace-builds/src-noconflict/theme-github";
-import "ace-builds/src-noconflict/theme-twilight";
-// import "ace-builds/webpack-resolver";
 import { usePostValidateCode } from "@/controllers/API/queries/nodes/use-post-validate-code";
 import { usePostValidateComponentCode } from "@/controllers/API/queries/nodes/use-post-validate-component-code";
 import useFlowStore from "@/stores/flowStore";
+import "ace-builds/src-noconflict/ace";
+import "ace-builds/src-noconflict/ext-language_tools";
+import "ace-builds/src-noconflict/ext-searchbox";
+import "ace-builds/src-noconflict/mode-python";
+import "ace-builds/src-noconflict/theme-github";
+import "ace-builds/src-noconflict/theme-twilight";
 import { useEffect, useRef, useState } from "react";
 import AceEditor from "react-ace";
 import ReactAce from "react-ace/lib/ace";


### PR DESCRIPTION
This pull request includes updates to dependencies, improvements to the `CodeAreaModal` component, and minor code cleanup. The most significant changes involve upgrading the `ace-builds` library, removing unused imports, and refining the code editor's behavior in the modal.

### Dependency Updates:
* Upgraded `ace-builds` from version `^1.35.0` to `^1.41.0` in `package.json` and `package-lock.json`, ensuring compatibility with the latest features and bug fixes. [[1]](diffhunk://#diff-9eaa8c31e85b60ae25c139f2d6363cc9dcb6926125b5bf1d0cac092547e8cfcbL37-R37) [[2]](diffhunk://#diff-12ee508ecc1901fe1a1d71ed459dba8454f3160983ee18b2c51b76ade45235d3L32-R32)
* Updated the `ace-builds` package metadata in `package-lock.json` to reflect the new version, updated integrity hash, and added the `BSD-3-Clause` license.
* Added the `MIT` license metadata for the `react-ace` package in `package-lock.json`.

### CodeAreaModal Component Improvements:
* Added the `"ext-searchbox"` module from `ace-builds` to enhance search functionality in the code editor.
* Removed unused imports (`useFlowStore` and `webpack-resolver`) and redundant code, simplifying the component. [[1]](diffhunk://#diff-ed7913a353eca9ac31bf9664f91d16518b15a92c8251fa7f568309bbb83b5e7cR1-L9) [[2]](diffhunk://#diff-ed7913a353eca9ac31bf9664f91d16518b15a92c8251fa7f568309bbb83b5e7cL57-L63)
* Improved logic for handling the code editor's autocomplete popup to ensure it checks for the existence of the `popup` property before accessing it.