### PR TITLE
fix: disable automatic retries for login user mutation

### DIFF
--- a/src/frontend/src/controllers/API/queries/auth/use-post-login-user.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-post-login-user.ts
@@ -29,6 +29,7 @@ export const useLoginUser: useMutationFunctionType<undefined, LoginType> = (
     ["useLoginUser"],
     loginUserFn,
     {
+      retry: false,
       ...options,
       onSettled: () => {
         queryClient.refetchQueries({ queryKey: ["useGetFolders"] });


### PR DESCRIPTION
Disable automatic retries for login user mutation to prevent multiple authentication attempts and potential rate limiting issues.

**Changed:** Set `retry: false` in `use-post-login-user.ts`