### PR TITLE
fix: updated flow pages to just set the flow if types are fetched

### DIFF
--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -100,7 +100,7 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
   // Set flow tab id
   useEffect(() => {
     const awaitgetTypes = async () => {
-      if (flows && currentFlowId === "") {
+      if (flows && currentFlowId === "" && Object.keys(types).length > 0) {
         const isAnExistingFlow = flows.find((flow) => flow.id === id);
 
         if (!isAnExistingFlow) {
@@ -114,7 +114,7 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
       }
     };
     awaitgetTypes();
-  }, [id, flows, currentFlowId]);
+  }, [id, flows, currentFlowId, types]);
 
   useEffect(() => {
     setOnFlowPage(true);


### PR DESCRIPTION
This pull request makes a minor update to the `FlowPage` component in `src/frontend/src/pages/FlowPage/index.tsx`. The changes improve the logic for setting the flow tab ID and ensure the `useEffect` dependency array is complete.
This fixes the problem where flows, if accessed through the main page, wouldn't get the nodes that needed update.

Key changes:

* **Logic improvement**: Updated the conditional check in the `awaitgetTypes` function to include a validation for `types` having keys, ensuring the function only runs when `types` is populated.
* **Dependency array update**: Added `types` to the dependency array of the `useEffect` hook to ensure it re-runs when `types` changes.