### PR TITLE
feat: Add frontend build cleaning and CLI run options

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,8 +4,8 @@ This document details how to set up a local development environment that will al
 
 ## Base Requirements
 
-* The project is hosted on GitHub, so you need an account there (and if you are reading this, you likely do!)
-* An IDE such as Microsoft VS Code IDE https://code.visualstudio.com/
+- The project is hosted on GitHub, so you need an account there (and if you are reading this, you likely do!)
+- An IDE such as Microsoft VS Code IDE https://code.visualstudio.com/
 
 ## Set up Git Repository Fork
 
@@ -27,8 +27,7 @@ git remote add upstream https://github.com/langflow-ai/langflow.git
 git remote set-url --push upstream no_push
 ```
 
-> [!TIP]
-> **Windows/WSL Users**: You may find that files "change", specifically the file mode e.g. "changed file mode 100755 → 100644". You can workaround this problem with `git config core.filemode false`.
+> [!TIP] > **Windows/WSL Users**: You may find that files "change", specifically the file mode e.g. "changed file mode 100755 → 100644". You can workaround this problem with `git config core.filemode false`.
 
 ## Set up Environment
 
@@ -40,19 +39,18 @@ Open this repository as a Dev Container per your IDEs instructions.
 
 #### Microsoft VS Code
 
-* See [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers)
-* You may also find it helpful to [share `git` credentials](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials) with the container
-
+- See [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers)
+- You may also find it helpful to [share `git` credentials](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials) with the container
 
 ### Option 2: Use Your Own Environment
 
 Install Pre-Requisites:
 
-* **Operating System**: macOS or Linux; Windows users ***MUST*** develop under WSL.
-* **`git`**: The project uses the ubiquitous `git` tool for change control.
-* **`make`**: The project uses `make` to coordidinate packaging.
-* **`uv`**: This project uses `uv` (`>=0.4`), a Python package and project manager from Astral. Install instructions at https://docs.astral.sh/uv/getting-started/installation/.
-* **`npm`**: The frontend files are built with Node.js (`v22.12 LTS`) and `npm` (`v10.9`). Install instructions at https://nodejs.org/en/download/package-manager.
+- **Operating System**: macOS or Linux; Windows users **_MUST_** develop under WSL.
+- **`git`**: The project uses the ubiquitous `git` tool for change control.
+- **`make`**: The project uses `make` to coordidinate packaging.
+- **`uv`**: This project uses `uv` (`>=0.4`), a Python package and project manager from Astral. Install instructions at https://docs.astral.sh/uv/getting-started/installation/.
+- **`npm`**: The frontend files are built with Node.js (`v22.12 LTS`) and `npm` (`v10.9`). Install instructions at https://nodejs.org/en/download/package-manager.
   - Windows (WSL) users: ensure `npm` is installed within WSL environment; `which npm` should resolve to a Linux location, not a Windows location.
 
 ### Initial Environment Validation
@@ -70,8 +68,18 @@ This sets up the development environment by installing backend and frontend depe
 
 After running `make init`, you have two options for running Langflow:
 
-* Use `make run_cli` to build and run the application immediately.
-* Continue to the next section to run Langflow in Development mode.
+- Use `make run_cli` to build and run the application immediately.
+- Continue to the next section to run Langflow in Development mode.
+
+**Troubleshooting frontend build issues:**
+
+If you encounter frontend build problems or are upgrading from an older version of Langflow, use `make run_clic` at least the first time:
+
+```bash
+make run_clic
+```
+
+This command cleans the build cache and rebuilds everything from scratch, which resolves most frontend-related issues when switching between versions.
 
 ## Complete development environment setup
 
@@ -84,7 +92,7 @@ Pre-commit hooks will help keep your changes clean and well-formatted.
 > [!NOTE]
 > With these installed, the `git commit` command needs to run within the Python environment; your syntax needs to change to `uv run git commit`.
 
- Install pre-commit hooks by running the following commands:
+Install pre-commit hooks by running the following commands:
 
 ```bash
 uv sync
@@ -96,7 +104,7 @@ uv run pre-commit install
 With the above validation, you can now run the backend (FastAPI) and frontend (Node) services in a way that will "hot-reload" your changes. In this mode, the FastAPI server requires a Node.js server to serve the frontend pages rather than serving them directly.
 
 > [!NOTE]
-> You will likely have multiple terminal sessions active in the normal development workflow. These will be annotated as *Backend Terminal*, *Frontend Terminal*, *Documentation Terminal*, and *Build Terminal*.
+> You will likely have multiple terminal sessions active in the normal development workflow. These will be annotated as _Backend Terminal_, _Frontend Terminal_, _Documentation Terminal_, and _Build Terminal_.
 
 ### Debug Mode
 
