### PR TITLE
fix: Add os.stat to blocklist for _load_revisions in alembic script

### DIFF
--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -83,6 +83,9 @@ def blockbuster(request):
             for func in ["os.path.abspath", "os.scandir"]:
                 bb.functions[func].can_block_in("alembic/script/base.py", "_load_revisions")
 
+            # Add os.stat to alembic/script/base.py _load_revisions
+            bb.functions["os.stat"].can_block_in("alembic/script/base.py", "_load_revisions")
+
             (
                 bb.functions["os.path.abspath"]
                 .can_block_in("loguru/_better_exceptions.py", {"_get_lib_dirs", "_format_exception"})


### PR DESCRIPTION
Include os.stat in the blocklist for the _load_revisions function to enhance functionality and prevent unwanted behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated test configuration to recognize additional blocking operations during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->