### PR TITLE
fix: voice_mode break fix

### DIFF
--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -11,7 +11,7 @@ from uuid import UUID
 import orjson
 from aiofile import async_open
 from anyio import Path
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Response, UploadFile
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
 from fastapi_pagination import Page, Params
@@ -526,6 +526,9 @@ async def download_multiple_file(
     return flows_without_api_keys[0]
 
 
+all_starter_folder_flows_response: Response | None = None
+
+
 @router.get("/basic_examples/", response_model=list[FlowRead], status_code=200)
 async def read_basic_examples(
     *,
@@ -540,17 +543,24 @@ async def read_basic_examples(
         list[FlowRead]: A list of basic example flows.
     """
     try:
-        # Get the starter project
+        global all_starter_folder_flows_response  # noqa: PLW0603
+
+        if all_starter_folder_flows_response:
+            return all_starter_folder_flows_response
+        # Get the starter folder
         starter_folder = (await session.exec(select(Folder).where(Folder.name == STARTER_FOLDER_NAME))).first()
 
         if not starter_folder:
             return []
 
-        # Get all flows in the starter project
-        flows = (await session.exec(select(Flow).where(Flow.folder_id == starter_folder.id))).all()
+        # Get all flows in the starter folder
+        all_starter_folder_flows = (await session.exec(select(Flow).where(Flow.folder_id == starter_folder.id))).all()
+
+        flow_reads = [FlowRead.model_validate(flow, from_attributes=True) for flow in all_starter_folder_flows]
+        all_starter_folder_flows_response = compress_response(flow_reads)
 
         # Return compressed response using our utility function
-        return compress_response(flows)
+        return all_starter_folder_flows_response  # noqa: TRY300
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/backend/base/langflow/api/v1/voice_mode.py
+++ b/src/backend/base/langflow/api/v1/voice_mode.py
@@ -1143,8 +1143,8 @@ async def flow_tts_websocket(
     try:
         await client_websocket.accept()
 
-        openai_send_q: asyncio.Queue[str] = asyncio.Queue()
-        client_send_q: asyncio.Queue[str] = asyncio.Queue()
+        openai_send_q: asyncio.Queue[dict] = asyncio.Queue()
+        client_send_q: asyncio.Queue[dict] = asyncio.Queue()
 
         log_event = create_event_logger()
 
@@ -1171,13 +1171,13 @@ async def flow_tts_websocket(
         def openai_send(payload):
             log_event(payload, LF_TO_OPENAI)
             logger.trace(f"Sending text {LF_TO_OPENAI}: {payload['type']}")
-            openai_send_q.put_nowait(json.dumps(payload))
+            openai_send_q.put_nowait(payload)
             logger.trace("JSON sent.")
 
         def client_send(payload):
             log_event(payload, LF_TO_CLIENT)
             logger.trace(f"Sending JSON {LF_TO_CLIENT}: {payload['type']}")
-            client_send_q.put_nowait(json.dumps(payload))
+            client_send_q.put_nowait(payload)
             logger.trace("JSON sent.")
 
         async def close():

--- a/src/frontend/src/controllers/API/queries/transactions/use-get-transactions.ts
+++ b/src/frontend/src/controllers/API/queries/transactions/use-get-transactions.ts
@@ -46,7 +46,10 @@ export const useGetTransactionsQuery: useQueryFunctionType<
   };
 
   const getTransactionsFn = async () => {
+    if (!id) return { pagination: {}, rows: [], columns: [] };
+
     const config = {};
+
     config["params"] = { flow_id: id };
     if (params) {
       config["params"] = { ...config["params"], ...params };

--- a/src/frontend/src/controllers/API/queries/variables/use-get-global-variables.ts
+++ b/src/frontend/src/controllers/API/queries/variables/use-get-global-variables.ts
@@ -20,6 +20,9 @@ export const useGetGlobalVariables: useQueryFunctionType<
   const setUnavailableFields = useGlobalVariablesStore(
     (state) => state.setUnavailableFields,
   );
+  const setGlobalVariablesEntities = useGlobalVariablesStore(
+    (state) => state.setGlobalVariablesEntities,
+  );
 
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
@@ -28,6 +31,7 @@ export const useGetGlobalVariables: useQueryFunctionType<
     const res = await api.get(`${getURL("VARIABLES")}/`);
     setGlobalVariablesEntries(res.data.map((entry) => entry.name));
     setUnavailableFields(getUnavailableFields(res.data));
+    setGlobalVariablesEntities(res.data);
     return res.data;
   };
 

--- a/src/frontend/src/controllers/API/queries/voice/use-get-voice-list.ts
+++ b/src/frontend/src/controllers/API/queries/voice/use-get-voice-list.ts
@@ -4,21 +4,17 @@ import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
 
-export const useGetVoiceList: useQueryFunctionType<undefined, any> = (
-  options,
-) => {
+export const useGetVoiceList = (elevenlabsApiKey: string, options?: any) => {
   const { query } = UseRequestProcessor();
   const setVoices = useVoiceStore((state) => state.setVoices);
   const voices = useVoiceStore((state) => state.voices);
 
-  const getVoiceListFn = async (): Promise<
-    {
-      name: string;
-      voice_id: string;
-    }[]
-  > => {
+  const getVoiceListFn = async () => {
     if (voices.length > 0) {
       return voices;
+    }
+    if (!elevenlabsApiKey) {
+      return [];
     }
 
     const res = await api.get(`${getURL("VOICE")}/elevenlabs/voice_ids`);
@@ -41,7 +37,7 @@ export const useGetVoiceList: useQueryFunctionType<undefined, any> = (
   };
 
   const queryResult = query(
-    ["useGetVoiceList"],
+    ["useGetVoiceList", elevenlabsApiKey],
     getVoiceListFn,
     defaultOptions,
   );

--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/components/audio-settings/audio-settings-dialog.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/components/audio-settings/audio-settings-dialog.tsx
@@ -9,7 +9,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Separator } from "@/components/ui/separator";
+import { usePatchGlobalVariables } from "@/controllers/API/queries/variables";
 import { useGetVoiceList } from "@/controllers/API/queries/voice/use-get-voice-list";
+import { useDebounce } from "@/hooks/use-debounce";
 import GeneralDeleteConfirmationModal from "@/shared/components/delete-confirmation-modal";
 import GeneralGlobalVariableModal from "@/shared/components/global-variable-modal";
 import { useGlobalVariablesStore } from "@/stores/globalVariablesStore/globalVariables";
@@ -67,6 +69,10 @@ const SettingsVoiceModal = ({
 
   const globalVariables = useGlobalVariablesStore(
     (state) => state.globalVariablesEntries,
+  );
+
+  const globalVariablesEntities = useGlobalVariablesStore(
+    (state) => state.globalVariablesEntities,
   );
 
   const openaiVoices = useVoiceStore((state) => state.openaiVoices);
@@ -158,6 +164,8 @@ const SettingsVoiceModal = ({
     return globalVariables?.map((variable) => variable).includes(variable);
   };
 
+  const { mutate: updateVariable } = usePatchGlobalVariables();
+
   const handleSetMicrophone = (deviceId: string) => {
     setSelectedMicrophone(deviceId);
     localStorage.setItem("lf_selected_microphone", deviceId);
@@ -226,6 +234,25 @@ const SettingsVoiceModal = ({
 
   const showAddOpenAIKeyButton = !hasOpenAIAPIKey || isEditingOpenAIKey;
   const showAllSettings = hasOpenAIAPIKey && !isEditingOpenAIKey;
+
+  const debouncedSetElevenLabsApiKey = useDebounce((value: string) => {
+    const globalVariable = globalVariablesEntities?.find(
+      (variable) => variable.name === "ELEVENLABS_API_KEY",
+    );
+
+    if (globalVariable) {
+      updateVariable({
+        name: "ELEVENLABS_API_KEY",
+        value: value,
+        id: globalVariable.id,
+      });
+    }
+  }, 2000);
+
+  const handleSetElevenLabsApiKey = (value: string) => {
+    setElevenLabsApiKey(value);
+    debouncedSetElevenLabsApiKey(value);
+  };
 
   return (
     <>
@@ -372,9 +399,7 @@ const SettingsVoiceModal = ({
                           />
                         )}
                         value={elevenLabsApiKey}
-                        onChange={(value) => {
-                          setElevenLabsApiKey(value);
-                        }}
+                        onChange={handleSetElevenLabsApiKey}
                         selectedOption={
                           checkIfGlobalVariableExists(elevenLabsApiKey)
                             ? elevenLabsApiKey

--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/components/audio-settings/audio-settings-dialog.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/components/audio-settings/audio-settings-dialog.tsx
@@ -83,7 +83,7 @@ const SettingsVoiceModal = ({
     data: voiceList,
     isFetched,
     refetch,
-  } = useGetVoiceList({
+  } = useGetVoiceList(elevenLabsApiKey, {
     enabled: shouldFetchVoices,
     refetchOnMount: shouldFetchVoices,
     refetchOnWindowFocus: shouldFetchVoices,

--- a/src/frontend/src/modals/flowLogsModal/index.tsx
+++ b/src/frontend/src/modals/flowLogsModal/index.tsx
@@ -7,6 +7,7 @@ import { FlowSettingsPropsType } from "@/types/components";
 import { convertUTCToLocalTimezone } from "@/utils/utils";
 import { ColDef, ColGroupDef } from "ag-grid-community";
 import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import BaseModal from "../baseModal";
 
 export default function FlowLogsModal({
@@ -19,9 +20,11 @@ export default function FlowLogsModal({
   const [pageSize, setPageSize] = useState(20);
   const [columns, setColumns] = useState<Array<ColDef | ColGroupDef>>([]);
   const [rows, setRows] = useState<any>([]);
+  const [searchParams] = useSearchParams();
+  const flowIdFromUrl = searchParams.get("id");
 
   const { data, isLoading, refetch } = useGetTransactionsQuery({
-    id: currentFlowId,
+    id: currentFlowId ?? flowIdFromUrl,
     params: {
       page: pageIndex,
       size: pageSize,

--- a/src/frontend/src/stores/globalVariablesStore/globalVariables.ts
+++ b/src/frontend/src/stores/globalVariablesStore/globalVariables.ts
@@ -11,5 +11,9 @@ export const useGlobalVariablesStore = create<GlobalVariablesStore>(
     setGlobalVariablesEntries: (entries) => {
       set({ globalVariablesEntries: entries });
     },
+    setGlobalVariablesEntities: (entities) => {
+      set({ globalVariablesEntities: entities });
+    },
+    globalVariablesEntities: undefined,
   }),
 );

--- a/src/frontend/src/types/zustand/globalVariables/index.ts
+++ b/src/frontend/src/types/zustand/globalVariables/index.ts
@@ -1,6 +1,10 @@
+import { GlobalVariable } from "@/types/global_variables";
+
 export type GlobalVariablesStore = {
   globalVariablesEntries: Array<string> | undefined;
   setGlobalVariablesEntries: (entries: Array<string>) => void;
   unavailableFields: { [name: string]: string };
   setUnavailableFields: (fields: { [name: string]: string }) => void;
+  globalVariablesEntities: Array<GlobalVariable> | undefined;
+  setGlobalVariablesEntities: (entities: GlobalVariable[]) => void;
 };


### PR DESCRIPTION
This pull request includes several changes to improve type safety, simplify code, and enhance functionality across both the backend and frontend. Key updates include modifying queue types to use dictionaries instead of strings, simplifying the polling manager logic, and improving API query functions with better parameter handling and type safety.

### Backend Changes:
* **Bug fix: Improved Type Safety in QueueCz/fix audio triggers**:
  - Updated `openai_send_q` and `client_send_q` in `flow_tts_websocket` to use `asyncio.Queue[dict]` instead of `asyncio.Queue[str]`. This ensures the queues handle structured data rather than raw JSON strings. This was breaking voice mode in the playground [[1]](diffhunk://#diff-41b04dcf95abc28892d4a8e3b2e674a8c014706c6f49c95cadb76b6efaef59b4L1146-R1147) [[2]](diffhunk://#diff-41b04dcf95abc28892d4a8e3b2e674a8c014706c6f49c95cadb76b6efaef59b4L1174-R1180)

### Frontend Changes:
#### Polling Manager Simplification:
* **Refactored Polling Logic**:
  - Simplified `enqueuePolling` by clearing the queue and stopping all active polls before adding new items.
  - Removed redundant queue filtering in `stopPoll` and `removeFromQueue`, replacing it with direct deletion of queue entries. [[1]](diffhunk://#diff-4fea796e5d628468b2b3167421b44c380156c9109fa29b67827d447ae6830c23L70-R62) [[2]](diffhunk://#diff-4fea796e5d628468b2b3167421b44c380156c9109fa29b67827d447ae6830c23L86-R73)
  - Ensured active polls are stopped before starting a new request in `useGetMessagesPollingMutation`. [[1]](diffhunk://#diff-4fea796e5d628468b2b3167421b44c380156c9109fa29b67827d447ae6830c23R132-R135) [[2]](diffhunk://#diff-4fea796e5d628468b2b3167421b44c380156c9109fa29b67827d447ae6830c23R179-L196)

#### API Query Enhancements:
* **Improved Query Parameter Handling**:
  - Added a fallback in `useGetTransactionsQuery` to return empty data if `id` is not provided, preventing unnecessary API calls.
  - Updated `useGetVoiceList` to require an `elevenlabsApiKey` and handle cases where the key is not provided, returning an empty list instead of making a request. [[1]](diffhunk://#diff-51a042d10e5c92d6abe2103a2f587404a1734131fec8e59bb9a57ec2ca634da9L7-R18) [[2]](diffhunk://#diff-51a042d10e5c92d6abe2103a2f587404a1734131fec8e59bb9a57ec2ca634da9L44-R40)

#### Component Updates:
* **Voice Assistant Integration**:
  - Modified `SettingsVoiceModal` to pass `elevenLabsApiKey` to `useGetVoiceList`, ensuring the API key is correctly utilized for fetching voice data.