### PR TITLE
fix: make tools be selected on mcp server after opening for the first time

### DIFF
--- a/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
+++ b/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
@@ -57,25 +57,31 @@ export default function ToolsTable({
     setSelectedRows(filter);
   }, [rows, open]);
 
-  useEffect(() => {
+  const applyInitialSelection = () => {
+    if (!agGrid.current?.api) return;
+    
     const initialData = cloneDeep(rows);
     const filter = initialData.filter((row) => row.status === true);
-    if (agGrid.current) {
-      agGrid.current?.api?.forEachNode((node) => {
-        if (
-          filter.some(
-            (row) =>
-              (row.display_name ?? row.name) ===
-              (node.data.display_name ?? node.data.name),
-          )
-        ) {
-          node.setSelected(true);
-        } else {
-          node.setSelected(false);
-        }
-      });
-    }
-  }, [agGrid.current]);
+    
+    agGrid.current.api.forEachNode((node) => {
+      if (
+        filter.some(
+          (row) =>
+            (row.display_name ?? row.name) ===
+            (node.data.display_name ?? node.data.name),
+        )
+      ) {
+        node.setSelected(true);
+      } else {
+        node.setSelected(false);
+      }
+    });
+  };
+
+  // Apply initial selection when data changes and grid is ready
+  useEffect(() => {
+    applyInitialSelection();
+  }, [rows, data]);
 
   useEffect(() => {
     if (!open) {
@@ -251,6 +257,11 @@ export default function ToolsTable({
     setSidebarOpen(true);
   };
 
+  const handleGridReady = () => {
+    // Apply initial selection when grid is ready
+    applyInitialSelection();
+  };
+
   const rowName = useMemo(() => {
     return parseString(focusedRow?.display_name || focusedRow?.name || "", [
       "space_case",
@@ -284,6 +295,7 @@ export default function ToolsTable({
             tableOptions={tableOptions}
             onRowClicked={handleRowClicked}
             getRowId={getRowId}
+            onGridReady={handleGridReady}
           />
         </div>
       </main>


### PR DESCRIPTION
This pull request refactors how initial row selection is applied in the `ToolsTable` component to ensure that the correct rows are selected both when the data changes and when the grid becomes ready. The changes improve reliability and maintainability by separating concerns and making the selection logic more explicit.

**Enhancements to initial row selection logic:**

* Extracted the initial selection logic into a dedicated `applyInitialSelection` function to clarify intent and improve code reuse.
* Updated the main `useEffect` to call `applyInitialSelection` whenever `rows` or `data` change, ensuring selection stays in sync with updates.

**Grid readiness handling:**

* Added a new `handleGridReady` callback that invokes `applyInitialSelection` when the grid is initialized, guaranteeing the selection is applied as soon as the grid API is available.
* Passed `handleGridReady` to the table component via the new `onGridReady` prop, wiring up the grid initialization event to the selection logic.