### PR TITLE
fix: Fix broken state from an invalid folderId in the path

### DIFF
--- a/src/frontend/src/CustomNodes/NoteNode/index.tsx
+++ b/src/frontend/src/CustomNodes/NoteNode/index.tsx
@@ -84,8 +84,7 @@ function NoteNode({
       ),
     [data, bgColor, selected],
   );
-  console.log(nodeData);
-  console.log();
+
   return (
     <>
       <NodeResizer

--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -8,6 +8,7 @@ import {
   ENABLE_DATASTAX_LANGFLOW,
   ENABLE_MCP,
 } from "@/customization/feature-flags";
+import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { useFolderStore } from "@/stores/foldersStore";
 import { FlowType } from "@/types/flow";
@@ -30,6 +31,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
   const [pageIndex, setPageIndex] = useState(1);
   const [pageSize, setPageSize] = useState(12);
   const [search, setSearch] = useState("");
+  const navigate = useCustomNavigate();
 
   const [flowType, setFlowType] = useState<"flows" | "components" | "mcp">(
     type,
@@ -41,6 +43,18 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
     folders[0]?.name ??
     "";
   const flows = useFlowsManagerStore((state) => state.flows);
+
+  useEffect(() => {
+    // Only check if we have a folderId and folders have loaded
+    if (folderId && folders && folders.length > 0) {
+      const folderExists = folders.find((folder) => folder.id === folderId);
+      if (!folderExists) {
+        // Folder doesn't exist for this user, redirect to /all
+        console.log("Invalid folderId, redirecting to /all");
+        navigate("/all");
+      }
+    }
+  }, [folderId, folders, navigate]);
 
   const { data: folderData, isLoading } = useGetFolderQuery({
     id: folderId ?? myCollectionId!,


### PR DESCRIPTION
**The Bug**
Discovered during superuser and new user testing there was a stale state when a user logged in to new users account when the login url contained a redirect to a specific folder which the now active user did not have.

The easier way to reproduce is just to update the folderId to something incorrect

**the fix**
Adds a simple check to see if the id in the url matches one of the users folders if not we redirect to `/all`