### PR TITLE
docs: cookie-banner-link

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -358,7 +358,7 @@ const config = {
               {
                 html: `<div class="footer-links">
                   <span>© ${new Date().getFullYear()} Langflow</span>
-                  <span id="preferenceCenterContainer"> ·&nbsp; <a href="/cookies">Manage Privacy Choices</a></span>
+                  <span id="preferenceCenterContainer"> ·&nbsp; <a href="https://langflow.org/preferences">Manage Privacy Choices</a></span>
                   </div>`,
               },
             ],


### PR DESCRIPTION
This pull request updates the "Manage Privacy Choices" link in the footer to point to `https://langflow.org/preferences` instead of `/cookies`.