### PR TITLE
fix: adds handling for WSL on installing MCP on Claude on Windows

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
@@ -409,7 +409,7 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
                       {
                         onSuccess: () => {
                           setSuccessData({
-                            title: `MCP Server installed successfully on ${installer.title}`,
+                            title: `MCP Server installed successfully on ${installer.title}. You may need to restart your client to see the changes.`,
                           });
                           setLoadingMCP(
                             loadingMCP.filter(


### PR DESCRIPTION
This pull request enhances the handling of configurations for MCP servers, particularly in WSL environments, and improves logging for better debugging and user feedback. Key changes include introducing WSL-specific logic for determining configuration paths, adding detailed debug logs, and updating user-facing messages.

### Backend Improvements

* **WSL-Specific Configuration Handling**:
  - Added logic to detect WSL environments and determine Windows configuration paths for Claude, including fallbacks for user directory discovery. This ensures compatibility with WSL setups. [[1]](diffhunk://#diff-59e508b675da2296985654fefffa69b74a00d283904743fb65f27dad798c6bd0R404-R460) [[2]](diffhunk://#diff-59e508b675da2296985654fefffa69b74a00d283904743fb65f27dad798c6bd0L463-R616)
  - Updated the `is_wsl` variable to improve readability and reusability across functions.

* **Enhanced Debug Logging**:
  - Added debug logs to track project server name generation and configuration checks for both Cursor and Claude clients, aiding in troubleshooting. [[1]](diffhunk://#diff-59e508b675da2296985654fefffa69b74a00d283904743fb65f27dad798c6bd0R404-R460) [[2]](diffhunk://#diff-59e508b675da2296985654fefffa69b74a00d283904743fb65f27dad798c6bd0L463-R616)
  - Included warnings for JSON parsing failures and fallback scenarios in WSL configuration handling.

### Frontend Improvement

* **Improved User Feedback**:
  - Updated the success message in `McpServerTab` to inform users that a client restart may be required to reflect changes.