### PR TITLE
ci: Add LFX release workflow and update nightly build script

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -82,10 +82,10 @@ jobs:
           MAIN_TAG="${{ steps.generate_main_tag.outputs.main_tag }}"
           BASE_TAG="${{ steps.generate_base_tag.outputs.base_tag }}"
           LFX_TAG="${{ steps.generate_lfx_tag.outputs.lfx_tag }}"
-          echo "Updating base project version to $BASE_TAG and updating main project version to $MAIN_TAG"
-          uv run ./scripts/ci/update_pyproject_combined.py main $MAIN_TAG $BASE_TAG $LFX_TAG
           echo "Updating LFX project version to $LFX_TAG"
           uv run ./scripts/ci/update_lfx_version.py $LFX_TAG
+          echo "Updating base project version to $BASE_TAG and updating main project version to $MAIN_TAG"
+          uv run ./scripts/ci/update_pyproject_combined.py main $MAIN_TAG $BASE_TAG $LFX_TAG
 
           uv lock
           cd src/backend/base && uv lock && cd ../../..

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -83,7 +83,7 @@ jobs:
           BASE_TAG="${{ steps.generate_base_tag.outputs.base_tag }}"
           LFX_TAG="${{ steps.generate_lfx_tag.outputs.lfx_tag }}"
           echo "Updating base project version to $BASE_TAG and updating main project version to $MAIN_TAG"
-          uv run ./scripts/ci/update_pyproject_combined.py main $MAIN_TAG $BASE_TAG
+          uv run ./scripts/ci/update_pyproject_combined.py main $MAIN_TAG $BASE_TAG $LFX_TAG
           echo "Updating LFX project version to $LFX_TAG"
           uv run ./scripts/ci/update_lfx_version.py $LFX_TAG
 

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -91,7 +91,7 @@ jobs:
           cd src/backend/base && uv lock && cd ../../..
           cd src/lfx && uv lock && cd ../..
 
-          git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml uv.lock src/backend/base/uv.lock src/lfx/uv.lock
+          git add pyproject.toml src/backend/base/pyproject.toml src/lfx/pyproject.toml uv.lock src/backend/base/uv.lock
           git commit -m "Update version and project name"
 
           echo "Tagging main with $MAIN_TAG"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -183,9 +183,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           prune-cache: false
       - name: Install LFX dependencies
-        run: uv sync --dev --package lfx
+        run: cd src/lfx && uv sync
       - name: Run LFX tests
-        run: cd src/lfx && uv run pytest tests/unit -v
+        run: cd src/lfx && make test
 
   # Not making nightly builds dependent on integration test success
   # due to inherent flakiness of 3rd party integrations

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -162,31 +162,6 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
-  lfx-tests:
-    if: github.repository == 'langflow-ai/langflow'
-    name: Run LFX Tests
-    needs: create-nightly-tag
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.create-nightly-tag.outputs.main_tag }}
-      - name: Setup Environment
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-          python-version: ${{ matrix.python-version }}
-          prune-cache: false
-      - name: Install LFX dependencies
-        run: cd src/lfx && uv sync
-      - name: Run LFX tests
-        run: cd src/lfx && make test
-
   # Not making nightly builds dependent on integration test success
   # due to inherent flakiness of 3rd party integrations
   # Revisit when https://github.com/langflow-ai/langflow/pull/3607 is merged.
@@ -201,7 +176,7 @@ jobs:
   release-nightly-build:
     if: github.repository == 'langflow-ai/langflow'
     name: Run Nightly Langflow Build
-    needs: [frontend-tests, backend-unit-tests, lfx-tests, create-nightly-tag]
+    needs: [frontend-tests, backend-unit-tests, create-nightly-tag]
     uses: ./.github/workflows/release_nightly.yml
     with:
       build_docker_base: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,17 @@ on:
         required: false
         type: boolean
         default: true
+      release_lfx:
+        description: "Release LFX"
+        required: false
+        type: boolean
+        default: false
 
 
 
 jobs:
   ci:
-    if: ${{ github.event.inputs.release_package_base == 'true' || github.event.inputs.release_package_main == 'true' }}
+    if: ${{ github.event.inputs.release_package_base == 'true' || github.event.inputs.release_package_main == 'true' || github.event.inputs.release_lfx == 'true' }}
     name: CI
     uses: ./.github/workflows/ci.yml
     with:
@@ -209,6 +214,31 @@ jobs:
       base-artifact-name: "dist-base"
       main-artifact-name: "dist-main"
 
