### PR TITLE
fix: Add help text to Lock Flow option

### DIFF
--- a/src/frontend/src/components/core/editFlowSettingsComponent/index.tsx
+++ b/src/frontend/src/components/core/editFlowSettingsComponent/index.tsx
@@ -179,18 +179,32 @@ export const EditFlowSettings: React.FC<
         <Form.Message match="valueMissing" className="field-invalid">
           Please enter a description
         </Form.Message>
-        <div className="flex items-center gap-2 mt-3">
-          <ForwardedIconComponent
-            name={locked ? "Lock" : "Unlock"}
-            className="text-muted-foreground !w-5 !h-5"
-          />
-          <Form.Label className="text-mmd font-medium">Lock Flow</Form.Label>
-          <Switch
-            checked={!!locked}
-            onCheckedChange={(v) => setLocked?.(v)}
-            className="data-[state=checked]:bg-primary ml-auto"
-            data-testid="lock-flow-switch"
-          />
+        <div className="mt-3">
+          <div className="flex items-center gap-2">
+            <div>
+              <div className="flex items-center gap-2">
+                <Form.Label className="text-mmd font-medium">
+                  Lock Flow
+                </Form.Label>
+
+                <ForwardedIconComponent
+                  name={locked ? "Lock" : "Unlock"}
+                  className="text-muted-foreground !w-5 !h-5"
+                />
+              </div>
+
+              <p className="text-xs text-muted-foreground/70 mt-1 font-normal">
+                Lock your flow to prevent edits or accidental changes.
+              </p>
+            </div>
+
+            <Switch
+              checked={!!locked}
+              onCheckedChange={(v) => setLocked?.(v)}
+              className="data-[state=checked]:bg-primary ml-auto"
+              data-testid="lock-flow-switch"
+            />
+          </div>
         </div>
       </Form.Field>
     </>


### PR DESCRIPTION
This pull request updates the `EditFlowSettings` component to improve the layout and clarity of the "Lock Flow" option. The most notable change is the addition of a descriptive help text below the "Lock Flow" label, making it clearer to users what the option does.

**UI/UX improvements:**

* Added a help text below the "Lock Flow" label explaining that locking the flow prevents edits or accidental changes, and adjusted the layout for better readability (`src/frontend/src/components/core/editFlowSettingsComponent/index.tsx`).

<img width="987" height="962" alt="image" src="https://github.com/user-attachments/assets/210fe1e4-b4f7-4c9c-ac7b-13d1b83ba9b5" />
