### PR TITLE
docs: replace ampersands in windows command

### DIFF
--- a/docs/docs/Contributing/contributing-how-to-contribute.mdx
+++ b/docs/docs/Contributing/contributing-how-to-contribute.mdx
@@ -23,7 +23,7 @@ During development, the frontend and backend services run separately on differen
 - Frontend development server: `http://localhost:3000` (with hot reload).
 - Backend API server: `http://localhost:7860`.
 
-When Langflow is deployed for end users, the backend serves the frontend internally, making both services available on a single port (`7860` by default).
+When you install Langflow as an end user, the backend serves the frontend internally, making both services available on a single port (`7860` by default).
 
 ## Install Langflow from source
 

--- a/docs/docs/Contributing/contributing-how-to-contribute.mdx
+++ b/docs/docs/Contributing/contributing-how-to-contribute.mdx
@@ -64,10 +64,13 @@ Do one of the following:
 
 * To run Langflow from the Windows Command Line:
 
-    1. Build the Langflow frontend:
+    1. Run the following commands separately to build the Langflow frontend:
 
         ```
-        cd src/frontend && npm install && npm run build && npm run start
+        cd src/frontend
+        npm install
+        npm run build
+        npm run start
         ```
 
     2. Copy the contents of the built `src/frontend/build` directory to `src/backend/base/langflow/frontend`.

--- a/docs/docs/Contributing/contributing-how-to-contribute.mdx
+++ b/docs/docs/Contributing/contributing-how-to-contribute.mdx
@@ -9,11 +9,25 @@ import TabItem from '@theme/TabItem';
 This guide is intended to help you start contributing to Langflow.
 As an open-source codebase in a rapidly developing field, Langflow welcomes contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
-To contribute code or documentation to Langflow, follow the [fork and pull request quickstart](https://docs.github.com/en/get-started/quickstart/contributing-to-projects).
+To contribute code or documentation to Langflow, follow the [pull request guide](#open-a-pull-request).
+
+## Langflow services overview
+
+This overview will help you understand how to set up your development environment.
+
+Langflow consists of two main services:
+- Frontend: A React/TypeScript application that provides the user interface.
+- Backend: A Python/FastAPI service that handles API requests.
+
+During development, the frontend and backend services run separately on different ports:
+- Frontend development server: `http://localhost:3000` (with hot reload).
+- Backend API server: `http://localhost:7860`.
+
+When Langflow is deployed for end users, the backend serves the frontend internally, making both services available on a single port (`7860` by default).
 
 ## Install Langflow from source
 
-Install Langflow from source by forking the repository, and then set up your development environment using Make.
+Install Langflow from source by forking the repository and setting up your development environment.
 
 ### Prerequisites
 
@@ -36,7 +50,9 @@ Replace the following:
 ### Run Langflow from source
 
 You can run Langflow from source after cloning the repository, even if you aren't contributing to the codebase.
-If you plan to contribute code, see [Set up development environment](#set-up-your-langflow-development-environment).
+This builds the frontend and serves it through the backend on port `7860`.
+
+The instructions below are for running Langflow from source. For development with hot reload, see [Set up development environment](#set-up-your-langflow-development-environment).
 
 <details>
 <summary>Run from source on macOS/Linux</summary>
@@ -64,13 +80,12 @@ Do one of the following:
 
 * To run Langflow from the Windows Command Line:
 
-    1. Run the following commands separately to build the Langflow frontend:
+    1. Build the frontend static files:
 
         ```
         cd src/frontend
         npm install
         npm run build
-        npm run start
         ```
 
     2. Copy the contents of the built `src/frontend/build` directory to `src/backend/base/langflow/frontend`.
@@ -86,7 +101,7 @@ The Langflow frontend is served at `http://localhost:7860`.
 </details>
 
 <details>
-<summary>Run from source with Powershell</summary>
+<summary>Run from source with PowerShell</summary>
 
 To run Langflow from source on Windows, you can use the Langflow repository's included scripts, or run the commands in the terminal.
 
@@ -94,15 +109,14 @@ Do one of the following:
 
 * To install and run Langflow with the included scripts, navigate to the `scripts/windows` directory, and then run the `build_and_run.ps1` file.
 
-* To run Langflow from a Powershell terminal:
+* To run Langflow from a PowerShell terminal:
 
-    1. Run the following commands separately to build the Langflow frontend:
+    1. Build the frontend static files:
 
         ```
         cd src/frontend
         npm install
         npm run build
-        npm run start
         ```
 
     2. Copy the contents of the built `src/frontend/build` directory to `src/backend/base/langflow/frontend`.
@@ -119,7 +133,7 @@ The Langflow frontend is served at `http://localhost:7860`.
 
 ### Set up your Langflow development environment
 
-This section is for contributors who want to develop and test code changes.
+This section is for contributors who want to develop and test code changes with hot reload enabled.
 
 If you just want to run Langflow locally without making code changes, see [Run Langflow from source](#run-langflow-from-source).
 
@@ -152,7 +166,7 @@ If you just want to run Langflow locally without making code changes, see [Run L
 
     The `make backend` and `make frontend` commands automatically install dependencies, so you don't need to run install commands separately.
 
-    The frontend is served at `http://localhost:7860`.
+    The frontend is served at `http://localhost:3000` and the backend at `http://localhost:7860`.
 
 3. Optional: Install pre-commit hooks to help keep your changes clean and well-formatted.
 
@@ -175,7 +189,7 @@ Since Windows doesn't include `make`, building and running Langflow from source 
 
 To set up the Langflow development environment, run the frontend and backend in separate terminals:
 
-1. To run the frontend, run the following commands:
+1. To run the frontend development server with hot reload, run the following commands:
 
     ```bash
     cd src/frontend
@@ -189,7 +203,7 @@ To set up the Langflow development environment, run the frontend and backend in 
     uv run langflow run --backend-only
     ```
 
-The frontend is served at `http://localhost:7860`.
+The frontend is served at `http://localhost:3000` and the backend at `http://localhost:7860`. This setup preserves hot reload for frontend development, with no need to copy build files after every edit.
 
 </TabItem>
 </Tabs>
@@ -243,7 +257,7 @@ For style guidance, see the [Google Developer Documentation Style Guide](https:/
     yarn start
     ```
 
-    The documentation is served at `localhost:3000`.
+    The documentation is served at `http://localhost:3000`.
 
 6. To edit and create content, work with the `.mdx` files in the `langflow/docs/docs` directory.
 


### PR DESCRIPTION
* Updated the Windows Command Line instructions in `docs/docs/Contributing/contributing-how-to-contribute.mdx` to list each frontend build command separately, because you can't use `&&` in Windows shell.

* Added an overview of what "frontend" and "backend" services are, and how they interact with each other during development setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Windows CMD “Run from source” guide. Replaced the single chained frontend command with a clear step-by-step sequence: “cd src/frontend”, “npm install”, “npm run build”, and “npm run start”. This makes the instructions easier to follow and reduces command-line execution issues on Windows. All subsequent steps (copying the built frontend to the backend path and starting the app) remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->