### PR TITLE
fix: Ensure flow_id is not None before logging vertex build details

### DIFF
--- a/src/backend/base/langflow/graph/graph/base.py
+++ b/src/backend/base/langflow/graph/graph/base.py
@@ -1689,14 +1689,15 @@ class Graph:
                     t.cancel()
                 raise result
             if isinstance(result, VertexBuildResult):
-                await log_vertex_build(
-                    flow_id=self.flow_id or "",
-                    vertex_id=result.vertex.id,
-                    valid=result.valid,
-                    params=result.params,
-                    data=result.result_dict,
-                    artifacts=result.artifacts,
-                )
+                if self.flow_id is not None:
+                    await log_vertex_build(
+                        flow_id=self.flow_id,
+                        vertex_id=result.vertex.id,
+                        valid=result.valid,
+                        params=result.params,
+                        data=result.result_dict,
+                        artifacts=result.artifacts,
+                    )
 
                 vertices.append(result.vertex)
             else:

--- a/src/backend/base/langflow/graph/utils.py
+++ b/src/backend/base/langflow/graph/utils.py
@@ -166,7 +166,7 @@ async def log_transaction(
 
 async def log_vertex_build(
     *,
-    flow_id: str,
+    flow_id: str | UUID,
     vertex_id: str,
     valid: bool,
     params: Any,
@@ -181,9 +181,15 @@ async def log_vertex_build(
     try:
         if not get_settings_service().settings.vertex_builds_storage_enabled:
             return
+        try:
+            if isinstance(flow_id, str):
+                flow_id = UUID(flow_id)
+        except ValueError:
+            msg = f"Invalid flow_id passed to log_vertex_build: {flow_id!r}(type: {type(flow_id)})"
+            raise ValueError(msg) from None
 
         vertex_build = VertexBuildBase(
-            flow_id=flow_id if isinstance(flow_id, UUID) else UUID(flow_id),
+            flow_id=flow_id,
             id=vertex_id,
             valid=valid,
             params=str(params) if params else None,


### PR DESCRIPTION
Fix for the flaky error surfacing in the test_simple_no_llm test:
https://github.com/langflow-ai/langflow/actions/runs/16174432316/job/45656012297?pr=8842#logs

* Updated log_vertex_build call to check if flow_id is not None, enhancing robustness and preventing potential errors when flow_id is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging behavior to prevent unnecessary log entries when a flow ID is not available.

* **Refactor**
  * Enhanced type handling for flow IDs in logging, ensuring more robust and descriptive error messages for invalid IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->