### PR TITLE
fix: fixes the little mic icon when you stop talking in voice mode

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx
@@ -300,6 +300,10 @@ export function VoiceAssistant({
   const handleCloseAudioInput = () => {
     setIsRecording(false);
     stopRecording();
+    if (audioContextRef.current) {
+      audioContextRef.current.close();
+      audioContextRef.current = null;
+    }
     setShowAudioInput(false);
     scrollToBottom();
   };


### PR DESCRIPTION
This pull request includes a small improvement to the audio input handling in the `VoiceAssistant` component. Now, when closing the audio input, the code ensures that the `audioContext` is properly closed and cleaned up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures voice input properly releases audio resources when closed, preventing stuck microphone states and reducing the chance of audio issues on subsequent uses.
* **Performance**
  * Lowers CPU and memory usage by cleaning up audio processing after voice input ends, improving battery life and overall responsiveness.
* **Stability**
  * Improves reliability of the voice assistant by avoiding lingering audio sessions, leading to smoother start/stop behavior across browsers and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->