### PR TITLE
fix: allow simple host URL for API request component

### DIFF
--- a/src/backend/base/langflow/components/data/api_request.py
+++ b/src/backend/base/langflow/components/data/api_request.py
@@ -519,7 +519,7 @@ class APIRequestComponent(Component):
         if self.use_curl and self.curl:
             self._build_config = self.parse_curl(self.curl, dotdict())
 
-        invalid_urls = [url for url in urls if not validators.url(url)]
+        invalid_urls = [url for url in urls if not validators.url(url, simple_host=True)]
         if invalid_urls:
             msg = f"Invalid URLs provided: {invalid_urls}"
             raise ValueError(msg)


### PR DESCRIPTION
I wanted to use the API request component to make an API request to an internal service. The URL in this case would look like `http://internalservice/endpoint`. This causes the validation to fail, thus forcing me to go for a Custom Component for a really simple use case.

This pull request makes the validation a little more lenient allowing hosts like in the above URL.

(imo there should be no validation at all :D happy to open a PR for the same if you guys share this opinion)