### PR TITLE
test: Add 500ms timeout to starter-projects spec for timing reliability

### DIFF
--- a/src/frontend/tests/core/integrations/starter-projects.spec.ts
+++ b/src/frontend/tests/core/integrations/starter-projects.spec.ts
@@ -126,6 +126,8 @@ test(
 
       await page.getByTestId("text_card_container").nth(i).click();
 
+      await page.waitForTimeout(500);
+
       await page.waitForSelector('[data-testid="fit_view"]', {
         timeout: 5000,
       });


### PR DESCRIPTION
This pull request includes a small change to the `src/frontend/tests/core/integrations/starter-projects.spec.ts` file. The change adds a 500ms timeout after clicking on a text card container to ensure proper timing before waiting for the next selector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of starter project tests by adding a short wait after selecting each template card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->