### PR TITLE
fix: Update templates modal dimensions for responsive layout

### DIFF
--- a/src/frontend/src/modals/baseModal/helpers/switch-case-size.ts
+++ b/src/frontend/src/modals/baseModal/helpers/switch-case-size.ts
@@ -57,7 +57,7 @@ export const switchCaseModalSize = (size: string) => {
     case "templates":
       minWidth = "w-[97vw] max-w-[1200px]";
       height =
-        "min-h-[500px] h-[90vh] md:h-[85vh] lg:h-[80vh] xl:h-[70vh] max-h-[90vh]";
+        "min-h-[700px] lg:min-h-0 h-[90vh] md:h-[80vh] lg:h-[50vw] lg:max-h-[620px]";
       break;
     case "three-cards":
       minWidth = "min-w-[1066px]";


### PR DESCRIPTION
This pull request includes a change to the `switchCaseModalSize` helper function in `src/frontend/src/modals/baseModal/helpers/switch-case-size.ts`. The modification updates the modal dimensions for the "templates" case to improve responsiveness and layout consistency.

### Modal dimension updates:
* [`src/frontend/src/modals/baseModal/helpers/switch-case-size.ts`](diffhunk://#diff-ab86c74c27d092d12c2281d0c788eb7227f5afc8cc84f754dcbf8a1a99ce0a56L60-R60): Adjusted the height properties for the "templates" modal to use `min-h-[700px] lg:min-h-0 h-[90vh] md:h-[80vh] lg:h-[50vw] lg:max-h-[620px]`, ensuring better scaling across different screen sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the sizing and height behavior for the "templates" modal to improve its appearance and responsiveness across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->