### PR TITLE
feat: add node alignment helper lines with toggle control in flow editor

### DIFF
--- a/src/frontend/src/components/core/canvasControlsComponent/index.tsx
+++ b/src/frontend/src/components/core/canvasControlsComponent/index.tsx
@@ -79,6 +79,10 @@ const CanvasControls = ({ children }) => {
   );
   const setCurrentFlow = useFlowStore((state) => state.setCurrentFlow);
   const autoSaving = useFlowsManagerStore((state) => state.autoSaving);
+  const setHelperLineEnabled = useFlowStore(
+    (state) => state.setHelperLineEnabled,
+  );
+  const helperLineEnabled = useFlowStore((state) => state.helperLineEnabled);
 
   useEffect(() => {
     store.setState({
@@ -108,6 +112,10 @@ const CanvasControls = ({ children }) => {
     });
     handleSaveFlow();
   }, [isInteractive, store, handleSaveFlow]);
+
+  const onToggleHelperLines = useCallback(() => {
+    setHelperLineEnabled(!helperLineEnabled);
+  }, [setHelperLineEnabled, helperLineEnabled]);
 
   return (
     <Panel
@@ -149,6 +157,15 @@ const CanvasControls = ({ children }) => {
           isInteractive ? "" : "text-primary-foreground dark:text-primary"
         }
         testId="lock_unlock"
+      />
+      {/* Display Helper Lines */}
+      <CustomControlButton
+        iconName="UnfoldHorizontal"
+        tooltipText="Display Helper Lines"
+        onClick={onToggleHelperLines}
+        backgroundClasses={cn(helperLineEnabled && "bg-muted")}
+        iconClasses={cn(helperLineEnabled && "text-muted-foreground")}
+        testId="helper_lines"
       />
     </Panel>
   );

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/components/helper-lines.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/components/helper-lines.tsx
@@ -1,0 +1,37 @@
+import { useViewport } from "@xyflow/react";
+import { HelperLinesState } from "../helpers/helper-lines";
+
+interface HelperLinesProps {
+  helperLines: HelperLinesState;
+}
+
+export default function HelperLines({ helperLines }: HelperLinesProps) {
+  const { x: viewportX, y: viewportY, zoom } = useViewport();
+
+  if (!helperLines.horizontal && !helperLines.vertical) {
+    return null;
+  }
+
+  return (
+    <svg className="helper-lines">
+      {helperLines.horizontal && (
+        <line
+          x1={0}
+          y1={helperLines.horizontal.position * zoom + viewportY}
+          x2="100%"
+          y2={helperLines.horizontal.position * zoom + viewportY}
+          className="helper-line horizontal"
+        />
+      )}
+      {helperLines.vertical && (
+        <line
+          x1={helperLines.vertical.position * zoom + viewportX}
+          y1={0}
+          x2={helperLines.vertical.position * zoom + viewportX}
+          y2="100%"
+          className="helper-line vertical"
+        />
+      )}
+    </svg>
+  );
+}

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/helpers/helper-lines.ts
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/helpers/helper-lines.ts
@@ -1,0 +1,191 @@
+import { Node, XYPosition } from "@xyflow/react";
+
+export interface HelperLine {
+  id: string;
+  position: number;
+  orientation: "horizontal" | "vertical";
+}
+
+export interface HelperLinesState {
+  horizontal?: HelperLine;
+  vertical?: HelperLine;
+}
+
+const SNAP_DISTANCE = 5;
+
+export function getHelperLines(
+  draggingNode: Node,
+  nodes: Node[],
+  nodeWidth = 150,
+  nodeHeight = 50,
+): HelperLinesState {
+  const helperLines: HelperLinesState = {};
+
+  // Get the dragging node bounds
+  const draggingNodeBounds = {
+    left: draggingNode.position.x,
+    right:
+      draggingNode.position.x + (draggingNode.measured?.width || nodeWidth),
+    top: draggingNode.position.y,
+    bottom:
+      draggingNode.position.y + (draggingNode.measured?.height || nodeHeight),
+    centerX:
+      draggingNode.position.x + (draggingNode.measured?.width || nodeWidth) / 2,
+    centerY:
+      draggingNode.position.y +
+      (draggingNode.measured?.height || nodeHeight) / 2,
+  };
+
+  const otherNodes = nodes.filter((node) => node.id !== draggingNode.id);
+
+  // Check for vertical alignment (horizontal lines)
+  for (const node of otherNodes) {
+    const nodeBounds = {
+      left: node.position.x,
+      right: node.position.x + (node.measured?.width || nodeWidth),
+      top: node.position.y,
+      bottom: node.position.y + (node.measured?.height || nodeHeight),
+      centerX: node.position.x + (node.measured?.width || nodeWidth) / 2,
+      centerY: node.position.y + (node.measured?.height || nodeHeight) / 2,
+    };
+
+    // Check top alignment
+    if (Math.abs(draggingNodeBounds.top - nodeBounds.top) < SNAP_DISTANCE) {
+      helperLines.horizontal = {
+        id: `horizontal-top-${node.id}`,
+        position: nodeBounds.top,
+        orientation: "horizontal",
+      };
+    }
+
+    // Check bottom alignment
+    if (
+      Math.abs(draggingNodeBounds.bottom - nodeBounds.bottom) < SNAP_DISTANCE
+    ) {
+      helperLines.horizontal = {
+        id: `horizontal-bottom-${node.id}`,
+        position: nodeBounds.bottom,
+        orientation: "horizontal",
+      };
+    }
+
+    // Check center alignment
+    if (
+      Math.abs(draggingNodeBounds.centerY - nodeBounds.centerY) < SNAP_DISTANCE
+    ) {
+      helperLines.horizontal = {
+        id: `horizontal-center-${node.id}`,
+        position: nodeBounds.centerY,
+        orientation: "horizontal",
+      };
+    }
+  }
+
+  // Check for horizontal alignment (vertical lines)
+  for (const node of otherNodes) {
+    const nodeBounds = {
+      left: node.position.x,
+      right: node.position.x + (node.measured?.width || nodeWidth),
+      top: node.position.y,
+      bottom: node.position.y + (node.measured?.height || nodeHeight),
+      centerX: node.position.x + (node.measured?.width || nodeWidth) / 2,
+      centerY: node.position.y + (node.measured?.height || nodeHeight) / 2,
+    };
+
+    // Check left alignment
+    if (Math.abs(draggingNodeBounds.left - nodeBounds.left) < SNAP_DISTANCE) {
+      helperLines.vertical = {
+        id: `vertical-left-${node.id}`,
+        position: nodeBounds.left,
+        orientation: "vertical",
+      };
+    }
+
+    // Check right alignment
+    if (Math.abs(draggingNodeBounds.right - nodeBounds.right) < SNAP_DISTANCE) {
+      helperLines.vertical = {
+        id: `vertical-right-${node.id}`,
+        position: nodeBounds.right,
+        orientation: "vertical",
+      };
+    }
+
+    // Check center alignment
+    if (
+      Math.abs(draggingNodeBounds.centerX - nodeBounds.centerX) < SNAP_DISTANCE
+    ) {
+      helperLines.vertical = {
+        id: `vertical-center-${node.id}`,
+        position: nodeBounds.centerX,
+        orientation: "vertical",
+      };
+    }
+  }
+
+  return helperLines;
+}
+
+export function getSnapPosition(
+  draggingNode: Node,
+  nodes: Node[],
+  nodeWidth = 150,
+  nodeHeight = 50,
+): XYPosition {
+  const helperLines = getHelperLines(
+    draggingNode,
+    nodes,
+    nodeWidth,
+    nodeHeight,
+  );
+  let snapPosition = { ...draggingNode.position };
+
+  if (helperLines.horizontal) {
+    const draggingNodeBounds = {
+      top: draggingNode.position.y,
+      bottom:
+        draggingNode.position.y + (draggingNode.measured?.height || nodeHeight),
+      centerY:
+        draggingNode.position.y +
+        (draggingNode.measured?.height || nodeHeight) / 2,
+    };
+
+    // Snap to the helper line position
+    if (helperLines.horizontal.id.includes("top")) {
+      snapPosition.y = helperLines.horizontal.position;
+    } else if (helperLines.horizontal.id.includes("bottom")) {
+      snapPosition.y =
+        helperLines.horizontal.position -
+        (draggingNode.measured?.height || nodeHeight);
+    } else if (helperLines.horizontal.id.includes("center")) {
+      snapPosition.y =
+        helperLines.horizontal.position -
+        (draggingNode.measured?.height || nodeHeight) / 2;
+    }
+  }
+
+  if (helperLines.vertical) {
+    const draggingNodeBounds = {
+      left: draggingNode.position.x,
+      right:
+        draggingNode.position.x + (draggingNode.measured?.width || nodeWidth),
+      centerX:
+        draggingNode.position.x +
+        (draggingNode.measured?.width || nodeWidth) / 2,
+    };
+
+    // Snap to the helper line position
+    if (helperLines.vertical.id.includes("left")) {
+      snapPosition.x = helperLines.vertical.position;
+    } else if (helperLines.vertical.id.includes("right")) {
+      snapPosition.x =
+        helperLines.vertical.position -
+        (draggingNode.measured?.width || nodeWidth);
+    } else if (helperLines.vertical.id.includes("center")) {
+      snapPosition.x =
+        helperLines.vertical.position -
+        (draggingNode.measured?.width || nodeWidth) / 2;
+    }
+  }
+
+  return snapPosition;
+}

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/helpers/helper-lines.ts
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/helpers/helper-lines.ts
@@ -21,7 +21,6 @@ export function getHelperLines(
 ): HelperLinesState {
   const helperLines: HelperLinesState = {};
 
-  // Get the dragging node bounds
   const draggingNodeBounds = {
     left: draggingNode.position.x,
     right:
@@ -38,7 +37,6 @@ export function getHelperLines(
 
   const otherNodes = nodes.filter((node) => node.id !== draggingNode.id);
 
-  // Check for vertical alignment (horizontal lines)
   for (const node of otherNodes) {
     const nodeBounds = {
       left: node.position.x,
@@ -49,7 +47,6 @@ export function getHelperLines(
       centerY: node.position.y + (node.measured?.height || nodeHeight) / 2,
     };
 
-    // Check top alignment
     if (Math.abs(draggingNodeBounds.top - nodeBounds.top) < SNAP_DISTANCE) {
       helperLines.horizontal = {
         id: `horizontal-top-${node.id}`,
@@ -58,7 +55,6 @@ export function getHelperLines(
       };
     }
 
-    // Check bottom alignment
     if (
       Math.abs(draggingNodeBounds.bottom - nodeBounds.bottom) < SNAP_DISTANCE
     ) {
@@ -69,7 +65,6 @@ export function getHelperLines(
       };
     }
 
-    // Check center alignment
     if (
       Math.abs(draggingNodeBounds.centerY - nodeBounds.centerY) < SNAP_DISTANCE
     ) {
@@ -81,7 +76,6 @@ export function getHelperLines(
     }
   }
 
-  // Check for horizontal alignment (vertical lines)
   for (const node of otherNodes) {
     const nodeBounds = {
       left: node.position.x,
@@ -92,7 +86,6 @@ export function getHelperLines(
       centerY: node.position.y + (node.measured?.height || nodeHeight) / 2,
     };
 
-    // Check left alignment
     if (Math.abs(draggingNodeBounds.left - nodeBounds.left) < SNAP_DISTANCE) {
       helperLines.vertical = {
         id: `vertical-left-${node.id}`,
@@ -101,7 +94,6 @@ export function getHelperLines(
       };
     }
 
-    // Check right alignment
     if (Math.abs(draggingNodeBounds.right - nodeBounds.right) < SNAP_DISTANCE) {
       helperLines.vertical = {
         id: `vertical-right-${node.id}`,
@@ -110,7 +102,6 @@ export function getHelperLines(
       };
     }
 
-    // Check center alignment
     if (
       Math.abs(draggingNodeBounds.centerX - nodeBounds.centerX) < SNAP_DISTANCE
     ) {
@@ -149,7 +140,6 @@ export function getSnapPosition(
         (draggingNode.measured?.height || nodeHeight) / 2,
     };
 
-    // Snap to the helper line position
     if (helperLines.horizontal.id.includes("top")) {
       snapPosition.y = helperLines.horizontal.position;
     } else if (helperLines.horizontal.id.includes("bottom")) {
@@ -173,7 +163,6 @@ export function getSnapPosition(
         (draggingNode.measured?.width || nodeWidth) / 2,
     };
 
-    // Snap to the helper line position
     if (helperLines.vertical.id.includes("left")) {
       snapPosition.x = helperLines.vertical.position;
     } else if (helperLines.vertical.id.includes("right")) {

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -1042,6 +1042,10 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
     );
     set({ dismissedNodes: newDismissedNodes });
   },
+  helperLineEnabled: false,
+  setHelperLineEnabled: (helperLineEnabled: boolean) => {
+    set({ helperLineEnabled });
+  },
 }));
 
 export default useFlowStore;

--- a/src/frontend/src/style/applies.css
+++ b/src/frontend/src/style/applies.css
@@ -1262,6 +1262,26 @@
     --tw-ring-offset-shadow: none !important;
     --tw-ring-color: none !important;
   }
+
+  .helper-lines {
+    @apply pointer-events-none absolute left-0 top-0 z-10 h-full w-full;
+  }
+
+  .helper-line {
+    stroke: hsl(var(--primary));
+    stroke-width: 1.5;
+    stroke-dasharray: 4 4;
+    opacity: 0.8;
+    filter: drop-shadow(0 0 2px hsl(var(--primary) / 0.3));
+  }
+
+  .helper-line.horizontal {
+    stroke: hsl(var(--primary));
+  }
+
+  .helper-line.vertical {
+    stroke: hsl(var(--primary));
+  }
 }
 
 /* Gradient background */

--- a/src/frontend/src/types/zustand/flow/index.ts
+++ b/src/frontend/src/types/zustand/flow/index.ts
@@ -285,4 +285,6 @@ export type FlowStoreType = {
   setCurrentBuildingNodeId: (nodeIds: string[] | undefined) => void;
   clearEdgesRunningByNodes: () => Promise<void>;
   updateToolMode: (nodeId: string, toolMode: boolean) => void;
+  helperLineEnabled: boolean;
+  setHelperLineEnabled: (helperLineEnabled: boolean) => void;
 };


### PR DESCRIPTION
This pull request introduces a new feature to display helper lines for node alignment in the flow editor, along with associated UI updates and state management. The changes include adding helper line rendering, snapping functionality, and a toggle control to enable or disable the feature.

### Helper Line Rendering and Snapping
* Added the `HelperLines` component to render horizontal and vertical alignment lines based on node positions (`src/frontend/src/pages/FlowPage/components/PageComponent/components/helper-lines.tsx`).
* Implemented logic in `getHelperLines` and `getSnapPosition` to calculate alignment lines and snap nodes to aligned positions (`src/frontend/src/pages/FlowPage/components/PageComponent/helpers/helper-lines.ts`).

### UI and Interaction Updates
* Added a new button to the `CanvasControls` component for toggling helper lines, with visual feedback based on the toggle state (`src/frontend/src/components/core/canvasControlsComponent/index.tsx`). [[1]](diffhunk://#diff-023dafab442d303c92f8df4e9bb014cbc9baa1d495e6f9f69cb760a1dc0c7c1cR82-R85) [[2]](diffhunk://#diff-023dafab442d303c92f8df4e9bb014cbc9baa1d495e6f9f69cb760a1dc0c7c1cR116-R119) [[3]](diffhunk://#diff-023dafab442d303c92f8df4e9bb014cbc9baa1d495e6f9f69cb760a1dc0c7c1cR161-R169)
* Updated the `Page` component to handle node dragging events, calculate helper lines, and snap positions dynamically (`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`). [[1]](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eR356-R363) [[2]](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eR372-R373) [[3]](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eL369-R452) [[4]](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eL585-R666) [[5]](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eR704)

### State Management
* Extended the `useFlowStore` state management to include `helperLineEnabled` and its corresponding setter (`src/frontend/src/stores/flowStore.ts`).
* Updated the `FlowStoreType` definition to include the new state properties (`src/frontend/src/types/zustand/flow/index.ts`).

### Styling
* Added CSS styles for the helper lines, including dashed lines and shadow effects for better visibility (`src/frontend/src/style/applies.css`).

This pull request adds a new button to the React Flow custom controls that enables alignment lines between components during use.
When enabled, alignment lines will appear as shown in the screenshot below:

<img width="1133" alt="image" src="https://github.com/user-attachments/assets/09d2d7c3-6cd4-4bba-9c88-1a903f3cd85c" />
-
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/06362c1a-e6c3-46c7-8675-6e6b6465f753" />
-
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/1e0ee4c2-5619-4600-8830-fad9197728f7" />
