### PR TITLE
fix: made disabled output button not appear as clickable

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx
@@ -138,10 +138,10 @@ const InspectButton = memo(
           className={cn(
             "icon-size",
             isToolMode
-              ? displayOutputPreview && !unknownOutput
+              ? displayOutputPreview && !unknownOutput && !disabled
                 ? "text-background hover:text-secondary-hover"
                 : "cursor-not-allowed text-placeholder-foreground opacity-80"
-              : displayOutputPreview && !unknownOutput
+              : displayOutputPreview && !unknownOutput && !disabled
                 ? "text-foreground hover:text-primary-hover"
                 : "cursor-not-allowed text-placeholder-foreground opacity-60",
             errorOutput ? "text-destructive" : "",


### PR DESCRIPTION
This pull request updates the `InspectButton` component in `NodeOutputfield` to include a check for a `disabled` state. This ensures that the button's styles and behavior are appropriately adjusted when it is disabled.

### Updates to `InspectButton` behavior and styling:

* [`src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx`](diffhunk://#diff-4742b353430022eb88d35ab987d50925c592f35702319e1d476e2d53818cd795L141-R144): Added a condition to check for the `disabled` state when determining the button's classes. This prevents hover effects and adjusts the appearance when the button is disabled.