### PR TITLE
fix: edit flow name settings not to be empty

### DIFF
--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -322,10 +322,6 @@ async def update_flow(
 
         update_data = flow.model_dump(exclude_unset=True, exclude_none=True)
 
-        # Specifically handle endpoint_name when it's explicitly set to null or empty string
-        if flow.endpoint_name is None or flow.endpoint_name == "":
-            update_data["endpoint_name"] = None
-
         if settings_service.settings.remove_api_keys:
             update_data = remove_api_keys(update_data)
 

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -322,6 +322,10 @@ async def update_flow(
 
         update_data = flow.model_dump(exclude_unset=True, exclude_none=True)
 
+        # Specifically handle endpoint_name when it's explicitly set to null or empty string
+        if flow.endpoint_name is None or flow.endpoint_name == "":
+            update_data["endpoint_name"] = None
+
         if settings_service.settings.remove_api_keys:
             update_data = remove_api_keys(update_data)
 

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -216,8 +216,8 @@ export const MenuBar = memo((): JSX.Element => {
   ]);
 
   useEffect(() => {
-    if (!editingName) {
-      setFlowName(currentFlowName ?? "Untitled Flow");
+    if (currentFlowName && !editingName) {
+      setFlowName(currentFlowName);
     }
   }, [currentFlowName, editingName]);
 
@@ -233,7 +233,7 @@ export const MenuBar = memo((): JSX.Element => {
       : getNumberFromString(currentFlowGradient ?? currentFlowId ?? "")) %
     swatchColors.length;
 
-  return onFlowPage ? (
+  return currentFlowName && onFlowPage ? (
     <div
       className="flex w-full items-center justify-center gap-2"
       data-testid="menu_bar_wrapper"
@@ -303,7 +303,7 @@ export const MenuBar = memo((): JSX.Element => {
                 onKeyDown={handleKeyDown}
                 onFocus={() => {
                   setEditingName(true);
-                  setFlowName(currentFlowName ?? "Untitled Flow");
+                  setFlowName(currentFlowName);
                   const flows = useFlowsManagerStore.getState().flows;
                   setFlowNames(
                     flows
@@ -315,7 +315,6 @@ export const MenuBar = memo((): JSX.Element => {
                 value={flowName}
                 id="input-flow-name"
                 data-testid="input-flow-name"
-                placeholder="Untitled Flow"
               />
               <span
                 ref={measureRef}
@@ -323,7 +322,7 @@ export const MenuBar = memo((): JSX.Element => {
                 aria-hidden="true"
                 data-testid="flow_name"
               >
-                {flowName || "Untitled Flow"}
+                {flowName}
               </span>
             </div>
           </div>

--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -216,8 +216,8 @@ export const MenuBar = memo((): JSX.Element => {
   ]);
 
   useEffect(() => {
-    if (currentFlowName && !editingName) {
-      setFlowName(currentFlowName);
+    if (!editingName) {
+      setFlowName(currentFlowName ?? "Untitled Flow");
     }
   }, [currentFlowName, editingName]);
 
@@ -233,7 +233,7 @@ export const MenuBar = memo((): JSX.Element => {
       : getNumberFromString(currentFlowGradient ?? currentFlowId ?? "")) %
     swatchColors.length;
 
-  return currentFlowName && onFlowPage ? (
+  return onFlowPage ? (
     <div
       className="flex w-full items-center justify-center gap-2"
       data-testid="menu_bar_wrapper"
@@ -303,7 +303,7 @@ export const MenuBar = memo((): JSX.Element => {
                 onKeyDown={handleKeyDown}
                 onFocus={() => {
                   setEditingName(true);
-                  setFlowName(currentFlowName);
+                  setFlowName(currentFlowName ?? "Untitled Flow");
                   const flows = useFlowsManagerStore.getState().flows;
                   setFlowNames(
                     flows
@@ -315,6 +315,7 @@ export const MenuBar = memo((): JSX.Element => {
                 value={flowName}
                 id="input-flow-name"
                 data-testid="input-flow-name"
+                placeholder="Untitled Flow"
               />
               <span
                 ref={measureRef}
@@ -322,7 +323,7 @@ export const MenuBar = memo((): JSX.Element => {
                 aria-hidden="true"
                 data-testid="flow_name"
               >
-                {flowName}
+                {flowName || "Untitled Flow"}
               </span>
             </div>
           </div>

--- a/src/frontend/src/components/core/editFlowSettingsComponent/index.tsx
+++ b/src/frontend/src/components/core/editFlowSettingsComponent/index.tsx
@@ -11,11 +11,13 @@ export const EditFlowSettings: React.FC<InputProps> = ({
   description,
   endpointName,
   maxLength = 50,
+  minLength = 1,
   setName,
   setDescription,
   setEndpointName,
 }: InputProps): JSX.Element => {
   const [isMaxLength, setIsMaxLength] = useState(false);
+  const [isMinLength, setIsMinLength] = useState(false);
   const [validEndpointName, setValidEndpointName] = useState(true);
   const [isInvalidName, setIsInvalidName] = useState(false);
 
@@ -26,6 +28,11 @@ export const EditFlowSettings: React.FC<InputProps> = ({
     } else {
       setIsMaxLength(false);
     }
+    if (value.length < minLength) {
+      setIsMinLength(true);
+    } else {
+      setIsMinLength(false);
+    }
     let invalid = false;
     for (let i = 0; i < invalidNameList!.length; i++) {
       if (value === invalidNameList![i]) {
@@ -35,7 +42,15 @@ export const EditFlowSettings: React.FC<InputProps> = ({
       invalid = false;
     }
     setIsInvalidName(invalid);
-    setName!(value);
+
+    // Only update the name if it's valid (not empty and not invalid)
+    if (value.length >= minLength && !invalid) {
+      setName!(value);
+    } else if (value.length === 0) {
+      // For empty string, update state but keep isMinLength true
+      setName!("");
+      setIsMinLength(true);
+    }
   };
 
   const handleDescriptionChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -43,11 +58,19 @@ export const EditFlowSettings: React.FC<InputProps> = ({
   };
 
   const handleEndpointNameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
     // Validate the endpoint name
     // use this regex r'^[a-zA-Z0-9_-]+$'
     const isValid = isEndpointNameValid(event.target.value, maxLength);
     setValidEndpointName(isValid);
-    setEndpointName!(event.target.value);
+
+    // Only update if valid and meets minimum length (if set)
+    if (isValid && value.length >= minLength) {
+      setEndpointName!(value);
+    } else if (value.length === 0) {
+      // Always allow empty endpoint name (it's optional)
+      setEndpointName!("");
+    }
   };
 
   //this function is necessary to select the text when double clicking, this was not working with the onFocus event
@@ -60,6 +83,11 @@ export const EditFlowSettings: React.FC<InputProps> = ({
           <span className="font-medium">Name{setName ? "" : ":"}</span>{" "}
           {isMaxLength && (
             <span className="edit-flow-span">Character limit reached</span>
+          )}
+          {isMinLength && (
+            <span className="edit-flow-span">
+              Minimum {minLength} character(s) required
+            </span>
           )}
           {isInvalidName && (
             <span className="edit-flow-span">
@@ -77,6 +105,8 @@ export const EditFlowSettings: React.FC<InputProps> = ({
             placeholder="Flow name"
             id="name"
             maxLength={maxLength}
+            minLength={minLength}
+            required={true}
             onDoubleClickCapture={(event) => {
               handleFocus(event);
             }}
@@ -137,6 +167,7 @@ export const EditFlowSettings: React.FC<InputProps> = ({
             value={endpointName ?? ""}
             placeholder="An alternative name to run the endpoint"
             maxLength={maxLength}
+            minLength={minLength}
             id="endpoint_name"
             onDoubleClickCapture={(event) => {
               handleFocus(event);

--- a/src/frontend/src/components/core/editFlowSettingsComponent/index.tsx
+++ b/src/frontend/src/components/core/editFlowSettingsComponent/index.tsx
@@ -11,13 +11,11 @@ export const EditFlowSettings: React.FC<InputProps> = ({
   description,
   endpointName,
   maxLength = 50,
-  minLength = 1,
   setName,
   setDescription,
   setEndpointName,
 }: InputProps): JSX.Element => {
   const [isMaxLength, setIsMaxLength] = useState(false);
-  const [isMinLength, setIsMinLength] = useState(false);
   const [validEndpointName, setValidEndpointName] = useState(true);
   const [isInvalidName, setIsInvalidName] = useState(false);
 
@@ -28,11 +26,6 @@ export const EditFlowSettings: React.FC<InputProps> = ({
     } else {
       setIsMaxLength(false);
     }
-    if (value.length < minLength) {
-      setIsMinLength(true);
-    } else {
-      setIsMinLength(false);
-    }
     let invalid = false;
     for (let i = 0; i < invalidNameList!.length; i++) {
       if (value === invalidNameList![i]) {
@@ -42,15 +35,7 @@ export const EditFlowSettings: React.FC<InputProps> = ({
       invalid = false;
     }
     setIsInvalidName(invalid);
-
-    // Only update the name if it's valid (not empty and not invalid)
-    if (value.length >= minLength && !invalid) {
-      setName!(value);
-    } else if (value.length === 0) {
-      // For empty string, update state but keep isMinLength true
-      setName!("");
-      setIsMinLength(true);
-    }
+    setName!(value);
   };
 
   const handleDescriptionChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -58,19 +43,11 @@ export const EditFlowSettings: React.FC<InputProps> = ({
   };
 
   const handleEndpointNameChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const { value } = event.target;
     // Validate the endpoint name
     // use this regex r'^[a-zA-Z0-9_-]+$'
     const isValid = isEndpointNameValid(event.target.value, maxLength);
     setValidEndpointName(isValid);
-
-    // Only update if valid and meets minimum length (if set)
-    if (isValid && value.length >= minLength) {
-      setEndpointName!(value);
-    } else if (value.length === 0) {
-      // Always allow empty endpoint name (it's optional)
-      setEndpointName!("");
-    }
+    setEndpointName!(event.target.value);
   };
 
   //this function is necessary to select the text when double clicking, this was not working with the onFocus event
@@ -83,11 +60,6 @@ export const EditFlowSettings: React.FC<InputProps> = ({
           <span className="font-medium">Name{setName ? "" : ":"}</span>{" "}
           {isMaxLength && (
             <span className="edit-flow-span">Character limit reached</span>
-          )}
-          {isMinLength && (
-            <span className="edit-flow-span">
-              Minimum {minLength} character(s) required
-            </span>
           )}
           {isInvalidName && (
             <span className="edit-flow-span">
@@ -105,8 +77,6 @@ export const EditFlowSettings: React.FC<InputProps> = ({
             placeholder="Flow name"
             id="name"
             maxLength={maxLength}
-            minLength={minLength}
-            required={true}
             onDoubleClickCapture={(event) => {
               handleFocus(event);
             }}
@@ -167,7 +137,6 @@ export const EditFlowSettings: React.FC<InputProps> = ({
             value={endpointName ?? ""}
             placeholder="An alternative name to run the endpoint"
             maxLength={maxLength}
-            minLength={minLength}
             id="endpoint_name"
             onDoubleClickCapture={(event) => {
               handleFocus(event);

--- a/src/frontend/src/modals/flowSettingsModal/index.tsx
+++ b/src/frontend/src/modals/flowSettingsModal/index.tsx
@@ -28,19 +28,17 @@ export default function FlowSettingsModal({
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const flows = useFlowsManagerStore((state) => state.flows);
   const flow = flowData ?? currentFlow;
+  useEffect(() => {
+    setName(flow?.name ?? "");
+    setDescription(flow?.description ?? "");
+  }, [flow?.name, flow?.description, open]);
+
   const [name, setName] = useState(flow?.name ?? "");
   const [description, setDescription] = useState(flow?.description ?? "");
   const [endpoint_name, setEndpointName] = useState(flow?.endpoint_name ?? "");
   const [isSaving, setIsSaving] = useState(false);
   const [disableSave, setDisableSave] = useState(true);
   const autoSaving = useFlowsManagerStore((state) => state.autoSaving);
-
-  useEffect(() => {
-    setName(flow?.name ?? "");
-    setDescription(flow?.description ?? "");
-    setEndpointName(flow?.endpoint_name ?? "");
-  }, [flow?.name, flow?.description, flow?.endpoint_name, open]);
-
   function handleClick(): void {
     setIsSaving(true);
     if (!flow) return;

--- a/src/frontend/src/modals/flowSettingsModal/index.tsx
+++ b/src/frontend/src/modals/flowSettingsModal/index.tsx
@@ -28,17 +28,19 @@ export default function FlowSettingsModal({
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const flows = useFlowsManagerStore((state) => state.flows);
   const flow = flowData ?? currentFlow;
-  useEffect(() => {
-    setName(flow?.name ?? "");
-    setDescription(flow?.description ?? "");
-  }, [flow?.name, flow?.description, open]);
-
   const [name, setName] = useState(flow?.name ?? "");
   const [description, setDescription] = useState(flow?.description ?? "");
   const [endpoint_name, setEndpointName] = useState(flow?.endpoint_name ?? "");
   const [isSaving, setIsSaving] = useState(false);
   const [disableSave, setDisableSave] = useState(true);
   const autoSaving = useFlowsManagerStore((state) => state.autoSaving);
+
+  useEffect(() => {
+    setName(flow?.name ?? "");
+    setDescription(flow?.description ?? "");
+    setEndpointName(flow?.endpoint_name ?? "");
+  }, [flow?.name, flow?.description, flow?.endpoint_name, open]);
+
   function handleClick(): void {
     setIsSaving(true);
     if (!flow) return;

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -149,7 +149,6 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
 
   const getFlowToAddToCanvas = async (id: string) => {
     const flow = await getFlow({ id: id });
-    console.log(flow);
     setCurrentFlow(flow);
   };
 

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -149,6 +149,7 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
 
   const getFlowToAddToCanvas = async (id: string) => {
     const flow = await getFlow({ id: id });
+    console.log(flow);
     setCurrentFlow(flow);
   };
 

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -303,7 +303,6 @@ export type InputProps = {
   description: string | null;
   endpointName?: string | null;
   maxLength?: number;
-  minLength?: number;
   setName?: (name: string) => void;
   setDescription?: (description: string) => void;
   setEndpointName?: (endpointName: string) => void;

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -303,6 +303,7 @@ export type InputProps = {
   description: string | null;
   endpointName?: string | null;
   maxLength?: number;
+  minLength?: number;
   setName?: (name: string) => void;
   setDescription?: (description: string) => void;
   setEndpointName?: (endpointName: string) => void;

--- a/src/frontend/tests/extended/features/edit-flow-name.spec.ts
+++ b/src/frontend/tests/extended/features/edit-flow-name.spec.ts
@@ -14,6 +14,7 @@ test(
     await page.getByRole("heading", { name: "Basic Prompting" }).click();
 
     await page.getByTestId("input-flow-name").click();
+    await page.waitForTimeout(1000);
 
     await page.getByTestId("input-flow-name").fill(randomName);
 


### PR DESCRIPTION
This pull request introduces updates to both the backend and frontend to improve flow handling, validation, and user experience. Key changes include better handling of null or empty values for flow names and endpoint names, the addition of minimum length validation for inputs, and placeholder and default values for improved usability.

### Backend Changes:
* **Flow Update Handling**:
  - Updated `update_flow` in `flows.py` to explicitly handle cases where `endpoint_name` is null or an empty string, ensuring it is set to `None` in the update data.

### Frontend Changes:

#### Flow Name and Endpoint Name Handling:
* **Default and Placeholder Values**:
  - Updated `FlowMenu` to set default flow names to "Untitled Flow" when `currentFlowName` is null or empty. This includes changes to `setFlowName` logic and the addition of a placeholder for flow name input. [[1]](diffhunk://#diff-22996ac0e1d31e677dd1f1b8a19404c313ac28d4f617d936618398b260072f07L219-R220) [[2]](diffhunk://#diff-22996ac0e1d31e677dd1f1b8a19404c313ac28d4f617d936618398b260072f07L306-R306) [[3]](diffhunk://#diff-22996ac0e1d31e677dd1f1b8a19404c313ac28d4f617d936618398b260072f07R318-R326)
  - Removed conditional rendering of the menu bar based on `currentFlowName`, ensuring it always renders on the flow page.

* **Validation Enhancements**:
  - Added `minLength` validation to `EditFlowSettings` for flow names and endpoint names, ensuring a minimum character requirement. Updated the UI to display a message when the minimum length is not met. [[1]](diffhunk://#diff-5322109bcb6cc8eaf15ca21a8a198aad47085e2fba25a118c9b7a5e6f13deb70R14-R20) [[2]](diffhunk://#diff-5322109bcb6cc8eaf15ca21a8a198aad47085e2fba25a118c9b7a5e6f13deb70R31-R35) [[3]](diffhunk://#diff-5322109bcb6cc8eaf15ca21a8a198aad47085e2fba25a118c9b7a5e6f13deb70R87-R91) [[4]](diffhunk://#diff-5322109bcb6cc8eaf15ca21a8a198aad47085e2fba25a118c9b7a5e6f13deb70R108-R109)
  - Modified the logic to only update flow or endpoint names if they meet the length and validity criteria. [[1]](diffhunk://#diff-5322109bcb6cc8eaf15ca21a8a198aad47085e2fba25a118c9b7a5e6f13deb70R45-R73) [[2]](diffhunk://#diff-5322109bcb6cc8eaf15ca21a8a198aad47085e2fba25a118c9b7a5e6f13deb70R170)

#### Miscellaneous:
* **Flow Settings Modal**:
  - Fixed the `useEffect` dependency in `FlowSettingsModal` to ensure `endpoint_name` is also reset when the modal opens or flow data changes.

* **Test Updates**:
  - Added a timeout to stabilize flow name input tests in `edit-flow-name.spec.ts`.

* **Type Updates**:
  - Extended `InputProps` type to include `minLength` for better type safety.

* **Code Cleanup**:
  - Removed an unnecessary `console.log` statement in `FlowPage`.