### PR TITLE
chore: add required API key secrets for CI workflows

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -145,6 +145,9 @@ jobs:
     uses: ./.github/workflows/python_test.yml
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
   # Not making nightly builds dependent on integration test success
   # due to inherent flakiness of 3rd party integrations


### PR DESCRIPTION
- Updated nightly_build.yml to include OPENAI_API_KEY and ANTHROPIC_API_KEY as required secrets for the Python test job, enhancing security and ensuring proper access to necessary APIs during CI execution.