### PR TITLE
feat: add configurable keep-alive functionality to streaming endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,11 @@ LANGFLOW_OPEN_BROWSER=
 # Example: LANGFLOW_REMOVE_API_KEYS=false
 LANGFLOW_REMOVE_API_KEYS=
 
+# Keep-alive timeout for streaming endpoints in seconds
+# Controls how often keep-alive messages are sent during streaming operations
+# Example: LANGFLOW_KEEP_ALIVE_TIMEOUT=15.0
+LANGFLOW_KEEP_ALIVE_TIMEOUT=
+
 # Whether to use RedisCache or ThreadingInMemoryCache or AsyncInMemoryCache
 # Values: async, memory, redis
 # Example: LANGFLOW_CACHE_TYPE=memory

--- a/docs/docs/Configuration/environment-variables.mdx
+++ b/docs/docs/Configuration/environment-variables.mdx
@@ -74,6 +74,7 @@ If it detects a supported environment variable, then it automatically adopts the
     LANGFLOW_DEV=false
     LANGFLOW_FALLBACK_TO_ENV_VAR=false
     LANGFLOW_HEALTH_CHECK_MAX_RETRIES=5
+    LANGFLOW_KEEP_ALIVE_TIMEOUT=15.0
     LANGFLOW_HOST=localhost
     LANGFLOW_LANGCHAIN_CACHE=InMemoryCache
     LANGFLOW_MAX_FILE_SIZE_UPLOAD=10000
