### PR TITLE
fix: Extract filename from path for storage service delete operations

### DIFF
--- a/src/backend/base/langflow/api/v2/files.py
+++ b/src/backend/base/langflow/api/v2/files.py
@@ -277,7 +277,7 @@ async def delete_files_batch(
 
         # Delete all files from the storage service
         for file in files:
-            await storage_service.delete_file(flow_id=str(current_user.id), file_name=file.path)
+            await storage_service.delete_file(flow_id=str(current_user.id), file_name=file.path.split("/")[-1])
             await session.delete(file)
 
         # Delete all files from the database
@@ -475,7 +475,7 @@ async def delete_file(
             raise HTTPException(status_code=404, detail="File not found")
 
         # Delete the file from the storage service
-        await storage_service.delete_file(flow_id=str(current_user.id), file_name=file_to_delete.path)
+        await storage_service.delete_file(flow_id=str(current_user.id), file_name=file_to_delete.path.split("/")[-1])
 
         # Delete from the database
         await session.delete(file_to_delete)
@@ -507,7 +507,7 @@ async def delete_all_files(
 
         # Delete all files from the storage service
         for file in files:
-            await storage_service.delete_file(flow_id=str(current_user.id), file_name=file.path)
+            await storage_service.delete_file(flow_id=str(current_user.id), file_name=file.path.split("/")[-1])
             await session.delete(file)
 
         # Delete all files from the database


### PR DESCRIPTION
## Overview
- Fixed storage service deletion operations by extracting filename from the file table's path using `file.path.split("/")[-1]`
- Previously, deletion operations were attempting to delete files at `user_id/user_id/filename` path, but now correctly deletes files at `user_id/filename` path
- Applied consistent filename extraction method that matches the existing `download_file` function in the same file

## Changes
- Modified `delete_files_batch`, `delete_file`, and `delete_all_files` functions in `src/backend/base/langflow/api/v2/files.py` to pass extracted filename string instead of passing the full path directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file deletion to ensure files are correctly identified and removed from storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->