### PR TITLE
Update perplexity.py

### DIFF
--- a/src/backend/base/langflow/components/perplexity/perplexity.py
+++ b/src/backend/base/langflow/components/perplexity/perplexity.py
@@ -20,19 +20,11 @@ class PerplexityComponent(LCModelComponent):
             name="model_name",
             display_name="Model Name",
             advanced=False,
-            options=[
-                "sonar",
-                "sonar-pro",
-                "sonar-reasoning",
-                "sonar-reasoning-pro",
-                "sonar-deep-research"
-            ],
+            options=["sonar", "sonar-pro", "sonar-reasoning", "sonar-reasoning-pro", "sonar-deep-research"],
             value="sonar",
         ),
         IntInput(
-            name="max_output_tokens",
-            display_name="Max Output Tokens",
-            info="The maximum number of tokens to generate."
+            name="max_output_tokens", display_name="Max Output Tokens", info="The maximum number of tokens to generate."
         ),
         SecretStrInput(
             name="api_key",
@@ -42,10 +34,7 @@ class PerplexityComponent(LCModelComponent):
             required=True,
         ),
         SliderInput(
-            name="temperature",
-            display_name="Temperature",
-            value=0.75,
-            range_spec=RangeSpec(min=0, max=2, step=0.05)
+            name="temperature", display_name="Temperature", value=0.75, range_spec=RangeSpec(min=0, max=2, step=0.05)
         ),
         FloatInput(
             name="top_p",
@@ -57,7 +46,7 @@ class PerplexityComponent(LCModelComponent):
             name="n",
             display_name="N",
             info="Number of chat completions to generate for each prompt. "
-                 "Note that the API may not return the full n completions if duplicates are generated.",
+            "Note that the API may not return the full n completions if duplicates are generated.",
             advanced=True,
         ),
         IntInput(

--- a/src/backend/base/langflow/components/perplexity/perplexity.py
+++ b/src/backend/base/langflow/components/perplexity/perplexity.py
@@ -10,7 +10,7 @@ from langflow.io import DropdownInput, FloatInput, IntInput, SecretStrInput, Sli
 class PerplexityComponent(LCModelComponent):
     display_name = "Perplexity"
     description = "Generate text using Perplexity LLMs."
-    documentation = "https://python.langchain.com/v0.2/docs/integrations/chat/perplexity/"
+    documentation = "https://docs.perplexity.ai/"
     icon = "Perplexity"
     name = "PerplexityModel"
 
@@ -21,18 +21,18 @@ class PerplexityComponent(LCModelComponent):
             display_name="Model Name",
             advanced=False,
             options=[
-                "llama-3.1-sonar-small-128k-online",
-                "llama-3.1-sonar-large-128k-online",
-                "llama-3.1-sonar-huge-128k-online",
-                "llama-3.1-sonar-small-128k-chat",
-                "llama-3.1-sonar-large-128k-chat",
-                "llama-3.1-8b-instruct",
-                "llama-3.1-70b-instruct",
+                "sonar",
+                "sonar-pro",
+                "sonar-reasoning",
+                "sonar-reasoning-pro",
+                "sonar-deep-research"
             ],
-            value="llama-3.1-sonar-small-128k-online",
+            value="sonar",
         ),
         IntInput(
-            name="max_output_tokens", display_name="Max Output Tokens", info="The maximum number of tokens to generate."
+            name="max_output_tokens",
+            display_name="Max Output Tokens",
+            info="The maximum number of tokens to generate."
         ),
         SecretStrInput(
             name="api_key",
@@ -42,7 +42,10 @@ class PerplexityComponent(LCModelComponent):
             required=True,
         ),
         SliderInput(
-            name="temperature", display_name="Temperature", value=0.75, range_spec=RangeSpec(min=0, max=2, step=0.05)
+            name="temperature",
+            display_name="Temperature",
+            value=0.75,
+            range_spec=RangeSpec(min=0, max=2, step=0.05)
         ),
         FloatInput(
             name="top_p",
@@ -54,7 +57,7 @@ class PerplexityComponent(LCModelComponent):
             name="n",
             display_name="N",
             info="Number of chat completions to generate for each prompt. "
-            "Note that the API may not return the full n completions if duplicates are generated.",
+                 "Note that the API may not return the full n completions if duplicates are generated.",
             advanced=True,
         ),
         IntInput(
@@ -67,19 +70,12 @@ class PerplexityComponent(LCModelComponent):
 
     def build_model(self) -> LanguageModel:  # type: ignore[type-var]
         api_key = SecretStr(self.api_key).get_secret_value()
-        temperature = self.temperature
-        model = self.model_name
-        max_output_tokens = self.max_output_tokens
-        top_k = self.top_k
-        top_p = self.top_p
-        n = self.n
-
         return ChatPerplexity(
-            model=model,
-            temperature=temperature or 0.75,
+            model=self.model_name,
+            temperature=self.temperature or 0.75,
             pplx_api_key=api_key,
-            top_k=top_k or None,
-            top_p=top_p or None,
-            n=n or 1,
-            max_output_tokens=max_output_tokens,
+            top_k=self.top_k or None,
+            top_p=self.top_p or None,
+            n=self.n or 1,
+            max_output_tokens=self.max_output_tokens,
         )


### PR DESCRIPTION
## Summary
This PR updates the `PerplexityComponent` in Langflow to use the **latest Perplexity API model names**.  
The current options reference deprecated `llama-3.1-sonar-*` models that return `model not found` errors when used.

## Changes
- Replaced outdated model options with:
  - `sonar`
  - `sonar-pro`
  - `sonar-reasoning`
  - `sonar-reasoning-pro`
  - `sonar-deep-research`
- Updated documentation link to [Perplexity API Docs](https://docs.perplexity.ai/)

## Why This Change Is Needed
- Perplexity has retired old `llama-3.1-sonar-*` model names
- Keeping outdated names breaks workflows for Langflow users
- This PR ensures compatibility with current API endpoints

## Testing
1. Verified dropdown loads new model names in Langflow UI
2. Tested model selection with valid Perplexity API key
3. Confirmed successful completions for each model via:
```python
from langchain_community.chat_models import ChatPerplexity
llm = ChatPerplexity(model="sonar-pro", pplx_api_key="YOUR_KEY")
print(llm.invoke("Give me today's top AI developments."))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the documentation link for the Perplexity component to point to the official Perplexity AI site.
  * Simplified the model selection dropdown with new, easier-to-understand model options and a new default value.

* **Style**
  * Streamlined internal parameter handling for improved maintainability (no impact on user-facing functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->