### PR TITLE
chore: update pre-commit configuration to use local ruff hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,17 @@ repos:
         args:
           - --fix=lf
       - id: trailing-whitespace
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+  - repo: local
     hooks:
       - id: ruff
         name: ruff check
+        entry: uv run ruff check
+        language: system
         types_or: [python, pyi]
         args: [--fix]
       - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
         types_or: [python, pyi]
         args: [--config, pyproject.toml]


### PR DESCRIPTION
Replaced the remote ruff pre-commit repository with local hooks for ruff check and ruff format. Updated entry points to utilize 'uv run' for executing the commands, enhancing the development workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit configuration to use a local setup for code checks and formatting, improving how these tools are invoked. No changes to the checks themselves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->