### PR TITLE
fix: updated Run Flow to not group outputs

### DIFF
--- a/src/backend/base/langflow/base/tools/run_flow.py
+++ b/src/backend/base/langflow/base/tools/run_flow.py
@@ -52,6 +52,7 @@ class RunFlowBaseComponent(Component):
             display_name="Flow Data Output",
             method="data_output",
             hidden=True,
+            group_outputs=True,
             tool_mode=False,  # This output is not intended to be used as a tool, so tool_mode is disabled.
         ),
         Output(
@@ -59,9 +60,12 @@ class RunFlowBaseComponent(Component):
             display_name="Flow Dataframe Output",
             method="dataframe_output",
             hidden=True,
+            group_outputs=True,
             tool_mode=False,  # This output is not intended to be used as a tool, so tool_mode is disabled.
         ),
-        Output(name="flow_outputs_message", display_name="Flow Message Output", method="message_output"),
+        Output(
+            name="flow_outputs_message", group_outputs=True, display_name="Flow Message Output", method="message_output"
+        ),
     ]
     default_keys = ["code", "_type", "flow_name_selected", "session_id"]
     FLOW_INPUTS: list[dotdict] = []


### PR DESCRIPTION
This pull request modifies the `Output` configuration in `src/backend/base/langflow/base/tools/run_flow.py` to introduce the `group_outputs` parameter for better organization of outputs. It also refactors the definition of `flow_outputs_message` for consistency.

Enhancements to output configuration:

* Added the `group_outputs=True` parameter to the `Output` definitions for `data_output`, `dataframe_output`, and `message_output` to enable grouping of outputs. This change improves the organization and handling of flow outputs.

Refactoring for consistency:

* Refactored the `flow_outputs_message` definition to align with the formatting style used for other `Output` definitions, making the code more consistent and readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the display by grouping related output items together for a more organized and user-friendly experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->