### PR TITLE
fix: Replace Google with GoogleGenerativeAI in provider options

### DIFF
--- a/src/backend/base/langflow/components/models/language_model.py
+++ b/src/backend/base/langflow/components/models/language_model.py
@@ -30,7 +30,7 @@ class LanguageModelComponent(LCModelComponent):
             value="OpenAI",
             info="Select the model provider",
             real_time_refresh=True,
-            options_metadata=[{"icon": "OpenAI"}, {"icon": "Anthropic"}, {"icon": "Google"}],
+            options_metadata=[{"icon": "OpenAI"}, {"icon": "Anthropic"}, {"icon": "GoogleGenerativeAI"}],
         ),
         DropdownInput(
             name="model_name",


### PR DESCRIPTION
This pull request includes a minor update to the `LanguageModelComponent` class in `src/backend/base/langflow/components/models/language_model.py`. The change updates the `options_metadata` list to replace `"Google"` with `"GoogleGenerativeAI"` as an option.