### PR TITLE
fix: correct use-mobile with removeEventListener

### DIFF
--- a/src/frontend/src/hooks/use-mobile.ts
+++ b/src/frontend/src/hooks/use-mobile.ts
@@ -24,7 +24,7 @@ export function useIsMobile({ maxWidth }: { maxWidth?: number } = {}) {
 
     return () => {
       mql.removeEventListener("change", handleResize);
-      window.addEventListener("resize", handleResize);
+      window.removeEventListener("resize", handleResize);
     };
   }, [breakpoint]);
 


### PR DESCRIPTION
Fixed a critical bug in the cleanup function of the `useIsMobile` hook where
`addEventListener` was incorrectly used instead of `removeEventListener`.
This was causing memory leaks and potential performance issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the window resize event listener was not properly removed, improving performance and preventing potential memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->