### PR TITLE
docs: fix sidebar behavior of last element

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -386,10 +386,6 @@ body {
   height: 100%;
 }
 
-.theme-doc-sidebar-menu > :nth-last-child(2) {
-  margin-bottom: auto;
-}
-
 /* Sidebar Ad Styles */
 .sidebar-ad {
   margin-left: -0.5rem;

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -390,7 +390,7 @@ body {
 .sidebar-ad {
   margin-left: -0.5rem;
   margin-right: -0.5rem;
-  margin-top: 1rem;
+  margin-top: auto;
   border-radius: 0;
   border-top: 1px solid var(--ifm-color-emphasis-300);
   position: sticky;


### PR DESCRIPTION
Fix behavior where Log section was being forced to the bottom of the navbar in the API.
<img width="342" height="308" alt="Screenshot 2025-09-03 at 2 03 38 PM" src="https://github.com/user-attachments/assets/b5970a1d-f5da-4858-ae80-9719c2937f4d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted documentation sidebar spacing to remove unintended extra bottom spacing near the end of the menu.
  * Improves visual consistency and alignment of sidebar items without affecting other styles.
  * Enhances readability and reduces layout quirks in the docs sidebar across pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->