### PR TITLE
fix: set mcp_composer feature as true by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,11 @@ LANGFLOW_SUPERUSER_PASSWORD=
 # Values: true, false
 LANGFLOW_STORE_ENVIRONMENT_VARIABLES=
 
+# Should enable the MCP composer feature in MCP projects
+# Values: true, false
+# Default: true
+LANGFLOW_FEATURE_MCP_COMPOSER=
+
 # STORE_URL
 # Example: LANGFLOW_STORE_URL=https://api.langflow.store
 # LANGFLOW_STORE_URL=

--- a/src/backend/base/langflow/services/settings/feature_flags.py
+++ b/src/backend/base/langflow/services/settings/feature_flags.py
@@ -3,7 +3,7 @@ from pydantic_settings import BaseSettings
 
 class FeatureFlags(BaseSettings):
     mvp_components: bool = False
-    mcp_composer: bool = False
+    mcp_composer: bool = True
 
     class Config:
         env_prefix = "LANGFLOW_FEATURE_"

--- a/src/frontend/vite.config.mts
+++ b/src/frontend/vite.config.mts
@@ -54,7 +54,7 @@ export default defineConfig(({ mode }) => {
         envLangflow.LANGFLOW_AUTO_LOGIN ?? true,
       ),
       "process.env.LANGFLOW_FEATURE_MCP_COMPOSER": JSON.stringify(
-        envLangflow.LANGFLOW_FEATURE_MCP_COMPOSER ?? "false",
+        envLangflow.LANGFLOW_FEATURE_MCP_COMPOSER ?? "true",
       ),
     },
     plugins: [react(), svgr(), tsconfigPaths()],


### PR DESCRIPTION
This pull request updates the default value of the `mcp_composer` feature flag to be enabled by default in both the backend and frontend configurations. This change ensures that the MCP Composer feature is active unless explicitly disabled.

Feature flag default changes:

* [`src/backend/base/langflow/services/settings/feature_flags.py`](diffhunk://#diff-51d26be4a43125ee4cd2a62207be8a427230de64bd0bb35c2ad7f3c0ed6e2067L6-R6): Changed the default value of `mcp_composer` to `True` in the `FeatureFlags` settings class.
* [`src/frontend/vite.config.mts`](diffhunk://#diff-ab340a3f0e9f35aca70752ac59ff7dd1425d53300ada832a62e26f329673b25dL57-R57): Updated the frontend environment configuration to default `LANGFLOW_FEATURE_MCP_COMPOSER` to `"true"` instead of `"false"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP Composer is now enabled by default across the application, giving users immediate access without additional setup. Administrators can still disable or override this behavior via configuration if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->