### PR TITLE
docs: update details summary css for better arrow alignment

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -403,6 +403,12 @@ body {
   gap: 0.5em;
   list-style: none;
   outline: none;
+  cursor: pointer;
+}
+
+.markdown details summary:focus-visible {
+  outline: 2px solid var(--ifm-color-primary, #a855f7);
+  outline-offset: 2px;
 }
 
 .markdown details [class^="collapsibleContent"] {


### PR DESCRIPTION
Fix details summary css to align arrow with text and trim the clickable label.

[Preview build at Results tab](https://d5rxiv0do0q3v.cloudfront.net/langflow-drafts/docs-align-details-style/typescript-client#retrieve-langflow-logs-with-the-typescript-client)

Before
<img width="995" alt="Screenshot 2025-06-04 at 1 43 33 PM" src="https://github.com/user-attachments/assets/e2dc7968-6093-4152-afef-d036d96661bd" />

After
<img width="1001" alt="Screenshot 2025-06-04 at 1 41 06 PM" src="https://github.com/user-attachments/assets/945bf282-109e-4c19-83dd-f391ee3b9b3a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
  - Improved the appearance and alignment of summary elements in markdown details for a cleaner and more consistent look.
  - Enhanced keyboard accessibility with a visible focus outline on summary elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->