### PR TITLE
feat: Allow renaming of knowledge bases

### DIFF
--- a/src/backend/base/langflow/api/v1/knowledge_bases.py
+++ b/src/backend/base/langflow/api/v1/knowledge_bases.py
@@ -375,7 +375,7 @@ async def get_knowledge_base(kb_name: str, current_user: CurrentActiveUser) -> K
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error getting knowledge base '{kb_name}': {e!s}") from e
-    
+
 
 @router.put("/{kb_name}", status_code=HTTPStatus.OK)
 async def rename_knowledge_base(kb_name: str, new_name: str, current_user: CurrentActiveUser) -> KnowledgeBaseInfo:


### PR DESCRIPTION
This pull request introduces a new API endpoint to allow renaming of knowledge bases, enhancing the management capabilities for users. The main change is the addition of a PUT endpoint that validates input, checks for conflicts, and updates the knowledge base metadata after renaming.

**Knowledge base management enhancements:**

* Added a new `PUT /{kb_name}` endpoint in `knowledge_bases.py` to support renaming knowledge bases, including validation for new names and error handling for conflicts or invalid input.