### PR TITLE
docs: Fix a broken anchor

### DIFF
--- a/docs/docs/Configuration/environment-variables.mdx
+++ b/docs/docs/Configuration/environment-variables.mdx
@@ -163,7 +163,7 @@ The following table lists the environment variables supported by Langflow.
 | `LANGFLOW_DB_CONNECTION_SETTINGS` | JSON | Not set | A JSON dictionary to centralize database connection parameters. Example: `{"pool_size": 10, "max_overflow": 20}` |
 | `LANGFLOW_DISABLE_TRACK_APIKEY_USAGE` | Boolean | `false` | If set to `true`, disables tracking of API key usage (`total_uses` and `last_used_at`) to avoid database contention under high concurrency. |
 | `LANGFLOW_ENABLE_LOG_RETRIEVAL` | Boolean | `false` | Enable log retrieval functionality. |
-| `LANGFLOW_ENABLE_SUPERUSER_CLI` | Boolean | `true` | Allow creation of superusers with the Langflow CLI. Recommended to be `false` in production for security reasons. See [`langflow superuser`](./configuration-cli.mdx#langflow-superuser). |
+| `LANGFLOW_ENABLE_SUPERUSER_CLI` | Boolean | `true` | Allow creation of superusers with the Langflow CLI command [`langflow superuser`](./configuration-cli.mdx#langflow-superuser). Recommended to be `false` in production for security reasons. |
 | `LANGFLOW_FALLBACK_TO_ENV_VAR` | Boolean | `true` | If enabled, [global variables](/configuration-global-variables) set in the Langflow UI fall back to an environment variable with the same name when Langflow fails to retrieve the variable value. |
 | `LANGFLOW_FRONTEND_PATH` | String | `./frontend` | Path to the frontend directory containing build files. This is for development purposes only. See [`--frontend-path`](./configuration-cli.mdx#run-frontend-path). |
 | `LANGFLOW_HEALTH_CHECK_MAX_RETRIES` | Integer | `5` | Set the maximum number of retries for the health check. See [`--health-check-max-retries`](./configuration-cli.mdx#run-health-check-max-retries). |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the environment variables documentation to correct a link anchor related to the `LANGFLOW_ENABLE_SUPERUSER_CLI` variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->