### PR TITLE
fix: made empty project appear instead of empty flows list when mcp is enabled

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -4,7 +4,10 @@ import { IS_MAC } from "@/constants/constants";
 import { useGetFolderQuery } from "@/controllers/API/queries/folders/use-get-folder";
 import { CustomBanner } from "@/customization/components/custom-banner";
 import { CustomMcpServerTab } from "@/customization/components/custom-McpServerTab";
-import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
+import {
+  ENABLE_DATASTAX_LANGFLOW,
+  ENABLE_MCP,
+} from "@/customization/feature-flags";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { useFolderStore } from "@/stores/foldersStore";
 import { FlowType } from "@/types/flow";
@@ -77,8 +80,11 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
   }, []);
 
   const isEmptyFolder =
-    flows?.find((flow) => flow.folder_id === (folderId ?? myCollectionId)) ===
-    undefined;
+    flows?.find(
+      (flow) =>
+        flow.folder_id === (folderId ?? myCollectionId) &&
+        (ENABLE_MCP ? flow.is_component === false : true),
+    ) === undefined;
 
   const handleFileDrop = useFileDrop(isEmptyFolder ? undefined : flowType);
 
@@ -239,7 +245,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
               {isEmptyFolder ? (
                 <EmptyFolder setOpenModal={setNewProjectModal} />
               ) : (
-                <div className="">
+                <div className="flex h-full flex-col">
                   {isLoading ? (
                     view === "grid" ? (
                       <div className="mt-4 grid grid-cols-1 gap-1 md:grid-cols-2 lg:grid-cols-3">
@@ -287,7 +293,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
                       </div>
                     )
                   ) : flowType === "flows" ? (
-                    <div className="pt-2 text-center text-sm text-secondary-foreground">
+                    <div className="pt-24 text-center text-sm text-secondary-foreground">
                       No flows in this project.{" "}
                       <a
                         onClick={() => setNewProjectModal(true)}
@@ -298,7 +304,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
                       , or browse the store.
                     </div>
                   ) : (
-                    <div className="pt-2 text-center text-sm text-secondary-foreground">
+                    <div className="pt-24 text-center text-sm text-secondary-foreground">
                       No saved or custom components. Learn more about{" "}
                       <a
                         href="https://docs.langflow.org/components-custom-components"


### PR DESCRIPTION
This pull request introduces updates to the `HomePage` component in `src/frontend/src/pages/MainPage/pages/homePage/index.tsx`, focusing on feature flag integration, conditional rendering, and UI adjustments. The changes enhance functionality and improve user experience for specific scenarios.

### Feature Flag Integration:
* Updated the import statement to include the `ENABLE_MCP` feature flag, allowing conditional logic based on this flag. (`[src/frontend/src/pages/MainPage/pages/homePage/index.tsxL7-R10](diffhunk://#diff-ff0f0473b212e9e2e6493c82b06f52752dd6602693587a4ead6cc8ae40bc5816L7-R10)`)
* Modified the `isEmptyFolder` logic to consider the `ENABLE_MCP` flag, ensuring that folders with components are correctly filtered when the flag is enabled. (`[src/frontend/src/pages/MainPage/pages/homePage/index.tsxL80-R87](diffhunk://#diff-ff0f0473b212e9e2e6493c82b06f52752dd6602693587a4ead6cc8ae40bc5816L80-R87)`)

### UI Adjustments:
* Adjusted the `div` container for non-empty folders to use a `flex` layout with full height, improving layout consistency. (`[src/frontend/src/pages/MainPage/pages/homePage/index.tsxL242-R248](diffhunk://#diff-ff0f0473b212e9e2e6493c82b06f52752dd6602693587a4ead6cc8ae40bc5816L242-R248)`)
* Increased the top padding for the "No flows in this project" and "No saved or custom components" messages, enhancing visual spacing and alignment. (`[[1]](diffhunk://#diff-ff0f0473b212e9e2e6493c82b06f52752dd6602693587a4ead6cc8ae40bc5816L290-R296)`, `[[2]](diffhunk://#diff-ff0f0473b212e9e2e6493c82b06f52752dd6602693587a4ead6cc8ae40bc5816L301-R307)`)