### PR TITLE
docs: bump node version in docs draft deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs-draft.yml
+++ b/.github/workflows/deploy-docs-draft.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
           cache-dependency-path: ./docs/yarn.lock
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Node.js version used in documentation deployment workflows to version 20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->