### PR TITLE
fix: ensure PdfReader is closed

### DIFF
--- a/src/backend/base/langflow/base/data/utils.py
+++ b/src/backend/base/langflow/base/data/utils.py
@@ -130,8 +130,7 @@ def read_docx_file(file_path: str) -> str:
 def parse_pdf_to_text(file_path: str) -> str:
     from pypdf import PdfReader
 
-    with Path(file_path).open("rb") as f:
-        reader = PdfReader(f)
+    with Path(file_path).open("rb") as f, PdfReader(f) as reader:
         return "\n\n".join([page.extract_text() for page in reader.pages])
 
 


### PR DESCRIPTION
The issue is that objects created by the PdfReader have a tendency to linger in memory.

I was memory profiling with `tracemalloc` my use-case and noticed a lot of Pdf-related objects in the summary. After applying this change the objects didn't show up in the trace summary and my memory consumption post-run was reduced.