### PR TITLE
Update model.py

### DIFF
--- a/src/backend/base/langflow/services/database/models/message/model.py
+++ b/src/backend/base/langflow/services/database/models/message/model.py
@@ -62,13 +62,14 @@ class MessageBase(SQLModel):
                 if hasattr(file, "path") and hasattr(file, "url") and file.path:
                     session_id = message.session_id
                     if session_id:
-                      #Split only once, if session_id not found, fall back to the basename to avoid indexError.
+                        # Split only once, if session_id not found, fall back to the basename to avoid indexError.
                         parts = file.path.split(str(session_id), 1)
                         if len(parts) > 1:
                             fname = parts[1]
                         else:
-                             import os
-                             fname = os.path.basename(file.path)
+                            import os
+
+                            fname = os.path.basename(file.path)
                         image_paths.append(f"{session_id}{fname}")
                     else:
                         image_paths.append(file.path)

--- a/src/backend/base/langflow/services/database/models/message/model.py
+++ b/src/backend/base/langflow/services/database/models/message/model.py
@@ -62,7 +62,14 @@ class MessageBase(SQLModel):
                 if hasattr(file, "path") and hasattr(file, "url") and file.path:
                     session_id = message.session_id
                     if session_id:
-                        image_paths.append(f"{session_id}{file.path.split(str(session_id))[1]}")
+                      #Split only once, if session_id not found, fall back to the basename to avoid indexError.
+                        parts = file.path.split(str(session_id), 1)
+                        if len(parts) > 1:
+                            fname = parts[1]
+                        else:
+                             import os
+                             fname = os.path.basename(file.path)
+                        image_paths.append(f"{session_id}{fname}")
                     else:
                         image_paths.append(file.path)
             if image_paths:


### PR DESCRIPTION
fix(langflow): safely handle file paths split to avoid IndexError

If message.session_id is not found in file.path, the original split() would return a list with only one element—causing a list index out-of-range error. This patch:
- Uses split(..., 1) to limit splitting,
- Checks the result length before indexing,
- Falls back to os.path.basename when needed.

Fixes: langflow-ai/langflow#7926

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path handling to prevent errors when processing image attachments, ensuring more reliable display and access to images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->