### PR TITLE
ci: update setup-uv to possibly fix caching

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -10,12 +10,8 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v6
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
-
-    - name: "Set up Python"
-      uses: actions/setup-python@v5
-      with:
         python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
Upgrade the setup-uv action to version 6 and eliminate the unnecessary Python setup step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the workflow to use a newer version of the setup action for environment setup.
  - Consolidated Python and environment setup into a single step for improved efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->