### PR TITLE
fix: add description to API Access dialog and link it to API Keys on settings

### DIFF
--- a/src/frontend/src/components/common/pageLayout/index.tsx
+++ b/src/frontend/src/components/common/pageLayout/index.tsx
@@ -1,5 +1,6 @@
 import { CustomBanner } from "@/customization/components/custom-banner";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
+import { To } from "react-router-dom";
 import { Button } from "../../ui/button";
 import { Separator } from "../../ui/separator";
 import ForwardedIconComponent from "../genericIconComponent";
@@ -17,7 +18,7 @@ export default function PageLayout({
   children: React.ReactNode;
   button?: React.ReactNode;
   betaIcon?: boolean;
-  backTo?: string;
+  backTo?: To;
 }) {
   const navigate = useCustomNavigate();
 

--- a/src/frontend/src/modals/apiModal/index.tsx
+++ b/src/frontend/src/modals/apiModal/index.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { CustomAPIGenerator } from "@/customization/components/custom-api-generator";
+import { CustomLink } from "@/customization/components/custom-link";
 import useSaveFlow from "@/hooks/flows/use-save-flow";
 import useAuthStore from "@/stores/authStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
@@ -169,21 +170,17 @@ export default function ApiModal({
       >
         <BaseModal.Header
           description={
-            autoLogin ? undefined : (
-              <>
-                <span className="pr-2">
-                  API access requires an API key. You can{" "}
-                  <a
-                    href="/settings/api-keys"
-                    className="text-accent-pink-foreground"
-                  >
-                    {" "}
-                    create an API key
-                  </a>{" "}
-                  in settings.
-                </span>
-              </>
-            )
+            <span className="pr-2">
+              API access requires an API key. You can{" "}
+              <CustomLink
+                to="/settings/api-keys"
+                className="text-accent-pink-foreground"
+              >
+                {" "}
+                create an API key
+              </CustomLink>{" "}
+              in settings.
+            </span>
           }
         >
           <IconComponent name="SlidersHorizontal" className="text-f h-6 w-6" />

--- a/src/frontend/src/modals/apiModal/index.tsx
+++ b/src/frontend/src/modals/apiModal/index.tsx
@@ -111,21 +111,17 @@ export default function ApiModal({
         <BaseModal.Trigger asChild>{children}</BaseModal.Trigger>
         <BaseModal.Header
           description={
-            autoLogin ? undefined : (
-              <>
-                <span className="pr-2">
-                  API access requires an API key. You can{" "}
-                  <a
-                    href="/settings/api-keys"
-                    className="text-accent-pink-foreground"
-                  >
-                    {" "}
-                    create an API key
-                  </a>{" "}
-                  in settings.
-                </span>
-              </>
-            )
+            <span className="pr-2">
+              API access requires an API key. You can{" "}
+              <CustomLink
+                to="/settings/api-keys"
+                className="text-accent-pink-foreground"
+              >
+                {" "}
+                create an API key
+              </CustomLink>{" "}
+              in settings.
+            </span>
           }
         >
           <IconComponent
@@ -168,21 +164,7 @@ export default function ApiModal({
         setOpen={setOpenTweaks}
         size="medium-small-tall"
       >
-        <BaseModal.Header
-          description={
-            <span className="pr-2">
-              API access requires an API key. You can{" "}
-              <CustomLink
-                to="/settings/api-keys"
-                className="text-accent-pink-foreground"
-              >
-                {" "}
-                create an API key
-              </CustomLink>{" "}
-              in settings.
-            </span>
-          }
-        >
+        <BaseModal.Header>
           <IconComponent name="SlidersHorizontal" className="text-f h-6 w-6" />
           <span className="pl-2">Input Schema</span>
         </BaseModal.Header>

--- a/src/frontend/src/pages/SettingsPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/customization/feature-flags";
 import useAuthStore from "@/stores/authStore";
 import { useStoreStore } from "@/stores/storeStore";
-import { Outlet } from "react-router-dom";
+import { Outlet, To } from "react-router-dom";
 import ForwardedIconComponent from "../../components/common/genericIconComponent";
 import PageLayout from "../../components/common/pageLayout";
 export default function SettingsPage(): JSX.Element {
@@ -89,7 +89,7 @@ export default function SettingsPage(): JSX.Element {
 
   return (
     <PageLayout
-      backTo={"/"}
+      backTo={-1 as To}
       title="Settings"
       description="Manage the general settings for Langflow."
     >


### PR DESCRIPTION
This pull request updates the `ApiModal` component in `src/frontend/src/modals/apiModal/index.tsx` to replace the use of a standard HTML anchor tag with the `CustomLink` component for improved customization and consistency. Additionally, it imports the `CustomLink` component from the appropriate module.

### Updates to `ApiModal` component:

* Replaced the HTML `<a>` tag with the `CustomLink` component for linking to the API key settings page, ensuring consistency with the application's design system. (`[src/frontend/src/modals/apiModal/index.tsxL172-L186](diffhunk://#diff-61e47d90dd63653762395badf4be9c46fcfbea4a36500b799b6c6fe284fafd16L172-L186)`)
* Added the import statement for the `CustomLink` component from `@/customization/components/custom-link`. (`[src/frontend/src/modals/apiModal/index.tsxR7](diffhunk://#diff-61e47d90dd63653762395badf4be9c46fcfbea4a36500b799b6c6fe284fafd16R7)`)…stomLink

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the API modal to use a styled link for navigating to API key settings.
  * Simplified the tweaks modal by removing the duplicate API key message from its header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->