### PR TITLE
fix: switch to docling-serve v1 API

### DIFF
--- a/src/lfx/src/lfx/components/docling/docling_remote.py
+++ b/src/lfx/src/lfx/components/docling/docling_remote.py
@@ -103,13 +103,13 @@ class DoclingRemoteComponent(BaseFileComponent):
     ]
 
     def process_files(self, file_list: list[BaseFileComponent.BaseFile]) -> list[BaseFileComponent.BaseFile]:
-        base_url = f"{self.api_url}/v1alpha"
+        base_url = f"{self.api_url}/v1"
 
         def _convert_document(client: httpx.Client, file_path: Path, options: dict[str, Any]) -> Data | None:
             encoded_doc = base64.b64encode(file_path.read_bytes()).decode()
             payload = {
                 "options": options,
-                "file_sources": [{"base64_string": encoded_doc, "filename": file_path.name}],
+                "sources": [{"kind": "file", "base64_string": encoded_doc, "filename": file_path.name}],
             }
 
             response = client.post(f"{base_url}/convert/source/async", json=payload)
@@ -165,7 +165,6 @@ class DoclingRemoteComponent(BaseFileComponent):
         docling_options = {
             "to_formats": ["json"],
             "image_export_mode": "placeholder",
-            "return_as_file": False,
             **(self.docling_serve_opts or {}),
         }
 


### PR DESCRIPTION
Replaces #9634

@erichare here is the clean PR from the latest `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated the Docling remote integration to the v1 API and aligned request payload structure and naming for compatibility.
* **Bug Fixes**
  * Improved reliability of document conversion requests with the updated service.
  * Removed an unused option to prevent confusion in conversion behavior.
* **Chores**
  * Internal configuration cleanup with no changes to public interfaces or exported APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->