### PR TITLE
fix: use custom file handler on chat view

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/components/chat-view.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/components/chat-view.tsx
@@ -8,6 +8,7 @@ import LangflowLogo from "@/assets/LangflowLogo.svg?react";
 import { TextEffectPerChar } from "@/components/ui/textAnimation";
 import CustomChatInput from "@/customization/components/custom-chat-input";
 import { ENABLE_IMAGE_ON_PLAYGROUND } from "@/customization/feature-flags";
+import useCustomUseFileHandler from "@/customization/hooks/use-custom-use-file-handler";
 import { track } from "@/customization/utils/analytics";
 import { useMessagesStore } from "@/stores/messagesStore";
 import { useUtilityStore } from "@/stores/utilityStore";
@@ -20,7 +21,6 @@ import type { ChatMessageType } from "../../../../../types/chat";
 import type { chatViewProps } from "../../../../../types/components";
 import FlowRunningSqueleton from "../../flow-running-squeleton";
 import useDragAndDrop from "../chatInput/hooks/use-drag-and-drop";
-import { useFileHandler } from "../chatInput/hooks/use-file-handler";
 import ChatMessage from "../chatMessage/chat-message";
 import { ChatScrollAnchor } from "./chat-scroll-anchor";
 
@@ -141,7 +141,7 @@ export default function ChatView({
       });
   }
 
-  const { files, setFiles, handleFiles } = useFileHandler(realFlowId);
+  const { files, setFiles, handleFiles } = useCustomUseFileHandler(realFlowId);
   const [isDragging, setIsDragging] = useState(false);
 
   const { dragOver, dragEnter, dragLeave } = useDragAndDrop(


### PR DESCRIPTION
This pull request updates the file handling logic in the `ChatView` component to use a custom file handler hook, improving flexibility for file uploads or drag-and-drop actions. The main change is swapping out the previous file handler for a customized version, which may support additional features or customizations.

File handling improvements:

* Replaced the import and usage of the standard `useFileHandler` hook with the new `useCustomUseFileHandler` hook in `chat-view.tsx`, updating both the import statement and the hook usage in the component. [[1]](diffhunk://#diff-c775c080404f14e69003e787738b3c5cbd0b8c5b5d476f8bae3fa0970ade4f12R11) [[2]](diffhunk://#diff-c775c080404f14e69003e787738b3c5cbd0b8c5b5d476f8bae3fa0970ade4f12L23) [[3]](diffhunk://#diff-c775c080404f14e69003e787738b3c5cbd0b8c5b5d476f8bae3fa0970ade4f12L144-R144)