### PR TITLE
fix: handle empty JSON String in Template loading

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -149,6 +149,8 @@ def update_projects_components_with_latest_component_versions(project_data, all_
 
 
 def scape_json_parse(json_string: str) -> dict:
+    if json_string is None:
+        return {}
     if isinstance(json_string, dict):
         return json_string
     parsed_string = json_string.replace("œ", '"')


### PR DESCRIPTION
This pull request includes a small change to the `scape_json_parse` function in `src/backend/base/langflow/initial_setup/setup.py`. The change ensures that if the input `json_string` is `None`, the function will return an empty dictionary.