### PR TITLE
test: skip Everything server on Python 3.13

### DIFF
--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -7,6 +7,7 @@ This test suite validates the MCP utility functions including:
 """
 
 import shutil
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -363,6 +364,10 @@ class TestMCPStdioClientWithEverythingServer:
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(not shutil.which("npx"), reason="Node.js not available")
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 13),
+        reason="Temporarily disabled on Python 3.13 due to frequent timeouts with MCP Everything server",
+    )
     async def test_connect_to_everything_server(self, stdio_client):
         """Test connecting to the Everything MCP server."""
         command = "npx -y @modelcontextprotocol/server-everything"


### PR DESCRIPTION
Temporarily skip MCP Everything server test on Python 3.13 due to timeouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved compatibility with Python 3.13+ by conditionally skipping a long-running server connectivity test to prevent timeouts and CI failures.
  * Enhanced test suite stability and consistency across environments, reducing flaky outcomes on newer Python versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->