### PR TITLE
fix: Use Runnable's asynchronous methods to prevent blocking the main…

### DIFF
--- a/src/backend/base/langflow/base/models/model.py
+++ b/src/backend/base/langflow/base/models/model.py
@@ -288,7 +288,7 @@ class LCModelComponent(Component):
             else:
                 session_id = None
             model_message = Message(
-                text=await runnable.astream(inputs),
+                text=runnable.astream(inputs),
                 sender=MESSAGE_SENDER_AI,
                 sender_name="AI",
                 properties={"icon": self.icon, "state": "partial"},

--- a/src/backend/base/langflow/base/models/model.py
+++ b/src/backend/base/langflow/base/models/model.py
@@ -252,7 +252,7 @@ class LCModelComponent(Component):
             if stream:
                 lf_message, result = await self._handle_stream(runnable, inputs)
             else:
-                message = runnable.invoke(inputs)
+                message = await runnable.ainvoke(inputs)
                 result = message.content if hasattr(message, "content") else message
             if isinstance(message, AIMessage):
                 status_message = self.build_status_message(message)
@@ -288,7 +288,7 @@ class LCModelComponent(Component):
             else:
                 session_id = None
             model_message = Message(
-                text=runnable.stream(inputs),
+                text=await runnable.astream(inputs),
                 sender=MESSAGE_SENDER_AI,
                 sender_name="AI",
                 properties={"icon": self.icon, "state": "partial"},
@@ -298,7 +298,7 @@ class LCModelComponent(Component):
             lf_message = await self.send_message(model_message)
             result = lf_message.text
         else:
-            message = runnable.invoke(inputs)
+            message = await runnable.ainvoke(inputs)
             result = message.content if hasattr(message, "content") else message
         return lf_message, result
 


### PR DESCRIPTION
Use Runnable's asynchronous methods to prevent blocking the main.The text_response method in the new version has been changed to asynchronous, but the corresponding LangChain calls remain synchronous. This may cause the service to get stuck when calling large models.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migrated chat and streaming processing to fully asynchronous execution, unifying streamed and non-streamed paths without altering outputs or interfaces.
  - Improves responsiveness and smoothness during live streaming and chat interactions, especially under load.
  - Maintains existing behavior and return formats; no user-facing configuration changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->