### PR TITLE
fix: add max note node width

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -19,7 +19,6 @@ body {
 }
 
 .react-flow__node {
-  width: fit-content !important;
   height: auto;
   border-radius: auto;
   min-width: inherit;

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx
@@ -155,7 +155,7 @@ export default function NodeDescription({
             maxLength={charLimit}
             className={cn(
               "nowheel w-full text-xs focus:border-primary focus:ring-0",
-              stickyNote ? "p-0" : "px-2 py-0.5",
+              stickyNote ? "p-0 pt-0.5 !text-mmd" : "px-2 py-0.5",
               inputClassName,
             )}
             autoFocus

--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -1,5 +1,7 @@
 import {
   COLOR_OPTIONS,
+  NOTE_NODE_MAX_HEIGHT,
+  NOTE_NODE_MAX_WIDTH,
   NOTE_NODE_MIN_HEIGHT,
   NOTE_NODE_MIN_WIDTH,
 } from "@/constants/constants";
@@ -111,6 +113,8 @@ function NoteNode({
       <NodeResizer
         minWidth={Math.max(DEFAULT_WIDTH, NOTE_NODE_MIN_WIDTH)}
         minHeight={Math.max(DEFAULT_HEIGHT, NOTE_NODE_MIN_HEIGHT)}
+        maxWidth={NOTE_NODE_MAX_WIDTH}
+        maxHeight={NOTE_NODE_MAX_HEIGHT}
         onResize={(_, params) => {
           const { width, height } = params;
           debouncedResize(width, height);
@@ -136,7 +140,7 @@ function NoteNode({
         ref={nodeDiv}
         className={cn(
           "relative flex h-full w-full flex-col gap-3 rounded-xl p-3",
-          "transition-all duration-200 ease-in-out",
+          "duration-200 ease-in-out",
           !isResizing && "transition-transform",
           COLOR_OPTIONS[bgColor] !== null &&
             `border ${!selected && "-z-50 shadow-sm"}`,
@@ -145,13 +149,13 @@ function NoteNode({
         {MemoNoteToolbarComponent}
         <div
           style={{
-            width: size.width,
+            width: "100%",
             height: "100%",
             display: "flex",
             overflow: "hidden",
           }}
           className={cn(
-            "flex-1 transition-all duration-200 ease-in-out",
+            "flex-1 duration-200 ease-in-out",
             !isResizing && "transition-[width,height]",
           )}
         >
@@ -166,6 +170,7 @@ function NoteNode({
               COLOR_OPTIONS[bgColor] === null
                 ? "dark:prose-invert"
                 : "dark:!text-background",
+              "min-w-full",
             )}
             style={{ backgroundColor: COLOR_OPTIONS[bgColor] ?? "#00000000" }}
             charLimit={CHAR_LIMIT}

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -987,7 +987,7 @@ export const DRAG_EVENTS_CUSTOM_TYPESS = {
 export const NOTE_NODE_MIN_WIDTH = 324;
 export const NOTE_NODE_MIN_HEIGHT = 324;
 export const NOTE_NODE_MAX_HEIGHT = 800;
-export const NOTE_NODE_MAX_WIDTH = 600;
+export const NOTE_NODE_MAX_WIDTH = 1000;
 
 export const COLOR_OPTIONS = {
   amber: "hsl(var(--note-amber))",


### PR DESCRIPTION
This pull request includes updates to the frontend codebase, focusing on improving the behavior and styling of custom nodes, particularly the `NoteNode` component. The changes include adjustments to size constraints, styling refinements, and enhancements to the user experience when resizing nodes.

### Updates to `NoteNode` Component:

* Added `NOTE_NODE_MAX_HEIGHT` and updated `NOTE_NODE_MAX_WIDTH` to allow larger dimensions for `NoteNode` resizing. This improves flexibility for users managing larger content. (`src/frontend/src/CustomNodes/NoteNode/index.tsx`, [[1]](diffhunk://#diff-f8b8ed9929042c70be90d199a6389270c4dde1e7ad261d8a5e5c560983220cdaR3-R4); `src/frontend/src/constants/constants.ts`, [[2]](diffhunk://#diff-3a3810648efc852f35a3780d6fe4ec65734c218f2281a175d9347a65db3fd360L990-R990)
* Integrated `maxWidth` and `maxHeight` into the `NodeResizer` component to enforce the new size constraints. (`src/frontend/src/CustomNodes/NoteNode/index.tsx`, [src/frontend/src/CustomNodes/NoteNode/index.tsxR116-R117](diffhunk://#diff-f8b8ed9929042c70be90d199a6389270c4dde1e7ad261d8a5e5c560983220cdaR116-R117))

### Styling Improvements:

* Removed redundant `transition-all` class in multiple places and refined transition effects for smoother resizing and appearance changes. (`src/frontend/src/CustomNodes/NoteNode/index.tsx`, [[1]](diffhunk://#diff-f8b8ed9929042c70be90d199a6389270c4dde1e7ad261d8a5e5c560983220cdaL139-R143) [[2]](diffhunk://#diff-f8b8ed9929042c70be90d199a6389270c4dde1e7ad261d8a5e5c560983220cdaL148-R158)
* Added `min-w-full` to ensure consistent minimum width styling for `NoteNode`. (`src/frontend/src/CustomNodes/NoteNode/index.tsx`, [src/frontend/src/CustomNodes/NoteNode/index.tsxR173](diffhunk://#diff-f8b8ed9929042c70be90d199a6389270c4dde1e7ad261d8a5e5c560983220cdaR173))

### Other Adjustments:

* Updated `NodeDescription` styling to include a new text size (`!text-mmd`) for sticky notes, enhancing readability. (`src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsx`, [src/frontend/src/CustomNodes/GenericNode/components/NodeDescription/index.tsxL158-R158](diffhunk://#diff-29f29ad00a7a070d08356cd7caef9f3c7746207bd09b69e65551917943849002L158-R158))
* Removed `width: fit-content` from `.react-flow__node` in CSS to simplify layout handling. (`src/frontend/src/App.css`, [src/frontend/src/App.cssL22](diffhunk://#diff-3e7904848c381eb53375a14db869438235df15b6e439845f23d09b12382c0d47L22))