### PR TITLE
fix: LFOSS-1227 - Type hint consistency

### DIFF
--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -15,7 +15,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.websockets import WebSocket
 
 from langflow.services.database.models.api_key.crud import check_key
-from langflow.services.database.models.user.crud import get_user_by_id, get_user_by_username, update_user_last_login_at
+from langflow.services.database.models.user.crud import (
+    get_user_by_id,
+    get_user_by_username,
+    update_user_last_login_at,
+)
 from langflow.services.database.models.user.model import User, UserRead
 from langflow.services.deps import get_db_service, get_session, get_settings_service
 from langflow.services.settings.service import SettingsService
@@ -27,8 +31,12 @@ oauth2_login = OAuth2PasswordBearer(tokenUrl="api/v1/login", auto_error=False)
 
 API_KEY_NAME = "x-api-key"
 
-api_key_query = APIKeyQuery(name=API_KEY_NAME, scheme_name="API key query", auto_error=False)
-api_key_header = APIKeyHeader(name=API_KEY_NAME, scheme_name="API key header", auto_error=False)
+api_key_query = APIKeyQuery(
+    name=API_KEY_NAME, scheme_name="API key query", auto_error=False
+)
+api_key_header = APIKeyHeader(
+    name=API_KEY_NAME, scheme_name="API key header", auto_error=False
+)
 
 MINIMUM_KEY_LENGTH = 32
 
@@ -61,7 +69,9 @@ async def api_key_security(
             if query_param or header_param:
                 result = await check_key(db, query_param or header_param)
             else:
-                result = await get_user_by_username(db, settings_service.auth_settings.SUPERUSER)
+                result = await get_user_by_username(
+                    db, settings_service.auth_settings.SUPERUSER
+                )
 
         elif not query_param and not header_param:
             raise HTTPException(
@@ -99,14 +109,18 @@ async def ws_api_key_security(
                     reason="Missing first superuser credentials",
                 )
             warnings.warn(
-                ("In v1.5, AUTO_LOGIN will *require* a valid API key or JWT. Please update your clients accordingly."),
+                (
+                    "In v1.5, AUTO_LOGIN will *require* a valid API key or JWT. Please update your clients accordingly."
+                ),
                 DeprecationWarning,
                 stacklevel=2,
             )
             if api_key:
                 result = await check_key(db, api_key)
             else:
-                result = await get_user_by_username(db, settings.auth_settings.SUPERUSER)
+                result = await get_user_by_username(
+                    db, settings.auth_settings.SUPERUSER
+                )
 
         # normal path: must provide an API key
         else:
@@ -140,7 +154,7 @@ async def get_current_user(
     query_param: Annotated[str, Security(api_key_query)],
     header_param: Annotated[str, Security(api_key_header)],
     db: Annotated[AsyncSession, Depends(get_session)],
-) -> User:
+) -> User | UserRead:
     if token:
         return await get_current_user_by_jwt(token, db)
     user = await api_key_security(query_param, header_param)
@@ -175,7 +189,9 @@ async def get_current_user_by_jwt(
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            payload = jwt.decode(token, secret_key, algorithms=[settings_service.auth_settings.ALGORITHM])
+            payload = jwt.decode(
+                token, secret_key, algorithms=[settings_service.auth_settings.ALGORITHM]
+            )
         user_id: UUID = payload.get("sub")  # type: ignore[assignment]
         token_type: str = payload.get("type")  # type: ignore[assignment]
         if expires := payload.get("exp", None):
@@ -218,7 +234,9 @@ async def get_current_user_for_websocket(
     websocket: WebSocket,
     db: AsyncSession,
 ) -> User | UserRead:
-    token = websocket.cookies.get("access_token_lf") or websocket.query_params.get("token")
+    token = websocket.cookies.get("access_token_lf") or websocket.query_params.get(
+        "token"
+    )
     if token:
         user = await get_current_user_by_jwt(token, db)
         if user:
@@ -236,27 +254,41 @@ async def get_current_user_for_websocket(
             return user_read
 
     raise WebSocketException(
-        code=status.WS_1008_POLICY_VIOLATION, reason="Missing or invalid credentials (cookie, token or API key)."
+        code=status.WS_1008_POLICY_VIOLATION,
+        reason="Missing or invalid credentials (cookie, token or API key).",
     )
 
 
-async def get_current_active_user(current_user: Annotated[User, Depends(get_current_user)]):
+async def get_current_active_user(
+    current_user: Annotated[User, Depends(get_current_user)],
+):
     if not current_user.is_active:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive user")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive user"
+        )
     return current_user
 
 
-async def get_current_active_superuser(current_user: Annotated[User, Depends(get_current_user)]) -> User:
+async def get_current_active_superuser(
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> User:
     if not current_user.is_active:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive user")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive user"
+        )
     if not current_user.is_superuser:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="The user doesn't have enough privileges")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The user doesn't have enough privileges",
+        )
     return current_user
 
 
 def verify_password(plain_password, hashed_password):
     settings_service = get_settings_service()
