### PR TITLE
fix: resolve circular import in Component class

### DIFF
--- a/src/backend/base/langflow/custom/custom_component/component.py
+++ b/src/backend/base/langflow/custom/custom_component/component.py
@@ -24,8 +24,10 @@ from langflow.base.tools.constants import (
 from langflow.custom.tree_visitor import RequiredInputsVisitor
 from langflow.exceptions.component import StreamingError
 from langflow.field_typing import Tool  # noqa: TC001 Needed by _add_toolkit_output
-from langflow.graph.state.model import create_state_model
-from langflow.graph.utils import has_chat_output
+# Lazy import to avoid circular dependency
+# from langflow.graph.state.model import create_state_model
+# Lazy import to avoid circular dependency
+# from langflow.graph.utils import has_chat_output
 from langflow.helpers.custom import format_type
 from langflow.memory import astore_message, aupdate_messages, delete_message
 from langflow.schema.artifact import get_artifact_type, post_process_raw
@@ -298,6 +300,8 @@ class Component(CustomComponent):
         fields = {}
         for output in self._outputs_map.values():
             fields[output.name] = getattr(self, output.method)
+        # Lazy import to avoid circular dependency
+        from langflow.graph.state.model import create_state_model
         self._state_model = create_state_model(model_name=model_name, **fields)
         return self._state_model
 
@@ -1371,6 +1375,8 @@ class Component(CustomComponent):
             )
 
     def is_connected_to_chat_output(self) -> bool:
+        # Lazy import to avoid circular dependency
+        from langflow.graph.utils import has_chat_output
         return has_chat_output(self.graph.get_vertex_neighbors(self._vertex))
 
     def _should_skip_message(self, message: Message) -> bool:


### PR DESCRIPTION
## Summary

This PR fixes a circular import issue in the Component class that was preventing component testing.

• **Problem**: Circular dependency chain preventing component test execution
• **Solution**: Move graph-related imports inside methods (lazy imports) 
• **Impact**: Enables component testing without import errors

## Root Cause

The circular import chain was:
```
Component -> graph.state.model -> graph.vertex -> Component
```

This created a circular dependency that prevented importing and testing components.

## Changes Made

### 🔧 Lazy Import Implementation

**File**: `src/backend/base/langflow/custom/custom_component/component.py`

1. **Moved `create_state_model` import inside `_build_state_model()` method**:
   ```python
   # Before: Top-level import causing circular dependency
   from langflow.graph.state.model import create_state_model
   
   # After: Lazy import inside method
   def _build_state_model(self):
       from langflow.graph.state.model import create_state_model  # Lazy import
       self._state_model = create_state_model(model_name=model_name, **fields)
   ```

2. **Moved `has_chat_output` import inside `is_connected_to_chat_output()` method**:
   ```python
   # Before: Top-level import causing circular dependency  
   from langflow.graph.utils import has_chat_output
   
   # After: Lazy import inside method
   def is_connected_to_chat_output(self) -> bool:
       from langflow.graph.utils import has_chat_output  # Lazy import
       return has_chat_output(self.graph.get_vertex_neighbors(self._vertex))
   ```

## Benefits

✅ **Enables Component Testing**: Components can now be imported and tested without circular import errors
✅ **Preserves Functionality**: No behavioral changes - imports happen when methods are called
✅ **Minimal Impact**: Only affects import timing, not component execution
✅ **Future-Proof**: Prevents similar circular import issues

## Test Plan

- [x] Verify components can be imported without errors
- [x] Confirm existing functionality remains unchanged
- [x] Test that component test suites can run successfully
- [x] Validate no regression in component behavior

## Related Issues

This fix was discovered while implementing comprehensive tests for DataFrame Operations component, where circular imports were preventing test execution.

🤖 Generated with [Claude Code](https://claude.ai/code)