### PR TITLE
ci: update regex pattern for langflow-base dependency to support PEP 440 version suffixes

### DIFF
--- a/scripts/ci/update_uv_dependency.py
+++ b/scripts/ci/update_uv_dependency.py
@@ -16,7 +16,8 @@ def update_uv_dep(base_version: str) -> None:
     content = pyproject_path.read_text(encoding="utf-8")
 
     # For the main project, update the langflow-base dependency in the UV section
-    pattern = re.compile(r'(dependencies\s*=\s*\[\s*\n\s*)("langflow-base==[\d.]+")')
+    # Updated pattern to handle PEP 440 version suffixes (.post, .dev, .a, .b, .rc, etc.)
+    pattern = re.compile(r'(dependencies\s*=\s*\[\s*\n\s*)("langflow-base==[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*")')
     replacement = rf'\1"langflow-base-nightly=={base_version}"'
 
     # Check if the pattern is found


### PR DESCRIPTION
Enhanced the regex pattern in the update_uv_dependency.py script to correctly handle PEP 440 version suffixes such as .post, .dev, .a, .b, and .rc. This change improves the accuracy of dependency updates for the langflow-base package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved support for advanced version formats when updating dependencies, allowing recognition of additional version suffixes (e.g., post, dev, alpha, beta, release candidate) in version strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->