### PR TITLE
refactor: Improve HomePage state management and tab switching

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -111,9 +111,18 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
           flow.is_component === (flowType === "components"),
       ) === undefined
     ) {
-      setFlowType(flowType === "flows" ? "components" : "flows");
+      const otherTabHasItems =
+        flows?.find(
+          (flow) =>
+            flow.folder_id === (folderId ?? myCollectionId) &&
+            flow.is_component === (flowType === "flows"),
+        ) !== undefined;
+
+      if (otherTabHasItems) {
+        setFlowType(flowType === "flows" ? "components" : "flows");
+      }
     }
-  }, [isEmptyFolder]);
+  }, [isEmptyFolder, flows, folderId, myCollectionId, flowType]);
 
   const [selectedFlows, setSelectedFlows] = useState<string[]>([]);
   const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(
@@ -222,7 +231,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
     setSelectedFlows((old) =>
       old.filter((id) => data.flows.some((flow) => flow.id === id)),
     );
-  }, [data.flows]);
+  }, [folderData?.flows?.items]);
 
   // Reset key states when navigating away
   useEffect(() => {

--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -122,7 +122,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
         setFlowType(flowType === "flows" ? "components" : "flows");
       }
     }
-  }, [isEmptyFolder, flows, folderId, myCollectionId, flowType]);
+  }, [isEmptyFolder]);
 
   const [selectedFlows, setSelectedFlows] = useState<string[]>([]);
   const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(


### PR DESCRIPTION
This pull request updates the `HomePage` component in `src/frontend/src/pages/MainPage/pages/homePage/index.tsx` to improve state management and handle dependencies more effectively. The changes primarily focus on refining the logic for switching tabs and updating selected flows based on new data.

### State Management Improvements:

* **Tab Switching Logic**: Added a check for whether the other tab contains items before automatically switching tabs. This ensures the user is only switched to a tab with relevant items. Updated the dependency array of the `useEffect` hook to include additional dependencies (`flows`, `folderId`, `myCollectionId`, and `flowType`) for more accurate updates.

* **Selected Flows Update**: Modified the dependency array for the `useEffect` hook responsible for updating `selectedFlows`. It now uses `folderData?.flows?.items` instead of `data.flows` for better alignment with the current data structure.

<img width="603" height="268" alt="image" src="https://github.com/user-attachments/assets/333233bb-063c-4a26-83af-1cbe6f5dd488" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab switching logic to only change tabs if the alternative tab contains items, preventing empty views.
  * Enhanced data synchronization by updating dependencies for selected items, ensuring more accurate and timely updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->