### PR TITLE
fix: Improve AppHeader layout responsiveness glitch

### DIFF
--- a/src/frontend/src/components/core/appHeaderComponent/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/index.tsx
@@ -51,7 +51,7 @@ export default function AppHeader(): JSX.Element {
 
   return (
     <div
-      className={`z-10 flex h-[48px] w-full items-center border-b px-6 dark:bg-background`}
+      className={`z-10 flex h-[48px] w-full items-center justify-between border-b px-6 dark:bg-background`}
       data-testid="app-header"
     >
       {/* Left Section */}
@@ -80,13 +80,13 @@ export default function AppHeader(): JSX.Element {
       </div>
 
       {/* Middle Section */}
-      <div className="flex min-w-0 flex-1 justify-center px-4">
+      <div className="absolute left-1/2 -translate-x-1/2">
         <FlowMenu />
       </div>
 
       {/* Right Section */}
       <div
-        className={`z-30 flex shrink-0 items-center gap-3`}
+        className={`relative left-3 z-30 flex shrink-0 items-center gap-3`}
         data-testid="header_right_section_wrapper"
       >
         <>

--- a/src/frontend/src/components/core/appHeaderComponent/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/index.tsx
@@ -51,12 +51,12 @@ export default function AppHeader(): JSX.Element {
 
   return (
     <div
-      className={`z-10 flex h-[48px] w-full items-center justify-between border-b px-6 dark:bg-background`}
+      className={`z-10 flex h-[48px] w-full items-center border-b px-6 dark:bg-background`}
       data-testid="app-header"
     >
       {/* Left Section */}
       <div
-        className={`z-30 flex items-center gap-2`}
+        className={`z-30 flex shrink-0 items-center gap-2`}
         data-testid="header_left_section_wrapper"
       >
         <Button
@@ -80,13 +80,13 @@ export default function AppHeader(): JSX.Element {
       </div>
 
       {/* Middle Section */}
-      <div className="absolute left-1/2 w-full flex-1 -translate-x-1/2">
+      <div className="flex min-w-0 flex-1 justify-center px-4">
         <FlowMenu />
       </div>
 
       {/* Right Section */}
       <div
-        className={`relative left-3 z-30 flex items-center gap-3`}
+        className={`z-30 flex shrink-0 items-center gap-3`}
         data-testid="header_right_section_wrapper"
       >
         <>


### PR DESCRIPTION
This pull request makes minor adjustments to the layout and styling of the `AppHeader` component in `src/frontend/src/components/core/appHeaderComponent/index.tsx`. These changes ensure better responsiveness and alignment for the header sections.

Styling improvements:

* Updated the `className` for the left and right sections of the header to include `shrink-0`, preventing unintended resizing when the layout changes. [[1]](diffhunk://#diff-72c7ef29884c2deb0c9da1d6a08fcd1203c5939012c0984fe298860e622a1c23L59-R59) [[2]](diffhunk://#diff-72c7ef29884c2deb0c9da1d6a08fcd1203c5939012c0984fe298860e622a1c23L83-R89)
* Removed the `flex-1` property from the middle section's `className`, ensuring it no longer stretches unnecessarily and maintains its intended alignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved header layout to prevent left and right sections from shrinking and refined centering of the middle section for a more consistent appearance across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->