### PR TITLE
feat: improve component as tool output serialization

### DIFF
--- a/src/backend/base/langflow/base/tools/component_tool.py
+++ b/src/backend/base/langflow/base/tools/component_tool.py
@@ -13,6 +13,7 @@ from langflow.base.tools.constants import TOOL_OUTPUT_NAME
 from langflow.io.schema import create_input_schema, create_input_schema_from_dict
 from langflow.schema.data import Data
 from langflow.schema.message import Message
+from langflow.serialization.serialization import serialize_or_str
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -108,9 +109,10 @@ def _build_output_function(component: Component, output_method: Callable, event_
             return result.get_text()
         if isinstance(result, Data):
             return result.data
+        # removing the model_dump() call here because it is not serializable
         if isinstance(result, BaseModel):
-            return result.model_dump()
-        return result
+            return serialize_or_str(result)
+        return serialize_or_str(result)
 
     return _patch_send_message_decorator(component, output_function)
 
@@ -132,9 +134,10 @@ def _build_output_async_function(
             return result.get_text()
         if isinstance(result, Data):
             return result.data
+        # removing the model_dump() call here because it is not serializable
         if isinstance(result, BaseModel):
-            return result.model_dump()
-        return result
+            return serialize_or_str(result)
+        return serialize_or_str(result)
 
     return _patch_send_message_decorator(component, output_function)
 


### PR DESCRIPTION
This pull request updates the `output_function` logic in `component_tool.py` to improve serialization handling for `BaseModel` instances. The most important changes include replacing the `model_dump()` method with a new `serialize_or_str` function and importing the necessary utility for this change.

### Serialization improvements:

* [`src/backend/base/langflow/base/tools/component_tool.py`](diffhunk://#diff-e6b607a8c5e404d2d308314cf694b33701ebcd21f8d564b6932c522d3a5e02cbR16): Added an import for `serialize_or_str` from `langflow.serialization.serialization` to handle serialization more effectively.
* [`src/backend/base/langflow/base/tools/component_tool.py`](diffhunk://#diff-e6b607a8c5e404d2d308314cf694b33701ebcd21f8d564b6932c522d3a5e02cbR112-R115): Updated the `output_function` and `async def output_function` to replace the `model_dump()` call with `serialize_or_str` for `BaseModel` instances, ensuring compatibility with non-serializable objects. [[1]](diffhunk://#diff-e6b607a8c5e404d2d308314cf694b33701ebcd21f8d564b6932c522d3a5e02cbR112-R115) [[2]](diffhunk://#diff-e6b607a8c5e404d2d308314cf694b33701ebcd21f8d564b6932c522d3a5e02cbR137-R140)