### PR TITLE
fix: add dropdown click to general bugs test

### DIFF
--- a/src/frontend/tests/extended/regression/generalBugs-shard-6.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-6.spec.ts
@@ -22,8 +22,12 @@ test(
 
     await page.getByTestId("sidebar-custom-component-button").click();
 
+    await page.getByTestId("canvas_controls_dropdown").click();
+
     await page.getByTestId("zoom_out").click();
     await page.getByTestId("zoom_out").click();
+
+    await page.getByTestId("canvas_controls_dropdown").click();
 
     await page.getByTestId("div-generic-node").click();
     await page.getByTestId("code-button-modal").click();


### PR DESCRIPTION
This pull request makes a minor update to the regression test file by adding steps to interact with the canvas controls dropdown before and after zooming out. This helps ensure the dropdown functionality is properly tested in different UI states.

* Added two interactions with the `canvas_controls_dropdown` via `getByTestId`—one before and one after zooming out—to improve test coverage of the dropdown's behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded regression coverage to include interactions that toggle canvas controls around zoom actions.
  * Improved sequencing of UI interactions following sidebar custom component usage to better reflect real user flows.
  * Strengthened test reliability for canvas controls and zoom behavior without altering assertions or error handling.
  * Helps detect regressions earlier in complex UI scenarios, improving overall confidence in stability without impacting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->