### PR TITLE
fix: file upload test

### DIFF
--- a/src/frontend/tests/core/unit/fileUploadComponent.spec.ts
+++ b/src/frontend/tests/core/unit/fileUploadComponent.spec.ts
@@ -596,17 +596,17 @@ test(
 );
 
 test(
-  "should show PNG file as disabled in file component",
+  "should show PSD file as disabled in file component",
   {
     tag: ["@release", "@workspace"],
   },
   async ({ page }) => {
     // Generate unique filenames for this test run
-    const pngFileName = generateRandomFilename();
+    const psdFileName = generateRandomFilename();
     const txtFileName = generateRandomFilename();
 
-    // Create PNG content (a simple 1x1 transparent PNG)
-    const pngFileContent = Buffer.from(
+    // Create PSD content (just a mock)
+    const psdFileContent = Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
       "base64",
     );
@@ -626,24 +626,24 @@ test(
     const title = await page.getByTestId("mainpage_title");
     expect(await title.textContent()).toContain("Files");
 
-    // Upload the PNG file
-    const fileChooserPromisePng = page.waitForEvent("filechooser");
+    // Upload the PSD file
+    const fileChooserPromisePsd = page.waitForEvent("filechooser");
     await page.getByTestId("upload-file-btn").click();
 
-    const fileChooserPng = await fileChooserPromisePng;
-    await fileChooserPng.setFiles([
+    const fileChooserPsd = await fileChooserPromisePsd;
+    await fileChooserPsd.setFiles([
       {
-        name: `${pngFileName}.png`,
-        mimeType: "image/png",
-        buffer: pngFileContent,
+        name: `${psdFileName}.psd`,
+        mimeType: "image/vnd.adobe.photoshop",
+        buffer: psdFileContent,
       },
     ]);
 
     // Wait for upload success message
     await expect(page.getByText("File uploaded successfully")).toBeVisible();
 
-    // Verify PNG file appears in the list
-    await expect(page.getByText(`${pngFileName}.png`)).toBeVisible();
+    // Verify PSD file appears in the list
+    await expect(page.getByText(`${psdFileName}.psd`)).toBeVisible();
 
     // Upload the TXT file
     const fileChooserPromiseTxt = page.waitForEvent("filechooser");
@@ -664,7 +664,7 @@ test(
     // Verify TXT file appears in the list
     await expect(page.getByText(`${txtFileName}.txt`)).toBeVisible();
 
-    // Step 2: Create a flow with File component and check if PNG file is disabled
+    // Step 2: Create a flow with File component and check if PSD file is disabled
     // Navigate to workspace page
     await page.getByText("Starter Project").first().click();
 
@@ -696,10 +696,10 @@ test(
 
     // Open the file management modal
     await page.getByTestId("button_open_file_management").click();
-    console.warn(pngFileName);
+    console.warn(psdFileName);
 
-    // Check if the PNG file has the disabled class (greyed out)
-    await expect(page.getByTestId(`file-item-${pngFileName}`)).toHaveClass(
+    // Check if the PSD file has the disabled class (greyed out)
+    await expect(page.getByTestId(`file-item-${psdFileName}`)).toHaveClass(
       /pointer-events-none cursor-not-allowed opacity-50/,
     );
 
@@ -708,9 +708,9 @@ test(
       /pointer-events-none cursor-not-allowed opacity-50/,
     );
 
-    // Verify the tooltip for PNG file states it's not supported
+    // Verify the tooltip for PSD file states it's not supported
     await page
-      .locator(`[data-testid="file-item-${pngFileName}"]`)
+      .locator(`[data-testid="file-item-${psdFileName}"]`)
       .locator("..")
       .hover();
 
@@ -718,11 +718,11 @@ test(
       page.getByText("Type not supported by component"),
     ).toBeVisible();
 
-    // Try to select the PNG file (should not change its state)
-    await expect(page.getByTestId(`checkbox-${pngFileName}`)).toBeDisabled();
+    // Try to select the PSD file (should not change its state)
+    await expect(page.getByTestId(`checkbox-${psdFileName}`)).toBeDisabled();
 
-    // Verify the PNG file checkbox remains unchecked
-    await expect(page.getByTestId(`checkbox-${pngFileName}`)).toHaveAttribute(
+    // Verify the PSD file checkbox remains unchecked
+    await expect(page.getByTestId(`checkbox-${psdFileName}`)).toHaveAttribute(
       "data-state",
       "unchecked",
     );
@@ -741,6 +741,6 @@ test(
 
     // Verify that only the TXT file was selected in the component
     await expect(page.getByText(`${txtFileName}.txt`)).toBeVisible();
-    await expect(page.getByText(`${pngFileName}.png`)).not.toBeVisible();
+    await expect(page.getByText(`${psdFileName}.psd`)).not.toBeVisible();
   },
 );

--- a/src/frontend/tests/extended/features/filterEdge-shard-1.spec.ts
+++ b/src/frontend/tests/extended/features/filterEdge-shard-1.spec.ts
@@ -71,7 +71,7 @@ test(
     const elementTestIds = [
       "input_outputChat Output",
       "dataAPI Request",
-      "vectorstoresAstra DB",
+      "vectorstoresAstra DB Graph",
       "langchain_utilitiesTool Calling Agent",
       "langchain_utilitiesConversationChain",
       "mem0Mem0 Chat Memory",
@@ -90,10 +90,11 @@ test(
     );
 
     await Promise.all(
-      elementTestIds.map((id) => {
+      elementTestIds.map(async (id) => {
         if (!expect(page.getByTestId(id).first()).toBeVisible()) {
           console.error(`${id} is not visible`);
         }
+        return expect(page.getByTestId(id).first()).toBeVisible();
       }),
     );
 


### PR DESCRIPTION
This pull request updates the unit test for the file upload component to use a PSD file instead of a PNG file when verifying that unsupported file types are disabled in the UI. The test logic and assertions have been adjusted accordingly to reflect the change from PNG to PSD.

**Test update to use PSD file instead of PNG:**

* Changed all references in the test from `pngFileName` and PNG-specific logic to `psdFileName` and PSD-specific logic, including file creation, upload, and UI assertions. [[1]](diffhunk://#diff-ae96c7cb442ce1a600dcdb410565fbd29d74cca9253d9db85232215270c680e9L599-R609) [[2]](diffhunk://#diff-ae96c7cb442ce1a600dcdb410565fbd29d74cca9253d9db85232215270c680e9L629-R646)
* Updated comments and test descriptions to indicate that the test now checks for PSD files being disabled, instead of PNG files.
* Modified assertions to verify that PSD files are shown as disabled, have the correct tooltip, and cannot be selected, replacing previous PNG-related checks. [[1]](diffhunk://#diff-ae96c7cb442ce1a600dcdb410565fbd29d74cca9253d9db85232215270c680e9L699-R702) [[2]](diffhunk://#diff-ae96c7cb442ce1a600dcdb410565fbd29d74cca9253d9db85232215270c680e9L711-R725)
* Ensured that the final assertion checks for the absence of the PSD file in the selected files list, instead of the PNG file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Updated file upload component unit tests to validate Adobe Photoshop (PSD) uploads, including MIME handling, list display, disabled states, tooltips, selection, and visibility rules.
  - Renamed scenarios and test data from PNG to PSD for clarity and consistency across the suite.
  - Enhanced assertions and debug logging to improve reliability and diagnostic insight during test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->