### PR TITLE
feat: Support multiple providers in model filtering

### DIFF
--- a/src/backend/base/langflow/api/v1/models.py
+++ b/src/backend/base/langflow/api/v1/models.py
@@ -10,7 +10,7 @@ router = APIRouter(prefix="/models", tags=["Models"])
 @router.get("", status_code=200)
 async def list_models(
     *,
-    provider: str | None = None,
+    provider: list[str] | None = None,
     model_name: str | None = None,
     model_type: str | None = None,
     include_unsupported: bool = False,

--- a/src/backend/base/langflow/base/models/unified_models.py
+++ b/src/backend/base/langflow/base/models/unified_models.py
@@ -7,7 +7,7 @@ MODELS_DETAILED = [ANTHROPIC_MODELS_DETAILED, OPENAI_MODELS_DETAILED, GOOGLE_GEN
 
 
 def get_unified_models_detailed(
-    provider: str | None = None,
+    provider: list[str] | None = None,
     model_name: str | None = None,
     model_type: str | None = None,
     include_unsupported: bool | None = None,
@@ -17,8 +17,8 @@ def get_unified_models_detailed(
 
     Parameters
     ----------
-    provider : str | None
-        If given, only models from this provider are returned.
+    provider : list[str] | None
+        If given, only models from these providers are returned.
     model_name : str | None
         If given, only the model with this exact name is returned.
     model_type : str | None
@@ -49,7 +49,7 @@ def get_unified_models_detailed(
         if (not include_unsupported) and md.get("not_supported", False):
             continue
 
-        if provider and md.get("provider") != provider:
+        if provider and md.get("provider") not in provider:
             continue
         if model_name and md.get("name") != model_name:
             continue

--- a/src/backend/tests/unit/test_unified_models.py
+++ b/src/backend/tests/unit/test_unified_models.py
@@ -23,7 +23,7 @@ def test_default_excludes_not_supported():
 
 
 def test_filter_by_provider():
-    result = get_unified_models_detailed(provider="Anthropic")
+    result = get_unified_models_detailed(provider=["Anthropic"])
     # Only one provider should be returned
     assert len(result) == 1
     assert result[0]["provider"] == "Anthropic"


### PR DESCRIPTION
Updated API, model utilities, and input logic to accept a list of providers for model filtering instead of a single provider string. Refactored model option generation to use unified provider-based model lists and adjusted tests accordingly.