### PR TITLE
refactor: Improve cookie security and centralized utility

### DIFF
--- a/src/frontend/src/contexts/authContext.tsx
+++ b/src/frontend/src/contexts/authContext.tsx
@@ -10,6 +10,7 @@ import { useGetUserData } from "@/controllers/API/queries/auth";
 import { useGetGlobalVariablesMutation } from "@/controllers/API/queries/variables/use-get-mutation-global-variables";
 import useAuthStore from "@/stores/authStore";
 import { setLocalStorage } from "@/utils/local-storage-util";
+import { setCookieWithOptions } from "@/utils/utils";
 import { useStoreStore } from "../stores/storeStore";
 import type { Users } from "../types/api";
 import type { AuthContextType } from "../types/contexts/auth";
@@ -82,12 +83,12 @@ export function AuthProvider({ children }): React.ReactElement {
     autoLogin: string,
     refreshToken?: string,
   ) {
-    cookies.set(LANGFLOW_ACCESS_TOKEN, newAccessToken, { path: "/" });
-    cookies.set(LANGFLOW_AUTO_LOGIN_OPTION, autoLogin, { path: "/" });
+    cookies.set(LANGFLOW_ACCESS_TOKEN, newAccessToken, setCookieWithOptions());
+    cookies.set(LANGFLOW_AUTO_LOGIN_OPTION, autoLogin, setCookieWithOptions());
     setLocalStorage(LANGFLOW_ACCESS_TOKEN, newAccessToken);
 
     if (refreshToken) {
-      cookies.set(LANGFLOW_REFRESH_TOKEN, refreshToken, { path: "/" });
+      cookies.set(LANGFLOW_REFRESH_TOKEN, refreshToken, setCookieWithOptions());
     }
     setAccessToken(newAccessToken);
     setIsAuthenticated(true);

--- a/src/frontend/src/controllers/API/queries/auth/use-post-refresh-access.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-refresh-access.ts
@@ -2,6 +2,7 @@ import { Cookies } from "react-cookie";
 import { IS_AUTO_LOGIN, LANGFLOW_REFRESH_TOKEN } from "@/constants/constants";
 import useAuthStore from "@/stores/authStore";
 import type { useMutationFunctionType } from "@/types/api";
+import { setCookieWithOptions } from "@/utils/utils";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
@@ -23,7 +24,11 @@ export const useRefreshAccessToken: useMutationFunctionType<
 
   async function refreshAccess(): Promise<IRefreshAccessToken> {
     const res = await api.post<IRefreshAccessToken>(`${getURL("REFRESH")}`);
-    cookies.set(LANGFLOW_REFRESH_TOKEN, res.data.refresh_token, { path: "/" });
+    cookies.set(
+      LANGFLOW_REFRESH_TOKEN,
+      res.data.refresh_token,
+      setCookieWithOptions(),
+    );
 
     return res.data;
   }

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -536,7 +536,9 @@ export function brokenEdgeMessage({
     field: string;
   };
 }) {
-  return `${source.nodeDisplayName}${source.outputDisplayName ? " | " + source.outputDisplayName : ""} -> ${target.displayName}${target.field ? " | " + target.field : ""}`;
+  return `${source.nodeDisplayName}${
+    source.outputDisplayName ? " | " + source.outputDisplayName : ""
+  } -> ${target.displayName}${target.field ? " | " + target.field : ""}`;
 }
 export function FormatColumns(columns: ColumnField[]): ColDef<any>[] {
   if (!columns) return [];
@@ -823,7 +825,8 @@ export interface CookieOptions {
   maxAge?: number;
   expires?: Date;
   secure?: boolean;
-  sameSite?: "Strict" | "Lax" | "None";
+  sameSite?: "strict" | "lax" | "none";
+  httpOnly?: boolean;
 }
 
 /**
@@ -1002,3 +1005,9 @@ export const stripReleaseStageFromVersion = (version: string): string => {
   }
   return version;
 };
+
+export const setCookieWithOptions = (): CookieOptions => ({
+  path: "/",
+  secure: true,
+  sameSite: "strict",
+});


### PR DESCRIPTION
This pull request introduces a utility function to standardize cookie settings and updates the codebase to use it, along with minor improvements to code formatting and type definitions. The most important changes are grouped below:

### Cookie Handling Updates:
* Added a new utility function, `setCookieWithOptions`, in `src/utils/utils.ts` to centralize and standardize cookie options (`path`, `secure`, `sameSite`).
* Updated cookie-setting logic in `src/contexts/authContext.tsx` and `src/controllers/API/queries/auth/use-post-refresh-access.ts` to use `setCookieWithOptions` for consistency. [[1]](diffhunk://#diff-0fb964d718a5a8ff7d38ca94ac032d3a515bb276b6751db4abd846e5db4bee67L85-R91) [[2]](diffhunk://#diff-c50b21a853224366318d6aa7b966ac24b277d79d95722d76fa79a638cabe966cL26-R31)

### Type and Interface Enhancements:
* Modified the `CookieOptions` interface in `src/utils/utils.ts` to include a new `httpOnly` property and updated the `sameSite` property to use lowercase values for better compatibility.

### Code Formatting:
* Improved readability of the `brokenEdgeMessage` function in `src/utils/utils.ts` by reformatting a complex string template.