### PR TITLE
feat: add configurable nginx proxy read timeout

### DIFF
--- a/docker/frontend/default.conf.template
+++ b/docker/frontend/default.conf.template
@@ -23,6 +23,7 @@ http {
         gzip_disable "MSIE [4-6] \.";
 
         listen ${FRONTEND_PORT};
+        proxy_read_timeout ${LANGFLOW_PROXY_READ_TIMEOUT}s;
 
         location / {
             root /usr/share/nginx/html;

--- a/docker/frontend/start-nginx.sh
+++ b/docker/frontend/start-nginx.sh
@@ -18,16 +18,19 @@ fi
 if [ -z "$LANGFLOW_MAX_FILE_SIZE_UPLOAD" ]; then
   LANGFLOW_MAX_FILE_SIZE_UPLOAD="1"
 fi
+if [ -z "$LANGFLOW_PROXY_READ_TIMEOUT" ]; then
+  LANGFLOW_PROXY_READ_TIMEOUT="60"
+fi
 if [ -z "$BACKEND_URL" ]; then
   echo "BACKEND_URL must be set as an environment variable or as first parameter. (e.g. http://localhost:7860)"
   exit 1
 fi
 
 # Export variables for envsubst
-export BACKEND_URL FRONTEND_PORT LANGFLOW_MAX_FILE_SIZE_UPLOAD
+export BACKEND_URL FRONTEND_PORT LANGFLOW_MAX_FILE_SIZE_UPLOAD LANGFLOW_PROXY_READ_TIMEOUT
 
 # Use envsubst to substitute environment variables in the template
-envsubst '${BACKEND_URL} ${FRONTEND_PORT} ${LANGFLOW_MAX_FILE_SIZE_UPLOAD}' < /etc/nginx/conf.d/default.conf.template > $CONFIG_DIR/default.conf
+envsubst '${BACKEND_URL} ${FRONTEND_PORT} ${LANGFLOW_MAX_FILE_SIZE_UPLOAD} ${LANGFLOW_PROXY_READ_TIMEOUT}' < /etc/nginx/conf.d/default.conf.template > $CONFIG_DIR/default.conf
 
 # Start nginx with the new configuration
 exec nginx -c $CONFIG_DIR/default.conf -g 'daemon off;'


### PR DESCRIPTION
## Description
Inspired by https://github.com/langflow-ai/langflow/pull/7664

This PR adds support for configurable nginx proxy read timeout in Docker deployments to handle long-running API requests that may exceed the default nginx timeout.

## Problem
For Docker deployments, long-running API requests (like large file processing, vector database operations, or complex workflows) may timeout due to nginx default proxy timeout settings. This causes failures for legitimate operations that require extended processing time.

Since the Nginx service is started via a `start-nginx.sh` file, adding timeout configurations to ingress annotations may not be sufficient for all deployment scenarios.

## Solution
Add support for configurable proxy read timeout using environment variable `LANGFLOW_PROXY_READ_TIMEOUT`. This follows the same pattern established in #7664 for upload size configuration.

## Changes Made
- Add `LANGFLOW_PROXY_READ_TIMEOUT` environment variable (default: 60 seconds)
- Update nginx configuration template to use configurable timeout
- Apply timeout to all proxy requests in the server block
- Export new environment variable in startup scriptㅔ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the proxy read timeout for the frontend server via an environment variable.

- **Chores**
  - Updated startup script to allow customization of the proxy read timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->