### PR TITLE
fix: add truncation to error

### DIFF
--- a/src/frontend/src/alerts/error/index.tsx
+++ b/src/frontend/src/alerts/error/index.tsx
@@ -77,7 +77,7 @@ export default function ErrorAlert({
                             ),
                             p({ node, ...props }) {
                               return (
-                                <span className="inline-block w-fit max-w-full align-text-top">
+                                <span className="inline-block w-fit max-w-full align-text-top truncate-multiline">
                                   {props.children}
                                 </span>
                               );

--- a/src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx
@@ -262,7 +262,7 @@ export default function FlowBuildingComponent() {
                             ),
                             p({ node, ...props }) {
                               return (
-                                <span className="inline-block w-fit max-w-full align-text-top">
+                                <span className="inline-block w-fit max-w-full align-text-top truncate-doubleline">
                                   {props.children}
                                 </span>
                               );


### PR DESCRIPTION
This pull request introduces updates to text truncation styles in two components to improve the display of overflowing text. The changes ensure better handling of multiline text truncation in different contexts.

Updates to text truncation styles:

* [`src/frontend/src/alerts/error/index.tsx`](diffhunk://#diff-eee3fbdd4a018ee0b258ec9b09964f3644d205d59925b0a2adce0c04dfd98ea2L80-R80): Modified the `ErrorAlert` component to use the `truncate-multiline` class for improved handling of multiline text truncation.
* [`src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx`](diffhunk://#diff-7b1cd929d2c00ae2d1002137585e7188b240b76ac4d09bdb2eea3c4ec0e44930L265-R265): Updated the `FlowBuildingComponent` to use the `truncate-doubleline` class for truncating text to two lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved error message display by adding multiline and double-line truncation, enhancing readability and preventing overflow in error alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->