### PR TITLE
test: Relax component loading test timeouts

### DIFF
--- a/src/backend/tests/unit/test_load_components.py
+++ b/src/backend/tests/unit/test_load_components.py
@@ -3,7 +3,6 @@ import asyncio
 import time
 
 import pytest
-
 from langflow.interface.components import aget_all_types_dict, import_langflow_components
 from langflow.services.settings.base import BASE_COMPONENTS_PATH
 

--- a/src/backend/tests/unit/test_load_components.py
+++ b/src/backend/tests/unit/test_load_components.py
@@ -3,6 +3,7 @@ import asyncio
 import time
 
 import pytest
+
 from langflow.interface.components import aget_all_types_dict, import_langflow_components
 from langflow.services.settings.base import BASE_COMPONENTS_PATH
 
@@ -64,9 +65,9 @@ class TestComponentLoading:
         print(f"aget_all_types_dict: {all_types_duration:.4f}s")
         print(f"Ratio (langflow/all_types): {langflow_duration / max(all_types_duration, 0.0001):.2f}")
 
-        # Both should complete in reasonable time (< 5s for langflow, < 15s for all_types)
-        assert langflow_duration < 5.0, f"get_langflow_components_list took too long: {langflow_duration}s"
-        assert all_types_duration < 15.0, f"aget_all_types_dict took too long: {all_types_duration}s"
+        # Both should complete in reasonable time (< 10s for langflow, < 20s for all_types)
+        assert langflow_duration < 10.0, f"get_langflow_components_list took too long: {langflow_duration}s"
+        assert all_types_duration < 20.0, f"aget_all_types_dict took too long: {all_types_duration}s"
 
         # Store results for further analysis
         return {


### PR DESCRIPTION
This pull request makes a minor update to the unit test for component loading performance by relaxing the time constraints for two performance assertions. The allowed durations for the component loading functions have been increased to better accommodate slower runs.

Testing adjustments:

* Increased the maximum allowed duration for `get_langflow_components_list` from 5 seconds to 10 seconds, and for `aget_all_types_dict` from 15 seconds to 20 seconds in the performance comparison test (`test_load_components.py`).

Other minor changes:

* Added a blank line for improved readability in the import section of `test_load_components.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated performance thresholds in performance comparison tests (increased duration limits).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->