### PR TITLE
fix: mcp test when there are a lot of flows

### DIFF
--- a/src/frontend/tests/extended/features/mcp-server-tab.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server-tab.spec.ts
@@ -93,17 +93,29 @@ test(
         expect(isCheckedAgainAgain).toBeFalsy();
 
         // Select first action
-        await page
-          .locator('input[data-ref="eInput"]')
-          .last()
-          .scrollIntoViewIfNeeded();
-        await page.locator('input[data-ref="eInput"]').last().click();
-        await page.waitForTimeout(1000);
+        let element = page.locator('input[data-ref="eInput"]').last();
+        let elementText = await element.getAttribute("id");
 
-        await page
-          .getByRole("gridcell")
-          .nth(cellsCount - 1)
-          .click();
+        await element.scrollIntoViewIfNeeded();
+
+        let count = 0;
+
+        while (
+          elementText !==
+            (await page
+              .locator('input[data-ref="eInput"]')
+              .last()
+              .getAttribute("id")) &&
+          count < 20
+        ) {
+          element = page.locator('input[data-ref="eInput"]').last();
+          elementText = await element.getAttribute("id");
+          await element.scrollIntoViewIfNeeded();
+          await page.waitForTimeout(500);
+        }
+
+        await page.locator('input[data-ref="eInput"]').last().click();
+
         await page.waitForTimeout(1000);
 
         const isLastChecked = await page
@@ -113,16 +125,22 @@ test(
 
         expect(isLastChecked).toBeTruthy();
 
+        await page
+          .getByRole("gridcell")
+          .nth(cellsCount - 1)
+          .click();
+        await page.waitForTimeout(1000);
+
         expect(
           await page.locator('[data-testid="input_update_name"]').isVisible(),
         ).toBe(true);
 
         await page.getByTestId("input_update_name").fill("mcp test name");
-        await page.waitForTimeout(500);
+        await page.waitForTimeout(2000);
 
         // Close the modal
         await page.getByText("Close").last().click();
-        await page.waitForTimeout(500);
+        await page.waitForTimeout(2000);
 
         // Verify the selected action is visible in the tab
         await expect(page.getByTestId("div-mcp-server-tools")).toBeVisible();


### PR DESCRIPTION
This pull request updates a test script in `src/frontend/tests/extended/features/mcp-server-tab.spec.ts` to improve the reliability of element selection and interaction, and adjusts timeout durations for better synchronization.

### Improvements to element selection and interaction:

* Added a loop to ensure the correct element is selected by repeatedly checking its `id` attribute and scrolling it into view if needed. This change enhances the reliability of selecting the last `input[data-ref="eInput"]` element.

### Adjustments to timeout durations:

* Increased the timeout duration from 500ms to 2000ms after filling the "input_update_name" field and after closing the modal. This change aims to improve test stability by allowing more time for UI updates.