### PR TITLE
test: enhance node connection tests in chatMemory component 

### DIFF
--- a/src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts
+++ b/src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts
@@ -5,7 +5,7 @@ import { addLegacyComponents } from "../../utils/add-legacy-components";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { initialGPTsetup } from "../../utils/initialGPTsetup";
 test(
-  "memory should work as expect",
+  "user should be able to use chat memory as expected",
   { tag: ["@release"] },
   async ({ page }) => {
     test.skip(

--- a/src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts
+++ b/src/frontend/tests/core/regression/generalBugs-shard-9.spec.ts
@@ -87,25 +87,38 @@ AI:
     await page.getByText("Edit Prompt", { exact: true }).click();
     await page.getByText("Check & Save").last().click();
 
+    await page.getByTestId("sidebar-search-input").click();
+    await page.getByTestId("sidebar-search-input").fill("Parser");
+
+    await page
+      .getByTestId("processingParser")
+      .first()
+      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+        targetPosition: { x: 50, y: 200 },
+      });
+
     await page.getByTestId("fit_view").click();
 
-    await page.getByTestId("dropdown-output-memory").click();
-
-    await page.getByTestId("dropdown-item-output-memory-message").click();
+    await page.getByTestId("tab_0_retrieve").click();
 
     //connection 1
-    const elementChatMemoryOutput = await page
-      .getByTestId("handle-memory-shownode-message-right")
-      .first();
-    await elementChatMemoryOutput.hover();
-    await page.mouse.down();
+    await page
+      .getByTestId("handle-memory-shownode-messages-right")
+      .first()
+      .click();
 
-    const promptInput = await page.getByTestId(
-      "handle-prompt-shownode-context-left",
-    );
+    await page
+      .getByTestId("handle-parsercomponent-shownode-data or dataframe-left")
+      .click();
 
-    await promptInput.hover();
-    await page.mouse.up();
+    await page
+      .getByTestId("handle-parsercomponent-shownode-parsed text-right")
+      .click();
+
+    await page
+      .getByTestId("handle-prompt-shownode-context-left")
+      .first()
+      .click();
 
     await page.locator('//*[@id="react-flow-id"]').hover();
 


### PR DESCRIPTION
This pull request updates the `generalBugs-shard-9.spec.ts` test file to enhance the regression tests for the frontend. The changes focus on improving test coverage for the drag-and-drop functionality, adding interactions with new UI elements, and refining test steps for better accuracy.

### Enhancements to regression tests:

* Replaced the click action on `fit_view` with interactions involving the `sidebar-search-input`, including clicking, filling with "Parser", and dragging the `processingParser` element to a specific position on the flowchart canvas.
* Updated the test to include clicking on the `tab_0_retrieve` element, ensuring coverage for tab navigation functionality.

### Refinements to test steps:

* Modified node connection steps by replacing hover and mouse down/up actions with direct click interactions on specific test IDs, such as `handle-memory-shownode-messages-right` and `handle-parsercomponent-shownode-data or dataframe-left`.
* Added additional click interactions for `handle-parsercomponent-shownode-parsed text-right` and `handle-prompt-shownode-context-left` to streamline node connection testing.