### PR TITLE
fix: Ensure correct Docling Remote URL for API

### DIFF
--- a/src/backend/base/langflow/components/docling/docling_remote.py
+++ b/src/backend/base/langflow/components/docling/docling_remote.py
@@ -103,13 +103,13 @@ class DoclingRemoteComponent(BaseFileComponent):
     ]
 
     def process_files(self, file_list: list[BaseFileComponent.BaseFile]) -> list[BaseFileComponent.BaseFile]:
-        base_url = f"{self.api_url}/v1alpha"
+        base_url = f"{self.api_url}/v1"
 
         def _convert_document(client: httpx.Client, file_path: Path, options: dict[str, Any]) -> Data | None:
             encoded_doc = base64.b64encode(file_path.read_bytes()).decode()
             payload = {
                 "options": options,
-                "file_sources": [{"base64_string": encoded_doc, "filename": file_path.name}],
+                "sources": [{"kind": "file", "base64_string": encoded_doc, "filename": file_path.name}],
             }
 
             response = client.post(f"{base_url}/convert/source/async", json=payload)
@@ -165,7 +165,6 @@ class DoclingRemoteComponent(BaseFileComponent):
         docling_options = {
             "to_formats": ["json"],
             "image_export_mode": "placeholder",
-            "return_as_file": False,
             **(self.docling_serve_opts or {}),
         }
 


### PR DESCRIPTION
This pull request updates the `DoclingRemoteComponent` in `docling_remote.py` to improve compatibility with the Docling API and streamline payload construction. The most important changes focus on updating the API version, restructuring the payload, and removing an unused option.

**Docling API integration:**

* Updated the API version in the `base_url` from `v1alpha` to `v1` to ensure requests are sent to the correct endpoint.
* Changed the payload key from `file_sources` to `sources`, and added a `kind: "file"` field, aligning the payload structure with the latest Docling API requirements.

**Payload options cleanup:**

* Removed the `return_as_file` option from `docling_options`, as it is no longer used or required.