### PR TITLE
fix: add scroll and max height on chosen files on File Component, fixed font weight on start page

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langflow",
-  "version": "1.3.4",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langflow",
-      "version": "1.3.4",
+      "version": "1.4.1",
       "dependencies": {
         "@chakra-ui/number-input": "^2.1.2",
         "@headlessui/react": "^2.0.4",

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
@@ -85,7 +85,7 @@ export const GetStartedProgress: FC<{
     <div className="mt-3 h-[10.8rem] w-full">
       <div className="mb-2 flex items-center justify-between">
         <span
-          className="text-sm font-semibold"
+          className="text-sm font-medium"
           data-testid="get_started_progress_title"
         >
           {percentageGetStarted >= 100 ? (

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/header-buttons.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/header-buttons.tsx
@@ -64,7 +64,7 @@ export const HeaderButtons = ({
           <IconComponent name="PanelLeftClose" className="h-4 w-4" />
         </SidebarTrigger>
 
-        <div className="flex-1 text-sm font-semibold">Projects</div>
+        <div className="flex-1 text-sm font-medium">Projects</div>
         <div className="flex items-center gap-1">
           <UploadFolderButton
             onClick={handleUploadFlowsToFolder}

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
@@ -202,7 +202,7 @@ export default function InputFileComponent({
           {ENABLE_FILE_MANAGEMENT && !tempFile ? (
             files && (
               <div className="relative flex w-full flex-col gap-2">
-                <div className="flex flex-col">
+                <div className="nopan nowheel flex max-h-44 flex-col overflow-y-auto">
                   <FilesRendererComponent
                     files={files.filter((file) =>
                       selectedFiles.includes(file.path),


### PR DESCRIPTION
This pull request includes updates to the frontend codebase, focusing on dependency version upgrades, UI styling adjustments, and improved file management functionality. Below are the most important changes grouped by theme:

### Dependency Updates:
* Updated the `langflow` package version from `1.3.4` to `1.4.1` in `package-lock.json` to reflect the latest release.

### UI Styling Adjustments:
* Changed the font weight from `font-semibold` to `font-medium` for the "Get Started Progress" title in `get-started-progress.tsx` for consistency with other UI elements.
* Updated the "Projects" text in `header-buttons.tsx` to use `font-medium` instead of `font-semibold` for uniform styling across components.

### File Management Enhancements:
* Enhanced the file list container in `inputFileComponent/index.tsx` by adding `nopan nowheel` classes and enabling scrollable behavior with `max-h-44` and `overflow-y-auto` for better usability when managing large file lists.
<img width="439" alt="image" src="https://github.com/user-attachments/assets/fe9dd0a7-41a7-4a0d-99a6-a4b47de805e8" />