### PR TITLE
fix: suppresses fastapi-pagination warnings

### DIFF
--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -247,7 +247,11 @@ async def read_flows(
             return compress_response(flows)
 
         stmt = stmt.where(Flow.folder_id == folder_id)
-        return await apaginate(session, stmt, params=params)
+
+        import warnings
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"fastapi_pagination\.ext\.sqlalchemy")
+            return await apaginate(session, stmt, params=params)
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -171,6 +171,9 @@ async def get_transactions(
             .where(TransactionTable.flow_id == flow_id)
             .order_by(col(TransactionTable.timestamp))
         )
-        return await apaginate(session, stmt, params=params, transformer=transform_transaction_table)
+        import warnings
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"fastapi_pagination\.ext\.sqlalchemy")
+            return await apaginate(session, stmt, params=params, transformer=transform_transaction_table)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -152,7 +152,10 @@ async def read_project(
                 stmt = stmt.where(Flow.is_component == False)  # noqa: E712
             if search:
                 stmt = stmt.where(Flow.name.like(f"%{search}%"))  # type: ignore[attr-defined]
-            paginated_flows = await apaginate(session, stmt, params=params)
+            import warnings
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"fastapi_pagination\.ext\.sqlalchemy")
+                paginated_flows = await apaginate(session, stmt, params=params)
 
             return FolderWithPaginatedFlows(folder=FolderRead.model_validate(project), flows=paginated_flows)
 


### PR DESCRIPTION
Suppresses the fastapi-pagination warnings that appear anytime an endpoint is called. 