### PR TITLE
docs: refresh external postgresql database page

### DIFF
--- a/docs/docs/Configuration/configuration-custom-database.mdx
+++ b/docs/docs/Configuration/configuration-custom-database.mdx
@@ -58,12 +58,13 @@ Launching Langflow and PostgreSQL containers in the same Docker network ensures 
 For an example, see the [`docker-compose.yml`](https://github.com/langflow-ai/langflow/blob/main/docker_example/docker-compose.yml) file in the Langflow repository.
 
 The configuration in the example `docker-compose.yml` also sets up persistent volumes for both Langflow and PostgreSQL data.
-Persistent volumes map directories inside of containers to storage on the host machine, so c data survives container restarts.
+Persistent volumes map directories inside of containers to storage on the host machine, so data persists through container restarts.
 
 Docker Compose creates an isolated network for all services defined in `docker-compose.yml`. This ensures that the services can communicate with each other using their service names as hostnames, such as `postgres` in the database URL.
 In contrast, if you run PostgreSQL separately with `docker run`, it launches in a different network than the Langflow container, and this prevents Langflow from connecting to PostgreSQL using the service name.
 
-To start the Langflow and PostgreSQL services, navigate to the `langflow/docker_example` directory, and then run `docker-compose up`.
+To start the Langflow and PostgreSQL services with the example Docker Compose file, navigate to the `langflow/docker_example` directory, and then run `docker-compose up`.
+If you're using a different `docker-compose.yml` file, run the `docker-compose up` command from the same directory as your `docker-compose.yml` file.
 
 ## Deploy multiple Langflow instances with a shared PostgreSQL database
 


### PR DESCRIPTION
1. Refresh External PostgreSQL page.
2. The location in leftnav is fine since the IA refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved and clarified instructions for configuring Langflow to use PostgreSQL, including setup for both local and containerized environments.
  * Expanded prerequisites and provided clearer guidance on creating and using the `.env` file.
  * Updated docker-compose instructions for better clarity, emphasizing use of the official configuration and persistent storage.
  * Enhanced guidance for multi-instance deployments and centralized configuration using environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->