### PR TITLE
ci: allow docs-only PRs to skip nightly status - second attempt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
         steps.filter.outputs.workspace != 'true' &&
         steps.filter.outputs.api != 'true' &&
         steps.filter.outputs.database != 'true'
-      }}
+        }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,19 @@ jobs:
       workspace: ${{ steps.filter.outputs.workspace }}
       api: ${{ steps.filter.outputs.api }}
       database: ${{ steps.filter.outputs.database }}
+      docs-only: ${{
+        steps.filter.outputs.docs == 'true' &&
+        steps.filter.outputs.python != 'true' &&
+        steps.filter.outputs.frontend != 'true' &&
+        steps.filter.outputs['frontend-tests'] != 'true' &&
+        steps.filter.outputs['components-changes'] != 'true' &&
+        steps.filter.outputs['starter-projects-changes'] != 'true' &&
+        steps.filter.outputs['starter-projects'] != 'true' &&
+        steps.filter.outputs.components != 'true' &&
+        steps.filter.outputs.workspace != 'true' &&
+        steps.filter.outputs.api != 'true' &&
+        steps.filter.outputs.database != 'true'
+      }}
 
     steps:
       - name: Checkout code
@@ -255,9 +268,11 @@ jobs:
     env:
       JOBS_JSON: ${{ toJSON(needs) }}
       RESULTS_JSON: ${{ toJSON(needs.*.result) }}
+      # Skip nightly build check if only docs files changed
+      DOCS_ONLY: ${{ needs.path-filter.outputs.docs-only }}
       EXIT_CODE: ${{ (contains(needs.*.result, 'failure') ||
                       contains(needs.*.result, 'cancelled') ||
-                      (needs.check-nightly-status.outputs.should-proceed != 'true' && github.event_name != 'workflow_dispatch'))
+                      (needs.check-nightly-status.outputs.should-proceed != 'true' && github.event_name != 'workflow_dispatch' && needs.path-filter.outputs.docs-only != 'true'))
                       && '1' || '0' }}
     steps:
       - name: "CI Success"
@@ -267,6 +282,10 @@ jobs:
           echo "Should run CI: ${{ needs.set-ci-condition.outputs.should-run-ci }}"
           echo "Nightly build status: ${{ needs.check-nightly-status.outputs.should-proceed }}"
           echo "Event type: ${{ github.event_name }}"
+          echo "Docs only changes: $DOCS_ONLY"
+          echo "Python changes: ${{ needs.path-filter.outputs.python }}"
+          echo "Frontend changes: ${{ needs.path-filter.outputs.frontend }}"
+          echo "Docs changes: ${{ needs.path-filter.outputs.docs }}"
           echo ""
 
           # Check for job failures
@@ -316,7 +335,7 @@ jobs:
             echo "  1. Check if the cancellation was intentional"
             echo "  2. Re-run the workflow if needed"
 
-          elif [[ "${{ needs.check-nightly-status.outputs.should-proceed }}" != "true" && "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+          elif [[ "${{ needs.check-nightly-status.outputs.should-proceed }}" != "true" && "${{ github.event_name }}" != "workflow_dispatch" && "$DOCS_ONLY" != "true" ]]; then
             echo "🚫 CI BLOCKED: Nightly build is broken"
             echo ""
             echo "The nightly PyPI package was not updated today, indicating the nightly build failed."
@@ -326,6 +345,7 @@ jobs:
             echo "  2. Check the nightly build logs for errors"
             echo "  3. Once the nightly build is fixed and publishes successfully, re-run this workflow"
             echo "  4. Alternatively, use 'workflow_dispatch' to manually override this check if needed"
+            echo "  5. Note: PRs with only documentation changes can bypass this check"
 
           else
             echo "✅ CI SUCCESS: All checks passed!"


### PR DESCRIPTION
Supersedes #9563 because it was cursed.

This pull request updates the CI workflow to allow pull requests that only change documentation files to bypass the nightly build status check. This makes the CI process more efficient by preventing unnecessary blocking of documentation-only PRs when the nightly build is broken.

**CI workflow improvements:**

* Added a `docs-only` output in the `path-filter` job to detect PRs that only modify documentation files and not code, tests, or starter projects.
* Updated the CI job's environment variables and exit code calculation to allow documentation-only PRs to skip the nightly build status check, ensuring these PRs are not blocked if the nightly build fails.
* Enhanced CI logging to display whether the changes are documentation-only, as well as changes to Python and frontend files, for better visibility during workflow runs.

**Nightly build status handling:**

* Modified the nightly build failure handling logic to bypass the block for documentation-only PRs, allowing them to proceed even if the nightly build is broken.
* Updated user-facing CI messages to clarify that PRs with only documentation changes can bypass the nightly build status check.