### PR TITLE
docs: cleanup and check of other deployments

### DIFF
--- a/docs/docs/Deployment/deployment-gcp.mdx
+++ b/docs/docs/Deployment/deployment-gcp.mdx
@@ -3,27 +3,25 @@ title: Deploy Langflow on Google Cloud Platform
 slug: /deployment-gcp
 ---
 
-This guide demonstrates deploying Langflow on Google Cloud Platform.
+This guide demonstrates how to deploy Langflow on Google Cloud Platform with a Cloud Shell script that walks through the process of setting up a Debian-based VM with the Langflow package, Nginx, and the necessary configurations to run the Langflow development environment in GCP.
 
-To deploy Langflow on Google Cloud Platform using Cloud Shell, use the below script.
+To use this script, you need a [Google Cloud](https://console.cloud.google.com/) project with the necessary permissions to create resources.
 
-The script guides you through setting up a Debian-based VM with the Langflow package, Nginx, and the necessary configurations to run the Langflow dev environment in GCP.
-
-## Prerequisites
-
-* A [Google Cloud](https://console.cloud.google.com/) project with the necessary permissions to create resources
-
-## Deploy Langflow in GCP
-
-1. Click the following button to launch Cloud Shell:
+1. Follow this link to launch the Cloud Shell with the GCP deployment script from the Langflow repository:
 
    [![Deploy to Google Cloud](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/langflow-ai/langflow&working_dir=scripts/gcp&shellonly=true&tutorial=walkthroughtutorial.md)
 
-2. Click **Trust repo**. Some gcloud commands may not run in an ephemeral Cloud Shell environment.
-3. Click **Start** and follow the tutorial to deploy Langflow.
+2. Click **Trust repo**.
 
-## Pricing
+    Some `gcloud` commands may not run in an ephemeral Cloud Shell environment.
 
-This deployment uses a [spot (preemptible) instance](https://cloud.google.com/compute/docs/instances/preemptible), which is a cost-effective option for running Langflow. However, **due to the nature of spot instances, the VM may be terminated at any time if Google Cloud needs to reclaim the resources**.
+3. Click **Start**, and then follow the tutorial to deploy Langflow.
+
+:::info
+This deployment uses a [spot (preemptible) instance](https://cloud.google.com/compute/docs/instances/preemptible) as a cost-effective option to demonstrate how to deploy Langflow on GCP.
+However, due to the nature of spot instances, the VM can be terminated at any time if Google Cloud needs to reclaim the resources.
+
+For a more stable deployment, consider using a regular VM instance instead of a spot instance.
 
 For more information, see the [GCP pricing calculator](https://cloud.google.com/products/calculator?hl=en).
+:::

--- a/docs/docs/Deployment/deployment-hugging-face-spaces.mdx
+++ b/docs/docs/Deployment/deployment-hugging-face-spaces.mdx
@@ -1,14 +1,13 @@
 ---
-title: Deploy Langflow on HuggingFace Spaces
+title: Deploy Langflow on Hugging Face Spaces
 slug: /deployment-hugging-face-spaces
 ---
 
-This guide explains how to deploy Langflow on [HuggingFace Spaces](https://huggingface.co/spaces/).
+This guide explains how to deploy Langflow on [Hugging Face Spaces](https://huggingface.co/spaces/).
 
 1. Go to the [Langflow Space](https://huggingface.co/spaces/Langflow/Langflow?duplicate=true).
-
 2. Click **Duplicate Space**.
-3. In the configuration dialog, do the following:
+3. In the configuration pane, do the following:
    - Enter a name for your Space.
    - Select either public or private visibility.
    - Click **Duplicate Space**

--- a/docs/docs/Deployment/deployment-hugging-face-spaces.mdx
+++ b/docs/docs/Deployment/deployment-hugging-face-spaces.mdx
@@ -7,14 +7,12 @@ This guide explains how to deploy Langflow on [Hugging Face Spaces](https://hugg
 
 1. Go to the [Langflow Space](https://huggingface.co/spaces/Langflow/Langflow?duplicate=true).
 2. Click **Duplicate Space**.
-3. In the configuration pane, do the following:
-   - Enter a name for your Space.
-   - Select either public or private visibility.
-   - Click **Duplicate Space**.
+3. Configure the duplicated Space:
+
+   1. Enter a name for your Space.
+   2. Select either public or private visibility.
+   3. Click **Duplicate Space**.
 
    ![Hugging Face deployment dialog](/img/hugging-face-deployment.png)
 
-Wait for the setup to complete. You'll be redirected to your new Space automatically.
-
-Your Langflow instance is now ready to use.
-
+When setup is complete, you're redirected to your new Space automatically, and your Langflow instance is ready to use.

--- a/docs/docs/Deployment/deployment-hugging-face-spaces.mdx
+++ b/docs/docs/Deployment/deployment-hugging-face-spaces.mdx
@@ -10,7 +10,7 @@ This guide explains how to deploy Langflow on [Hugging Face Spaces](https://hugg
 3. In the configuration pane, do the following:
    - Enter a name for your Space.
    - Select either public or private visibility.
-   - Click **Duplicate Space**
+   - Click **Duplicate Space**.
 
    ![Hugging Face deployment dialog](/img/hugging-face-deployment.png)
 

--- a/docs/docs/Deployment/deployment-railway.mdx
+++ b/docs/docs/Deployment/deployment-railway.mdx
@@ -1,16 +1,23 @@
 ---
 title: Deploy Langflow on Railway
+description: Deploy Langflow to Railway using a one-click template
 slug: /deployment-railway
 ---
 
-This guide explains how to deploy Langflow on [Railway](https://railway.app/), a cloud infrastructure platform that provides auto-deploy, managed databases, and automatic scaling.
+This guide explains how to [deploy Langflow on Railway](https://railway.com/?utm_medium=integration&utm_source=docs&utm_campaign=langflow), a cloud infrastructure platform that provides auto-deploy, managed databases, and automatic scaling.
 
-1. Follow this link to go to the Langflow template on Railway:
+1. Create a Railway account.
 
-   [![Deploy on Railway](/logos/railway-deploy.svg)](https://railway.app/template/JMXEWp?referralCode=MnPSdg)
+   A Hobby account on Railway is sufficient for Langflow's dual-core CPU and 2 GB RAM requirements. For more information, see [Railway pricing](https://railway.com/pricing?utm_medium=integration&utm_source=docs&utm_campaign=langflow).
 
-2. Click **Deploy Now**.
+2. Follow this link to deploy the Langflow template on Railway:
+
+   [![Deploy on Railway](/logos/railway-deploy.svg)](https://railway.com/new/template/JMXEWp?referralCode=MnPSdg&utm_medium=integration&utm_source=docs&utm_campaign=langflow)
+
+3. Optional: Add any custom configuration for your Langflow deployment.
 
    The Langflow Railway template automatically sets up the infrastructure, deploys Langflow, and then starts the application.
 
-When the deployment is complete, your Langflow instance is ready to use.
+4. Wait for the deployment to complete.
+
+5. Navigate to your Langflow instance at your deployment's public URL, such as `https://APP-NAME.up.railway.app`.

--- a/docs/docs/Deployment/deployment-railway.mdx
+++ b/docs/docs/Deployment/deployment-railway.mdx
@@ -5,16 +5,12 @@ slug: /deployment-railway
 
 This guide explains how to deploy Langflow on [Railway](https://railway.app/), a cloud infrastructure platform that provides auto-deploy, managed databases, and automatic scaling.
 
-1. Click the following button to go to Railway:
+1. Follow this link to go to the Langflow template on Railway:
 
    [![Deploy on Railway](/logos/railway-deploy.svg)](https://railway.app/template/JMXEWp?referralCode=MnPSdg)
 
 2. Click **Deploy Now**.
-Railway automatically does the following:
-   - Sets up the infrastructure.
-   - Deploys Langflow.
-   - Starts the application.
 
-Wait for the deployment to complete.
+   The Langflow Railway template automatically sets up the infrastructure, deploys Langflow, and then starts the application.
 
-Your Langflow instance is now ready to use.
+When the deployment is complete, your Langflow instance is ready to use.

--- a/docs/docs/Deployment/deployment-render.mdx
+++ b/docs/docs/Deployment/deployment-render.mdx
@@ -7,15 +7,14 @@ This guide explains how to deploy Langflow on [Render](https://render.com/), a c
 
 1. Prepare a Render instance that can support Langflow.
 
-   Langflow requires at least 2 GB of RAM to run, so you must use a **Standard** or better Render instance type.
+   Langflow requires at least 2 GB of RAM to run, so you must use a Render instance type of **Standard** or better.
    This requires a paid Render account.
    For more information, see [Render Web Services](https://render.com/docs/web-services) and [Render pricing](https://render.com/pricing).
 
-2. Click the following button to go to Render:
+2. Follow this link to start a Langflow deployment on Render:
 
    [![Deploy to Render](/logos/render-deploy.svg)](https://render.com/deploy?repo=https%3A%2F%2Fgithub.com%2Flangflow-ai%2Flangflow%2Ftree%2Fdev)
 
-3. Enter a blueprint name, and then select the branch for your `render.yaml` file.
+3. Enter a blueprint name, select the branch for your `render.yaml` file, and then click **Deploy Blueprint**.
 
-4. Click **Deploy Blueprint**, and then wait for the deployment to complete.
-Once complete, your Langflow instance is ready to use.
+When deployment is complete, your Langflow instance is ready to use.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -231,7 +231,7 @@ module.exports = {
         },
         {
           type: "category",
-          label: "Cloud Platforms",
+          label: "Cloud platforms",
           items: [
             {
               type: "doc",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -227,6 +227,12 @@ module.exports = {
                 }
               ]
             },
+          ],
+        },
+        {
+          type: "category",
+          label: "Cloud Platforms",
+          items: [
             {
               type: "doc",
               id: "Deployment/deployment-gcp",


### PR DESCRIPTION
* Move additional cloud deployments to a shared location called "Cloud platforms" in the sidebar.
* Some cleanup of brand names and minor changes.

Include Railway contributions from @sarahkb125 in #9237 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology and formatting in the Hugging Face Spaces deployment guide for clarity and consistency.
  * Added a new "Cloud platforms" category to the deployment documentation sidebar, featuring guides for Google Cloud Platform, Hugging Face Spaces, Railway, and Render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->