### PR TITLE
ci: change nightly to run in UTC time to fix nightly-status check

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -3,8 +3,8 @@ name: Nightly Build
 on:
   workflow_dispatch:
   schedule:
-    # Run job at 6:30 UTC, 10.30pm PST, or 11.30pm PDT
-    - cron: "30 6 * * *"
+    # Run job at 00:00 UTC (4:00 PM PST / 5:00 PM PDT)
+    - cron: "0 0 * * *"
 
 env:
   POETRY_VERSION: "1.8.3"


### PR DESCRIPTION
Nightly builds ran at 06:30 UTC. `check-nightly-status` checked that the day the PR ran was the same day the latest nightly was published. Thus, there was a window where the latest published nightly was from the "day before" from the perspective of the PR, but that's just because the workflow hadn't run yet for the (UTC-based) day. 

This PR changes the nightly to run in UTC time. Seems more standard. 