### PR TITLE
fix: Update banner formatting from emojis to plain text

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -467,8 +467,8 @@ def print_banner(host: str, port: int, protocol: str) -> None:
 
     title = f"[bold]Welcome to {styled_package_name}[/bold]\n"
     info_text = (
-        ":star2: GitHub: Star for updates → https://github.com/langflow-ai/langflow\n"
-        ":speech_balloon: Discord: Join for support → https://discord.com/invite/EqksyE2EX9"
+        "* GitHub: Star for updates → https://github.com/langflow-ai/langflow\n"
+        "* Discord: Join for support → https://discord.com/invite/EqksyE2EX9"
     )
     telemetry_text = (
         (
@@ -482,7 +482,7 @@ def print_banner(host: str, port: int, protocol: str) -> None:
         )
     )
     access_host = get_best_access_host(host, port)
-    access_link = f"[bold]🟢 Open Langflow →[/bold] [link={protocol}://{access_host}:{port}]{protocol}://{access_host}:{port}[/link]"
+    access_link = f"[bold]> Open Langflow →[/bold] [link={protocol}://{access_host}:{port}]{protocol}://{access_host}:{port}[/link]"
 
     message = f"{title}\n{info_text}\n\n{telemetry_text}\n\n{access_link}"
 


### PR DESCRIPTION
This pull request makes minor adjustments to the `print_banner` function in `src/backend/base/langflow/__main__.py` to improve the formatting of displayed text. 

Formatting changes:

* Updated bullet point symbols in the `info_text` variable from emojis (`:star2:` and `:speech_balloon:`) to plain asterisks (`*`) for a cleaner look.
* Changed the emoji in the `access_link` variable from "🟢" to a plain ">" for a more professional appearance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the visual formatting of the console banner, replacing emoji symbols with simpler text characters for links and access information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->