### PR TITLE
fix: make session_id visible in Message History Retrieve mode

### DIFF
--- a/src/backend/base/langflow/components/helpers/memory.py
+++ b/src/backend/base/langflow/components/helpers/memory.py
@@ -19,10 +19,10 @@ class MemoryComponent(Component):
     documentation: str = "https://docs.langflow.org/components-helpers#message-history"
     icon = "message-square-more"
     name = "Memory"
-    default_keys = ["mode", "memory"]
+    default_keys = ["mode", "memory", "session_id"]
     mode_config = {
         "Store": ["message", "memory", "sender", "sender_name", "session_id"],
-        "Retrieve": ["n_messages", "order", "template", "memory"],
+        "Retrieve": ["n_messages", "order", "template", "memory", "session_id"],
     }
 
     inputs = [


### PR DESCRIPTION
## Summary
Fixes the UI bug where the `session_id` input field was hidden when the Message History component was in "Retrieve" mode, preventing users from dynamically setting the session ID for retrieving specific conversation history.

## Changes Made
- Added `session_id` to `default_keys` list to make it visible by default  
- Added `session_id` to the `Retrieve` mode configuration in `mode_config`
- Kept `advanced=True` as requested to maintain proper field categorization

## Root Cause
The issue was caused by dual visibility control:
1. `session_id` was missing from `mode_config["Retrieve"]` list
2. `session_id` was missing from `default_keys` list  

## Test Plan
- [ ] Verify session_id field is now visible in Message History component when in Retrieve mode
- [ ] Verify session_id field appears in advanced settings section  
- [ ] Verify the field accepts input and properly retrieves messages for specific sessions

Fixes #9464

## Technical Details
**Files modified:**
- `src/backend/base/langflow/components/helpers/memory.py`
  - Line 22: Added `session_id` to `default_keys` 
  - Line 25: Added `session_id` to `Retrieve` mode config

The fix ensures the session_id field is properly visible and functional when using the Message History component in Retrieve mode, allowing users to dynamically specify which conversation's messages to retrieve.