### PR TITLE
fix: removed fit view that caused duck duck go test to fail

### DIFF
--- a/src/frontend/tests/extended/integrations/duckduckgo.spec.ts
+++ b/src/frontend/tests/extended/integrations/duckduckgo.spec.ts
@@ -32,8 +32,6 @@ test(
 
     await page.getByTestId("button_run_duckduckgo search").click();
 
-    await page.getByTestId("fit_view").click();
-
     const result = await Promise.race([
       page.waitForSelector("text=built successfully", { timeout: 30000 }),
       page.waitForSelector("text=ratelimit", { timeout: 30000 }),


### PR DESCRIPTION
This pull request removes an unnecessary click action in a test file to streamline the test flow.

* [`src/frontend/tests/extended/integrations/duckduckgo.spec.ts`](diffhunk://#diff-4adeafe8432cd447af72a709cfd02bf951cabc4df1e40abb0ca6b725b98e9ae8L35-L36): Removed the `fit_view` button click action, as it was redundant and did not contribute to the test outcome.