### PR TITLE
fix: remove connected edges when enabling tool mode for them to not reconnect later

### DIFF
--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -95,6 +95,7 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
       const templateFieldType = targetNode.data.node!.template[field]?.type;
       const inputTypes = targetNode.data.node!.template[field]?.input_types;
       const hasProxy = targetNode.data.node!.template[field]?.proxy;
+      const isToolMode = targetNode.data.node!.template[field]?.tool_mode;
 
       if (
         !field &&
@@ -124,7 +125,10 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
           id.proxy = targetNode.data.node!.template[field]?.proxy;
         }
       }
-      if (scapedJSONStringfy(id) !== targetHandle) {
+      if (
+        scapedJSONStringfy(id) !== targetHandle ||
+        (targetNode.data.node?.tool_mode && isToolMode)
+      ) {
         newEdges = newEdges.filter((e) => e.id !== edge.id);
       }
     }


### PR DESCRIPTION
This pull request updates the `cleanEdges` function in `src/frontend/src/utils/reactflowUtils.ts` to introduce a new `tool_mode` property and adjust edge-cleaning logic to account for this property.

### Updates to edge-cleaning logic:

* Added a new `isToolMode` variable to capture the `tool_mode` property from the `template` field of the `targetNode`. (`[src/frontend/src/utils/reactflowUtils.tsR98](diffhunk://#diff-a380d7691b7dad914af3baf94d210fa2df4f56c0f8533eb0e17c29bb8dc0e91cR98)`)
* Modified the condition for filtering edges to include a check for `tool_mode` compatibility between the `targetNode` and the edge's `id`. This ensures edges are removed if the `tool_mode` property is mismatched. (`[src/frontend/src/utils/reactflowUtils.tsL127-R131](diffhunk://#diff-a380d7691b7dad914af3baf94d210fa2df4f56c0f8533eb0e17c29bb8dc0e91cL127-R131)`)