### PR TITLE
chore: Bump `lfx` version to 0.1.11

### DIFF
--- a/src/lfx/pyproject.toml
+++ b/src/lfx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx"
-version = "0.1.10"
+version = "0.1.11"
 description = "Langflow Executor - A lightweight CLI tool for executing and serving Langflow AI flows"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -2338,7 +2338,6 @@ dependencies = [
     { name = "numpy" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/1f/d0ac8e9d6fc7fc37dc682878f56edb23000c31b74f48cafe9f1a6efaae20/faiss_cpu-1.9.0.post1.tar.gz", hash = "sha256:920725d485aab05dd87d34ef63257332441e9b53d382069f034996465827143a", size = 67799, upload-time = "2024-11-20T02:21:01.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/85/ee4bafafa70bc99904a61f06e7f5e36d06ab6b37335e687085786f9a248d/faiss_cpu-1.9.0.post1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:e18602465f5a96c3c973ab440f9263a0881034fb54810be20bc8cdb8b069456d", size = 7672124, upload-time = "2024-11-20T02:20:02.33Z" },
     { url = "https://files.pythonhosted.org/packages/c3/99/50496057d52241a77f0d2a021a73b97f25f6500c6f02a584a7b3d43c3e3f/faiss_cpu-1.9.0.post1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5dddeecdb68fb95b4a3343a6ff89498fd7c222726706538f360132bfe3d8aebe", size = 3225595, upload-time = "2024-11-20T02:20:04.341Z" },
@@ -5775,7 +5774,7 @@ wheels = [
 
 [[package]]
 name = "lfx"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "src/lfx" }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
Update the version number in `pyproject.toml` and `uv.lock` to reflect the new release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented application version to 0.1.11 for release tagging and distribution.
  * No feature additions, bug fixes, or dependency updates included.
  * No configuration or migration steps required; existing installations continue to work as before.
  * Maintenance-only release with metadata updates to support packaging and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->