### PR TITLE
fix: Restore Prompt Component functionality by disallowing use of {code} template variable

### DIFF
--- a/src/backend/base/langflow/base/prompts/api_utils.py
+++ b/src/backend/base/langflow/base/prompts/api_utils.py
@@ -25,6 +25,7 @@ _INVALID_CHARACTERS = {
 }
 
 _INVALID_NAMES = {
+    "code",
     "input_variables",
     "output_parser",
     "partial_variables",


### PR DESCRIPTION
This pull request fixes an issue with the Prompt template when using {code} as a template variable, by disallowing that variable and providing a clean error message indicating the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to prevent the use of "code" as an input variable name in prompt templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->