### PR TITLE
fix: prevent unintentional sidebar text selection

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -222,3 +222,9 @@ code {
 .cm-gutters {
   display: none !important;
 }
+
+.user-select-none {
+  user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+}

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/bundleItems/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/bundleItems/index.tsx
@@ -48,7 +48,7 @@ export const BundleItem = memo(
               <div
                 tabIndex={0}
                 onKeyDown={(e) => handleKeyDownInput(e, item.name)}
-                className="flex cursor-pointer items-center gap-2"
+                className="flex cursor-pointer items-center gap-2 user-select-none"
                 data-testid={`disclosure-bundles-${item.display_name.toLowerCase()}`}
               >
                 <ForwardedIconComponent

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/categoryDisclouse/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/categoryDisclouse/index.tsx
@@ -61,7 +61,7 @@ export const CategoryDisclosure = memo(function CategoryDisclosure({
               data-testid={`disclosure-${item.display_name.toLocaleLowerCase()}`}
               tabIndex={0}
               onKeyDown={handleKeyDownInput}
-              className="flex cursor-pointer items-center gap-2"
+              className="flex cursor-pointer items-center gap-2 user-select-none"
             >
               <ForwardedIconComponent
                 name={item.icon}

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/featureTogglesComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/featureTogglesComponent/index.tsx
@@ -29,7 +29,7 @@ const FeatureToggles = ({
       {toggles.map((toggle) => (
         <div key={toggle.label} className="flex items-center justify-between">
           <div className="flex items-center space-x-2">
-            <span className="flex gap-2 text-sm font-medium">
+            <span className="flex gap-2 text-sm font-medium cursor-default">
               Show
               <Badge variant={toggle.badgeVariant} size="xq">
                 {toggle.label}

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarBundles/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarBundles/index.tsx
@@ -33,7 +33,7 @@ export const MemoizedSidebarGroup = memo(
 
     return (
       <SidebarGroup className="p-3">
-        <SidebarGroupLabel>Bundles</SidebarGroupLabel>
+        <SidebarGroupLabel className="cursor-default">Bundles</SidebarGroupLabel>
         <SidebarGroupContent>
           <SidebarMenu>
             {sortedBundles.map((item) => (

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarHeader/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarHeader/index.tsx
@@ -39,7 +39,7 @@ export const SidebarHeaderComponent = memo(function SidebarHeaderComponent({
           <SidebarTrigger className="text-muted-foreground">
             <ForwardedIconComponent name="PanelLeftClose" />
           </SidebarTrigger>
-          <h3 className="flex-1 text-sm font-semibold">Components</h3>
+          <h3 className="flex-1 text-sm font-semibold cursor-default">Components</h3>
           <DisclosureTrigger>
             <div>
               <ShadTooltip content="Component settings" styleClasses="z-50">

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
@@ -291,7 +291,7 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
     <Sidebar
       collapsible="offcanvas"
       data-testid="shad-sidebar"
-      className="noflow"
+      className="noflow select-none"
     >
       <SidebarHeaderComponent
         showConfig={showConfig}


### PR DESCRIPTION
This PR ensures that no text or elements in the sidebar can be selected or highlighted, preventing accidental selection and improving UX.\n\n- Applies select-none to the sidebar container.\n- Cleans up redundant select-none from children.\n- Keeps cursor-default on headers/labels for correct cursor behavior.\n\nFixes: accidental sidebar selection issue.