### PR TITLE
feat: adds authentication to mcp server under feature flag

### DIFF
--- a/src/backend/base/langflow/alembic/versions/3162e83e485f_add_auth_settings_to_folder_and_merge.py
+++ b/src/backend/base/langflow/alembic/versions/3162e83e485f_add_auth_settings_to_folder_and_merge.py
@@ -1,0 +1,58 @@
+"""Add auth_settings column to folder table and merge migration branches.
+
+Revision ID: 3162e83e485f
+Revises: 0ae3a2674f32, d9a6ea21edcd
+Create Date: 2025-01-16 13:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3162e83e485f"
+down_revision: str | Sequence[str] | None = ("0ae3a2674f32", "d9a6ea21edcd")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add auth_settings column to folder table and merge migration branches."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    # Check if folder table exists
+    table_names = inspector.get_table_names()
+    if "folder" not in table_names:
+        # If folder table doesn't exist, skip this migration
+        return
+
+    # Get current column names in folder table
+    column_names = [column["name"] for column in inspector.get_columns("folder")]
+
+    # Add auth_settings column to folder table if it doesn't exist
+    with op.batch_alter_table("folder", schema=None) as batch_op:
+        if "auth_settings" not in column_names:
+            batch_op.add_column(sa.Column("auth_settings", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove auth_settings column from folder table."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    # Check if folder table exists
+    table_names = inspector.get_table_names()
+    if "folder" not in table_names:
+        # If folder table doesn't exist, skip this migration
+        return
+
+    # Get current column names in folder table
+    column_names = [column["name"] for column in inspector.get_columns("folder")]
+
+    # Remove auth_settings column from folder table if it exists
+    with op.batch_alter_table("folder", schema=None) as batch_op:
+        if "auth_settings" in column_names:
+            batch_op.drop_column("auth_settings")

--- a/src/backend/base/langflow/api/v1/schemas.py
+++ b/src/backend/base/langflow/api/v1/schemas.py
@@ -440,6 +440,16 @@ class CancelFlowResponse(BaseModel):
     message: str
 
 
+class AuthSettings(BaseModel):
+    """Model representing authentication settings for MCP."""
+
+    auth_type: str = "none"
+    api_key: str | None = None
+    username: str | None = None
+    password: str | None = None
+    bearer_token: str | None = None
+
+
 class MCPSettings(BaseModel):
     """Model representing MCP settings for a flow."""
 
@@ -449,6 +459,21 @@ class MCPSettings(BaseModel):
     action_description: str | None = None
     name: str | None = None
     description: str | None = None
+    auth_settings: AuthSettings | None = None
+
+
+class MCPProjectUpdateRequest(BaseModel):
+    """Request model for updating MCP project settings including auth."""
+
+    settings: list[MCPSettings]
+    auth_settings: AuthSettings | None = None
+
+
+class MCPProjectResponse(BaseModel):
+    """Response model for MCP project tools with auth settings."""
+
+    tools: list[MCPSettings]
+    auth_settings: AuthSettings | None = None
 
 
 class MCPInstallRequest(BaseModel):

--- a/src/backend/base/langflow/api/v1/schemas.py
+++ b/src/backend/base/langflow/api/v1/schemas.py
@@ -448,6 +448,7 @@ class AuthSettings(BaseModel):
     username: str | None = None
     password: str | None = None
     bearer_token: str | None = None
+    iam_endpoint: str | None = None
 
 
 class MCPSettings(BaseModel):

--- a/src/backend/base/langflow/services/database/models/folder/model.py
+++ b/src/backend/base/langflow/services/database/models/folder/model.py
@@ -2,7 +2,7 @@ from typing import Optional
 from uuid import UUID, uuid4
 
 from sqlalchemy import Text, UniqueConstraint
-from sqlmodel import Column, Field, Relationship, SQLModel
+from sqlmodel import JSON, Column, Field, Relationship, SQLModel
 
 from langflow.services.database.models.flow.model import Flow, FlowRead
 from langflow.services.database.models.user.model import User
@@ -11,6 +11,11 @@ from langflow.services.database.models.user.model import User
 class FolderBase(SQLModel):
     name: str = Field(index=True)
     description: str | None = Field(default=None, sa_column=Column(Text))
+    auth_settings: dict | None = Field(
+        default=None,
+        sa_column=Column(JSON, nullable=True),
+        description="Authentication settings for the folder/project",
+    )
 
 
 class Folder(FolderBase, table=True):  # type: ignore[call-arg]
@@ -53,3 +58,4 @@ class FolderUpdate(SQLModel):
     parent_id: UUID | None = None
     components: list[UUID] = Field(default_factory=list)
     flows: list[UUID] = Field(default_factory=list)
+    auth_settings: dict | None = None

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1175,6 +1175,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-popover": "^1.0.7",
+        "@radix-ui/react-radio-group": "^1.3.7",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slider": "^1.2.1",
@@ -1175,7 +1176,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5033,6 +5033,38 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.7.tgz",
+      "integrity": "sha512-9w5XhD0KPOrm92OTTE0SysH3sYzHsSTHNvZgUBo/VZ80VdYyB5RneDbc0dKpURS24IxkoFRu/hI0i4XyfFwY6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.7",
+    "@radix-ui/react-radio-group": "^1.3.7",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slider": "^1.2.1",

--- a/src/frontend/src/components/core/parameterRenderComponent/components/ToolsComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/ToolsComponent/index.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { ICON_STROKE_WIDTH } from "@/constants/constants";
 import ToolsModal from "@/modals/toolsModal";
-import type { AuthSettingsType } from "@/types/mcp";
 import { cn, testIdCase } from "@/utils/utils";
 import { ForwardedIconComponent } from "../../../../common/genericIconComponent";
 import { Badge } from "../../../../ui/badge";
@@ -22,10 +21,7 @@ export default function ToolsComponent({
   icon,
   disabled = false,
   template,
-  authSettings,
-}: InputProps<any[] | undefined, ToolsComponentType> & {
-  authSettings?: AuthSettingsType;
-}): JSX.Element {
+}: InputProps<any[] | undefined, ToolsComponentType>): JSX.Element {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const actions = value
     ?.filter((action) => action.status === true)
@@ -48,7 +44,7 @@ export default function ToolsComponent({
     <div
       className={cn(
         "flex w-full items-center",
-        disabled && "cursor-not-allowed",
+        disabled && "cursor-not-allowed"
       )}
     >
       <ToolsModal
@@ -61,7 +57,6 @@ export default function ToolsComponent({
         handleOnNewValue={handleOnNewValue}
         title={title}
         icon={icon}
-        authSettings={authSettings}
       />
       <div
         className="relative flex w-full items-center gap-3"
@@ -73,7 +68,7 @@ export default function ToolsComponent({
             disabled={!value || disabled}
             size={"iconMd"}
             className={cn(
-              "absolute -top-8 right-0 !text-mmd font-normal text-muted-foreground group-hover:text-primary",
+              "absolute -top-8 right-0 !text-mmd font-normal text-muted-foreground group-hover:text-primary"
             )}
             data-testid="button_open_actions"
             onClick={() => setIsModalOpen(true)}

--- a/src/frontend/src/components/core/parameterRenderComponent/components/ToolsComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/ToolsComponent/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ICON_STROKE_WIDTH } from "@/constants/constants";
 import ToolsModal from "@/modals/toolsModal";
+import type { AuthSettingsType } from "@/types/mcp";
 import { cn, testIdCase } from "@/utils/utils";
 import { ForwardedIconComponent } from "../../../../common/genericIconComponent";
 import { Badge } from "../../../../ui/badge";
@@ -21,7 +22,10 @@ export default function ToolsComponent({
   icon,
   disabled = false,
   template,
-}: InputProps<any[] | undefined, ToolsComponentType>): JSX.Element {
+  authSettings,
+}: InputProps<any[] | undefined, ToolsComponentType> & {
+  authSettings?: AuthSettingsType;
+}): JSX.Element {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const actions = value
     ?.filter((action) => action.status === true)
@@ -57,6 +61,7 @@ export default function ToolsComponent({
         handleOnNewValue={handleOnNewValue}
         title={title}
         icon={icon}
+        authSettings={authSettings}
       />
       <div
         className="relative flex w-full items-center gap-3"

--- a/src/frontend/src/components/ui/radio-group.tsx
+++ b/src/frontend/src/components/ui/radio-group.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { CircleIcon } from "lucide-react";
+import { cn } from "@/utils/utils";
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  );
+}
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+export { RadioGroup, RadioGroupItem };

--- a/src/frontend/src/controllers/API/queries/mcp/use-get-flows-mcp.ts
+++ b/src/frontend/src/controllers/API/queries/mcp/use-get-flows-mcp.ts
@@ -1,5 +1,5 @@
 import type { useQueryFunctionType } from "@/types/api";
-import type { MCPSettingsType } from "@/types/mcp";
+import type { MCPProjectResponseType } from "@/types/mcp";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
@@ -8,7 +8,7 @@ interface IGetFlowsMCP {
   projectId: string;
 }
 
-type getFlowsMCPResponse = Array<MCPSettingsType>;
+type getFlowsMCPResponse = MCPProjectResponseType;
 
 export const useGetFlowsMCP: useQueryFunctionType<
   IGetFlowsMCP,
@@ -24,7 +24,7 @@ export const useGetFlowsMCP: useQueryFunctionType<
       return data;
     } catch (error) {
       console.error(error);
-      return [];
+      return { tools: [], auth_settings: undefined };
     }
   };
 

--- a/src/frontend/src/controllers/API/queries/mcp/use-patch-flows-mcp.ts
+++ b/src/frontend/src/controllers/API/queries/mcp/use-patch-flows-mcp.ts
@@ -1,6 +1,6 @@
 import type { UseMutationResult } from "@tanstack/react-query";
 import type { useMutationFunctionType } from "@/types/api";
-import type { MCPSettingsType } from "@/types/mcp";
+import type { AuthSettingsType, MCPSettingsType } from "@/types/mcp";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
@@ -9,21 +9,26 @@ interface PatchFlowMCPParams {
   project_id: string;
 }
 
+interface PatchFlowMCPRequest {
+  settings: MCPSettingsType[];
+  auth_settings?: AuthSettingsType;
+}
+
 interface PatchFlowMCPResponse {
   message: string;
 }
 
 export const usePatchFlowsMCP: useMutationFunctionType<
   PatchFlowMCPParams,
-  MCPSettingsType[],
+  PatchFlowMCPRequest,
   PatchFlowMCPResponse
 > = (params, options?) => {
   const { mutate, queryClient } = UseRequestProcessor();
 
-  async function patchFlowMCP(flowMCP: MCPSettingsType[]): Promise<any> {
+  async function patchFlowMCP(requestData: PatchFlowMCPRequest): Promise<any> {
     const res = await api.patch(
       `${getURL("MCP")}/${params.project_id}`,
-      flowMCP,
+      requestData,
     );
     return res.data.message;
   }
@@ -31,7 +36,7 @@ export const usePatchFlowsMCP: useMutationFunctionType<
   const mutation: UseMutationResult<
     PatchFlowMCPResponse,
     any,
-    MCPSettingsType[]
+    PatchFlowMCPRequest
   > = mutate(["usePatchFlowsMCP"], patchFlowMCP, {
     onSettled: () => {
       queryClient.refetchQueries({ queryKey: ["useGetFlowsMCP"] });

--- a/src/frontend/src/customization/feature-flags.ts
+++ b/src/frontend/src/customization/feature-flags.ts
@@ -15,3 +15,4 @@ export const ENABLE_VOICE_ASSISTANT = true;
 export const ENABLE_IMAGE_ON_PLAYGROUND = false;
 export const ENABLE_MCP = true;
 export const ENABLE_MCP_NOTICE = false;
+export const ENABLE_MCP_AUTH = true;

--- a/src/frontend/src/modals/authModal/index.tsx
+++ b/src/frontend/src/modals/authModal/index.tsx
@@ -79,7 +79,7 @@ const AuthModal = ({ open, setOpen, authSettings, onSave }: AuthModalProps) => {
 
   return (
     <BaseModal open={open} setOpen={setOpen} size="small-h-full">
-      <BaseModal.Header>Authentication Type</BaseModal.Header>
+      <BaseModal.Header>Authentication</BaseModal.Header>
       <BaseModal.Content className="h-full" overflowHidden>
         <div className="flex items-center  gap-6 border rounded-md p-4 h-[180px]">
           {/* Left column - Radio buttons */}

--- a/src/frontend/src/modals/authModal/index.tsx
+++ b/src/frontend/src/modals/authModal/index.tsx
@@ -1,0 +1,241 @@
+import { useState, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import type { AuthSettingsType } from "@/types/mcp";
+import BaseModal from "../baseModal";
+import { Separator } from "@/components/ui/separator";
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+
+interface AuthModalProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  authSettings?: AuthSettingsType;
+  onSave: (authSettings: AuthSettingsType) => void;
+}
+
+const AuthModal = ({ open, setOpen, authSettings, onSave }: AuthModalProps) => {
+  const [authType, setAuthType] = useState<string>(
+    authSettings?.auth_type || "none"
+  );
+  const [authFields, setAuthFields] = useState<{
+    apiKey?: string;
+    iamEndpoint?: string;
+    username?: string;
+    password?: string;
+    bearerToken?: string;
+  }>({
+    apiKey: authSettings?.api_key || "",
+    iamEndpoint: authSettings?.iam_endpoint || "",
+    username: authSettings?.username || "",
+    password: authSettings?.password || "",
+    bearerToken: authSettings?.bearer_token || "",
+  });
+
+  // Update auth state when authSettings prop changes
+  useEffect(() => {
+    if (authSettings) {
+      setAuthType(authSettings.auth_type || "none");
+      setAuthFields({
+        apiKey: authSettings.api_key || "",
+        iamEndpoint: authSettings.iam_endpoint || "",
+        username: authSettings.username || "",
+        password: authSettings.password || "",
+        bearerToken: authSettings.bearer_token || "",
+      });
+    }
+  }, [authSettings]);
+
+  const handleAuthTypeChange = (value: string) => {
+    setAuthType(value);
+    setAuthFields({});
+  };
+
+  const handleAuthFieldChange = (field: string, value: string) => {
+    setAuthFields((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleSave = () => {
+    const authSettingsToSave: AuthSettingsType = {
+      auth_type: authType,
+      ...(authType === "apikey" && { api_key: authFields.apiKey }),
+      ...(authType === "userpass" && {
+        username: authFields.username,
+        password: authFields.password,
+      }),
+      ...(authType === "iam" && {
+        iam_endpoint: authFields.iamEndpoint,
+        api_key: authFields.apiKey,
+      }),
+      ...(authType === "bearer" && { bearer_token: authFields.bearerToken }),
+    };
+
+    onSave(authSettingsToSave);
+    setOpen(false);
+  };
+
+  return (
+    <BaseModal open={open} setOpen={setOpen} size="small-h-full">
+      <BaseModal.Header>Authentication Type</BaseModal.Header>
+      <BaseModal.Content className="h-full" overflowHidden>
+        <div className="flex items-center  gap-6 border rounded-md p-4 h-[180px]">
+          {/* Left column - Radio buttons */}
+          <div className="flex flex-col flex-1">
+            <RadioGroup value={authType} onValueChange={handleAuthTypeChange}>
+              {[
+                { id: "none", label: "None" },
+                { id: "apikey", label: "API Key" },
+                { id: "userpass", label: "Username & Password" },
+                { id: "bearer", label: "Bearer Token" },
+                { id: "iam", label: "IAM" },
+              ].map((option) => (
+                <div key={option.id} className="flex items-center space-x-2">
+                  <RadioGroupItem value={option.id} id={option.id} />
+                  <Label
+                    htmlFor={option.id}
+                    className="!text-mmd font-normal cursor-pointer flex items-center gap-3"
+                  >
+                    {option.label}
+                    {option.id === "none" && authType === "none" && (
+                      <span className="text-accent-amber-foreground flex gap-1.5 text-xs items-center">
+                        <ForwardedIconComponent
+                          name="AlertTriangle"
+                          className="h-3.5 w-3.5 shrink-0"
+                        />
+                        Public endpoint - no auth. Use only in dev or trusted
+                        envs.
+                      </span>
+                    )}
+                  </Label>
+                </div>
+              ))}
+            </RadioGroup>
+          </div>
+          {authType !== "none" && <Separator orientation="vertical" />}
+
+          {/* Right column - Input fields */}
+          {authType !== "none" && (
+            <div className="w-3/5 min-h-[136px]">
+              {authType === "apikey" && (
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="api-key" className="!text-mmd font-medium">
+                    API Key Value
+                  </Label>
+                  <Input
+                    id="api-key"
+                    type="text"
+                    placeholder="Placeholder"
+                    value={authFields.apiKey || ""}
+                    onChange={(e) =>
+                      handleAuthFieldChange("apiKey", e.target.value)
+                    }
+                  />
+                </div>
+              )}
+
+              {authType === "userpass" && (
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="username" className="!text-mmd font-medium">
+                      Username
+                    </Label>
+                    <Input
+                      id="username"
+                      type="text"
+                      placeholder="Placeholder"
+                      value={authFields.username || ""}
+                      onChange={(e) =>
+                        handleAuthFieldChange("username", e.target.value)
+                      }
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="password" className="!text-mmd font-medium">
+                      Password
+                    </Label>
+                    <Input
+                      id="password"
+                      type="password"
+                      placeholder="Placeholder"
+                      value={authFields.password || ""}
+                      onChange={(e) =>
+                        handleAuthFieldChange("password", e.target.value)
+                      }
+                    />
+                  </div>
+                </div>
+              )}
+
+              {authType === "bearer" && (
+                <div className="flex flex-col gap-2">
+                  <Label
+                    htmlFor="bearer-token"
+                    className="!text-mmd font-medium"
+                  >
+                    Bearer Token
+                  </Label>
+                  <Input
+                    id="bearer-token"
+                    type="password"
+                    placeholder="Placeholder"
+                    value={authFields.bearerToken || ""}
+                    onChange={(e) =>
+                      handleAuthFieldChange("bearerToken", e.target.value)
+                    }
+                  />
+                </div>
+              )}
+
+              {authType === "iam" && (
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-2">
+                    <Label
+                      htmlFor="iam-endpoint"
+                      className="!text-mmd font-medium"
+                    >
+                      IAM Endpoint
+                    </Label>
+                    <Input
+                      id="iam-endpoint"
+                      type="text"
+                      placeholder="Placeholder"
+                      value={authFields.iamEndpoint || ""}
+                      onChange={(e) =>
+                        handleAuthFieldChange("iamEndpoint", e.target.value)
+                      }
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="api-key" className="!text-mmd font-medium">
+                      API Key or Token
+                    </Label>
+                    <Input
+                      id="password"
+                      type="password"
+                      placeholder="Placeholder"
+                      value={authFields.apiKey || ""}
+                      onChange={(e) =>
+                        handleAuthFieldChange("apiKey", e.target.value)
+                      }
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </BaseModal.Content>
+      <BaseModal.Footer
+        submit={{
+          label: "Save Authentication",
+          onClick: handleSave,
+        }}
+      />
+    </BaseModal>
+  );
+};
+
+export default AuthModal;

--- a/src/frontend/src/modals/authModal/index.tsx
+++ b/src/frontend/src/modals/authModal/index.tsx
@@ -127,7 +127,7 @@ const AuthModal = ({ open, setOpen, authSettings, onSave }: AuthModalProps) => {
                   <Input
                     id="api-key"
                     type="text"
-                    placeholder="Placeholder"
+                    placeholder="Enter API Key"
                     value={authFields.apiKey || ""}
                     onChange={(e) =>
                       handleAuthFieldChange("apiKey", e.target.value)
@@ -145,7 +145,7 @@ const AuthModal = ({ open, setOpen, authSettings, onSave }: AuthModalProps) => {
                     <Input
                       id="username"
                       type="text"
-                      placeholder="Placeholder"
+                      placeholder="Enter Username"
                       value={authFields.username || ""}
                       onChange={(e) =>
                         handleAuthFieldChange("username", e.target.value)
@@ -159,7 +159,7 @@ const AuthModal = ({ open, setOpen, authSettings, onSave }: AuthModalProps) => {
                     <Input
                       id="password"
                       type="password"
-                      placeholder="Placeholder"
+                      placeholder="Enter Password"
                       value={authFields.password || ""}
                       onChange={(e) =>
                         handleAuthFieldChange("password", e.target.value)
@@ -180,7 +180,7 @@ const AuthModal = ({ open, setOpen, authSettings, onSave }: AuthModalProps) => {
                   <Input
                     id="bearer-token"
                     type="password"
-                    placeholder="Placeholder"
+                    placeholder="Enter Bearer Token"
                     value={authFields.bearerToken || ""}
                     onChange={(e) =>
                       handleAuthFieldChange("bearerToken", e.target.value)
@@ -201,7 +201,7 @@ const AuthModal = ({ open, setOpen, authSettings, onSave }: AuthModalProps) => {
                     <Input
                       id="iam-endpoint"
                       type="text"
-                      placeholder="Placeholder"
+                      placeholder="Enter IAM Endpoint"
                       value={authFields.iamEndpoint || ""}
                       onChange={(e) =>
                         handleAuthFieldChange("iamEndpoint", e.target.value)
@@ -215,7 +215,7 @@ const AuthModal = ({ open, setOpen, authSettings, onSave }: AuthModalProps) => {
                     <Input
                       id="password"
                       type="password"
-                      placeholder="Placeholder"
+                      placeholder="Enter API Key or Token"
                       value={authFields.apiKey || ""}
                       onChange={(e) =>
                         handleAuthFieldChange("apiKey", e.target.value)

--- a/src/frontend/src/modals/authModal/index.tsx
+++ b/src/frontend/src/modals/authModal/index.tsx
@@ -78,8 +78,15 @@ const AuthModal = ({ open, setOpen, authSettings, onSave }: AuthModalProps) => {
   };
 
   return (
-    <BaseModal open={open} setOpen={setOpen} size="small-h-full">
-      <BaseModal.Header>Authentication</BaseModal.Header>
+    <BaseModal
+      open={open}
+      setOpen={setOpen}
+      size="small-h-full"
+      className="p-4"
+    >
+      <BaseModal.Header>
+        <div className="flex items-center gap-2 text-base">Authentication</div>
+      </BaseModal.Header>
       <BaseModal.Content className="h-full" overflowHidden>
         <div className="flex items-center  gap-6 border rounded-md p-4 h-[180px]">
           {/* Left column - Radio buttons */}

--- a/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
+++ b/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
@@ -17,7 +17,6 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { Textarea } from "@/components/ui/textarea";
-import type { AuthSettingsType } from "@/types/mcp";
 import { parseString, sanitizeMcpName } from "@/utils/stringManipulation";
 
 export default function ToolsTable({
@@ -28,8 +27,6 @@ export default function ToolsTable({
   placeholder,
   open,
   handleOnNewValue,
-  authType,
-  authFields,
 }: {
   rows: any[];
   data: any[];
@@ -38,13 +35,6 @@ export default function ToolsTable({
   handleOnNewValue: handleOnNewValueType;
   isAction: boolean;
   placeholder: string;
-  authType: string;
-  authFields: {
-    apiKey?: string;
-    username?: string;
-    password?: string;
-    bearerToken?: string;
-  };
 }) {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedRows, setSelectedRows] = useState<any[] | null>(null);
@@ -76,7 +66,7 @@ export default function ToolsTable({
           filter.some(
             (row) =>
               (row.display_name ?? row.name) ===
-              (node.data.display_name ?? node.data.name),
+              (node.data.display_name ?? node.data.name)
           )
         ) {
           node.setSelected(true);
@@ -89,15 +79,6 @@ export default function ToolsTable({
 
   useEffect(() => {
     if (!open) {
-      // Prepare auth_settings from current authentication state
-      const auth_settings: AuthSettingsType = {
-        auth_type: authType,
-        api_key: authFields.apiKey || undefined,
-        username: authFields.username || undefined,
-        password: authFields.password || undefined,
-        bearer_token: authFields.bearerToken || undefined,
-      };
-
       handleOnNewValue({
         value: data.map((row) => {
           const name = parseString(row.name, [
@@ -114,8 +95,8 @@ export default function ToolsTable({
             name !== "" && name !== display_name
               ? name
               : isAction
-                ? sanitizeMcpName(display_name || row.name, 46)
-                : display_name
+              ? sanitizeMcpName(display_name || row.name, 46)
+              : display_name
           ).slice(0, 46);
 
           const processedDescription =
@@ -123,13 +104,13 @@ export default function ToolsTable({
             row.description !== row.display_description
               ? row.description
               : isAction
-                ? ""
-                : row.display_description;
+              ? ""
+              : row.display_description;
 
           return selectedRows?.some(
             (selected) =>
               (selected.display_name ?? selected.name) ===
-              (row.display_name ?? row.name),
+              (row.display_name ?? row.name)
           )
             ? {
                 ...row,
@@ -144,7 +125,6 @@ export default function ToolsTable({
                 description: processedDescription,
               };
         }),
-        auth_settings,
       });
     }
   }, [open]);
@@ -170,7 +150,7 @@ export default function ToolsTable({
               params.data.display_name !== ""
                 ? params.data.display_name
                 : params.data.name,
-              ["space_case"],
+              ["space_case"]
             )
           : params.data.display_name,
     },
@@ -193,11 +173,11 @@ export default function ToolsTable({
               "uppercase",
             ])
           : isAction
-            ? sanitizeMcpName(params.data.display_name, 46).toUpperCase()
-            : parseString(params.data.tags.join(", "), [
-                "snake_case",
-                "uppercase",
-              ]),
+          ? sanitizeMcpName(params.data.display_name, 46).toUpperCase()
+          : parseString(params.data.tags.join(", "), [
+              "snake_case",
+              "uppercase",
+            ]),
       cellClass: "text-muted-foreground",
     },
     {
@@ -216,7 +196,7 @@ export default function ToolsTable({
 
   const handleSidebarInputChange = (
     field: "name" | "description",
-    value: string,
+    value: string
   ) => {
     if (!focusedRow) return;
 
@@ -232,7 +212,7 @@ export default function ToolsTable({
       });
 
       const updatedData = data.map((row) =>
-        (row.display_name ?? row.name) === originalName ? updatedRow : row,
+        (row.display_name ?? row.name) === originalName ? updatedRow : row
       );
       setData(updatedData);
     }
@@ -244,7 +224,7 @@ export default function ToolsTable({
         display_name: value.title,
         name: key,
         description: value.description ?? null,
-      }),
+      })
     );
   }, [focusedRow]);
 

--- a/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
+++ b/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
@@ -17,6 +17,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { Textarea } from "@/components/ui/textarea";
+import type { AuthSettingsType } from "@/types/mcp";
 import { parseString, sanitizeMcpName } from "@/utils/stringManipulation";
 
 export default function ToolsTable({
@@ -27,6 +28,8 @@ export default function ToolsTable({
   placeholder,
   open,
   handleOnNewValue,
+  authType,
+  authFields,
 }: {
   rows: any[];
   data: any[];
@@ -35,6 +38,13 @@ export default function ToolsTable({
   handleOnNewValue: handleOnNewValueType;
   isAction: boolean;
   placeholder: string;
+  authType: string;
+  authFields: {
+    apiKey?: string;
+    username?: string;
+    password?: string;
+    bearerToken?: string;
+  };
 }) {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedRows, setSelectedRows] = useState<any[] | null>(null);
@@ -79,6 +89,15 @@ export default function ToolsTable({
 
   useEffect(() => {
     if (!open) {
+      // Prepare auth_settings from current authentication state
+      const auth_settings: AuthSettingsType = {
+        auth_type: authType,
+        api_key: authFields.apiKey || undefined,
+        username: authFields.username || undefined,
+        password: authFields.password || undefined,
+        bearer_token: authFields.bearerToken || undefined,
+      };
+
       handleOnNewValue({
         value: data.map((row) => {
           const name = parseString(row.name, [
@@ -125,6 +144,7 @@ export default function ToolsTable({
                 description: processedDescription,
               };
         }),
+        auth_settings,
       });
     }
   }, [open]);

--- a/src/frontend/src/modals/toolsModal/index.tsx
+++ b/src/frontend/src/modals/toolsModal/index.tsx
@@ -3,7 +3,10 @@ import { cloneDeep } from "lodash";
 import { type ForwardedRef, forwardRef, useEffect, useState } from "react";
 import type { handleOnNewValueType } from "@/CustomNodes/hooks/use-handle-new-value";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { SidebarProvider } from "@/components/ui/sidebar";
+import type { AuthSettingsType } from "@/types/mcp";
 import BaseModal from "../baseModal";
 import ToolsTable from "./components/toolsTable";
 
@@ -22,6 +25,7 @@ interface ToolsModalProps {
   title: string;
   icon?: string;
   isAction?: boolean;
+  authSettings?: AuthSettingsType;
 }
 
 const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
@@ -36,6 +40,7 @@ const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
       open,
       isAction = false,
       setOpen,
+      authSettings,
     }: ToolsModalProps,
     ref: ForwardedRef<AgGridReact>,
   ) => {
@@ -46,6 +51,20 @@ const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
     };
 
     const [data, setData] = useState<any[]>(cloneDeep(rows));
+    const [authType, setAuthType] = useState<string>(
+      authSettings?.auth_type || "none",
+    );
+    const [authFields, setAuthFields] = useState<{
+      apiKey?: string;
+      username?: string;
+      password?: string;
+      bearerToken?: string;
+    }>({
+      apiKey: authSettings?.api_key || "",
+      username: authSettings?.username || "",
+      password: authSettings?.password || "",
+      bearerToken: authSettings?.bearer_token || "",
+    });
 
     useEffect(() => {
       if (placeholder === "Loading actions...") {
@@ -54,6 +73,31 @@ const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
         });
       }
     }, [placeholder]);
+
+    // Update auth state when authSettings prop changes
+    useEffect(() => {
+      if (authSettings) {
+        setAuthType(authSettings.auth_type || "none");
+        setAuthFields({
+          apiKey: authSettings.api_key || "",
+          username: authSettings.username || "",
+          password: authSettings.password || "",
+          bearerToken: authSettings.bearer_token || "",
+        });
+      }
+    }, [authSettings]);
+
+    const handleAuthTypeChange = (type: string) => {
+      setAuthType(type);
+      setAuthFields({});
+    };
+
+    const handleAuthFieldChange = (field: string, value: string) => {
+      setAuthFields((prev) => ({
+        ...prev,
+        [field]: value,
+      }));
+    };
 
     return (
       <BaseModal
@@ -73,18 +117,137 @@ const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
           </div>
         </BaseModal.Header>
         <BaseModal.Content overflowHidden className="flex flex-col p-0">
-          <div className="flex h-full">
-            <SidebarProvider width="20rem" defaultOpen={false}>
-              <ToolsTable
-                rows={rows}
-                isAction={isAction}
-                placeholder={placeholder}
-                data={data}
-                setData={setData}
-                open={open}
-                handleOnNewValue={handleOnNewValue}
-              />
-            </SidebarProvider>
+          <div className="flex flex-col w-full h-full">
+            <div className="p-4 border-b border-border">
+              <div className="space-y-4">
+                <div>
+                  <Label className="text-sm font-medium mb-3 block">
+                    Authentication
+                  </Label>
+                  <div className="space-y-2">
+                    {[
+                      { id: "none", label: "None" },
+                      { id: "apikey", label: "API Key" },
+                      { id: "userpass", label: "Username & Password" },
+                      { id: "bearer", label: "Bearer Token" },
+                      { id: "iam", label: "IAM" },
+                    ].map((option) => (
+                      <div
+                        key={option.id}
+                        className="flex items-center space-x-2"
+                      >
+                        <input
+                          type="radio"
+                          id={option.id}
+                          name="auth-type"
+                          value={option.id}
+                          checked={authType === option.id}
+                          onChange={(e) => handleAuthTypeChange(e.target.value)}
+                          className="h-4 w-4 text-primary focus:ring-primary focus:ring-2"
+                        />
+                        <Label
+                          htmlFor={option.id}
+                          className="text-sm font-normal cursor-pointer"
+                        >
+                          {option.label}
+                        </Label>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {authType === "apikey" && (
+                  <div className="space-y-2">
+                    <Label htmlFor="api-key" className="text-sm font-medium">
+                      API Key
+                    </Label>
+                    <Input
+                      id="api-key"
+                      type="password"
+                      placeholder="Enter API key"
+                      value={authFields.apiKey || ""}
+                      onChange={(e) =>
+                        handleAuthFieldChange("apiKey", e.target.value)
+                      }
+                    />
+                  </div>
+                )}
+
+                {authType === "userpass" && (
+                  <div className="space-y-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="username" className="text-sm font-medium">
+                        Username
+                      </Label>
+                      <Input
+                        id="username"
+                        type="text"
+                        placeholder="Enter username"
+                        value={authFields.username || ""}
+                        onChange={(e) =>
+                          handleAuthFieldChange("username", e.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="password" className="text-sm font-medium">
+                        Password
+                      </Label>
+                      <Input
+                        id="password"
+                        type="password"
+                        placeholder="Enter password"
+                        value={authFields.password || ""}
+                        onChange={(e) =>
+                          handleAuthFieldChange("password", e.target.value)
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {authType === "bearer" && (
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="bearer-token"
+                      className="text-sm font-medium"
+                    >
+                      Bearer Token
+                    </Label>
+                    <Input
+                      id="bearer-token"
+                      type="password"
+                      placeholder="Enter bearer token"
+                      value={authFields.bearerToken || ""}
+                      onChange={(e) =>
+                        handleAuthFieldChange("bearerToken", e.target.value)
+                      }
+                    />
+                  </div>
+                )}
+
+                {authType === "iam" && (
+                  <div className="text-sm text-muted-foreground">
+                    IAM authentication will use your configured AWS credentials.
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="flex h-full">
+              <SidebarProvider width="20rem" defaultOpen={false}>
+                <ToolsTable
+                  rows={rows}
+                  isAction={isAction}
+                  placeholder={placeholder}
+                  data={data}
+                  setData={setData}
+                  open={open}
+                  handleOnNewValue={handleOnNewValue}
+                  authType={authType}
+                  authFields={authFields}
+                />
+              </SidebarProvider>
+            </div>
           </div>
         </BaseModal.Content>
       </BaseModal>

--- a/src/frontend/src/modals/toolsModal/index.tsx
+++ b/src/frontend/src/modals/toolsModal/index.tsx
@@ -3,10 +3,7 @@ import { cloneDeep } from "lodash";
 import { type ForwardedRef, forwardRef, useEffect, useState } from "react";
 import type { handleOnNewValueType } from "@/CustomNodes/hooks/use-handle-new-value";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import type { AuthSettingsType } from "@/types/mcp";
 import BaseModal from "../baseModal";
 import ToolsTable from "./components/toolsTable";
 
@@ -25,7 +22,6 @@ interface ToolsModalProps {
   title: string;
   icon?: string;
   isAction?: boolean;
-  authSettings?: AuthSettingsType;
 }
 
 const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
@@ -40,9 +36,8 @@ const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
       open,
       isAction = false,
       setOpen,
-      authSettings,
     }: ToolsModalProps,
-    ref: ForwardedRef<AgGridReact>,
+    ref: ForwardedRef<AgGridReact>
   ) => {
     const handleSetOpen = (newOpen: boolean) => {
       if (setOpen) {
@@ -51,20 +46,6 @@ const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
     };
 
     const [data, setData] = useState<any[]>(cloneDeep(rows));
-    const [authType, setAuthType] = useState<string>(
-      authSettings?.auth_type || "none",
-    );
-    const [authFields, setAuthFields] = useState<{
-      apiKey?: string;
-      username?: string;
-      password?: string;
-      bearerToken?: string;
-    }>({
-      apiKey: authSettings?.api_key || "",
-      username: authSettings?.username || "",
-      password: authSettings?.password || "",
-      bearerToken: authSettings?.bearer_token || "",
-    });
 
     useEffect(() => {
       if (placeholder === "Loading actions...") {
@@ -73,31 +54,6 @@ const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
         });
       }
     }, [placeholder]);
-
-    // Update auth state when authSettings prop changes
-    useEffect(() => {
-      if (authSettings) {
-        setAuthType(authSettings.auth_type || "none");
-        setAuthFields({
-          apiKey: authSettings.api_key || "",
-          username: authSettings.username || "",
-          password: authSettings.password || "",
-          bearerToken: authSettings.bearer_token || "",
-        });
-      }
-    }, [authSettings]);
-
-    const handleAuthTypeChange = (type: string) => {
-      setAuthType(type);
-      setAuthFields({});
-    };
-
-    const handleAuthFieldChange = (field: string, value: string) => {
-      setAuthFields((prev) => ({
-        ...prev,
-        [field]: value,
-      }));
-    };
 
     return (
       <BaseModal
@@ -118,121 +74,6 @@ const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
         </BaseModal.Header>
         <BaseModal.Content overflowHidden className="flex flex-col p-0">
           <div className="flex flex-col w-full h-full">
-            <div className="p-4 border-b border-border">
-              <div className="space-y-4">
-                <div>
-                  <Label className="text-sm font-medium mb-3 block">
-                    Authentication
-                  </Label>
-                  <div className="space-y-2">
-                    {[
-                      { id: "none", label: "None" },
-                      { id: "apikey", label: "API Key" },
-                      { id: "userpass", label: "Username & Password" },
-                      { id: "bearer", label: "Bearer Token" },
-                      { id: "iam", label: "IAM" },
-                    ].map((option) => (
-                      <div
-                        key={option.id}
-                        className="flex items-center space-x-2"
-                      >
-                        <input
-                          type="radio"
-                          id={option.id}
-                          name="auth-type"
-                          value={option.id}
-                          checked={authType === option.id}
-                          onChange={(e) => handleAuthTypeChange(e.target.value)}
-                          className="h-4 w-4 text-primary focus:ring-primary focus:ring-2"
-                        />
-                        <Label
-                          htmlFor={option.id}
-                          className="text-sm font-normal cursor-pointer"
-                        >
-                          {option.label}
-                        </Label>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                {authType === "apikey" && (
-                  <div className="space-y-2">
-                    <Label htmlFor="api-key" className="text-sm font-medium">
-                      API Key
-                    </Label>
-                    <Input
-                      id="api-key"
-                      type="password"
-                      placeholder="Enter API key"
-                      value={authFields.apiKey || ""}
-                      onChange={(e) =>
-                        handleAuthFieldChange("apiKey", e.target.value)
-                      }
-                    />
-                  </div>
-                )}
-
-                {authType === "userpass" && (
-                  <div className="space-y-4">
-                    <div className="space-y-2">
-                      <Label htmlFor="username" className="text-sm font-medium">
-                        Username
-                      </Label>
-                      <Input
-                        id="username"
-                        type="text"
-                        placeholder="Enter username"
-                        value={authFields.username || ""}
-                        onChange={(e) =>
-                          handleAuthFieldChange("username", e.target.value)
-                        }
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="password" className="text-sm font-medium">
-                        Password
-                      </Label>
-                      <Input
-                        id="password"
-                        type="password"
-                        placeholder="Enter password"
-                        value={authFields.password || ""}
-                        onChange={(e) =>
-                          handleAuthFieldChange("password", e.target.value)
-                        }
-                      />
-                    </div>
-                  </div>
-                )}
-
-                {authType === "bearer" && (
-                  <div className="space-y-2">
-                    <Label
-                      htmlFor="bearer-token"
-                      className="text-sm font-medium"
-                    >
-                      Bearer Token
-                    </Label>
-                    <Input
-                      id="bearer-token"
-                      type="password"
-                      placeholder="Enter bearer token"
-                      value={authFields.bearerToken || ""}
-                      onChange={(e) =>
-                        handleAuthFieldChange("bearerToken", e.target.value)
-                      }
-                    />
-                  </div>
-                )}
-
-                {authType === "iam" && (
-                  <div className="text-sm text-muted-foreground">
-                    IAM authentication will use your configured AWS credentials.
-                  </div>
-                )}
-              </div>
-            </div>
             <div className="flex h-full">
               <SidebarProvider width="20rem" defaultOpen={false}>
                 <ToolsTable
@@ -243,8 +84,6 @@ const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
                   setData={setData}
                   open={open}
                   handleOnNewValue={handleOnNewValue}
-                  authType={authType}
-                  authFields={authFields}
                 />
               </SidebarProvider>
             </div>
@@ -252,7 +91,7 @@ const ToolsModal = forwardRef<AgGridReact, ToolsModalProps>(
         </BaseModal.Content>
       </BaseModal>
     );
-  },
+  }
 );
 
 export default ToolsModal;

--- a/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
@@ -228,6 +228,14 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
   const getAuthHeaders = () => {
     if (isAutoLogin) return "";
 
+    // If MCP auth is disabled, use the previous API key behavior
+    if (!ENABLE_MCP_AUTH) {
+      return `
+        "--headers",
+        "x-api-key",
+        "${apiKey || "YOUR_API_KEY"}",`;
+    }
+
     if (!currentAuthSettings || currentAuthSettings.auth_type === "none") {
       return "";
     }
@@ -357,7 +365,7 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
           </div>
         </div>
         <div className="flex gap-4 items-center">
-          {!hasAuthentication && (
+          {ENABLE_MCP_AUTH && !hasAuthentication && (
             <span className="text-accent-amber-foreground flex gap-2 text-mmd items-center">
               <ForwardedIconComponent
                 name="AlertTriangle"
@@ -366,17 +374,19 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
               Public endpoint - no auth. Use only in dev or trusted envs.
             </span>
           )}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setAuthModalOpen(true)}
-          >
-            <ForwardedIconComponent
-              name="Fingerprint"
-              className="h-4 w-4 shrink-0"
-            />
-            {hasAuthentication ? "Edit Auth" : "Add Auth"}
-          </Button>
+          {ENABLE_MCP_AUTH && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setAuthModalOpen(true)}
+            >
+              <ForwardedIconComponent
+                name="Fingerprint"
+                className="h-4 w-4 shrink-0"
+              />
+              {hasAuthentication ? "Edit Auth" : "Add Auth"}
+            </Button>
+          )}
         </div>
       </div>
       <div className="flex flex-col justify-between gap-8 xl:flex-row">
@@ -570,12 +580,14 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
           )}
         </div>
       </div>
-      <AuthModal
-        open={authModalOpen}
-        setOpen={setAuthModalOpen}
-        authSettings={currentAuthSettings}
-        onSave={handleAuthSave}
-      />
+      {ENABLE_MCP_AUTH && (
+        <AuthModal
+          open={authModalOpen}
+          setOpen={setAuthModalOpen}
+          authSettings={currentAuthSettings}
+          onSave={handleAuthSave}
+        />
+      )}
     </div>
   );
 };

--- a/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
@@ -224,6 +224,47 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
 
   const apiUrl = customGetMCPUrl(projectId);
 
+  // Generate auth headers based on the authentication type
+  const getAuthHeaders = () => {
+    if (isAutoLogin) return "";
+
+    if (!currentAuthSettings || currentAuthSettings.auth_type === "none") {
+      return "";
+    }
+
+    switch (currentAuthSettings.auth_type) {
+      case "apikey":
+        return `
+        "--headers",
+        "x-api-key",
+        "${currentAuthSettings.api_key || "YOUR_API_KEY"}",`;
+      case "userpass":
+        return `
+        "--headers",
+        "Authorization",
+        "Basic ${btoa(
+          `${currentAuthSettings.username || "USERNAME"}:${
+            currentAuthSettings.password || "PASSWORD"
+          }`
+        )}",`;
+      case "bearer":
+        return `
+        "--headers",
+        "Authorization",
+        "Bearer ${currentAuthSettings.bearer_token || "YOUR_BEARER_TOKEN"}",`;
+      case "iam":
+        return `
+        "--headers",
+        "x-api-key",
+        "${currentAuthSettings.api_key || "YOUR_IAM_TOKEN"}",
+        "--headers",
+        "x-iam-endpoint",
+        "${currentAuthSettings.iam_endpoint || "YOUR_IAM_ENDPOINT"}",`;
+      default:
+        return "";
+    }
+  };
+
   const MCP_SERVER_JSON = `{
   "mcpServers": {
     "lf-${parseString(folderName ?? "project", [
@@ -248,14 +289,7 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
             ? `"uvx",
         `
             : ""
-        }"mcp-proxy",${
-    isAutoLogin
-      ? ""
-      : `
-        "--headers",
-        "x-api-key",
-        "${apiKey || "YOUR_API_KEY"}",`
-  }
+        }"mcp-proxy",${getAuthHeaders()}
         "${apiUrl}"
       ]
     }

--- a/src/frontend/src/types/mcp/index.ts
+++ b/src/frontend/src/types/mcp/index.ts
@@ -4,6 +4,7 @@ export type AuthSettingsType = {
   username?: string;
   password?: string;
   bearer_token?: string;
+  iam_endpoint?: string;
 };
 
 export type MCPSettingsType = {

--- a/src/frontend/src/types/mcp/index.ts
+++ b/src/frontend/src/types/mcp/index.ts
@@ -1,3 +1,11 @@
+export type AuthSettingsType = {
+  auth_type: string;
+  api_key?: string;
+  username?: string;
+  password?: string;
+  bearer_token?: string;
+};
+
 export type MCPSettingsType = {
   id: string;
   mcp_enabled: boolean;
@@ -6,6 +14,11 @@ export type MCPSettingsType = {
   name?: string;
   description?: string;
   input_schema?: Record<string, any>;
+};
+
+export type MCPProjectResponseType = {
+  tools: MCPSettingsType[];
+  auth_settings?: AuthSettingsType;
 };
 
 export type MCPServerInfoType = {


### PR DESCRIPTION
This pull request introduces authentication settings (`auth_settings`) for MCP (Managed Cloud Projects), including database schema updates, API enhancements, and frontend changes to support the new functionality. Additionally, it includes minor frontend updates and dependency additions.

### Backend Changes

#### Database and Migration Updates:
* Added an `auth_settings` column to the `folder` table in the database to store project-level authentication settings. This change includes a new Alembic migration script to handle schema updates. (`src/backend/base/langflow/alembic/versions/3162e83e485f_add_auth_settings_to_folder_and_merge.py`)
* Updated the `FolderBase` and `FolderUpdate` models to include the `auth_settings` field. (`src/backend/base/langflow/services/database/models/folder/model.py`) [[1]](diffhunk://#diff-d8fba966a52b658aab55845074cd0d412fe22bcd90069919b28335c7286fd757R14-R18) [[2]](diffhunk://#diff-d8fba966a52b658aab55845074cd0d412fe22bcd90069919b28335c7286fd757R61)

#### API Enhancements:
* Modified the `list_project_tools` endpoint to include `auth_settings` in the response by introducing a new `MCPProjectResponse` model. (`src/backend/base/langflow/api/v1/mcp_projects.py`) [[1]](diffhunk://#diff-59e508b675da2296985654fefffa69b74a00d283904743fb65f27dad798c6bd0L67-R73) [[2]](diffhunk://#diff-59e508b675da2296985654fefffa69b74a00d283904743fb65f27dad798c6bd0R127-R139)
* Updated the `update_project_mcp_settings` endpoint to allow updating project-level `auth_settings` alongside flow settings. (`src/backend/base/langflow/api/v1/mcp_projects.py`) [[1]](diffhunk://#diff-59e508b675da2296985654fefffa69b74a00d283904743fb65f27dad798c6bd0L225-R241) [[2]](diffhunk://#diff-59e508b675da2296985654fefffa69b74a00d283904743fb65f27dad798c6bd0R256-R265) [[3]](diffhunk://#diff-59e508b675da2296985654fefffa69b74a00d283904743fb65f27dad798c6bd0L263-R283)
* Added a new `AuthSettings` model to encapsulate authentication-related fields. (`src/backend/base/langflow/api/v1/schemas.py`) [[1]](diffhunk://#diff-0af520cbcf89ace99473e6b372b9c67eed878fb92d82985a0b9bbea52842dcfcR443-R453) [[2]](diffhunk://#diff-0af520cbcf89ace99473e6b372b9c67eed878fb92d82985a0b9bbea52842dcfcR463-R477)

### Frontend Changes

#### Authentication Support:
* Updated the `useGetFlowsMCP` and `usePatchFlowsMCP` hooks to handle `auth_settings` in API requests and responses. (`src/frontend/src/controllers/API/queries/mcp/use-get-flows-mcp.ts`, `src/frontend/src/controllers/API/queries/mcp/use-patch-flows-mcp.ts`) [[1]](diffhunk://#diff-b56d9b1e6842c01a240be71077626a787fcec27782afaa36dc41a3055af19b88L11-R11) [[2]](diffhunk://#diff-b56d9b1e6842c01a240be71077626a787fcec27782afaa36dc41a3055af19b88L27-R27) [[3]](diffhunk://#diff-7b76db089422785c498e7e7d024d35e2baabf0fcf76f7e9e0ab8385ca49c864eR12-R39)

#### UI Enhancements:
* Added a new `RadioGroup` component using the `@radix-ui/react-radio-group` library for improved UI interactions. (`src/frontend/src/components/ui/radio-group.tsx`)
* Enabled the `ENABLE_MCP_AUTH` feature flag in `feature-flags.ts` to toggle MCP authentication functionality. (`src/frontend/src/customization/feature-flags.ts`)

#### Dependency Updates:
* Added `@radix-ui/react-radio-group` to the project dependencies. (`src/frontend/package-lock.json`, `src/frontend/package.json`) [[1]](diffhunk://#diff-9eaa8c31e85b60ae25c139f2d6363cc9dcb6926125b5bf1d0cac092547e8cfcbR23) [[2]](diffhunk://#diff-9eaa8c31e85b60ae25c139f2d6363cc9dcb6926125b5bf1d0cac092547e8cfcbR5052-R5083) [[3]](diffhunk://#diff-12ee508ecc1901fe1a1d71ed459dba8454f3160983ee18b2c51b76ade45235d3R18)

### Minor Frontend Fixes
* Removed redundant trailing commas in `ToolsComponent` for cleaner code. (`src/frontend/src/components/core/parameterRenderComponent/components/ToolsComponent/index.tsx`) [[1]](diffhunk://#diff-62aa53a680e9a4d22febcd683d6df0bea9fbaa1be7456c02762c96185be48792L47-R47) [[2]](diffhunk://#diff-62aa53a680e9a4d22febcd683d6df0bea9fbaa1be7456c02762c96185be48792L71-R71)