### PR TITLE
fix: make MCP naming changes, change actions to tools

### DIFF
--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/mcp-server-notice.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/mcp-server-notice.tsx
@@ -24,7 +24,7 @@ export const MCPServerNotice: FC<{
         </div>
         <img src={MCPLangflow} alt="MCP Notice Modal" className="rounded-xl" />
         <p className="text-sm text-secondary-foreground">
-          Expose flows as actions from clients like Cursor or Claude.
+          Expose flows as tools from clients like Cursor or Claude.
         </p>
       </div>
 

--- a/src/frontend/src/components/core/parameterRenderComponent/components/mcpComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/mcpComponent/index.tsx
@@ -31,8 +31,8 @@ export default function McpComponent({
                 : "Error"
               : "Loading..."
             : !server.toolsCount
-              ? "No actions found"
-              : `${server.toolsCount} action${server.toolsCount === 1 ? "" : "s"}`,
+              ? "No tools found"
+              : `${server.toolsCount} tool${server.toolsCount === 1 ? "" : "s"}`,
       })),
     [mcpServers],
   );

--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -252,7 +252,7 @@ export default function AddMcpServerModal({
               {initialData ? "Update MCP Server" : "Add MCP Server"}
             </div>
             <span className="text-mmd font-normal text-muted-foreground">
-              Save MCP Servers. Manage added connections in{" "}
+              Save MCP Servers. Manage added servers in{" "}
               <CustomLink className="underline" to="/settings/mcp-servers">
                 settings
               </CustomLink>

--- a/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
+++ b/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
@@ -300,7 +300,7 @@ export default function ToolsTable({
                     className="text-mmd font-medium"
                     htmlFor="sidebar-name-input"
                   >
-                    Name
+                    {isAction ? "Tool name" : "Name"}
                   </label>
 
                   <Input
@@ -322,7 +322,7 @@ export default function ToolsTable({
                     className="text-mmd font-medium"
                     htmlFor="sidebar-desc-input"
                   >
-                    Description
+                    {isAction ? "Tool description" : "Description"}
                   </label>
 
                   <Textarea
@@ -335,7 +335,7 @@ export default function ToolsTable({
                   />
                   <div className="text-xs text-muted-foreground">
                     {isAction
-                      ? "This is the description for the tool exposed to the clients."
+                      ? "This is the description for the tool exposed to a client."
                       : "This is the description for the tool exposed to the agents."}
                   </div>
                 </div>

--- a/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
+++ b/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
@@ -162,7 +162,7 @@ export default function ToolsTable({
     },
     {
       field: "name",
-      headerName: isAction ? "Action" : "Slug",
+      headerName: isAction ? "Tool" : "Slug",
       flex: 1,
       resizable: false,
       valueGetter: (params) =>
@@ -263,7 +263,7 @@ export default function ToolsTable({
         <div className="flex-none px-4">
           <Input
             icon="Search"
-            placeholder="Search actions..."
+            placeholder="Search tools..."
             inputClassName="h-8"
             value={searchQuery}
             onChange={handleSearchChange}
@@ -335,7 +335,7 @@ export default function ToolsTable({
                   />
                   <div className="text-xs text-muted-foreground">
                     {isAction
-                      ? "This is the description for the action exposed to the clients."
+                      ? "This is the description for the tool exposed to the clients."
                       : "This is the description for the tool exposed to the agents."}
                   </div>
                 </div>
@@ -370,7 +370,7 @@ export default function ToolsTable({
                           Parameters
                         </h3>
                         <p className="text-mmd text-muted-foreground">
-                          Manage inputs for this action
+                          Manage inputs for this tool
                         </p>
                       </div>
                     )}

--- a/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
@@ -253,8 +253,8 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
         MCP Server
       </div>
       <div className="pb-4 text-mmd text-muted-foreground">
-        Access your Project's flows as Actions within a MCP Server. Learn more
-        in our
+        Access your Project's flows as Tools within a MCP Server. Learn more in
+        our
         <a
           className="text-accent-pink-foreground"
           href={MCP_SERVER_DEPLOY_TUTORIAL_LINK}
@@ -269,11 +269,11 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
         <div className="w-full xl:w-2/5">
           <div className="flex flex-row justify-between">
             <ShadTooltip
-              content="Flows in this project can be exposed as callable MCP actions."
+              content="Flows in this project can be exposed as callable MCP tools."
               side="right"
             >
               <div className="flex items-center text-mmd font-medium hover:cursor-help">
-                Flows/Actions
+                Flows/Tools
                 <ForwardedIconComponent
                   name="info"
                   className="ml-1.5 h-4 w-4 text-muted-foreground"
@@ -285,11 +285,11 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
           <div className="flex flex-row flex-wrap gap-2 pt-2">
             <ToolsComponent
               value={flowsMCPData}
-              title="MCP Server Actions"
-              description="Select actions to add to this server"
+              title="MCP Server Tools"
+              description="Select tools to add to this server"
               handleOnNewValue={handleOnNewValue}
               id="mcp-server-tools"
-              button_description="Edit Actions"
+              button_description="Edit Tools"
               editNode={false}
               isAction
               disabled={false}

--- a/src/frontend/src/pages/SettingsPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/index.tsx
@@ -39,7 +39,7 @@ export default function SettingsPage(): JSX.Element {
 
   sidebarNavItems.push(
     {
-      title: "MCP Connections",
+      title: "MCP Servers",
       href: "/settings/mcp-servers",
       icon: (
         <ForwardedIconComponent

--- a/src/frontend/src/pages/SettingsPage/pages/MCPServersPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/MCPServersPage/index.tsx
@@ -61,7 +61,7 @@ export default function MCPServersPage() {
       <div className="flex w-full items-start justify-between gap-6">
         <div className="flex flex-col">
           <h2 className="flex items-center text-lg font-semibold tracking-tight">
-            MCP Connections
+            MCP Servers
             <ForwardedIconComponent
               name="Mcp"
               className="ml-2 h-5 w-5 text-primary"
@@ -116,7 +116,7 @@ export default function MCPServersPage() {
                               ? "Timeout"
                               : "Error"
                             : "Loading..."
-                          : `${server.toolsCount} action${server.toolsCount === 1 ? "" : "s"}`}
+                          : `${server.toolsCount} tool${server.toolsCount === 1 ? "" : "s"}`}
                       </span>
                     </ShadTooltip>
                   </div>

--- a/src/frontend/src/pages/SettingsPage/pages/MCPServersPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/MCPServersPage/index.tsx
@@ -116,7 +116,9 @@ export default function MCPServersPage() {
                               ? "Timeout"
                               : "Error"
                             : "Loading..."
-                          : `${server.toolsCount} tool${server.toolsCount === 1 ? "" : "s"}`}
+                          : !server.toolsCount
+                            ? "No tools found"
+                            : `${server.toolsCount} tool${server.toolsCount === 1 ? "" : "s"}`}
                       </span>
                     </ShadTooltip>
                   </div>

--- a/src/frontend/src/pages/SettingsPage/pages/MCPServersPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/MCPServersPage/index.tsx
@@ -92,7 +92,7 @@ export default function MCPServersPage() {
               </div>
             ) : (
               <div className="text-sm font-medium text-muted-foreground">
-                Servers
+                Added MCP Servers
               </div>
             )}
             <div className="flex flex-col gap-1">

--- a/src/frontend/tests/extended/features/edit-tools.spec.ts
+++ b/src/frontend/tests/extended/features/edit-tools.spec.ts
@@ -40,7 +40,7 @@ test(
       state: "visible",
     });
 
-    await page.waitForSelector("text=actions", { timeout: 30000 });
+    await page.waitForSelector("text=tools", { timeout: 30000 });
 
     await page.getByTestId("button_open_actions").click();
 

--- a/src/frontend/tests/extended/features/mcp-server-tab.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server-tab.spec.ts
@@ -3,7 +3,7 @@ import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { zoomOut } from "../../utils/zoom-out";
 
 test(
-  "user should be able to manage MCP server actions and configuration",
+  "user should be able to manage MCP server tools and configuration",
   { tag: ["@release", "@workspace", "@components"] },
   async ({ page }) => {
     const maxRetries = 5;
@@ -47,14 +47,14 @@ test(
 
         // Verify MCP server tab is visible
         await expect(page.getByTestId("mcp-server-title")).toBeVisible();
-        await expect(page.getByText("Flows/Actions")).toBeVisible();
+        await expect(page.getByText("Flows/Tools")).toBeVisible();
 
-        // Click on Edit Actions button
+        // Click on Edit Tools button
         await page.getByTestId("button_open_actions").click();
         await page.waitForTimeout(500);
 
         // Verify actions modal is open
-        await expect(page.getByText("MCP Server Actions")).toBeVisible();
+        await expect(page.getByText("MCP Server Tools")).toBeVisible();
 
         // Select some actions
         const rowsCount = await page.getByRole("row").count();

--- a/src/frontend/tests/extended/features/mcp-server.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server.spec.ts
@@ -105,13 +105,11 @@ test(
 
     await page.getByTestId("menu_settings_button").click({ timeout: 3000 });
 
-    await page.waitForSelector('[data-testid="sidebar-nav-MCP Connections"]', {
+    await page.waitForSelector('[data-testid="sidebar-nav-MCP Servers"]', {
       timeout: 30000,
     });
 
-    await page
-      .getByTestId("sidebar-nav-MCP Connections")
-      .click({ timeout: 3000 });
+    await page.getByTestId("sidebar-nav-MCP Servers").click({ timeout: 3000 });
 
     await page.waitForSelector('[data-testid="add-mcp-server-button-page"]', {
       timeout: 3000,


### PR DESCRIPTION
This pull request focuses on renaming terminology across the frontend codebase to improve clarity and consistency. Specifically, it replaces references to "actions" with "tools" and updates related labels, descriptions, and test cases accordingly. The changes span multiple files and components, ensuring the new terminology is consistently applied throughout the application.

### Terminology Updates:

* **Component and UI Updates**:
  - Updated descriptions, placeholders, and labels in `MCPServerNotice`, `McpComponent`, `ToolsTable`, and `McpServerTab` components to replace "actions" with "tools." For example, "Search actions..." was changed to "Search tools..." and "Flows/Actions" was changed to "Flows/Tools." (`[[1]](diffhunk://#diff-f61b943ddbd5597b737df702e9dfa7cb61a4f61ff75c9a5d1c21346e392f182dL27-R27)`, `[[2]](diffhunk://#diff-6627057181c3970ed9c9daea69fa855a4915363c9297f365fccded5c744c5e27L34-R35)`, `[[3]](diffhunk://#diff-74c8a3a7d322d9e3c2682246b095581a079f097b77acf319fd19a7922a39c7baL165-R165)`, `[[4]](diffhunk://#diff-74c8a3a7d322d9e3c2682246b095581a079f097b77acf319fd19a7922a39c7baL266-R266)`, `[[5]](diffhunk://#diff-da4edd139a58d412a5bba68a4e4e84c77cf40f53711bceee9c9a12da4ea2eda8L256-R257)`, `[[6]](diffhunk://#diff-da4edd139a58d412a5bba68a4e4e84c77cf40f53711bceee9c9a12da4ea2eda8L272-R276)`)

* **Settings Page Updates**:
  - Renamed "MCP Connections" to "MCP Servers" in the Settings page and updated related labels and descriptions. For example, "Servers" was changed to "Added MCP Servers." (`[[1]](diffhunk://#diff-71d4eb4d8471e6b2c846279e40537123edcd7c0e0cac0c39bb6bbcbf16391ce3L42-R42)`, `[[2]](diffhunk://#diff-a4b5b22b3fc381cf0106e514b25841e55c25b132acca137a25bdc0215eb243c3L64-R64)`, `[[3]](diffhunk://#diff-a4b5b22b3fc381cf0106e514b25841e55c25b132acca137a25bdc0215eb243c3L95-R95)`)

* **Modal Updates**:
  - Adjusted text in the `AddMcpServerModal` to reflect the change from "connections" to "servers." (`[src/frontend/src/modals/addMcpServerModal/index.tsxL255-R255](diffhunk://#diff-2761edaffa0fb75a00335954fd6059dd4c93c3032fc2aa7282a472acdd59968dL255-R255)`)

* **Test Updates**:
  - Updated test cases to align with the new terminology, ensuring references to "actions" are replaced with "tools" in selectors, labels, and assertions. For example, "user should be able to manage MCP server actions and configuration" was changed to "user should be able to manage MCP server tools and configuration." (`[[1]](diffhunk://#diff-12076cff30d0cc193e72edab3d5f11b01ed45e94e88ede30bbc3ae7267450665L43-R43)`, `[[2]](diffhunk://#diff-7be38a6d14c366a786e62666ed82fb46f758a4d65b76f8c486a56eb90b700e39L6-R6)`, `[[3]](diffhunk://#diff-7be38a6d14c366a786e62666ed82fb46f758a4d65b76f8c486a56eb90b700e39L50-R57)`, `[[4]](diffhunk://#diff-37d0e42832061615b47a8d9aac2a99d55e565969f0e0e9311e1e536152013f9aL108-R112)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated all user interface text to replace references to "actions" with "tools" and "MCP Connections" with "MCP Servers" for improved clarity and consistency across the application.

* **Tests**
  * Adjusted test cases to align with the new terminology, ensuring test steps and validations now reference "tools" and "MCP Servers" where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->