### PR TITLE
docs: remove duplicate intro text

### DIFF
--- a/docs/docs/Concepts/concepts-publish.md
+++ b/docs/docs/Concepts/concepts-publish.md
@@ -16,17 +16,16 @@ If you use Microsoft Windows or WSL, you might need to adjust the filepaths give
 :::
 
 The **API access** pane presents code templates for integrating your flow into external applications.
-Langflow provides code snippets to help you get started with the Langflow API.
+
+![API pane](/img/api-pane.png)
 
 As of Langflow version 1.5, all API requests require authentication with a Langflow API key, even if `AUTO_LOGIN` is set to `True`.
 For more information, see [API keys](/configuration-api-keys).
 The API access pane’s code snippets include a script that looks for a `LANGFLOW_API_KEY` environment variable set in your terminal session.
 To set this variable in your terminal:
-```bash
-export LANGFLOW_API_KEY="sk..."
-```
-
-![API pane](/img/api-pane.png)
+    ```bash
+    export LANGFLOW_API_KEY="sk..."
+    ```
 
 For more information, see [Run your flows from external applications](/get-started-quickstart#run-your-flows-from-external-applications).
 


### PR DESCRIPTION
* Remove a duplicate intro sentence that [This PR](https://github.com/langflow-ai/langflow/pull/8951) introduced to the API pane.
* Move the image up so it isn't next to a code snippet.
<img width="1027" height="835" alt="Screenshot 2025-07-10 at 12 25 51 PM" src="https://github.com/user-attachments/assets/cc097d06-dd99-4e47-b495-9856a77a8c92" />
