### PR TITLE
Doc: fixed quick install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,15 @@ Langflow requires [Python 3.10 to 3.13](https://www.python.org/downloads/release
 1. To install Langflow, run:
 
 ```shell
+uv venv  
+```
+
+```shell
 uv pip install langflow -U
+```
+
+```shell
+make build_frontend
 ```
 
 2. To run Langflow, run:


### PR DESCRIPTION
**Reordering Installation Steps:**
The uv venv and make build_frontend commands were added explicitly as separate steps in the installation instructions for better clarity. Previously, these steps might have been implied or missing.