### PR TITLE
docs: add instructions for defining path in claude desktop

### DIFF
--- a/docs/docs/Concepts/mcp-server.md
+++ b/docs/docs/Concepts/mcp-server.md
@@ -300,3 +300,50 @@ You can use the ngrok console output to monitor requests for your project's endp
 ```
 16:35:48.566 EDT GET /api/v1/mcp/project/fdbc12af-0dd4-43dc-b9ce-c324d1ce5cd1 200 OK
 ```
+
+## Troubleshooting
+
+If Claude for Desktop is not using your server's tools correctly, you may need to explicitly define the path to your local `uvx` or `npx` executable file in `claude_desktop_config.json` configuration file.
+
+1. To find your UVX path, run `which uvx`.
+To find your NPX path, run `which npx`.
+
+2. Copy the path, and then replace `PATH_TO_UVX` or `PATH_TO_NPX` in your `claude_desktop_config.json` file.
+
+<Tabs>
+  <TabItem value="uvx" label="uvx" default>
+
+```json
+{
+  "mcpServers": {
+    "PROJECT_NAME": {
+      "command": "PATH_TO_UVX",
+      "args": [
+        "mcp-proxy",
+        "http://LANGFLOW_SERVER_ADDRESS/api/v1/mcp/project/PROJECT_ID/sse"
+      ]
+    }
+  }
+}
+```
+  </TabItem>
+
+  <TabItem value="npx" label="npx">
+
+```json
+{
+  "mcpServers": {
+    "langflow-my_projects": {
+      "command": "PATH_TO_NPX",
+      "args": [
+        "-y",
+        "supergateway",
+        "--sse",
+        "http://LANGFLOW_SERVER_ADDRESS/api/v1/mcp/project/PROJECT_ID/sse"
+      ]
+    }
+  }
+}
+```
+  </TabItem>
+</Tabs>

--- a/docs/docs/Concepts/mcp-server.md
+++ b/docs/docs/Concepts/mcp-server.md
@@ -301,9 +301,9 @@ You can use the ngrok console output to monitor requests for your project's endp
 16:35:48.566 EDT GET /api/v1/mcp/project/fdbc12af-0dd4-43dc-b9ce-c324d1ce5cd1 200 OK
 ```
 
-## Troubleshooting
+## Troubleshooting MCP server
 
-If Claude for Desktop is not using your server's tools correctly, you may need to explicitly define the path to your local `uvx` or `npx` executable file in `claude_desktop_config.json` configuration file.
+If Claude for Desktop is not using your server's tools correctly, you may need to explicitly define the path to your local `uvx` or `npx` executable file in the `claude_desktop_config.json` configuration file.
 
 1. To find your UVX path, run `which uvx`.
 To find your NPX path, run `which npx`.

--- a/docs/docs/Concepts/mcp-server.md
+++ b/docs/docs/Concepts/mcp-server.md
@@ -333,7 +333,7 @@ To find your NPX path, run `which npx`.
 ```json
 {
   "mcpServers": {
-    "langflow-my_projects": {
+    "PROJECT_NAME": {
       "command": "PATH_TO_NPX",
       "args": [
         "-y",


### PR DESCRIPTION
[Preview build](https://d5rxiv0do0q3v.cloudfront.net/langflow-drafts/docs-claude-mcp-path/mcp-server#troubleshooting)
This PR adds instructions for explicitly defining the path to the uvx or npx executables for Claude for Desktop.
Some users have reported issues with Claude for Desktop and Langflow MCP servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new troubleshooting section for MCP server setup in Claude for Desktop.
  - Provided step-by-step instructions for specifying full paths to local executables in the configuration file.
  - Included example configurations for both `uvx` and `npx` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->