### PR TITLE
fix: Refactor run_link access to avoid unnecessary external call

### DIFF
--- a/src/backend/base/langflow/services/tracing/langsmith.py
+++ b/src/backend/base/langflow/services/tracing/langsmith.py
@@ -140,7 +140,6 @@ class LangSmithTracer(BaseTracer):
             child.patch()
         else:
             child.post()
-        self._child_link[trace_name] = child.get_url()
 
     @staticmethod
     def _error_to_string(error: Exception | None):
@@ -164,7 +163,12 @@ class LangSmithTracer(BaseTracer):
             self._run_tree.add_metadata(serialize(metadata))
         self._run_tree.end(outputs=serialize(outputs), error=self._error_to_string(error))
         self._run_tree.post()
-        self._run_link = self._run_tree.get_url()
+
+    @property
+    def run_link(self):
+        if not self._ready or not self._run_tree:
+            return None
+        return self._run_tree.get_url()
 
     @override
     def get_langchain_callback(self) -> BaseCallbackHandler | None:


### PR DESCRIPTION
Replace direct access to the run_link with a property to enhance encapsulation and maintainability.