### PR TITLE
ci: Skip truncated values test for refactoring

### DIFF
--- a/src/frontend/tests/extended/regression/general-bugs-truncate-results.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-truncate-results.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "@playwright/test";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 
-test(
+// TODO: This test needs to be rebuilt/refactored
+test.skip(
   "truncated values must be displayed correctly",
   { tag: ["@release", "@components"] },
   async ({ page }) => {


### PR DESCRIPTION
Skip the test for truncated values to allow for necessary refactoring.