### PR TITLE
chore: update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v5.0.0
     hooks:
       - id: check-case-conflict
       - id: end-of-file-fixer
@@ -12,7 +12,7 @@ repos:
           - --fix=lf
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.3
+    rev: v0.12.2
     hooks:
       - id: ruff
         name: ruff check


### PR DESCRIPTION
- Bumped pre-commit-hooks from v4.1.0 to v5.0.0.
- Updated ruff-pre-commit from v0.8.3 to v0.12.2 for improved linting capabilities.