### PR TITLE
feat: add export option to deploy dropdown

### DIFF
--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
@@ -14,6 +14,7 @@ import { ENABLE_PUBLISH, ENABLE_WIDGET } from "@/customization/feature-flags";
 import { customMcpOpen } from "@/customization/utils/custom-mcp-open";
 import ApiModal from "@/modals/apiModal/new-api-modal";
 import EmbedModal from "@/modals/EmbedModal/embed-modal";
+import ExportModal from "@/modals/exportModal";
 import useAlertStore from "@/stores/alertStore";
 import useAuthStore from "@/stores/authStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
@@ -39,6 +40,7 @@ export default function PublishDropdown() {
   const hasIO = useFlowStore((state) => state.hasIO);
   const isAuth = useAuthStore((state) => !!state.autoLogin);
   const [openApiModal, setOpenApiModal] = useState(false);
+  const [openExportModal, setOpenExportModal] = useState(false);
 
   const handlePublishedSwitch = async (checked: boolean) => {
     mutateAsync(
@@ -114,6 +116,18 @@ export default function PublishDropdown() {
                 className={`${groupStyle} icon-size mr-2`}
               />
               <span>API access</span>
+            </div>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="deploy-dropdown-item group"
+            onClick={() => setOpenExportModal(true)}
+          >
+            <div className="group-hover:bg-accent">
+              <IconComponent
+                name="Download"
+                className={`${groupStyle} icon-size mr-2`}
+              />
+              <span>Export</span>
             </div>
           </DropdownMenuItem>
           <CustomLink
@@ -229,6 +243,7 @@ export default function PublishDropdown() {
         tweaksBuildedObject={{}}
         activeTweaks={false}
       ></EmbedModal>
+      <ExportModal open={openExportModal} setOpen={setOpenExportModal} />
     </>
   );
 }


### PR DESCRIPTION
Introduce an export flow in the deploy dropdown, allowing users to access the export functionality directly from the interface.