### PR TITLE
feat: add Composio YouTube component

### DIFF
--- a/src/backend/base/langflow/components/composio/__init__.py
+++ b/src/backend/base/langflow/components/composio/__init__.py
@@ -2,10 +2,11 @@ from .composio_api import ComposioAPIComponent
 from .gmail_composio import ComposioGmailAPIComponent
 from .googlecalendar_composio import ComposioGoogleCalendarAPIComponent
 from .slack_composio import ComposioSlackAPIComponent
-
+from .youtube_composio import ComposioYoutubeAPIComponent
 __all__ = [
     "ComposioAPIComponent",
     "ComposioGmailAPIComponent",
     "ComposioGoogleCalendarAPIComponent",
     "ComposioSlackAPIComponent",
+    "ComposioYoutubeAPIComponent"
 ]

--- a/src/backend/base/langflow/components/composio/__init__.py
+++ b/src/backend/base/langflow/components/composio/__init__.py
@@ -3,10 +3,11 @@ from .gmail_composio import ComposioGmailAPIComponent
 from .googlecalendar_composio import ComposioGoogleCalendarAPIComponent
 from .slack_composio import ComposioSlackAPIComponent
 from .youtube_composio import ComposioYoutubeAPIComponent
+
 __all__ = [
     "ComposioAPIComponent",
     "ComposioGmailAPIComponent",
     "ComposioGoogleCalendarAPIComponent",
     "ComposioSlackAPIComponent",
-    "ComposioYoutubeAPIComponent"
+    "ComposioYoutubeAPIComponent",
 ]

--- a/src/backend/base/langflow/components/composio/youtube_composio.py
+++ b/src/backend/base/langflow/components/composio/youtube_composio.py
@@ -13,21 +13,21 @@ from langflow.logging import logger
 class ComposioYoutubeAPIComponent(ComposioBaseComponent):
     display_name: str = "Youtube"
     description: str = "Youtube API"
-    icon = "Youtube"
+    icon = "YouTube"
     documentation: str = "https://docs.composio.dev"
     app_name = "youtube"
 
     _actions_data: dict = {
         "YOUTUBE_GET_CHANNEL_ID_BY_HANDLE": {
-            "display_name": "Get Channel Id by Handle",
+            "display_name": "Get Channel ID by Handle",
             "action_fields": ["YOUTUBE_GET_CHANNEL_ID_BY_HANDLE_channel_handle"],
         },
         "YOUTUBE_LIST_CAPTION_TRACK": {
-            "display_name": "List caption track",
+            "display_name": "List Caption Track",
             "action_fields": ["YOUTUBE_LIST_CAPTION_TRACK_part", "YOUTUBE_LIST_CAPTION_TRACK_videoId"],
         },
         "YOUTUBE_LIST_CHANNEL_VIDEOS": {
-            "display_name": "List channel videos",
+            "display_name": "List Channel Videos",
             "action_fields": [
                 "YOUTUBE_LIST_CHANNEL_VIDEOS_channelId",
                 "YOUTUBE_LIST_CHANNEL_VIDEOS_maxResults",
@@ -36,7 +36,7 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
             ],
         },
         "YOUTUBE_LIST_USER_PLAYLISTS": {
-            "display_name": "List user playlists",
+            "display_name": "List User Playlists",
             "action_fields": [
                 "YOUTUBE_LIST_USER_PLAYLISTS_maxResults",
                 "YOUTUBE_LIST_USER_PLAYLISTS_pageToken",
@@ -44,7 +44,7 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
             ],
         },
         "YOUTUBE_LIST_USER_SUBSCRIPTIONS": {
-            "display_name": "List user subscriptions",
+            "display_name": "List User Subscriptions",
             "action_fields": [
                 "YOUTUBE_LIST_USER_SUBSCRIPTIONS_maxResults",
                 "YOUTUBE_LIST_USER_SUBSCRIPTIONS_pageToken",
@@ -52,11 +52,11 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
             ],
         },
         "YOUTUBE_LOAD_CAPTIONS": {
-            "display_name": "Load captions",
+            "display_name": "Load Captions",
             "action_fields": ["YOUTUBE_LOAD_CAPTIONS_id", "YOUTUBE_LOAD_CAPTIONS_tfmt"],
         },
         "YOUTUBE_SEARCH_YOU_TUBE": {
-            "display_name": "Search you tube",
+            "display_name": "Search YouTube",
             "action_fields": [
                 "YOUTUBE_SEARCH_YOU_TUBE_maxResults",
                 "YOUTUBE_SEARCH_YOU_TUBE_pageToken",
@@ -66,15 +66,15 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
             ],
         },
         "YOUTUBE_SUBSCRIBE_CHANNEL": {
-            "display_name": "Subscribe channel",
+            "display_name": "Subscribe Channel",
             "action_fields": ["YOUTUBE_SUBSCRIBE_CHANNEL_channelId"],
         },
         "YOUTUBE_UPDATE_THUMBNAIL": {
-            "display_name": "Update thumbnail",
+            "display_name": "Update Thumbnail",
             "action_fields": ["YOUTUBE_UPDATE_THUMBNAIL_thumbnailUrl", "YOUTUBE_UPDATE_THUMBNAIL_videoId"],
         },
         "YOUTUBE_UPDATE_VIDEO": {
-            "display_name": "Update video",
+            "display_name": "Update Video",
             "action_fields": [
                 "YOUTUBE_UPDATE_VIDEO_categoryId",
                 "YOUTUBE_UPDATE_VIDEO_description",
@@ -85,7 +85,7 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
             ],
         },
         "YOUTUBE_UPLOAD_VIDEO": {
-            "display_name": "Upload video",
+            "display_name": "Upload Video",
             "action_fields": [
                 "YOUTUBE_UPLOAD_VIDEO_categoryId",
                 "YOUTUBE_UPLOAD_VIDEO_description",
@@ -96,7 +96,7 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
             ],
         },
         "YOUTUBE_VIDEO_DETAILS": {
-            "display_name": "Video details",
+            "display_name": "Video Details",
             "action_fields": ["YOUTUBE_VIDEO_DETAILS_id", "YOUTUBE_VIDEO_DETAILS_part"],
         },
     }
@@ -104,8 +104,6 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
     _list_variables = {"YOUTUBE_UPDATE_VIDEO_tags", "YOUTUBE_UPLOAD_VIDEO_tags"}
 
     _all_fields = {field for action_data in _actions_data.values() for field in action_data["action_fields"]}