@@ -204,6 +205,7 @@ The following table lists the environment variables supported by Langflow.
 | <Link id="LANGFLOW_FALLBACK_TO_ENV_VAR"/><span class="env-prefix">LANGFLOW_</span>FALLBACK_TO_ENV_VAR | Boolean | `true` | If enabled, [global variables](../Configuration/configuration-global-variables.mdx) set in the Langflow UI fall back to an environment variable with the same name when Langflow fails to retrieve the variable value. |
 | <Link id="LANGFLOW_FRONTEND_PATH"/><span class="env-prefix">LANGFLOW_</span>FRONTEND_PATH | String | `./frontend` | Path to the frontend directory containing build files. This is for development purposes only.<br/>See [`--frontend-path` option](./configuration-cli.mdx#run-frontend-path). |
 | <Link id="LANGFLOW_HEALTH_CHECK_MAX_RETRIES"/><span class="env-prefix">LANGFLOW_</span>HEALTH_CHECK_MAX_RETRIES | Integer | `5` | Set the maximum number of retries for the health check.<br/>See [`--health-check-max-retries` option](./configuration-cli.mdx#run-health-check-max-retries). |
+| <Link id="LANGFLOW_KEEP_ALIVE_TIMEOUT"/><span class="env-prefix">LANGFLOW_</span>KEEP_ALIVE_TIMEOUT | Float | `15.0` | Keep-alive timeout for streaming endpoints in seconds. Controls how often keep-alive messages are sent during streaming operations to prevent connection timeouts. |
 | <Link id="LANGFLOW_HOST"/><span class="env-prefix">LANGFLOW_</span>HOST | String | `localhost` | The host on which the Langflow server will run.<br/>See [`--host` option](./configuration-cli.mdx#run-host). |
 | <Link id="LANGFLOW_LANGCHAIN_CACHE"/><span class="env-prefix">LANGFLOW_</span>LANGCHAIN_CACHE | String | `InMemoryCache` | Type of cache to use. Possible values: `InMemoryCache`, `SQLiteCache`.<br/>See [`--cache` option](./configuration-cli.mdx#run-cache). |
 | <Link id="LANGFLOW_LOG_LEVEL"/><span class="env-prefix">LANGFLOW_</span>LOG_LEVEL | String | `INFO` | Set the logging level for Langflow. Possible values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. |
@@ -268,6 +270,7 @@ LANGFLOW_DATABASE_URL=postgresql://user:password@localhost:5432/langflow
 LANGFLOW_DEV=false
 LANGFLOW_FALLBACK_TO_ENV_VAR=false
 LANGFLOW_HEALTH_CHECK_MAX_RETRIES=5
+LANGFLOW_KEEP_ALIVE_TIMEOUT=15.0
 LANGFLOW_HOST=localhost
 LANGFLOW_LANGCHAIN_CACHE=InMemoryCache
 LANGFLOW_MAX_FILE_SIZE_UPLOAD=10000
@@ -309,6 +312,7 @@ Environment="LANGFLOW_DATABASE_URL=postgresql://user:password@localhost:5432/lan
 Environment="LANGFLOW_DEV=false"
 Environment="LANGFLOW_FALLBACK_TO_ENV_VAR=false"
 Environment="LANGFLOW_HEALTH_CHECK_MAX_RETRIES=5"
+Environment="LANGFLOW_KEEP_ALIVE_TIMEOUT=15.0"
 Environment="LANGFLOW_HOST=localhost"
 Environment="LANGFLOW_LANGCHAIN_CACHE=InMemoryCache"
 Environment="LANGFLOW_MAX_FILE_SIZE_UPLOAD=10000"
@@ -357,6 +361,7 @@ Create or edit the `.vscode/tasks.json` file in your project root:
             "LANGFLOW_DEV": "false",
             "LANGFLOW_FALLBACK_TO_ENV_VAR": "false",
             "LANGFLOW_HEALTH_CHECK_MAX_RETRIES": "5",
+            "LANGFLOW_KEEP_ALIVE_TIMEOUT": "15.0",
             "LANGFLOW_HOST": "localhost",
             "LANGFLOW_LANGCHAIN_CACHE": "InMemoryCache",
             "LANGFLOW_MAX_FILE_SIZE_UPLOAD": "10000",

--- a/src/backend/base/langflow/api/build.py
+++ b/src/backend/base/langflow/api/build.py
@@ -151,7 +151,7 @@ async def get_flow_events_response(
 
 
 async def create_flow_response(
-    queue: asyncio.Queue,
+    queue: asyncio.Queue[tuple[str | None, bytes | None, float]],
     event_manager: EventManager,
     event_task: asyncio.Task,
 ) -> DisconnectHandlerStreamingResponse:

--- a/src/backend/base/langflow/events/event_manager.py
+++ b/src/backend/base/langflow/events/event_manager.py
@@ -28,7 +28,7 @@ class PartialEventCallback(Protocol):
 
 
 class EventManager:
-    def __init__(self, queue: asyncio.Queue):
+    def __init__(self, queue: asyncio.Queue[tuple[str | None, bytes | None, float]]) -> None:
         self.queue = queue
         self.events: dict[str, PartialEventCallback] = {}
 

--- a/src/backend/tests/unit/api/test_build.py
+++ b/src/backend/tests/unit/api/test_build.py
@@ -1,0 +1,270 @@
+import asyncio
+import os
+import time
+from unittest.mock import Mock
+
+import pytest
+from langflow.api.build import create_flow_response
+from langflow.api.disconnect import DisconnectHandlerStreamingResponse
+from langflow.events.event_manager import EventManager
+
+
+class TestCreateFlowResponse:
+    """Test suite for create_flow_response function in langflow.api.build."""
+
+    @pytest.fixture
+    def mock_event_manager(self):
+        """Create a mock EventManager for testing."""
+        mock = Mock(spec=EventManager)
+        mock.on_end = Mock()
+        return mock
+
+    @pytest.fixture
+    def mock_event_task(self):
+        """Create a mock event task for testing."""
+        task = Mock()
+        task.cancel = Mock()
+        task.done.return_value = False
+        task.cancelled.return_value = False
+        return task
+
+    async def test_create_flow_response_returns_proper_streaming_response(self, mock_event_manager, mock_event_task):
+        """Test that create_flow_response returns a proper DisconnectHandlerStreamingResponse."""
+        queue = asyncio.Queue()
+        await queue.put((1, b'{"event": "test", "data": {}}', time.time()))
+        await queue.put((None, None, time.time()))  # End marker
+
+        response = await create_flow_response(
+            queue=queue,
+            event_manager=mock_event_manager,
+            event_task=mock_event_task,
+        )
+
+        assert isinstance(response, DisconnectHandlerStreamingResponse)
+        assert response.media_type == "application/x-ndjson"
+        assert response.on_disconnect is not None
+
+    async def test_create_flow_response_streams_events_successfully(self, mock_event_manager, mock_event_task):
+        """Test that create_flow_response streams events from queue successfully."""
+        queue = asyncio.Queue()
+
+        test_events = [
+            (1, b'{"event": "vertex_start", "data": {"vertex_id": "test1"}}', time.time()),
+            (2, b'{"event": "vertex_end", "data": {"vertex_id": "test1", "result": "success"}}', time.time()),
+            (3, None, time.time()),  # End of stream
+        ]
+
+        for event in test_events:
+            await queue.put(event)
+
+        response = await create_flow_response(
+            queue=queue,
+            event_manager=mock_event_manager,
+            event_task=mock_event_task,
+        )
+
+        generator = response.body_iterator
+        yielded_values = [value async for value in generator if value is not None]
+
+        assert len(yielded_values) == 2
+        assert '"event": "vertex_start"' in yielded_values[0]
+        assert '"event": "vertex_end"' in yielded_values[1]
+
+    async def test_create_flow_response_sends_keepalive_on_timeout(self, mock_event_manager, mock_event_task):
+        """Test that create_flow_response sends keep-alive events when queue times out."""
+        original_timeout = os.getenv("LANGFLOW_KEEP_ALIVE_TIMEOUT")
+        os.environ["LANGFLOW_KEEP_ALIVE_TIMEOUT"] = "0.1"
+
+        import importlib
+
+        from langflow.api import build
+
+        importlib.reload(build)
+
+        try:
+            queue = asyncio.Queue()
+
+            response = await build.create_flow_response(
+                queue=queue,
+                event_manager=mock_event_manager,
+                event_task=mock_event_task,
+            )
+
+            generator = response.body_iterator
+            start_time = time.time()
+
+            # Should get a keepalive event due to timeout
+            first_value = await generator.__anext__()
+            elapsed = time.time() - start_time
+
+            assert elapsed >= 0.1
+            assert first_value == '{"event": "keepalive", "data": {}}\n\n'
+
+        finally:
+            # Restore original timeout
+            if original_timeout is not None:
+                os.environ["LANGFLOW_KEEP_ALIVE_TIMEOUT"] = original_timeout
+            else:
+                os.environ.pop("LANGFLOW_KEEP_ALIVE_TIMEOUT", None)
+            importlib.reload(build)
+
+    async def test_create_flow_response_handles_exceptions_gracefully(self, mock_event_manager, mock_event_task):
+        """Test that create_flow_response handles queue exceptions gracefully."""
+        queue = asyncio.Queue()
+
+        # Put an event that will cause the queue to be accessed normally first
+        await queue.put((1, b'{"event": "test", "data": {}}', time.time()))
+
+        response = await create_flow_response(
+            queue=queue,
+            event_manager=mock_event_manager,
+            event_task=mock_event_task,
+        )
+
+        generator = response.body_iterator
+
+        # Get the first event successfully
+        first_value = await generator.__anext__()
+        assert '"event": "test"' in first_value
+
+        # Now the queue is empty and will timeout, sending a keepalive event
+        # The generator should handle this gracefully by sending keepalive
+        try:
+            # This should get a keepalive event due to timeout
+            second_value = await asyncio.wait_for(generator.__anext__(), timeout=1.0)
+            assert "keepalive" in second_value
+        except asyncio.TimeoutError:
+            # This is also acceptable - it means the generator is handling timeouts properly
+            pass
+
+    async def test_create_flow_response_handles_empty_queue(self, mock_event_manager, mock_event_task):
+        """Test that create_flow_response handles empty queue properly."""
+        queue = asyncio.Queue()
+        await queue.put((1, None, time.time()))  # Immediate end marker
+
+        response = await create_flow_response(
+            queue=queue,
+            event_manager=mock_event_manager,
+            event_task=mock_event_task,
+        )
+
+        generator = response.body_iterator
+        yielded_values = [value async for value in generator if value is not None]
+
+        assert len(yielded_values) == 0
+
+    async def test_create_flow_response_handles_malformed_events(self, mock_event_manager, mock_event_task):
+        """Test that create_flow_response handles malformed events gracefully."""
+        queue = asyncio.Queue()
+
+        # Add malformed event (not valid JSON bytes)
+        await queue.put((1, b"invalid json{", time.time()))
+        await queue.put((2, b'{"valid": "json"}', time.time()))
+        await queue.put((3, None, time.time()))
+
+        response = await create_flow_response(
+            queue=queue,
+            event_manager=mock_event_manager,
+            event_task=mock_event_task,
+        )
+
+        generator = response.body_iterator
+        yielded_values = [value async for value in generator if value is not None]
+
+        # Should yield both events, malformed content is passed through as-is
+        assert len(yielded_values) == 2
+        assert yielded_values[0] == "invalid json{"
+        assert '{"valid": "json"}' in yielded_values[1]
+
+    async def test_create_flow_response_on_disconnect_callback(self, mock_event_manager, mock_event_task):
+        """Test that the on_disconnect callback works properly."""
+        queue = asyncio.Queue()
+        await queue.put((1, None, time.time()))
+
+        response = await create_flow_response(
+            queue=queue,
+            event_manager=mock_event_manager,
+            event_task=mock_event_task,
+        )
+
+        # Call the disconnect callback
+        response.on_disconnect()
+
+        # Verify the callback cancels the task and calls event_manager.on_end
+        mock_event_task.cancel.assert_called_once()
+        mock_event_manager.on_end.assert_called_once_with(data={})
+
+    async def test_create_flow_response_with_cancelled_event_task(self, mock_event_manager):
+        """Test create_flow_response behavior when event_task is already cancelled."""
+        queue = asyncio.Queue()
+        await queue.put((1, b'{"event": "test"}', time.time()))
+        await queue.put((2, None, time.time()))
+
+        # Create a cancelled task
+        cancelled_task = Mock()
+        cancelled_task.cancel = Mock()
+        cancelled_task.done.return_value = True
+        cancelled_task.cancelled.return_value = True
+
+        response = await create_flow_response(
+            queue=queue,
+            event_manager=mock_event_manager,
+            event_task=cancelled_task,
+        )
+
+        # Should still work normally
+        assert isinstance(response, DisconnectHandlerStreamingResponse)
+
+        # Test the disconnect callback
+        response.on_disconnect()
+        cancelled_task.cancel.assert_called_once()
+        mock_event_manager.on_end.assert_called_once_with(data={})
+
+    async def test_create_flow_response_with_large_events(self, mock_event_manager, mock_event_task):
+        """Test create_flow_response handles large events properly."""
+        queue = asyncio.Queue()
+
+        # Create a large event (1MB of data)
+        large_data = "x" * (1024 * 1024)
+        large_event = f'{{"event": "large_data", "data": "{large_data}"}}'
+
+        await queue.put((1, large_event.encode(), time.time()))
+        await queue.put((2, None, time.time()))
+
+        response = await create_flow_response(
+            queue=queue,
+            event_manager=mock_event_manager,
+            event_task=mock_event_task,
+        )
+
+        generator = response.body_iterator
+        yielded_values = [value async for value in generator if value is not None]
+
+        assert len(yielded_values) == 1
+        assert len(yielded_values[0]) > 1024 * 1024  # Should be large
+        assert '"event": "large_data"' in yielded_values[0]
+
+    async def test_create_flow_response_with_rapid_events(self, mock_event_manager, mock_event_task):
+        """Test create_flow_response handles rapid succession of events."""
+        queue = asyncio.Queue()
+
+        # Add many events rapidly
+        num_events = 100
+        for i in range(num_events):
+            event_data = f'{{"event": "rapid_event", "data": {{"id": {i}}}}}'
+            await queue.put((i, event_data.encode(), time.time()))
+
+        await queue.put((num_events, None, time.time()))
+
+        response = await create_flow_response(
+            queue=queue,
+            event_manager=mock_event_manager,
+            event_task=mock_event_task,
+        )
+
+        generator = response.body_iterator
+        yielded_values = [value async for value in generator if value is not None]
+
+        assert len(yielded_values) == num_events
+        for i, value in enumerate(yielded_values):
+            assert f'"id": {i}' in value


### PR DESCRIPTION
# Summary

Add configurable keep-alive functionality to streaming endpoints to prevent proxy server timeouts during long-running operations.

# Problem

When a proxy server (such as AWS CloudFront) is placed in front of the backend, streaming endpoints can be disconnected due to response timeout settings. AWS CloudFront, for example, has a default 30-second timeout that terminates connections when no response data is sent within that period, causing interruptions during long-running flow builds and executions.

# Solution

This PR implements periodic keep-alive messages for the two main streaming endpoints:

- /api/v1/flows/run/{flow_id} (simplified run flow)
- /build/{flow_id}/flow (flow build process)

# Key Features

- Configurable timeout: Uses LANGFLOW_KEEP_ALIVE_TIMEOUT environment variable (default: 15.0 seconds)
- Keep-alive message format: Sends {"event": "keepalive", "data": {}}\n\n when no events are available within the timeout period
- Non-intrusive: Does not affect deprecated streaming APIs
- Type safety: Added proper type hints to queue parameters
- Logging: Debug logging for keep-alive events

# Changes Made

## Core Implementation

- src/backend/base/langflow/api/v1/endpoints.py: Added keep-alive functionality to consume_and_yield() function
- src/backend/base/langflow/api/build.py: Added keep-alive functionality to flow build streaming response
- src/backend/base/langflow/events/event_manager.py: Enhanced type hints for event queues

## Configuration & Documentation

- .env.example: Added LANGFLOW_KEEP_ALIVE_TIMEOUT environment variable
- docs/docs/Configuration/environment-variables.md: Documented the new environment variable

## Testing & Quality

- src/backend/tests/unit/api/test_build.py: Added comprehensive tests for keep-alive functionality
- src/backend/tests/unit/api/v1/test_endpoints.py: Added tests for streaming endpoint keep-alive
- .pre-commit-config.yaml: Aligned ruff version for consistent formatting

## Testing

- Added comprehensive unit tests covering timeout scenarios and keep-alive message generation
- Verified keep-alive messages are sent at configured intervals
- Confirmed existing functionality remains unaffected

## Configuration

```
# Set keep-alive timeout (in seconds)
LANGFLOW_KEEP_ALIVE_TIMEOUT=15.0
```

The keep-alive interval should be set shorter than your proxy server's timeout to ensure connections remain active during long-running operations.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable keep-alive timeout for streaming endpoints via the new `LANGFLOW_KEEP_ALIVE_TIMEOUT` environment variable. This ensures clients receive periodic keep-alive messages during inactivity to maintain stable connections.

* **Documentation**
  * Updated environment variable documentation to describe the new keep-alive timeout setting and its usage in various deployment scenarios.

* **Bug Fixes**
  * Improved streaming stability by periodically sending keep-alive events to prevent connection timeouts.

* **Tests**
  * Added comprehensive tests for the new keep-alive mechanism and streaming event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->