### PR TITLE
fix: change chatOutput drop coordinates on general bugs test

### DIFF
--- a/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
@@ -34,12 +34,8 @@ test(
     await page
       .getByTestId("input_outputChat Output")
       .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 0, y: 0 },
+        targetPosition: { x: 400, y: 100 },
       });
-
-    await page
-      .getByTestId("input_outputChat Output")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'));
 
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("chat input");


### PR DESCRIPTION
This pull request makes a small adjustment to a regression test in `generalBugs-shard-3.spec.ts`. The change updates the drag-and-drop behavior to use a specific target position and removes a redundant drag operation.

* Testing improvement: The drag-and-drop action for the node with test ID `input_outputChat Output` now targets coordinates `{ x: 400, y: 100 }` instead of `{ x: 0, y: 0 }`, and the duplicate drag operation has been removed to streamline the test.