### PR TITLE
fix: fix regex on mcp server tab test

### DIFF
--- a/src/frontend/tests/extended/features/mcp-server-tab.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server-tab.spec.ts
@@ -135,12 +135,12 @@ test(
       // Get the SSE URL from the configuration
       const configJson = await page.locator("pre").textContent();
       expect(configJson).toContain("mcpServers");
-      expect(configJson).toContain("supergateway");
-      expect(configJson).toContain("sse");
+      expect(configJson).toContain("mcp-proxy");
+      expect(configJson).toContain("uvx");
 
       // Extract the SSE URL from the configuration
       const sseUrlMatch = configJson?.match(
-        /"args":\s*\[\s*"-y",\s*"supergateway",\s*"--sse",\s*"([^"]+)"/,
+        /"args":\s*\[\s*"mcp-proxy",\s*"([^"]+)"/,
       );
       expect(sseUrlMatch).not.toBeNull();
       const sseUrl = sseUrlMatch![1];


### PR DESCRIPTION
This pull request updates test expectations in the `mcp-server-tab.spec.ts` file to reflect changes in the configuration format and naming conventions.

### Test updates for configuration changes:

* Updated test assertions to check for "mcp-proxy" and "uvx" instead of "supergateway" and "sse" in the configuration JSON.
* Modified the regular expression used to extract the SSE URL to align with the new "mcp-proxy" format.