### PR TITLE
fix: increase timeout on saas pricing test

### DIFF
--- a/src/frontend/tests/core/integrations/SaaS Pricing.spec.ts
+++ b/src/frontend/tests/core/integrations/SaaS Pricing.spec.ts
@@ -35,7 +35,7 @@ withEventDeliveryModes(
     await initialGPTsetup(page);
 
     await page.getByTestId("button_run_chat output").click();
-    await page.waitForSelector("text=built successfully", { timeout: 30000 });
+    await page.waitForSelector("text=built successfully", { timeout: 120000 });
 
     await page.getByRole("button", { name: "Playground", exact: true }).click();
     await page


### PR DESCRIPTION
This pull request makes a minor adjustment to the SaaS Pricing integration test. The timeout for waiting for the "built successfully" message has been increased to reduce test flakiness and accommodate longer build times.

* Increased the timeout in `withEventDeliveryModes(` in `src/frontend/tests/core/integrations/SaaS Pricing.spec.ts` from 30 seconds to 120 seconds when waiting for "built successfully".