-    return settings_service.auth_settings.pwd_context.verify(plain_password, hashed_password)
+    return settings_service.auth_settings.pwd_context.verify(
+        plain_password, hashed_password
+    )
 
 
 def get_password_hash(password):
@@ -307,7 +339,10 @@ async def create_user_longterm_token(db: AsyncSession) -> tuple[UUID, dict]:
     username = settings_service.auth_settings.SUPERUSER
     super_user = await get_user_by_username(db, username)
     if not super_user:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Super user hasn't been created")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Super user hasn't been created",
+        )
     access_token_expires_longterm = timedelta(days=365)
     access_token = create_token(
         data={"sub": str(super_user.id), "type": "access"},
@@ -341,16 +376,22 @@ def get_user_id_from_token(token: str) -> UUID:
         return UUID(int=0)
 
 
-async def create_user_tokens(user_id: UUID, db: AsyncSession, *, update_last_login: bool = False) -> dict:
+async def create_user_tokens(
+    user_id: UUID, db: AsyncSession, *, update_last_login: bool = False
+) -> dict:
     settings_service = get_settings_service()
 
-    access_token_expires = timedelta(seconds=settings_service.auth_settings.ACCESS_TOKEN_EXPIRE_SECONDS)
+    access_token_expires = timedelta(
+        seconds=settings_service.auth_settings.ACCESS_TOKEN_EXPIRE_SECONDS
+    )
     access_token = create_token(
         data={"sub": str(user_id), "type": "access"},
         expires_delta=access_token_expires,
     )
 
-    refresh_token_expires = timedelta(seconds=settings_service.auth_settings.REFRESH_TOKEN_EXPIRE_SECONDS)
+    refresh_token_expires = timedelta(
+        seconds=settings_service.auth_settings.REFRESH_TOKEN_EXPIRE_SECONDS
+    )
     refresh_token = create_token(
         data={"sub": str(user_id), "type": "refresh"},
         expires_delta=refresh_token_expires,
@@ -383,12 +424,16 @@ async def create_refresh_token(refresh_token: str, db: AsyncSession):
         token_type: str = payload.get("type")  # type: ignore[assignment]
 
         if user_id is None or token_type == "":
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token"
+            )
 
         user_exists = await get_user_by_id(db, user_id)
 
         if user_exists is None:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token"
+            )
 
         return await create_user_tokens(user_id, db)
 
@@ -400,7 +445,9 @@ async def create_refresh_token(refresh_token: str, db: AsyncSession):
         ) from e
 
 
-async def authenticate_user(username: str, password: str, db: AsyncSession) -> User | None:
+async def authenticate_user(
+    username: str, password: str, db: AsyncSession
+) -> User | None:
     user = await get_user_by_username(db, username)
 
     if not user:
@@ -408,8 +455,12 @@ async def authenticate_user(username: str, password: str, db: AsyncSession) -> U
 
     if not user.is_active:
         if not user.last_login_at:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Waiting for approval")
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive user")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail="Waiting for approval"
+            )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive user"
+        )
 
     return user if verify_password(password, user.password) else None
 

--- a/src/backend/tests/unit/utils/test_user_auth.py
+++ b/src/backend/tests/unit/utils/test_user_auth.py
@@ -1,12 +1,12 @@
-import pytest
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
-from datetime import datetime, timezone
-from fastapi import HTTPException, status
-from sqlmodel.ext.asyncio.session import AsyncSession
 
