### PR TITLE
docs: clarify multi-user access

### DIFF
--- a/docs/docs/Configuration/configuration-authentication.md
+++ b/docs/docs/Configuration/configuration-authentication.md
@@ -23,6 +23,9 @@ When `True`, Langflow automatically logs users in with username `langflow` and p
 To disable automatic login and enforce user authentication, set this value to `False` in your `.env` file.
 By default, this variable is set to `True`.
 
+Langflow **does not** allow users simultaneous or shared access to flows.
+If `AUTO_LOGIN` is enabled and user management is disabled (`LANGFLOW_NEW_USER_IS_ACTIVE=true`), users can access the same environment, but it is not password protected. If two users access the same flow, only the work of the last user to save is saved.
+
 ```bash
 LANGFLOW_AUTO_LOGIN=True
 ```


### PR DESCRIPTION
This pull request updates the documentation to clarify user authentication and access behavior in Langflow. The key addition explains the limitations of simultaneous or shared access to flows when `AUTO_LOGIN` is enabled.