### PR TITLE
fix: clean edges of same type but different name when switching outputs, update color when deleting edges

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx
@@ -222,6 +222,8 @@ const HandleRenderComponent = memo(function HandleRenderComponent({
     targetHandle: semiConnection.targetHandle ?? myId,
   });
 
+  const edges = useFlowStore((state) => state.edges);
+
   const {
     sameNode,
     ownHandle,
@@ -266,11 +268,9 @@ const HandleRenderComponent = memo(function HandleRenderComponent({
     const openHandle = filterOpenHandle || draggingOpenHandle;
     const filterPresent = handleDragging || filterType;
 
-    const connectedEdge = useFlowStore
-      .getState()
-      .edges.find(
-        (edge) => edge.target === nodeId && edge.targetHandle === myId,
-      );
+    const connectedEdge = edges.find(
+      (edge) => edge.target === nodeId && edge.targetHandle === myId,
+    );
     const outputType = connectedEdge?.data?.sourceHandle?.output_types?.[0];
     const connectedColor = outputType ? nodeColorsName[outputType] : "gray";
 
@@ -344,6 +344,7 @@ const HandleRenderComponent = memo(function HandleRenderComponent({
     colors,
     colorName,
     tooltipTitle,
+    edges,
   ]);
 
   const handleMouseDown = useCallback(

--- a/src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx
@@ -184,6 +184,8 @@ const HandleRenderComponent = memo(function HandleRenderComponent({
     useShallow((state) => state.currentFlow?.locked),
   );
 
+  const edges = useFlowStore((state) => state.edges);
+
   const {
     setHandleDragging,
     setFilterType,
@@ -221,8 +223,6 @@ const HandleRenderComponent = memo(function HandleRenderComponent({
     target: semiConnection.target ?? nodeId,
     targetHandle: semiConnection.targetHandle ?? myId,
   });
-
-  const edges = useFlowStore((state) => state.edges);
 
   const {
     sameNode,

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -77,7 +77,6 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
   let newEdges: EdgeType[] = cloneDeep(
     edges.map((edge) => ({ ...edge, selected: false, animated: false })),
   );
-  console.log("edges", edges);
   edges.forEach((edge) => {
     // check if the source and target node still exists
     const sourceNode = nodes.find((node) => node.id === edge.source);
@@ -151,8 +150,6 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
                 )?.length ?? 0) <= 1) &&
               output.name === name,
           );
-
-        console.log("output", output);
 
         if (output) {
           const outputTypes =

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -162,8 +162,6 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
             dataType: sourceNode.data.type,
           };
 
-          console.log("id", id, scapedJSONStringfy(id), sourceHandle);
-
           if (scapedJSONStringfy(id) !== sourceHandle) {
             newEdges = newEdges.filter((e) => e.id !== edge.id);
           }

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -77,6 +77,7 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
   let newEdges: EdgeType[] = cloneDeep(
     edges.map((edge) => ({ ...edge, selected: false, animated: false })),
   );
+  console.log("edges", edges);
   edges.forEach((edge) => {
     // check if the source and target node still exists
     const sourceNode = nodes.find((node) => node.id === edge.source);
@@ -151,16 +152,20 @@ export function cleanEdges(nodes: AllNodeType[], edges: EdgeType[]) {
               output.name === name,
           );
 
+        console.log("output", output);
+
         if (output) {
           const outputTypes =
             output!.types.length === 1 ? output!.types : [output!.selected!];
 
           const id: sourceHandleType = {
             id: sourceNode.data.id,
-            name: name,
+            name: output?.name ?? name,
             output_types: outputTypes,
             dataType: sourceNode.data.type,
           };
+
+          console.log("id", id, scapedJSONStringfy(id), sourceHandle);
 
           if (scapedJSONStringfy(id) !== sourceHandle) {
             newEdges = newEdges.filter((e) => e.id !== edge.id);


### PR DESCRIPTION
This pull request introduces optimizations and refactors to improve the handling of edges in the React Flow integration. The changes primarily focus on simplifying edge-related logic and enhancing code readability.

### Optimizations and Refactors in Edge Handling:

* [`src/frontend/src/CustomNodes/GenericNode/components/handleRenderComponent/index.tsx`](diffhunk://#diff-6b00d330838431fd5fd114f3ed4159196f47f74d00a65bd4d5fa2ed70cf726fbR225-R226): Refactored edge-related logic by introducing a `useFlowStore` hook to retrieve `edges` directly, reducing redundant calls to `useFlowStore.getState()` and improving code clarity. [[1]](diffhunk://#diff-6b00d330838431fd5fd114f3ed4159196f47f74d00a65bd4d5fa2ed70cf726fbR225-R226) [[2]](diffhunk://#diff-6b00d330838431fd5fd114f3ed4159196f47f74d00a65bd4d5fa2ed70cf726fbL269-R271) [[3]](diffhunk://#diff-6b00d330838431fd5fd114f3ed4159196f47f74d00a65bd4d5fa2ed70cf726fbR347)

* [`src/frontend/src/utils/reactflowUtils.ts`](diffhunk://#diff-a380d7691b7dad914af3baf94d210fa2df4f56c0f8533eb0e17c29bb8dc0e91cL160-R160): Updated the `cleanEdges` function to use a fallback value for `output?.name`, ensuring robust handling of edge data when `output.name` is undefined.