### PR TITLE
fix: updating the optput structured url in the custom component generator template

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
@@ -1486,7 +1486,7 @@
                 "type": "str",
                 "value": [
                   "https://github.com/langflow-ai/langflow/blob/main/src/backend/base/langflow/components/agents/agent.py",
-                  "https://github.com/langflow-ai/langflow/blob/main/src/backend/base/langflow/components/helpers/structured_output.py",
+                  "https://github.com/langflow-ai/langflow/blob/main/src/backend/base/langflow/components/processing/structured_output.py",
                   "https://raw.githubusercontent.com/langflow-ai/langflow/refs/heads/main/src/backend/base/langflow/components/tools/calculator.py",
                   "https://raw.githubusercontent.com/langflow-ai/langflow/refs/heads/main/src/backend/base/langflow/components/tools/tavily_search.py",
                   "https://raw.githubusercontent.com/langflow-ai/langflow/refs/heads/main/src/backend/base/langflow/components/models/ollama.py",


### PR DESCRIPTION
Fixed the repository URL of the Structured Output component - it was previously pointing to a non-existent path.