### PR TITLE
fix: update agent_llm display name to "Model Provider" in AgentComponent

### DIFF
--- a/src/backend/base/langflow/components/agents/agent.py
+++ b/src/backend/base/langflow/components/agents/agent.py
@@ -483,6 +483,7 @@ class AgentComponent(ToolCallingAgentComponent):
                     build_config.update(fields_to_add)
                 # Reset input types for agent_llm
                 build_config["agent_llm"]["input_types"] = []
+                build_config["agent_llm"]["display_name"] = "Model Provider"
             elif field_value == "Custom":
                 # Delete all provider fields
                 self.delete_fields(build_config, ALL_PROVIDER_FIELDS)


### PR DESCRIPTION
This pull request introduces a minor update to the agent build configuration logic. The main change is an improvement to the display name for the model provider in the agent configuration.

* In `src/backend/base/langflow/components/agents/agent.py`, the `display_name` for `agent_llm` is now set to "Model Provider" during build config updates to improve clarity in the configuration UI.