### PR TITLE
fix: deprecate claude 3 sonnet model

### DIFF
--- a/src/backend/base/langflow/base/models/anthropic_constants.py
+++ b/src/backend/base/langflow/base/models/anthropic_constants.py
@@ -8,7 +8,9 @@ ANTHROPIC_MODELS_DETAILED = [
     create_model_metadata(provider="Anthropic", name="claude-3-5-sonnet-latest", icon="Anthropic", tool_calling=True),
     create_model_metadata(provider="Anthropic", name="claude-3-5-haiku-latest", icon="Anthropic", tool_calling=True),
     create_model_metadata(provider="Anthropic", name="claude-3-opus-latest", icon="Anthropic", tool_calling=True),
-    create_model_metadata(provider="Anthropic", name="claude-3-sonnet-20240229", icon="Anthropic", tool_calling=True),
+    create_model_metadata(
+        provider="Anthropic", name="claude-3-sonnet-20240229", icon="Anthropic", tool_calling=True, deprecated=True
+    ),
     # Tool calling unsupported models
     create_model_metadata(provider="Anthropic", name="claude-2.1", icon="Anthropic", tool_calling=False),
     create_model_metadata(provider="Anthropic", name="claude-2.0", icon="Anthropic", tool_calling=False),


### PR DESCRIPTION
This pull request makes a minor update to the Anthropic model metadata to indicate that the `claude-3-sonnet-20240229` model is now deprecated. This helps clarify the status of the model for future development and usage.

* Marked the `claude-3-sonnet-20240229` model as deprecated by adding the `deprecated=True` flag in its metadata in `src/backend/base/langflow/base/models/anthropic_constants.py`.