### PR TITLE
Fix: Remove Constraint in ChatInput Object to Enable Flow Run

### DIFF
--- a/src/backend/base/langflow/components/inputs/chat.py
+++ b/src/backend/base/langflow/components/inputs/chat.py
@@ -29,7 +29,6 @@ class ChatInput(ChatComponent):
             display_name="Text",
             value="",
             info="Message to be passed as input.",
-            input_types=[],
         ),
         BoolInput(
             name="should_store_message",


### PR DESCRIPTION
The ChatInput object did not specify the message type in the inputText, which prevented it from being used as an input in Flow run. This fix removes that constraint.

With this change, the FlowRun component can now properly use the Message object as input.