### PR TITLE
Fix: correct ChatInput import path in conftest.py

### DIFF
--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -17,7 +17,7 @@ from blockbuster import blockbuster_ctx
 from dotenv import load_dotenv
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
-from langflow.components.input_output import ChatInput
+from langflow.components.inputs import ChatInput
 from langflow.graph import Graph
 from langflow.initial_setup.constants import STARTER_FOLDER_NAME
 from langflow.main import create_app


### PR DESCRIPTION

## 🐛 Bug Fix: Incorrect import path for `ChatInput` in `conftest.py`

### 📌 Problem

Running the test suite results in the following error:

```

ModuleNotFoundError: No module named 'langflow\.components.input\_output'

````

This is caused by an outdated import in `tests/conftest.py`:

```python
from langflow.components.input_output import ChatInput
````

In recent versions of Langflow, the `ChatInput` component has been moved to a new module.

---

### ✅ Solution

Updated the import to match the current structure of the codebase:

```python
from langflow.components.inputs import ChatInput
```

This resolves the `ModuleNotFoundError` and ensures compatibility with the latest Langflow layout.

---

### 🧪 Testing

The issue was verified by running:

```bash
pytest
```

✅ Tests now execute correctly without import-related errors.

---

### 📝 Notes

This is a minimal but essential fix that restores test compatibility for contributors working with a fresh clone.

Thanks for maintaining such a great project!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal import paths for improved code organization. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->