### PR TITLE
fix: filter Update All components to not include edited ones, changed Node Toolbar to show Restore for edited componetns

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -119,6 +119,7 @@ function GenericNode({
       state.componentsToUpdate.find((component) => component.id === data.id),
     ),
   );
+
   const {
     outdated: isOutdated,
     breakingChange: hasBreakingChange,
@@ -330,7 +331,7 @@ function GenericNode({
             openAdvancedModal={false}
             onCloseAdvancedModal={() => {}}
             updateNode={() => handleUpdateCode()}
-            isOutdated={isOutdated && dismissAll}
+            isOutdated={isOutdated && (dismissAll || isUserEdited)}
             isUserEdited={isUserEdited}
             hasBreakingChange={hasBreakingChange}
           />

--- a/src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx
@@ -48,7 +48,8 @@ export default function UpdateAllComponents({}: {}) {
   const componentsToUpdateFiltered = useMemo(
     () =>
       componentsToUpdate.filter(
-        (component) => !dismissedNodes.includes(component.id),
+        (component) =>
+          !dismissedNodes.includes(component.id) && !component.userEdited,
       ),
     [componentsToUpdate, dismissedNodes],
   );

--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -606,7 +606,9 @@ const NodeToolbarComponent = memo(
                         shortcuts.find((obj) => obj.name === "Update")
                           ?.shortcut!
                       }
-                      style={hasBreakingChange ? "text-warning" : ""}
+                      style={
+                        hasBreakingChange ? "text-accent-amber-foreground" : ""
+                      }
                       value={isUserEdited ? "Restore" : "Update"}
                       icon={isUserEdited ? "RefreshCcwDot" : "CircleArrowUp"}
                       dataTestId="update-button-modal"


### PR DESCRIPTION
This pull request introduces changes to improve the handling of user-edited components and enhance the UI for better clarity. The most significant updates include refining the logic for determining outdated components, filtering components based on user edits, and updating the visual styling of UI elements.

### Enhancements to component update logic:

* [`src/frontend/src/CustomNodes/GenericNode/index.tsx`](diffhunk://#diff-b6793e0279f94c374aae18db97958c0af6befc2b49b7ce30e0294f9c80ba0d0eL333-R334): Updated the `isOutdated` property to account for user-edited components by adding a check for `isUserEdited` alongside `dismissAll`.
* [`src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx`](diffhunk://#diff-1fa6c72d078cb9d7b501ddccdfdf2babb7ed1c958eca52d03d718ac420deb751L51-R52): Refined the filtering logic for components to exclude those marked as user-edited (`!component.userEdited`).

### UI improvements:

* [`src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx`](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL609-R611): Changed the `style` property for components with breaking changes to use a more descriptive and visually distinct class, `text-accent-amber-foreground`, instead of the generic `text-warning`.

### Code formatting:

* [`src/frontend/src/CustomNodes/GenericNode/index.tsx`](diffhunk://#diff-b6793e0279f94c374aae18db97958c0af6befc2b49b7ce30e0294f9c80ba0d0eR122): Added a blank line for better readability in the `GenericNode` function.