### PR TITLE
fix: make starter projects auto refactor not remove selected output

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -539,7 +539,6 @@ class Component(CustomComponent):
             raise ValueError(msg)
         return_types = self._get_method_return_type(output.method)
         output.add_types(return_types)
-        output.set_selected()
 
     def _set_output_required_inputs(self) -> None:
         for output in self.outputs:
@@ -851,7 +850,6 @@ class Component(CustomComponent):
                 continue
             return_types = self._get_method_return_type(output.method)
             output.add_types(return_types)
-            output.set_selected()
 
         frontend_node.validate_component()
         frontend_node.set_base_classes_from_outputs()

--- a/src/backend/base/langflow/custom/utils.py
+++ b/src/backend/base/langflow/custom/utils.py
@@ -381,17 +381,6 @@ def build_custom_component_template_from_inputs(
         return_types = [format_type(return_type) for return_type in return_types]
         output.add_types(return_types)
 
-    # Get the selected output from field_config if it exists
-    selected_output = next((output for output in field_config.get("outputs", []) if output.get("selected")), None)
-
-    # Only attempt to set selected output if we have both a valid selected_output and its name
-    if selected_output and selected_output.get("name"):
-        # Find the matching output in frontend_node.outputs
-        next_output = next((output for output in frontend_node.outputs if output.name == selected_output["name"]), None)
-        # Set the selected state if we found a matching output
-        if next_output:
-            next_output.selected = selected_output.get("selected", True)
-
     # Validate that there is not name overlap between inputs and outputs
     frontend_node.validate_component()
     # ! This should be removed when we have a better way to handle this

--- a/src/backend/base/langflow/custom/utils.py
+++ b/src/backend/base/langflow/custom/utils.py
@@ -380,7 +380,13 @@ def build_custom_component_template_from_inputs(
         return_types = cc_instance.get_method_return_type(output.method)
         return_types = [format_type(return_type) for return_type in return_types]
         output.add_types(return_types)
-        output.set_selected()
+
+    selected_output = next((output for output in field_config.get("outputs", []) if output.get("selected")), None)
+
+    next_output = next((output for output in frontend_node.outputs if output.name == selected_output.get("name")), None)
+    if next_output and selected_output:
+        next_output.selected = selected_output.get("selected")
+
     # Validate that there is not name overlap between inputs and outputs
     frontend_node.validate_component()
     # ! This should be removed when we have a better way to handle this

--- a/src/backend/base/langflow/custom/utils.py
+++ b/src/backend/base/langflow/custom/utils.py
@@ -381,11 +381,16 @@ def build_custom_component_template_from_inputs(
         return_types = [format_type(return_type) for return_type in return_types]
         output.add_types(return_types)
 
+    # Get the selected output from field_config if it exists
     selected_output = next((output for output in field_config.get("outputs", []) if output.get("selected")), None)
 
-    next_output = next((output for output in frontend_node.outputs if output.name == selected_output.get("name")), None)
-    if next_output and selected_output:
-        next_output.selected = selected_output.get("selected")
+    # Only attempt to set selected output if we have both a valid selected_output and its name
+    if selected_output and selected_output.get("name"):
+        # Find the matching output in frontend_node.outputs
+        next_output = next((output for output in frontend_node.outputs if output.name == selected_output["name"]), None)
+        # Set the selected state if we found a matching output
+        if next_output:
+            next_output.selected = selected_output.get("selected", True)
 
     # Validate that there is not name overlap between inputs and outputs
     frontend_node.validate_component()

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -64,7 +64,16 @@ def update_projects_components_with_latest_component_versions(project_data, all_
             is_tool_or_agent = node_data.get("tool_mode", False) or node_data.get("key") == "Agent"
             has_tool_outputs = any(output.get("types") == ["Tool"] for output in node_data.get("outputs", []))
             if "outputs" in latest_node and not has_tool_outputs and not is_tool_or_agent:
+                # Set selected output as the previous selected output
+                for output in latest_node["outputs"]:
+                    node_data_output = next(
+                        (output_ for output_ in node_data["outputs"] if output_["name"] == output["name"]),
+                        None,
+                    )
+                    if node_data_output:
+                        output["selected"] = node_data_output.get("selected")
                 node_data["outputs"] = latest_node["outputs"]
+
             if node_data["template"]["_type"] != latest_template["_type"]:
                 node_data["template"]["_type"] = latest_template["_type"]
                 if node_type != "Prompt":

--- a/src/backend/base/langflow/template/field/base.py
+++ b/src/backend/base/langflow/template/field/base.py
@@ -224,6 +224,9 @@ class Output(BaseModel):
         if self.types is None:
             self.types = []
         self.types.extend([t for t in type_ if t not in self.types])
+        # If no type is selected and we have types, select the first one
+        if self.selected is None and self.types:
+            self.selected = self.types[0]
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/src/backend/base/langflow/template/field/base.py
+++ b/src/backend/base/langflow/template/field/base.py
@@ -225,10 +225,6 @@ class Output(BaseModel):
             self.types = []
         self.types.extend([t for t in type_ if t not in self.types])
 
-    def set_selected(self) -> None:
-        if not self.selected and self.types:
-            self.selected = self.types[0]
-
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
         result = handler(self)

--- a/src/backend/tests/unit/test_schema.py
+++ b/src/backend/tests/unit/test_schema.py
@@ -127,11 +127,6 @@ class TestOutput:
         output_obj.add_types(["str", "int"])
         assert output_obj.types == ["str", "int"]
 
-    def test_output_set_selected(self):
-        output_obj = Output(name="test_output", types=["str", "int"])
-        output_obj.set_selected()
-        assert output_obj.selected == "str"
-
     def test_output_to_dict(self):
         output_obj = Output(name="test_output")
         assert output_obj.to_dict() == {


### PR DESCRIPTION
This pull request includes a variety of changes across documentation, configuration, and code functionality. Key updates include improvements to documentation for contributors, the addition of a new environment variable, removal of deprecated code, and adjustments to backend logic for handling output selection in custom components.

### Documentation Updates:
* [`docs/docs/Contributing/contributing-how-to-contribute.md`](diffhunk://#diff-533ff347191d114e5bd68d07c2c2c12beda984ff8f22bb513f44e95b648f8d5bR116-R122): Added links to additional contribution guides for bundles, components, tests, and templates to provide more detailed instructions for contributors.
* [`docs/docs/Configuration/environment-variables.md`](diffhunk://#diff-399d4d1c73ad43a4b15b37260a4e6dd7c5b102a0fb003123c60eb824a2ecc705R194): Introduced the `LANGFLOW_DISABLE_TRACK_APIKEY_USAGE` environment variable to allow disabling API key usage tracking under high concurrency.

### Codebase Simplification:
* [`src/backend/base/langflow/custom/custom_component/component.py`](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169L542): Removed calls to `output.set_selected()` in `_set_output_return_type` and `to_frontend_node` methods, simplifying output handling logic. [[1]](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169L542) [[2]](diffhunk://#diff-22fd745de33f20981c7cbcbf3c91d4a6f8719de20761eb22cf42f8ed6ec50169L854)
* [`src/backend/base/langflow/custom/utils.py`](diffhunk://#diff-2e2f6c39b81a54132b9626a70077b7080d44556fd1aa79bd029ecf5a98d88646L383-R389): Refactored logic for setting selected outputs in `build_custom_component_template_from_inputs`, ensuring proper handling of selected outputs based on field configuration.

### Configuration Changes:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L236-L245): Removed the `call_docker_build_main_ep` job, simplifying the release workflow by eliminating unused Docker build logic.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the project version to `1.4.3` and synchronized the dependency version for `langflow-base` to `0.4.3`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L13-R20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved handling of output selection to better preserve user preferences during component updates.
- **Tests**
  - Removed tests related to the previous output selection mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->