+import pytest
+from fastapi import HTTPException, status
 from langflow.services.auth.utils import get_current_user
 from langflow.services.database.models.user.model import User, UserRead
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 @pytest.fixture
@@ -53,17 +53,13 @@ class TestGetCurrentUser:
     """Test cases for get_current_user function."""
 
     @pytest.mark.asyncio
-    async def test_get_current_user_with_valid_jwt_returns_user(
-        self, mock_db, mock_user
-    ):
+    async def test_get_current_user_with_valid_jwt_returns_user(self, mock_db, mock_user):
         """Test that valid JWT token returns User object."""
         token = "valid.jwt.token"
         query_param = None
         header_param = None
 
-        with patch(
-            "langflow.services.auth.utils.get_current_user_by_jwt"
-        ) as mock_jwt_auth:
+        with patch("langflow.services.auth.utils.get_current_user_by_jwt") as mock_jwt_auth:
             mock_jwt_auth.return_value = mock_user
 
             result = await get_current_user(token, query_param, header_param, mock_db)
@@ -74,17 +70,13 @@ class TestGetCurrentUser:
 
     # Run this to test the new type hint as per LFOSS-1227
     @pytest.mark.asyncio
-    async def test_get_current_user_with_valid_api_key_returns_user_read(
-        self, mock_db, mock_user_read
-    ):
+    async def test_get_current_user_with_valid_api_key_returns_user_read(self, mock_db, mock_user_read):
         """Test that valid API key returns UserRead object."""
         token = None
         query_param = "valid-api-key"
         header_param = None
 
-        with patch(
-            "langflow.services.auth.utils.api_key_security"
-        ) as mock_api_key_auth:
+        with patch("langflow.services.auth.utils.api_key_security") as mock_api_key_auth:
             mock_api_key_auth.return_value = mock_user_read
 
             result = await get_current_user(token, query_param, header_param, mock_db)
@@ -94,17 +86,13 @@ class TestGetCurrentUser:
             mock_api_key_auth.assert_called_once_with(query_param, header_param)
 
     @pytest.mark.asyncio
-    async def test_get_current_user_with_api_key_in_header_returns_user_read(
-        self, mock_db, mock_user_read
-    ):
+    async def test_get_current_user_with_api_key_in_header_returns_user_read(self, mock_db, mock_user_read):
         """Test that valid API key in header returns UserRead object."""
         token = None
         query_param = None
         header_param = "valid-api-key-header"
 
-        with patch(
-            "langflow.services.auth.utils.api_key_security"
-        ) as mock_api_key_auth:
+        with patch("langflow.services.auth.utils.api_key_security") as mock_api_key_auth:
             mock_api_key_auth.return_value = mock_user_read
 
             result = await get_current_user(token, query_param, header_param, mock_db)
@@ -114,18 +102,14 @@ class TestGetCurrentUser:
             mock_api_key_auth.assert_called_once_with(query_param, header_param)
 
     @pytest.mark.asyncio
-    async def test_get_current_user_jwt_takes_precedence_over_api_key(
-        self, mock_db, mock_user, mock_user_read
-    ):
+    async def test_get_current_user_jwt_takes_precedence_over_api_key(self, mock_db, mock_user, mock_user_read):
         """Test that JWT token takes precedence over API key when both are provided."""
         token = "valid.jwt.token"
         query_param = "valid-api-key"
         header_param = "valid-api-key-header"
 
         with (
-            patch(
-                "langflow.services.auth.utils.get_current_user_by_jwt"
-            ) as mock_jwt_auth,
+            patch("langflow.services.auth.utils.get_current_user_by_jwt") as mock_jwt_auth,
             patch("langflow.services.auth.utils.api_key_security") as mock_api_key_auth,
         ):
             mock_jwt_auth.return_value = mock_user
@@ -145,12 +129,8 @@ class TestGetCurrentUser:
         query_param = "valid-api-key"
         header_param = None
 
