### PR TITLE
ref: Deprecate regex and update data components

### DIFF
--- a/src/backend/base/langflow/components/processing/regex.py
+++ b/src/backend/base/langflow/components/processing/regex.py
@@ -10,6 +10,7 @@ class RegexExtractorComponent(Component):
     display_name = "Regex Extractor"
     description = "Extract patterns from text using regular expressions."
     icon = "regex"
+    legacy = True
 
     inputs = [
         MessageTextInput(

--- a/src/backend/base/langflow/components/processing/update_data.py
+++ b/src/backend/base/langflow/components/processing/update_data.py
@@ -20,6 +20,7 @@ class UpdateDataComponent(Component):
     name: str = "UpdateData"
     MAX_FIELDS = 15  # Define a constant for maximum number of fields
     icon = "FolderSync"
+    legacy = True
 
     inputs = [
         DataInput(


### PR DESCRIPTION
This pull request marks two components as legacy by adding a `legacy = True` attribute to their definitions. These changes help identify outdated components in the codebase.

* **Marking components as legacy:**
  * [`src/backend/base/langflow/components/processing/regex.py`](diffhunk://#diff-2a632913895f9dc0b7c2965c3f2f57b1a28f84c35a2bfea6f6016f49b36370e0R13): Added `legacy = True` to the `RegexExtractorComponent` class.
  * [`src/backend/base/langflow/components/processing/update_data.py`](diffhunk://#diff-050cb4102347879d1fece343bacd8b4dd1e3afcb0038fc38deb6588f7e34055dR23): Added `legacy = True` to the `UpdateDataComponent` class.