### PR TITLE
Refactor MCP session manager for better configurability and cleanup

### DIFF
--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -96,6 +96,22 @@ class Settings(BaseSettings):
     """The number of seconds to wait before giving up on a lock to released or establishing a connection to the
     database."""
 
+    # ---------------------------------------------------------------------
+    # MCP Session-manager tuning
+    # ---------------------------------------------------------------------
+    mcp_max_sessions_per_server: int = 10
+    """Maximum number of MCP sessions to keep per unique server (command/url).
+    Mirrors the default constant MAX_SESSIONS_PER_SERVER in util.py. Adjust to
+    control resource usage or concurrency per server."""
+
+    mcp_session_idle_timeout: int = 400  # seconds
+    """How long (in seconds) an MCP session can stay idle before the background
+    cleanup task disposes of it. Defaults to 5 minutes."""
+
+    mcp_session_cleanup_interval: int = 120  # seconds
+    """Frequency (in seconds) at which the background cleanup task wakes up to
+    reap idle sessions."""
+
     # sqlite configuration
     sqlite_pragmas: dict | None = {"synchronous": "NORMAL", "journal_mode": "WAL"}
     """SQLite pragmas to use when connecting to the database."""


### PR DESCRIPTION
Replaces hardcoded MCP session manager constants with settings-driven values for max sessions, idle timeout, and cleanup interval. Improves session reuse and cleanup logic by introducing context-to-session mapping and reference counting for backward compatibility. Enhances session connectivity validation, error handling, and adds best-effort remote session termination for SSE clients. Updates settings to expose new MCP session manager tuning parameters.