### PR TITLE
optimize: move get_all_flows_similar_to_project() out of loop to avoi…

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -882,6 +882,7 @@ async def create_or_update_starter_projects(all_types_dict: dict, *, do_create: 
         starter_projects = await load_starter_projects()
         await delete_start_projects(session, new_folder.id)
         await copy_profile_pictures()
+        existing_flows = await get_all_flows_similar_to_project(session, new_folder.id)
         for project_path, project in starter_projects:
             (
                 project_name,
@@ -905,7 +906,6 @@ async def create_or_update_starter_projects(all_types_dict: dict, *, do_create: 
                     # We also need to update the project data in the file
                     await update_project_file(project_path, project, updated_project_data)
             if do_create and project_name and project_data:
-                existing_flows = await get_all_flows_similar_to_project(session, new_folder.id)
                 for existing_project in existing_flows:
                     await session.delete(existing_project)
 


### PR DESCRIPTION
…d redundant DB queries

Previously, get_all_flows_similar_to_project() was called inside the for-loop over starter_projects, resulting in dozens of identical database queries during startup. This change moves the query outside the loop and caches the result, significantly improving startup performance and reducing load on the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved performance when setting up starter projects by optimizing how existing flows are retrieved. End users may experience faster initialization times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->