### PR TITLE
ci: Remove cache restoration from workflows

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -19,12 +19,3 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
-
-    - name: Restore uv cache
-      uses: actions/cache@v4
-      with:
-        path: /tmp/.uv-cache
-        key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-        restore-keys: |
-          uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-          uv-${{ runner.os }}

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -33,8 +33,6 @@ jobs:
   build:
     name: Unit Tests - Python ${{ matrix.python-version }} - Group ${{ matrix.group }}
     runs-on: ubuntu-latest
-    env:
-      UV_CACHE_DIR: /tmp/.uv-cache
     strategy:
       matrix:
         python-version: ${{ fromJson(inputs.python-versions || '["3.10", "3.11", "3.12", "3.13"]' ) }}

--- a/.github/workflows/store_pytest_durations.yml
+++ b/.github/workflows/store_pytest_durations.yml
@@ -20,7 +20,6 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
       ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
-      UV_CACHE_DIR: /tmp/.uv-cache
     steps:
       - uses: actions/checkout@v4
       - name: "Setup Environment"

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -256,7 +256,6 @@ jobs:
       ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}"
       TAVILY_API_KEY: "${{ secrets.TAVILY_API_KEY }}"
       LANGFLOW_DEACTIVE_TRACING: "true"
-      UV_CACHE_DIR: /tmp/.uv-cache
     outputs:
       failed: ${{ steps.check-failure.outputs.failed }}
     steps:


### PR DESCRIPTION
Eliminate the UV_CACHE_DIR environment variable and the associated cache restoration step from GitHub workflows to streamline the CI process.

The setup-uv action cached with one key but we looked up a different format, causing cache misses.
Example: 
```
cache saved with the key: setup-uv-1-x86_64-unknown-linux-gnu-0.7.9-2b8ee67a007765037fec8b697d12ed35e766c5e388e33f436dac807b058ccc6b
```

```
Cache not found for input keys: uv-Linux-2b8ee67a007765037fec8b697d12ed35e766c5e388e33f436dac807b058ccc6b, uv-Linux-2b8ee67a007765037fec8b697d12ed35e766c5e388e33f436dac807b058ccc6b, uv-Linux
```