### PR TITLE
fix: Improve performance by removing unnecessary client flush in LangFuseTracer

### DIFF
--- a/src/backend/base/langflow/services/tracing/langfuse.py
+++ b/src/backend/base/langflow/services/tracing/langfuse.py
@@ -151,7 +151,6 @@ class LangFuseTracer(BaseTracer):
             "metadata": metadata,
         }
         self.trace.update(**serialize(content_update))
-        self._client.flush()
 
     def get_langchain_callback(self) -> BaseCallbackHandler | None:
         if not self._ready:


### PR DESCRIPTION
Eliminate an unnecessary client flush in the LangFuseTracer to enhance performance.