### PR TITLE
fix: change fit view button label to "Zoom to Fit"

### DIFF
--- a/src/frontend/src/components/core/canvasControlsComponent/index.tsx
+++ b/src/frontend/src/components/core/canvasControlsComponent/index.tsx
@@ -142,7 +142,7 @@ const CanvasControls = ({ children }) => {
       {/* Zoom To Fit */}
       <CustomControlButton
         iconName="maximize"
-        tooltipText="Fit To Zoom"
+        tooltipText="Zoom To Fit"
         onClick={fitView}
         testId="fit_view"
       />


### PR DESCRIPTION
This updates the tooltip text for the button that zooms to fit the entire flow from "Fit to Zoom" to "Zoom to Fit". 

"Zoom to Fit" better describes what the button does: it zooms the canvas to fit the content.
"Fit to Zoom" implied that the content would be shifted in some way in order to fit the current zoom level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the tooltip text for the "Zoom To Fit" control button for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->