-
-    _bool_variables = {}
 
     inputs = [
         *ComposioBaseComponent._base_inputs,
@@ -385,9 +383,6 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
                     if field in self._list_variables and value:
                         value = [item.strip() for item in value.split(",")]
 
-                    if field in self._bool_variables:
-                        value = bool(value)
-
                     param_name = field.replace(action_key + "_", "")
 
                     params[param_name] = value
@@ -400,10 +395,9 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
                 return {"error": result.get("error", "No response")}
 
             result_data = result.get("data", [])
-            # Get the first key from the data dict dynamically instead of hardcoding "response_data"
             if result_data and isinstance(result_data, dict):
                 return result_data[next(iter(result_data))]
-            return result_data
+            return result_data  # noqa: TRY300
         except Exception as e:
             logger.error(f"Error executing action: {e}")
             display_name = self.action[0]["name"] if isinstance(self.action, list) and self.action else str(self.action)

--- a/src/backend/base/langflow/components/composio/youtube_composio.py
+++ b/src/backend/base/langflow/components/composio/youtube_composio.py
@@ -1,0 +1,437 @@
+from typing import Any
+
+from composio import Action
+
+from langflow.base.composio.composio_base import ComposioBaseComponent
+from langflow.inputs import (
+    IntInput,
+    MessageTextInput,
+)
+from langflow.logging import logger
+
+
+class ComposioYoutubeAPIComponent(ComposioBaseComponent):
+    display_name: str = "Youtube"
+    description: str = "Youtube API"
+    icon = "Youtube"
+    documentation: str = "https://docs.composio.dev"
+    app_name = "youtube"
+    
+    _actions_data: dict = {
+        "YOUTUBE_GET_CHANNEL_ID_BY_HANDLE": {
+      "display_name": "Get Channel Id by Handle",
+      "action_fields": [
+        "YOUTUBE_GET_CHANNEL_ID_BY_HANDLE_channel_handle"
+      ]
+    },
+    "YOUTUBE_LIST_CAPTION_TRACK": {
+      "display_name": "List caption track",
+      "action_fields": [
+        "YOUTUBE_LIST_CAPTION_TRACK_part",
+        "YOUTUBE_LIST_CAPTION_TRACK_videoId"
+      ]
+    },
+    "YOUTUBE_LIST_CHANNEL_VIDEOS": {
+      "display_name": "List channel videos",
+      "action_fields": [
+        "YOUTUBE_LIST_CHANNEL_VIDEOS_channelId",
+        "YOUTUBE_LIST_CHANNEL_VIDEOS_maxResults",
+        "YOUTUBE_LIST_CHANNEL_VIDEOS_pageToken",
+        "YOUTUBE_LIST_CHANNEL_VIDEOS_part"
+      ]
+    },
+    "YOUTUBE_LIST_USER_PLAYLISTS": {
+      "display_name": "List user playlists",
+      "action_fields": [
+        "YOUTUBE_LIST_USER_PLAYLISTS_maxResults",
+        "YOUTUBE_LIST_USER_PLAYLISTS_pageToken",
+        "YOUTUBE_LIST_USER_PLAYLISTS_part"
+      ]
+    },
+    "YOUTUBE_LIST_USER_SUBSCRIPTIONS": {
+      "display_name": "List user subscriptions",
+      "action_fields": [
+        "YOUTUBE_LIST_USER_SUBSCRIPTIONS_maxResults",
+        "YOUTUBE_LIST_USER_SUBSCRIPTIONS_pageToken",
+        "YOUTUBE_LIST_USER_SUBSCRIPTIONS_part"
+      ]
+    },
+    "YOUTUBE_LOAD_CAPTIONS": {
+      "display_name": "Load captions",
+      "action_fields": [
+        "YOUTUBE_LOAD_CAPTIONS_id",
+        "YOUTUBE_LOAD_CAPTIONS_tfmt"
+      ]
+    },
+    "YOUTUBE_SEARCH_YOU_TUBE": {
+      "display_name": "Search you tube",
+      "action_fields": [
+        "YOUTUBE_SEARCH_YOU_TUBE_maxResults",
+        "YOUTUBE_SEARCH_YOU_TUBE_pageToken",
+        "YOUTUBE_SEARCH_YOU_TUBE_part",
+        "YOUTUBE_SEARCH_YOU_TUBE_q",
+        "YOUTUBE_SEARCH_YOU_TUBE_type"
+      ]
+    },
+    "YOUTUBE_SUBSCRIBE_CHANNEL": {
+      "display_name": "Subscribe channel",
+      "action_fields": [
+        "YOUTUBE_SUBSCRIBE_CHANNEL_channelId"
+      ]
+    },
+    "YOUTUBE_UPDATE_THUMBNAIL": {
+      "display_name": "Update thumbnail",
+      "action_fields": [
+        "YOUTUBE_UPDATE_THUMBNAIL_thumbnailUrl",
+        "YOUTUBE_UPDATE_THUMBNAIL_videoId"
+      ]
+    },
+    "YOUTUBE_UPDATE_VIDEO": {
+      "display_name": "Update video",
+      "action_fields": [
+        "YOUTUBE_UPDATE_VIDEO_categoryId",
+        "YOUTUBE_UPDATE_VIDEO_description",
+        "YOUTUBE_UPDATE_VIDEO_privacyStatus",
+        "YOUTUBE_UPDATE_VIDEO_tags",
+        "YOUTUBE_UPDATE_VIDEO_title",
+        "YOUTUBE_UPDATE_VIDEO_videoId"
+      ]
+    },
+    "YOUTUBE_UPLOAD_VIDEO": {
+      "display_name": "Upload video",
+      "action_fields": [
+        "YOUTUBE_UPLOAD_VIDEO_categoryId",
+        "YOUTUBE_UPLOAD_VIDEO_description",
+        "YOUTUBE_UPLOAD_VIDEO_privacyStatus",
+        "YOUTUBE_UPLOAD_VIDEO_tags",
+        "YOUTUBE_UPLOAD_VIDEO_title",
+        "YOUTUBE_UPLOAD_VIDEO_videoFilePath"
+      ]
+    },
+    "YOUTUBE_VIDEO_DETAILS": {
+      "display_name": "Video details",
+      "action_fields": [
+        "YOUTUBE_VIDEO_DETAILS_id",
+        "YOUTUBE_VIDEO_DETAILS_part"
+      ]
+    }
+
+    }
+    
+    _list_variables = {
+        "YOUTUBE_UPDATE_VIDEO_tags",
+        "YOUTUBE_UPLOAD_VIDEO_tags"
+    }
+    
+    _all_fields = {field for action_data in _actions_data.values() for field in action_data["action_fields"]}
+    
+    _bool_variables = {}
+    
+    inputs = [
+        *ComposioBaseComponent._base_inputs,
+        MessageTextInput(
+        name="YOUTUBE_GET_CHANNEL_ID_BY_HANDLE_channel_handle",
+        display_name="Channel Handle",
+        info="The channelId parameter specifies the YouTube channel ID to subscribe to.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_LIST_CAPTION_TRACK_part",
+        display_name="Part",
+        info="The part parameter specifies a comma-separated list of one or more caption resource properties that the API response will include.",
+        show=False,
+        value="snippet",
+    ),
+    MessageTextInput(
+        name="YOUTUBE_LIST_CAPTION_TRACK_videoId",
+        display_name="Video Id",
+        info="The videoId parameter specifies the YouTube video ID for which the API should return caption tracks.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_LIST_CHANNEL_VIDEOS_channelId",
+        display_name="Channel Id",
+        info="The channelId parameter specifies the YouTube channel ID for which the API should return videos.",
+        show=False,
+        required=True,
+    ),
+    IntInput(
+        name="YOUTUBE_LIST_CHANNEL_VIDEOS_maxResults",
+        display_name="Max Results",
+        info="The maxResults parameter specifies the maximum number of items that should be returned in the result set. The default value is 5.",
+        show=False,
+        value=5,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_LIST_CHANNEL_VIDEOS_pageToken",
+        display_name="Page Token",
+        info="The pageToken parameter identifies a specific page in the result set that should be returned. The value is a token that identifies a page of results that has been returned by a previous API request.",
+        show=False,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_LIST_CHANNEL_VIDEOS_part",
+        display_name="Part",
+        info="The part parameter specifies a comma-separated list of one or more search resource properties that the API response will include.",
+        show=False,
+        value="snippet",
+    ),
+    IntInput(
+        name="YOUTUBE_LIST_USER_PLAYLISTS_maxResults",
+        display_name="Max Results",
+        info="The maxResults parameter specifies the maximum number of items that should be returned in the result set. The default value is 5.",
+        show=False,
+        value=5,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_LIST_USER_PLAYLISTS_pageToken",
+        display_name="Page Token",
+        info="The pageToken parameter identifies a specific page in the result set that should be returned. The value is a token that identifies a page of results that has been returned by a previous API request.",
+        show=False,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_LIST_USER_PLAYLISTS_part",
+        display_name="Part",
+        info="The part parameter specifies a comma-separated list of one or more playlist resource properties that the API response will include.",
+        show=False,
+        value="snippet",
+    ),
+    IntInput(
+        name="YOUTUBE_LIST_USER_SUBSCRIPTIONS_maxResults",
+        display_name="Max Results",
+        info="The maxResults parameter specifies the maximum number of items that should be returned in the result set. The default value is 5.",
+        show=False,
+        value=5,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_LIST_USER_SUBSCRIPTIONS_pageToken",
+        display_name="Page Token",
+        info="The pageToken parameter identifies a specific page in the result set that should be returned. The value is a token that identifies a page of results that has been returned by a previous API request.",
+        show=False,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_LIST_USER_SUBSCRIPTIONS_part",
+        display_name="Part",
+        info="The part parameter specifies a comma-separated list of one or more subscription resource properties that the API response will include.",
+        show=False,
+        value="snippet,contentDetails",
+    ),
+    MessageTextInput(
+        name="YOUTUBE_LOAD_CAPTIONS_id",
+        display_name="Id",
+        info="The id parameter specifies the ID of the caption track to be downloaded. Note: You can only download captions for videos you own.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_LOAD_CAPTIONS_tfmt",
+        display_name="Tfmt",
+        info="The tfmt parameter specifies that the API response should return the captions in SubRip subtitle format.",
+        show=False,
+        value="srt",
+    ),
+    IntInput(
+        name="YOUTUBE_SEARCH_YOU_TUBE_maxResults",
+        display_name="Max Results",
+        info="The maxResults parameter specifies the maximum number of items that should be returned in the result set. The default value is 5.",
+        show=False,
+        value=5,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_SEARCH_YOU_TUBE_pageToken",
+        display_name="Page Token",
+        info="The pageToken parameter identifies a specific page in the result set that should be returned. The value is a token that identifies a page of results that has been returned by a previous API request.",
+        show=False,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_SEARCH_YOU_TUBE_part",
+        display_name="Part",
+        info="The part parameter specifies a comma-separated list of one or more search resource properties that the API response will include.",
+        show=False,
+        value="snippet",
+    ),
+    MessageTextInput(
+        name="YOUTUBE_SEARCH_YOU_TUBE_q",
+        display_name="Q",
+        info="The q parameter specifies the query term to search for.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_SEARCH_YOU_TUBE_type",
+        display_name="Type",
+        info="The type parameter restricts a search query to only retrieve a particular type of resource. The value can be one or more of: 'video', 'channel', 'playlist'.",
+        show=False,
+        value="video",
+    ),
+    MessageTextInput(
+        name="YOUTUBE_SUBSCRIBE_CHANNEL_channelId",
+        display_name="Channel Id",
+        info="The channelId parameter specifies the YouTube channel ID to subscribe to.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPDATE_THUMBNAIL_thumbnailUrl",
+        display_name="Thumbnail Url",
+        info="The URL of the new thumbnail image.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPDATE_THUMBNAIL_videoId",
+        display_name="Video Id",
+        info="The videoId parameter specifies the YouTube video ID for which the thumbnail should be updated.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPDATE_VIDEO_categoryId",
+        display_name="Category Id",
+        info="The YouTube category ID of the video.",
+        show=False,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPDATE_VIDEO_description",
+        display_name="Description",
+        info="The description of the video.",
+        show=False,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPDATE_VIDEO_privacyStatus",
+        display_name="Privacy Status",
+        info="The privacy status of the video. Valid values are 'public', 'private', and 'unlisted'.",
+        show=False,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPDATE_VIDEO_tags",
+        display_name="Tags",
+        info="A list of tags associated with the video.",
+        show=False,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPDATE_VIDEO_title",
+        display_name="Title",
+        info="The title of the video.",
+        show=False,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPDATE_VIDEO_videoId",
+        display_name="Video Id",
+        info="The videoId parameter specifies the YouTube video ID to be updated.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPLOAD_VIDEO_categoryId",
+        display_name="Category Id",
+        info="The YouTube category ID of the video.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPLOAD_VIDEO_description",
+        display_name="Description",
+        info="The description of the video.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPLOAD_VIDEO_privacyStatus",
+        display_name="Privacy Status",
+        info="The privacy status of the video. Valid values are 'public', 'private', and 'unlisted'.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPLOAD_VIDEO_tags",
+        display_name="Tags",
+        info="A list of tags associated with the video.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPLOAD_VIDEO_title",
+        display_name="Title",
+        info="The title of the video.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_UPLOAD_VIDEO_videoFilePath",
+        display_name="Video File Path",
+        info="The file path of the video to be uploaded.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_VIDEO_DETAILS_id",
+        display_name="Id",
+        info="The id parameter specifies the YouTube video ID for which the API should return details.",
+        show=False,
+        required=True,
+    ),
+    MessageTextInput(
+        name="YOUTUBE_VIDEO_DETAILS_part",
+        display_name="Part",
+        info="The part parameter specifies a comma-separated list of one or more video resource properties that the API response will include.",
+        show=False,
+        value="snippet,contentDetails,statistics",
+    ),
+
+    ]
+    
+    def execute_action(self):
+        """Execute action and return response as Message."""
+        toolset = self._build_wrapper()
+
+        try:
+            self._build_action_maps()
+            display_name = self.action[0]["name"] if isinstance(self.action, list) and self.action else self.action
+            action_key = self._display_to_key_map.get(display_name)
+            if not action_key:
+                msg = f"Invalid action: {display_name}"
+                raise ValueError(msg)
+
+            enum_name = getattr(Action, action_key)
+            params = {}
+            if action_key in self._actions_data:
+                for field in self._actions_data[action_key]["action_fields"]:
+                    value = getattr(self, field)
+
+                    if value is None or value == "":
+                        continue
+                    
+                    if field in self._list_variables and value:
+                        value = [item.strip() for item in value.split(",")]
+
+                    if field in self._bool_variables:
+                        value = bool(value)
+
+                    param_name = field.replace(action_key + "_", "")
+
+                    params[param_name] = value
+
+            result = toolset.execute_action(
+                action=enum_name,
+                params=params,
+            )
+            if not result.get("successful"):
+                return {"error": result.get("error", "No response")}
+
+            return result.get("data", [])
+        except Exception as e:
+            logger.error(f"Error executing action: {e}")
+            display_name = self.action[0]["name"] if isinstance(self.action, list) and self.action else str(self.action)
+            msg = f"Failed to execute {display_name}: {e!s}"
+            raise ValueError(msg) from e
+
+    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:
+        return super().update_build_config(build_config, field_value, field_name)
+
+    def set_default_tools(self):
+        self._default_tools = {
+            self.sanitize_action_name("YOUTUBE_SEARCH_YOU_TUBE").replace(" ", "-"),
+            self.sanitize_action_name("YOUTUBE_VIDEO_DETAILS").replace(" ", "-"),
+        }

--- a/src/backend/base/langflow/components/composio/youtube_composio.py
+++ b/src/backend/base/langflow/components/composio/youtube_composio.py
@@ -399,7 +399,11 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
             if not result.get("successful"):
                 return {"error": result.get("error", "No response")}
 
-            return result.get("data", []).get("response_data", [])
+            result_data = result.get("data", [])
+            # Get the first key from the data dict dynamically instead of hardcoding "response_data"
+            if result_data and isinstance(result_data, dict):
+                return result_data[next(iter(result_data))]
+            return result_data
         except Exception as e:
             logger.error(f"Error executing action: {e}")
             display_name = self.action[0]["name"] if isinstance(self.action, list) and self.action else str(self.action)

--- a/src/backend/base/langflow/components/composio/youtube_composio.py
+++ b/src/backend/base/langflow/components/composio/youtube_composio.py
@@ -16,372 +16,351 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
     icon = "Youtube"
     documentation: str = "https://docs.composio.dev"
     app_name = "youtube"
-    
+
     _actions_data: dict = {
         "YOUTUBE_GET_CHANNEL_ID_BY_HANDLE": {
-      "display_name": "Get Channel Id by Handle",
-      "action_fields": [
-        "YOUTUBE_GET_CHANNEL_ID_BY_HANDLE_channel_handle"
-      ]
-    },
-    "YOUTUBE_LIST_CAPTION_TRACK": {
-      "display_name": "List caption track",
-      "action_fields": [
-        "YOUTUBE_LIST_CAPTION_TRACK_part",
-        "YOUTUBE_LIST_CAPTION_TRACK_videoId"
-      ]
-    },
-    "YOUTUBE_LIST_CHANNEL_VIDEOS": {
-      "display_name": "List channel videos",
-      "action_fields": [
-        "YOUTUBE_LIST_CHANNEL_VIDEOS_channelId",
-        "YOUTUBE_LIST_CHANNEL_VIDEOS_maxResults",
-        "YOUTUBE_LIST_CHANNEL_VIDEOS_pageToken",
-        "YOUTUBE_LIST_CHANNEL_VIDEOS_part"
-      ]
-    },
-    "YOUTUBE_LIST_USER_PLAYLISTS": {
-      "display_name": "List user playlists",
-      "action_fields": [
-        "YOUTUBE_LIST_USER_PLAYLISTS_maxResults",
-        "YOUTUBE_LIST_USER_PLAYLISTS_pageToken",
-        "YOUTUBE_LIST_USER_PLAYLISTS_part"
-      ]
-    },
-    "YOUTUBE_LIST_USER_SUBSCRIPTIONS": {
-      "display_name": "List user subscriptions",
-      "action_fields": [
-        "YOUTUBE_LIST_USER_SUBSCRIPTIONS_maxResults",
-        "YOUTUBE_LIST_USER_SUBSCRIPTIONS_pageToken",
-        "YOUTUBE_LIST_USER_SUBSCRIPTIONS_part"
-      ]
-    },
-    "YOUTUBE_LOAD_CAPTIONS": {
-      "display_name": "Load captions",
-      "action_fields": [
-        "YOUTUBE_LOAD_CAPTIONS_id",
-        "YOUTUBE_LOAD_CAPTIONS_tfmt"
-      ]
-    },
-    "YOUTUBE_SEARCH_YOU_TUBE": {
-      "display_name": "Search you tube",
-      "action_fields": [
-        "YOUTUBE_SEARCH_YOU_TUBE_maxResults",
-        "YOUTUBE_SEARCH_YOU_TUBE_pageToken",
-        "YOUTUBE_SEARCH_YOU_TUBE_part",
-        "YOUTUBE_SEARCH_YOU_TUBE_q",
-        "YOUTUBE_SEARCH_YOU_TUBE_type"
-      ]
-    },
-    "YOUTUBE_SUBSCRIBE_CHANNEL": {
-      "display_name": "Subscribe channel",
-      "action_fields": [
-        "YOUTUBE_SUBSCRIBE_CHANNEL_channelId"
-      ]
-    },
-    "YOUTUBE_UPDATE_THUMBNAIL": {
-      "display_name": "Update thumbnail",
-      "action_fields": [
-        "YOUTUBE_UPDATE_THUMBNAIL_thumbnailUrl",
-        "YOUTUBE_UPDATE_THUMBNAIL_videoId"
-      ]
-    },
-    "YOUTUBE_UPDATE_VIDEO": {
-      "display_name": "Update video",
-      "action_fields": [
-        "YOUTUBE_UPDATE_VIDEO_categoryId",
-        "YOUTUBE_UPDATE_VIDEO_description",
-        "YOUTUBE_UPDATE_VIDEO_privacyStatus",
-        "YOUTUBE_UPDATE_VIDEO_tags",
-        "YOUTUBE_UPDATE_VIDEO_title",
-        "YOUTUBE_UPDATE_VIDEO_videoId"
-      ]
-    },
-    "YOUTUBE_UPLOAD_VIDEO": {
-      "display_name": "Upload video",
-      "action_fields": [
-        "YOUTUBE_UPLOAD_VIDEO_categoryId",
-        "YOUTUBE_UPLOAD_VIDEO_description",
-        "YOUTUBE_UPLOAD_VIDEO_privacyStatus",
-        "YOUTUBE_UPLOAD_VIDEO_tags",
-        "YOUTUBE_UPLOAD_VIDEO_title",
-        "YOUTUBE_UPLOAD_VIDEO_videoFilePath"
-      ]
-    },
-    "YOUTUBE_VIDEO_DETAILS": {
-      "display_name": "Video details",
-      "action_fields": [
-        "YOUTUBE_VIDEO_DETAILS_id",
-        "YOUTUBE_VIDEO_DETAILS_part"
-      ]
+            "display_name": "Get Channel Id by Handle",
+            "action_fields": ["YOUTUBE_GET_CHANNEL_ID_BY_HANDLE_channel_handle"],
+        },
+        "YOUTUBE_LIST_CAPTION_TRACK": {
+            "display_name": "List caption track",
+            "action_fields": ["YOUTUBE_LIST_CAPTION_TRACK_part", "YOUTUBE_LIST_CAPTION_TRACK_videoId"],
+        },
+        "YOUTUBE_LIST_CHANNEL_VIDEOS": {
+            "display_name": "List channel videos",
+            "action_fields": [
+                "YOUTUBE_LIST_CHANNEL_VIDEOS_channelId",
+                "YOUTUBE_LIST_CHANNEL_VIDEOS_maxResults",
+                "YOUTUBE_LIST_CHANNEL_VIDEOS_pageToken",
+                "YOUTUBE_LIST_CHANNEL_VIDEOS_part",
+            ],
+        },
+        "YOUTUBE_LIST_USER_PLAYLISTS": {
+            "display_name": "List user playlists",
+            "action_fields": [
+                "YOUTUBE_LIST_USER_PLAYLISTS_maxResults",
+                "YOUTUBE_LIST_USER_PLAYLISTS_pageToken",
+                "YOUTUBE_LIST_USER_PLAYLISTS_part",
+            ],
+        },
+        "YOUTUBE_LIST_USER_SUBSCRIPTIONS": {
+            "display_name": "List user subscriptions",
+            "action_fields": [
+                "YOUTUBE_LIST_USER_SUBSCRIPTIONS_maxResults",
+                "YOUTUBE_LIST_USER_SUBSCRIPTIONS_pageToken",
+                "YOUTUBE_LIST_USER_SUBSCRIPTIONS_part",
+            ],
+        },
+        "YOUTUBE_LOAD_CAPTIONS": {
+            "display_name": "Load captions",
+            "action_fields": ["YOUTUBE_LOAD_CAPTIONS_id", "YOUTUBE_LOAD_CAPTIONS_tfmt"],
+        },
+        "YOUTUBE_SEARCH_YOU_TUBE": {
+            "display_name": "Search you tube",
+            "action_fields": [
+                "YOUTUBE_SEARCH_YOU_TUBE_maxResults",
+                "YOUTUBE_SEARCH_YOU_TUBE_pageToken",
+                "YOUTUBE_SEARCH_YOU_TUBE_part",
+                "YOUTUBE_SEARCH_YOU_TUBE_q",
+                "YOUTUBE_SEARCH_YOU_TUBE_type",
+            ],
+        },
+        "YOUTUBE_SUBSCRIBE_CHANNEL": {
+            "display_name": "Subscribe channel",
+            "action_fields": ["YOUTUBE_SUBSCRIBE_CHANNEL_channelId"],
+        },
+        "YOUTUBE_UPDATE_THUMBNAIL": {
+            "display_name": "Update thumbnail",
+            "action_fields": ["YOUTUBE_UPDATE_THUMBNAIL_thumbnailUrl", "YOUTUBE_UPDATE_THUMBNAIL_videoId"],
+        },
+        "YOUTUBE_UPDATE_VIDEO": {
+            "display_name": "Update video",
+            "action_fields": [
+                "YOUTUBE_UPDATE_VIDEO_categoryId",
+                "YOUTUBE_UPDATE_VIDEO_description",
+                "YOUTUBE_UPDATE_VIDEO_privacyStatus",
+                "YOUTUBE_UPDATE_VIDEO_tags",
+                "YOUTUBE_UPDATE_VIDEO_title",
+                "YOUTUBE_UPDATE_VIDEO_videoId",
+            ],
+        },
+        "YOUTUBE_UPLOAD_VIDEO": {
+            "display_name": "Upload video",
+            "action_fields": [
+                "YOUTUBE_UPLOAD_VIDEO_categoryId",
+                "YOUTUBE_UPLOAD_VIDEO_description",
+                "YOUTUBE_UPLOAD_VIDEO_privacyStatus",
+                "YOUTUBE_UPLOAD_VIDEO_tags",
+                "YOUTUBE_UPLOAD_VIDEO_title",
+                "YOUTUBE_UPLOAD_VIDEO_videoFilePath",
+            ],
+        },
+        "YOUTUBE_VIDEO_DETAILS": {
+            "display_name": "Video details",
+            "action_fields": ["YOUTUBE_VIDEO_DETAILS_id", "YOUTUBE_VIDEO_DETAILS_part"],
+        },
     }
 
-    }
-    
-    _list_variables = {
-        "YOUTUBE_UPDATE_VIDEO_tags",
-        "YOUTUBE_UPLOAD_VIDEO_tags"
-    }
-    
+    _list_variables = {"YOUTUBE_UPDATE_VIDEO_tags", "YOUTUBE_UPLOAD_VIDEO_tags"}
+
     _all_fields = {field for action_data in _actions_data.values() for field in action_data["action_fields"]}
