### PR TITLE
refactor(docker): remove --extra deploy flag from uv sync commands

### DIFF
--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -40,7 +40,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=src/backend/base/README.md,target=src/backend/base/README.md \
     --mount=type=bind,source=src/backend/base/uv.lock,target=src/backend/base/uv.lock \
     --mount=type=bind,source=src/backend/base/pyproject.toml,target=src/backend/base/pyproject.toml \
-    uv sync --frozen --no-install-project --no-editable --extra deploy --extra couchbase --extra cassio --extra local --extra clickhouse-connect --extra nv-ingest --extra postgresql
+    uv sync --frozen --no-install-project --no-editable --extra couchbase --extra cassio --extra local --extra clickhouse-connect --extra nv-ingest --extra postgresql
 
 COPY ./src /app/src
 
@@ -58,7 +58,7 @@ COPY ./uv.lock /app/uv.lock
 COPY ./README.md /app/README.md
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-editable --extra deploy --extra couchbase --extra cassio --extra local --extra clickhouse-connect --extra nv-ingest --extra postgresql
+    uv sync --frozen --no-editable --extra couchbase --extra cassio --extra local --extra clickhouse-connect --extra nv-ingest --extra postgresql
 
 ################################
 # RUNTIME


### PR DESCRIPTION
This pull request makes minor adjustments to the `docker/build_and_push_with_extras.Dockerfile` to streamline the `uv sync` command by removing the `--extra deploy` flag.

Changes to `uv sync` command:

* Updated the `uv sync` command in two locations within the Dockerfile to remove the `--extra deploy` flag, simplifying the list of extras used during synchronization. (`[[1]](diffhunk://#diff-7f4f06ef3e145c4a9c5c4f56a6a7b8f0960b4ed2c09d61710600079f9d60b3ebL43-R43)`, `[[2]](diffhunk://#diff-7f4f06ef3e145c4a9c5c4f56a6a7b8f0960b4ed2c09d61710600079f9d60b3ebL61-R61)`)