### PR TITLE
fix: change icon color for mcp, remove color setting of icons

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/nodeIcon/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/nodeIcon/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { checkLucideIcons } from "@/CustomNodes/helpers/check-lucide-icons";
 import { ICON_STROKE_WIDTH } from "@/constants/constants";
 import { useTypesStore } from "@/stores/typesStore";
-import { iconExists, nodeColors } from "@/utils/styleUtils";
+import { iconExists } from "@/utils/styleUtils";
 import IconComponent from "../../../../components/common/genericIconComponent";
 
 export function NodeIcon({
@@ -36,15 +36,11 @@ export function NodeIcon({
 
     return (
       <div className="flex h-4 w-4 items-center justify-center">
-        {isLucideIcon ? (
-          <IconComponent
-            strokeWidth={ICON_STROKE_WIDTH}
-            name={iconName}
-            className="h-4 w-4"
-          />
-        ) : (
-          <IconComponent name={iconName} className="h-4 w-4" />
-        )}
+        <IconComponent
+          strokeWidth={isLucideIcon ? ICON_STROKE_WIDTH : undefined}
+          name={iconName}
+          className="h-4 w-4"
+        />
       </div>
     );
   };

--- a/src/frontend/src/CustomNodes/GenericNode/components/nodeIcon/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/nodeIcon/index.tsx
@@ -25,7 +25,6 @@ export function NodeIcon({
   }, [dataType, types]);
 
   const isEmoji = emojiRegex().test(icon ?? "");
-  const iconColor = nodeColors[types[dataType]];
   const iconName = icon || (isGroup ? "group_components" : name);
 
   const isLucideIcon = checkLucideIcons(iconName);
@@ -44,11 +43,7 @@ export function NodeIcon({
             className="h-4 w-4"
           />
         ) : (
-          <IconComponent
-            name={iconName}
-            iconColor={iconColor}
-            className="h-4 w-4"
-          />
+          <IconComponent name={iconName} className="h-4 w-4" />
         )}
       </div>
     );

--- a/src/frontend/src/CustomNodes/helpers/check-lucide-icons.ts
+++ b/src/frontend/src/CustomNodes/helpers/check-lucide-icons.ts
@@ -1,11 +1,6 @@
-import * as lucideIcons from "lucide-react";
 import dynamicIconImports from "lucide-react/dynamicIconImports";
 import { categoryIcons } from "@/utils/styleUtils";
 
 export const checkLucideIcons = (iconName: string): boolean => {
-  return (
-    !!lucideIcons[iconName] ||
-    !!dynamicIconImports[iconName] ||
-    !!categoryIcons[iconName]
-  );
+  return !!dynamicIconImports[iconName] || !!categoryIcons[iconName];
 };

--- a/src/frontend/tests/extended/features/mcp-server.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server.spec.ts
@@ -24,6 +24,20 @@ test(
       .dragTo(page.locator('//*[@id="react-flow-id"]'), {
         targetPosition: { x: 100, y: 100 },
       });
+
+    // See if the color matches
+
+    const isDark = await page.evaluate(() => {
+      return document.body.classList.contains("dark");
+    });
+
+    for (const path of await page
+      .getByTestId("icon-Mcp")
+      .locator("path")
+      .all()) {
+      expect(path).toHaveAttribute("fill", isDark ? "white" : "black");
+    }
+
     await page.getByTestId("canvas_controls_dropdown").click();
 
     await page.getByTestId("fit_view").click();

--- a/src/frontend/tests/extended/features/mcp-server.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server.spec.ts
@@ -32,10 +32,14 @@ test(
     });
 
     for (const path of await page
+      .getByTestId("generic-node-title-arrangement")
       .getByTestId("icon-Mcp")
       .locator("path")
       .all()) {
-      expect(path).toHaveAttribute("fill", isDark ? "white" : "black");
+      const color = await path.evaluate(
+        (el) => window.getComputedStyle(el).fill,
+      );
+      expect(color).toBe(isDark ? "rgb(255, 255, 255)" : "rgb(0, 0, 0)");
     }
 
     await page.getByTestId("canvas_controls_dropdown").click();


### PR DESCRIPTION
This pull request makes improvements to how the MCP icon is rendered and tested, ensuring better theme support and simplifying icon color handling in the UI. The most important changes are grouped below by theme.

**Theme support and icon rendering:**

* The `SvgMcpIcon` component now sets its `fill` color dynamically based on the `isDark` prop, using white for dark mode and black for light mode, instead of always using the current color.
* The automated test for the MCP icon verifies that the icon's SVG paths have the correct fill color depending on the current theme (dark or light mode).

**Codebase simplification:**

* The `NodeIcon` component no longer calculates or passes an explicit `iconColor` to `IconComponent`, simplifying the props and color management. [[1]](diffhunk://#diff-108b8898385719cca096f06d0b63e5ff9ab30ab55a020f819400c01fe2123abfL28) [[2]](diffhunk://#diff-108b8898385719cca096f06d0b63e5ff9ab30ab55a020f819400c01fe2123abfL47-R46)