### PR TITLE
feat: Add prerelease-aware version comparison logic

### DIFF
--- a/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
@@ -12,7 +12,7 @@ import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import useAuthStore from "@/stores/authStore";
 import { useDarkStore } from "@/stores/darkStore";
-import { cn } from "@/utils/utils";
+import { cn, computeNonPrereleaseVersion } from "@/utils/utils";
 import { FaDiscord, FaGithub, FaTwitter } from "react-icons/fa";
 import { useParams } from "react-router-dom";
 import {
@@ -41,7 +41,14 @@ export const AccountMenu = () => {
     mutationLogout();
   };
 
-  const isLatestVersion = version === latestVersion;
+  const isLatestVersion = (() => {
+    if (!version || !latestVersion) return false;
+
+    const currentBaseVersion = computeNonPrereleaseVersion(version);
+    const latestBaseVersion = computeNonPrereleaseVersion(latestVersion);
+
+    return currentBaseVersion === latestBaseVersion;
+  })();
 
   return (
     <>

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -992,3 +992,15 @@ export function prepareSessionIdForAPI(session_id: string): string {
   const formatted = sessionIdFormatted(session_id);
   return encodeSessionId(formatted);
 }
+
+export const computeNonPrereleaseVersion = (
+  prereleaseVersion: string,
+): string => {
+  const prereleaseKeywords = ["a", "b", "rc", "dev", "post"];
+  for (const keyword of prereleaseKeywords) {
+    if (prereleaseVersion.includes(keyword)) {
+      return prereleaseVersion.split(keyword)[0].slice(0, -1);
+    }
+  }
+  return prereleaseVersion;
+};


### PR DESCRIPTION
This pull request introduces a new utility function, `computeNonPrereleaseVersion`, and integrates it into the `AccountMenu` component to enhance version comparison logic. The changes improve the accuracy of determining whether the current version matches the latest version by excluding prerelease identifiers.

### Integration of version comparison improvements:

* [`src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx`](diffhunk://#diff-f5be199ae8b645172b639f40ca4924e45fa9f5db2b53c1b7b11119b5eefe30faL44-R51): Updated the `isLatestVersion` logic to use the new `computeNonPrereleaseVersion` function, ensuring that prerelease identifiers are excluded during version comparison.
* [`src/frontend/src/utils/utils.ts`](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81R995-R1006): Added the `computeNonPrereleaseVersion` function, which extracts the base version by removing prerelease keywords (`a`, `b`, `rc`, `dev`, `post`) from version strings.

### Code enhancements:

* [`src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx`](diffhunk://#diff-f5be199ae8b645172b639f40ca4924e45fa9f5db2b53c1b7b11119b5eefe30faL15-R15): Imported the `computeNonPrereleaseVersion` function from `utils` to facilitate the updated version comparison logic.