### PR TITLE
fix: made clean edges clean after changing dropdown of output

### DIFF
--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -138,9 +138,9 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
       const name = parsedSourceHandle.name;
 
       if (sourceNode.type == "genericNode") {
-        const output = sourceNode.data.node!.outputs?.find(
-          (output) => output.name === name,
-        );
+        const output = sourceNode.data
+          .node!.outputs?.filter((output) => output.selected)
+          .find((output) => output.name === name);
 
         if (output) {
           const outputTypes =


### PR DESCRIPTION
This pull request updates the `cleanEdges` function in `src/frontend/src/utils/reactflowUtils.ts` to refine how outputs are filtered for generic nodes. The change ensures that only selected outputs are considered when matching by name.

* Modified `cleanEdges` function to filter outputs by the `selected` property before finding an output by name, improving the precision of output handling for generic nodes. (`[src/frontend/src/utils/reactflowUtils.tsL141-R143](diffhunk://#diff-a380d7691b7dad914af3baf94d210fa2df4f56c0f8533eb0e17c29bb8dc0e91cL141-R143)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy when identifying outputs in certain nodes, ensuring only selected outputs are considered during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->