### PR TITLE
fix: updated mcp server link to docs

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
@@ -218,7 +218,7 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
     "https://docs.langflow.org/mcp-server#connect-clients-to-use-the-servers-actions";
 
   const MCP_SERVER_DEPLOY_TUTORIAL_LINK =
-    "https://docs.langflow.org/mcp-server#deploy-your-server-externally";
+    "https://docs.langflow.org/mcp-server";
 
   const copyToClipboard = useCallback(() => {
     navigator.clipboard


### PR DESCRIPTION
This pull request includes a minor update to the `McpServerTab` component in the `src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx` file. The change updates a URL to point to a more general documentation page.

* Updated the `MCP_SERVER_DEPLOY_TUTORIAL_LINK` constant to reference the main MCP Server documentation page instead of a specific section. (`[src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsxL221-R221](diffhunk://#diff-da4edd139a58d412a5bba68a4e4e84c77cf40f53711bceee9c9a12da4ea2eda8L221-R221)`)