### PR TITLE
fix: make deletion of single file commit to DB, create tests for file deletion

### DIFF
--- a/src/backend/base/langflow/api/v2/files.py
+++ b/src/backend/base/langflow/api/v2/files.py
@@ -275,7 +275,6 @@ async def delete_files_batch(
             await session.delete(file)
 
         # Delete all files from the database
-        await session.flush()  # Ensures delete is staged
         await session.commit()  # Commit deletion
 
     except Exception as e:
@@ -474,7 +473,6 @@ async def delete_file(
 
         # Delete from the database
         await session.delete(file_to_delete)
-        await session.flush()  # Ensures delete is staged
         await session.commit()
 
     except HTTPException:
@@ -507,7 +505,6 @@ async def delete_all_files(
             await session.delete(file)
 
         # Delete all files from the database
-        await session.flush()  # Ensures delete is staged
         await session.commit()  # Commit deletion
 
     except Exception as e:

--- a/src/backend/base/langflow/api/v2/files.py
+++ b/src/backend/base/langflow/api/v2/files.py
@@ -474,6 +474,7 @@ async def delete_file(
 
         # Delete from the database
         await session.delete(file_to_delete)
+        await session.commit()
         await session.flush()  # Ensures delete is staged
 
     except HTTPException:

--- a/src/backend/base/langflow/api/v2/files.py
+++ b/src/backend/base/langflow/api/v2/files.py
@@ -474,8 +474,8 @@ async def delete_file(
 
         # Delete from the database
         await session.delete(file_to_delete)
-        await session.commit()
         await session.flush()  # Ensures delete is staged
+        await session.commit()
 
     except HTTPException:
         # Re-raise HTTPException to avoid being caught by the generic exception handler

--- a/src/backend/tests/unit/api/v2/test_files.py
+++ b/src/backend/tests/unit/api/v2/test_files.py
@@ -207,3 +207,52 @@ async def test_edit_file(files_client, files_created_api_key):
     assert response.status_code == 200
     file = response.json()
     assert file["name"] == "potato.txt"
+
+
+async def test_upload_list_delete_and_validate_files(files_client, files_created_api_key):
+    headers = {"x-api-key": files_created_api_key.api_key}
+
+    # Upload two files
+    response1 = await files_client.post(
+        "api/v2/files",
+        files={"file": ("file1.txt", b"content1")},
+        headers=headers,
+    )
+    assert response1.status_code == 201
+    file1 = response1.json()
+
+    response2 = await files_client.post(
+        "api/v2/files",
+        files={"file": ("file2.txt", b"content2")},
+        headers=headers,
+    )
+    assert response2.status_code == 201
+    file2 = response2.json()
+
+    # List files and validate both are present
+    response = await files_client.get("api/v2/files", headers=headers)
+    assert response.status_code == 200
+    files = response.json()
+    file_names = [f["name"] for f in files]
+    file_ids = [f["id"] for f in files]
+    assert file1["name"] in file_names
+    assert file2["name"] in file_names
+    assert file1["id"] in file_ids
+    assert file2["id"] in file_ids
+    assert len(files) == 2
+
+    # Delete one file
+    response = await files_client.delete(f"api/v2/files/{file1['id']}", headers=headers)
+    assert response.status_code == 200
+
+    # List files again and validate only the other remains
+    response = await files_client.get("api/v2/files", headers=headers)
+    assert response.status_code == 200
+    files = response.json()
+    file_names = [f["name"] for f in files]
+    file_ids = [f["id"] for f in files]
+    assert file1["name"] not in file_names
+    assert file1["id"] not in file_ids
+    assert file2["name"] in file_names
+    assert file2["id"] in file_ids
+    assert len(files) == 1


### PR DESCRIPTION
This pull request refines the file deletion logic in the backend by removing unnecessary session flushes and adds a new comprehensive test for file upload, listing, deletion, and validation. These changes improve both the efficiency of database operations and the robustness of the testing suite.

### Backend improvements to file deletion:

* Removed `session.flush()` calls in `async def delete_files_batch`, `async def delete_file`, and `async def delete_all_files` to streamline database operations. Committing changes directly ensures staged deletions are applied without redundant flushes. (`src/backend/base/langflow/api/v2/files.py`, [[1]](diffhunk://#diff-2244ebb981cf8eb326129689687b71a55e97cbbe25d17eefbd7f57321383795bL278) [[2]](diffhunk://#diff-2244ebb981cf8eb326129689687b71a55e97cbbe25d17eefbd7f57321383795bL477-R476) [[3]](diffhunk://#diff-2244ebb981cf8eb326129689687b71a55e97cbbe25d17eefbd7f57321383795bL509)

### Enhancements to testing:

* Added a new test case `async def test_upload_list_delete_and_validate_files` to validate the full lifecycle of file operations, including upload, listing, deletion, and post-deletion validation. This ensures the API behaves as expected across multiple scenarios. (`src/backend/tests/unit/api/v2/test_files.py`, [src/backend/tests/unit/api/v2/test_files.pyR210-R258](diffhunk://#diff-4a30feb41700eb6cd449ed31b29e06a833214bc80b1c7da884744b87392cb8afR210-R258))