### PR TITLE
fix: made ctrl and shift state reset when switching windows to solve bulk editing issues

### DIFF
--- a/src/frontend/src/modals/fileManagerModal/components/recentFilesComponent/index.tsx
+++ b/src/frontend/src/modals/fileManagerModal/components/recentFilesComponent/index.tsx
@@ -79,12 +79,23 @@ export default function RecentFilesComponent({
       }
     };
 
+    // Reset key states when window loses focus
+    const handleBlur = () => {
+      setIsShiftPressed(false);
+    };
+
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("keyup", handleKeyUp);
+    window.addEventListener("blur", handleBlur);
 
+    // Clean up event listeners when component unmounts
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
       document.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("blur", handleBlur);
+
+      // Reset key state on unmount
+      setIsShiftPressed(false);
     };
   }, []);
 

--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -119,12 +119,25 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
       }
     };
 
+    // Reset key states when window loses focus
+    const handleBlur = () => {
+      setIsShiftPressed(false);
+      setIsCtrlPressed(false);
+    };
+
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("keyup", handleKeyUp);
+    window.addEventListener("blur", handleBlur);
 
+    // Clean up event listeners when component unmounts
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
       document.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("blur", handleBlur);
+
+      // Reset key states on unmount
+      setIsShiftPressed(false);
+      setIsCtrlPressed(false);
     };
   }, []);
 
@@ -169,6 +182,14 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
       old.filter((id) => data.flows.some((flow) => flow.id === id)),
     );
   }, [data.flows]);
+
+  // Reset key states when navigating away
+  useEffect(() => {
+    return () => {
+      setIsShiftPressed(false);
+      setIsCtrlPressed(false);
+    };
+  }, [folderId]);
 
   return (
     <CardsWrapComponent


### PR DESCRIPTION
This pull request enhances keyboard state management by adding logic to reset key states (`Shift` and `Ctrl`) under specific conditions, ensuring a consistent user experience. The changes primarily focus on handling window focus loss, component unmounting, and navigation events.

### Enhancements to keyboard state management:

* **Reset key states on window focus loss**:
  - Added a `handleBlur` function to reset `Shift` and `Ctrl` key states when the window loses focus. This is implemented in both `RecentFilesComponent` and `HomePage` components. [[1]](diffhunk://#diff-c6f351d6c91a6cc5a12366ddfba8a9201635642f6d029947c0fcc58baaef28aeR82-R98) [[2]](diffhunk://#diff-ff0f0473b212e9e2e6493c82b06f52752dd6602693587a4ead6cc8ae40bc5816R122-R140)

* **Clean up on component unmount**:
  - Ensured that event listeners for `blur`, `keydown`, and `keyup` are removed during component unmounting. Additionally, key states are reset to avoid lingering states. [[1]](diffhunk://#diff-c6f351d6c91a6cc5a12366ddfba8a9201635642f6d029947c0fcc58baaef28aeR82-R98) [[2]](diffhunk://#diff-ff0f0473b212e9e2e6493c82b06f52752dd6602693587a4ead6cc8ae40bc5816R122-R140)

* **Reset key states on navigation**:
  - Introduced a `useEffect` cleanup in the `HomePage` component to reset key states when navigating away from the current folder.