### PR TITLE
feat: Refactor Listen and Notify, fix related logic 

### DIFF
--- a/src/backend/base/langflow/components/logic/listen.py
+++ b/src/backend/base/langflow/components/logic/listen.py
@@ -1,29 +1,17 @@
-from langflow.custom import CustomComponent
+from langflow.custom import Component
+from langflow.io import Output, StrInput
 from langflow.schema import Data
 
 
-class ListenComponent(CustomComponent):
+class ListenComponent(Component):
     display_name = "Listen"
     description = "A component to listen for a notification."
     name = "Listen"
     beta: bool = True
     icon = "Radio"
+    inputs = [StrInput(name="context_key", display_name="Context Key", info="The key of the context to listen for.")]
 
-    def build_config(self):
-        return {
-            "name": {
-                "display_name": "Name",
-                "info": "The name of the notification to listen for.",
-            },
-        }
+    outputs = [Output(name="data", display_name="Data", method="build")]
 
-    def build(self, name: str) -> Data:
-        state = self.get_state(name)
-        self._set_successors_ids()
-        self.status = state
-        return state
-
-    def _set_successors_ids(self):
-        self._vertex.is_state = True
-        successors = self._vertex.graph.successor_map.get(self._vertex.id, [])
-        return successors + self._vertex.graph.activated_vertices
+    def build(self) -> Data:
+        return self.ctx.get(self.context_key, Data(data={}))

--- a/src/backend/base/langflow/components/logic/notify.py
+++ b/src/backend/base/langflow/components/logic/notify.py
@@ -1,46 +1,80 @@
-from langflow.custom import CustomComponent
+from langflow.custom import Component
+from langflow.io import BoolInput, DataInput, Output, StrInput
 from langflow.schema import Data
 
 
-class NotifyComponent(CustomComponent):
+class NotifyComponent(Component):
     display_name = "Notify"
     description = "A component to generate a notification to Get Notified component."
     icon = "Notify"
     name = "Notify"
     beta: bool = True
 
-    def build_config(self):
-        return {
-            "name": {"display_name": "Name", "info": "The name of the notification."},
-            "data": {"display_name": "Data", "info": "The data to store."},
-            "append": {
-                "display_name": "Append",
-                "info": "If True, the record will be appended to the notification.",
-            },
-        }
+    inputs = [
+        StrInput(
+            name="context_key",
+            display_name="Context Key",
+            info="The key of the context to store the notification.",
+            required=True,
+        ),
+        DataInput(
+            name="input_data",
+            display_name="Input Data",
+            info="The data to store.",
+            required=False,
+        ),
+        BoolInput(
+            name="append",
+            display_name="Append",
+            info="If True, the record will be appended to the notification.",
+            value=False,
+            required=False,
+        ),
+    ]
 
-    def build(self, name: str, *, data: Data | None = None, append: bool = False) -> Data:
-        if data and not isinstance(data, Data):
-            if isinstance(data, str):
-                data = Data(text=data)
-            elif isinstance(data, dict):
-                data = Data(data=data)
+    outputs = [
+        Output(
+            display_name="Data",
+            name="result",
+            method="build",
+            info="The data that was stored in the notification.",
+        ),
+    ]
+
+    async def build(self) -> Data:
+        if self.input_data and not isinstance(self.input_data, Data):
+            if isinstance(self.input_data, str):
+                self.input_data = Data(text=self.input_data)
+            elif isinstance(self.input_data, dict):
+                self.input_data = Data(data=self.input_data)
             else:
-                data = Data(text=str(data))
-        elif not data:
-            data = Data(text="")
-        if data:
-            if append:
-                self.append_state(name, data)
+                self.input_data = Data(text=str(self.input_data))
+        elif not self.input_data:
+            self.input_data = Data(text="")
+        if self.input_data:
+            if self.append:
+                current_data = self.ctx.get(self.context_key, [])
+                if not isinstance(current_data, list):
+                    current_data = [current_data]
+                current_data.append(self.input_data)
+                self.update_ctx({self.context_key: current_data})
             else:
-                self.update_state(name, data)
+                self.update_ctx({self.context_key: self.input_data})
         else:
             self.status = "No record provided."
-        self.status = data
-        self._set_successors_ids()
-        return data
-
-    def _set_successors_ids(self):
+        self.status = self.input_data
         self._vertex.is_state = True
-        successors = self._vertex.graph.successor_map.get(self._vertex.id, [])
-        return successors + self._vertex.graph.activated_vertices
+        self.set_activated_vertices()
+        return self.input_data
+
+    def set_activated_vertices(self):
+        # Append all `Listen` components that have the same `context_key`
+        self._vertex.graph.activated_vertices.extend(
+            [
+                vertex.id
+                for vertex in self._vertex.graph.vertices
+                if vertex.custom_component
+                and vertex.custom_component.name == "Listen"
+                and vertex.custom_component.context_key == self.context_key
+            ]
+        )

--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -1597,6 +1597,8 @@ class Graph:
             if cache and self.flow_id is not None:
                 set_cache_coro = partial(get_chat_service().set_cache, key=self.flow_id)
                 await set_cache_coro(data=self, lock=lock)
+        if vertex.is_state:
+            next_runnable_vertices.extend(self.activated_vertices)
         return next_runnable_vertices
 
     async def _log_vertex_build_from_exception(self, vertex_id: str, result: Exception) -> None:

--- a/src/backend/base/langflow/graph/vertex/vertex_types.py
+++ b/src/backend/base/langflow/graph/vertex/vertex_types.py
@@ -463,14 +463,6 @@ class StateVertex(ComponentVertex):
     def __init__(self, data: NodeData, graph):
         super().__init__(data, graph=graph)
         self.steps = [self._build]
-        self.is_state = False
-
-    @property
-    def successors_ids(self) -> list[str]:
-        if self._successors_ids is None:
-            self.is_state = False
-            return super().successors_ids
-        return self._successors_ids
 
     def built_object_repr(self):
         if self.artifacts and "repr" in self.artifacts:


### PR DESCRIPTION
Refactor `Notify` and `Listen` to improve input/output handling and context management. Extend functionality to activate next runnable vertices based on state vertices. Clean up unused properties and methods in the `StateVertex` class.