### PR TITLE
tests: Add pyleak for task and thread leak detection in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ dev = [
     'elevenlabs>=1.52.0; python_version != "3.12"',
     "faker>=37.0.0",
     "pytest-timeout>=2.3.1",
+    "pyleak>=0.1.8",
 ]
 
 [tool.uv.sources]

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -31,6 +31,14 @@ from langflow.services.database.models.vertex_builds.crud import delete_vertex_b
 from langflow.services.database.utils import session_getter
 from langflow.services.deps import get_db_service, session_scope
 from loguru import logger
+from pyleak import (
+    EventLoopBlockError,
+    TaskLeakError,
+    ThreadLeakError,
+    no_event_loop_blocking,
+    no_task_leaks,
+    no_thread_leaks,
+)
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, SQLModel, create_engine, select
@@ -355,6 +363,21 @@ def deactivate_tracing(monkeypatch):
     monkeypatch.setenv("LANGFLOW_DEACTIVATE_TRACING", "true")
     yield
     monkeypatch.undo()
+
+
+@pytest.fixture(autouse=True)
+async def break_if_there_are_leaky_tasks():
+    try:
+        async with no_task_leaks(action="raise", enable_creation_tracking=True):
+            with no_thread_leaks(action="raise"):
+                with no_event_loop_blocking(action="raise"):
+                    yield
+    except TaskLeakError as e:
+        pytest.fail(str(e))
+    except ThreadLeakError as e:
+        pytest.fail(str(e))
+    except EventLoopBlockError as e:
+        pytest.fail(str(e))
 
 
 @pytest.fixture(name="client")

--- a/uv.lock
+++ b/uv.lock
@@ -4744,6 +4744,7 @@ dev = [
     { name = "pandas-stubs" },
     { name = "pre-commit" },
     { name = "pydantic-ai" },
+    { name = "pyleak" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -4916,6 +4917,7 @@ dev = [
     { name = "pandas-stubs", specifier = ">=2.1.4.231227" },
     { name = "pre-commit", specifier = ">=3.7.0" },
     { name = "pydantic-ai", specifier = ">=0.0.19" },
+    { name = "pyleak", specifier = ">=0.1.8" },
     { name = "pytest", specifier = ">=8.2.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -8180,6 +8182,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+]
+
+[[package]]
+name = "pyleak"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/c5/a8eab06c37b29348a247fdd6fdbb1eabc677bbdbda44cbad8215982d01f0/pyleak-0.1.8.tar.gz", hash = "sha256:4bdff0d6ebc2e9edbbc265ff119c65c7e140a50d3eed01b861671ad62bbbd481", size = 101499 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/c4/9b3b604d484423024e0c1e979b8beea07231afa4001361be73e74e7027f4/pyleak-0.1.8-py3-none-any.whl", hash = "sha256:3844bc9579b16ba4514b618cf27133988931a3f02af131d0f79ab2b07311109e", size = 20533 },
 ]
 
 [[package]]


### PR DESCRIPTION
Integrate pyleak into the testing framework to detect task and thread leaks, enhancing test reliability.