### PR TITLE
ci(cross-platform): add LFX wheel artifact handling and tests

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -18,6 +18,10 @@ on:
         description: "Name of the main package artifact"
         required: true
         type: string
+      lfx-artifact-name:
+        description: "Name of the LFX package artifact"
+        required: false
+        type: string
 
 jobs:
   build-if-needed:
@@ -142,6 +146,13 @@ jobs:
           ignore-empty-workdir: true
 
       # Download artifacts for wheel installation
+      - name: Download LFX package artifact
+        if: steps.install-method.outputs.method == 'wheel' && inputs.lfx-artifact-name != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.lfx-artifact-name }}
+          path: ./lfx-dist
+
       - name: Download base package artifact
         if: steps.install-method.outputs.method == 'wheel'
         uses: actions/download-artifact@v4
@@ -162,6 +173,20 @@ jobs:
         shell: bash
 
       # Wheel installation steps
+      - name: Install LFX package from wheel (Windows)
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows' && inputs.lfx-artifact-name != ''
+        run: |
+          ls -la ./lfx-dist/
+          find ./lfx-dist -name "*.whl" -type f
+          WHEEL_FILE=$(find ./lfx-dist -name "*.whl" -type f | head -1)
+          if [ -n "$WHEEL_FILE" ]; then
+            uv pip install --python ./test-env/Scripts/python.exe "$WHEEL_FILE"
+          else
+            echo "No wheel file found in ./lfx-dist/"
+            exit 1
+          fi
+        shell: bash
+
       - name: Install base package from wheel (Windows)
         if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows'
         run: |
@@ -186,6 +211,20 @@ jobs:
             uv pip install --python ./test-env/Scripts/python.exe "$WHEEL_FILE"
           else
             echo "No wheel file found in ./main-dist/"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Install LFX package from wheel (Unix)
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os != 'windows' && inputs.lfx-artifact-name != ''
+        run: |
+          ls -la ./lfx-dist/
+          find ./lfx-dist -name "*.whl" -type f
+          WHEEL_FILE=$(find ./lfx-dist -name "*.whl" -type f | head -1)
+          if [ -n "$WHEEL_FILE" ]; then
+            uv pip install --python ./test-env/bin/python "$WHEEL_FILE"
+          else
+            echo "No wheel file found in ./lfx-dist/"
             exit 1
           fi
         shell: bash
@@ -395,6 +434,13 @@ jobs:
           ignore-empty-workdir: true
 
       # Download artifacts for wheel installation
+      - name: Download LFX package artifact
+        if: steps.install-method.outputs.method == 'wheel' && inputs.lfx-artifact-name != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.lfx-artifact-name }}
+          path: ./lfx-dist
+
       - name: Download base package artifact
         if: steps.install-method.outputs.method == 'wheel'
         uses: actions/download-artifact@v4
@@ -415,6 +461,20 @@ jobs:
         shell: bash
 
       # Wheel installation steps
+      - name: Install LFX package from wheel (Windows)
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows' && inputs.lfx-artifact-name != ''
+        run: |
+          ls -la ./lfx-dist/
+          find ./lfx-dist -name "*.whl" -type f
+          WHEEL_FILE=$(find ./lfx-dist -name "*.whl" -type f | head -1)
+          if [ -n "$WHEEL_FILE" ]; then
+            uv pip install --python ./test-env/Scripts/python.exe "$WHEEL_FILE"
+          else
+            echo "No wheel file found in ./lfx-dist/"
+            exit 1
+          fi
+        shell: bash
+
       - name: Install base package from wheel (Windows)
         if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows'
         run: |
@@ -439,6 +499,20 @@ jobs:
             uv pip install --python ./test-env/Scripts/python.exe "$WHEEL_FILE"
           else
             echo "No wheel file found in ./main-dist/"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Install LFX package from wheel (Unix)
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os != 'windows' && inputs.lfx-artifact-name != ''
+        run: |
+          ls -la ./lfx-dist/
+          find ./lfx-dist -name "*.whl" -type f
+          WHEEL_FILE=$(find ./lfx-dist -name "*.whl" -type f | head -1)
+          if [ -n "$WHEEL_FILE" ]; then
+            uv pip install --python ./test-env/bin/python "$WHEEL_FILE"
+          else
+            echo "No wheel file found in ./lfx-dist/"
             exit 1
           fi
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,11 +208,12 @@ jobs:
   test-cross-platform:
     name: Test Cross-Platform Installation
     if: inputs.release_package_base == true || inputs.release_package_main == true
-    needs: [build-base, build-main]
+    needs: [build-base, build-main, build-lfx]
     uses: ./.github/workflows/cross-platform-test.yml
     with:
       base-artifact-name: "dist-base"
       main-artifact-name: "dist-main"
+      lfx-artifact-name: ${{ inputs.release_lfx == true && 'dist-lfx' || '' }}
 
   test-lfx-cross-platform:
     name: Test LFX Cross-Platform Installation

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -298,11 +298,12 @@ jobs:
 
   test-cross-platform:
     name: Test Cross-Platform Installation
-    needs: [build-nightly-base, build-nightly-main]
+    needs: [build-nightly-lfx, build-nightly-base, build-nightly-main]
     uses: ./.github/workflows/cross-platform-test.yml
     with:
       base-artifact-name: "dist-nightly-base"
       main-artifact-name: "dist-nightly-main"
+      lfx-artifact-name: "dist-nightly-lfx"
 
   publish-nightly-lfx:
     name: Publish LFX Nightly to PyPI


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional LFX artifact support in cross-platform tests, enabling wheel-based installation across Windows, macOS, and Linux.
  - Dedicated cross-platform LFX test job for releases, covering multiple OS and Python versions and verifying installation.

- Tests
  - Release and nightly pipelines now depend on LFX builds and pass the artifact name to cross-platform tests.

- Chores
  - Introduced a new workflow input to specify the LFX artifact name for test and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->