### PR TITLE
docs: update path to config dir instead of cache

### DIFF
--- a/docs/docs/Components/components-vector-stores.mdx
+++ b/docs/docs/Components/components-vector-stores.mdx
@@ -263,7 +263,7 @@ After running the flow once, you can click <Icon name="TextSearch" aria-hidden="
 ### Local DB
 
 The **Local DB** component reads and writes to a persistent, in-memory Chroma DB instance intended for use with Langflow.
-It has separate modes for reads and writes, automatic collection management, and default persistence in your Langflow cache directory.
+It has separate modes for reads and writes, automatic collection management, and default persistence in your Langflow configuration directory.
 
 ![A basic flow with a Local DB component in Retrieve mode.](/img/component-local-db.png)
 
@@ -280,7 +280,7 @@ The following parameters are available in **Ingest** mode:
 | Name | Type | Description |
 |------|------|-------------|
 | **Name Your Collection** (`collection_name`) | String | Input parameter. The name for your Chroma vector store collection. Default: `langflow`. Only available in **Ingest** mode. |
-| **Persist Directory** (`persist_directory`) | String | Input parameter. The base directory where you want to create and persist the vector store. If you use the **Local DB** component in multiple flows or to create multiple collections, collections are stored at `$PERSISTENT_DIRECTORY/vector_stores/$COLLECTION_NAME`. If not specified, the default location is your Langflow cache directory (`LANGFLOW_CONFIG_DIR`). For more information, see [Memory management options](/memory). |
+| **Persist Directory** (`persist_directory`) | String | Input parameter. The base directory where you want to create and persist the vector store. If you use the **Local DB** component in multiple flows or to create multiple collections, collections are stored at `$PERSISTENT_DIRECTORY/vector_stores/$COLLECTION_NAME`. If not specified, the default location is your Langflow configuration directory (`LANGFLOW_CONFIG_DIR`). For more information, see [Memory management options](/memory). |
 | **Embedding** (`embedding`) | Embeddings | Input parameter. The embedding function to use for the vector store. |
 | **Allow Duplicates** (`allow_duplicates`) | Boolean | Input parameter. If true (default), writes don't check for existing duplicates in the collection, allowing you to store multiple copies of the same content. If false, writes won't add documents that match existing documents already present in the collection. If false, it can strictly enforce deduplication by searching the entire collection or only search the number of records, specified in `limit`. Only available in **Ingest** mode. |
 | **Ingest Data** (`ingest_data`) | Data or DataFrame | Input parameter. The records to write to the collection. Records are embedded and indexed for semantic search. Only available in **Ingest** mode. |
@@ -295,7 +295,7 @@ The following parameters are available in **Retrieve** mode:
 
 | Name | Type | Description |
 |------|------|-------------|
-| **Persist Directory** (`persist_directory`) | String | Input parameter. The base directory where you want to create and persist the vector store. If you use the **Local DB** component in multiple flows or to create multiple collections, collections are stored at `$PERSISTENT_DIRECTORY/vector_stores/$COLLECTION_NAME`. If not specified, the default location is your Langflow cache directory (`LANGFLOW_CONFIG_DIR`). For more information, see [Memory management options](/memory). |
+| **Persist Directory** (`persist_directory`) | String | Input parameter. The base directory where you want to create and persist the vector store. If you use the **Local DB** component in multiple flows or to create multiple collections, collections are stored at `$PERSISTENT_DIRECTORY/vector_stores/$COLLECTION_NAME`. If not specified, the default location is your Langflow configuration directory (`LANGFLOW_CONFIG_DIR`). For more information, see [Memory management options](/memory). |
 | **Existing Collections** (`existing_collections`) | String | Input parameter. Select a previously-created collection to search. Only available in **Retrieve** mode. |
 | **Embedding** (`embedding`) | Embeddings | Input parameter. The embedding function to use for the vector store. |
 | **Search Type** (`search_type`) | String | Input parameter. The type of search to perform, either `Similarity` or `MMR`. Only available in **Retrieve** mode. |

--- a/docs/docs/Concepts/concepts-flows.mdx
+++ b/docs/docs/Concepts/concepts-flows.mdx
@@ -104,10 +104,10 @@ To get back to the **Projects** page after editing a flow, click the project nam
 
 By default, flows and [flow logs](/logging) are stored on local disk at the following default locations:
 
