### PR TITLE
fix: Remove Docker duplicated build step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,16 +233,6 @@ jobs:
       pre_release: ${{ inputs.pre_release }}
     secrets: inherit
 
-  call_docker_build_main_ep:
-    name: Call Docker Build Workflow for Langflow with Entrypoint
-    if: inputs.build_docker_ep == true
-    needs: [release-main]
-    uses: ./.github/workflows/docker-build.yml
-    with:
-      main_version: ${{ needs.release-main.outputs.version }}
-      release_type: main-ep
-      pre_release: False
-    secrets: inherit
 
   create_release:
     name: Create Release


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed a separate Docker build step for the Entrypoint variant from the release workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->