### PR TITLE
docs: how to add a missing dependency to langflow desktop

### DIFF
--- a/docs/docs/Develop/install-custom-dependencies.md
+++ b/docs/docs/Develop/install-custom-dependencies.md
@@ -23,7 +23,22 @@ To install multiple extras, use commas to separate each dependency group:
 uv pip install "langflow[deploy,local,postgresql]"
 ```
 
-## Install custom dependencies
+## Install custom dependencies in Langflow Desktop {#langflow-desktop}
+
+To add dependencies to **Langflow Desktop**, add an entry for the package to the application's `requirements.txt` file.
+
+    * On macOS, the file is located at `/Users/<name>/.langflow/data/requirements.txt`.
+    * On Windows, the file is located at `C:\Users\<name>\AppData\Roaming\com.Langflow\data\requirements.txt`.
+
+Add the dependency and version to `requirements.txt` in the following format:
+
+    ```
+    docling==2.40.0
+    ```
+
+Restart Langflow desktop to install the dependency.
+
+## Install custom dependencies in Langflow OSS
 
 To install your own custom dependencies in your Langflow environment, add them with your package manager.
 

--- a/docs/docs/Develop/install-custom-dependencies.md
+++ b/docs/docs/Develop/install-custom-dependencies.md
@@ -27,8 +27,8 @@ uv pip install "langflow[deploy,local,postgresql]"
 
 To add dependencies to **Langflow Desktop**, add an entry for the package to the application's `requirements.txt` file.
 
-    * On macOS, the file is located at `/Users/<name>/.langflow/data/requirements.txt`.
-    * On Windows, the file is located at `C:\Users\<name>\AppData\Roaming\com.Langflow\data\requirements.txt`.
+    * On macOS, the file is located at `/Users/USER/.langflow/data/requirements.txt`.
+    * On Windows, the file is located at `C:\Users\USER\AppData\Roaming\com.Langflow\data\requirements.txt`.
 
 Add the dependency and version to `requirements.txt` in the following format:
 

--- a/docs/docs/Get-Started/get-started-installation.md
+++ b/docs/docs/Get-Started/get-started-installation.md
@@ -39,6 +39,10 @@ To manage your version of Langflow Desktop, follow these steps:
   3. To apply the change, click **Confirm**.
   Langflow desktop restarts to install and activate the new version.
 
+### Manage dependencies in Langflow Desktop
+
+To manage dependencies in Langflow Desktop, see [Install custom dependencies in Langflow Desktop](/install-custom-dependencies#langflow-desktop).
+
 ## Install and run Langflow with Docker {#install-and-run-langflow-docker}
 
 You can use the [Langflow Docker image](https://hub.docker.com/r/langflowai/langflow) to run Langflow in an isolated environment.

--- a/docs/docs/Support/troubleshooting.md
+++ b/docs/docs/Support/troubleshooting.md
@@ -108,6 +108,12 @@ There are two possible reasons for this error:
 
 * **Version conflict during installation**: Some version conflicts might have occurred during the installation process. To resolve this issue, reinstall Langflow and its dependencies by running `python -m pip install langflow --pre -U --force-reinstall`.
 
+### Package is not installed in Langflow Desktop
+
+In Langflow OSS, you can follow the error message's instructions to install the missing dependency.
+
+For managing dependencies in Langflow Desktop, see [Install custom dependencies in Langflow Desktop](/install-custom-dependencies#langflow-desktop).
+
 ## Langflow upgrade issues
 
 The following issues can occur when upgrading your Langflow version.


### PR DESCRIPTION
Update the documentation to provide instructions for managing custom dependencies in Langflow Desktop and references these instructions in related sections.