### PR TITLE
ci(docker): update Buildx setup to use BuildKit container backend

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -206,7 +206,7 @@ jobs:
           version: latest
           driver: docker-container
           driver-opts: |
-            image=moby/buildkit:master
+            image=moby/buildkit:v0.22.0
             network=host
 
       - name: Login to Docker Hub
@@ -286,7 +286,7 @@ jobs:
           version: latest
           driver: docker-container
           driver-opts: |
-            image=moby/buildkit:master
+            image=moby/buildkit:v0.22.0
             network=host
 
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -204,6 +204,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           version: latest
+          driver: docker-container
+          driver-opts: |
+            image=moby/buildkit:master
+            network=host
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -278,6 +282,13 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+          driver: docker-container
+          driver-opts: |
+            image=moby/buildkit:master
+            network=host
+
 
       - name: Login to Docker Hub
         if: ${{ matrix.component == 'docker-backend' }} || ${{ matrix.component == 'docker-frontend' }}


### PR DESCRIPTION
This is a possible fix for the nightly build that is failing to cache (because we now use our Runner instead of GH's).

https://github.com/docker/build-push-action/issues/163#issuecomment-824079057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to use a specific BuildKit container image and network settings for Docker builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->