@@ -104,7 +112,7 @@ A debug configuration is provided for VS Code users: this can be launched from t
 
 ### Start the Backend Service
 
-The backend service runs as a FastAPI service on Python, and is responsible for servicing API requests. In the *Backend Terminal*, start the backend service:
+The backend service runs as a FastAPI service on Python, and is responsible for servicing API requests. In the _Backend Terminal_, start the backend service:
 
 ```bash
 make backend
@@ -123,12 +131,12 @@ Starting Langflow ...
 At which point you can check http://localhost:7860/health in a browser; when the backend service is ready it will return a document like:
 
 ```json
-{"status":"ok"}
+{ "status": "ok" }
 ```
 
 ### Start the Frontend Service
 
-The frontend (User Interface) is, in shipped code (i.e. via `langflow run`), statically-compiled files that the backend FastAPI service provides to clients via port `7860`. In development mode, these are served by a Node.js service on port `3000`. In the *Frontend Terminal*, start the frontend service:
+The frontend (User Interface) is, in shipped code (i.e. via `langflow run`), statically-compiled files that the backend FastAPI service provides to clients via port `7860`. In development mode, these are served by a Node.js service on port `3000`. In the _Frontend Terminal_, start the frontend service:
 
 ```bash
 make frontend
@@ -169,7 +177,6 @@ If the frontend service is running on port `3000` you might be prompted `Would y
 
 Navigate to http://localhost:3001/ in a browser and view the documentation. Documentation updates will be visible as they are saved, though sometimes the browser page will also need to be refreshed.
 
-
 ## Adding or Modifying a Component
 
 Components reside in folders under `src/backend/base/langflow`, and their unit tests under `src/backend/base/tests/unit/components`.
@@ -179,7 +186,7 @@ Components reside in folders under `src/backend/base/langflow`, and their unit t
 Add the component to the appropriate subdirectory, and add the component to the `__init__.py` file (alphabetical ordering on the `import` and the `__all__` list). Assuming the backend and frontend services are running, the backend service will restart as these files are changed. The new component will be visible after the backend is restarted, _*and*_ after you hit "refresh" in the browser.
 
 > [!TIP]
-> It is faster to copy-paste the component code from your editor into the UI *without* saving in the source code in the editor, and once you are satisfied it is working you can save (restarting the backend) and refresh the browser to confirm it is present.
+> It is faster to copy-paste the component code from your editor into the UI _without_ saving in the source code in the editor, and once you are satisfied it is working you can save (restarting the backend) and refresh the browser to confirm it is present.
 
 You should try to add a unit test for your component, though templates and best practices for this is a work in progress. At the very least, please create a Markdown file in the unit test subdirectory associated with your component (create the directory if not present), with the same filename as the component but with a `.md` extension. Within this should be the steps you have taken to manually test the component.
 
@@ -194,13 +201,13 @@ Modifying a component is much the same as adding a component: it is generally ea
 
 When you are ready to commit, and before you commit, you should consider the following:
 
-* `make lint`
-* `make format_backend` and `make format_frontend` will run code formatters on their respective codebases
-* `make unit_tests` runs the (backend) unit tests (see "Quirks" below for more about testing).
+- `make lint`
+- `make format_backend` and `make format_frontend` will run code formatters on their respective codebases
+- `make unit_tests` runs the (backend) unit tests (see "Quirks" below for more about testing).
 
 Once these changes are ready, it is helpful to rebase your changes on top of `upstream`'s `main` branch, to ensure you have the latest code version! Of course if you have had to merge changes into your component you may want to re-lint/format/unit_test.
 
-As a final validation, stop the backend and frontend services and run `make init`; this will do a clean build and the UI should be available in port `7860` (as it has invoked `langflow run`). Open a **new** browser tab to this  service and do a final check of your changes by adding your new/modified component onto the canvas from the Components list.
+As a final validation, stop the backend and frontend services and run `make init`; this will do a clean build and the UI should be available in port `7860` (as it has invoked `langflow run`). Open a **new** browser tab to this service and do a final check of your changes by adding your new/modified component onto the canvas from the Components list.
 
 ## Committing, Pushing, and Pull Requests
 
@@ -215,15 +222,15 @@ You may observe some quirky things:
 
 ### Testing
 
-* Backend test `src/backend/tests/unit/test_database.py` can fail when running with `make tests` but passes when running manually
-  * You can validate this by running the test cases sequentially: `uv run pytest src/backend/tests/unit/test_database.py`
-* There are some other test targets: `integration_tests`, `coverage`, `tests_frontend` but these require additional setup not covered in this document.
+- Backend test `src/backend/tests/unit/test_database.py` can fail when running with `make tests` but passes when running manually
+  - You can validate this by running the test cases sequentially: `uv run pytest src/backend/tests/unit/test_database.py`
+- There are some other test targets: `integration_tests`, `coverage`, `tests_frontend` but these require additional setup not covered in this document.
 
 ### Files That Change
 
 There are some files that change without you having made changes:
 
-* Files in `src/backend/base/langflow/initial_setup/starter_projects` modify after `langflow run`; these are formatting changes. Feel free to commit (or ignore) them.
-* `uv.lock` and `src/frontend/package-lock.json` files can be modified by `make` targets; changes should not be committed by individual contributors.
-   * You can exclude these from consideration in git: `git update-index --assume-unchanged uv.lock src/frontend/package-lock.json`
-   * You can re-include these from consideration in git: `git update-index --no-assume-unchanged uv.lock src/frontend/package-lock.json`
+- Files in `src/backend/base/langflow/initial_setup/starter_projects` modify after `langflow run`; these are formatting changes. Feel free to commit (or ignore) them.
+- `uv.lock` and `src/frontend/package-lock.json` files can be modified by `make` targets; changes should not be committed by individual contributors.
+  - You can exclude these from consideration in git: `git update-index --assume-unchanged uv.lock src/frontend/package-lock.json`
+  - You can re-include these from consideration in git: `git update-index --no-assume-unchanged uv.lock src/frontend/package-lock.json`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,9 +71,9 @@ After running `make init`, you have two options for running Langflow:
 - Use `make run_cli` to build and run the application immediately.
 - Continue to the next section to run Langflow in Development mode.
 
-**Troubleshooting frontend build issues:**
+### Troubleshooting frontend build issues
 
-If you encounter frontend build problems or are upgrading from an older version of Langflow, use `make run_clic` at least the first time:
+If you encounter frontend build problems or are upgrading from an older version of Langflow, run `make run_clic` once.
 
 ```bash
 make run_clic

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all init format_backend format lint build run_backend dev help tests coverage clean_python_cache clean_npm_cache clean_all
+.PHONY: all init format_backend format lint build run_backend dev help tests coverage clean_python_cache clean_npm_cache clean_frontend_build clean_all run_cli_cached
 
 # Configurations
 VERSION=$(shell grep "^version" pyproject.toml | sed 's/.*\"\(.*\)\"$$/\1/')
