### PR TITLE
docs: voice mode audio dependency

### DIFF
--- a/docs/docs/Concepts/concepts-voice-mode.md
+++ b/docs/docs/Concepts/concepts-voice-mode.md
@@ -14,7 +14,7 @@ Your flow must have a [Chat input](/components-io#chat-input) component to inter
 ## Prerequisite
 
 - [An OpenAI API key](https://platform.openai.com/)
-- The Langflow audio dependency installed.
+- The Langflow `[audio]` dependency installed.
     To install the extra dependency:
     ```bash
     uv pip install "langflow[audio]"

--- a/docs/docs/Concepts/concepts-voice-mode.md
+++ b/docs/docs/Concepts/concepts-voice-mode.md
@@ -14,7 +14,11 @@ Your flow must have a [Chat input](/components-io#chat-input) component to inter
 ## Prerequisite
 
 - [An OpenAI API key](https://platform.openai.com/)
-
+- The Langflow audio dependency installed.
+    To install the extra dependency:
+    ```bash
+    uv pip install "langflow[audio]"
+    ```
 ## Use voice mode in the Langflow Playground
 
 Chat with an agent in the **Playground**, and get more recent results by asking the agent to use tools.


### PR DESCRIPTION
Splitting the `webcrtvad` package out requires that the dependency be installed before using Voice Mode.
Add the prerequisite and install instruction to Voice Mode page. 
The troubleshooting for the installation is[ here](https://docs.langflow.org/troubleshoot#installation-failure-from-webrtcvad-package).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated "Voice mode" documentation to include instructions for installing the required audio dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->