### PR TITLE
docs: link to docling libraries for components

### DIFF
--- a/docs/docs/Integrations/Docling/integrations-docling.mdx
+++ b/docs/docs/Integrations/Docling/integrations-docling.mdx
@@ -64,6 +64,8 @@ The **Docling** language model component ingest documents, and then uses Docling
 
 It outputs `files`, which is the processed files with `DoclingDocument` data.
 
+For more information, see the [Docling IBM models project repository](https://github.com/docling-project/docling-ibm-models).
+
 #### Docling parameters
 
 | Name | Type | Description |
@@ -78,7 +80,7 @@ The **Docling Serve** component runs Docling as an API service.
 
 It outputs `files`, which is the processed files with `DoclingDocument` data.
 
-For more information, see the [Docling Serve project repository](https://github.com/docling-project/docling-serve).
+For more information, see the [Docling serve project repository](https://github.com/docling-project/docling-serve).
 
 #### Docling Serve parameters
 
@@ -97,6 +99,8 @@ The **Chunk DoclingDocument** component uses the `DoclingDocument` chunkers to s
 
 It outputs the chunked documents as a [`DataFrame`](/data-types#dataframe).
 
+For more information, see the [Docling core project repository](https://github.com/docling-project/docling-core).
+
 #### Chunk DoclingDocument parameters
 
 | Name | Type | Description |
@@ -114,6 +118,8 @@ It outputs the chunked documents as a [`DataFrame`](/data-types#dataframe).
 The **Export DoclingDocument** component exports `DoclingDocument` to Markdown, HTML, and other formats.
 
 It can output the exported data as either [`Data`](/data-types#data) or [`DataFrame`](/data-types#dataframe).
+
+For more information, see the [Docling core project repository](https://github.com/docling-project/docling-core).
 
 #### Export DoclingDocument parameters
 

--- a/docs/docs/Integrations/Docling/integrations-docling.mdx
+++ b/docs/docs/Integrations/Docling/integrations-docling.mdx
@@ -74,9 +74,11 @@ It outputs `files`, which is the processed files with `DoclingDocument` data.
 
 ### Docling Serve
 
-The **Docling Serve** component ingests documents, and then uses Docling to process them by connecting to your instance of Docling Serve.
+The **Docling Serve** component runs Docling as an API service.
 
 It outputs `files`, which is the processed files with `DoclingDocument` data.
+
+For more information, see the [Docling Serve project repository](https://github.com/docling-project/docling-serve).
 
 #### Docling Serve parameters
 


### PR DESCRIPTION
Provide direct links to the relevant Docling project repositories for each component.
Not all of the libraries have docs built, or are represented on the [docling docs page](https://docling-project.github.io/docling/).