### PR TITLE
feat: Add CustomTermsLinks component to GeneralPage

### DIFF
--- a/src/frontend/src/customization/components/custom-terms-links.tsx
+++ b/src/frontend/src/customization/components/custom-terms-links.tsx
@@ -1,0 +1,3 @@
+export const CustomTermsLinks = () => {
+  return <></>;
+};

--- a/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
@@ -10,6 +10,7 @@ import {
   useUpdateUser,
 } from "@/controllers/API/queries/auth";
 import { useGetProfilePicturesQuery } from "@/controllers/API/queries/files";
+import { CustomTermsLinks } from "@/customization/components/custom-terms-links";
 import { ENABLE_PROFILE_ICONS } from "@/customization/feature-flags";
 import useAuthStore from "@/stores/authStore";
 import { cloneDeep } from "lodash";
@@ -160,6 +161,8 @@ export const GeneralPage = () => {
           />
         )}
       </div>
+
+      <CustomTermsLinks />
     </div>
   );
 };


### PR DESCRIPTION
This pull request introduces a new `CustomTermsLinks` component and integrates it into the `GeneralPage` of the settings section. The changes primarily focus on adding this new component and updating imports accordingly.

### Component Addition:

* [`src/frontend/src/customization/components/custom-terms-links.tsx`](diffhunk://#diff-c56e44e55aa820428cff9ee9fcacaf816c92635d527cb00dea04c7fe3ce0a2b9R1-R3): Added a new `CustomTermsLinks` component, which currently renders an empty fragment.

### Integration with `GeneralPage`:

* `src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx`: 
  - Imported the `CustomTermsLinks` component.
  - Added the `CustomTermsLinks` component to the JSX structure of `GeneralPage`.