### PR TITLE
chore: Add framework name into UserAgent header for bedrock integration

### DIFF
--- a/src/backend/base/langflow/components/amazon/amazon_bedrock_embedding.py
+++ b/src/backend/base/langflow/components/amazon/amazon_bedrock_embedding.py
@@ -79,6 +79,7 @@ class AmazonBedrockEmbeddingsComponent(LCModelComponent):
             raise ImportError(msg) from e
         try:
             import boto3
+            from botocore.config import Config
         except ImportError as e:
             msg = "boto3 is not installed. Please install it with `pip install boto3`."
             raise ImportError(msg) from e
@@ -99,6 +100,7 @@ class AmazonBedrockEmbeddingsComponent(LCModelComponent):
         if self.region_name:
             client_params["region_name"] = self.region_name
 
+        client_params["config"] = Config(user_agent_extra="x-client-framework:langflow")
         boto3_client = session.client("bedrock-runtime", **client_params)
         return BedrockEmbeddings(
             credentials_profile_name=self.credentials_profile_name,

--- a/src/backend/base/langflow/components/amazon/amazon_bedrock_model.py
+++ b/src/backend/base/langflow/components/amazon/amazon_bedrock_model.py
@@ -84,6 +84,7 @@ class AmazonBedrockComponent(LCModelComponent):
             raise ImportError(msg) from e
         try:
             import boto3
+            from botocore.config import Config
         except ImportError as e:
             msg = "boto3 is not installed. Please install it with `pip install boto3`."
             raise ImportError(msg) from e
@@ -108,6 +109,7 @@ class AmazonBedrockComponent(LCModelComponent):
         if self.region_name:
             client_params["region_name"] = self.region_name
 
+        client_params["config"] = Config(user_agent_extra="x-client-framework:langflow")
         boto3_client = session.client("bedrock-runtime", **client_params)
         try:
             output = ChatBedrock(


### PR DESCRIPTION
# Description

This PR adds the framework name into User-Agent header of Bedrock API call. It only append the framework name langflow into the User-Agent header field for Bedrock API call, which can be used to collect the usage. Similar change had been made to other framework such as [langchain](https://github.com/langchain-ai/langchain-aws/pull/558)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration with Amazon Bedrock services to include a custom user agent for improved client identification. No changes to user-facing features or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->