### PR TITLE
fix: makes action title follow the flow name after editing to old title

### DIFF
--- a/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
+++ b/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
@@ -81,17 +81,16 @@ export default function ToolsTable({
       handleOnNewValue({
         value: data.map((row) => {
           const processedValue = (
-            row.name !== ""
+            row.name !== "" && row.name !== row.display_name
               ? parseString(row.name, ["snake_case", "no_blank", "lowercase"])
-              : parseString(row.display_name, [
-                  "snake_case",
-                  "no_blank",
-                  "lowercase",
-                ])
+              : ""
           ).slice(0, 46);
 
           const processedDescription =
-            row.description !== "" ? row.description : row.display_description;
+            row.description !== "" &&
+            row.description !== row.display_description
+              ? row.description
+              : "";
 
           return selectedRows?.some(
             (selected) =>

--- a/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
+++ b/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
@@ -80,17 +80,31 @@ export default function ToolsTable({
     if (!open && selectedRows) {
       handleOnNewValue({
         value: data.map((row) => {
+          const name = parseString(row.name, [
+            "snake_case",
+            "no_blank",
+            "lowercase",
+          ]);
+          const display_name = parseString(row.display_name, [
+            "snake_case",
+            "no_blank",
+            "lowercase",
+          ]);
           const processedValue = (
-            row.name !== "" && row.name !== row.display_name
-              ? parseString(row.name, ["snake_case", "no_blank", "lowercase"])
-              : ""
+            name !== "" && name !== display_name
+              ? name
+              : isAction
+                ? ""
+                : display_name
           ).slice(0, 46);
 
           const processedDescription =
             row.description !== "" &&
             row.description !== row.display_description
               ? row.description
-              : "";
+              : isAction
+                ? ""
+                : row.display_description;
 
           return selectedRows?.some(
             (selected) =>

--- a/src/frontend/src/utils/stringManipulation.ts
+++ b/src/frontend/src/utils/stringManipulation.ts
@@ -78,6 +78,14 @@ export function parseString(
 ): string {
   let result = str;
 
+  if (result === "") {
+    return "";
+  }
+
+  if (parsers.includes("no_blank") && result.trim() === "") {
+    return "";
+  }
+
   let parsersArray: FieldParserType[] = [];
 
   if (typeof parsers === "string") {


### PR DESCRIPTION
This pull request refactors the string parsing logic in the `ToolsTable` component and enhances the `parseString` utility function to handle edge cases more robustly. The changes improve code clarity and ensure consistent behavior when processing empty or blank strings.

### Refactoring in `ToolsTable` component:

* Refactored the logic for processing `name` and `display_name` fields in `ToolsTable` to improve readability and ensure that `name` and `display_name` are parsed separately before comparison. Updated the `processedValue` and `processedDescription` logic to handle cases where fields are empty or identical, with additional consideration for the `isAction` flag. (`src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx`, [src/frontend/src/modals/toolsModal/components/toolsTable/index.tsxL83-R107](diffhunk://#diff-74c8a3a7d322d9e3c2682246b095581a079f097b77acf319fd19a7922a39c7baL83-R107))

### Enhancements to `parseString` utility:

* Enhanced the `parseString` function to return an empty string if the input string is empty or if the `no_blank` parser is included and the string contains only whitespace. This ensures more robust handling of edge cases during string manipulation. (`src/frontend/src/utils/stringManipulation.ts`, [src/frontend/src/utils/stringManipulation.tsR81-R88](diffhunk://#diff-aad2b0bc5901e08b28a00c014a192e16cac00357c9c192ff8f15b222b380bcefR81-R88))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling and normalization of name and description fields in the tools modal for more accurate display and selection logic.
- **Bug Fixes**
  - Enhanced string parsing to better handle empty or blank values, preventing unintended errors or display issues when processing input fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->