### PR TITLE
fix: mcp command

### DIFF
--- a/src/backend/base/langflow/base/mcp/util.py
+++ b/src/backend/base/langflow/base/mcp/util.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import platform
+import shlex
 import shutil
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -318,9 +319,10 @@ class MCPStdioClient:
                 env=env_data,
             )
         else:
+            quoted_command = shlex.quote(command_str)
             server_params = StdioServerParameters(
                 command="bash",
-                args=["-c", f"{command_str} || echo 'Command failed with exit code $?' >&2"],
+                args=["-c", f"exec {quoted_command} || echo 'Command failed with exit code $?' >&2"],
                 env=env_data,
             )
 

--- a/src/backend/base/langflow/base/mcp/util.py
+++ b/src/backend/base/langflow/base/mcp/util.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import platform
-import shlex
 import shutil
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -319,10 +318,9 @@ class MCPStdioClient:
                 env=env_data,
             )
         else:
-            quoted_command = shlex.quote(command_str)
             server_params = StdioServerParameters(
                 command="bash",
-                args=["-c", f"exec {quoted_command} || echo 'Command failed with exit code $?' >&2"],
+                args=["-c", f"exec {command_str} || echo 'Command failed with exit code $?' >&2"],
                 env=env_data,
             )
 


### PR DESCRIPTION
This pull request includes a minor but important change to the `connect_to_server` method in `src/backend/base/langflow/base/mcp/util.py`. The change ensures that the executed command replaces the current shell process, improving resource management and behavior consistency.

* [`src/backend/base/langflow/base/mcp/util.py`](diffhunk://#diff-37c079efebed1e9da327c409abb8b1b6ec68d70c6a2a98885f0e1a11c087283cL323-R323): Updated the `args` parameter to use `exec` when executing the command string, ensuring the command replaces the current shell process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution reliability for non-Windows platforms when connecting to servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->