### PR TITLE
feat: Add not contains filter operator in DataFrame Operations Component

### DIFF
--- a/src/backend/base/langflow/components/processing/dataframe_operations.py
+++ b/src/backend/base/langflow/components/processing/dataframe_operations.py
@@ -79,7 +79,7 @@ class DataFrameOperationsComponent(Component):
         DropdownInput(
             name="filter_operator",
             display_name="Filter Operator",
-            options=["equals", "not equals", "contains", "starts with", "ends with", "greater than", "less than"],
+            options=["equals", "not equals", "contains", "not contains", "starts with", "ends with", "greater than", "less than"],
             value="equals",
             info="The operator to apply for filtering rows.",
             advanced=False,
@@ -254,6 +254,8 @@ class DataFrameOperationsComponent(Component):
             mask = column != filter_value
         elif operator == "contains":
             mask = column.astype(str).str.contains(str(filter_value), na=False)
+        elif operator == "not contains":
+            mask = ~column.astype(str).str.contains(str(filter_value), na=False)
         elif operator == "starts with":
             mask = column.astype(str).str.startswith(str(filter_value), na=False)
         elif operator == "ends with":


### PR DESCRIPTION
This pull request adds support for a new "not contains" filter operator in the `DataFrameOperationsComponent`, allowing users to filter rows where a column does not contain a specified value. The change updates both the UI options and the filtering logic.

**Enhancements to DataFrame filtering:**

* Added "not contains" to the `filter_operator` dropdown options in the `DataFrameOperationsComponent`, expanding the available filter types for users.
* Implemented the "not contains" operator in the `filter_rows_by_value` method, enabling filtering of rows where the column value does not contain the specified filter value.