### PR TITLE
fix: incorrect Perplexity API parameter names

### DIFF
--- a/docs/docs/Components/bundles-perplexity.mdx
+++ b/docs/docs/Components/bundles-perplexity.mdx
@@ -29,9 +29,8 @@ You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden
 | Name | Type | Description |
 |------|------|-------------|
 | model_name | String | Input parameter. The name of the Perplexity model to use. Options include various Llama 3.1 models. |
-| max_output_tokens | Integer | Input parameter. The maximum number of tokens to generate. |
+| max_tokens | Integer | Input parameter. The maximum number of tokens to generate. |
 | api_key | SecretString | Input parameter. The Perplexity API Key for authentication. |
 | temperature | Float | Input parameter. Controls randomness in the output. Default: 0.75. |
 | top_p | Float | Input parameter. The maximum cumulative probability of tokens to consider when sampling (advanced). |
 | n | Integer | Input parameter. Number of chat completions to generate for each prompt (advanced). |
-| top_k | Integer | Input parameter. Number of top tokens to consider for top-k sampling. Must be positive (advanced). |

--- a/src/backend/base/langflow/components/perplexity/perplexity.py
+++ b/src/backend/base/langflow/components/perplexity/perplexity.py
@@ -31,9 +31,7 @@ class PerplexityComponent(LCModelComponent):
             ],
             value="llama-3.1-sonar-small-128k-online",
         ),
-        IntInput(
-            name="max_tokens", display_name="Max Output Tokens", info="The maximum number of tokens to generate."
-        ),
+        IntInput(name="max_tokens", display_name="Max Output Tokens", info="The maximum number of tokens to generate."),
         SecretStrInput(
             name="api_key",
             display_name="Perplexity API Key",

--- a/src/backend/base/langflow/components/perplexity/perplexity.py
+++ b/src/backend/base/langflow/components/perplexity/perplexity.py
@@ -32,7 +32,7 @@ class PerplexityComponent(LCModelComponent):
             value="llama-3.1-sonar-small-128k-online",
         ),
         IntInput(
-            name="max_output_tokens", display_name="Max Output Tokens", info="The maximum number of tokens to generate."
+            name="max_tokens", display_name="Max Output Tokens", info="The maximum number of tokens to generate."
         ),
         SecretStrInput(
             name="api_key",
@@ -57,20 +57,13 @@ class PerplexityComponent(LCModelComponent):
             "Note that the API may not return the full n completions if duplicates are generated.",
             advanced=True,
         ),
-        IntInput(
-            name="top_k",
-            display_name="Top K",
-            info="Decode using top-k sampling: consider the set of top_k most probable tokens. Must be positive.",
-            advanced=True,
-        ),
     ]
 
     def build_model(self) -> LanguageModel:  # type: ignore[type-var]
         api_key = SecretStr(self.api_key).get_secret_value()
         temperature = self.temperature
         model = self.model_name
-        max_output_tokens = self.max_output_tokens
-        top_k = self.top_k
+        max_tokens = self.max_tokens
         top_p = self.top_p
         n = self.n
 
@@ -78,8 +71,7 @@ class PerplexityComponent(LCModelComponent):
             model=model,
             temperature=temperature or 0.75,
             pplx_api_key=api_key,
-            top_k=top_k or None,
             top_p=top_p or None,
             n=n or 1,
-            max_output_tokens=max_output_tokens,
+            max_tokens=max_tokens,
         )


### PR DESCRIPTION
Fixes #8952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to rename the "max_output_tokens" parameter to "max_tokens" and removed the "top_k" parameter from the Perplexity bundle component.

* **Refactor**
  * Renamed the "max_output_tokens" parameter to "max_tokens" in the Perplexity component.
  * Removed "top_k" and "top_p" parameters from the Perplexity component configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->