### PR TITLE
fix: Properly allow the non-specification of an OCR Engine

### DIFF
--- a/src/backend/base/langflow/base/data/docling_utils.py
+++ b/src/backend/base/langflow/base/data/docling_utils.py
@@ -133,7 +133,7 @@ def docling_worker(file_paths: list[str], queue, pipeline: str, ocr_engine: str)
         check_shutdown()  # Check before heavy operations
 
         pipeline_options = PdfPipelineOptions()
-        pipeline_options.do_ocr = ocr_engine != ""
+        pipeline_options.do_ocr = ocr_engine != "None"
         if pipeline_options.do_ocr:
             ocr_factory = get_ocr_factory(
                 allow_external_plugins=False,

--- a/src/backend/base/langflow/components/data/file.py
+++ b/src/backend/base/langflow/components/data/file.py
@@ -115,8 +115,8 @@ class FileComponent(BaseFileComponent):
             name="ocr_engine",
             display_name="OCR Engine",
             info="OCR engine to use. Only available when pipeline is set to 'standard'.",
-            options=["", "easyocr"],
-            value="",
+            options=["None", "easyocr"],
+            value="None",
             show=False,
             advanced=True,
         ),
@@ -305,7 +305,7 @@ class FileComponent(BaseFileComponent):
             "md_image_placeholder": str(self.md_image_placeholder),
             "md_page_break_placeholder": str(self.md_page_break_placeholder),
             "pipeline": str(self.pipeline),
-            "ocr_engine": str(self.ocr_engine) if getattr(self, "ocr_engine", "") else None,
+            "ocr_engine": str(self.ocr_engine) if self.ocr_engine and self.ocr_engine is not None else None,
         }
 
         # The child is a tiny, self-contained script to keep memory/state isolated.


### PR DESCRIPTION
This pull request updates how the OCR engine option is handled in the document processing pipeline. The main change is to consistently use `"None"` as the default value for no OCR engine, instead of an empty string, which improves clarity and prevents confusion in option handling.

**OCR Engine Option Handling Improvements:**

* Changed the default value and available options for the `ocr_engine` field in `FileComponent` to use `"None"` instead of an empty string, ensuring consistency and better user experience.
* Updated the logic in `_get_standard_opts()` in `docling_utils.py` to check for `"None"` instead of an empty string when determining whether to enable OCR, aligning with the new default.
* Refined the conditional assignment for `ocr_engine` in `_process_docling_in_subprocess()` to properly handle cases where the value is `"None"` or not set, reducing ambiguity.