### PR TITLE
docs: add tip about icon usage with Lucide in custom components doc

### DIFF
--- a/docs/docs/Components/components-custom-components.md
+++ b/docs/docs/Components/components-custom-components.md
@@ -41,6 +41,10 @@ class MyCsvReader(Component):
 * **name**: A unique internal identifier.
 * **documentation**: An optional link to external docs.
 
+:::tip Icon usage
+Langflow uses [Lucide Icons](https://lucide.dev/icons) for component visualization. To assign an icon to your component, set the icon attribute to the name of a Lucide icon (e.g., "sparkles", "file-text", "table"). Just provide the icon name as a string and Langflow will render it automatically.
+:::
+
 ### Structure of a custom component
 
 A **Langflow custom component** goes beyond a simple class with inputs and outputs. It includes an internal structure with optional lifecycle steps, output generation, front-end interaction, and logic organization.

--- a/docs/docs/Components/components-custom-components.md
+++ b/docs/docs/Components/components-custom-components.md
@@ -42,7 +42,7 @@ class MyCsvReader(Component):
 * **documentation**: An optional link to external docs.
 
 :::tip Icon usage
-Langflow uses [Lucide Icons](https://lucide.dev/icons) for component visualization. To assign an icon to your component, set the icon attribute to the name of a Lucide icon (e.g., "sparkles", "file-text", "table"). Just provide the icon name as a string and Langflow will render it automatically.
+Langflow uses [Lucide](https://lucide.dev/icons) for icons. To assign an icon to your component, set the icon attribute to the name of a Lucide icon as a string, such as `icon = "file-text"`. Langflow renders icons from the Lucide library automatically.
 :::
 
 ### Structure of a custom component


### PR DESCRIPTION
Adds a tip about using Lucide icons for custom components, explaining how to set the icon attribute with a Lucide icon name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated custom components documentation to include guidance on assigning icons using Lucide Icons by setting the `icon` attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->