### PR TITLE
docs: update deploy_gh-pages.yml

### DIFF
--- a/.github/workflows/deploy_gh-pages.yml
+++ b/.github/workflows/deploy_gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
           cache-dependency-path: ./docs/yarn.lock
 


### PR DESCRIPTION
Bump node version in github pages build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to use Node.js version 20 for GitHub Pages deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->