### PR TITLE
fix: import bug

### DIFF
--- a/src/backend/base/langflow/components/nvidia/system_assist.py
+++ b/src/backend/base/langflow/components/nvidia/system_assist.py
@@ -20,6 +20,8 @@ class NvidiaSystemAssistComponent(ComponentWithCache):
     rise_initialized = False
 
     def maybe_register_rise_client(self):
+        with contextlib.suppress(ImportError):
+            from gassist.rise import register_rise_client
         rise_initialized = self._shared_component_cache.get("rise_initialized")
         if not isinstance(rise_initialized, CacheMiss) and rise_initialized:
             return


### PR DESCRIPTION
This pull request introduces a change to the `NvidiaSystemAssistComponent` class in `src/backend/base/langflow/components/nvidia/system_assist.py`. The key update ensures that the `register_rise_client` import is safely handled using `contextlib.suppress` to avoid errors if the `gassist.rise` module is unavailable.

### Error handling improvement:

* Wrapped the import of `register_rise_client` from `gassist.rise` in a `contextlib.suppress(ImportError)` block to prevent potential `ImportError` exceptions from disrupting the execution of the `maybe_register_rise_client` method.