### PR TITLE
fix: add error handling in url component

### DIFF
--- a/src/backend/base/langflow/components/data/url.py
+++ b/src/backend/base/langflow/components/data/url.py
@@ -203,7 +203,7 @@ class URLComponent(Component):
             self.status = data
 
         except Exception as e:
-			message = e.message if hasattr(e, "message") else e
+            message = e.message if hasattr(e, "message") else e
             msg = f"Error loading documents: {message!s}"
             logger.exception(msg)
             raise ValueError(msg) from e

--- a/src/backend/base/langflow/components/data/url.py
+++ b/src/backend/base/langflow/components/data/url.py
@@ -203,7 +203,8 @@ class URLComponent(Component):
             self.status = data
 
         except Exception as e:
-            msg = f"Error loading documents: {e.message!s}"
+			message = e.message if hasattr(e, "message") else e
+            msg = f"Error loading documents: {message!s}"
             logger.exception(msg)
             raise ValueError(msg) from e
 

--- a/src/backend/base/langflow/components/data/url.py
+++ b/src/backend/base/langflow/components/data/url.py
@@ -203,8 +203,8 @@ class URLComponent(Component):
             self.status = data
 
         except Exception as e:
-            message = e.message if hasattr(e, "message") else e
-            msg = f"Error loading documents: {message!s}"
+            error_msg = e.message if hasattr(e, "message") else e
+            msg = f"Error loading documents: {error_msg!s}"
             logger.exception(msg)
             raise ValueError(msg) from e
 


### PR DESCRIPTION
This pull request refactors the `fetch_content` method in `src/backend/base/langflow/components/data/url.py` to enhance error handling and replace the `requests` library with `httpx`. Key changes include improved error propagation for single URLs, expanded exception handling, and updates to the `RecursiveUrlLoader` configuration.

### Library Migration:
* Replaced the `requests` library with `httpx` for HTTP requests, updating exception handling to use `httpx`-specific error classes. (`[[1]](diffhunk://#diff-be3b89252611954c8d88cb52a4f9a322d881951fe48d1bcd31d9b6af8838d794L3-R3)`, `[[2]](diffhunk://#diff-be3b89252611954c8d88cb52a4f9a322d881951fe48d1bcd31d9b6af8838d794R179-R206)`)

### Error Handling Improvements:
* Added logic to propagate errors (e.g., HTTP errors, decoding errors, unexpected exceptions) when processing a single URL, ensuring better feedback for users in these cases. (`[[1]](diffhunk://#diff-be3b89252611954c8d88cb52a4f9a322d881951fe48d1bcd31d9b6af8838d794R147-R168)`, `[[2]](diffhunk://#diff-be3b89252611954c8d88cb52a4f9a322d881951fe48d1bcd31d9b6af8838d794R179-R206)`)
* Expanded exception handling to include `UnicodeDecodeError` and a general `Exception` catch block for unexpected errors, with re-raising for single URLs. (`[src/backend/base/langflow/components/data/url.pyR179-R206](diffhunk://#diff-be3b89252611954c8d88cb52a4f9a322d881951fe48d1bcd31d9b6af8838d794R179-R206)`)

### RecursiveUrlLoader Configuration:
* Updated the `RecursiveUrlLoader` initialization to include `httpx`-compatible settings and a `continue_on_failure` flag, allowing for improved control over error handling during multi-URL processing. (`[src/backend/base/langflow/components/data/url.pyR147-R168](diffhunk://#diff-be3b89252611954c8d88cb52a4f9a322d881951fe48d1bcd31d9b6af8838d794R147-R168)`)

### Minor Adjustments:
* Improved error messages for better clarity and debugging, including changes to the final exception message format. (`[src/backend/base/langflow/components/data/url.pyR179-R206](diffhunk://#diff-be3b89252611954c8d88cb52a4f9a322d881951fe48d1bcd31d9b6af8838d794R179-R206)`)