### PR TITLE
fix: remove float limits when not defined

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/floatComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/floatComponent/index.tsx
@@ -20,8 +20,8 @@ export default function FloatComponent({
   id = "",
 }: InputProps<number, FloatComponentType>): JSX.Element {
   const step = rangeSpec?.step ?? 0.1;
-  const min = rangeSpec?.min ?? -2;
-  const max = rangeSpec?.max ?? 2;
+  const min = rangeSpec?.min;
+  const max = rangeSpec?.max;
 
   // Local state for input value
   const [localValue, setLocalValue] = useState<string>(value.toString());


### PR DESCRIPTION
Eliminate default float limits in the FloatComponent to allow for more flexible input handling.