### PR TITLE
fix: added error width limitation, truncation and tooltip on MCP dialog

### DIFF
--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -302,7 +302,7 @@ export default function AddMcpServerModal({
                   <ShadTooltip content={error}>
                     <div
                       className={cn(
-                        "absolute right-4 top-3 truncate text-xs font-medium text-red-500",
+                        "absolute right-4 top-4 truncate text-xs font-medium text-red-500",
                         type === "JSON" ? "w-3/5" : "w-4/5",
                       )}
                     >


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `AddMcpServerModal` component by integrating a tooltip for better error message display. The tooltip improves user experience by providing additional context for error messages.

Enhancement to error message display:

* [`src/frontend/src/modals/addMcpServerModal/index.tsx`](diffhunk://#diff-2761edaffa0fb75a00335954fd6059dd4c93c3032fc2aa7282a472acdd59968dR4): Added the `ShadTooltip` component to wrap error messages, enabling tooltips with truncated text and additional context. [[1]](diffhunk://#diff-2761edaffa0fb75a00335954fd6059dd4c93c3032fc2aa7282a472acdd59968dR4) [[2]](diffhunk://#diff-2761edaffa0fb75a00335954fd6059dd4c93c3032fc2aa7282a472acdd59968dL298-R303)

Previous behavior:

![image](https://github.com/user-attachments/assets/46ed3671-76e9-4b37-8909-cf9765e03c37)

Current behavior:

<img width="569" alt="Screenshot 2025-07-03 at 12 13 05" src="https://github.com/user-attachments/assets/b32c1754-15d4-43e3-b67f-57bfd0240a9a" />
<img width="619" alt="Screenshot 2025-07-03 at 12 13 09" src="https://github.com/user-attachments/assets/bb8670c0-ed7a-4fcd-ab62-c7f2a2c6a935" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Error messages in the add server modal are now displayed within a tooltip, with improved positioning, width constraints, and text truncation for a cleaner user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->