### PR TITLE
feat: Add .env file support to Windows build scripts

### DIFF
--- a/scripts/windows/build_and_run.bat
+++ b/scripts/windows/build_and_run.bat
@@ -2,9 +2,9 @@
 echo Starting Langflow build and run process...
 
 REM Load environment variables from .env file if it exists
-if exist "..\..\..\.env" (
+if exist "..\..\..env" (
     echo Loading environment variables from .env file...
-    for /f "usebackq tokens=1,2 delims==" %%A in ("..\..\..\.env") do (
+    for /f "usebackq tokens=1,2 delims==" %%A in ("..\..\..env") do (
         REM Skip empty lines and comments
         echo %%A | findstr /r "^[^#]" >nul
         if not errorlevel 1 (
@@ -102,4 +102,4 @@ if errorlevel 1 (
 
 echo.
 echo Langflow build and run process completed!
-pause 
+pause

--- a/scripts/windows/build_and_run.bat
+++ b/scripts/windows/build_and_run.bat
@@ -3,11 +3,15 @@ echo Starting Langflow build and run process...
 
 REM Check if .env file exists and set env file parameter
 set "ENV_FILE_PARAM="
-if exist "..\..\..env" (
-    echo Found .env file, will pass to langflow run
-    set "ENV_FILE_PARAM=--env-file "..\..\..env""
+REM Get the script directory and resolve project root
+for %%I in ("%~dp0..\..") do set "PROJECT_ROOT=%%~fI"
+set "ENV_PATH=%PROJECT_ROOT%\.env"
+if exist "%ENV_PATH%" (
+    echo Found .env file at: %ENV_PATH%
+    set "ENV_FILE_PARAM=--env-file "%ENV_PATH%""
 ) else (
-    echo .env file not found, langflow will use default configuration
+    echo .env file not found at: %ENV_PATH%
+    echo Langflow will use default configuration
 )
 
 echo.

--- a/scripts/windows/build_and_run.bat
+++ b/scripts/windows/build_and_run.bat
@@ -1,25 +1,13 @@
 @echo off
 echo Starting Langflow build and run process...
 
-REM Load environment variables from .env file if it exists
+REM Check if .env file exists and set env file parameter
+set "ENV_FILE_PARAM="
 if exist "..\..\..env" (
-    echo Loading environment variables from .env file...
-    for /f "usebackq tokens=1,2 delims==" %%A in ("..\..\..env") do (
-        REM Skip empty lines and comments
-        echo %%A | findstr /r "^[^#]" >nul
-        if not errorlevel 1 (
-            REM Remove quotes if present and set environment variable
-            set "temp_value=%%B"
-            setlocal enabledelayedexpansion
-            set "temp_value=!temp_value:"=!"
-            set "temp_value=!temp_value:'=!"
-            endlocal & set "%%A=!temp_value!"
-            echo Set %%A
-        )
-    )
-    echo Environment variables loaded successfully!
+    echo Found .env file, will pass to langflow run
+    set "ENV_FILE_PARAM=--env-file "..\..\..env""
 ) else (
-    echo .env file not found, skipping environment variable loading
+    echo .env file not found, langflow will use default configuration
 )
 
 echo.
@@ -93,7 +81,11 @@ echo Step 4: Running Langflow...
 echo.
 echo Attention: Wait until uvicorn is running before opening the browser
 echo.
-uv run langflow run
+if defined ENV_FILE_PARAM (
+    uv run langflow run %ENV_FILE_PARAM%
+) else (
+    uv run langflow run
+)
 if errorlevel 1 (
     echo Error: Failed to run langflow
     pause

--- a/scripts/windows/build_and_run.bat
+++ b/scripts/windows/build_and_run.bat
@@ -1,6 +1,27 @@
 @echo off
 echo Starting Langflow build and run process...
 
+REM Load environment variables from .env file if it exists
+if exist "..\..\..\.env" (
+    echo Loading environment variables from .env file...
+    for /f "usebackq tokens=1,2 delims==" %%A in ("..\..\..\.env") do (
+        REM Skip empty lines and comments
+        echo %%A | findstr /r "^[^#]" >nul
+        if not errorlevel 1 (
+            REM Remove quotes if present and set environment variable
+            set "temp_value=%%B"
+            setlocal enabledelayedexpansion
+            set "temp_value=!temp_value:"=!"
+            set "temp_value=!temp_value:'=!"
+            endlocal & set "%%A=!temp_value!"
+            echo Set %%A
+        )
+    )
+    echo Environment variables loaded successfully!
+) else (
+    echo .env file not found, skipping environment variable loading
+)
+
 echo.
 echo Step 1: Installing frontend dependencies...
 cd ..\..\src\frontend

--- a/scripts/windows/build_and_run.ps1
+++ b/scripts/windows/build_and_run.ps1
@@ -4,7 +4,7 @@ Write-Host "Starting Langflow build and run process..." -ForegroundColor Green
 
 # Function to load .env file if it exists
 function Load-EnvFile {
-    $envPath = "..\..\..\.env"
+    $envPath = "..\..\..env"
     if (Test-Path $envPath) {
         Write-Host "Loading environment variables from .env file..." -ForegroundColor Cyan
         Get-Content $envPath | ForEach-Object {
@@ -60,7 +60,7 @@ try {
 Write-Host "`nStep 3: Copying build files to backend..." -ForegroundColor Yellow
 try {
     Set-Location "..\.."
-    
+
     # Determine build directory
     $buildDir = if (Test-Path "src\frontend\build") {
         "src\frontend\build"
@@ -69,25 +69,25 @@ try {
     } else {
         throw "Neither build nor dist directory found in src\frontend"
     }
-    
+
     $targetDir = "src\backend\base\langflow\frontend"
     Write-Host "Copying from $buildDir to $targetDir"
-    
+
     # Create target directory if it doesn't exist
     if (-not (Test-Path $targetDir)) {
         New-Item -Path $targetDir -ItemType Directory -Force | Out-Null
     }
-    
+
     # Remove existing files in target directory (FORCES CLEAN REPLACEMENT)
     Write-Host "Removing existing files from target directory..." -ForegroundColor Cyan
     if (Test-Path "$targetDir\*") {
         Remove-Item "$targetDir\*" -Recurse -Force
     }
-    
+
     # Copy all files from build directory
     Copy-Item "$buildDir\*" -Destination $targetDir -Recurse -Force
     Write-Host "Build files copied successfully!" -ForegroundColor Green
-    
+
 } catch {
     Write-Host "Error copying files: $_" -ForegroundColor Red
     Read-Host "Press Enter to exit"
@@ -106,4 +106,4 @@ try {
 }
 
 Write-Host "`nLangflow build and run process completed!" -ForegroundColor Green
-Read-Host "Press Enter to exit" 
+Read-Host "Press Enter to exit"

--- a/scripts/windows/build_and_run.ps1
+++ b/scripts/windows/build_and_run.ps1
@@ -3,13 +3,16 @@
 Write-Host "Starting Langflow build and run process..." -ForegroundColor Green
 
 # Check if .env file exists and set env file parameter
-$envPath = "..\..\..env"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$projectRoot = Resolve-Path (Join-Path $scriptDir "..\..")
+$envPath = Join-Path $projectRoot ".env"
 $envFileParam = ""
 if (Test-Path $envPath) {
-    Write-Host "Found .env file, will pass to langflow run" -ForegroundColor Cyan
+    Write-Host "Found .env file at: $envPath" -ForegroundColor Cyan
     $envFileParam = "--env-file `"$envPath`""
 } else {
-    Write-Host ".env file not found, langflow will use default configuration" -ForegroundColor Yellow
+    Write-Host ".env file not found at: $envPath" -ForegroundColor Yellow
+    Write-Host "Langflow will use default configuration" -ForegroundColor Yellow
 }
 
 # Step 1: Install frontend dependencies

--- a/scripts/windows/build_and_run.ps1
+++ b/scripts/windows/build_and_run.ps1
@@ -2,6 +2,31 @@
 
 Write-Host "Starting Langflow build and run process..." -ForegroundColor Green
 
+# Function to load .env file if it exists
+function Load-EnvFile {
+    $envPath = "..\..\..\.env"
+    if (Test-Path $envPath) {
+        Write-Host "Loading environment variables from .env file..." -ForegroundColor Cyan
+        Get-Content $envPath | ForEach-Object {
+            if ($_ -match "^\s*([^#][^=]*?)\s*=\s*(.*?)\s*$") {
+                $name = $matches[1]
+                $value = $matches[2]
+                # Remove quotes if present
+                $value = $value -replace '^"(.*)"$', '$1'
+                $value = $value -replace "^'(.*)'$", '$1'
+                [Environment]::SetEnvironmentVariable($name, $value, "Process")
+                Write-Host "Set $name" -ForegroundColor DarkGray
+            }
+        }
+        Write-Host "Environment variables loaded successfully!" -ForegroundColor Green
+    } else {
+        Write-Host ".env file not found, skipping environment variable loading" -ForegroundColor Yellow
+    }
+}
+
+# Load environment variables from .env file
+Load-EnvFile
+
 # Step 1: Install frontend dependencies
 Write-Host "`nStep 1: Installing frontend dependencies..." -ForegroundColor Yellow
 try {


### PR DESCRIPTION
This pull request enhances the Windows build and run scripts for Langflow by adding support for `.env` files. The scripts now automatically detect and use a `.env` file if it exists, or fall back to default configurations if it does not. This improvement ensures better configuration management for the application.

### Enhancements to `.env` file handling:

* **Batch script (`scripts/windows/build_and_run.bat`)**:
  - Added logic to check for the existence of a `.env` file in the project root directory and set an `--env-file` parameter if the file is found. If the file is not found, a message is displayed, and the script uses the default configuration.
  - Updated the command to run Langflow (`uv run langflow run`) to include the `--env-file` parameter when applicable.

* **PowerShell script (`scripts/windows/build_and_run.ps1`)**:
  - Implemented similar logic to detect the `.env` file and set the `--env-file` parameter dynamically. Informative messages are displayed based on whether the file is found.
  - Modified the Langflow execution command to conditionally include the `--env-file` parameter.