### PR TITLE
fix: include folder name in default download filename

### DIFF
--- a/src/frontend/src/customization/utils/custom-get-download-folders.ts
+++ b/src/frontend/src/customization/utils/custom-get-download-folders.ts
@@ -16,6 +16,10 @@ export const customGetDownloadFolderBlob = (
   folderName?: string,
   setSuccessData?: (data: any) => void,
 ) => {
+  if (folderName === "My Projects") {
+    folderName = "Starter Project";
+  }
+
   // Create a blob from the response data
   const blob = new Blob([response.data], {
     type: "application/x-zip-compressed",

--- a/src/frontend/src/customization/utils/custom-get-download-folders.ts
+++ b/src/frontend/src/customization/utils/custom-get-download-folders.ts
@@ -29,7 +29,7 @@ export const customGetDownloadFolderBlob = (
   const filename =
     response.headers?.["content-disposition"]
       ?.split("filename=")[1]
-      ?.replace(/['"]/g, "") ?? "flows.zip";
+      ?.replace(/['"]/g, "") ?? `${folderName}.zip`;
 
   link.setAttribute("download", filename);
   document.body.appendChild(link);

--- a/src/frontend/src/customization/utils/custom-get-download-folders.ts
+++ b/src/frontend/src/customization/utils/custom-get-download-folders.ts
@@ -33,7 +33,7 @@ export const customGetDownloadFolderBlob = (
   const filename =
     response.headers?.["content-disposition"]
       ?.split("filename=")[1]
-      ?.replace(/['"]/g, "") ?? `${folderName}.zip`;
+      ?.replace(/['"]/g, "") ?? `${folderName || "flows"}.zip`;
 
   link.setAttribute("download", filename);
   document.body.appendChild(link);


### PR DESCRIPTION
This pull request updates the `customGetDownloadFolderBlob` function in `src/frontend/src/customization/utils/custom-get-download-folders.ts` to improve folder name handling and file naming logic.

Changes to folder name handling:

* Updated the function to replace the folder name "My Projects" with "Starter Project" when specified.

Changes to file naming logic:

* Modified the default filename for downloads to dynamically use the folder name instead of a static "flows.zip".

OSS:
<img width="1724" alt="image" src="https://github.com/user-attachments/assets/307422fd-7c76-4a32-9b34-f5bc0b094704" />

Desktop:
<img width="1238" alt="image" src="https://github.com/user-attachments/assets/8cbfa1f3-661c-4f6b-9a16-eb510ab87056" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Downloaded ZIP files for the "My Projects" folder are now named "Starter Project.zip" instead.
  - Downloaded folder ZIP files use the folder name as the filename, making downloads easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->