### PR TITLE
fix: replace dead `callback.py` link with working fork URL

### DIFF
--- a/src/backend/base/langflow/api/v1/callback.py
+++ b/src/backend/base/langflow/api/v1/callback.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from langflow.services.socket.service import SocketIOService
 
 
-# https://github.com/hwchase17/chat-langchain/blob/master/callback.py
+# https://github.com/tbroadley/ai-safety-conversational-agent/blob/master/callback.py
 class AsyncStreamingLLMCallbackHandleSIO(AsyncCallbackHandler):
     """Callback handler for streaming LLM responses."""
 


### PR DESCRIPTION
# Description
The original link to `callback.py` in `langchain-ai/chat-langchain` now returns **404** because the file was removed upstream.  
This PR updates the reference to the file’s active copy in the fork `tbroadley/ai-safety-conversational-agent`, restoring a valid navigation path and preventing broken links for users.






