### PR TITLE
style: Adjust copy button position in APITabsComponent

### DIFF
--- a/src/frontend/src/modals/apiModal/codeTabs/code-tabs.tsx
+++ b/src/frontend/src/modals/apiModal/codeTabs/code-tabs.tsx
@@ -149,7 +149,7 @@ export default function APITabsComponent() {
               size="icon"
               onClick={copyToClipboard}
               data-testid="btn-copy-code"
-              className="!hover:bg-foreground group absolute right-2 top-2"
+              className="!hover:bg-foreground group absolute right-4 top-2"
             >
               {isCopied ? (
                 <IconComponent


### PR DESCRIPTION
This pull request includes a minor adjustment to the `APITabsComponent` in `code-tabs.tsx`. The change modifies the `className` property of the copy button to adjust its position slightly, moving it further to the right.