### PR TITLE
bug: multiple templates present disconnected edges due to wrong output type logic

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -3391,6 +3391,7 @@
             "metadata": {},
             "minimized": false,
             "output_types": [],
+            "selected_output": "dataframe",
             "outputs": [
               {
                 "allows_loop": false,

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputParameter/NodeOutputs.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeOutputParameter/NodeOutputs.tsx
@@ -77,11 +77,17 @@ export default function NodeOutputs({
         ? outputs.filter((output) => output.hidden)
         : outputs.filter((output) => !output.hidden);
 
-    if (selectedOutput) {
-      return (
-        filteredOutputs.find((output) => output.name === selectedOutput.name) ||
-        filteredOutputs[0]
-      );
+    console.log("data.node", data.node.selected_output);
+
+    if (data.node?.selected_output) {
+      const selectedByField =
+        filteredOutputs.find(
+          (output) => output.name === data.node.selected_output,
+        ) || filteredOutputs[0];
+
+      if (selectedByField) {
+        return selectedByField;
+      }
     }
 
     const outputWithSelection = filteredOutputs.find(


### PR DESCRIPTION
This pull request introduces a new feature to handle a `selected_output` property for components, ensuring better control over output selection and validation. The changes span backend and frontend code, adding validation, serialization, and handling of the `selected_output` field.

### Backend changes:

* **Added `selected_output` field to `Component` class**: This optional field allows specifying a selected output for a component. (`src/backend/base/langflow/custom/custom_component/component.py`)
* **Validation of `selected_output`**: Added a `_validate_outputs` method to ensure that the `selected_output` value is valid and matches one of the available output names. Raises a `ValueError` if the validation fails. (`src/backend/base/langflow/custom/custom_component/component.py`)
* **Updated `to_frontend_node` method**: Modified the method to include `selected_output` in the serialized node dictionary if it is specified. (`src/backend/base/langflow/custom/custom_component/component.py`)
* **Starter project JSON update**: Added a `selected_output` field with the value `"dataframe"` in the `Vector Store RAG.json` starter project. (`src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json`)

### Frontend changes:

* **Enhanced `NodeOutputs` component**: Updated the logic to handle the `selected_output` field from the backend, ensuring the correct output is selected based on the field's value. (`src/frontend/src/CustomNodes/GenericNode/components/NodeOutputParameter/NodeOutputs.tsx`)