### PR TITLE
fix: Properly respect the order parameter for Message History

### DIFF
--- a/src/backend/base/langflow/components/helpers/memory.py
+++ b/src/backend/base/langflow/components/helpers/memory.py
@@ -199,10 +199,12 @@ class MemoryComponent(Component):
             stored = await self.memory.aget_messages()
             # langchain memories are supposed to return messages in ascending order
 
-            if order == "DESC":
-                stored = stored[::-1]
             if n_messages:
-                stored = stored[-n_messages:] if order == "ASC" else stored[:n_messages]
+                stored = stored[-n_messages:]  # Get last N messages first
+
+            if order == "DESC":
+                stored = stored[::-1]  # Then reverse if needed
+
             stored = [Message.from_lc_message(m) for m in stored]
             if sender_type:
                 expected_type = MESSAGE_SENDER_AI if sender_type == MESSAGE_SENDER_AI else MESSAGE_SENDER_USER
@@ -217,7 +219,7 @@ class MemoryComponent(Component):
                 order=order,
             )
             if n_messages:
-                stored = stored[-n_messages:] if order == "ASC" else stored[:n_messages]
+                stored = stored[-n_messages:]  # Get last N messages
 
         # self.status = stored
         return cast("Data", stored)


### PR DESCRIPTION
This pull request refactors how message retrieval ordering and slicing are handled in the `retrieve_messages` method of `src/backend/base/langflow/components/helpers/memory.py`. The main change ensures that the slicing for the last N messages is always performed before any ordering is applied, making the logic more consistent and easier to understand.

**Improvements to message retrieval logic:**

* Changed the order of operations so that slicing to get the last N messages (`stored[-n_messages:]`) is always done before applying the `DESC` order reversal, ensuring the correct subset of messages is retrieved regardless of order.
* Simplified the slicing logic for message retrieval by removing conditional slicing based on order; now the last N messages are always selected first, and then reversed if needed for descending order.