### PR TITLE
feat: refactor component tool description format to prioritize component description

### DIFF
--- a/src/backend/base/langflow/base/tools/component_tool.py
+++ b/src/backend/base/langflow/base/tools/component_tool.py
@@ -40,7 +40,7 @@ def _get_input_type(input_: InputTypes):
 
 def build_description(component: Component, output: Output) -> str:
     name = component.name or component.__class__.__name__
-    return f"{name}. {output.method} - {component.description}"
+    return f"{component.description} ({name}.{output.method})"
 
 
 async def send_message_noop(


### PR DESCRIPTION
This pull request includes a minor update to the `build_description` function in `src/backend/base/langflow/base/tools/component_tool.py`. The change modifies the format of the returned string to prioritize the component's description and include the method in parentheses.

* [`src/backend/base/langflow/base/tools/component_tool.py`](diffhunk://#diff-e6b607a8c5e404d2d308314cf694b33701ebcd21f8d564b6932c522d3a5e02cbL43-R43): Updated the `build_description` function to return a string in the format `{component.description} ({name}.{output.method})` instead of `{name}. {output.method} - {component.description}`.