### PR TITLE
fix: dockerfile proper case capitalization refinement

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM langflowai/backend_build as backend_build
+FROM langflowai/backend_build AS backend_build
 
 FROM python:3.10-slim
 WORKDIR /app

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine as frontend_build
+FROM node:20-alpine AS frontend_build
 ARG BACKEND_URL
 WORKDIR /app
 


### PR DESCRIPTION
There are AS keyword capitalization inconsistency (somewhere it's **AS**, in other places it's **as**). And because of it I've faced exceptions during local run where docker fired an exception during execution because of casing inconsistency. Fixing it solved the problem and improved overall codestyle 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated capitalization in Dockerfile stage aliases for consistency.
  - Added a newline at the end of the frontend Dockerfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->