### PR TITLE
refactor: Improve HeaderButtons state sync with userData

### DIFF
--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/header-buttons.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/header-buttons.tsx
@@ -5,7 +5,7 @@ import { useUpdateUser } from "@/controllers/API/queries/auth";
 import CustomGetStartedProgress from "@/customization/components/custom-get-started-progress";
 import useAuthStore from "@/stores/authStore";
 import { Separator } from "@radix-ui/react-separator";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AddFolderButton } from "./add-folder-button";
 import { UploadFolderButton } from "./upload-folder-button";
 
@@ -21,13 +21,26 @@ export const HeaderButtons = ({
   addNewFolder: () => void;
 }) => {
   const userData = useAuthStore((state) => state.userData);
-  const userDismissedDialog = userData?.optins?.dialog_dismissed;
-  const isGithubStarred = userData?.optins?.github_starred;
-  const isDiscordJoined = userData?.optins?.discord_clicked;
-  const [isDismissedDialog, setIsDismissedDialog] =
-    useState(userDismissedDialog);
+
+  const [isDismissedDialog, setIsDismissedDialog] = useState(
+    userData?.optins?.dialog_dismissed,
+  );
+  const [isGithubStarred, setIsGithubStarred] = useState(
+    userData?.optins?.github_starred,
+  );
+  const [isDiscordJoined, setIsDiscordJoined] = useState(
+    userData?.optins?.discord_clicked,
+  );
 
   const { mutate: updateUser } = useUpdateUser();
+
+  useEffect(() => {
+    if (userData) {
+      setIsDismissedDialog(userData.optins?.dialog_dismissed);
+      setIsGithubStarred(userData.optins?.github_starred);
+      setIsDiscordJoined(userData.optins?.discord_clicked);
+    }
+  }, [userData]);
 
   const handleDismissDialog = () => {
     setIsDismissedDialog(true);
@@ -44,7 +57,7 @@ export const HeaderButtons = ({
 
   return (
     <>
-      {!isDismissedDialog && (
+      {!isDismissedDialog && userData && (
         <>
           <CustomGetStartedProgress
             userData={userData!}


### PR DESCRIPTION
This pull request refactors the `HeaderButtons` component in `src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/header-buttons.tsx` to improve state synchronization with user data and enhance component behavior. The most notable changes include adding a `useEffect` hook to update state variables when `userData` changes and modifying conditional rendering logic for better reliability.

### State synchronization improvements:

* Added `useEffect` to synchronize state variables (`isDismissedDialog`, `isGithubStarred`, `isDiscordJoined`) with `userData` whenever it changes. This ensures the state remains consistent with the latest user data.

### Component behavior enhancements:

* Updated conditional rendering to include a check for `userData` before rendering the `CustomGetStartedProgress` component, preventing potential errors when `userData` is null or undefined.

### Code cleanup:

* Refactored initialization of state variables (`useState`) to directly use values from `userData` for better readability and maintainability.
* Imported `useEffect` to support the new state synchronization logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of user preferences, ensuring dialog and related features accurately reflect the latest user data.
  * Enhanced reliability of conditional rendering for dialog sections based on user data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->