### PR TITLE
feat: add rss component

### DIFF
--- a/src/backend/base/langflow/components/data/__init__.py
+++ b/src/backend/base/langflow/components/data/__init__.py
@@ -3,6 +3,7 @@ from .csv_to_data import CSVToDataComponent
 from .directory import DirectoryComponent
 from .file import FileComponent
 from .json_to_data import JSONToDataComponent
+from .rss import RSSReaderComponent
 from .sql_executor import SQLComponent
 from .url import URLComponent
 from .webhook import WebhookComponent
@@ -13,6 +14,7 @@ __all__ = [
     "DirectoryComponent",
     "FileComponent",
     "JSONToDataComponent",
+    "RSSReaderComponent",
     "SQLComponent",
     "URLComponent",
     "WebhookComponent",

--- a/src/backend/base/langflow/components/data/rss.py
+++ b/src/backend/base/langflow/components/data/rss.py
@@ -21,6 +21,7 @@ class RSSReaderComponent(Component):
             info="URL of the RSS feed to parse.",
             tool_mode=True,
             input_types=[],
+            required=True,
         )
     ]
 
@@ -46,6 +47,7 @@ class RSSReaderComponent(Component):
             for item in items
         ]
 
-        df_articles = pd.DataFrame(articles)
+        # Ensure the DataFrame has the correct columns even if empty
+        df_articles = pd.DataFrame(articles, columns=["title", "link", "published", "summary"])
         logger.info(f"Fetched {len(df_articles)} articles.")
         return DataFrame(df_articles)

--- a/src/backend/tests/unit/components/data/test_rss.py
+++ b/src/backend/tests/unit/components/data/test_rss.py
@@ -1,11 +1,9 @@
 from unittest.mock import Mock, patch
 
-import pandas as pd
 import pytest
-from bs4 import BeautifulSoup
+import requests
 from langflow.components.data.rss import RSSReaderComponent
 from langflow.schema import DataFrame
-import requests
 
 from tests.base import ComponentTestBaseWithoutClient
 

--- a/src/backend/tests/unit/components/data/test_rss.py
+++ b/src/backend/tests/unit/components/data/test_rss.py
@@ -1,0 +1,131 @@
+from unittest.mock import Mock, patch
+
+import pandas as pd
+import pytest
+from bs4 import BeautifulSoup
+from langflow.components.data.rss import RSSReaderComponent
+from langflow.schema import DataFrame
+import requests
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestRSSReaderComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        """Return the component class to test."""
+        return RSSReaderComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        """Return the default kwargs for the component."""
+        return {
+            "rss_url": "https://example.com/feed.xml",
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        """Return an empty list since this component doesn't have version-specific files."""
+        return []
+
+    def test_successful_rss_fetch(self):
+        # Mock RSS feed content
+        mock_rss_content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <title>Test Article 1</title>
+                    <link>https://example.com/1</link>
+                    <pubDate>2024-03-20</pubDate>
+                    <description>Test summary 1</description>
+                </item>
+                <item>
+                    <title>Test Article 2</title>
+                    <link>https://example.com/2</link>
+                    <pubDate>2024-03-21</pubDate>
+                    <description>Test summary 2</description>
+                </item>
+            </channel>
+        </rss>
+        """
+
+        # Mock the requests.get response
+        mock_response = Mock()
+        mock_response.content = mock_rss_content.encode("utf-8")
+        mock_response.raise_for_status = Mock()
+
+        with patch("requests.get", return_value=mock_response):
+            component = RSSReaderComponent(rss_url="https://example.com/feed.xml")
+            result = component.read_rss()
+
+            assert isinstance(result, DataFrame)
+            assert len(result) == 2
+            assert list(result.columns) == ["title", "link", "published", "summary"]
+            assert result.iloc[0]["title"] == "Test Article 1"
+            assert result.iloc[1]["title"] == "Test Article 2"
+
+    def test_rss_fetch_with_missing_fields(self):
+        # Mock RSS feed content with missing fields
+        mock_rss_content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <title>Test Article</title>
+                    <!-- Missing link -->
+                    <pubDate>2024-03-20</pubDate>
+                    <!-- Missing description -->
+                </item>
+            </channel>
+        </rss>
+        """
+
+        mock_response = Mock()
+        mock_response.content = mock_rss_content.encode("utf-8")
+        mock_response.raise_for_status = Mock()
+
+        with patch("requests.get", return_value=mock_response):
+            component = RSSReaderComponent(rss_url="https://example.com/feed.xml")
+            result = component.read_rss()
+
+            assert isinstance(result, DataFrame)
+            assert len(result) == 1
+            assert result.iloc[0]["title"] == "Test Article"
+            assert result.iloc[0]["link"] == ""
+            assert result.iloc[0]["summary"] == ""
+
+    def test_rss_fetch_error(self):
+        # Mock a failed request
+        with patch("requests.get", side_effect=requests.RequestException("Network error")):
+            component = RSSReaderComponent(rss_url="https://example.com/feed.xml")
+            result = component.read_rss()
+
+            assert isinstance(result, DataFrame)
+            assert len(result) == 1
+            assert result.iloc[0]["title"] == "Error"
+            assert result.iloc[0]["link"] == ""
+            assert result.iloc[0]["published"] == ""
+            assert "Network error" in result.iloc[0]["summary"]
+
+    def test_empty_rss_feed(self):
+        # Mock empty RSS feed
+        mock_rss_content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+            </channel>
+        </rss>
+        """
+
+        mock_response = Mock()
+        mock_response.content = mock_rss_content.encode("utf-8")
+        mock_response.raise_for_status = Mock()
+
+        with patch("requests.get", return_value=mock_response):
+            component = RSSReaderComponent(rss_url="https://example.com/feed.xml")
+            result = component.read_rss()
+
+            assert isinstance(result, DataFrame)
+            assert len(result) == 0
+            assert list(result.columns) == ["title", "link", "published", "summary"]


### PR DESCRIPTION
This pull request introduces a new `RSSReaderComponent` to the codebase, enabling the parsing of RSS feeds and returning their contents in a structured format. It also includes corresponding unit tests to ensure the component's functionality and error handling. The key changes are summarized below:

### Addition of the `RSSReaderComponent`:

* **Component Implementation**: Added the `RSSReaderComponent` class in `src/backend/base/langflow/components/data/rss.py`. This component fetches and parses RSS feeds, returning the articles as a `DataFrame`. It includes error handling for network issues and malformed feeds.
* **Component Registration**: Registered `RSSReaderComponent` in `src/backend/base/langflow/components/data/__init__.py` by importing it and adding it to the `__all__` list. [[1]](diffhunk://#diff-c1dde49edb857967e1bf14a3d2e4cf73350ab80f6e1d7696d69f48833c560b2eR6) [[2]](diffhunk://#diff-c1dde49edb857967e1bf14a3d2e4cf73350ab80f6e1d7696d69f48833c560b2eR17)

### Unit Tests for `RSSReaderComponent`:

* **Test Cases**: Added comprehensive unit tests in `src/backend/tests/unit/components/data/test_rss.py` to validate the component's behavior, including successful RSS fetches, handling of missing fields, network errors, and empty feeds.