### PR TITLE
fix: updated tooltip side for actions

### DIFF
--- a/src/frontend/src/components/core/canvasControlsComponent/index.tsx
+++ b/src/frontend/src/components/core/canvasControlsComponent/index.tsx
@@ -44,7 +44,7 @@ export const CustomControlButton = ({
       disabled={disabled}
       title={testId?.replace(/_/g, " ")}
     >
-      <ShadTooltip content={tooltipText} side="left">
+      <ShadTooltip content={tooltipText} side="right">
         <div className={cn("rounded p-2.5", backgroundClasses)}>
           <IconComponent
             name={iconName}


### PR DESCRIPTION
This pull request includes a small change to the `CustomControlButton` component in `src/frontend/src/components/core/canvasControlsComponent/index.tsx`. The change modifies the tooltip position from the left side to the right side.