### PR TITLE
fix: Add JSON sanitization to handle NaN values in streaming requests

### DIFF
--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -272,6 +272,16 @@ export type StreamingRequestParams = {
   eventDeliveryConfig?: EventDeliveryType;
 };
 
+// Helper function to sanitize JSON strings
+function sanitizeJsonString(jsonStr: string): string {
+  // Replace NaN with null (valid JSON)
+  return jsonStr
+    .replace(/:\s*NaN\b/g, ": null")
+    .replace(/\[\s*NaN\s*\]/g, "[null]")
+    .replace(/,\s*NaN\s*,/g, ", null,")
+    .replace(/,\s*NaN\s*\]/g, ", null]");
+}
+
 async function performStreamingRequest({
   method,
   url,
@@ -323,7 +333,8 @@ async function performStreamingRequest({
           const allString = current.join("") + string;
           let data: object;
           try {
-            data = JSON.parse(allString);
+            const sanitizedJson = sanitizeJsonString(allString);
+            data = JSON.parse(sanitizedJson);
             current = [];
           } catch (e) {
             current.push(string);
@@ -342,7 +353,8 @@ async function performStreamingRequest({
     if (current.length > 0) {
       const allString = current.join("");
       if (allString) {
-        const data = JSON.parse(current.join(""));
+        const sanitizedJson = sanitizeJsonString(allString);
+        const data = JSON.parse(sanitizedJson);
         await onData(data);
       }
     }


### PR DESCRIPTION
This pull request introduces a helper function to sanitize JSON strings and integrates it into the `performStreamingRequest` function in `src/frontend/src/controllers/API/api.tsx`. The changes aim to handle invalid JSON structures by replacing occurrences of `NaN` with `null`, ensuring compatibility with JSON parsing.

### Enhancements to JSON handling:

* **Added `sanitizeJsonString` function**: A new helper function was introduced to replace invalid JSON values (`NaN`) with valid ones (`null`). This ensures that JSON strings are sanitized before parsing. (`[src/frontend/src/controllers/API/api.tsxR275-R284](diffhunk://#diff-40877b80b2243cdac1ce21fa28ef5d9e9ab22eaf0051893e4c3236c3ec273150R275-R284)`)

* **Integrated `sanitizeJsonString` into `performStreamingRequest`**: Updated the JSON parsing logic in two places within the `performStreamingRequest` function to use the `sanitizeJsonString` function, ensuring sanitized JSON strings are parsed without errors. (`[[1]](diffhunk://#diff-40877b80b2243cdac1ce21fa28ef5d9e9ab22eaf0051893e4c3236c3ec273150L326-R337)`, `[[2]](diffhunk://#diff-40877b80b2243cdac1ce21fa28ef5d9e9ab22eaf0051893e4c3236c3ec273150L345-R357)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of streamed data to prevent errors caused by invalid JSON values, ensuring smoother and more reliable data processing during streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->