### PR TITLE
feat: Add Gemini 2.5 and 2.0 model metadata

### DIFF
--- a/src/backend/base/langflow/base/models/google_generative_ai_constants.py
+++ b/src/backend/base/langflow/base/models/google_generative_ai_constants.py
@@ -12,6 +12,20 @@ GOOGLE_GENERATIVE_AI_MODELS_DETAILED = [
     create_model_metadata(
         provider="Google Generative AI", name="gemini-1.5-flash-8b", icon="GoogleGenerativeAI", tool_calling=True
     ),
+    # GEMINI 2.5
+    create_model_metadata(
+        provider="Google Generative AI", name="gemini-2.5-pro", icon="GoogleGenerativeAI", tool_calling=True
+    ),
+    create_model_metadata(
+        provider="Google Generative AI", name="gemini-2.5-flash", icon="GoogleGenerativeAI", tool_calling=True
+    ),
+    create_model_metadata(
+        provider="Google Generative AI", name="gemini-2.5-flash-lite", icon="GoogleGenerativeAI", tool_calling=True
+    ),
+    # GEMINI 2.0
+    create_model_metadata(
+        provider="Google Generative AI", name="gemini-2.0-flash-lite", icon="GoogleGenerativeAI", tool_calling=True
+    ),
     # PREVIEW
     create_model_metadata(
         provider="Google Generative AI",


### PR DESCRIPTION
This pull request adds new entries to the `Google Generative AI` model metadata in the `src/backend/base/langflow/base/models/google_generative_ai_constants.py` file. These changes expand the list of supported models.

### Additions to Google Generative AI model metadata:

* Added metadata for three `gemini-2.5` models: `gemini-2.5-pro`, `gemini-2.5-flash`, and `gemini-2.5-flash-lite`.
* Added metadata for one `gemini-2.0` model: `gemini-2.0-flash-lite`.


<img width="494" height="835" alt="image" src="https://github.com/user-attachments/assets/f8d12489-cd60-4000-b3fb-029073a287d0" />
