### PR TITLE
fix: reset files count after deletion, enable files filtering by column

### DIFF
--- a/src/frontend/src/customization/hooks/custom-handle-bulk-files-download.tsx
+++ b/src/frontend/src/customization/hooks/custom-handle-bulk-files-download.tsx
@@ -5,8 +5,6 @@ export const useCustomHandleBulkFilesDownload = () => {
 
   const handleBulkDownload = async (
     selectedFiles: any,
-    setSelectedFiles: (files: any[]) => void,
-    setQuantitySelected: (quantity: number) => void,
     setSuccessData: (data: { title: string }) => void,
     setErrorData: (data: { title: string; list: string[] }) => void,
     setIsDownloading: (isDownloading: boolean) => void,
@@ -20,8 +18,6 @@ export const useCustomHandleBulkFilesDownload = () => {
         onSuccess: (data) => {
           setSuccessData({ title: data.message });
           setIsDownloading(false);
-          setQuantitySelected(0);
-          setSelectedFiles([]);
         },
         onError: (error) => {
           setErrorData({

--- a/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
@@ -431,7 +431,14 @@ export const FilesPage = () => {
                         selectedFiles.length > 0 ? "opacity-100" : "opacity-0",
                       )}
                     >
-                      <div className="pointer-events-auto ml-12 flex h-full flex-1 items-center justify-between bg-background">
+                      <div
+                        className={cn(
+                          "ml-12 flex h-full flex-1 items-center justify-between bg-background",
+                          selectedFiles.length > 0
+                            ? "pointer-events-auto"
+                            : "pointer-events-none",
+                        )}
+                      >
                         <span className="text-xs text-muted-foreground">
                           {quantitySelected} selected
                         </span>

--- a/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
@@ -260,8 +260,6 @@ export const FilesPage = () => {
   const handleDownload = () => {
     handleBulkDownload(
       selectedFiles,
-      setSelectedFiles,
-      setQuantitySelected,
       setSuccessData,
       setErrorData,
       setIsDownloading,

--- a/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
@@ -114,6 +114,12 @@ export const FilesPage = () => {
 
   const { mutate: uploadFileDirect } = customPostUploadFileV2();
 
+  useEffect(() => {
+    if (files && files.length > 0) {
+      setQuantitySelected(0);
+    }
+  }, [files]);
+
   const colDefs: ColDef[] = [
     {
       headerName: "Name",
@@ -259,6 +265,8 @@ export const FilesPage = () => {
       {
         onSuccess: (data) => {
           setSuccessData({ title: data.message });
+          setQuantitySelected(0);
+          setSelectedFiles([]);
         },
         onError: (error) => {
           setErrorData({
@@ -279,6 +287,8 @@ export const FilesPage = () => {
       {
         onSuccess: (data) => {
           setSuccessData({ title: data.message });
+          setQuantitySelected(0);
+          setSelectedFiles([]);
         },
         onError: (error) => {
           setErrorData({


### PR DESCRIPTION
This pull request introduces several updates to the `FilesPage` component in `src/frontend/src/pages/MainPage/pages/filesPage/index.tsx`. The changes aim to improve the user experience by resetting selection states and enhancing UI behavior based on file selection. 

### State Management Updates:
* Added a `useEffect` hook to reset `quantitySelected` to `0` whenever the `files` array changes. This ensures the selection count is cleared when files are updated.
* Updated the `onSuccess` callback to reset `quantitySelected` and clear `selectedFiles` after a successful operation, ensuring the UI reflects the cleared state. [[1]](diffhunk://#diff-7b6e0a86c0561d1cd55b3c0bf391901d6c1b7a2138aa6400327f54d894d330c2R268-R269) [[2]](diffhunk://#diff-7b6e0a86c0561d1cd55b3c0bf391901d6c1b7a2138aa6400327f54d894d330c2R290-R291)

### UI Behavior Enhancements:
* Modified the `selectedFiles` container to dynamically toggle `pointer-events` based on whether files are selected. This prevents interaction with the container when no files are selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The selection count and selected files list now reset automatically after downloading or deleting files.
  * The selection count also resets when the file list changes.

* **Style**
  * Action buttons for file operations are now visually and functionally disabled when no files are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->