### PR TITLE
test: Mock config endpoint for auth regression tests 

### DIFF
--- a/src/frontend/tests/extended/regression/general-bugs-component-webhook-api-key-display.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-component-webhook-api-key-display.spec.ts
@@ -18,6 +18,20 @@ test(
       });
     });
 
+    await page.route("**/api/v1/config", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          webhook_auth_enable: true,
+        }),
+        headers: {
+          "content-type": "application/json",
+          ...route.request().headers(),
+        },
+      });
+    });
+
     await loginLangflow(page);
 
     await awaitBootstrapTest(page, { skipGoto: true });
@@ -61,6 +75,20 @@ test(
   "user must be able to not see api key in webhook component when auto login is enabled",
   { tag: ["@release"] },
   async ({ page }) => {
+    await page.route("**/api/v1/config", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          webhook_auth_enable: false,
+        }),
+        headers: {
+          "content-type": "application/json",
+          ...route.request().headers(),
+        },
+      });
+    });
+
     await awaitBootstrapTest(page);
 
     await page.waitForSelector('[data-testid="blank-flow"]', {


### PR DESCRIPTION
This pull request updates the regression tests for the webhook API key display to ensure they correctly simulate different backend configurations for `webhook_auth_enable`. The main change is the addition of request interception to mock the `/api/v1/config` endpoint, allowing the tests to control whether webhook authentication is enabled or disabled.

Test improvements:

* Added a route handler in the test setup to mock the `/api/v1/config` API response with `webhook_auth_enable: true`, ensuring the test environment accurately reflects the scenario where webhook authentication is enabled.
* Added a similar route handler in another test to mock the `/api/v1/config` API response with `webhook_auth_enable: false`, allowing the test to verify behavior when webhook authentication is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded regression coverage for the webhook component to verify API key visibility behavior under different authentication settings.
  * Added scenarios for auto-login enabled vs. disabled to ensure correct display or masking of the API key in curl examples.
  * Improved test reliability by standardizing config responses and headers handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->