### PR TITLE
fix: Revert Typescript Shards

### DIFF
--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -220,12 +220,12 @@ jobs:
 
           echo "Total tests to run: $TEST_COUNT"
 
-          # Calculate optimal shard count - 1 shard per 5 tests, min 1, max 40
+          # Calculate optimal shard count - 1 shard per 5 tests, min 1, max 10
           SHARD_COUNT=$(( (TEST_COUNT + 4) / 5 ))
           if [ $SHARD_COUNT -lt 1 ]; then
             SHARD_COUNT=1
-          elif [ $SHARD_COUNT -gt 40 ]; then
-            SHARD_COUNT=40
+          elif [ $SHARD_COUNT -gt 10 ]; then
+            SHARD_COUNT=10
           fi
 
           # Create the matrix combinations string


### PR DESCRIPTION
This pull request modifies the test sharding logic in the TypeScript test workflow to reduce the maximum number of shards from 40 to 10.

* [`.github/workflows/typescript_test.yml`](diffhunk://#diff-5d797ebb3ae4ad03df6436d2142e2362e045f06db4f745ec0a5a414a91504d03L223-R228): Updated the calculation of `SHARD_COUNT` to cap the maximum number of shards at 10 instead of 40. This change ensures a more constrained and manageable number of test shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the maximum number of parallel test shards for frontend tests, potentially affecting test run distribution and duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->