### PR TITLE
fix: File manager rerenders

### DIFF
--- a/src/frontend/src/modals/fileManagerModal/components/recentFilesComponent/index.tsx
+++ b/src/frontend/src/modals/fileManagerModal/components/recentFilesComponent/index.tsx
@@ -26,7 +26,7 @@ export default function RecentFilesComponent({
         ...file,
         type: file.path.split(".").pop()?.toLowerCase(),
       })),
-    [files]
+    [files],
   );
 
   const fuse = useMemo(
@@ -35,7 +35,7 @@ export default function RecentFilesComponent({
         keys: ["name", "type"],
         threshold: 0.3,
       }),
-    [filesWithType]
+    [filesWithType],
   );
 
   const [searchQuery, setSearchQuery] = useState("");

--- a/src/frontend/src/modals/fileManagerModal/components/recentFilesComponent/index.tsx
+++ b/src/frontend/src/modals/fileManagerModal/components/recentFilesComponent/index.tsx
@@ -20,11 +20,24 @@ export default function RecentFilesComponent({
   types: string[];
   isList: boolean;
 }) {
-  const filesWithType = files.map((file) => ({
-    ...file,
-    type: file.path.split(".").pop()?.toLowerCase(),
-  }));
-  const [fuse, setFuse] = useState<Fuse<FileType>>(new Fuse([]));
+  const filesWithType = useMemo(
+    () =>
+      files.map((file) => ({
+        ...file,
+        type: file.path.split(".").pop()?.toLowerCase(),
+      })),
+    [files]
+  );
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(filesWithType, {
+        keys: ["name", "type"],
+        threshold: 0.3,
+      }),
+    [filesWithType]
+  );
+
   const [searchQuery, setSearchQuery] = useState("");
 
   const { mutate: renameFile } = usePostRenameFileV2();
@@ -39,18 +52,7 @@ export default function RecentFilesComponent({
       return fileExtension && (!types || types.includes(fileExtension));
     });
     return filteredFiles;
-  }, [searchQuery, filesWithType, selectedFiles, types]);
-
-  useEffect(() => {
-    if (filesWithType) {
-      setFuse(
-        new Fuse(filesWithType, {
-          keys: ["name", "type"],
-          threshold: 0.3,
-        }),
-      );
-    }
-  }, [filesWithType]);
+  }, [searchQuery, filesWithType, types]);
 
   const handleFileSelect = (filePath: string) => {
     setSelectedFiles(


### PR DESCRIPTION
The Issue

`RectentFilesComponent` infinitely rerenders

`filesWithType` is created on each render and is a dependency for the `useEffect`
That useEffect call calls `setFuse` which triggers a rerender and we have an infinite loop