### PR TITLE
docs: add required API key headers for 1.5

### DIFF
--- a/docs/docs/API-Reference/api-build.md
+++ b/docs/docs/API-Reference/api-build.md
@@ -32,6 +32,7 @@ curl -X POST \
   "$LANGFLOW_URL/api/v1/build/$FLOW_ID/flow" \
   -H "accept: application/json" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
     "inputs": {
       "input_value": "Tell me a story"
@@ -59,7 +60,8 @@ curl -X POST \
 ```text
 curl -X GET \
   "$LANGFLOW_URL/api/v1/build/123e4567-e89b-12d3-a456-426614174000/events" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
    </TabItem>
@@ -84,7 +86,8 @@ To disable streaming and get all events at once, set `stream` to `false`.
 ```text
 curl -X GET \
   "$LANGFLOW_URL/api/v1/build/123e4567-e89b-12d3-a456-426614174000/events?stream=false" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
 ## Build headers
@@ -136,6 +139,7 @@ curl -X POST \
   "$LANGFLOW_URL/api/v1/build/$FLOW_ID/flow" \
   -H "accept: application/json" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
     "data": {
       "nodes": [],

--- a/docs/docs/API-Reference/api-files.md
+++ b/docs/docs/API-Reference/api-files.md
@@ -43,6 +43,7 @@ curl -X POST \
   "$LANGFLOW_URL/api/v1/files/upload/$FLOW_ID" \
   -H "accept: application/json" \
   -H "Content-Type: multipart/form-data" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -F "file=@FILE_NAME.txt"
 ```
 
@@ -72,6 +73,7 @@ For more information, see [Supported environment variables](/environment-variabl
 ```bash
 curl -X POST "$LANGFLOW_URL/api/v1/files/upload/a430cc57-06bb-4c11-be39-d3d4de68d2c4" \
   -H "Content-Type: multipart/form-data" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -F "file=@FILE_NAME.png"
 ```
 
@@ -92,7 +94,8 @@ The API returns the image file path in the format `"file_path":"<YOUR-FLOW-ID>/<
 ```bash
 curl -X POST \
     "$LANGFLOW_URL/api/v1/run/a430cc57-06bb-4c11-be39-d3d4de68d2c4?stream=false" \
-    -H 'Content-Type: application/json'\
+    -H 'Content-Type: application/json' \
+    -H "x-api-key: $LANGFLOW_API_KEY" \
     -d '{
     "output_type": "chat",
     "input_type": "chat",
@@ -120,7 +123,8 @@ List all files associated with a specific flow.
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/files/list/$FLOW_ID" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -146,6 +150,7 @@ Download a specific file from a flow.
 curl -X GET \
   "$LANGFLOW_URL/api/v1/files/download/$FLOW_ID/2024-12-30_15-19-43_your_file.txt" \
   -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   --output downloaded_file.txt
 ```
 
@@ -169,7 +174,8 @@ Delete a specific file from a flow.
 ```bash
 curl -X DELETE \
   "$LANGFLOW_URL/api/v1/files/delete/$FLOW_ID/2024-12-30_15-19-43_your_file.txt" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -201,7 +207,8 @@ To retrieve your current `user_id`, call the `/whoami` endpoint.
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/users/whoami" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
 Result:
@@ -280,6 +287,7 @@ In this example, the file uploaded to `/v2/files` is included with the `/v1/run`
 curl --request POST \
   --url "$LANGFLOW_URL/api/v1/run/$FLOW_ID" \
   --header "Content-Type: application/json" \
+  --header "x-api-key: $LANGFLOW_API_KEY" \
   --data '{
   "input_value": "what do you see?",
   "output_type": "chat",

--- a/docs/docs/API-Reference/api-flows-run.md
+++ b/docs/docs/API-Reference/api-flows-run.md
@@ -27,6 +27,7 @@ The parameters are passed in the request body. In this example, the values are t
 curl -X POST \
   "$LANGFLOW_URL/api/v1/run/$FLOW_ID" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
     "input_value": "Tell me about something interesting!",
     "session_id": "chat-123",
@@ -87,6 +88,7 @@ curl -X POST \
   "$LANGFLOW_URL/api/v1/run/$FLOW_ID?stream=true" \
   -H "accept: application/json" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
     "message": "Tell me something interesting!",
     "session_id": "chat-123"
@@ -151,7 +153,7 @@ curl -X POST \
   "http://$LANGFLOW_URL/api/v1/run/$FLOW_ID?stream=true" \
   -H "Content-Type: application/json" \
   -H "accept: application/json" \
-  -H "x-api-key: sk-..." \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
     "input_value": "Tell me a story",
     "input_type": "chat",
@@ -178,6 +180,7 @@ After you add a **Webhook** component to a flow, open the [**API access** pane](
 curl -X POST \
   "$LANGFLOW_URL/api/v1/webhook/$FLOW_ID" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{"data": "example-data"}'
 ```
 

--- a/docs/docs/API-Reference/api-flows.md
+++ b/docs/docs/API-Reference/api-flows.md
@@ -22,6 +22,7 @@ curl -X POST \
   "$LANGFLOW_URL/api/v1/flows/" \
   -H "accept: application/json" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
   "name": "string2",
   "description": "string",
@@ -74,6 +75,7 @@ curl -X POST \
   "$LANGFLOW_URL/api/v1/flows/batch/" \
   -H "accept: application/json" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
   "flows": [
     {
@@ -126,7 +128,8 @@ Retrieves a specific flow by its ID.
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/flows/$FLOW_ID" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -160,7 +163,8 @@ Retrieve all flows with pagination:
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/flows/?remove_example_flows=false&components_only=false&get_all=true&header_flows=false&page=1&size=50" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
 To retrieve flows from a specific project, use the `project_id` query parameter:
@@ -168,7 +172,8 @@ To retrieve flows from a specific project, use the `project_id` query parameter:
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/flows/?remove_example_flows=true&components_only=false&get_all=false&project_id=$PROJECT_ID&header_flows=false&page=1&size=1" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
 ## Read sample flows
@@ -178,7 +183,8 @@ Retrieves a list of sample flows:
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/flows/basic_examples/" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
 ## Update flow
@@ -195,6 +201,7 @@ curl -X PATCH \
   "$LANGFLOW_URL/api/v1/flows/$FLOW_ID" \
   -H "accept: application/json" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
   "name": "string",
   "description": "string",
@@ -241,7 +248,8 @@ Deletes a specific flow by its ID.
 ```bash
 curl -X DELETE \
   "$LANGFLOW_URL/api/v1/flows/$FLOW_ID" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
 </TabItem>
@@ -271,6 +279,7 @@ curl -X POST \
   "$LANGFLOW_URL/api/v1/flows/download/" \
   -H "accept: application/json" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '[
   "e1e40c77-0541-41a9-88ab-ddb3419398b5",
   "92f9a4c5-cfc8-4656-ae63-1f0881163c28"
@@ -307,6 +316,7 @@ curl -X POST \
   "$LANGFLOW_URL/api/v1/flows/upload/?project_id=$PROJECT_ID" \
   -H "accept: application/json" \
   -H "Content-Type: multipart/form-data" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -F "file=@agent-with-astra-db-tool.json;type=application/json"
 ```
 

--- a/docs/docs/API-Reference/api-logs.md
+++ b/docs/docs/API-Reference/api-logs.md
@@ -38,7 +38,8 @@ Stream logs in real-time using Server Sent Events (SSE).
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/logs-stream" \
-  -H "accept: text/event-stream"
+  -H "accept: text/event-stream" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -84,7 +85,8 @@ With default values, the endpoint returns the last 10 lines of logs.
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/logs?lines_before=0&lines_after=0&timestamp=0" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>

--- a/docs/docs/API-Reference/api-monitor.md
+++ b/docs/docs/API-Reference/api-monitor.md
@@ -18,7 +18,8 @@ Retrieve Vertex builds for a specific flow.
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/monitor/builds?flow_id=$FLOW_ID" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -397,7 +398,8 @@ Delete Vertex builds for a specific flow.
 ```bash
 curl -X DELETE \
   "$LANGFLOW_URL/api/v1/monitor/builds?flow_id=$FLOW_ID" \
-  -H "accept: */*"
+  -H "accept: */*" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -417,7 +419,8 @@ Retrieve a list of all messages:
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/monitor/messages" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
 To filter messages, use the `flow_id`, `session_id`, `sender`, and `sender_name` query parameters.
@@ -432,7 +435,8 @@ This example retrieves messages sent by `Machine` and `AI` in a given chat sessi
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/monitor/messages?flow_id=$FLOW_ID&session_id=01ce083d-748b-4b8d-97b6-33adbb6a528a&sender=Machine&sender_name=AI&order_by=timestamp" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -488,6 +492,7 @@ curl -v -X DELETE \
   "$LANGFLOW_URL/api/v1/monitor/messages" \
   -H "accept: */*" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '["MESSAGE_ID_1", "MESSAGE_ID_2"]'
 ```
 
@@ -515,6 +520,7 @@ curl -X PUT \
   "$LANGFLOW_URL/api/v1/monitor/messages/3ab66cc6-c048-48f8-ab07-570f5af7b160" \
   -H "accept: application/json" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
   "text": "testing 1234"
 }'
@@ -566,7 +572,8 @@ This example updates the `session_ID` value `01ce083d-748b-4b8d-97b6-33adbb6a528
 ```bash
 curl -X PATCH \
   "$LANGFLOW_URL/api/v1/monitor/messages/session/01ce083d-748b-4b8d-97b6-33adbb6a528a?new_session_id=different_session_id" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -618,7 +625,8 @@ Delete all messages for a specific session.
 ```bash
 curl -X DELETE \
   "$LANGFLOW_URL/api/v1/monitor/messages/session/different_session_id_2" \
-  -H "accept: */*"
+  -H "accept: */*" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -641,7 +649,8 @@ Retrieve all transactions, which are interactions between components, for a spec
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/monitor/transactions?flow_id=$FLOW_ID&page=1&size=50" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>

--- a/docs/docs/API-Reference/api-projects.md
+++ b/docs/docs/API-Reference/api-projects.md
@@ -20,7 +20,8 @@ Get a list of Langflow projects, including project IDs, names, and descriptions.
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/projects/" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -51,6 +52,7 @@ Create a new project.
 curl -X POST \
   "$LANGFLOW_URL/api/v1/projects/" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
   "name": "new_project_name",
   "description": "string",
@@ -83,6 +85,7 @@ curl -X POST \
   "$LANGFLOW_URL/api/v1/projects/" \
   -H "accept: application/json" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
   "name": "new_project_name",
   "description": "string",
@@ -107,7 +110,8 @@ To find the UUID of your project, call the [read projects](#read-projects) endpo
 ```bash
 curl -X GET \
   "$LANGFLOW_URL/api/v1/projects/$PROJECT_ID" \
-  -H "accept: application/json"
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -142,6 +146,7 @@ If you send the same values multiple times, the update is still processed, even 
 curl -X PATCH \
   "$LANGFLOW_URL/api/v1/projects/b408ddb9-6266-4431-9be8-e04a62758331" \
   -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
   "name": "string",
   "description": "string",
@@ -180,7 +185,8 @@ Delete a specific project.
 ```bash
 curl -X DELETE \
   "$LANGFLOW_URL/api/v1/projects/$PROJECT_ID" \
-  -H "accept: */*"
+  -H "accept: */*" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
   </TabItem>
@@ -203,6 +209,7 @@ The `--output` flag is optional.
 curl -X GET \
   "$LANGFLOW_URL/api/v1/projects/download/b408ddb9-6266-4431-9be8-e04a62758331" \
   -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   --output langflow-project.zip
 ```
 
@@ -215,5 +222,6 @@ curl -X POST \
   "$LANGFLOW_URL/api/v1/projects/upload/" \
   -H "accept: application/json" \
   -H "Content-Type: multipart/form-data" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -F "file=@20241230_135006_langflow_flows.zip;type=application/zip"
 ```

--- a/docs/docs/API-Reference/api-reference-api-examples.md
+++ b/docs/docs/API-Reference/api-reference-api-examples.md
@@ -84,7 +84,7 @@ For example:
 export LANGFLOW_URL="http://localhost:7860"
 export FLOW_ID="359cd752-07ea-46f2-9d3b-a4407ef618da"
 export PROJECT_ID="1415de42-8f01-4f36-bf34-539f23e47466"
-export API_KEY="sk-..."
+export LANGFLOW_API_KEY="sk-..."
 ```
 
 :::tip
@@ -145,14 +145,15 @@ curl -X GET \
 ```
 </details>
 
-### Get all components
+### Get current user
 
-Returns a dictionary of all Langflow components:
+Returns a user object.
 
 ```bash
 curl -X GET \
-  "$LANGFLOW_URL/api/v1/all" \
-  -H "accept: application/json"
+  "$LANGFLOW_URL/api/v1/users/whoami" \
+  -H "accept: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
 ## Next steps

--- a/docs/docs/API-Reference/api-users.md
+++ b/docs/docs/API-Reference/api-users.md
@@ -24,6 +24,7 @@ This creates a new UUID for the user's `id`, which is mapped to `user_id` in the
 curl -X POST \
   "$LANGFLOW_URL/api/v1/users/" \
   -H "Content-Type: application/json" \
+  -H "x-api-key: $LANGFLOW_API_KEY" \
   -d '{
     "username": "newuser2",
     "password": "securepassword123"

--- a/docs/docs/Components/components-data.md
+++ b/docs/docs/Components/components-data.md
@@ -269,7 +269,8 @@ When a **Webhook** component is added to the workspace, a new **Webhook cURL** t
 ```bash
 curl -X POST \
   "http://localhost:7860/api/v1/webhook/**YOUR_FLOW_ID**" \
-  -H 'Content-Type: application/json'\
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: LANGFLOW_API_KEY' \
   -d '{"any": "data"}'
   ```
 

--- a/docs/docs/Components/components-io.md
+++ b/docs/docs/Components/components-io.md
@@ -213,6 +213,7 @@ It looks similar to this:
 curl --request POST \
   --url 'http://localhost:7860/api/v1/run/51eed711-4530-4fdc-9bce-5db4351cc73a?stream=false' \
   --header 'Content-Type: application/json' \
+  --header 'x-api-key: LANGFLOW_API_KEY' \
   --data '{
   "input_value": "What's the recommended way to install Docker on Mac M1?",
   "output_type": "chat",
@@ -228,6 +229,7 @@ Note the `output_type` and `input_type` parameters that are passed with the mess
 curl --request POST \
   --url 'http://localhost:7860/api/v1/run/51eed711-4530-4fdc-9bce-5db4351cc73a?stream=false' \
   --header 'Content-Type: application/json' \
+  --header 'x-api-key: LANGFLOW_API_KEY' \
   --data '{
   "input_value": "Whats the recommended way to install Docker on Mac M1",
   "session_id": "docker-question-on-m1",
@@ -248,6 +250,7 @@ For example, disabling storing messages from the **Chat Input** component adds a
 curl --request POST \
   --url 'http://localhost:7860/api/v1/run/51eed711-4530-4fdc-9bce-5db4351cc73a?stream=false' \
   --header 'Content-Type: application/json' \
+  --header 'x-api-key: LANGFLOW_API_KEY' \
   --data '{
   "input_value": "Text to input to the flow",
   "output_type": "chat",

--- a/docs/docs/Components/components-processing.md
+++ b/docs/docs/Components/components-processing.md
@@ -114,6 +114,7 @@ Replace `YOUR_FLOW_ID` with your flow ID.
 ```bash
 curl -X POST "http://localhost:7860/api/v1/webhook/YOUR_FLOW_ID" \
 -H 'Content-Type: application/json' \
+-H 'x-api-key: LANGFLOW_API_KEY' \
 -d '{
   "id": 1,
   "name": "Leanne Graham",
@@ -207,6 +208,7 @@ This example uses the default Langflow server address.
 ```text
 curl -X POST "http://localhost:7860/api/v1/webhook/YOUR_FLOW_ID" \
 -H 'Content-Type: application/json' \
+-H 'x-api-key: LANGFLOW_API_KEY' \
 -d '{
     "text": "Alex Cruz - Employee Profile",
     "data": {
@@ -229,6 +231,7 @@ The **Data to DataFrame** component converts the webhook request into a `DataFra
 ```text
 curl -X POST "http://localhost:7860/api/v1/webhook/YOUR_FLOW_ID" \
 -H 'Content-Type: application/json' \
+-H 'x-api-key: LANGFLOW_API_KEY' \
 -d '{
     "text": "Kalani Smith - Employee Profile",
     "data": {
@@ -414,6 +417,7 @@ This example uses the default Langflow server address.
 ```text
 curl -X POST "http://localhost:7860/api/v1/webhook/YOUR_FLOW_ID" \
 -H 'Content-Type: application/json' \
+-H 'x-api-key: LANGFLOW_API_KEY' \
 -d '{
     "Name": ["Alex Cruz", "Kalani Smith", "Noam Johnson"],
     "Role": ["Developer", "Designer", "Manager"],

--- a/docs/docs/Concepts/concepts-playground.md
+++ b/docs/docs/Concepts/concepts-playground.md
@@ -45,6 +45,7 @@ To post a message to a flow with a specific Session ID with curl, enter the foll
 ```bash
    curl -X POST "http://localhost:7860/api/v1/run/$FLOW_ID" \
    -H 'Content-Type: application/json' \
+   -H 'x-api-key: LANGFLOW_API_KEY' \
    -d '{
        "session_id": "custom_session_123",
        "input_value": "message",
@@ -78,6 +79,7 @@ This example sends a base64-encoded image to the Playground using curl:
 ```bash
 curl -X POST "http://localhost:7860/api/v1/run/$FLOW_ID" \
 -H 'Content-Type: application/json' \
+-H 'x-api-key: LANGFLOW_API_KEY' \
 -d '{
     "session_id": "custom_session_123",
     "input_value": "What is in this image?",

--- a/docs/docs/Configuration/configuration-api-keys.md
+++ b/docs/docs/Configuration/configuration-api-keys.md
@@ -16,16 +16,25 @@ Generate a user-specific token to use with Langflow.
 ### Generate an API key with the Langflow UI
 
 1. Click your user icon, and then select **Settings**.
-2. Click **Langflow API**, and then click **Add New**.
-3. Name your key, and then click **Create Secret Key**.
+2. Click **Langflow API Keys**, and then click **Add New**.
+3. Name your key, and then click **Create API Key**.
 4. Copy the API key and store it in a secure location.
 
 ### Generate an API key with the Langflow CLI
 
+This command only works if `AUTO_LOGIN` is set to `FALSE` and the user is a superuser.
+
+For example, if you're serving your flow with `--backend-only=true`, you don't have a way to create an API key within the UI.
+
+```
+LANGFLOW_AUTO_LOGIN=False
+LANGFLOW_SUPERUSER=admin
+LANGFLOW_SUPERUSER_PASSWORD=password
+```
+
 ```shell
-langflow api-key
-# or
-python -m langflow api-key
+uv run langflow api-key
+
 ╭─────────────────────────────────────────────────────────────────────╮
 │ API Key Created Successfully:                                       │
 │                                                                     │
@@ -36,7 +45,6 @@ python -m langflow api-key
 │                                                                     │
 │ The API key has been copied to your clipboard. Cmd + V to paste it. │
 ╰──────────────────────────────
-
 ```
 
 ## Authenticate requests with the Langflow API key
@@ -53,7 +61,7 @@ To use the API key when making API requests, include the API key in the HTTP hea
 curl -X POST \
   "http://localhost:7860/api/v1/run/FLOW_ID?stream=false" \
   -H 'Content-Type: application/json' \
-  -H 'x-api-key: API_KEY' \
+  -H 'x-api-key: LANGFLOW_API_KEY' \
   -d '{"inputs": {"text":""}, "tweaks": {}}'
 ```
 

--- a/docs/docs/Develop/session-id.md
+++ b/docs/docs/Develop/session-id.md
@@ -21,6 +21,7 @@ If you set a custom session ID in a payload, all downstream components use the u
 curl --request POST \
   --url 'http://localhost:7860/api/v1/run/$FLOW_ID' \
   --header 'Content-Type: application/json' \
+  --header 'x-api-key: LANGFLOW_API_KEY' \
   --data '{
   "input_value": "Hello",
   "output_type": "chat",

--- a/docs/docs/Develop/webhook.md
+++ b/docs/docs/Develop/webhook.md
@@ -34,6 +34,7 @@ Replace **FLOW_ID** with your flow's ID, which can be found on the [Publish pane
     ```bash
     curl -X POST "http://localhost:7860/api/v1/webhook/YOUR_FLOW_ID" \
         -H 'Content-Type: application/json' \
+        -H 'x-api-key: LANGFLOW_API_KEY' \
         -d '{"id": "12345", "name": "alex", "email": "alex@email.com"}'
     ```
 

--- a/docs/docs/Get-Started/get-started-quickstart.md
+++ b/docs/docs/Get-Started/get-started-quickstart.md
@@ -13,6 +13,30 @@ Get started with Langflow by loading a template flow, running it, and then servi
 
 - [A running Langflow instance](/get-started-installation)
 - [An OpenAI API key](https://platform.openai.com/api-keys)
+- [A Langflow API key](/configuration-api-keys)
+
+<details>
+<summary>Need help creating an API key?</summary>
+
+To generate a user-specific token to use with Langflow, do the following.
+
+1. Open the Langflow UI, click your user icon, and then select **Settings**.
+2. Click **Langflow API Keys**, and then click **Add New**.
+3. Name your key, and then click **Create API Key**.
+4. Copy the API key and store it in a secure location.
+5. Include your `LANGFLOW_API_KEY` in requests like this:
+    ```
+    curl --request POST \
+     --url 'http://localhost:7860/api/v1/run/0901b40b-9212-41cb-87c6-ac66a427913c?stream=false' \
+     --header 'Content-Type: application/json' \
+     --header 'x-api-key: LANGFLOW_API_KEY' \
+     --data '{
+       "output_type": "chat",
+       "input_type": "chat",
+       "input_value": "Hello"
+     }'
+    ```
+</details>
 
 ## Run the Simple Agent template flow
 
@@ -88,7 +112,8 @@ Langflow provides code snippets to help you get started with the Langflow API.
 
     # Request headers
     headers = {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "x-api-key: LANGFLOW_API_KEY"
     }
 
     try:
@@ -119,7 +144,8 @@ Langflow provides code snippets to help you get started with the Langflow API.
     const options = {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'x-api-key: LANGFLOW_API_KEY'
         },
         body: JSON.stringify(payload)
     };
@@ -136,13 +162,14 @@ Langflow provides code snippets to help you get started with the Langflow API.
 
     ```text
     curl --request POST \
-         --url 'http://LANGFLOW_SERVER_ADDRESS/api/v1/run/FLOW_ID?stream=false' \
-         --header 'Content-Type: application/json' \
-         --data '{
-    		           "output_type": "chat",
-    		           "input_type": "chat",
-    		           "input_value": "hello world!"
-    		         }'
+     --url 'http://localhost:7860/api/v1/run/0901b40b-9212-41cb-87c6-ac66a427913c?stream=false' \
+     --header 'Content-Type: application/json' \
+     --header 'x-api-key: LANGFLOW_API_KEY' \
+     --data '{
+       "output_type": "chat",
+       "input_type": "chat",
+       "input_value": "Hello"
+     }'
 
     # A 200 response confirms the call succeeded.
     ```
@@ -353,7 +380,10 @@ This script runs a question-and-answer chat in your terminal and stores the Agen
             "input_value": question,
         }
 
-        headers = {"Content-Type": "application/json"}
+        headers = {
+        "Content-Type": "application/json",
+        "x-api-key: LANGFLOW_API_KEY"
+        }
 
         try:
             response = requests.post(url, json=payload, headers=headers)
@@ -426,7 +456,8 @@ This script runs a question-and-answer chat in your terminal and stores the Agen
         const options = {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'x-api-key: LANGFLOW_API_KEY'
             },
             body: JSON.stringify(payload)
         };


### PR DESCRIPTION
This pull request updates the API documentation to include the `x-api-key` header in all relevant examples, ensuring that API requests are authenticated. The changes span multiple API reference files and cover endpoints for builds, files, flows, logs, monitoring, and projects.

TODO: Explain `AUTO_LOGIN` setting changes.
TODO: Ensure CLI key creation setting is correct.