### PR TITLE
fix: main branch ruff error in NV Ingest

### DIFF
--- a/src/backend/base/langflow/components/nvidia/nvidia_ingest.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia_ingest.py
@@ -3,7 +3,6 @@ from urllib.parse import urlparse
 from pypdf import PdfReader
 
 from langflow.base.data import BaseFileComponent
-from langflow.base.data.base_file import BaseFileComponent
 from langflow.inputs.inputs import BoolInput, DropdownInput, FloatInput, IntInput, MessageTextInput, SecretStrInput
 from langflow.schema.data import Data
 


### PR DESCRIPTION
This pull request includes a minor cleanup in the `src/backend/base/langflow/components/nvidia/nvidia_ingest.py` file. The duplicate import of `BaseFileComponent` from `langflow.base.data.base_file` was removed, as it is already imported from `langflow.base.data`.