### PR TITLE
docs: add release notes

### DIFF
--- a/docs/docs/Release-Notes/release-notes.md
+++ b/docs/docs/Release-Notes/release-notes.md
@@ -1,0 +1,43 @@
+---
+title: Langflow release notes
+slug: /release notes
+---
+
+This page summarizes significant changes and updates to Langflow.
+
+## 1.4.2
+
+The following updates are included in this version:
+
+### New features and enhancements
+- Enhanced file and flow management system with improved bulk capabilities.
+
+### New integrations and bundles
+- BigQuery component for connecting to BQ datasets.
+- Twelve Labs integration bundle.
+- NVIDIA system assistant component.
+
+### Deprecated features
+
+- Deprecated the Combine text component.
+
+## 1.4.1
+
+The following updates are included in this version:
+
+### New features and enhancements
+
+- Added an enhanced "Breaking Changes" feature to help update components during version updates without breaking flows.
+
+## 1.4.0
+
+The following updates are included in this version:
+
+### New features and enhancements
+
+- Introduced MCP server functionality to serve Langflow tools to MCP-compatible clients.
+- Renamed "Folders" to "Projects". The `/folders` endpoints now redirect to `/projects`.
+
+### Deprecated features
+
+- Deprecated the Google Gmail, Drive, and Search components.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -238,8 +238,9 @@ module.exports = {
     },
     {
       type: "category",
-      label: "Changelog",
+      label: "Release notes",
       items: [
+        "Release-Notes/release-notes",
         {
           type: "link",
           label: "Changelog",


### PR DESCRIPTION
This pull request updates the documentation to include detailed release notes for recent versions of Langflow.

[Preview build](https://d5rxiv0do0q3v.cloudfront.net/langflow-drafts/docs-add-release-notes/release%20notes)