### PR TITLE
docs: contributing page links

### DIFF
--- a/docs/docs/Contributing/contributing-how-to-contribute.md
+++ b/docs/docs/Contributing/contributing-how-to-contribute.md
@@ -116,7 +116,7 @@ For more information, see the [Python Developer's Guide](https://devguide.python
 
 ## Additional contribution guides
 
-- [Contributing Bundles](./contributing-bundles.md)
-- [Contributing Components](./contributing-components.md)
-- [Contributing Tests](./contributing-component-tests.md)
-- [Contributing Templates](./contributing-templates.md)
+- [Contribute Bundles](./contributing-bundles.md)
+- [Contribute Components](./contributing-components.md)
+- [Contribute Tests](./contributing-component-tests.md)
+- [Contribute Templates](./contributing-templates.md)


### PR DESCRIPTION
Add links to contributing pages and 

* Updated the `git remote add` command to use a customizable fork name instead of a fixed name (`fork`). 
* Removed the recommendation to use virtual environments like `venv` or `conda` for dependency isolation, simplifying the setup instructions - uv is used.
* Added links to new contributing guides for Bundles, Components, Tests, and Templates, providing more structured guidance for specific contribution areas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified instructions for adding a new remote with explicit placeholders and guidance.
  - Removed the recommendation to use virtual environments for dependency isolation.
  - Added a new section linking to additional contributing guides on Bundles, Components, Tests, and Templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->