### PR TITLE
fix: add bigger timeout to pokedex test

### DIFF
--- a/src/frontend/tests/core/integrations/Pokedex Agent.spec.ts
+++ b/src/frontend/tests/core/integrations/Pokedex Agent.spec.ts
@@ -35,10 +35,10 @@ withEventDeliveryModes(
     await page.getByTestId("button-send").last().click();
 
     const stopButton = page.getByRole("button", { name: "Stop" });
-    await stopButton.waitFor({ state: "visible", timeout: 30000 });
+    await stopButton.waitFor({ state: "visible", timeout: 40000 });
 
     if (await stopButton.isVisible()) {
-      await expect(stopButton).toBeHidden({ timeout: 120000 });
+      await expect(stopButton).toBeHidden({ timeout: 200000 });
     }
 
     const output = await page.getByTestId("div-chat-message").innerText();


### PR DESCRIPTION
This pull request makes a minor adjustment to the test timeout values in the Pokedex Agent integration test to improve reliability for slow-running scenarios.

* Increased the timeout for waiting for the "Stop" button to become visible from 30 seconds to 40 seconds, and for it to be hidden from 120 seconds to 200 seconds in `src/frontend/tests/core/integrations/Pokedex Agent.spec.ts`.