### PR TITLE
fix: Improve flow export error handling and validation

### DIFF
--- a/src/frontend/src/modals/exportModal/index.tsx
+++ b/src/frontend/src/modals/exportModal/index.tsx
@@ -53,46 +53,61 @@ const ExportModal = forwardRef(
         size="smaller-h-full"
         open={open}
         setOpen={setOpen}
-        onSubmit={() => {
-          if (checked) {
-            downloadFlow(
-              {
-                id: currentFlow!.id,
-                data: currentFlow!.data!,
+        onSubmit={async () => {
+          try {
+            let filePath: string | undefined | void;
+
+            if (checked) {
+              filePath = await downloadFlow(
+                {
+                  id: currentFlow!.id,
+                  data: currentFlow!.data!,
+                  description,
+                  name,
+                  last_tested_version: version,
+                  endpoint_name: currentFlow!.endpoint_name,
+                  is_component: false,
+                  tags: currentFlow!.tags,
+                },
+                name!,
                 description,
-                name,
-                last_tested_version: version,
-                endpoint_name: currentFlow!.endpoint_name,
-                is_component: false,
-                tags: currentFlow!.tags,
-              },
-              name!,
-              description,
-            );
-            setNoticeData({
-              title: API_WARNING_NOTICE_ALERT,
-            });
-          } else
-            downloadFlow(
-              removeApiKeys({
-                id: currentFlow!.id,
-                data: currentFlow!.data!,
+              );
+
+              if (filePath) {
+                setNoticeData({
+                  title: API_WARNING_NOTICE_ALERT,
+                });
+                setOpen(false);
+                track("Flow Exported", { flowId: currentFlow!.id });
+              }
+            } else {
+              filePath = await downloadFlow(
+                removeApiKeys({
+                  id: currentFlow!.id,
+                  data: currentFlow!.data!,
+                  description,
+                  name,
+                  last_tested_version: version,
+                  endpoint_name: currentFlow!.endpoint_name,
+                  is_component: false,
+                  tags: currentFlow!.tags,
+                }),
+                name!,
                 description,
-                name,
-                last_tested_version: version,
-                endpoint_name: currentFlow!.endpoint_name,
-                is_component: false,
-                tags: currentFlow!.tags,
-              }),
-              name!,
-              description,
-            ).then(() => {
-              setSuccessData({
-                title: "Flow exported successfully",
-              });
-            });
-          setOpen(false);
-          track("Flow Exported", { flowId: currentFlow!.id });
+              );
+
+              if (filePath) {
+                setSuccessData({
+                  title: "Flow exported successfully",
+                });
+                setOpen(false);
+                track("Flow Exported", { flowId: currentFlow!.id });
+              }
+            }
+          } catch (error) {
+            console.error("Error exporting flow:", error);
+            // Handle error - maybe show an error alert
+          }
         }}
       >
         <BaseModal.Trigger asChild>{props.children ?? <></>}</BaseModal.Trigger>

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -1904,7 +1904,7 @@ export async function downloadFlow(
   flow: FlowType,
   flowName: string,
   flowDescription?: string,
-) {
+): Promise<string | undefined | void> {
   try {
     const clonedFlow = cloneDeep(flow);
 
@@ -1919,9 +1919,10 @@ export async function downloadFlow(
     const sortedData = sortJsonStructure(flowData);
     const sortedJsonString = JSON.stringify(sortedData, null, 2);
 
-    customDownloadFlow(flow, sortedJsonString, flowName);
+    return await customDownloadFlow(flow, sortedJsonString, flowName);
   } catch (error) {
     console.error("Error downloading flow:", error);
+    throw error;
   }
 }
 


### PR DESCRIPTION
This pull request improves the flow export functionality in the `ExportModal` component by adding error handling and ensuring the `downloadFlow` function returns a value. It also updates the `downloadFlow` utility function to return a promise, enabling better control over the flow export process.

### Changes to `ExportModal` component:

* Updated the `onSubmit` method in `src/frontend/src/modals/exportModal/index.tsx` to handle errors during the export process and check if the `downloadFlow` function returns a valid file path before proceeding with success or warning notices. [[1]](diffhunk://#diff-7a63ffc1f33441ef5be5d96a4f6ebe6f97247429f5fbeb600fb6259d1fb913c5L56-R61) [[2]](diffhunk://#diff-7a63ffc1f33441ef5be5d96a4f6ebe6f97247429f5fbeb600fb6259d1fb913c5R75-R84) [[3]](diffhunk://#diff-7a63ffc1f33441ef5be5d96a4f6ebe6f97247429f5fbeb600fb6259d1fb913c5L89-R110)

### Changes to `downloadFlow` utility function:

* Modified the `downloadFlow` function in `src/frontend/src/utils/reactflowUtils.ts` to return a `Promise` of `string | undefined | void`, allowing the caller to determine the success of the operation.
* Ensured the `customDownloadFlow` invocation within `downloadFlow` returns a value and added error propagation for better error handling.