### PR TITLE
fix(components): exclude base path from component loading and refine caching

### DIFF
--- a/src/backend/base/langflow/custom/utils.py
+++ b/src/backend/base/langflow/custom/utils.py
@@ -25,7 +25,6 @@ from langflow.custom.schema import MissingDefault
 from langflow.field_typing.range_spec import RangeSpec
 from langflow.helpers.custom import format_type
 from langflow.schema.dotdict import dotdict
-from langflow.services.settings.base import BASE_COMPONENTS_PATH
 from langflow.template.field.base import Input
 from langflow.template.frontend_node.custom_components import ComponentFrontendNode, CustomComponentFrontendNode
 from langflow.type_extraction.type_extraction import extract_inner_type
@@ -559,7 +558,6 @@ def build_custom_components(components_paths: list[str]):
 
 async def abuild_custom_components(components_paths: list[str]):
     """Build custom components from the specified paths."""
-    components_paths = [path for path in components_paths if path != BASE_COMPONENTS_PATH]
     if not components_paths:
         return {}
 

--- a/src/backend/base/langflow/custom/utils.py
+++ b/src/backend/base/langflow/custom/utils.py
@@ -25,6 +25,7 @@ from langflow.custom.schema import MissingDefault
 from langflow.field_typing.range_spec import RangeSpec
 from langflow.helpers.custom import format_type
 from langflow.schema.dotdict import dotdict
+from langflow.services.settings.base import BASE_COMPONENTS_PATH
 from langflow.template.field.base import Input
 from langflow.template.frontend_node.custom_components import ComponentFrontendNode, CustomComponentFrontendNode
 from langflow.type_extraction.type_extraction import extract_inner_type
@@ -558,6 +559,7 @@ def build_custom_components(components_paths: list[str]):
 
 async def abuild_custom_components(components_paths: list[str]):
     """Build custom components from the specified paths."""
+    components_paths = [path for path in components_paths if path != BASE_COMPONENTS_PATH]
     if not components_paths:
         return {}
 


### PR DESCRIPTION
Without this the Components are loaded twice. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of custom components to prevent unintended loading or merging when the components path matches the base path.
  - Enhanced initialization and merging of component cache for more reliable component management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->