### PR TITLE
fix: Typo in Milvus consistency input

### DIFF
--- a/src/backend/base/langflow/components/vectorstores/milvus.py
+++ b/src/backend/base/langflow/components/vectorstores/milvus.py
@@ -41,7 +41,7 @@ class MilvusVectorStoreComponent(LCVectorStoreComponent):
         StrInput(name="vector_field", display_name="Vector Field Name", value="vector"),
         DropdownInput(
             name="consistency_level",
-            display_name="Consistencey Level",
+            display_name="Consistency Level",
             options=["Bounded", "Session", "Strong", "Eventual"],
             value="Session",
             advanced=True,


### PR DESCRIPTION
Spotted this typo when using the Milvus node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typographical error in the "consistency_level" dropdown label, updating it from "Consistencey Level" to "Consistency Level".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->