### PR TITLE
docs: hide breadcrumbs from landing page

### DIFF
--- a/docs/docs/Get-Started/welcome-to-langflow.md
+++ b/docs/docs/Get-Started/welcome-to-langflow.md
@@ -1,6 +1,7 @@
 ---
 title: Welcome to Langflow
 slug: /
+hide_table_of_contents: true
 ---
 
 Langflow is a new, visual framework for building multi-agent and RAG applications. It is open-source, Python-powered, fully customizable, and LLM and vector store agnostic.


### PR DESCRIPTION
Remove breadcrumbs from landing page.

Not sure how I feel about it. 

<img width="1719" alt="Screenshot 2025-06-20 at 1 53 10 PM" src="https://github.com/user-attachments/assets/cc332e39-0561-4ae0-ba2f-bc206df14306" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the welcome page in the documentation to hide the table of contents for a cleaner reading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->