### PR TITLE
fix: filter flow JSON from component JSON in MCP Servers

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -76,7 +76,7 @@ async def list_project_tools(
                 raise HTTPException(status_code=404, detail="Project not found")
 
             # Query flows in the project
-            flows_query = select(Flow).where(Flow.folder_id == project_id)
+            flows_query = select(Flow).where(Flow.folder_id == project_id, Flow.is_component == False)  # noqa: E712
 
             # Optionally filter for MCP-enabled flows only
             if mcp_enabled:


### PR DESCRIPTION
This pull request modifies the query used to list project tools in the `list_project_tools` function to exclude flows that are components. 

Key change:

* [`src/backend/base/langflow/api/v1/mcp_projects.py`](diffhunk://#diff-59e508b675da2296985654fefffa69b74a00d283904743fb65f27dad798c6bd0L79-R79): Updated the `flows_query` to include a condition that filters out flows where `Flow.is_component` is `True`. This ensures that only non-component flows are included in the results.