### PR TITLE
fix: ModuleNotFoundError occurs due to broken or incomplete install of the elevenlabs==2.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,7 +230,7 @@ postgresql = [
 override-dependencies = [
     # temporary force a newer python-pptx
     "python-pptx>=1.0.2"
-    "elevenlabs = "==2.7.0" #Use Stable version as 2.8.1 is broken 
+    "elevenlabs = "==2.7.1" #Use Stable version as 2.8.1 is broken 
 ]
 
 [project.scripts]


### PR DESCRIPTION
Fixes #9299 

### Description 
A ModuleNotFoundError occurs when running Langflow after a fresh installation using the uv package manager. The error points to a missing module in the elevenlabs library
It happens because langflow indirectly uses latest version of elevenlabs==2.8.1 which is broken

By explicitly locking the version to 2.7.1:
Override the broken 2.8.1 version, which is causing the ModuleNotFoundError
Force all packages (including Langflow) to use only 2.7.1, as long as it's compatible

### ✅ Summary:
Pinned elevenlabs to ==2.7.1 in pyproject.toml (or uv.lock)
Prevents transitive dependency conflicts or breaking changes from newer releases
Ensures consistent behavior across environments

### Additional
You can also change it directly by using the command
```
uv pip install 'elevenlabs==2.7.1'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency settings to use a stable version of the elevenlabs package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->