### PR TITLE
fix: google_generative_ai always select first model

### DIFF
--- a/src/backend/base/langflow/components/models/google_generative_ai.py
+++ b/src/backend/base/langflow/components/models/google_generative_ai.py
@@ -140,7 +140,6 @@ class GoogleGenerativeAIComponent(LCModelComponent):
                         logger.exception(f"Error getting model names: {e}")
                         ids = GOOGLE_GENERATIVE_AI_MODELS
                 build_config["model_name"]["options"] = ids
-                build_config["model_name"]["value"] = ids[0]
             except Exception as e:
                 msg = f"Error getting model names: {e}"
                 raise ValueError(msg) from e


### PR DESCRIPTION
<img width="390" alt="image" src="https://github.com/user-attachments/assets/c84c6b13-1b11-421d-a8d8-4d1d5dd28fbe" />
Fix bug google_generative_ai always select first model