### PR TITLE
fix: update mutate template to preserve minimized outputs

### DIFF
--- a/src/frontend/src/CustomNodes/helpers/mutate-template.ts
+++ b/src/frontend/src/CustomNodes/helpers/mutate-template.ts
@@ -6,6 +6,7 @@ import {
 import { APIClassType, ResponseErrorDetailAPI } from "@/types/api";
 import { UseMutationResult } from "@tanstack/react-query";
 import { cloneDeep, debounce } from "lodash";
+import { updateHiddenOutputs } from "./update-hidden-outputs";
 
 // Map to store debounced functions for each node ID
 const debouncedFunctions = new Map<string, ReturnType<typeof debounce>>();
@@ -53,7 +54,10 @@ export const mutateTemplate = async (
             });
             if (newTemplate) {
               newNode.template = newTemplate.template;
-              newNode.outputs = newTemplate.outputs;
+              newNode.outputs = updateHiddenOutputs(
+                newNode.outputs ?? [],
+                newTemplate.outputs ?? [],
+              );
               newNode.tool_mode = toolMode ?? node.tool_mode;
             }
             setNodeClass(newNode);


### PR DESCRIPTION
This pull request updates the `mutate-template.ts` file to improve how node outputs are handled during template mutations. The key changes involve introducing a utility function to manage hidden outputs.

### Improvements to output handling:

* [`src/frontend/src/CustomNodes/helpers/mutate-template.ts`](diffhunk://#diff-a65752801640d4acb83ee2c8787c474b31940dec9357cec061f4db81634b65cdR9): Added an import for the new `updateHiddenOutputs` utility function to handle hidden outputs during template mutations.
* [`src/frontend/src/CustomNodes/helpers/mutate-template.ts`](diffhunk://#diff-a65752801640d4acb83ee2c8787c474b31940dec9357cec061f4db81634b65cdL56-R60): Updated the `mutateTemplate` function to use `updateHiddenOutputs` for merging existing outputs with new template outputs, ensuring hidden outputs are preserved.