### PR TITLE
feat: add image input support to LCModelComponent

### DIFF
--- a/src/backend/base/langflow/base/models/model.py
+++ b/src/backend/base/langflow/base/models/model.py
@@ -40,6 +40,7 @@ class LCModelComponent(Component):
 
     _base_inputs: list[InputTypes] = [
         MessageInput(name="input_value", display_name="Input"),
+        MultilineInput(name="image", display_name="Image", info="Image in Base64.", advanced=True),
         MultilineInput(
             name="system_message",
             display_name="System Message",
@@ -228,6 +229,16 @@ class LCModelComponent(Component):
                             ]
                             system_message_added = True
                         runnable = prompt | runnable
+                    elif self.image:
+                        content_parts = []
+                        image_part = {
+                            "type": "image_url",
+                            "image_url": self.image,
+                        }
+                        text_part = {"type": "text", "text": input_value.text}
+                        content_parts.append(image_part)
+                        content_parts.append(text_part)
+                        messages.append(HumanMessage(content=content_parts))
                     else:
                         messages.append(input_value.to_lc_message())
             else:

--- a/src/backend/base/langflow/base/models/model.py
+++ b/src/backend/base/langflow/base/models/model.py
@@ -230,14 +230,19 @@ class LCModelComponent(Component):
                             system_message_added = True
                         runnable = prompt | runnable
                     elif self.image:
-                        content_parts = []
-                        image_part = {
-                            "type": "image_url",
-                            "image_url": self.image,
-                        }
-                        text_part = {"type": "text", "text": input_value.text}
-                        content_parts.append(image_part)
-                        content_parts.append(text_part)
+                        # Ensure image is in proper data URL format
+                        image_url = self.image
+                        if not image_url.startswith("data:"):
+                            # Assume it's raw base64 and add appropriate prefix
+                            image_url = f"data:image/jpeg;base64,{image_url}"
+
+                        content_parts = [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": image_url},
+                            },
+                            {"type": "text", "text": input_value.text},
+                        ]
                         messages.append(HumanMessage(content=content_parts))
                     else:
                         messages.append(input_value.to_lc_message())


### PR DESCRIPTION
This pull request changes the parent class for models components (like ollama) to add a new field in the advanced mode that allows the user to send an image in base64 format thru the API (using tweaks) so multimodal models can interpret images without the need to download the image and store it in the langflow file system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for submitting an image (in Base64 format) alongside text input.
  * Enhanced message handling to display both image and text content in chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->