### PR TITLE
feat: Ability to bind the images instead of messages only with bytes

### DIFF
--- a/src/backend/base/langflow/base/models/chat_result.py
+++ b/src/backend/base/langflow/base/models/chat_result.py
@@ -27,6 +27,8 @@ def build_messages_and_runnable(
                         system_message_added = True
                     runnable = prompt | runnable
                 else:
+                    if hasattr(input_value, "images") and input_value.images and hasattr(original_runnable, "bind"):
+                        runnable = original_runnable.bind(images=input_value.images)
                     messages.append(input_value.to_lc_message())
         else:
             messages.append(HumanMessage(content=input_value))


### PR DESCRIPTION
It allows to use Ollama local in a faster way.
When the images are big, it bloats local llms to process images with the number of tokens being limited. 
Binding bypasses this limit. 
Tested with local LLMs wtih Ollama 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message handling to ensure images included in input messages are properly processed and incorporated during chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->