### PR TITLE
fix: add error handling when node stops existing before update completes

### DIFF
--- a/src/frontend/src/CustomNodes/helpers/mutate-template.ts
+++ b/src/frontend/src/CustomNodes/helpers/mutate-template.ts
@@ -60,7 +60,15 @@ export const mutateTemplate = async (
               );
               newNode.tool_mode = toolMode ?? node.tool_mode;
             }
-            setNodeClass(newNode);
+            try {
+              setNodeClass(newNode);
+            } catch (e) {
+              if (e instanceof Error && e.message === "Node not found") {
+                console.log("Node not found");
+              } else {
+                throw e;
+              }
+            }
             callback?.();
           } catch (e) {
             const error = e as ResponseErrorDetailAPI;

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -304,6 +304,10 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
     isUserChange: boolean = true,
     callback?: () => void,
   ) => {
+    if (!get().nodes.find((node) => node.id === id)) {
+      throw new Error("Node not found");
+    }
+
     let newChange =
       typeof change === "function"
         ? change(get().nodes.find((node) => node.id === id)!)


### PR DESCRIPTION
Implement error handling to manage cases where a node does not exist, improving robustness and user feedback.