### PR TITLE
fix: not allow selecting texts that shouldn't be selectable

### DIFF
--- a/src/frontend/src/style/applies.css
+++ b/src/frontend/src/style/applies.css
@@ -1247,6 +1247,14 @@
     @apply absolute right-3 w-14 -translate-y-3.5 cursor-text rounded-sm px-2 py-[1px] text-center hover:ring-[1px] hover:ring-slider-input-border;
   }
 
+  .cursor-pointer,
+  .cursor-default,
+  .cursor-not-allowed,
+  label,
+  button {
+    @apply select-none;
+  }
+
   .btn-add-input-list {
     @apply flex h-6 w-full items-center justify-center rounded-md p-2 text-sm hover:bg-muted;
   }


### PR DESCRIPTION
This pull request introduces a minor update to the `src/style/applies.css` file to enhance styling consistency. It adds a new rule to apply the `select-none` utility to specific elements, preventing text selection for improved user experience.

Styling updates:

* [`src/frontend/src/style/applies.css`](diffhunk://#diff-f227a8805837a247ce52fbbc51e193ce8de9e83c5810af44a0887ee4d888baa2R1250-R1257): Added `@apply select-none` to `.cursor-pointer`, `.cursor-default`, `.cursor-not-allowed`, `label`, and `button` elements to prevent text selection on these components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Disabled text selection for buttons, labels, and elements with certain cursor styles to improve user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->