### PR TITLE
chore: skip mcp everything server test

### DIFF
--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -354,6 +354,7 @@ class TestMCPUtilityFunctions:
         assert result is None
 
 
+@pytest.mark.skip(reason="Skipping MCPStdioClientWithEverythingServer tests.")
 class TestMCPStdioClientWithEverythingServer:
     """Test MCPStdioClient with the Everything MCP server."""
 


### PR DESCRIPTION
This pull request makes a small change to the test suite by skipping the `TestMCPStdioClientWithEverythingServer` test class. This is done by adding a `pytest.mark.skip` decorator with a reason explaining the skip.