@@ -86,6 +86,14 @@ clean_npm_cache:
 	$(call CLEAR_DIRS,src/frontend/node_modules src/frontend/build src/backend/base/langflow/frontend)
 	rm -f src/frontend/package-lock.json
 	@echo "$(GREEN)NPM cache and frontend directories cleaned.$(NC)"
+
+clean_frontend_build: ## clean frontend build artifacts to ensure fresh build
+	@echo "Cleaning frontend build artifacts..."
+	@echo "  - Removing src/frontend/build directory"
+	$(call CLEAR_DIRS,src/frontend/build)
+	@echo "  - Removing built frontend files from backend"
+	$(call CLEAR_DIRS,src/backend/base/langflow/frontend)
+	@echo "$(GREEN)Frontend build artifacts cleaned - fresh build guaranteed.$(NC)"
 
 clean_all: clean_python_cache clean_npm_cache # clean all caches and temporary directories
 	@echo "$(GREEN)All caches and temporary directories cleaned.$(NC)"
@@ -205,8 +213,18 @@ lint: install_backend ## run linters
 
 
 
-run_cli: install_frontend install_backend build_frontend ## run the CLI
-	@echo 'Running the CLI'
+run_cli: clean_frontend_build install_frontend install_backend build_frontend ## run the CLI with fresh frontend build
+	@echo 'Running the CLI with fresh frontend build'
+	@uv run langflow run \
+		--frontend-path $(path) \
+		--log-level $(log_level) \
+		--host $(host) \
+		--port $(port) \
+		$(if $(env),--env-file $(env),) \
+		$(if $(filter false,$(open_browser)),--no-open-browser)
+
+run_cli_cached: install_frontend install_backend build_frontend ## run the CLI quickly (without cleaning build cache)
+	@echo 'Running the CLI quickly (reusing existing build cache if available)'
 	@uv run langflow run \
 		--frontend-path $(path) \
 		--log-level $(log_level) \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all init format_backend format lint build run_backend dev help tests coverage clean_python_cache clean_npm_cache clean_frontend_build clean_all run_cli_cached
+.PHONY: all init format_backend format lint build run_backend dev help tests coverage clean_python_cache clean_npm_cache clean_frontend_build clean_all run_clic
 
 # Configurations
 VERSION=$(shell grep "^version" pyproject.toml | sed 's/.*\"\(.*\)\"$$/\1/')
@@ -213,7 +213,7 @@ lint: install_backend ## run linters
 
 
 