-        with patch(
-            "langflow.services.auth.utils.get_current_user_by_jwt"
-        ) as mock_jwt_auth:
-            mock_jwt_auth.side_effect = HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
-            )
+        with patch("langflow.services.auth.utils.get_current_user_by_jwt") as mock_jwt_auth:
+            mock_jwt_auth.side_effect = HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
 
             # JWT exception should be propagated, not caught
             with pytest.raises(HTTPException) as exc_info:
@@ -167,9 +147,7 @@ class TestGetCurrentUser:
         query_param = None
         header_param = None
 
-        with patch(
-            "langflow.services.auth.utils.api_key_security"
-        ) as mock_api_key_auth:
+        with patch("langflow.services.auth.utils.api_key_security") as mock_api_key_auth:
             mock_api_key_auth.return_value = None
 
             with pytest.raises(HTTPException) as exc_info:
@@ -179,17 +157,13 @@ class TestGetCurrentUser:
             assert "Invalid or missing API key" in exc_info.value.detail
 
     @pytest.mark.asyncio
-    async def test_get_current_user_with_invalid_api_key_raises_forbidden(
-        self, mock_db
-    ):
+    async def test_get_current_user_with_invalid_api_key_raises_forbidden(self, mock_db):
         """Test that invalid API key raises 403 Forbidden."""
         token = None
         query_param = "invalid-api-key"
         header_param = None
 
-        with patch(
-            "langflow.services.auth.utils.api_key_security"
-        ) as mock_api_key_auth:
+        with patch("langflow.services.auth.utils.api_key_security") as mock_api_key_auth:
             mock_api_key_auth.return_value = None
 
             with pytest.raises(HTTPException) as exc_info:
@@ -205,9 +179,7 @@ class TestGetCurrentUser:
         query_param = "some-api-key"
         header_param = None
 
-        with patch(
-            "langflow.services.auth.utils.api_key_security"
-        ) as mock_api_key_auth:
+        with patch("langflow.services.auth.utils.api_key_security") as mock_api_key_auth:
             mock_api_key_auth.side_effect = HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="API key validation failed",
@@ -221,17 +193,13 @@ class TestGetCurrentUser:
 
     # Run this to test the new type hint as per LFOSS-1227
     @pytest.mark.asyncio
-    async def test_get_current_user_empty_string_token_uses_api_key(
-        self, mock_db, mock_user_read
-    ):
+    async def test_get_current_user_empty_string_token_uses_api_key(self, mock_db, mock_user_read):
         """Test that empty string token falls back to API key authentication."""
         token = ""
         query_param = "valid-api-key"
         header_param = None
 
-        with patch(
-            "langflow.services.auth.utils.api_key_security"
-        ) as mock_api_key_auth:
+        with patch("langflow.services.auth.utils.api_key_security") as mock_api_key_auth:
             mock_api_key_auth.return_value = mock_user_read
 
             result = await get_current_user(token, query_param, header_param, mock_db)
@@ -248,13 +216,9 @@ class TestGetCurrentUser:
         header_param = None
 
         # Whitespace token will be treated as a JWT token and fail validation
-        with patch(
-            "langflow.services.auth.utils.get_current_user_by_jwt"
-        ) as mock_jwt_auth:
+        with patch("langflow.services.auth.utils.get_current_user_by_jwt") as mock_jwt_auth:
             # The JWT library will raise a ValueError for malformed tokens
-            mock_jwt_auth.side_effect = ValueError(
-                "not enough values to unpack (expected 2, got 1)"
-            )
+            mock_jwt_auth.side_effect = ValueError("not enough values to unpack (expected 2, got 1)")
 
             with pytest.raises(ValueError) as exc_info:
                 await get_current_user(token, query_param, header_param, mock_db)
@@ -264,17 +228,13 @@ class TestGetCurrentUser:
 
     # Run this to test the new type hint as per LFOSS-1227
     @pytest.mark.asyncio
-    async def test_get_current_user_both_api_key_params_provided(
-        self, mock_db, mock_user_read
-    ):
+    async def test_get_current_user_both_api_key_params_provided(self, mock_db, mock_user_read):
         """Test that when both query and header API keys are provided, both are passed to api_key_security."""
         token = None
         query_param = "query-api-key"
         header_param = "header-api-key"
 