+  test-lfx-cross-platform:
+    name: Test LFX Cross-Platform Installation
+    if: inputs.release_lfx == true
+    needs: [build-lfx]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Download LFX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-lfx
+          path: dist-lfx
+      - name: Setup Environment
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
+          python-version: ${{ matrix.python-version }}
+      - name: Test LFX installation
+        run: |
+          uv pip install dist-lfx/*.whl
+          uv run lfx --help
+
   publish-base:
     name: Publish Langflow Base to PyPI
     if: inputs.release_package_base == true
@@ -300,22 +330,100 @@ jobs:
     secrets: inherit
 
 
+  build-lfx:
+    name: Build LFX
+    needs: [ci]
+    if: inputs.release_lfx == true
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check-version.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Environment
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.13"
+          prune-cache: false
+      - name: Install LFX dependencies
+        run: uv sync --dev --package lfx
+      - name: Check Version
+        id: check-version
+        run: |
+          cd src/lfx
+          version=$(uv tree | grep 'lfx' | head -n 1 | awk '{print $2}' | sed 's/^v//')
+          last_released_version=$(curl -s "https://pypi.org/pypi/lfx/json" | jq -r '.releases | keys | .[]' | sort -V | tail -n 1)
+          if [ "$version" = "$last_released_version" ]; then
+            echo "Version $version is already released. Skipping release."
+            exit 1
+          else
+            echo version=$version >> $GITHUB_OUTPUT
+          fi
+      - name: Build project for distribution
+        run: |
+          cd src/lfx
+          rm -rf dist/
+          uv build --wheel --out-dir dist
+      - name: Test CLI
+        run: |
+          cd src/lfx
+          uv pip install dist/*.whl --force-reinstall
+          uv run lfx --help
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-lfx
+          path: src/lfx/dist
+
+  publish-lfx:
+    name: Publish LFX to PyPI
+    if: inputs.release_lfx == true
+    needs: [build-lfx, test-lfx-cross-platform]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download LFX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-lfx
+          path: src/lfx/dist
+      - name: Setup Environment
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
+          python-version: "3.13"
+      - name: Publish LFX to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          cd src/lfx && uv publish dist/*.whl
+
   create_release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: publish-main
+    needs: [publish-main, publish-lfx]
+    if: always() && inputs.create_release == 'true' && (needs.publish-main.result == 'success' || needs.publish-lfx.result == 'success')
     steps:
       - uses: actions/download-artifact@v4
+        if: needs.publish-main.result == 'success'
         with:
           name: dist-main
           path: dist
+      - uses: actions/download-artifact@v4
+        if: needs.publish-lfx.result == 'success'
+        with:
+          name: dist-lfx
+          path: dist-lfx
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "dist/*"
+          artifacts: |
+            dist/*
+            dist-lfx/*
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           generateReleaseNotes: true
           prerelease: ${{ inputs.pre_release }}
-          tag: ${{ needs.publish-main.needs.build-main.outputs.version }}
+          tag: ${{ needs.publish-main.needs.build-main.outputs.version || needs.publish-lfx.needs.build-lfx.outputs.version }}
           commit: ${{ github.ref }}

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -99,7 +99,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           prune-cache: false
       - name: Install LFX dependencies
-        run: uv sync --dev --package lfx
+        run: cd src/lfx uv sync
 
       - name: Verify Nightly Name and Version
         id: verify

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -99,7 +99,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           prune-cache: false
       - name: Install LFX dependencies
-        run: cd src/lfx uv sync
+        run: cd src/lfx && uv sync
 
       - name: Verify Nightly Name and Version
         id: verify

--- a/scripts/ci/update_lfx_version.py
+++ b/scripts/ci/update_lfx_version.py
@@ -1,5 +1,6 @@
 """Script to update LFX version for nightly builds."""
 
+import re
 import sys
 from pathlib import Path
 
@@ -9,6 +10,28 @@ from update_pyproject_version import update_pyproject_version
 # Add the current directory to the path so we can import the other scripts
 current_dir = Path(__file__).resolve().parent
 sys.path.append(str(current_dir))
+
+BASE_DIR = Path(__file__).parent.parent.parent
+
+
+def update_lfx_workspace_dep(pyproject_path: str, new_project_name: str) -> None:
+    """Update the LFX workspace dependency in pyproject.toml."""
+    filepath = BASE_DIR / pyproject_path
+    content = filepath.read_text(encoding="utf-8")
+
+    if new_project_name == "lfx-nightly":
+        pattern = re.compile(r"lfx = \{ workspace = true \}")
+        replacement = "lfx-nightly = { workspace = true }"
+    else:
+        msg = f"Invalid LFX project name: {new_project_name}"
+        raise ValueError(msg)
+
+    # Updates the dependency name for uv
+    if not pattern.search(content):
+        msg = f"lfx workspace dependency not found in {filepath}"
+        raise ValueError(msg)
+    content = pattern.sub(replacement, content)
+    filepath.write_text(content, encoding="utf-8")
 
 
 def update_lfx_for_nightly(lfx_tag: str):
@@ -25,6 +48,9 @@ def update_lfx_for_nightly(lfx_tag: str):
     # Update version (strip 'v' prefix if present)
     version = lfx_tag.lstrip("v")
     update_pyproject_version(lfx_pyproject_path, version)
+
+    # Update workspace dependency in root pyproject.toml
+    update_lfx_workspace_dep("pyproject.toml", "lfx-nightly")
 
     print(f"Updated LFX package to lfx-nightly version {version}")
 


### PR DESCRIPTION
Introduce a new workflow for LFX releases, including cross-platform testing and integration into the nightly build process. Update the versioning script to accommodate LFX_TAG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional LFX release alongside the main package.
  - GitHub Releases now include LFX artifacts when selected.
  - Release tag auto-derives from either main or LFX build.

- Tests
  - Added cross-platform installation tests for LFX across multiple OS and Python versions.

- Chores
  - Updated release workflow to support LFX builds, testing, and conditional publishing to PyPI.
  - CI triggers extended to run when LFX release is requested.
  - Nightly build updated to pass an additional tag parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->