### PR TITLE
fix: apply to fields in settings page 

### DIFF
--- a/src/frontend/src/controllers/API/queries/flows/use-get-refresh-flows-query.ts
+++ b/src/frontend/src/controllers/API/queries/flows/use-get-refresh-flows-query.ts
@@ -7,7 +7,7 @@ import { useTypesStore } from "@/stores/typesStore";
 import type { useQueryFunctionType } from "@/types/api";
 import type { FlowType, PaginatedFlowsType } from "@/types/flow";
 import {
-  extractFieldsFromComponenents,
+  extractSecretFieldsFromComponents,
   processFlows,
 } from "@/utils/reactflowUtils";
 import { api } from "../../api";
@@ -58,7 +58,7 @@ export const useGetRefreshFlowsQuery: useQueryFunctionType<
         const { data } = processFlows(dbDataComponents);
         useTypesStore.setState((state) => ({
           data: { ...state.data, ["saved_components"]: data },
-          ComponentFields: extractFieldsFromComponenents({
+          ComponentFields: extractSecretFieldsFromComponents({
             ...state.data,
             ["saved_components"]: data,
           }),

--- a/src/frontend/src/stores/typesStore.ts
+++ b/src/frontend/src/stores/typesStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import type { APIDataType } from "../types/api";
 import type { TypesStoreType } from "../types/zustand/types";
 import {
-  extractFieldsFromComponenents,
+  extractSecretFieldsFromComponents,
   templatesGenerator,
   typesGenerator,
 } from "../utils/reactflowUtils";
@@ -22,7 +22,7 @@ export const useTypesStore = create<TypesStoreType>((set, get) => ({
     set((old) => ({
       types: typesGenerator(data),
       data: { ...old.data, ...data },
-      ComponentFields: extractFieldsFromComponenents({
+      ComponentFields: extractSecretFieldsFromComponents({
         ...old.data,
         ...data,
       }),
@@ -36,6 +36,6 @@ export const useTypesStore = create<TypesStoreType>((set, get) => ({
     const newChange =
       typeof change === "function" ? change(get().data) : change;
     set({ data: newChange });
-    get().setComponentFields(extractFieldsFromComponenents(newChange));
+    get().setComponentFields(extractSecretFieldsFromComponents(newChange));
   },
 }));

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -1821,6 +1821,77 @@ export function templatesGenerator(data: APIObjectType) {
   }, {});
 }
 
+/**
+ * Determines if a field is a SecretStr field type
+ */
+function isSecretField(fieldData: any): boolean {
+  // Check if field type is specifically SecretStr
+  if (fieldData?.type === "SecretStr") {
+    return true;
+  }
+  
+  // Also check for fields that have both password=true and load_from_db=true 
+  // which are characteristics of SecretStrInput fields
+  if (fieldData?.password === true && fieldData?.load_from_db === true) {
+    return true;
+  }
+  
+  return false;
+}
+
+/**
+ * Extract only SecretStr type fields from components for global variables
+ */
+export function extractSecretFieldsFromComponents(data: APIObjectType) {
+  const fields = new Set<string>();
+
+  // Check if data exists
+  if (!data) {
+    console.warn("[Types] Data is undefined in extractSecretFieldsFromComponents");
+    return fields;
+  }
+
+  Object.keys(data).forEach((key) => {
+    // Check if data[key] exists
+    if (!data[key]) {
+      console.warn(
+        `[Types] data["${key}"] is undefined in extractSecretFieldsFromComponents`,
+      );
+      return;
+    }
+
+    Object.keys(data[key]).forEach((kind) => {
+      // Check if data[key][kind] exists
+      if (!data[key][kind]) {
+        console.warn(
+          `[Types] data["${key}"]["${kind}"] is undefined in extractSecretFieldsFromComponents`,
+        );
+        return;
+      }
+
+      // Check if template exists
+      if (!data[key][kind].template) {
+        console.warn(
+          `[Types] data["${key}"]["${kind}"].template is undefined in extractSecretFieldsFromComponents`,
+        );
+        return;
+      }
+
+      Object.keys(data[key][kind].template).forEach((field) => {
+        const fieldData = data[key][kind].template[field];
+        if (
+          fieldData?.display_name &&
+          fieldData?.show &&
+          isSecretField(fieldData)
+        )
+          fields.add(fieldData.display_name!);
+      });
+    });
+  });
+
+  return fields;
+}
+
 export function extractFieldsFromComponenents(data: APIObjectType) {
   const fields = new Set<string>();
 

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -1829,13 +1829,13 @@ function isSecretField(fieldData: any): boolean {
   if (fieldData?.type === "SecretStr") {
     return true;
   }
-  
-  // Also check for fields that have both password=true and load_from_db=true 
+
+  // Also check for fields that have both password=true and load_from_db=true
   // which are characteristics of SecretStrInput fields
   if (fieldData?.password === true && fieldData?.load_from_db === true) {
     return true;
   }
-  
+
   return false;
 }
 
@@ -1847,7 +1847,9 @@ export function extractSecretFieldsFromComponents(data: APIObjectType) {
 
   // Check if data exists
   if (!data) {
-    console.warn("[Types] Data is undefined in extractSecretFieldsFromComponents");
+    console.warn(
+      "[Types] Data is undefined in extractSecretFieldsFromComponents",
+    );
     return fields;
   }
 


### PR DESCRIPTION
This pull request refactors the way component fields are extracted throughout the codebase, focusing specifically on handling secret fields. It replaces the previous generic field extraction logic with a new function that targets only secret fields, improving the security and clarity of global variable management. The main changes are grouped below:

**Secret field extraction improvements:**

* Added a new function `extractSecretFieldsFromComponents` in `reactflowUtils.ts` that identifies and extracts only fields of type `SecretStr` or those with both `password=true` and `load_from_db=true`, ensuring only secret fields are included.
* Replaced all usages of the old `extractFieldsFromComponenents` function with the new `extractSecretFieldsFromComponents` function in `typesStore.ts` and `use-get-refresh-flows-query.ts`, ensuring consistent handling of secret fields across the application. [[1]](diffhunk://#diff-5a99bcf646c7556a80cff23c021764458987129bac7bc1e9bcfea22a970ca84aL5-R5) [[2]](diffhunk://#diff-5a99bcf646c7556a80cff23c021764458987129bac7bc1e9bcfea22a970ca84aL25-R25) [[3]](diffhunk://#diff-5a99bcf646c7556a80cff23c021764458987129bac7bc1e9bcfea22a970ca84aL39-R39) [[4]](diffhunk://#diff-c70b5e2e0695512c8ec4c67ea960b49e6a4be89aa8af4f2ac81563b6990fa750L10-R10) [[5]](diffhunk://#diff-c70b5e2e0695512c8ec4c67ea960b49e6a4be89aa8af4f2ac81563b6990fa750L61-R61)

These changes improve the accuracy and security of component field extraction by focusing on secret fields, and update all relevant stores and queries to use the new logic.