### PR TITLE
refactor(ui): remove Tool Mode option from node toolbar

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx
@@ -711,20 +711,6 @@ const NodeToolbarComponent = memo(
                     </span>
                   </div>
                 </SelectItem>
-                {hasToolMode && (
-                  <SelectItem value="toolMode">
-                    <ToolbarSelectItem
-                      shortcut={
-                        shortcuts.find((obj) => obj.name === "Tool Mode")
-                          ?.shortcut!
-                      }
-                      value={"Tool Mode"}
-                      icon={"Hammer"}
-                      dataTestId="tool-mode-button"
-                      style={`${toolMode ? "text-primary" : ""} transition-all`}
-                    />
-                  </SelectItem>
-                )}
               </SelectContentWithoutPortal>
             </Select>
           </div>


### PR DESCRIPTION
This pull request removes the "Tool Mode" option from the `NodeToolbarComponent` in the `FlowPage` directory. The change simplifies the toolbar by eliminating the conditional rendering of the "Tool Mode" option.

### Removal of "Tool Mode" option:
* [`src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx`](diffhunk://#diff-d393b1ee50eb66298a5ab133ad2f25d072667612a1c6457f24aa6733c98131aaL714-L727): Removed the `SelectItem` for "Tool Mode," including its associated properties such as the shortcut, icon, and styling. This change reduces complexity in the toolbar component.