-    
+
     _bool_variables = {}
-    
+
     inputs = [
         *ComposioBaseComponent._base_inputs,
         MessageTextInput(
-        name="YOUTUBE_GET_CHANNEL_ID_BY_HANDLE_channel_handle",
-        display_name="Channel Handle",
-        info="The channelId parameter specifies the YouTube channel ID to subscribe to.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_LIST_CAPTION_TRACK_part",
-        display_name="Part",
-        info="The part parameter specifies a comma-separated list of one or more caption resource properties that the API response will include.",
-        show=False,
-        value="snippet",
-    ),
-    MessageTextInput(
-        name="YOUTUBE_LIST_CAPTION_TRACK_videoId",
-        display_name="Video Id",
-        info="The videoId parameter specifies the YouTube video ID for which the API should return caption tracks.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_LIST_CHANNEL_VIDEOS_channelId",
-        display_name="Channel Id",
-        info="The channelId parameter specifies the YouTube channel ID for which the API should return videos.",
-        show=False,
-        required=True,
-    ),
-    IntInput(
-        name="YOUTUBE_LIST_CHANNEL_VIDEOS_maxResults",
-        display_name="Max Results",
-        info="The maxResults parameter specifies the maximum number of items that should be returned in the result set. The default value is 5.",
-        show=False,
-        value=5,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_LIST_CHANNEL_VIDEOS_pageToken",
-        display_name="Page Token",
-        info="The pageToken parameter identifies a specific page in the result set that should be returned. The value is a token that identifies a page of results that has been returned by a previous API request.",
-        show=False,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_LIST_CHANNEL_VIDEOS_part",
-        display_name="Part",
-        info="The part parameter specifies a comma-separated list of one or more search resource properties that the API response will include.",
-        show=False,
-        value="snippet",
-    ),
-    IntInput(
-        name="YOUTUBE_LIST_USER_PLAYLISTS_maxResults",
-        display_name="Max Results",
-        info="The maxResults parameter specifies the maximum number of items that should be returned in the result set. The default value is 5.",
-        show=False,
-        value=5,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_LIST_USER_PLAYLISTS_pageToken",
-        display_name="Page Token",
-        info="The pageToken parameter identifies a specific page in the result set that should be returned. The value is a token that identifies a page of results that has been returned by a previous API request.",
-        show=False,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_LIST_USER_PLAYLISTS_part",
-        display_name="Part",
-        info="The part parameter specifies a comma-separated list of one or more playlist resource properties that the API response will include.",
-        show=False,
-        value="snippet",
-    ),
-    IntInput(
-        name="YOUTUBE_LIST_USER_SUBSCRIPTIONS_maxResults",
-        display_name="Max Results",
-        info="The maxResults parameter specifies the maximum number of items that should be returned in the result set. The default value is 5.",
-        show=False,
-        value=5,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_LIST_USER_SUBSCRIPTIONS_pageToken",
-        display_name="Page Token",
-        info="The pageToken parameter identifies a specific page in the result set that should be returned. The value is a token that identifies a page of results that has been returned by a previous API request.",
-        show=False,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_LIST_USER_SUBSCRIPTIONS_part",
-        display_name="Part",
-        info="The part parameter specifies a comma-separated list of one or more subscription resource properties that the API response will include.",
-        show=False,
-        value="snippet,contentDetails",
-    ),
-    MessageTextInput(
-        name="YOUTUBE_LOAD_CAPTIONS_id",
-        display_name="Id",
-        info="The id parameter specifies the ID of the caption track to be downloaded. Note: You can only download captions for videos you own.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_LOAD_CAPTIONS_tfmt",
-        display_name="Tfmt",
-        info="The tfmt parameter specifies that the API response should return the captions in SubRip subtitle format.",
-        show=False,
-        value="srt",
-    ),
-    IntInput(
-        name="YOUTUBE_SEARCH_YOU_TUBE_maxResults",
-        display_name="Max Results",
-        info="The maxResults parameter specifies the maximum number of items that should be returned in the result set. The default value is 5.",
-        show=False,
-        value=5,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_SEARCH_YOU_TUBE_pageToken",
-        display_name="Page Token",
-        info="The pageToken parameter identifies a specific page in the result set that should be returned. The value is a token that identifies a page of results that has been returned by a previous API request.",
-        show=False,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_SEARCH_YOU_TUBE_part",
-        display_name="Part",
-        info="The part parameter specifies a comma-separated list of one or more search resource properties that the API response will include.",
-        show=False,
-        value="snippet",
-    ),
-    MessageTextInput(
-        name="YOUTUBE_SEARCH_YOU_TUBE_q",
-        display_name="Q",
-        info="The q parameter specifies the query term to search for.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_SEARCH_YOU_TUBE_type",
-        display_name="Type",
-        info="The type parameter restricts a search query to only retrieve a particular type of resource. The value can be one or more of: 'video', 'channel', 'playlist'.",
-        show=False,
-        value="video",
-    ),
-    MessageTextInput(
-        name="YOUTUBE_SUBSCRIBE_CHANNEL_channelId",
-        display_name="Channel Id",
-        info="The channelId parameter specifies the YouTube channel ID to subscribe to.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPDATE_THUMBNAIL_thumbnailUrl",
-        display_name="Thumbnail Url",
-        info="The URL of the new thumbnail image.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPDATE_THUMBNAIL_videoId",
-        display_name="Video Id",
-        info="The videoId parameter specifies the YouTube video ID for which the thumbnail should be updated.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPDATE_VIDEO_categoryId",
-        display_name="Category Id",
-        info="The YouTube category ID of the video.",
-        show=False,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPDATE_VIDEO_description",
-        display_name="Description",
-        info="The description of the video.",
-        show=False,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPDATE_VIDEO_privacyStatus",
-        display_name="Privacy Status",
-        info="The privacy status of the video. Valid values are 'public', 'private', and 'unlisted'.",
-        show=False,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPDATE_VIDEO_tags",
-        display_name="Tags",
-        info="A list of tags associated with the video.",
-        show=False,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPDATE_VIDEO_title",
-        display_name="Title",
-        info="The title of the video.",
-        show=False,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPDATE_VIDEO_videoId",
-        display_name="Video Id",
-        info="The videoId parameter specifies the YouTube video ID to be updated.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPLOAD_VIDEO_categoryId",
-        display_name="Category Id",
-        info="The YouTube category ID of the video.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPLOAD_VIDEO_description",
-        display_name="Description",
-        info="The description of the video.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPLOAD_VIDEO_privacyStatus",
-        display_name="Privacy Status",
-        info="The privacy status of the video. Valid values are 'public', 'private', and 'unlisted'.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPLOAD_VIDEO_tags",
-        display_name="Tags",
-        info="A list of tags associated with the video.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPLOAD_VIDEO_title",
-        display_name="Title",
-        info="The title of the video.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_UPLOAD_VIDEO_videoFilePath",
-        display_name="Video File Path",
-        info="The file path of the video to be uploaded.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_VIDEO_DETAILS_id",
-        display_name="Id",
-        info="The id parameter specifies the YouTube video ID for which the API should return details.",
-        show=False,
-        required=True,
-    ),
-    MessageTextInput(
-        name="YOUTUBE_VIDEO_DETAILS_part",
-        display_name="Part",
-        info="The part parameter specifies a comma-separated list of one or more video resource properties that the API response will include.",
-        show=False,
-        value="snippet,contentDetails,statistics",
-    ),
-
+            name="YOUTUBE_GET_CHANNEL_ID_BY_HANDLE_channel_handle",
+            display_name="Channel Handle",
+            info="YouTube channel ID to subscribe to",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_LIST_CAPTION_TRACK_part",
+            display_name="Part",
+            info="Comma-separated list of one or more caption resource properties that the response will include",
+            show=False,
+            value="snippet",
+        ),
+        MessageTextInput(
+            name="YOUTUBE_LIST_CAPTION_TRACK_videoId",
+            display_name="Video ID",
+            info="YouTube video ID for which the API should return caption tracks",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_LIST_CHANNEL_VIDEOS_channelId",
+            display_name="Channel ID",
+            info="channel ID for which the API should return videos",
+            show=False,
+            required=True,
+        ),
+        IntInput(
+            name="YOUTUBE_LIST_CHANNEL_VIDEOS_maxResults",
+            display_name="Max Results",
+            info="Maximum number of items that should be returned in the result set. Default is 5",
+            show=False,
+            value=5,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_LIST_CHANNEL_VIDEOS_pageToken",
+            display_name="Page Token",
+            info="Token that identifies a page of results that has been returned by a previous API request",
+            show=False,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_LIST_CHANNEL_VIDEOS_part",
+            display_name="Part",
+            info="Comma-separated list of one or more search resource properties that the API response will include",
+            show=False,
+            value="snippet",
+        ),
+        IntInput(
+            name="YOUTUBE_LIST_USER_PLAYLISTS_maxResults",
+            display_name="Max Results",
+            info="Maximum number of items that should be returned in the result set. Default is 5",
+            show=False,
+            value=5,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_LIST_USER_PLAYLISTS_pageToken",
+            display_name="Page Token",
+            info="Token that identifies a page of results that has been returned by a previous API request",
+            show=False,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_LIST_USER_PLAYLISTS_part",
+            display_name="Part",
+            info="Comma-separated list of one or more playlist resource properties that the response will include",
+            show=False,
+            value="snippet",
+        ),
+        IntInput(
+            name="YOUTUBE_LIST_USER_SUBSCRIPTIONS_maxResults",
+            display_name="Max Results",
+            info="Maximum number of items that should be returned in the result set. Default is 5",
+            show=False,
+            value=5,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_LIST_USER_SUBSCRIPTIONS_pageToken",
+            display_name="Page Token",
+            info="Token that identifies a page of results that has been returned by a previous API request",
+            show=False,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_LIST_USER_SUBSCRIPTIONS_part",
+            display_name="Part",
+            info="Comma-separated list of one or more subscription resource properties that the response will include",
+            show=False,
+            value="snippet,contentDetails",
+        ),
+        MessageTextInput(
+            name="YOUTUBE_LOAD_CAPTIONS_id",
+            display_name="ID",
+            info="ID of the caption track to be downloaded. Note: You can only download captions for videos you own",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_LOAD_CAPTIONS_tfmt",
+            display_name="Tfmt",
+            info="API response should return the captions in SubRip subtitle format",
+            show=False,
+            value="srt",
+        ),
+        IntInput(
+            name="YOUTUBE_SEARCH_YOU_TUBE_maxResults",
+            display_name="Max Results",
+            info="Maximum number of items that should be returned in the result set. Default is 5",
+            show=False,
+            value=5,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_SEARCH_YOU_TUBE_pageToken",
+            display_name="Page Token",
+            info="Token that identifies a page of results that has been returned by a previous API request",
+            show=False,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_SEARCH_YOU_TUBE_part",
+            display_name="Part",
+            info="Comma-separated list of one or more search resource properties that the API response will include",
+            show=False,
+            value="snippet",
+        ),
+        MessageTextInput(
+            name="YOUTUBE_SEARCH_YOU_TUBE_q",
+            display_name="Search Query",
+            info="Query term to search for",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_SEARCH_YOU_TUBE_type",
+            display_name="Type",
+            info="Restricts a search query to only retrieve a particular type of resource. The value can be one or more of: 'video', 'channel', 'playlist'",  # noqa: E501
+            show=False,
+            value="video",
+        ),
+        MessageTextInput(
+            name="YOUTUBE_SUBSCRIBE_CHANNEL_channelId",
+            display_name="Channel ID",
+            info="YouTube channel ID to subscribe to",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPDATE_THUMBNAIL_thumbnailUrl",
+            display_name="Thumbnail URL",
+            info="URL of the new thumbnail image",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPDATE_THUMBNAIL_videoId",
+            display_name="Video ID",
+            info="YouTube video ID for which the thumbnail should be updated",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPDATE_VIDEO_categoryId",
+            display_name="Category ID",
+            info="YouTube category ID of the video",
+            show=False,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPDATE_VIDEO_description",
+            display_name="Description",
+            info="Description of the video",
+            show=False,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPDATE_VIDEO_privacyStatus",
+            display_name="Privacy Status",
+            info="Privacy status of the video. Valid values are 'public', 'private', and 'unlisted'",
+            show=False,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPDATE_VIDEO_tags",
+            display_name="Tags",
+            info="List of tags associated with the video",
+            show=False,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPDATE_VIDEO_title",
+            display_name="Title",
+            info="The title of the video.",
+            show=False,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPDATE_VIDEO_videoId",
+            display_name="Video ID",
+            info="YouTube video ID to be updated",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPLOAD_VIDEO_categoryId",
+            display_name="Category ID",
+            info="YouTube category ID of the video",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPLOAD_VIDEO_description",
+            display_name="Description",
+            info="The description of the video",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPLOAD_VIDEO_privacyStatus",
+            display_name="Privacy Status",
+            info="The privacy status of the video. Valid values are 'public', 'private', and 'unlisted'",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPLOAD_VIDEO_tags",
+            display_name="Tags",
+            info="List of tags associated with the video",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPLOAD_VIDEO_title",
+            display_name="Title",
+            info="The title of the video",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_UPLOAD_VIDEO_videoFilePath",
+            display_name="Video File Path",
+            info="File path of the video to be uploaded",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_VIDEO_DETAILS_id",
+            display_name="ID",
+            info="YouTube video ID for which the API should return details",
+            show=False,
+            required=True,
+        ),
+        MessageTextInput(
+            name="YOUTUBE_VIDEO_DETAILS_part",
+            display_name="Part",
+            info="Comma-separated list of one or more video resource properties that the API response will include",
+            show=False,
+            value="snippet,contentDetails,statistics",
+        ),
     ]
