### PR TITLE
Update perplexity.py

### DIFF
--- a/src/backend/base/langflow/components/perplexity/perplexity.py
+++ b/src/backend/base/langflow/components/perplexity/perplexity.py
@@ -20,13 +20,7 @@ class PerplexityComponent(LCModelComponent):
             name="model_name",
             display_name="Model Name",
             advanced=False,
-            options=[
-                  "sonar",
-                  "sonar-pro",
-                  "sonar-reasoning",
-                  "sonar-reasoning-pro",
-                  "sonar-deep-research"
-            ],
+            options=["sonar", "sonar-pro", "sonar-reasoning", "sonar-reasoning-pro", "sonar-deep-research"],
             value="sonar",
         ),
         IntInput(

--- a/src/backend/base/langflow/components/perplexity/perplexity.py
+++ b/src/backend/base/langflow/components/perplexity/perplexity.py
@@ -21,15 +21,13 @@ class PerplexityComponent(LCModelComponent):
             display_name="Model Name",
             advanced=False,
             options=[
-                "llama-3.1-sonar-small-128k-online",
-                "llama-3.1-sonar-large-128k-online",
-                "llama-3.1-sonar-huge-128k-online",
-                "llama-3.1-sonar-small-128k-chat",
-                "llama-3.1-sonar-large-128k-chat",
-                "llama-3.1-8b-instruct",
-                "llama-3.1-70b-instruct",
+                  "sonar",
+                  "sonar-pro",
+                  "sonar-reasoning",
+                  "sonar-reasoning-pro",
+                  "sonar-deep-research"
             ],
-            value="llama-3.1-sonar-small-128k-online",
+            value="sonar",
         ),
         IntInput(
             name="max_output_tokens", display_name="Max Output Tokens", info="The maximum number of tokens to generate."


### PR DESCRIPTION
fix(perplexity): update model list to latest Perplexity API

Replaced outdated `llama-3.1-sonar-*` models with the latest Perplexity API models:
- sonar
- sonar-pro
- sonar-reasoning
- sonar-reasoning-pro
- sonar-deep-research

This ensures Langflow users can select currently available Perplexity models without API errors.

References:
- https://docs.perplexity.ai/

## Summary
This PR updates the `PerplexityComponent` in Langflow to use the **latest Perplexity API model names**.  
The current options reference deprecated `llama-3.1-sonar-*` models that return `model not found` errors when used.

## Changes
- Replaced outdated model options with:
  - `sonar`
  - `sonar-pro`
  - `sonar-reasoning`
  - `sonar-reasoning-pro`
  - `sonar-deep-research`
- Updated documentation link to [Perplexity API Docs](https://docs.perplexity.ai/)

## Why This Change Is Needed
- Perplexity has retired old `llama-3.1-sonar-*` model names
- Keeping outdated names breaks workflows for Langflow users
- This PR ensures compatibility with current API endpoints

## Testing
1. Verified dropdown loads new model names in Langflow UI
2. Tested model selection with valid Perplexity API key
3. Confirmed successful completions for each model via:
```python
from langchain_community.chat_models import ChatPerplexity
llm = ChatPerplexity(model="sonar-pro", pplx_api_key="YOUR_KEY")
print(llm.invoke("Give me today's top AI developments."))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the dropdown options for model selection in the Perplexity component with a simplified list of model names.
  * Changed the default model selection to "sonar".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->