### PR TITLE
docs: endquote in code alias

### DIFF
--- a/docs/docs/Concepts/concepts-publish.mdx
+++ b/docs/docs/Concepts/concepts-publish.mdx
@@ -94,7 +94,7 @@ If you want your requests to use an alias instead of the actual flow ID, you can
 
 4. To save the change, close the **Input Schema** pane.
 
-The automatically generated code snippets now use your new endpoint name instead of the original flow ID, such as `url = "http://localhost:7868/api/v1/run/flow-customer-database-agent`.
+The automatically generated code snippets now use your new endpoint name instead of the original flow ID, such as `url = "http://localhost:7868/api/v1/run/flow-customer-database-agent"`.
 
 ## Embed a flow into a website {#embedded-chat-widget}
 


### PR DESCRIPTION
url = "http://localhost:7868/api/v1/run/flow-customer-database-agent"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a formatting issue in the documentation by adding a missing closing double quote in an example URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->