### PR TITLE
ci: add checkout step to publish to pypi steps in nightly workflow

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -221,6 +221,8 @@ jobs:
     needs: [build-nightly-base, test-cross-platform]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Download base artifact
         uses: actions/download-artifact@v4
         with:
@@ -244,6 +246,8 @@ jobs:
     needs: [build-nightly-main, test-cross-platform, publish-nightly-base]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Download main artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Adds checkout to nightly publish step. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of nightly release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->