### PR TITLE
docs: reference exported key

### DIFF
--- a/docs/docs/Get-Started/get-started-quickstart.mdx
+++ b/docs/docs/Get-Started/get-started-quickstart.mdx
@@ -35,9 +35,9 @@ Get started with Langflow by loading a template flow, running it, and then servi
 
         # Send request
         curl --request POST \
-        --url 'http://LANGFLOW_SERVER_ADDRESS/api/v1/run/FLOW_ID' \
-        --header 'Content-Type: application/json' \
-        --header 'x-api-key: $LANGFLOW_API_KEY' \
+        --url "http://LANGFLOW_SERVER_ADDRESS/api/v1/run/FLOW_ID" \
+        --header "Content-Type: application/json" \
+        --header "x-api-key: $LANGFLOW_API_KEY" \
         --data '{
           "output_type": "chat",
           "input_type": "chat",

--- a/docs/docs/Get-Started/get-started-quickstart.mdx
+++ b/docs/docs/Get-Started/get-started-quickstart.mdx
@@ -37,7 +37,7 @@ Get started with Langflow by loading a template flow, running it, and then servi
         curl --request POST \
         --url 'http://LANGFLOW_SERVER_ADDRESS/api/v1/run/FLOW_ID' \
         --header 'Content-Type: application/json' \
-        --header 'x-api-key: LANGFLOW_API_KEY' \
+        --header 'x-api-key: $LANGFLOW_API_KEY' \
         --data '{
           "output_type": "chat",
           "input_type": "chat",


### PR DESCRIPTION
Reference the exported key in the code sample.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the curl command example to correctly reference the Langflow API key environment variable, ensuring proper usage when copying and running the command in a terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->