### PR TITLE
docs: update file size limit to 1024 mb

### DIFF
--- a/docs/docs/API-Reference/api-files.mdx
+++ b/docs/docs/API-Reference/api-files.mdx
@@ -420,3 +420,7 @@ curl -X DELETE \
 ## Create upload file (Deprecated)
 
 This endpoint is deprecated. Use the `/files` endpoints instead.
+
+## See also
+
+* [Manage files](/concepts-file-management)

--- a/docs/docs/API-Reference/api-files.mdx
+++ b/docs/docs/API-Reference/api-files.mdx
@@ -61,7 +61,7 @@ Not all file types are supported.
 
 Send image files to Langflow to use them in flows.
 
-The default file limit is 100 MB.
+The default file limit is 1024 MB.
 To change this limit, set the `LANGFLOW_MAX_FILE_SIZE_UPLOAD` [environment variable](/environment-variables).
 
 1. Attach the image to a `POST /v1/files/upload/$FLOW_ID` request with `--form` (`-F`) and the file path:
@@ -240,7 +240,7 @@ To send image files to your flows through the API, see [Upload image files (v1)]
 This endpoint uploads files to your Langflow server's file management system.
 To use an uploaded file in a flow, send the file path to a flow with a [**File** component](/components-data#file).
 
-The default file limit is 100 MB. To configure this value, change the `LANGFLOW_MAX_FILE_SIZE_UPLOAD` [environment variable](/environment-variables).
+The default file limit is 1024 MB. To configure this value, change the `LANGFLOW_MAX_FILE_SIZE_UPLOAD` [environment variable](/environment-variables).
 
 1. To send a file to your flow with the API, POST the file to the `/api/v2/files` endpoint.
 

--- a/docs/docs/API-Reference/api-monitor.mdx
+++ b/docs/docs/API-Reference/api-monitor.mdx
@@ -6,9 +6,26 @@ slug: /api-monitor
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Use the `/monitor` endpoint to monitor and modify messages passed between Langflow components, vertex builds, and transactions.
+The `/monitor` endpoints are for internal Langflow functionality, primarily related to running flows in the **Playground**, storing chat history, and generating flow logs.
 
-## Get Vertex builds
+This information is primarily for those who are building custom components or contributing to the Langflow codebase in a way that requires calling or understanding these endpoints.
+
+For typical application development with Langflow, there are more appropriate options for monitoring, debugging, and memory management.
+For more information, see the following:
+
+* [Logs](/logging): Langflow log storage locations, customization options, and where to view logs in the visual editor
+* [Test flows in the Playground](/concepts-playground): Run flows and inspect message history
+* [Memory management options](/memory): Langflow storage locations and options, including the database, cache, and chat history
+
+## Vertex builds
+
+The Vertex build endpoints (`/monitor/builds`) are exclusively for **Playground** functionality.
+
+When you run a flow in the **Playground**, Langflow calls the `/build/$FLOW_ID/flow` endpoint in [chat.py](https://github.com/langflow-ai/langflow/blob/main/src/backend/base/langflow/api/v1/chat.py#L143). This call retrieves the flow data, builds a graph, and executes the graph. As each component (or node) is executed, the `build_vertex` function calls `build_and_run`, which may call the individual components' `def_build` method, if it exists. If a component doesn't have a `def_build` function, the build still returns a component.
+
+The `build` function allows components to execute logic at runtime. For example, the [**Recursive Character Text Splitter** component](https://github.com/langflow-ai/langflow/blob/main/src/backend/base/langflow/components/langchain_utilities/recursive_character.py) is a child of the `LCTextSplitterComponent` class. When text needs to be processed, the parent class's `build` method is called, which creates a `RecursiveCharacterTextSplitter` object and uses it to split the text according to the defined parameters. The split text is then passed on to the next component. This all occurs when the component is built.
+
+### Get Vertex builds
 
 Retrieve Vertex builds for a specific flow.
 
@@ -384,7 +401,7 @@ curl -X GET \
 
 </details>
 
-## Delete Vertex builds
+### Delete Vertex builds
 
 Delete Vertex builds for a specific flow.
 
@@ -404,7 +421,12 @@ curl -X DELETE \
 
 </details>
 
-## Get messages
+## Messages endpoints
+
+The `/monitor/messages` endpoints store, retrieve, edit, and delete records in the message table in [`langflow.db`](/memory)
+Typically, these are called implicitly when running flows that produce message history, or when inspecting and modifying **Playground** memories.
+
+### Get messages
 
 Retrieve a list of all messages:
 
@@ -466,7 +488,7 @@ curl -X GET \
 
 </details>
 
-## Delete messages
+### Delete messages
 
 Delete specific messages by their IDs.
 
@@ -490,7 +512,7 @@ curl -v -X DELETE \
 
 </details>
 
-## Update message
+### Update message
 
 Update a specific message by its ID.
 
@@ -540,7 +562,7 @@ curl -X PUT \
 
 </details>
 
-## Update session ID
+### Update session ID
 
 Update the session ID for messages.
 
@@ -591,7 +613,7 @@ curl -X PATCH \
 
 </details>
 
-## Delete messages by session
+### Delete messages by session
 
 Delete all messages for a specific session.
 
@@ -614,6 +636,7 @@ HTTP/1.1 204 No Content
 ## Get transactions
 
 Retrieve all transactions, which are interactions between components, for a specific flow.
+This information is also available in [flow logs](/logging).
 
 ```bash
 curl -X GET \
@@ -651,4 +674,5 @@ curl -X GET \
 
 ## See also
 
+- [Use voice mode](/concepts-voice-mode)
 - [Session ID](/session-id)

--- a/docs/docs/API-Reference/api-reference-api-examples.mdx
+++ b/docs/docs/API-Reference/api-reference-api-examples.mdx
@@ -186,9 +186,198 @@ curl -X GET \
   -H "x-api-key: $LANGFLOW_API_KEY"
 ```
 
+## Available endpoints
+
+Because you can run Langflow as either an IDE (frontend and backend) or a runtime (headless, backend-only), it serves endpoints that support frontend and backend operations.
+Many endpoints are for orchestration between the frontend and backend, reading and writing to the Langflow database, or enabling frontend functionality, like the **Playground**.
+Unless you are contributing to the Langflow codebase, you won't directly call most of the Langflow endpoints.
+
+For application development, the most commonly used endpoints are the `/run` and `/webhook` [flow trigger endpoints](/api-flows-run).
+For some use cases, you might use some other endpoints, such as the `/files` endpoints to use files in flows.
+
+To help you explore the available endpoints, the following lists are sorted by primary use case, although some endpoints might support multiple use cases.
+
+<Tabs>
+<TabItem value="Application development" label="Application development" default>
+
+The following endpoints are useful for developing applications with Langflow and administering Langflow deployments with one or more users.
+You will most often use the flow trigger endpoints.
+Other endpoints are helpful for specific use cases, such as administration and flow management in runtime deployments that don't have a visual editor.
+
+* [Flow trigger endpoints](/api-flows-run):
+  * POST `/v1/run/{flow_id_or_name}`: Run a flow.
+  * POST `/v1/run/advanced/{flow_id}`: Advanced run with explicit `inputs`, `outputs`, `tweaks`, and optional `session_id`.
+  * POST `/v1/webhook/{flow_id_or_name}`: Trigger a flow via webhook payload.
+
+* Deployment details:
+  * GET `/v1/version`: Return Langflow version. See [Get version](/api-reference-api-examples#get-version).
+  * GET `/v1/config`: Return deployment configuration. See [Get configuration](/api-reference-api-examples#get-configuration).
+
+* [Projects endpoints](/api-projects):
+  * POST `/v1/projects/`: Create a project.
+  * GET `/v1/projects/`: List projects.
+  * GET `/v1/projects/{project_id}`: Read a project (with paginated flows support).
+  * PATCH `/v1/projects/{project_id}`: Update project info and membership.
+  * DELETE `/v1/projects/{project_id}`: Delete a project.
+  * GET `/v1/projects/download/{project_id}`: Export all flows in a project as ZIP.
+  * POST `/v1/projects/upload/`: Import a project ZIP (creates project and flows).
+  * GET `/v1/starter-projects/`: Return a list of templates.
+
+* [Files endpoints](/api-files):
+  * Files (v1)
+    * POST `/v1/files/upload/{flow_id}`: Upload a file to a specific flow.
+    * GET `/v1/files/download/{flow_id}/{file_name}`: Download a file from a flow.
+    * GET `/v1/files/images/{flow_id}/{file_name}`: Stream an image from a flow.
+    * GET `/v1/files/profile_pictures/{folder_name}/{file_name}`: Get a profile picture asset.
+    * GET `/v1/files/profile_pictures/list`: List available profile picture assets.
+    * GET `/v1/files/list/{flow_id}`: List files for a flow.
+    * DELETE `/v1/files/delete/{flow_id}/{file_name}`: Delete a file from a flow.
+  * Files (v2)
+    * POST `/v2/files` (alias `/v2/files/`): Upload a file owned by the current user.
+    * GET `/v2/files` (alias `/v2/files/`): List files owned by the current user.
+    * DELETE `/v2/files/batch/`: Delete multiple files by IDs.
+    * POST `/v2/files/batch/`: Download multiple files as a ZIP by IDs.
+    * GET `/v2/files/{file_id}`: Download a file by ID (or return raw content internally).
+    * PUT `/v2/files/{file_id}`: Edit a file name by ID.
+    * DELETE `/v2/files/{file_id}`: Delete a file by ID.
+    * DELETE `/v2/files` (alias `/v2/files/`): Delete all files for the current user.
+
+* [API keys and authentication](/api-keys-and-authentication):
+  * GET `/v1/api_key/`: List API keys for the current user.
+  * POST `/v1/api_key/`: Create a new API key.
+  * DELETE `/v1/api_key/{api_key_id}`: Delete an API key.
+  * POST `/v1/api_key/store`: Save an encrypted Store API key (cookie set).
+
+* [Flow management endpoints](/api-flows):
+  * POST `/v1/flows/`: Create a flow.
+  * GET `/v1/flows/`: List flows (supports pagination and filters).
+  * GET `/v1/flows/{flow_id}`: Read a flow by ID.
+  * GET `/v1/flows/public_flow/{flow_id}`: Read a public flow by ID.
+  * PATCH `/v1/flows/{flow_id}`: Update a flow.
+  * DELETE `/v1/flows/{flow_id}`: Delete a flow.
+  * POST `/v1/flows/batch/`: Create multiple flows.
+  * POST `/v1/flows/upload/`: Import flows from a JSON file.
+  * DELETE `/v1/flows/`: Delete multiple flows by IDs.
+  * POST `/v1/flows/download/`: Export flows to a ZIP file.
+  * GET `/v1/flows/basic_examples/`: List basic example flows.
+
+* [Users endpoints](/api-users):
+  * POST `/v1/users/`: Add a user (superuser required when auth enabled).
+  * GET `/v1/users/whoami`: Return the current authenticated user.
+  * GET `/v1/users/`: List all users (superuser required).
+  * PATCH `/v1/users/{user_id}`: Update a user (with role checks).
+  * PATCH `/v1/users/{user_id}/reset-password`: Reset own password.
+  * DELETE `/v1/users/{user_id}`: Delete a user (cannot delete yourself).
+
+</TabItem>
+<TabItem value="Custom components" label="Custom components">
+
+You might use these endpoints when developing custom Langflow components for your own use or to share with the Langflow community:
+
+* Develop custom components:
+    * GET `/v1/all`: Return all available Langflow component types. See [Get all components](/api-reference-api-examples#get-all-components).
+    * POST `/v1/custom_component`: Build a custom component from code and return its node.
+    * POST `/v1/custom_component/update`: Update an existing custom component's build config and outputs.
+    * POST `/v1/validate/code`: Validate a Python code snippet for a custom component.
+
+* Langflow Store:
+    * GET `/v1/store/check/`: Return whether the Store feature is enabled.
+    * GET `/v1/store/check/api_key`: Check if a Store API key exists and is valid.
+    * POST `/v1/store/components/`: Share a component to the Store.
+    * PATCH `/v1/store/components/{component_id}`: Update a shared component.
+    * GET `/v1/store/components/`: List available Store components (filters supported).
+    * GET `/v1/store/components/{component_id}`: Download a component from the Store.
+    * GET `/v1/store/tags`: List Store tags.
+    * GET `/v1/store/users/likes`: List components liked by the current user.
+    * POST `/v1/store/users/likes/{component_id}`: Like a component.
+
+</TabItem>
+<TabItem value="MCP" label="MCP servers and clients">
+
+The following endpoints are for managing Langflow MCP servers, both Langflow-hosted MCP servers and external MCP server connections:
+
+* **MCP (global)**:
+  * HEAD `/v1/mcp/sse`: Health check for MCP SSE.
+  * GET `/v1/mcp/sse`: Open SSE stream for MCP server events.
+  * POST `/v1/mcp/`: Post messages to the MCP server.
+
+* **MCP (project-specific)**:
+  * GET `/v1/mcp/project/{project_id}`: List MCP-enabled tools and project auth settings.
+  * HEAD `/v1/mcp/project/{project_id}/sse`: Health check for project SSE.
+  * GET `/v1/mcp/project/{project_id}/sse`: Open project-scoped MCP SSE.
+  * POST `/v1/mcp/project/{project_id}`: Post messages to project MCP server.
+  * POST `/v1/mcp/project/{project_id}/` (trailing slash): Same as above.
+  * PATCH `/v1/mcp/project/{project_id}`: Update MCP settings for flows and project auth settings.
+  * POST `/v1/mcp/project/{project_id}/install`: Install MCP client config for Cursor/Windsurf/Claude (local only).
+  * GET `/v1/mcp/project/{project_id}/installed`: Check which clients have MCP config installed.
+
+</TabItem>
+<TabItem value="Codebase contribution" label="Codebase development">
+
+The following endpoints are most often used when contributing to the Langflow codebase, and you need to understand or call endpoints that support frontend-to-backend orchestration or other internal functionality.
+
+* Base (metadata):
+  * GET `/v1/all`: Return all available Langflow component types. See [Get all components](/api-reference-api-examples#get-all-components).
+  * GET `/v1/version`: Return Langflow version. See [Get version](/api-reference-api-examples#get-version).
+  * GET `/v1/config`: Return deployment configuration. See [Get configuration](/api-reference-api-examples#get-configuration).
+  * GET `/v1/starter-projects/`: Return a list of templates.
+
+* [Build endpoints](/api-build) (internal editor support):
+  * POST `/v1/build/{flow_id}/flow`: Start a flow build and return a job ID.
+  * GET `/v1/build/{job_id}/events`: Stream or fetch build events.
+  * POST `/v1/build/{job_id}/cancel`: Cancel a build job.
+  * POST `/v1/build_public_tmp/{flow_id}/flow`: Build a public flow without auth.
+  * POST `/v1/validate/prompt`: Validate a prompt payload.
+
+* [API keys and authentication](/api-keys-and-authentication):
+  * POST `/v1/login`: Login and set tokens as cookies.
+  * GET `/v1/auto_login`: Auto-login (if enabled) and set tokens.
+  * POST `/v1/refresh`: Refresh tokens using refresh cookie.
+  * POST `/v1/logout`: Logout and clear cookies.
+
+* [Monitor endpoints](/api-monitor):
+  * GET `/v1/monitor/builds`: Get vertex builds for a flow.
+  * DELETE `/v1/monitor/builds`: Delete vertex builds for a flow.
+  * GET `/v1/monitor/messages/sessions`: List message session IDs (auth required).
+  * GET `/v1/monitor/messages`: List messages with optional filters.
+  * DELETE `/v1/monitor/messages`: Delete messages by IDs (auth required).
+  * PUT `/v1/monitor/messages/{message_id}`: Update a message.
+  * PATCH `/v1/monitor/messages/session/{old_session_id}`: Change a session ID for all messages in that session.
+  * DELETE `/v1/monitor/messages/session/{session_id}`: Delete messages by session.
+  * GET `/v1/monitor/transactions`: List transactions for a flow (paginated).
+
+* Variables:
+  * POST `/v1/variables/`: Create a variable, such as an API key, for the user.
+  * GET `/v1/variables/`: List variables for the user.
+  * PATCH `/v1/variables/{variable_id}`: Update a variable.
+  * DELETE `/v1/variables/{variable_id}`: Delete a variable.
+
+* [Use voice mode](/concepts-voice-mode):
+  * WS `/v1/voice/ws/flow_as_tool/{flow_id}`: Bi-directional voice session exposing the flow as a tool.
+  * WS `/v1/voice/ws/flow_as_tool/{flow_id}/{session_id}`: Same as above with explicit session ID.
+  * WS `/v1/voice/ws/flow_tts/{flow_id}`: Voice-to-text session that runs a flow and returns TTS.
+  * WS `/v1/voice/ws/flow_tts/{flow_id}/{session_id}`: Same as above with explicit session ID.
+  * GET `/v1/voice/elevenlabs/voice_ids`: List available ElevenLabs voice IDs for the user.
+
+</TabItem>
+<TabItem value="Deprecated" label="Deprecated">
+
+The following endpoints are deprecated:
+
+* POST `/v1/predict/{flow_id}`: Use [`/v1/run/{flow_id}`](/api-flows-run) instead.
+* POST `/v1/process/{flow_id}`: Use [`/v1/run/{flow_id}`](/api-flows-run) instead.
+* GET `/v1/task/{task_id}`: Deprecated functionality.
+* POST `/v1/upload/{flow_id}`: Use [`/files`](/api-files) instead.
+* POST `/v1/build/{flow_id}/vertices`: Replaced by [`/monitor/builds`](/api-monitor).
+* POST `/v1/build/{flow_id}/vertices/{vertex_id}`: Replaced by [`/monitor/builds`](/api-monitor).
+* GET `/v1/build/{flow_id}/{vertex_id}/stream`: Replaced by [`/monitor/builds`](/api-monitor).
+
+</TabItem>
+</Tabs>
+
 ## Next steps
 
-- Use the Langflow API to [run a flow](/api-flows-run).
-- Use the Langflow API to [upload files](/api-files).
-- Use the Langflow API to [get flow logs](/api-logs).
-- Explore all endpoints in the [Langflow API specification](/api).
+* Use the Langflow API to [run a flow](/api-flows-run).
+* Use the Langflow API to [upload files](/api-files).
+* Use the Langflow API to [get flow logs](/api-logs).
+* Explore all endpoints in the [Langflow API specification](/api).

--- a/docs/docs/Components/components-data.mdx
+++ b/docs/docs/Components/components-data.mdx
@@ -114,7 +114,7 @@ For more information about uploading files and working with files in flows, see 
 
 ### File type and size limits
 
-By default, the maximum file size is 100 MB.
+By default, the maximum file size is 1024 MB.
 To modify this value, change the `--max-file-size-upload` [environment variable](/environment-variables).
 
 <details>

--- a/docs/docs/Concepts/concepts-file-management.mdx
+++ b/docs/docs/Concepts/concepts-file-management.mdx
@@ -93,7 +93,7 @@ For videos, see the **Twelve Labs** and **YouTube** [bundles](/components-bundle
 
 ## Set the maximum file size
 
-By default, the maximum file size is 100 MB.
+By default, the maximum file size is 1024 MB.
 To modify this value, change the `--max-file-size-upload` [environment variable](/environment-variables).
 
 ## See also

--- a/docs/docs/Concepts/concepts-playground.mdx
+++ b/docs/docs/Concepts/concepts-playground.mdx
@@ -29,14 +29,7 @@ For flows that require another type of input, such as a webhook event, file uplo
 
 ![Playground window](/img/playground.png)
 
-<details>
-<summary>Playground mechanics</summary>
-
-When you run a flow in the **Playground**, Langflow calls the `/build/$FLOW_ID/flow` endpoint in [chat.py](https://github.com/langflow-ai/langflow/blob/main/src/backend/base/langflow/api/v1/chat.py#L143). This call retrieves the flow data, builds a graph, and executes the graph. As each component (or node) is executed, the `build_vertex` function calls `build_and_run`, which may call the individual components' `def_build` method, if it exists. If a component doesn't have a `def_build` function, the build still returns a component.
-
-The `build` function allows components to execute logic at runtime. For example, the [**Recursive Character Text Splitter** component](https://github.com/langflow-ai/langflow/blob/main/src/backend/base/langflow/components/langchain_utilities/recursive_character.py) is a child of the `LCTextSplitterComponent` class. When text needs to be processed, the parent class's `build` method is called, which creates a `RecursiveCharacterTextSplitter` object and uses it to split the text according to the defined parameters. The split text is then passed on to the next component. This all occurs when the component is built.
-
-</details>
+For technical details about how the **Playground** works, see [Monitor endpoints](/api-monitor).
 
 ### Review agent logic
 


### PR DESCRIPTION
Release 1.5.0.post2 includes the change for increasing the default file size.
This updates the value in docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API, Components, and Concepts docs to reflect the new default upload size limit of 1024 MB (up from 100 MB).
  * Clarifies limits for image and general file uploads across v1/v2 flows; override instructions via environment configuration remain unchanged.
  * Aligns all end-user guidance with current service defaults; no functional or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->