### PR TITLE
fix: enable tool mode only if a server is selected

### DIFF
--- a/src/backend/base/langflow/components/agents/mcp_component.py
+++ b/src/backend/base/langflow/components/agents/mcp_component.py
@@ -280,6 +280,7 @@ class MCPToolsComponent(ComponentWithCache):
                     build_config["tool"]["options"] = []
                     build_config["tool"]["value"] = ""
                     build_config["tool"]["placeholder"] = ""
+                    build_config["tool_placeholder"]["tool_mode"] = False
                     self.remove_non_default_keys(build_config)
                     return build_config
 

--- a/src/backend/base/langflow/components/agents/mcp_component.py
+++ b/src/backend/base/langflow/components/agents/mcp_component.py
@@ -332,7 +332,7 @@ class MCPToolsComponent(ComponentWithCache):
 
             elif field_name == "tool_mode":
                 build_config["tool"]["placeholder"] = ""
-                build_config["tool"]["show"] = not field_value and build_config["mcp_server"]
+                build_config["tool"]["show"] = not bool(field_value) and bool(build_config["mcp_server"])
                 self.remove_non_default_keys(build_config)
                 self.tool = build_config["tool"]["value"]
                 if field_value:

--- a/src/backend/base/langflow/components/agents/mcp_component.py
+++ b/src/backend/base/langflow/components/agents/mcp_component.py
@@ -120,7 +120,7 @@ class MCPToolsComponent(ComponentWithCache):
             info="Placeholder for the tool",
             value="",
             show=False,
-            tool_mode=True,
+            tool_mode=False,
         ),
     ]
 
@@ -283,6 +283,8 @@ class MCPToolsComponent(ComponentWithCache):
                     self.remove_non_default_keys(build_config)
                     return build_config
 
+                build_config["tool_placeholder"]["tool_mode"] = True
+
                 current_server_name = field_value.get("name") if isinstance(field_value, dict) else field_value
                 _last_selected_server = self._shared_component_cache.get("last_selected_server") or ""
 
@@ -329,7 +331,7 @@ class MCPToolsComponent(ComponentWithCache):
 
             elif field_name == "tool_mode":
                 build_config["tool"]["placeholder"] = ""
-                build_config["tool"]["show"] = not field_value
+                build_config["tool"]["show"] = not field_value and build_config["mcp_server"]
                 self.remove_non_default_keys(build_config)
                 self.tool = build_config["tool"]["value"]
                 if field_value:


### PR DESCRIPTION
This pull request makes adjustments to the `tool_mode` behavior in the `MCPComponent` class within `src/backend/base/langflow/components/agents/mcp_component.py`. The changes primarily focus on refining how `tool_mode` is set and used in the build configuration, ensuring better alignment with the `mcp_server` state.

### Updates to `tool_mode` behavior:

* [`src/backend/base/langflow/components/agents/mcp_component.py`](diffhunk://#diff-96136250e193835af65ee07edd4df6436ae6fa04be305f0b4bdaac770e6b0c50L123-R123): Changed the default value of `tool_mode` in the `__init__` method from `True` to `False`.
* [`src/backend/base/langflow/components/agents/mcp_component.py`](diffhunk://#diff-96136250e193835af65ee07edd4df6436ae6fa04be305f0b4bdaac770e6b0c50R286-R287): Updated the `update_build_config` method to explicitly set `tool_mode` to `True` within the `tool_placeholder` key in the build configuration.
* [`src/backend/base/langflow/components/agents/mcp_component.py`](diffhunk://#diff-96136250e193835af65ee07edd4df6436ae6fa04be305f0b4bdaac770e6b0c50L332-R334): Refined the logic for setting the `show` attribute of the `tool` object in the `update_build_config` method to depend on both `field_value` and the `mcp_server` state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved configuration options for tool mode and tool visibility in the agent settings, providing more dynamic control based on server selection.

* **Bug Fixes**
  * Adjusted the initial state and toggling behavior for tool mode and tool visibility to ensure more accurate and intuitive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->