### PR TITLE
fix: add dropdown clicking to change output type of message history on shard 9

### DIFF
--- a/src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts
+++ b/src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts
@@ -89,6 +89,10 @@ AI:
 
     await page.getByTestId("fit_view").click();
 
+    await page.getByTestId("dropdown-output-memory").click();
+
+    await page.getByTestId("dropdown-item-output-memory-message").click();
+
     //connection 1
     const elementChatMemoryOutput = await page
       .getByTestId("handle-memory-shownode-message-right")


### PR DESCRIPTION
This pull request adds a test case in `src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts` to validate the functionality of selecting an output memory message from a dropdown menu.

### Test enhancement:
* Added steps to interact with the "output memory" dropdown and select a specific "output memory message" option. This ensures the dropdown functionality is tested.