-        with patch(
-            "langflow.services.auth.utils.api_key_security"
-        ) as mock_api_key_auth:
+        with patch("langflow.services.auth.utils.api_key_security") as mock_api_key_auth:
             mock_api_key_auth.return_value = mock_user_read
 
             result = await get_current_user(token, query_param, header_param, mock_db)
@@ -290,9 +250,7 @@ class TestGetCurrentUser:
         query_param = "valid-api-key"
         header_param = None
 
-        with patch(
-            "langflow.services.auth.utils.get_current_user_by_jwt"
-        ) as mock_jwt_auth:
+        with patch("langflow.services.auth.utils.get_current_user_by_jwt") as mock_jwt_auth:
             mock_jwt_auth.side_effect = HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Database connection failed",
@@ -311,9 +269,7 @@ class TestGetCurrentUser:
         query_param = "some-api-key"
         header_param = None
 
-        with patch(
-            "langflow.services.auth.utils.api_key_security"
-        ) as mock_api_key_auth:
+        with patch("langflow.services.auth.utils.api_key_security") as mock_api_key_auth:
             mock_api_key_auth.side_effect = HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="API key service unavailable",
@@ -332,9 +288,7 @@ class TestGetCurrentUser:
         query_param = None
         header_param = None
 
-        with patch(
-            "langflow.services.auth.utils.get_current_user_by_jwt"
-        ) as mock_jwt_auth:
+        with patch("langflow.services.auth.utils.get_current_user_by_jwt") as mock_jwt_auth:
             # Simulate JWT library error for malformed token
             mock_jwt_auth.side_effect = HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid JWT format"

