### PR TITLE
fix: update import statement in astradb_cql.py to silence warning

### DIFF
--- a/src/backend/base/langflow/components/datastax/astradb_cql.py
+++ b/src/backend/base/langflow/components/datastax/astradb_cql.py
@@ -5,8 +5,8 @@ from http import HTTPStatus
 from typing import Any
 
 import requests
-from langchain.pydantic_v1 import BaseModel, Field, create_model
 from langchain_core.tools import StructuredTool, Tool
+from pydantic import BaseModel, Field, create_model
 
 from langflow.base.langchain_utilities.model import LCToolComponent
 from langflow.io import DictInput, IntInput, SecretStrInput, StrInput, TableInput


### PR DESCRIPTION
Replace the import statement for Pydantic to ensure compatibility with the latest version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal dependencies for improved compatibility. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->