### PR TITLE
chore(deps): update pyleak version and activate pyleak_marker in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ dev = [
     "faker>=37.0.0",
     "pytest-timeout>=2.3.1",
     "pyyaml>=6.0.2",
-    "pyleak>=0.1.12",
+    "pyleak>=0.1.14",
 ]
 
 [tool.uv.sources]

--- a/src/backend/tests/integration/components/helpers/test_parse_json_data.py
+++ b/src/backend/tests/integration/components/helpers/test_parse_json_data.py
@@ -3,11 +3,9 @@ from langflow.components.processing.parse_json_data import ParseJSONDataComponen
 from langflow.schema import Data
 
 from tests.integration.components.mock_components import TextToData
-from tests.integration.utils import ComponentInputHandle, run_single_component
+from tests.integration.utils import ComponentInputHandle, pyleak_marker, run_single_component
 
-# TODO: Fix pyleak issue
-# https://github.com/langflow-ai/langflow/actions/runs/16013103799/job/45208685212
-# pytestmark = pyleak_marker()
+pytestmark = pyleak_marker()
 
 
 async def test_from_data():

--- a/src/backend/tests/integration/flows/test_basic_prompting.py
+++ b/src/backend/tests/integration/flows/test_basic_prompting.py
@@ -3,12 +3,10 @@ from langflow.components.processing import PromptComponent
 from langflow.graph import Graph
 from langflow.schema.message import Message
 
-from tests.integration.utils import run_flow
+from tests.integration.utils import pyleak_marker, run_flow
 
 
-# TODO: Fix pyleak issue
-# https://github.com/langflow-ai/langflow/actions/runs/16013103799/job/45208685212
-# @pyleak_marker()
+@pyleak_marker()
 async def test_simple_no_llm():
     graph = Graph()
     flow_input = graph.add_component(ChatInput())

--- a/uv.lock
+++ b/uv.lock
@@ -5156,7 +5156,7 @@ dev = [
     { name = "pandas-stubs", specifier = ">=2.1.4.231227" },
     { name = "pre-commit", specifier = ">=3.7.0" },
     { name = "pydantic-ai", specifier = ">=0.0.19" },
-    { name = "pyleak", specifier = ">=0.1.12" },
+    { name = "pyleak", specifier = ">=0.1.14" },
     { name = "pytest", specifier = ">=8.2.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -8479,14 +8479,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/5d/ab/34ec41718af73c001
 
 [[package]]
 name = "pyleak"
-version = "0.1.12"
+version = "0.1.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/55/bdc246baf6870185555d6ebcb35a7361f9bb95ba3fd0ff295d8fc4ff9e6e/pyleak-0.1.12.tar.gz", hash = "sha256:6af479b2dd5d4c71ff2b33ba5eeccda04b2d248f884801cf414fc84777a636de", size = 104742, upload-time = "2025-07-01T12:04:44.708Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/fd/49af96e55001fe611abd891b7c482cf1324fb6997e3430c87a7ec0f7c887/pyleak-0.1.14.tar.gz", hash = "sha256:51be2741542fdaa6024c31a1b8212e59485e2a91e7fdc34c151d488e9a6fb3c4", size = 105644, upload-time = "2025-07-03T09:28:54.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/08/e8bc7e2f63deca307575bcf98d112fe75f80ecd716d3dcc69330ad096fff/pyleak-0.1.12-py3-none-any.whl", hash = "sha256:17a1c8b11d89fdcee79f0a479378bd6de23de323754a81efe8d8d9550ac12863", size = 23762, upload-time = "2025-07-01T12:04:43.494Z" },
+    { url = "https://files.pythonhosted.org/packages/67/75/55c968828bf81a73d9c484f7be4e6f7d04d07da3d1d78cc5705461802b24/pyleak-0.1.14-py3-none-any.whl", hash = "sha256:98d6cf19f3eeed172effef42415bf9f01a3d46cbde59780b85924f9dcd57003a", size = 24813, upload-time = "2025-07-03T09:28:53.79Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updating pyleak and reactivating because issue seems to be fixed.

https://github.com/deepankarm/pyleak/issues/7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency for `pyleak` to a newer version.
  * Enabled `pyleak_marker` on selected integration tests for improved test coverage and leak detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->