### PR TITLE
fix: Prevent Authorization header on external URLs

### DIFF
--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -45,11 +45,11 @@ function ApiInterceptor() {
       request: function (url, config) {
         const accessToken = customGetAccessToken();
 
-        if (accessToken && !isAuthorizedURL(config?.url)) {
-          config.headers["Authorization"] = `Bearer ${accessToken}`;
-        }
-
         if (!isExternalURL(url)) {
+          if (accessToken && !isAuthorizedURL(config?.url)) {
+            config.headers["Authorization"] = `Bearer ${accessToken}`;
+          }
+
           for (const [key, value] of Object.entries(customHeaders)) {
             config.headers[key] = value;
           }


### PR DESCRIPTION
This pull request includes a minor update to the `ApiInterceptor` function in `src/frontend/src/controllers/API/api.tsx`. The change ensures that the `Authorization` header is only set when the URL is internal and authorized.

* [`src/frontend/src/controllers/API/api.tsx`](diffhunk://#diff-40877b80b2243cdac1ce21fa28ef5d9e9ab22eaf0051893e4c3236c3ec273150R48-L52): Refactored the conditional logic to prevent setting the `Authorization` header for external URLs, improving clarity and correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by ensuring the Authorization header is only added to internal API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->