### PR TITLE
fix: make json edit modal have fixed height and be readOnly if its on View mode

### DIFF
--- a/src/frontend/src/modals/dictAreaModal/index.tsx
+++ b/src/frontend/src/modals/dictAreaModal/index.tsx
@@ -102,14 +102,15 @@ export default function DictAreaModal({
   );
 
   const renderContent = () => (
-    <BaseModal.Content>
-      <div className="flex h-full w-full flex-col transition-all">
+    <BaseModal.Content overflowHidden>
+      <div className="flex h-[500px] w-full flex-col transition-all">
         <JsonEditor
           data={{ json: value }}
           jsonRef={jsonEditorRef}
-          height="400px"
+          readOnly={!onChange}
+          height="500px"
           width="100%"
-          className="h-[400px] w-full overflow-visible"
+          className="h-full w-full overflow-auto"
         />
       </div>
     </BaseModal.Content>


### PR DESCRIPTION
This pull request updates the `DictAreaModal` component to improve its layout and behavior. The changes primarily focus on enhancing the modal's appearance and functionality by modifying its height, overflow handling, and editor properties.

**Improvements to layout and functionality:**

* [`src/frontend/src/modals/dictAreaModal/index.tsx`](diffhunk://#diff-722a895c63c25ba2ae7f6898b91fc5500ea87dbeb2b61ba5faff33390bfd5787L105-R113): Updated `BaseModal.Content` to include the `overflowHidden` prop and adjusted the height of the container to `500px` for better usability.
* [`src/frontend/src/modals/dictAreaModal/index.tsx`](diffhunk://#diff-722a895c63c25ba2ae7f6898b91fc5500ea87dbeb2b61ba5faff33390bfd5787L105-R113): Modified the `JsonEditor` component to make it read-only when no `onChange` handler is provided, increased its height to `500px`, and updated its class to use `overflow-auto` for better scrolling behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The modal's content layout and scrolling behavior have been improved for a better user experience.
  - The embedded JSON editor is now read-only when editing is not enabled.
- **Style**
  - Adjusted modal and editor heights for improved visibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->