### PR TITLE
fix: disable elevate edges on node select

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -693,7 +693,7 @@ export default function Page({
             onNodeDrag={onNodeDrag}
             onNodeDragStart={onNodeDragStart}
             onSelectionDragStart={onSelectionDragStart}
-            elevateEdgesOnSelect={true}
+            elevateEdgesOnSelect={false}
             onSelectionEnd={onSelectionEnd}
             onSelectionStart={onSelectionStart}
             connectionRadius={30}


### PR DESCRIPTION
This pull request includes a minor change to the behavior of the flow diagram in the `PageComponent`. The change disables the elevation of edges when nodes are selected, which may affect how selected connections are visually highlighted.

It solves this problem, when selecting components:
<img width="1602" height="928" alt="image" src="https://github.com/user-attachments/assets/0032e1c1-58f5-4ae9-ad29-08b949fc3535" />


* Set `elevateEdgesOnSelect` to `false` in the `PageComponent`, disabling edge elevation on node selection (`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`).