### PR TITLE
refactor: Remove extraneous flag from package lock

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1176,7 +1176,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
The 'extraneous' flag was removed from the is-unicode-supported dependency in package-lock.json to reflect its correct status in the bundle.