### PR TITLE
fix: paste edges between components selected even if edges are not selected, fixed shift-select behavior

### DIFF
--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -385,6 +385,21 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
     track("Component Connection Deleted", { edgeId });
   },
   paste: (selection, position) => {
+    // Collect IDs of nodes in the selection
+    const selectedNodeIds = new Set(selection.nodes.map((node) => node.id));
+    // Find existing edges in the flow that connect nodes within the selection
+    const existingEdgesToCopy = get().edges.filter((edge) => {
+      return (
+        selectedNodeIds.has(edge.source) &&
+        selectedNodeIds.has(edge.target) &&
+        !selection.edges.some((selEdge) => selEdge.id === edge.id)
+      );
+    });
+    // Add these edges to the selection's edges
+    if (existingEdgesToCopy.length > 0) {
+      selection.edges = selection.edges.concat(existingEdgesToCopy);
+    }
+
     if (
       selection.nodes.some((node) => node.data.type === "ChatInput") &&
       checkChatInput(get().nodes)


### PR DESCRIPTION
This pull request introduces an enhancement to the `paste` functionality in the `flowStore`. The change ensures that edges connecting nodes within a selection are preserved when pasting, improving the behavior and consistency of the flow editor.

Enhancements to the `paste` functionality:

* [`src/frontend/src/stores/flowStore.ts`](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357R388-R402): Updated the `paste` method to identify and include edges connecting nodes within the selection that were not explicitly selected as edges. This ensures a more complete and accurate representation of the flow during paste operations.