### PR TITLE
Updated newline, carriage return and tab escaping

### DIFF
--- a/src/backend/base/langflow/components/data/webhook.py
+++ b/src/backend/base/langflow/components/data/webhook.py
@@ -45,7 +45,7 @@ class WebhookComponent(Component):
             self.status = "No data provided."
             return Data(data={})
         try:
-            my_data = re.sub(r'(?<!\\)(\r|\n|\t)', lambda m: '\\n' if m.group() == '\n' else '\\t', self.data)
+            my_data = re.sub(r"(?<!\\)(\r|\n|\t)", lambda m: "\\n" if m.group() == "\n" else "\\t", self.data)
             body = json.loads(my_data or "{}")
         except json.JSONDecodeError:
             body = {"payload": self.data}

--- a/src/backend/base/langflow/components/data/webhook.py
+++ b/src/backend/base/langflow/components/data/webhook.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from langflow.custom.custom_component.component import Component
 from langflow.io import MultilineInput, Output
@@ -44,7 +45,7 @@ class WebhookComponent(Component):
             self.status = "No data provided."
             return Data(data={})
         try:
-            my_data = self.data.replace('"\n"', '"\\n"')
+            my_data = re.sub(r'(?<!\\)(\r|\n|\t)', lambda m: '\\n' if m.group() == '\n' else '\\t', self.data)
             body = json.loads(my_data or "{}")
         except json.JSONDecodeError:
             body = {"payload": self.data}

--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -11,7 +11,6 @@ import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from langflow.base.mcp import util
 from langflow.base.mcp.util import MCPSessionManager, MCPSseClient, MCPStdioClient, _process_headers, validate_headers
 


### PR DESCRIPTION
This update resolves an issue in the webhook component where newline characters could be double-escaped if already escaped. The escaping logic has also been extended to include carriage return and tab characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook payload parsing to gracefully handle unescaped control characters (newlines, carriage returns, tabs).
  * Reduces “invalid payload” errors and increases compatibility with a wider range of webhook senders.
  * Ensures more reliable JSON processing and consistent payload handling without changing existing behavior or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->