### PR TITLE
fix: remove data to dataframe and message to data

### DIFF
--- a/src/backend/base/langflow/components/processing/data_to_dataframe.py
+++ b/src/backend/base/langflow/components/processing/data_to_dataframe.py
@@ -12,6 +12,7 @@ class DataToDataFrameComponent(Component):
     )
     icon = "table"
     name = "DataToDataFrame"
+    legacy = True
 
     inputs = [
         DataInput(

--- a/src/backend/base/langflow/components/processing/message_to_data.py
+++ b/src/backend/base/langflow/components/processing/message_to_data.py
@@ -12,6 +12,7 @@ class MessageToDataComponent(Component):
     icon = "message-square-share"
     beta = True
     name = "MessagetoData"
+    legacy = True
 
     inputs = [
         MessageInput(

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
@@ -712,7 +712,7 @@
             "frozen": false,
             "icon": "message-square-share",
             "key": "MessagetoData",
-            "legacy": false,
+            "legacy": true,
             "lf_version": "1.1.5",
             "metadata": {},
             "minimized": false,
@@ -752,7 +752,7 @@
                 "show": true,
                 "title_case": false,
                 "type": "code",
-                "value": "from loguru import logger\n\nfrom langflow.custom import Component\nfrom langflow.io import MessageInput, Output\nfrom langflow.schema import Data\nfrom langflow.schema.message import Message\n\n\nclass MessageToDataComponent(Component):\n    display_name = \"Message to Data\"\n    description = \"Convert a Message object to a Data object\"\n    icon = \"message-square-share\"\n    beta = True\n    name = \"MessagetoData\"\n\n    inputs = [\n        MessageInput(\n            name=\"message\",\n            display_name=\"Message\",\n            info=\"The Message object to convert to a Data object\",\n        ),\n    ]\n\n    outputs = [\n        Output(display_name=\"Data\", name=\"data\", method=\"convert_message_to_data\"),\n    ]\n\n    def convert_message_to_data(self) -> Data:\n        if isinstance(self.message, Message):\n            # Convert Message to Data\n            return Data(data=self.message.data)\n\n        msg = \"Error converting Message to Data: Input must be a Message object\"\n        logger.opt(exception=True).debug(msg)\n        self.status = msg\n        return Data(data={\"error\": msg})\n"
+                "value": "from loguru import logger\n\nfrom langflow.custom import Component\nfrom langflow.io import MessageInput, Output\nfrom langflow.schema import Data\nfrom langflow.schema.message import Message\n\n\nclass MessageToDataComponent(Component):\n    display_name = \"Message to Data\"\n    description = \"Convert a Message object to a Data object\"\n    icon = \"message-square-share\"\n    beta = True\n    name = \"MessagetoData\"\n    legacy = True\n\n    inputs = [\n        MessageInput(\n            name=\"message\",\n            display_name=\"Message\",\n            info=\"The Message object to convert to a Data object\",\n        ),\n    ]\n\n    outputs = [\n        Output(display_name=\"Data\", name=\"data\", method=\"convert_message_to_data\"),\n    ]\n\n    def convert_message_to_data(self) -> Data:\n        if isinstance(self.message, Message):\n            # Convert Message to Data\n            return Data(data=self.message.data)\n\n        msg = \"Error converting Message to Data: Input must be a Message object\"\n        logger.opt(exception=True).debug(msg)\n        self.status = msg\n        return Data(data={\"error\": msg})\n"
               },
               "message": {
                 "_input_type": "MessageInput",


### PR DESCRIPTION
This pull request introduces updates to mark certain components as "legacy" in the codebase and starter project configuration files. The changes ensure consistency across the components and their corresponding representations in starter projects.

### Updates to Component Definitions:

* [`src/backend/base/langflow/components/processing/data_to_dataframe.py`](diffhunk://#diff-4ccabd238ebb224a1256d6550087fb48b5cda5b8e5ab3b986de66e525f3ec23dR15): Added the `legacy = True` attribute to the `DataToDataFrameComponent` class to mark it as a legacy component.
* [`src/backend/base/langflow/components/processing/message_to_data.py`](diffhunk://#diff-25d98ae789096fdba7cdaa873c5b2e97a32420228c63251e80cfb62c99f653bfR15): Added the `legacy = True` attribute to the `MessageToDataComponent` class to mark it as a legacy component.

### Updates to Starter Project Configuration:

* [`src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json`](diffhunk://#diff-e0809f54bfa91112c675371d85f07adebda918bc184de15a8fcd3a0f1e498cf0L715-R715): Updated the `legacy` property for the `MessagetoData` component to `true` to align with the component definition.
* [`src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json`](diffhunk://#diff-e0809f54bfa91112c675371d85f07adebda918bc184de15a8fcd3a0f1e498cf0L755-R755): Modified the embedded code snippet for the `MessagetoData` component to include the `legacy = True` attribute, ensuring consistency with the component's class definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated components to mark "DataToDataFrame" and "MessageToData" as legacy.
  - Adjusted the "Research Translation Loop" starter project to reflect the legacy status of the "MessagetoData" component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->