### PR TITLE
tests: Update Pokedex Agent test expectations

### DIFF
--- a/src/frontend/tests/core/integrations/Pokedex Agent.spec.ts
+++ b/src/frontend/tests/core/integrations/Pokedex Agent.spec.ts
@@ -46,7 +46,6 @@ withEventDeliveryModes(
       .last()
       .innerText();
     expect(output).toContain("Charmander");
-    expect(output).toContain("Route 24");
     expect(output.length).toBeGreaterThan(100);
   },
 );


### PR DESCRIPTION
Remove outdated expectation for "Route 24" in the Pokedex Agent integration test to align with current test requirements.