### PR TITLE
feat: Add conditional API key display for auth and auto-login

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx
@@ -16,6 +16,7 @@ import {
   DEFAULT_TOOLSET_PLACEHOLDER,
   FLEX_VIEW_TYPES,
   ICON_STROKE_WIDTH,
+  IS_AUTO_LOGIN,
   LANGFLOW_SUPPORTED_TYPES,
 } from "../../../../constants/constants";
 import useFlowStore from "../../../../stores/flowStore";
@@ -44,13 +45,19 @@ export default function NodeInputField({
   isToolMode = false,
 }: NodeInputFieldComponentType): JSX.Element {
   const ref = useRef<HTMLDivElement>(null);
-  const isAuth = useAuthStore((state) => state.isAuthenticated);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const autoLogin = useAuthStore((state) => state.autoLogin);
+  const isAutoLoginEnv = IS_AUTO_LOGIN;
+  const isAutoLogin = autoLogin ?? isAutoLoginEnv;
+  const shouldDisplayApiKey = isAuthenticated && !isAutoLogin;
+
   const { currentFlowId, currentFlowName } = useFlowStore(
     useShallow((state) => ({
       currentFlowId: state.currentFlow?.id,
       currentFlowName: state.currentFlow?.name,
     })),
   );
+
   const myData = useTypesStore((state) => state.data);
   const postTemplateValue = usePostTemplateValue({
     node: data.node!,
@@ -75,10 +82,10 @@ export default function NodeInputField({
       flowId: currentFlowId ?? "",
       nodeType: data?.type?.toLowerCase() ?? "",
       flowName: currentFlowName ?? "",
-      isAuth,
+      isAuth: shouldDisplayApiKey!,
       variableName: name,
     };
-  }, [data?.node?.id, isAuth, name]);
+  }, [data?.node?.id, shouldDisplayApiKey, name]);
 
   useFetchDataOnMount(
     data.node!,

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableNodeCellRender/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableNodeCellRender/index.tsx
@@ -2,6 +2,7 @@ import useHandleOnNewValue from "@/CustomNodes/hooks/use-handle-new-value";
 import useHandleNodeClass from "@/CustomNodes/hooks/use-handle-node-class";
 import { ParameterRenderComponent } from "@/components/core/parameterRenderComponent";
 import { NodeInfoType } from "@/components/core/parameterRenderComponent/types";
+import { IS_AUTO_LOGIN } from "@/constants/constants";
 import useAuthStore from "@/stores/authStore";
 import useFlowStore from "@/stores/flowStore";
 import { APIClassType } from "@/types/api";
@@ -17,7 +18,11 @@ export default function TableNodeCellRender({
   const node = useFlowStore((state) => state.getNode(nodeId));
   const parameter = node?.data?.node?.template?.[parameterId];
   const currentFlow = useFlowStore((state) => state.currentFlow);
-  const isAuth = useAuthStore((state) => state.isAuthenticated);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const autoLogin = useAuthStore((state) => state.autoLogin);
+  const isAutoLoginEnv = IS_AUTO_LOGIN;
+  const isAutoLogin = autoLogin ?? isAutoLoginEnv;
+  const shouldDisplayApiKey = isAuthenticated && !isAutoLogin;
 
   const disabled = isTargetHandleConnected(
     edges,
@@ -43,10 +48,10 @@ export default function TableNodeCellRender({
       flowId: currentFlow?.id ?? "",
       nodeType: node?.data?.type?.toLowerCase() ?? "",
       flowName: currentFlow?.name ?? "",
-      isAuth,
+      isAuth: shouldDisplayApiKey!,
       variableName: parameterId,
     };
-  }, [nodeId, isAuth, parameterId]);
+  }, [nodeId, shouldDisplayApiKey, parameterId]);
 
   return (
     parameter && (

--- a/src/frontend/tests/extended/regression/general-bugs-component-webhook-api-key-display.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-component-webhook-api-key-display.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+import { adjustScreenView } from "../../utils/adjust-screen-view";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { extractAndCleanCode } from "../../utils/extract-and-clean-code";
+import { loginLangflow } from "../../utils/login-langflow";
+
+test(
+  "user must be able to see api key in webhook component when auto login is disabled",
+  { tag: ["@release"] },
+  async ({ page }) => {
+    await page.route("**/api/v1/auto_login", (route) => {
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          detail: { auto_login: false },
+        }),
+      });
+    });
+
+    await loginLangflow(page);
+
+    await awaitBootstrapTest(page, { skipGoto: true });
+
+    await page.waitForSelector('[data-testid="blank-flow"]', {
+      timeout: 30000,
+    });
+    await page.getByTestId("blank-flow").click();
+    await page.getByTestId("sidebar-search-input").click();
+
+    await page.getByTestId("sidebar-search-input").fill("webhook");
+
+    await page.waitForSelector('[data-testid="dataWebhook"]', {
+      timeout: 3000,
+    });
+
+    await page
+      .getByTestId("dataWebhook")
+      .hover()
+      .then(async () => {
+        await page.getByTestId("add-component-button-webhook").click();
+      });
+
+    await adjustScreenView(page);
+
+    await page.getByTestId("title-Webhook").click();
+
+    await page.getByTestId("edit-button-modal").click();
+
+    await page
+      .getByTestId("button_open_text_area_modal_str_edit_curl_advanced")
+      .click();
+
+    const curl = await page.getByTestId("text-area-modal").inputValue();
+
+    expect(curl).toContain("x-api-key");
+  },
+);
+
+test(
+  "user must be able to not see api key in webhook component when auto login is enabled",
+  { tag: ["@release"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page);
+
+    await page.waitForSelector('[data-testid="blank-flow"]', {
+      timeout: 30000,
+    });
+    await page.getByTestId("blank-flow").click();
+    await page.getByTestId("sidebar-search-input").click();
+
+    await page.getByTestId("sidebar-search-input").fill("webhook");
+
+    await page.waitForSelector('[data-testid="dataWebhook"]', {
+      timeout: 3000,
+    });
+
+    await page
+      .getByTestId("dataWebhook")
+      .hover()
+      .then(async () => {
+        await page.getByTestId("add-component-button-webhook").click();
+      });
+
+    await adjustScreenView(page);
+
+    await page.getByTestId("title-Webhook").click();
+
+    await page.getByTestId("edit-button-modal").click();
+
+    await page
+      .getByTestId("button_open_text_area_modal_str_edit_curl_advanced")
+      .click();
+
+    const curl = await page.getByTestId("text-area-modal").inputValue();
+
+    expect(curl).not.toContain("x-api-key");
+  },
+);

