### PR TITLE
refactor: enhance superuser credential handling in setup process

### DIFF
--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -19,6 +19,7 @@ from langflow.services.database.models.api_key.crud import check_key
 from langflow.services.database.models.user.crud import get_user_by_id, get_user_by_username, update_user_last_login_at
 from langflow.services.database.models.user.model import User, UserRead
 from langflow.services.deps import get_db_service, get_session, get_settings_service
+from langflow.services.settings.constants import DEFAULT_SUPERUSER
 from langflow.services.settings.service import SettingsService
 
 if TYPE_CHECKING:
@@ -319,7 +320,8 @@ async def create_user_longterm_token(db: AsyncSession) -> tuple[UUID, dict]:
     settings_service = get_settings_service()
 
     # Prefer configured username; fall back to default or any existing superuser
-    username = settings_service.auth_settings.SUPERUSER or "langflow"
+    #NOTE: This user name cannot be a dynamic current user name since it is only used when autologin is True
+    username = settings_service.auth_settings.SUPERUSER or DEFAULT_SUPERUSER
     super_user = await get_user_by_username(db, username)
     if not super_user:
         from langflow.services.database.models.user.crud import get_all_superusers

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -320,7 +320,7 @@ async def create_user_longterm_token(db: AsyncSession) -> tuple[UUID, dict]:
     settings_service = get_settings_service()
 
     # Prefer configured username; fall back to default or any existing superuser
-    #NOTE: This user name cannot be a dynamic current user name since it is only used when autologin is True
+    # NOTE: This user name cannot be a dynamic current user name since it is only used when autologin is True
     username = settings_service.auth_settings.SUPERUSER or DEFAULT_SUPERUSER
     super_user = await get_user_by_username(db, username)
     if not super_user:


### PR DESCRIPTION
This pull request improves the handling of superuser credentials in the authentication and setup logic, ensuring consistent fallback to default values when custom credentials are not provided. The main changes clarify how the system determines which superuser username and password to use, especially when auto-login is disabled.

**Superuser credential handling:**

* Updated logic in both `create_user_longterm_token` and `setup_superuser` to consistently fall back to `DEFAULT_SUPERUSER` when no custom superuser username is configured, improving reliability and clarity. [[1]](diffhunk://#diff-d31c9154fb25c0b324fd719f128f5294e2e42b6565a61db3fa6946587aa47079R22) [[2]](diffhunk://#diff-d31c9154fb25c0b324fd719f128f5294e2e42b6565a61db3fa6946587aa47079L322-R324) [[3]](diffhunk://#diff-a9234e837b7c6feefbe0a0d215ac723519dfe195538fa13333127e367836db91L79-R87)
* Improved password assignment in `setup_superuser` by defaulting to `DEFAULT_SUPERUSER_PASSWORD` if no password is provided, streamlining credential management and reducing the risk of missing credentials.