### PR TITLE
docs: redirect link from template

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -281,6 +281,10 @@ const config = {
             to: "/contributing-github-issues",
             from: "/contributing-github-discussions",
           },
+          {
+            to: "/agents",
+            from: "/agents-tool-calling-agent-component",
+          },
           // add more redirects like this
           // {
           //   to: '/docs/anotherpage',


### PR DESCRIPTION
Add a redirect to `/agents` from `/agents-tool-calling-agent-component`.
The simple agent starter template still uses the latter, this way it's not a 404.