### PR TITLE
fix: Exclude base path from custom component loading

### DIFF
--- a/src/backend/base/langflow/interface/components.py
+++ b/src/backend/base/langflow/interface/components.py
@@ -168,12 +168,11 @@ async def get_and_cache_all_types_dict(
             # Partial loading mode - just load component metadata
             logger.debug("Using partial component loading")
             component_cache.all_types_dict = await aget_component_metadata(settings_service.settings.components_path)
-        elif (
-            settings_service.settings.components_path
-            and BASE_COMPONENTS_PATH not in settings_service.settings.components_path
-        ):
-            # Traditional full loading
-            component_cache.all_types_dict = await aget_all_types_dict(settings_service.settings.components_path)
+        elif settings_service.settings.components_path:
+            # Traditional full loading - filter out base components path to only load custom components
+            custom_paths = [p for p in settings_service.settings.components_path if p != BASE_COMPONENTS_PATH]
+            if custom_paths:
+                component_cache.all_types_dict = await aget_all_types_dict(custom_paths)
 
         # Log custom component loading stats
         components_dict = component_cache.all_types_dict or {}


### PR DESCRIPTION
This pull request refines the logic for loading component metadata in the `get_and_cache_all_types_dict` function to better handle custom component paths. The most notable change ensures that the base components path is excluded when loading custom components.

### Improvements to custom component loading:

* [`src/backend/base/langflow/interface/components.py`](diffhunk://#diff-6535ef7700eab0f25fe8de90f85ed0dee20a3ba150c869ff0a8cd38a822efd24L171-R175): Updated the `get_and_cache_all_types_dict` function to filter out the base components path (`BASE_COMPONENTS_PATH`) when performing traditional full loading, ensuring only custom component paths are processed. This prevents unnecessary reloading of base components.