### PR TITLE
fix: updated timeout for blog writer

### DIFF
--- a/src/frontend/tests/core/integrations/Blog Writer.spec.ts
+++ b/src/frontend/tests/core/integrations/Blog Writer.spec.ts
@@ -47,7 +47,9 @@ withEventDeliveryModes(
 
     await page.getByTestId("button_run_chat output").click();
 
-    await page.waitForSelector("text=built successfully", { timeout: 30000 });
+    await page.waitForSelector("text=built successfully", {
+      timeout: 30000 * 3,
+    });
 
     await page.getByRole("button", { name: "Playground", exact: true }).click();
     await page


### PR DESCRIPTION
This pull request includes a small change to the `Blog Writer.spec.ts` test file. The change increases the timeout for the `waitForSelector` method by multiplying the original value by 3 to account for potentially longer wait times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the waiting time for detecting the successful build message in tests, allowing more time for the build process to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->