--- a/src/frontend/tests/utils/login-langflow.ts
+++ b/src/frontend/tests/utils/login-langflow.ts
@@ -1,0 +1,8 @@
+import { Page } from "playwright/test";
+
+export const loginLangflow = async (page: Page) => {
+  await page.goto("/");
+  await page.getByPlaceholder("Username").fill("langflow");
+  await page.getByPlaceholder("Password").fill("langflow");
+  await page.getByRole("button", { name: "Sign In" }).click();
+};


### PR DESCRIPTION
This pull request introduces functionality to handle the display of API keys based on authentication and auto-login settings. It also adds regression tests to ensure correct behavior in these scenarios. Key changes include updates to `NodeInputField` and `TableNodeCellRender` components, new constants for auto-login handling, and tests for webhook API key visibility.

### Authentication and Auto-Login Handling:

* [`src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx`](diffhunk://#diff-b68d4cff4ce636f41882b2e6c2fb46ce2e134bdf292e38bcf6df9c6c5807d518R19): Refactored logic to determine whether the API key should be displayed based on authentication and auto-login settings. Introduced `shouldDisplayApiKey` variable for clarity. [[1]](diffhunk://#diff-b68d4cff4ce636f41882b2e6c2fb46ce2e134bdf292e38bcf6df9c6c5807d518R19) [[2]](diffhunk://#diff-b68d4cff4ce636f41882b2e6c2fb46ce2e134bdf292e38bcf6df9c6c5807d518L47-R60) [[3]](diffhunk://#diff-b68d4cff4ce636f41882b2e6c2fb46ce2e134bdf292e38bcf6df9c6c5807d518L78-R88)
* [`src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableNodeCellRender/index.tsx`](diffhunk://#diff-7ce98d0f4cafc8c8bc548103b58f827f155f435b31d863d850f7ad0fe8ae8755R5): Added similar logic for API key visibility in the `TableNodeCellRender` component using the `shouldDisplayApiKey` variable. [[1]](diffhunk://#diff-7ce98d0f4cafc8c8bc548103b58f827f155f435b31d863d850f7ad0fe8ae8755R5) [[2]](diffhunk://#diff-7ce98d0f4cafc8c8bc548103b58f827f155f435b31d863d850f7ad0fe8ae8755L20-R25) [[3]](diffhunk://#diff-7ce98d0f4cafc8c8bc548103b58f827f155f435b31d863d850f7ad0fe8ae8755L46-R54)

### Testing:

* [`src/frontend/tests/extended/regression/general-bugs-component-webhook-api-key-display.spec.ts`](diffhunk://#diff-7a59ffc8dcc83e3285695649a8366fc46f5064b4ea2ba68adc99e5fe33ca4c68R1-R99): Added regression tests to verify API key visibility in webhook components under different auto-login scenarios.
* [`src/frontend/tests/utils/login-langflow.ts`](diffhunk://#diff-2d41c089750934017671dda8b24ed4422edcaad84d2ac8d0b30cafbeb926dbbbR1-R8): Created a utility function for logging into the application during tests.