### PR TITLE
test: Update notification test selectors for clarity

### DIFF
--- a/src/frontend/tests/extended/features/notifications.spec.ts
+++ b/src/frontend/tests/extended/features/notifications.spec.ts
@@ -7,12 +7,12 @@ test(
   async ({ page }) => {
     await awaitBootstrapTest(page);
     await page.getByTestId("blank-flow").click();
-    await page.waitForSelector('[data-testid="disclosure-i/o"]', {
+    await page.waitForSelector('[data-testid="disclosure-input / output"]', {
       timeout: 3000,
       state: "visible",
     });
 
-    await page.getByTestId("disclosure-i/o").click();
+    await page.getByTestId("disclosure-input / output").click();
     await page.waitForSelector('[data-testid="input_outputText Input"]', {
       timeout: 3000,
       state: "visible",


### PR DESCRIPTION
This pull request includes a minor update to the `src/frontend/tests/extended/features/notifications.spec.ts` file. The change updates test selectors to use more descriptive names for clarity.

* Updated test selectors from `disclosure-i/o` to `disclosure-input / output` and from `input_outputText Input` to `input_outputText Input` for improved readability.