### PR TITLE
Fix: Resolve MCP server mismatch error on settings page

### DIFF
--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -95,7 +95,13 @@ export default function AddMcpServerModal({
 
   useEffect(() => {
     if (open) {
-      setType(initialData ? (initialData.command ? "STDIO" : "SSE") : "JSON");
+      setType(
+        initialData
+          ? initialData.command
+            ? "STDIO"
+            : "SSE"
+          : type
+      );
       setError(null);
       setJsonValue("");
       setStdioName(initialData?.name || "");


### PR DESCRIPTION
This pull request addresses a minor bug on the MCP settings page by ensuring that the MCP server is correctly added when a model error mismatch occurs.

<img width="698" height="630" alt="image" src="https://github.com/user-attachments/assets/19c2c6e1-ee91-413a-be28-f82651c42ee4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Add/Update MCP Server modal now remembers your last selected tab when opened without prefilled data, instead of always defaulting to JSON.
  * Other fields and error states continue to reset on open for a clean start.
  * This update streamlines repeated entries and reduces friction when switching between configuration methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->