--- a/src/backend/tests/unit/utils/test_user_auth.py
+++ b/src/backend/tests/unit/utils/test_user_auth.py
@@ -1,0 +1,348 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+from datetime import datetime, timezone
+from fastapi import HTTPException, status
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from langflow.services.auth.utils import get_current_user
+from langflow.services.database.models.user.model import User, UserRead
+
+
+@pytest.fixture
+def mock_db():
+    return AsyncMock(spec=AsyncSession)
+
+
+@pytest.fixture
+def mock_user():
+    now = datetime.now(timezone.utc)
+    return User(
+        id=uuid4(),
+        username="langflowrocks",
+        password="senhasecreta",
+        is_active=True,
+        is_superuser=False,
+        last_login_at=now,
+        profile_image=None,
+        store_api_key=None,
+        create_at=now,
+        updated_at=now,
+        optins=None,
+    )
+
+
+@pytest.fixture
+def mock_user_read():
+    now = datetime.now(timezone.utc)
+    return UserRead(
+        id=uuid4(),
+        username="langflowrocks",
+        is_active=True,
+        is_superuser=False,
+        last_login_at=now,
+        profile_image=None,
+        store_api_key=None,
+        create_at=now,
+        updated_at=now,
+        optins=None,
+    )
+
+
+class TestGetCurrentUser:
+    """Test cases for get_current_user function."""
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_with_valid_jwt_returns_user(
+        self, mock_db, mock_user
+    ):
+        """Test that valid JWT token returns User object."""
+        token = "valid.jwt.token"
+        query_param = None
+        header_param = None
+
+        with patch(
+            "langflow.services.auth.utils.get_current_user_by_jwt"
+        ) as mock_jwt_auth:
+            mock_jwt_auth.return_value = mock_user
+
+            result = await get_current_user(token, query_param, header_param, mock_db)
+
+            assert isinstance(result, User)
+            assert result == mock_user
+            mock_jwt_auth.assert_called_once_with(token, mock_db)
+
+    # Run this to test the new type hint as per LFOSS-1227
+    @pytest.mark.asyncio
+    async def test_get_current_user_with_valid_api_key_returns_user_read(
+        self, mock_db, mock_user_read
+    ):
+        """Test that valid API key returns UserRead object."""
+        token = None
+        query_param = "valid-api-key"
+        header_param = None
+
+        with patch(
+            "langflow.services.auth.utils.api_key_security"
+        ) as mock_api_key_auth:
+            mock_api_key_auth.return_value = mock_user_read
+
+            result = await get_current_user(token, query_param, header_param, mock_db)
+
+            assert isinstance(result, UserRead)
+            assert result == mock_user_read
+            mock_api_key_auth.assert_called_once_with(query_param, header_param)
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_with_api_key_in_header_returns_user_read(
+        self, mock_db, mock_user_read
+    ):
+        """Test that valid API key in header returns UserRead object."""
+        token = None
+        query_param = None
+        header_param = "valid-api-key-header"
+
+        with patch(
+            "langflow.services.auth.utils.api_key_security"
+        ) as mock_api_key_auth:
+            mock_api_key_auth.return_value = mock_user_read
+
+            result = await get_current_user(token, query_param, header_param, mock_db)
+
+            assert isinstance(result, UserRead)
+            assert result == mock_user_read
+            mock_api_key_auth.assert_called_once_with(query_param, header_param)
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_jwt_takes_precedence_over_api_key(
+        self, mock_db, mock_user, mock_user_read
+    ):
+        """Test that JWT token takes precedence over API key when both are provided."""
+        token = "valid.jwt.token"
+        query_param = "valid-api-key"
+        header_param = "valid-api-key-header"
+
+        with (
+            patch(
+                "langflow.services.auth.utils.get_current_user_by_jwt"
+            ) as mock_jwt_auth,
+            patch("langflow.services.auth.utils.api_key_security") as mock_api_key_auth,
+        ):
+            mock_jwt_auth.return_value = mock_user
+            mock_api_key_auth.return_value = mock_user_read
+
+            result = await get_current_user(token, query_param, header_param, mock_db)
+
+            assert isinstance(result, User)
+            assert result == mock_user
+            mock_jwt_auth.assert_called_once_with(token, mock_db)
+            mock_api_key_auth.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_with_invalid_jwt_propagates_error(self, mock_db):
+        """Test that invalid JWT token propagates the JWT error."""
+        token = "invalid.jwt.token"
+        query_param = "valid-api-key"
+        header_param = None
+
+        with patch(
+            "langflow.services.auth.utils.get_current_user_by_jwt"
+        ) as mock_jwt_auth:
+            mock_jwt_auth.side_effect = HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            )
+
+            # JWT exception should be propagated, not caught
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(token, query_param, header_param, mock_db)
+
+            assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+            assert "Invalid token" in exc_info.value.detail
+            mock_jwt_auth.assert_called_once_with(token, mock_db)
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_with_no_credentials_raises_forbidden(self, mock_db):
+        """Test that no credentials raises 403 Forbidden."""
+        token = None
+        query_param = None
+        header_param = None
+
+        with patch(
+            "langflow.services.auth.utils.api_key_security"
+        ) as mock_api_key_auth:
+            mock_api_key_auth.return_value = None
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(token, query_param, header_param, mock_db)
+
+            assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+            assert "Invalid or missing API key" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_with_invalid_api_key_raises_forbidden(
+        self, mock_db
+    ):
+        """Test that invalid API key raises 403 Forbidden."""
+        token = None
+        query_param = "invalid-api-key"
+        header_param = None
+
+        with patch(
+            "langflow.services.auth.utils.api_key_security"
+        ) as mock_api_key_auth:
+            mock_api_key_auth.return_value = None
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(token, query_param, header_param, mock_db)
+
+            assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+            assert "Invalid or missing API key" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_api_key_security_raises_exception(self, mock_db):
+        """Test that api_key_security exceptions are propagated."""
+        token = None
+        query_param = "some-api-key"
+        header_param = None
+
+        with patch(
+            "langflow.services.auth.utils.api_key_security"
+        ) as mock_api_key_auth:
+            mock_api_key_auth.side_effect = HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="API key validation failed",
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(token, query_param, header_param, mock_db)
+
+            assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+            assert "API key validation failed" in exc_info.value.detail
+
+    # Run this to test the new type hint as per LFOSS-1227
+    @pytest.mark.asyncio
+    async def test_get_current_user_empty_string_token_uses_api_key(
+        self, mock_db, mock_user_read
+    ):
+        """Test that empty string token falls back to API key authentication."""
+        token = ""
+        query_param = "valid-api-key"
+        header_param = None
+
+        with patch(
+            "langflow.services.auth.utils.api_key_security"
+        ) as mock_api_key_auth:
+            mock_api_key_auth.return_value = mock_user_read
+
+            result = await get_current_user(token, query_param, header_param, mock_db)
+
+            assert isinstance(result, UserRead)
+            assert result == mock_user_read
+            mock_api_key_auth.assert_called_once_with(query_param, header_param)
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_whitespace_token_causes_jwt_error(self, mock_db):
+        """Test that whitespace-only token causes JWT validation error."""
+        token = "   "
+        query_param = "valid-api-key"
+        header_param = None
+
+        # Whitespace token will be treated as a JWT token and fail validation
+        with patch(
+            "langflow.services.auth.utils.get_current_user_by_jwt"
+        ) as mock_jwt_auth:
+            # The JWT library will raise a ValueError for malformed tokens
+            mock_jwt_auth.side_effect = ValueError(
+                "not enough values to unpack (expected 2, got 1)"
+            )
+
+            with pytest.raises(ValueError) as exc_info:
+                await get_current_user(token, query_param, header_param, mock_db)
+
+            assert "not enough values to unpack" in str(exc_info.value)
+            mock_jwt_auth.assert_called_once_with(token, mock_db)
+
+    # Run this to test the new type hint as per LFOSS-1227
+    @pytest.mark.asyncio
+    async def test_get_current_user_both_api_key_params_provided(
+        self, mock_db, mock_user_read
+    ):
+        """Test that when both query and header API keys are provided, both are passed to api_key_security."""
+        token = None
+        query_param = "query-api-key"
+        header_param = "header-api-key"
+
+        with patch(
+            "langflow.services.auth.utils.api_key_security"
+        ) as mock_api_key_auth:
+            mock_api_key_auth.return_value = mock_user_read
+
+            result = await get_current_user(token, query_param, header_param, mock_db)
+
+            assert isinstance(result, UserRead)
+            assert result == mock_user_read
+            mock_api_key_auth.assert_called_once_with(query_param, header_param)
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_jwt_server_error_propagated(self, mock_db):
+        """Test that JWT server errors are propagated."""
+        token = "some.jwt.token"
+        query_param = "valid-api-key"
+        header_param = None
+
+        with patch(
+            "langflow.services.auth.utils.get_current_user_by_jwt"
+        ) as mock_jwt_auth:
+            mock_jwt_auth.side_effect = HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Database connection failed",
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(token, query_param, header_param, mock_db)
+
+            assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+            assert "Database connection failed" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_api_key_server_error_propagated(self, mock_db):
+        """Test that API key server errors are propagated."""
+        token = None
+        query_param = "some-api-key"
+        header_param = None
+
+        with patch(
+            "langflow.services.auth.utils.api_key_security"
+        ) as mock_api_key_auth:
+            mock_api_key_auth.side_effect = HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="API key service unavailable",
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(token, query_param, header_param, mock_db)
+
+            assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+            assert "API key service unavailable" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_malformed_jwt_token_error(self, mock_db):
+        """Test that malformed JWT tokens cause appropriate errors."""
+        token = "not.a.valid.jwt.format.token"
+        query_param = None
+        header_param = None
+
+        with patch(
+            "langflow.services.auth.utils.get_current_user_by_jwt"
+        ) as mock_jwt_auth:
+            # Simulate JWT library error for malformed token
+            mock_jwt_auth.side_effect = HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid JWT format"
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(token, query_param, header_param, mock_db)
+
+            assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+            assert "Invalid JWT format" in exc_info.value.detail
+            mock_jwt_auth.assert_called_once_with(token, mock_db)


### PR DESCRIPTION
Fixes a type hint issue reported on https://datastax.jira.com/browse/LFOSS-1278. Please note the addition of UT that covers the dual return from get_current_use. It could be that other UTs already test this indirectly. 

	•	Additions – src/backend/tests/unit/utils/test_user_auth.py
	•	Modifications – src/backend/base/langflow/services/auth/utils.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved formatting and readability of authentication-related code without changing functionality.

- **Tests**
  - Added comprehensive unit tests for user authentication, covering various authentication scenarios and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->