### PR TITLE
docs: add agent docs link from component

### DIFF
--- a/src/backend/base/langflow/components/agents/agent.py
+++ b/src/backend/base/langflow/components/agents/agent.py
@@ -33,6 +33,7 @@ MODEL_PROVIDERS_LIST = ["Anthropic", "Google Generative AI", "Groq", "OpenAI"]
 class AgentComponent(ToolCallingAgentComponent):
     display_name: str = "Agent"
     description: str = "Define the agent's instructions, then enter a task to complete using tools."
+    documentation: str = "https://docs.langflow.org/agents"
     icon = "bot"
     beta = False
     name = "Agent"

--- a/src/backend/base/langflow/components/datastax/astradb_tool.py
+++ b/src/backend/base/langflow/components/datastax/astradb_tool.py
@@ -17,7 +17,7 @@ from langflow.schema.table import EditMode
 class AstraDBToolComponent(LCToolComponent):
     display_name: str = "Astra DB Tool"
     description: str = "Tool to run hybrid vector and metadata search on DataStax Astra DB Collection"
-    documentation: str = "https://docs.langflow.org/components-tools#astra-db-tool"
+    documentation: str = "https://docs.langflow.org/components-bundle-components"
     icon: str = "AstraDB"
 
     inputs = [

--- a/src/backend/base/langflow/components/datastax/astradb_tool.py
+++ b/src/backend/base/langflow/components/datastax/astradb_tool.py
@@ -17,7 +17,7 @@ from langflow.schema.table import EditMode
 class AstraDBToolComponent(LCToolComponent):
     display_name: str = "Astra DB Tool"
     description: str = "Tool to run hybrid vector and metadata search on DataStax Astra DB Collection"
-    documentation: str = "https://docs.langflow.org/Components/components-tools#astra-db-tool"
+    documentation: str = "https://docs.langflow.org/components-tools#astra-db-tool"
     icon: str = "AstraDB"
 
     inputs = [


### PR DESCRIPTION
* Add docs link from Agent component to Agents page.
* Update AstraDB Tool link to bundles page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a documentation link for the agent component.
  * Updated the documentation link for the AstraDB tool component to correct the URL path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->