### PR TITLE
fix: simplify GetStartedProgress percentage calculation logic

### DIFF
--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
@@ -35,25 +35,27 @@ export const GetStartedProgress: FC<{
   const hasFlows = flows && flows?.length > 0;
 
   const percentageGetStarted = useMemo(() => {
-    const totalSteps = 3;
-    let hasFlowsCount = 0;
-    const completedSteps = Object.keys(userData?.optins ?? {}).filter(
-      (key) => userData?.optins?.[key],
-    )?.length;
+    const stepValue = 33;
+    let totalPercentage = 0;
 
-    if (hasFlows) {
-      hasFlowsCount = 33;
+    if (userData?.optins?.github_starred) {
+      totalPercentage += stepValue;
     }
 
-    const percentage =
-      Math.round((completedSteps / totalSteps) * 100) + hasFlowsCount;
+    if (userData?.optins?.discord_clicked) {
+      totalPercentage += stepValue;
+    }
 
-    if (percentage > 100) {
+    if (hasFlows) {
+      totalPercentage += stepValue;
+    }
+
+    if (totalPercentage === 99) {
       return 100;
     }
 
-    return percentage;
-  }, [userData?.optins, isGithubStarredChild, isDiscordJoinedChild, hasFlows]);
+    return Math.min(totalPercentage, 100);
+  }, [userData?.optins, hasFlows]);
 
   const handleUserTrack = (key: string) => {
     const optins = userData?.optins ?? {};


### PR DESCRIPTION
This pull request refactors the logic for calculating the "Get Started" progress percentage in the `GetStartedProgress` component. The changes simplify the calculation by introducing a `stepValue` constant and restructuring the logic to increment `totalPercentage` directly for each completed step.

### Refactoring of progress calculation:

* [`src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx`](diffhunk://#diff-8d321fde6165c43e414eab942a430830c848898375d8ab3c1edc2e6acdcfe423L38-R58): Simplified the progress calculation by replacing the `totalSteps` and `completedSteps` logic with a `stepValue` constant and directly incrementing `totalPercentage` for each completed step. Adjusted the maximum percentage to be capped at 100 using `Math.min`.