### PR TITLE
fix: added check to upload .md files correctly

### DIFF
--- a/src/frontend/src/hooks/files/use-upload-file.ts
+++ b/src/frontend/src/hooks/files/use-upload-file.ts
@@ -38,12 +38,10 @@ const useUploadFile = ({
       for (const file of filesToUpload) {
         validateFileSize(file);
         // Check if file extension is allowed
-        const fileExtension = file.type
-          ? file.name.split(".").pop()?.toLowerCase()
-          : null;
-        if (types && (!fileExtension || !types.includes(fileExtension))) {
+        const fileExtension = file.name.split(".").pop()?.toLowerCase();
+        if (!fileExtension || (types && !types.includes(fileExtension))) {
           throw new Error(
-            `File type not allowed. Allowed types: ${types.join(", ")}`,
+            `File type ${fileExtension} not allowed. Allowed types: ${types?.join(", ")}`,
           );
         }
         if (!fileExtension) {


### PR DESCRIPTION
This pull request refines the file upload validation logic in the `useUploadFile` hook by simplifying the handling of file extensions and improving error messaging.

Validation improvements:

* [`src/frontend/src/hooks/files/use-upload-file.ts`](diffhunk://#diff-5a343839628bab9956b47ee640a69fe9b2cd564728b38a1339d025ab653b3fe1L41-R44): Removed the redundant conditional check for `file.type` when extracting the file extension, ensuring the logic is simpler and more consistent. Enhanced the error message to include the disallowed file type for better clarity.