### PR TITLE
chore: update package versions to include post-release tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow"
-version = "1.5.0"
+version = "1.5.0.post1"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.14"
 license = "MIT"
@@ -17,7 +17,7 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
-    "langflow-base==0.5.0",
+    "langflow-base~=0.5.0",
     "beautifulsoup4==4.12.3",
     "google-search-results>=2.4.1,<3.0.0",
     "google-api-python-client==2.154.0",

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-base"
-version = "0.5.0"
+version = "0.5.0.post1"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.14"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -4676,7 +4676,7 @@ wheels = [
 
 [[package]]
 name = "langflow"
-version = "1.5.0"
+version = "1.5.0.post1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofile" },
@@ -5043,7 +5043,7 @@ dev = [
 
 [[package]]
 name = "langflow-base"
-version = "0.5.0"
+version = "0.5.0.post1"
 source = { editable = "src/backend/base" }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
* Bump langflow version to 1.5.0.post1 in pyproject.toml and uv.lock.
* Update langflow-base version to 0.5.0.post1 in related files for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version to 1.5.0.post1 to reflect a post-release iteration.
  * Adjusted dependency specification for "langflow-base" to allow patch-level updates within the 0.5.x series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->