### PR TITLE
refactor: remove Anthropic provider test 

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1176,6 +1176,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/frontend/tests/core/integrations/Research Translation Loop.spec.ts
+++ b/src/frontend/tests/core/integrations/Research Translation Loop.spec.ts
@@ -10,8 +10,8 @@ withEventDeliveryModes(
   { tag: ["@release", "@starter-projects"] },
   async ({ page }) => {
     test.skip(
-      !process?.env?.ANTHROPIC_API_KEY,
-      "ANTHROPIC_API_KEY required to run this test",
+      !process?.env?.OPENAI_API_KEY,
+      "OPENAI_API_KEY required to run this test",
     );
 
     if (!process.env.CI) {

--- a/src/frontend/tests/core/integrations/Research Translation Loop.spec.ts
+++ b/src/frontend/tests/core/integrations/Research Translation Loop.spec.ts
@@ -34,14 +34,14 @@ withEventDeliveryModes(
       skipAddNewApiKeys: true,
       skipSelectGptModel: true,
     });
-
-    await page.getByTestId("dropdown_str_provider").click();
-    await page.getByTestId("Anthropic-1-option").click();
+    // TODO: Uncomment this when we have a way to test Anthropic
+    // await page.getByTestId("dropdown_str_provider").click();
+    // await page.getByTestId("Anthropic-1-option").click();
 
     await page
       .getByTestId("popover-anchor-input-api_key")
       .last()
-      .fill(process.env.ANTHROPIC_API_KEY ?? "");
+      .fill(process.env.OPENAI_API_KEY ?? "");
 
     await page.waitForSelector('[data-testid="dropdown_str_model_name"]', {
       timeout: 5000,


### PR DESCRIPTION
Temporarily commented out the Anthropic provider selection in the Research Translation Loop integration test and switched the API key input to use OPENAI_API_KEY. This change is made pending a way to properly test Anthropic integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end research translation flow tests to default to the OpenAI provider, removing prior provider-selection steps.
  * Switched test authentication to use the OpenAI API key environment variable.
  * Maintains the same user flow assertions; no user-facing behavior changes.
  * Improves test stability and consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->