-run_cli: clean_frontend_build install_frontend install_backend build_frontend ## run the CLI with fresh frontend build
+run_clic: clean_frontend_build install_frontend install_backend build_frontend ## run the CLI with fresh frontend build
 	@echo 'Running the CLI with fresh frontend build'
 	@uv run langflow run \
 		--frontend-path $(path) \
@@ -223,7 +223,7 @@ run_cli: clean_frontend_build install_frontend install_backend build_frontend ##
 		$(if $(env),--env-file $(env),) \
 		$(if $(filter false,$(open_browser)),--no-open-browser)
 
-run_cli_cached: install_frontend install_backend build_frontend ## run the CLI quickly (without cleaning build cache)
+run_cli: install_frontend install_backend build_frontend ## run the CLI quickly (without cleaning build cache)
 	@echo 'Running the CLI quickly (reusing existing build cache if available)'
 	@uv run langflow run \
 		--frontend-path $(path) \

--- a/docs/docs/Contributing/contributing-how-to-contribute.mdx
+++ b/docs/docs/Contributing/contributing-how-to-contribute.mdx
@@ -51,6 +51,16 @@ This command does the following:
 
 The Langflow frontend is served at `http://localhost:7860`.
 
+**Troubleshooting frontend build issues:**
+
+If you encounter frontend build problems or are upgrading from an older version of Langflow, use `make run_clic` at least the first time:
+
+```bash
+make run_clic
+```
+
+This command cleans the build cache and rebuilds everything from scratch, which resolves most frontend-related issues when switching between versions.
+
 </details>
 
 <details>

--- a/docs/docs/Contributing/contributing-how-to-contribute.mdx
+++ b/docs/docs/Contributing/contributing-how-to-contribute.mdx
@@ -50,17 +50,6 @@ This command does the following:
 - Starts the application with default settings
 
 The Langflow frontend is served at `http://localhost:7860`.
-
-**Troubleshooting frontend build issues:**
-
-If you encounter frontend build problems or are upgrading from an older version of Langflow, use `make run_clic` at least the first time:
-
-```bash
-make run_clic
-```
-
-This command cleans the build cache and rebuilds everything from scratch, which resolves most frontend-related issues when switching between versions.
-
 </details>
 
 <details>
@@ -201,9 +190,19 @@ The frontend is served at `http://localhost:7860`.
 </TabItem>
 </Tabs>
 
+### Troubleshoot frontend build issues
+
+If you encounter frontend build problems or are upgrading from an older version of Langflow, run `make run_clic`.
+
+```bash
+make run_clic
+```
+
+This command cleans the build cache and rebuilds everything from scratch, which resolves most frontend-related issues when switching between versions.
+
 ### Debug
 
-The repo includes a `.vscode/launch.json` file for debugging the backend in VSCode, which is faster than debugging with Docker Compose. To debug Langflow with the `launch.json` file in VSCode:
+The repo includes a `.vscode/launch.json` file for debugging the backend in VSCode, which is faster than debugging with Docker Compose.
 
 For more information, see the [VSCode documentation](https://code.visualstudio.com/docs/debugtest/debugging#_start-a-debugging-session).
 

--- a/docs/docs/Contributing/contributing-how-to-contribute.mdx
+++ b/docs/docs/Contributing/contributing-how-to-contribute.mdx
@@ -192,7 +192,7 @@ The frontend is served at `http://localhost:7860`.
 
 ### Troubleshoot frontend build issues
 
-If you encounter frontend build problems or are upgrading from an older version of Langflow, run `make run_clic`.
+If you encounter frontend build problems or are upgrading from an older version of Langflow, run `make run_clic` once.
 
 ```bash
 make run_clic


### PR DESCRIPTION
This pull request updates the `Makefile` to improve frontend build management and provide more flexible CLI run options. The main changes introduce a dedicated target for cleaning frontend build artifacts, ensure a fresh frontend build when running the CLI, and add a faster CLI run option that skips cleaning.

**Frontend build management:**
* Added a new `clean_frontend_build` target to remove frontend build artifacts and ensure a fresh build environment.
* Updated `.PHONY` targets to include `clean_frontend_build` and `run_cli_cached`.

**CLI run improvements:**
* Modified the `run_cli` target to clean frontend build artifacts before running, guaranteeing a fresh frontend build each time.
* Added a `run_cli_cached` target to run the CLI without cleaning the build cache, allowing for faster iteration when a fresh build is not needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Choose between a fresh frontend build for reliability or a cached build for faster CLI startup.
  * More flexible CLI options: configure host, port, log level, frontend path, optional env file, and disable auto-opening the browser.

* **Chores**
  * Streamlined frontend build cleanup to reduce leftover artifacts and improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->