### PR TITLE
Polish Ace Editor: theme, border, background, and mode-aware styling

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -1,3 +1,4 @@
+@import "./style/custom-ace-overrides.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/frontend/src/modals/codeAreaModal/index.tsx
+++ b/src/frontend/src/modals/codeAreaModal/index.tsx
@@ -5,8 +5,29 @@ import "ace-builds/src-noconflict/ace";
 import "ace-builds/src-noconflict/ext-language_tools";
 import "ace-builds/src-noconflict/ext-searchbox";
 import "ace-builds/src-noconflict/mode-python";
-import "ace-builds/src-noconflict/theme-github";
+import "ace-builds/src-noconflict/theme-one_dark";
+import "ace-builds/src-noconflict/theme-github_dark";
 import "ace-builds/src-noconflict/theme-twilight";
+import "ace-builds/src-noconflict/theme-dracula";
+import "ace-builds/src-noconflict/theme-monokai";
+import "ace-builds/src-noconflict/theme-nord_dark";
+import "ace-builds/src-noconflict/theme-pastel_on_dark";
+import "ace-builds/src-noconflict/theme-solarized_dark";
+import "ace-builds/src-noconflict/theme-terminal";
+import "ace-builds/src-noconflict/theme-tomorrow_night";
+import "ace-builds/src-noconflict/theme-vibrant_ink";
+import "ace-builds/src-noconflict/theme-chaos";
+import "ace-builds/src-noconflict/theme-cobalt";
+import "ace-builds/src-noconflict/theme-gruvbox";
+import "ace-builds/src-noconflict/theme-idle_fingers";
+import "ace-builds/src-noconflict/theme-kr_theme";
+import "ace-builds/src-noconflict/theme-merbivore";
+import "ace-builds/src-noconflict/theme-merbivore_soft";
+import "ace-builds/src-noconflict/theme-mono_industrial";
+import "ace-builds/src-noconflict/theme-ambiance";
+import "ace-builds/src-noconflict/theme-clouds_midnight";
+import "ace-builds/src-noconflict/theme-gob";
+import "ace-builds/src-noconflict/theme-sqlserver";
 import { useEffect, useRef, useState } from "react";
 import AceEditor from "react-ace";
 import ReactAce from "react-ace/lib/ace";
@@ -221,7 +242,7 @@ export default function CodeAreaModal({
               fontSize={14}
               showGutter
               enableLiveAutocompletion
-              theme={dark ? "twilight" : "github"}
+              theme={dark ? "monokai" : "github"}
               name="CodeEditor"
               onChange={(value) => {
                 setCode(value);

--- a/src/frontend/src/style/custom-ace-overrides.css
+++ b/src/frontend/src/style/custom-ace-overrides.css
@@ -1,0 +1,70 @@
+/* Custom override for Ace Editor GitHub Dark theme background */
+.ace-github-dark, .ace-github-dark .ace_scroller {
+  background-color: #111 !important;
+}
+
+/* Custom override for Ace Editor Monokai theme background - only in dark mode */
+.dark .ace-monokai, .dark .ace-monokai .ace_scroller {
+  background-color: #141417 !important;
+}
+
+/* Monokai gutter (sidebar/line numbers) */
+.ace-monokai .ace_gutter,
+.ace-monokai .ace_gutter-active-line {
+  background: #181818 !important;
+  color: #555 !important;
+}
+
+/* Strongest override for Monokai selected line highlight */
+.ace-monokai .ace_marker-layer .ace_active-line,
+.ace-monokai .ace_active-line,
+.ace-monokai .ace_gutter-active-line,
+.ace-monokai .ace_marker-layer .ace_selected-word {
+  background-color: #181818 !important;
+  background: #181818 !important;
+  box-shadow: none !important;
+  border: 0px !important;
+}
+
+.dark .ace-monokai .ace_gutter,
+.dark .ace-monokai .ace_gutter-active-line {
+  background: #1a1a1e !important;
+  color: #555 !important;
+}
+
+.dark .ace-monokai .ace_marker-layer .ace_active-line,
+.dark .ace-monokai .ace_active-line,
+.dark .ace-monokai .ace_gutter-active-line,
+.dark .ace-monokai .ace_marker-layer .ace_selected-word {
+  background-color: #181818 !important;
+  background: #181818 !important;
+  box-shadow: none !important;
+  border: 1px !important;
+}
+
+.dark .ace-monokai .ace_content,
+.ace-github
+
+.dark .ace-monokai .ace_gutter,
+.ace-github
+
+.dark .ace-monokai,
+.ace-github {
+  border: 1px solid rgba(255,255,255,0.18) !important;
+  box-shadow: none !important;
+}
+
+.dark .ace-monokai .ace_marker-layer .ace_active-line,
+.ace-github .ace_marker-layer .ace_active-line {
+  top: 24px !important;
+  bottom: 24px !important;
+}
+
+.ace-github, .ace-github .ace_scroller {
+  background-color: #fafbfc !important;
+}
+
+.ace-github {
+  border: 1px solid rgba(0,0,0,0.10) !important;
+  box-shadow: none !important;
+} 


### PR DESCRIPTION
This PR improves the Ace code editor experience in Langflow by:\n\n- Dynamically switching between Monokai (dark) and GitHub (light) themes based on UI mode\n- Customizing background, gutter, and border colors for both themes\n- Ensuring subtle, modern contrast and a clean look in both modes\n- Removing all unnecessary padding and legacy overrides\n\nAll changes are isolated to:\n- src/frontend/src/style/custom-ace-overrides.css\n- src/frontend/src/modals/codeAreaModal/index.tsx\n- src/frontend/src/App.css\n\nThis PR brings a more polished, visually consistent, and mode-aware code editing experience to Langflow.\n\nCloses: # (add issue number if applicable)