### PR TITLE
bug: fix the manual cross platform test run

### DIFF
--- a/.github/workflows/cross-platform-test-shared.yml
+++ b/.github/workflows/cross-platform-test-shared.yml
@@ -79,6 +79,35 @@ jobs:
             python-version: "3.12"
 
     steps:
+      - name: Debug workflow inputs
+        run: |
+          echo "Shared workflow received inputs:"
+          echo "  install-method: ${{ inputs.install-method }}"
+          echo "  test-timeout: ${{ inputs.test-timeout }}"
+          echo "  base-artifact-name: '${{ inputs.base-artifact-name }}'"
+          echo "  main-artifact-name: '${{ inputs.main-artifact-name }}'"
+          echo "  langflow-version: '${{ inputs.langflow-version }}'"
+          echo "  run-id: '${{ inputs.run-id }}'"
+          echo ""
+          echo "Matrix values:"
+          echo "  os: ${{ matrix.os }}"
+          echo "  arch: ${{ matrix.arch }}"
+          echo "  python-version: ${{ matrix.python-version }}"
+          echo "  runner: ${{ matrix.runner }}"
+        shell: bash
+
+      - name: Validate required parameters for wheel installation
+        if: inputs.install-method == 'wheel'
+        run: |
+          if [ -z "${{ inputs.base-artifact-name }}" ] || [ -z "${{ inputs.main-artifact-name }}" ]; then
+            echo "❌ Error: base-artifact-name and main-artifact-name are required when install-method is 'wheel'"
+            echo "  base-artifact-name: '${{ inputs.base-artifact-name }}'"
+            echo "  main-artifact-name: '${{ inputs.main-artifact-name }}'"
+            exit 1
+          fi
+          echo "✅ Required parameters for wheel installation are present"
+        shell: bash
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -81,17 +81,44 @@ jobs:
         run: |
           echo "base-artifact-name=adhoc-dist-base" >> $GITHUB_OUTPUT
           echo "main-artifact-name=adhoc-dist-main" >> $GITHUB_OUTPUT
+      - name: Debug artifact names
+        run: |
+          echo "Build job outputs:"
+          echo "  base-artifact-name: adhoc-dist-base"
+          echo "  main-artifact-name: adhoc-dist-main"
+          echo "Input parameters:"
+          echo "  inputs.base-artifact-name: '${{ inputs.base-artifact-name }}'"
+          echo "  inputs.main-artifact-name: '${{ inputs.main-artifact-name }}'"
+
+  debug-parameters:
+    name: Debug Parameters
+    needs: [build-if-needed]
+    if: always() && (needs.build-if-needed.result == 'success' || needs.build-if-needed.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show parameters being passed to shared workflow
+        run: |
+          echo "Parameters that will be passed to shared workflow:"
+          echo "  install-method: wheel"
+          echo "  test-timeout: ${{ inputs.test-timeout || 5 }}"
+          echo "  base-artifact-name: ${{ inputs.base-artifact-name != '' && inputs.base-artifact-name || needs.build-if-needed.outputs.base-artifact-name || 'adhoc-dist-base' }}"
+          echo "  main-artifact-name: ${{ inputs.main-artifact-name != '' && inputs.main-artifact-name || needs.build-if-needed.outputs.main-artifact-name || 'adhoc-dist-main' }}"
+          echo ""
+          echo "Build job results:"
+          echo "  build-if-needed.result: ${{ needs.build-if-needed.result }}"
+          echo "  build-if-needed.outputs.base-artifact-name: ${{ needs.build-if-needed.outputs.base-artifact-name }}"
+          echo "  build-if-needed.outputs.main-artifact-name: ${{ needs.build-if-needed.outputs.main-artifact-name }}"
 
   test-wheel-installation:
     name: Test Wheel Installation
-    needs: [build-if-needed]
+    needs: [build-if-needed, debug-parameters]
     if: always() && (needs.build-if-needed.result == 'success' || needs.build-if-needed.result == 'skipped')
     uses: ./.github/workflows/cross-platform-test-shared.yml
     with:
       install-method: "wheel"
-      test-timeout: ${{ inputs.test-timeout }}
-      base-artifact-name: ${{ inputs.base-artifact-name || needs.build-if-needed.outputs.base-artifact-name }}
-      main-artifact-name: ${{ inputs.main-artifact-name || needs.build-if-needed.outputs.main-artifact-name }}
+      test-timeout: ${{ inputs.test-timeout || 5 }}
+      base-artifact-name: ${{ inputs.base-artifact-name != '' && inputs.base-artifact-name || needs.build-if-needed.outputs.base-artifact-name || 'adhoc-dist-base' }}
+      main-artifact-name: ${{ inputs.main-artifact-name != '' && inputs.main-artifact-name || needs.build-if-needed.outputs.main-artifact-name || 'adhoc-dist-main' }}
 
   test-summary:
     name: Cross-Platform Test Summary


### PR DESCRIPTION
An attempt to fix the manual cross-platform install test.  Formerly the build worked but the test didn't initiate.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added enhanced debugging and input validation steps to the cross-platform test workflows.
  * Introduced a new job to display workflow parameters and artifact names for improved traceability.
  * Updated job dependencies and input handling to ensure consistent parameter passing with default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->