-    
+
     def execute_action(self):
         """Execute action and return response as Message."""
         toolset = self._build_wrapper()
@@ -402,7 +381,7 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
 
                     if value is None or value == "":
                         continue
-                    
+
                     if field in self._list_variables and value:
                         value = [item.strip() for item in value.split(",")]
 
@@ -420,7 +399,7 @@ class ComposioYoutubeAPIComponent(ComposioBaseComponent):
             if not result.get("successful"):
                 return {"error": result.get("error", "No response")}
 
-            return result.get("data", [])
+            return result.get("data", []).get("response_data", [])
         except Exception as e:
             logger.error(f"Error executing action: {e}")
             display_name = self.action[0]["name"] if isinstance(self.action, list) and self.action else str(self.action)

--- a/src/backend/tests/unit/components/bundles/composio/test_youtube.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_youtube.py
@@ -1,0 +1,168 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from composio import Action
+from langflow.components.composio.youtube_composio import ComposioYoutubeAPIComponent
+from langflow.schema.dataframe import DataFrame
+
+from tests.base import DID_NOT_EXIST, ComponentTestBaseWithoutClient
+
+from .test_base import MockComposioToolSet
+
+
+class MockAction:
+    YOUTUBE_GET_CHANNEL_ID_BY_HANDLE = "YOUTUBE_GET_CHANNEL_ID_BY_HANDLE"
+    YOUTUBE_LIST_CHANNEL_VIDEOS = "YOUTUBE_LIST_CHANNEL_VIDEOS"
+
+
+class TestYoutubeComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture(autouse=True)
+    def mock_composio_toolset(self):
+        with patch("langflow.base.composio.composio_base.ComposioToolSet", MockComposioToolSet):
+            yield
+
+    @pytest.fixture
+    def component_class(self):
+        return ComposioYoutubeAPIComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "api_key": "",
+            "entity_id": "default",
+            "action": None,
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        # Component not yet released, mark all versions as non-existent
+        return [
+            {"version": "1.0.17", "module": "composio", "file_name": DID_NOT_EXIST},
+            {"version": "1.0.18", "module": "composio", "file_name": DID_NOT_EXIST},
+            {"version": "1.0.19", "module": "composio", "file_name": DID_NOT_EXIST},
+            {"version": "1.1.0", "module": "composio", "file_name": DID_NOT_EXIST},
+            {"version": "1.1.1", "module": "composio", "file_name": DID_NOT_EXIST},
+        ]
+
+    def test_init(self, component_class, default_kwargs):
+        component = component_class(**default_kwargs)
+        assert component.display_name == "Youtube"
+        assert component.app_name == "youtube"
+        assert "YOUTUBE_GET_CHANNEL_ID_BY_HANDLE" in component._actions_data
+        assert "YOUTUBE_LIST_CHANNEL_VIDEOS" in component._actions_data
+
+    def test_execute_action_get_channel_id_by_handle(self, component_class, default_kwargs, monkeypatch):
+        monkeypatch.setattr(Action, "YOUTUBE_GET_CHANNEL_ID_BY_HANDLE", MockAction.YOUTUBE_GET_CHANNEL_ID_BY_HANDLE)
+
+        # Setup component
+        component = component_class(**default_kwargs)
+        component.api_key = "test_key"
+        component.action = [{"name": "Get Channel ID by Handle"}]
+        component.channel_handle = "test_handle"
+
+        component._actions_data = {
+            "YOUTUBE_GET_CHANNEL_ID_BY_HANDLE": {
+                "display_name": "Get Channel ID by Handle",
+                "action_fields": ["channel_handle"],
+            }
+        }
+
+        # Execute action
+        result = component.execute_action()
+        # assert result == {"result": "mocked response"}
+        assert result == "mocked response"
+
+    def test_execute_action_list_channel_videos(self, component_class, default_kwargs, monkeypatch):
+        # Mock Action enum
+        monkeypatch.setattr(Action, "YOUTUBE_LIST_CHANNEL_VIDEOS", MockAction.YOUTUBE_LIST_CHANNEL_VIDEOS)
+
+        # Setup component
+        component = component_class(**default_kwargs)
+        component.api_key = "test_key"
+        component.action = [{"name": "List Channel Videos"}]
+        component.channel_id = "test_channel_id"
+
+        # For this specific test, we need to customize the action_data to handle results field
+        component._actions_data = {
+            "YOUTUBE_LIST_CHANNEL_VIDEOS": {
+                "display_name": "List Channel Videos",
+                "action_fields": ["channel_id"],
+            }
+        }
+
+        mock_toolset = MagicMock()
+        mock_toolset.execute_action.return_value = {"successful": True, "data": {"videos": "mocked response"}}
+
+        # Patch the _build_wrapper method
+        with patch.object(component, "_build_wrapper", return_value=mock_toolset):
+            result = component.execute_action()
+            # Based on the component's actual behavior, it returns the result_field directly
+            assert result == "mocked response"
+
+    
+    def test_execute_action_invalid_action(self, component_class, default_kwargs):
+        # Setup component
+        component = component_class(**default_kwargs)
+        component.api_key = "test_key"
+        component.action = [{"name": "Invalid Action"}]
+
+        # Execute action should raise ValueError
+        with pytest.raises(ValueError, match="Invalid action: Invalid Action"):
+            component.execute_action()
+
+    def test_as_dataframe(self, component_class, default_kwargs, monkeypatch):
+        # Mock Action enum
+        monkeypatch.setattr(Action, "YOUTUBE_GET_CHANNEL_ID_BY_HANDLE", MockAction.YOUTUBE_GET_CHANNEL_ID_BY_HANDLE)
+
+        # Setup component
+        component = component_class(**default_kwargs)
+        component.api_key = "test_key"
+        component.action = [{"name": "Get Channel ID by Handle"}]
+        component.channel_handle = "test_handle"
+
+        # Create mock email data that would be returned by execute_action
+        mock_emails = [
+            {
+                "channel_handle": "channel1",
+            },
+            {
+                "channel_handle": "channel2",
+            },
+        ]
+
+        # Mock the execute_action method to return our mock data
+        with patch.object(component, "execute_action", return_value=mock_emails):
+            # Test as_dataframe method
+            result = component.as_dataframe()
+
+            # Verify the result is a DataFrame
+            assert isinstance(result, DataFrame)
+
+            # Verify the DataFrame is not empty
+            assert not result.empty
+
+            # Check for expected content in the DataFrame string representation
+            data_str = str(result)
+            assert "channel1" in data_str
+
+    def test_update_build_config(self, component_class, default_kwargs):
+        component = component_class(**default_kwargs)
+        build_config = {
+            "auth_link": {"value": "", "auth_tooltip": ""},
+            "action": {
+                "options": [],
+                "helper_text": "",
+                "helper_text_metadata": {},
+            },
+        }
+
+        # Test with empty API key
+        result = component.update_build_config(build_config, "", "api_key")
+        assert result["auth_link"]["value"] == ""
+        assert "Please provide a valid Composio API Key" in result["auth_link"]["auth_tooltip"]
+        assert result["action"]["options"] == []
+
+        # Test with valid API key
+        component.api_key = "test_key"
+        result = component.update_build_config(build_config, "test_key", "api_key")
+        assert len(result["action"]["options"]) > 0  


### PR DESCRIPTION
This pull request introduces a new YouTube component to the `langflow` project, including backend support & unit tests. The most important changes are:

Backend support:

* `src/backend/base/langflow/components/composio/__init__.py`: Added import and registration for `ComposioYoutubeAPIComponent `.

Unit tests:

* `src/backend/tests/unit/components/bundles/composio/test_youtube.py`: Added comprehensive unit tests for `ComposioYoutubeAPIComponent`, including tests for initialization, action execution, data conversion, and configuration updates.