-- **macOS Desktop**: `/Users/<username>/.langflow/cache`
-- **Windows Desktop**: `C:\Users\<username>\AppData\Roaming\com.Langflow\cache`
-- **OSS macOS/Windows/Linux/WSL (uv pip install)**: `<path_to_venv>/lib/python3.12/site-packages/langflow/cache`
-- **OSS macOS/Windows/Linux/WSL (git clone)**: `<path_to_clone>/src/backend/base/langflow/cache`
+- **macOS Desktop**: `/Users/<username>/Library/Application Support/langflow/`
+- **Windows Desktop**: `C:\Users\<username>\AppData\Roaming\langflow\`
+- **OSS macOS/Windows/Linux/WSL (uv pip install)**: `<path_to_venv>/lib/python3.12/site-packages/langflow/`
+- **OSS macOS/Windows/Linux/WSL (git clone)**: `<path_to_clone>/src/backend/base/langflow/`
 
 The overall storage location can be customized with the `LANGFLOW_CONFIG_DIR` environment variable, and the flow log storage location can be customized separately with the `LANGFLOW_LOG_FILE` environment variable.
 

--- a/docs/docs/Configuration/configuration-cli.mdx
+++ b/docs/docs/Configuration/configuration-cli.mdx
@@ -152,12 +152,12 @@ langflow api-key
 
 ### langflow copy-db
 
-Copies the Langflow database files from the cache directory to the current Langflow installation directory, which is the directory containing `__main__.py`.
+Copies the Langflow database files from the configuration directory to the current Langflow installation directory, which is the directory containing `__main__.py`.
 You can find the copy target directory by running `which langflow`.
 
-The following files are copied if they exist in the cache directory:
+The following files are copied if they exist in the configuration directory:
 
-* `langflow.db`: The main Langflow database, stored in the user cache directory
+* `langflow.db`: The main Langflow database, stored in the user configuration directory
 * `langflow-pre.db`: The pre-release database, if it exists
 
 <Tabs groupId="Invocation">

--- a/docs/docs/Develop/install-custom-dependencies.mdx
+++ b/docs/docs/Develop/install-custom-dependencies.mdx
@@ -14,8 +14,8 @@ The Langflow codebase uses two `pyproject.toml` files to manage dependencies, wi
 
 To add dependencies to Langflow Desktop, add an entry for the package to the application's `requirements.txt` file:
 
-    * On macOS, the file is located at `/Users/USER/.langflow/data/requirements.txt`.
-    * On Windows, the file is located at `C:\Users\USER\AppData\Roaming\com.Langflow\data\requirements.txt`.
+    * On macOS, the file is located at `/Users/USER/Library/Application Support/langflow/requirements.txt`.
+    * On Windows, the file is located at `C:\Users\USER\AppData\Roaming\langflow\requirements.txt`.
 
 Add each dependency to `requirements.txt` on its own line in the format `DEPENDENCY==VERSION`, such as `docling==2.40.0`.
 

--- a/docs/docs/Develop/logging.mdx
+++ b/docs/docs/Develop/logging.mdx
@@ -16,10 +16,10 @@ Langflow also produces logfiles for flows.
 
 The default logfile storage location depends on your operating system:
 
-- **macOS Desktop**:`/Users/<username>/.langflow/cache`
-- **Windows Desktop**:`C:\Users\<username>\AppData\Roaming\com.Langflow\cache`
-- **OSS macOS/Windows/Linux/WSL (`uv pip install`)**: `<path_to_venv>/lib/python3.12/site-packages/langflow/cache`
-- **OSS macOS/Windows/Linux/WSL (`git clone`)**: `<path_to_clone>/src/backend/base/langflow/cache`
+- **macOS Desktop**:`/Users/<username>/Library/Application Support/langflow/`
+- **Windows Desktop**:`C:\Users\<username>\AppData\Roaming\langflow\`
+- **OSS macOS/Windows/Linux/WSL (`uv pip install`)**: `<path_to_venv>/lib/python3.12/site-packages/langflow/`
+- **OSS macOS/Windows/Linux/WSL (`git clone`)**: `<path_to_clone>/src/backend/base/langflow/`
 
 To customize log storage, see [Configure log options](#configure-log-options).
 

--- a/docs/docs/Develop/memory.mdx
+++ b/docs/docs/Develop/memory.mdx
@@ -10,11 +10,11 @@ This includes essential Langflow database tables, file management, and caching, 
 
 Langflow supports both local memory and external memory options.
 
-Langflow's default storage option is a [SQLite](https://www.sqlite.org/) database stored in your system's cache directory.
+Langflow's default storage option is a [SQLite](https://www.sqlite.org/) database stored in your system's configuration directory.
 The default storage path depends on your operation system and installation method:
 
-- **macOS Desktop**: `/Users/<username>/.langflow/data/database.db`
-- **Windows Desktop**: `C:\Users\<name>\AppData\Roaming\com.Langflow\data\langflow.db`
+- **macOS Desktop**: `/Users/<username>/Library/Application Support/langflow/langflow.db`
+- **Windows Desktop**: `C:\Users\<username>\AppData\Roaming\langflow\langflow.db`
 - **OSS macOS/Windows/Linux/WSL (`uv pip install`)**: `<path_to_venv>/lib/python3.12/site-packages/langflow/langflow.db` (Python version may vary)
 - **OSS macOS/Windows/Linux/WSL (`git clone`)**: `<path_to_clone>/src/backend/base/langflow/langflow.db`
 


### PR DESCRIPTION
Update docs to reflect the proposed changes to the default `LANGFLOW_DIR` location in PR #8656 

Current:
macOS | ~/Library/Caches/langflow/
Linux | ~/.cache/langflow/
Windows | %LOCALAPPDATA%\langflow\Cache\

Proposed:
macOS | ~/Library/Application Support/langflow/
Linux | ~/.config/langflow/
Windows | %APPDATA%\langflow\

Refer to the directory as the "configuration" directory.