### PR TITLE
fix: updated folder name to not be the deprecated

### DIFF
--- a/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx
@@ -10,7 +10,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { SAVED_HOVER } from "@/constants/constants";
+import {
+  DEFAULT_FOLDER,
+  DEFAULT_FOLDER_DEPRECATED,
+  SAVED_HOVER,
+} from "@/constants/constants";
 import { useGetRefreshFlowsQuery } from "@/controllers/API/queries/flows/use-get-refresh-flows-query";
 import { useGetFoldersQuery } from "@/controllers/API/queries/folders/use-get-folders";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
@@ -111,7 +115,9 @@ export const MenuBar = memo((): JSX.Element => {
                     );
                   }}
                 >
-                  {currentFolder?.name}
+                  {currentFolder?.name == DEFAULT_FOLDER_DEPRECATED
+                    ? DEFAULT_FOLDER
+                    : currentFolder?.name}
                 </div>
               </div>
             )}


### PR DESCRIPTION
This pull request updates the `FlowMenu` component in `index.tsx` to enhance folder handling by introducing new constants and improving folder name display logic.

### Enhancements to folder handling:

* [`src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx`](diffhunk://#diff-22996ac0e1d31e677dd1f1b8a19404c313ac28d4f617d936618398b260072f07L13-R17): Added `DEFAULT_FOLDER` and `DEFAULT_FOLDER_DEPRECATED` constants to the imports for better folder management.
* [`src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/index.tsx`](diffhunk://#diff-22996ac0e1d31e677dd1f1b8a19404c313ac28d4f617d936618398b260072f07L114-R120): Updated the folder name display logic to replace `DEFAULT_FOLDER_DEPRECATED` with `DEFAULT_FOLDER` when applicable, ensuring a more user-friendly representation.