### PR TITLE
fix: fixes nightly tests

### DIFF
--- a/src/frontend/tests/extended/features/mcp-server-tab.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server-tab.spec.ts
@@ -95,8 +95,9 @@ test(
         // Select first action
         await page
           .locator('input[data-ref="eInput"]')
-          .nth(rowsCount + 1)
-          .click();
+          .last()
+          .scrollIntoViewIfNeeded();
+        await page.locator('input[data-ref="eInput"]').last().click();
         await page.waitForTimeout(1000);
 
         await page
@@ -107,7 +108,7 @@ test(
 
         const isLastChecked = await page
           .locator('input[data-ref="eInput"]')
-          .nth(rowsCount + 1)
+          .last()
           .isChecked();
 
         expect(isLastChecked).toBeTruthy();

--- a/src/frontend/tests/extended/features/notifications.spec.ts
+++ b/src/frontend/tests/extended/features/notifications.spec.ts
@@ -25,8 +25,12 @@ test(
         await page.getByTestId("button_run_text input").click();
       });
 
-    await page.waitForSelector("text=built successfully", { timeout: 30000 });
+    await page.waitForSelector("text=Running", {
+      timeout: 30000,
+      state: "visible",
+    });
 
+    await page.waitForSelector("text=built successfully", { timeout: 30000 });
     await page.getByTestId("notification_button").click();
 
     // Add explicit waits before checking visibility
@@ -35,10 +39,6 @@ test(
       state: "visible",
     });
 
-    await page.waitForSelector("text=Running", {
-      timeout: 30000,
-      state: "visible",
-    });
     // Then check visibility
     const notificationsText = page
       .getByText("Notifications", { exact: true })
@@ -47,9 +47,6 @@ test(
 
     const trashIcon = page.getByTestId("icon-Trash2").last();
     await expect(trashIcon).toBeVisible();
-
-    const runningComponentsText = page.getByText("Running").last();
-    await expect(runningComponentsText).toBeVisible();
 
     const builtSuccessfullyText = page
       .getByText("Flow built successfully", { exact: true })

--- a/src/frontend/tests/extended/regression/general-bugs-shard-3909.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-shard-3909.spec.ts
@@ -39,7 +39,7 @@ test(
     await page.getByTestId("side_nav_options_all-templates").click();
     await page.getByRole("heading", { name: "Basic Prompting" }).click();
     await page.waitForSelector("text=playground", { timeout: 30000 });
-    await page.waitForSelector("text=publish", { timeout: 30000 });
+    await page.waitForSelector("text=share", { timeout: 30000 });
 
     await expect(page.getByTestId("button_run_chat output")).toBeVisible({
       timeout: 30000,


### PR DESCRIPTION
This pull request updates test cases in the frontend test suite to improve reliability and accuracy. The most significant changes include replacing the use of `.nth()` with `.last()` for better targeting of elements, refining selector conditions for improved stability, and updating text expectations to match recent UI changes.

### Improvements to element targeting:

* Updated `mcp-server-tab.spec.ts` to replace `.nth(rowsCount + 1)` with `.last()` for selecting the last input element, ensuring more robust element targeting. Additionally, added `scrollIntoViewIfNeeded()` before clicking the element for better test stability. [[1]](diffhunk://#diff-7be38a6d14c366a786e62666ed82fb46f758a4d65b76f8c486a56eb90b700e39L98-R100) [[2]](diffhunk://#diff-7be38a6d14c366a786e62666ed82fb46f758a4d65b76f8c486a56eb90b700e39L110-R111)

### Refinements to selector conditions:

* Modified `notifications.spec.ts` to include an additional wait for the "Running" state to become visible before checking for "built successfully" text, improving test reliability.
* Removed redundant checks for "Running" state visibility in `notifications.spec.ts` to streamline the test flow. [[1]](diffhunk://#diff-83d2e89ec2cacf9aa14d857a376c5362031817b889e2256873cbe697cc634928L38-L41) [[2]](diffhunk://#diff-83d2e89ec2cacf9aa14d857a376c5362031817b889e2256873cbe697cc634928L51-L53)

### Updates to match UI changes:

* Updated `general-bugs-shard-3909.spec.ts` to replace the expected text "publish" with "share" in a selector, aligning the test with recent UI modifications.