### PR TITLE
chore: Remove unused imports in docs, apply partials for frequently used text, small editorial touchups

### DIFF
--- a/docs/docs/API-Reference/api-build.mdx
+++ b/docs/docs/API-Reference/api-build.mdx
@@ -3,9 +3,6 @@ title: Build endpoints
 slug: /api-build
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 :::important
 The `/build` endpoints are used by Langflow's frontend visual editor code.
 These endpoints are part of the internal Langflow codebase.

--- a/docs/docs/API-Reference/api-files.mdx
+++ b/docs/docs/API-Reference/api-files.mdx
@@ -3,9 +3,6 @@ title: Files endpoints
 slug: /api-files
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Use the `/files` endpoints to move files between your local machine and Langflow.
 
 ## Differences between `/v1/files` and `/v2/files`

--- a/docs/docs/API-Reference/api-flows-run.mdx
+++ b/docs/docs/API-Reference/api-flows-run.mdx
@@ -3,9 +3,6 @@ title: Flow trigger endpoints
 slug: /api-flows-run
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Use the `/run` and `/webhook` endpoints to run flows.
 
 To create, read, update, and delete flows, see [Flow management endpoints](/api-flows).

--- a/docs/docs/API-Reference/api-flows.mdx
+++ b/docs/docs/API-Reference/api-flows.mdx
@@ -3,9 +3,6 @@ title: Flow management endpoints
 slug: /api-flows
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Use the `/flows` endpoint to create, read, update, and delete flows.
 
 If you want to use the Langflow API to run a flow, see [Flow trigger endpoints](/api-flows-run).

--- a/docs/docs/API-Reference/api-logs.mdx
+++ b/docs/docs/API-Reference/api-logs.mdx
@@ -3,9 +3,6 @@ title: Logs endpoints
 slug: /api-logs
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Retrieve logs for your Langflow flow.
 
 ## Enable log retrieval

--- a/docs/docs/API-Reference/api-monitor.mdx
+++ b/docs/docs/API-Reference/api-monitor.mdx
@@ -3,9 +3,6 @@ title: Monitor endpoints
 slug: /api-monitor
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 The `/monitor` endpoints are for internal Langflow functionality, primarily related to running flows in the **Playground**, storing chat history, and generating flow logs.
 
 This information is primarily for those who are building custom components or contributing to the Langflow codebase in a way that requires calling or understanding these endpoints.

--- a/docs/docs/API-Reference/api-projects.mdx
+++ b/docs/docs/API-Reference/api-projects.mdx
@@ -3,9 +3,6 @@ title: Projects endpoints
 slug: /api-projects
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Use the `/projects` endpoint to create, read, update, and delete [Langflow projects](/concepts-flows#projects).
 
 ## Read projects

--- a/docs/docs/API-Reference/api-users.mdx
+++ b/docs/docs/API-Reference/api-users.mdx
@@ -3,9 +3,6 @@ title: Users endpoints
 slug: /api-users
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Use the `/users` endpoint to manage user accounts in Langflow.
 
 ## Add user

--- a/docs/docs/Agents/agents.mdx
+++ b/docs/docs/Agents/agents.mdx
@@ -4,29 +4,14 @@ slug: /agents
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
+import PartialAgentsWork from '@site/docs/_partial-agents-work.mdx';
 
 Langflow's [**Agent** component](/components-agents) is critical for building agent flows.
 This component provides everything you need to create an agent, including multiple Large Language Model (LLM) providers, tool calling, and custom instructions.
 It simplifies agent configuration so you can focus on application development.
 
-<details>
-<summary>How do agents work?</summary>
-
-Agents extend LLMs by integrating _tools_, which are functions that provide additional context and enable autonomous task execution.
-These integrations make agents more specialized and powerful than standalone LLMs.
-
-Whereas an LLM might generate acceptable, inert responses to general queries and tasks, an agent can leverage the integrated context and tools to provide more relevant responses and even take action.
-For example, you might create an agent that can access your company's knowledge base, repositories, and other resources to help your team with tasks that require knowledge of your specific products, customers, and code.
-
-Agents use LLMs as a reasoning engine to process input, determine which actions to take to address the query, and then generate a response.
-The response could be a typical text-based LLM response, or it could involve an action, like editing a file, running a script, or calling an external API.
-
-In an agentic context, tools are functions that the agent can run to perform tasks or access external resources.
-A function is wrapped as a `Tool` object with a common interface that the agent understands.
-Agents become aware of tools through tool registration, which is when the agent is provided a list of available tools typically at agent initialization.
-The `Tool` object's description tells the agent what the tool can do so that it can decide whether the tool is appropriate for a given request.
-
-</details>
+<PartialAgentsWork />
 
 ## Use the Agent component in a flow
 
@@ -94,10 +79,7 @@ For a multi-agent example, see [Use an agent as a tool](/agents-tools#use-an-age
 
 You can configure the **Agent** component to use your preferred provider and model, custom instructions, and tools.
 
-:::tip
-Many optional **Agent** component input parameters are hidden by default in the visual editor.
-You can access all component parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
-:::
+<PartialParams />
 
 ### Provider and model
 
@@ -148,22 +130,21 @@ It is recommended to use custom session IDs if you need to segregate chat memory
 
 By default, the **Agent** component uses your Langflow installation's storage, and it retrieves a limited number of chat messages, which you can configure with the **Number of Chat History Messages** parameter.
 
-Although the **Message History** component isn't required for default chat memory, it provides more options for sorting, filtering, and limiting memories, and the **Message History** component is required to use external chat memory like Mem0.
+The **Message History** component isn't required for default chat memory, but it is required if you want to use external chat memory like Mem0.
+Additionally, the **Message History** component provides more options for sorting, filtering, and limiting memories. Although, most of these options are built-in to the **Agent** component with default values.
 
 For more information, see [Store chat memory](/memory#store-chat-memory) and [**Message History** component](/components-helpers#message-history).
 
 ### Additional parameters
 
-With the **Agent** component, the available parameters can change depending on the selected provider and model.
-For example, some models support additional modes, arguments, or features like chat memory and temperature.
-
-Some additional input parameters include the following:
+With the **Agent** component, the available parameters can change depending on the selected provider and model, including support for additional modes, arguments, or features like chat memory and temperature.
+For example:
 
 * **Current Date** (`add_current_date_tool`): When enabled (true), this setting adds a tool to the agent that can retrieve the current date.
 * **Handle Parse Errors** (`handle_parsing_errors`): When enabled (true), this setting allows the agent to fix errors, like typos, when analyzing user input.
 * **Verbose** (`verbose`): When enabled (true), this setting records detailed logging output for debugging and analysis.
 
-To view and configure all parameters, click <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 ## Agent component output
 

--- a/docs/docs/Components/bundles-aiml.mdx
+++ b/docs/docs/Components/bundles-aiml.mdx
@@ -4,6 +4,7 @@ slug: /bundles-aiml
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -41,8 +42,7 @@ For more information about using embedding model components in flows, see [**Emb
 
 ### AI/ML API Embeddings parameters
 
-Some **AI/ML API Embeddings** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-amazon.mdx
+++ b/docs/docs/Components/bundles-amazon.mdx
@@ -4,6 +4,7 @@ slug: /bundles-amazon
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -16,25 +17,27 @@ This component generates text using [Amazon Bedrock LLMs](https://docs.aws.amazo
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 Specifically, the **Language Model** output is an instance of [`ChatBedrock`](https://python.langchain.com/docs/integrations/chat/bedrock/) configured according to the component's parameters.
 
-Use the **Language Model** output when you want to use an Amazon Bedrock model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use an Amazon Bedrock model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### Amazon Bedrock parameters
 
-Many **Amazon Bedrock** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|
-| model_id | String | Input parameter. The ID of the Amazon Bedrock model to use. Options include various models. |
-| aws_access_key | SecretString | Input parameter. AWS Access Key for authentication. |
-| aws_secret_key | SecretString | Input parameter. AWS Secret Key for authentication. |
+| input | String | Input parameter. The input string for text generation. |
+| system_message | String | Input parameter. A system message to pass to the model. |
+| stream | Boolean | Input parameter. Whether to stream the response. Only works in chat. Default: false. |
+| model_id | String | Input parameter. The Amazon Bedrock model to use. |
+| aws_access_key_id | SecretString | Input parameter. AWS Access Key for authentication. |
+| aws_secret_access_key | SecretString | Input parameter. AWS Secret Key for authentication. |
 | aws_session_token | SecretString | Input parameter. The session key for your AWS account. |
 | credentials_profile_name | String | Input parameter. Name of the AWS credentials profile to use. |
-| region_name | String | Input parameter. AWS region name. Default: `us-east-1`. |
-| model_kwargs | Dictionary | Input parameter. Additional keyword arguments for the model. |
-| endpoint_url | String | Input parameter. Custom endpoint URL for the Bedrock service. |
+| region_name | String | Input parameter. AWS region where your Bedrock resources are located. Default: `us-east-1`. |
+| model_kwargs | Dictionary | Input parameter. Additional keyword arguments to pass to the model. |
+| endpoint_url | String | Input parameter. Custom endpoint URL for a Bedrock service. |
 
 ## Amazon Bedrock Embeddings
 
@@ -44,12 +47,14 @@ For more information about using embedding model components in flows, see [**Emb
 
 ### Amazon Bedrock Embeddings parameters
 
-Some **Amazon Bedrock Embeddings** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|
-| credentials_profile_name | String | Input parameter. The name of the AWS credentials profile in `~/.aws/credentials` or `~/.aws/config`, which has access keys or role information. |
 | model_id | String | Input parameter. The ID of the model to call, such as `amazon.titan-embed-text-v1`. This is equivalent to the `modelId` property in the `list-foundation-models` API. |
-| endpoint_url | String | Input parameter. The URL to set a specific service endpoint other than the default AWS endpoint. |
+| aws_access_key_id | SecretString | Input parameter. AWS Access Key for authentication. |
+| aws_secret_access_key | SecretString | Input parameter. AWS Secret Key for authentication. |
+| aws_session_token | SecretString | Input parameter. The session key for your AWS account. |
+| credentials_profile_name | String | Input parameter. The name of the AWS credentials profile in `~/.aws/credentials` or `~/.aws/config`, which has access keys or role information. |
 | region_name | String | Input parameter. The AWS region to use, such as `us-west-2`. Falls back to the `AWS_DEFAULT_REGION` environment variable or region specified in `~/.aws/config` if not provided. |
+| endpoint_url | String | Input parameter. The URL to set a specific service endpoint other than the default AWS endpoint. |

--- a/docs/docs/Components/bundles-anthropic.mdx
+++ b/docs/docs/Components/bundles-anthropic.mdx
@@ -4,6 +4,7 @@ slug: /bundles-anthropic
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -18,14 +19,13 @@ The **Anthropic** component generates text using Anthropic Chat and Language mod
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 Specifically, the **Language Model** output is an instance of [`ChatAnthropic`](https://python.langchain.com/docs/integrations/chat/anthropic/) configured according to the component's parameters.
 
-Use the **Language Model** output when you want to use an Anthropic model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use an Anthropic model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### Anthropic text generation parameters
 
-Many **Anthropic** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-azure.mdx
+++ b/docs/docs/Components/bundles-azure.mdx
@@ -4,6 +4,7 @@ slug: /bundles-azure
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -16,14 +17,13 @@ This component generates text using [Azure OpenAI LLMs](https://learn.microsoft.
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 Specifically, the **Language Model** output is an instance of [`AzureChatOpenAI`](https://python.langchain.com/docs/integrations/chat/azure_chat_openai/) configured according to the component's parameters.
 
-Use the **Language Model** output when you want to use an Azure OpenAI model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use an Azure OpenAI model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### Azure OpenAI parameters
 
-Many **Azure OpenAI** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|
@@ -45,8 +45,7 @@ For more information about using embedding model components in flows, see [**Emb
 
 ### Azure OpenAI Embeddings parameters
 
-Some **Azure OpenAI Embeddings** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-baidu.mdx
+++ b/docs/docs/Components/bundles-baidu.mdx
@@ -15,6 +15,6 @@ The **Qianfan** component generates text using Qianfan's language models.
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use a Qianfan model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use a Qianfan model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models) and [Qianfan documentation](https://github.com/baidubce/bce-qianfan-sdk).

--- a/docs/docs/Components/bundles-bing.mdx
+++ b/docs/docs/Components/bundles-bing.mdx
@@ -4,6 +4,7 @@ slug: /bundles-bing
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -17,8 +18,7 @@ It returns a list of search results as a [`DataFrame`](/data-types#dataframe).
 
 ### Bing Search API parameters
 
-Some **Bing Search API** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-cloudflare.mdx
+++ b/docs/docs/Components/bundles-cloudflare.mdx
@@ -4,6 +4,7 @@ slug: /bundles-cloudflare
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -17,8 +18,7 @@ For more information about using embedding model components in flows, see [**Emb
 
 ### Cloudflare Workers AI Embeddings parameters
 
-Some **Cloudflare Workers AI Embeddings** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|

--- a/docs/docs/Components/bundles-cohere.mdx
+++ b/docs/docs/Components/bundles-cohere.mdx
@@ -4,6 +4,7 @@ slug: /bundles-cohere
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -11,29 +12,29 @@ This page describes the components that are available in the **Cohere** bundle.
 
 For more information about Cohere features and functionality used by Cohere components, see the [Cohere documentation](https://cohere.ai/).
 
-### Cohere text generation
+## Cohere text generation
 
 This component generates text using Cohere's language models.
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use a Cohere model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use a Cohere model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### Cohere text generation parameters
 
-Many **Cohere** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|
+| Input | String | Input parameter. Specifies the input text for text generation. |
+| System Message | String | Input parameter. A [system message](https://docs.cohere.com/docs/system-instructions) to pass to the model. |
+| Stream | Boolean | Input parameter. Whether to stream the response. Only works in chat. Default: false. |
 | Cohere API Key | SecretString | Input parameter. Your Cohere API key. |
-| Max Tokens | Integer | Input parameter. Specifies the maximum number of tokens to generate. Defaults to `256`. |
-| Temperature | Float | Input parameter. Specifies the sampling temperature. Defaults to `0.75`. |
-| Input Value | String | Input parameter. Specifies the input text for text generation. |
+| Temperature | Float | Input parameter. Specifies the randomness of sampling. Lower values (near 0) are more deterministic, and higher values (near 1) are more creative. Defaults to `0.75`. |
 
-### Cohere Embeddings
+## Cohere Embeddings
 
 The **Cohere Embeddings** component is used to load embedding models from Cohere.
 
@@ -41,8 +42,13 @@ For more information about using embedding model components in flows, see [**Emb
 
 ### Cohere Embeddings parameters
 
+<PartialParams />
+
 | Name | Type | Description |
 |------|------|-------------|
 | cohere_api_key | String | Input parameter. The API key required to authenticate with the Cohere service. |
-| model | String | Input parameter. The language model used for embedding text documents and performing queries. Default: `embed-english-v2.0`. |
-| truncate | Boolean | Input parameter. Whether to truncate the input text to fit within the model's constraints. Default: false. |
+| model | String | Input parameter. The language model used for embedding text documents and performing queries. Default: `embed-english-v2.0` |
+| truncate | Boolean | Input parameter. How to handle input that exceeds the model's token limit. One of `NONE`, `START`, or `END` (default). For more information, see the [Cohere `truncate` API reference](https://docs.cohere.com/reference/embed#request.body.truncate). |
+| max_retries | Integer | Input parameter. The maximum number of retry attempts for failed requests. Default: `3` |
+| user_agent | String | Input parameter. A user agent string to include in requests. Default: `langchain`|
+| request_timeout | Float | Input parameter. The timeout duration for requests in milliseconds. Default: `10000` |

--- a/docs/docs/Components/bundles-deepseek.mdx
+++ b/docs/docs/Components/bundles-deepseek.mdx
@@ -4,6 +4,7 @@ slug: /bundles-deepseek
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -17,14 +18,13 @@ The **DeepSeek** component generates text using DeepSeek's language models.
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use a DeepSeek model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use a DeepSeek model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### DeepSeek text generation parameters
 
-Many **DeepSeek** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-duckduckgo.mdx
+++ b/docs/docs/Components/bundles-duckduckgo.mdx
@@ -4,6 +4,7 @@ slug: /bundles-duckduckgo
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -17,8 +18,7 @@ It outputs a list of search results as a [`DataFrame`](/data-types#dataframe) wi
 
 ### DuckDuckGo Search parameters
 
-Some **DuckDuckGo Search** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-glean.mdx
+++ b/docs/docs/Components/bundles-glean.mdx
@@ -4,6 +4,7 @@ slug: /bundles-glean
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -17,8 +18,7 @@ It returns a list of search results as a [`DataFrame`](/data-types#dataframe).
 
 ### Glean Search API parameters
 
-Some **Glean Search API** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-google.mdx
+++ b/docs/docs/Components/bundles-google.mdx
@@ -96,50 +96,31 @@ To connect your flows to Google OAuth services, use [Composio components](/integ
 <details>
 <summary>Gmail Loader</summary>
 
-This component loads emails from Gmail using provided credentials and filters.
+This component loads emails from Gmail using [Service Account JSON](https://developers.google.com/identity/protocols/oauth2/service-account) credentials and label ID filters.
 
-| Input       | Type             | Description                                                                          |
-| ----------- | ---------------- | ------------------------------------------------------------------------------------ |
-| json_string | SecretStrInput   | Input parameter. A JSON string containing OAuth 2.0 access token information for service account access. For information about creating a service account JSON, see [Service Account JSON](https://developers.google.com/identity/protocols/oauth2/service-account). |
-| label_ids   | MessageTextInput | Input parameter. A comma-separated list of label IDs to filter emails.                                |
-| max_results | MessageTextInput | Input parameter. The maximum number of emails to load.                                                |
-| data   | Data | Output parameter.The loaded email data. |
+As an alternative, you can use [Composio components](/integrations-composio) to connect your flows to Google services.
 
 </details>
 
 <details>
-<summary>Google Calendar Loader</summary>
+<summary>Google Drive Loader</summary>
 
-This component accepts the following parameters:
+This component loads documents from Google Drive using [Service Account JSON](https://developers.google.com/identity/protocols/oauth2/service-account) credentials and document ID filters.
 
-| Input       | Type             | Description                                                                          |
-| ----------- | ---------------- | ------------------------------------------------------------------------------------ |
-| json_string | SecretStrInput   | Input parameter. A JSON string containing OAuth 2.0 access token information for service account access. For information about creating a service account JSON, see [Service Account JSON](https://developers.google.com/identity/protocols/oauth2/service-account). |
-| document_id | MessageTextInput | Input parameter. A single Google Drive document ID.                                                   |
-| docs   | Data | Output parameter. The loaded document data. |
+While there is no direct replacement, consider using the [**API Request** component](/components-data#api-request) to call the Google Drive API.
 
 </details>
 
 <details>
 <summary>Google Drive Search</summary>
 
-This component searches Google Drive files using provided credentials and query parameters.
+This component searches Google Drive using [Service Account JSON](https://developers.google.com/identity/protocols/oauth2/service-account) credentials and various query strings and filters.
 
-| Input          | Type             | Description                                                                          |
-| -------------- | ---------------- | ------------------------------------------------------------------------------------ |
-| token_string   | SecretStrInput   | Input parameter. A JSON string containing OAuth 2.0 access token information for service account access. For information about creating a service account JSON, see [Service Account JSON](https://developers.google.com/identity/protocols/oauth2/service-account).  |
-| query_item     | DropdownInput    | Input parameter. The field to query.                                                                  |
-| valid_operator | DropdownInput    | Input parameter. The operator to use in the query.                                                    |
-| search_term    | MessageTextInput | Input parameter. The value to search for in the specified query item.                                 |
-| query_string   | MessageTextInput | Input parameter. The query string used for searching.                      |
-| doc_urls   | List[str] | Output parameter. The URLs of the found documents.                |
-| doc_ids    | List[str] | Output parameter. The IDs of the found documents.                 |
-| doc_titles | List[str] | Output parameter. The titles of the found documents.              |
-| Data       | Data      | Output parameter. The document titles and URLs in a structured format. |
+While there is no direct replacement, consider using the [**API Request** component](/components-data#api-request) to call the Google Drive API.
 
 </details>
 
 ## See also
 
-- [Composio bundle](/integrations-composio)
-- [Vertex AI bundle](/bundles-vertexai)
+- [**Composio** bundle](/integrations-composio)
+- [**Vertex AI** bundle](/bundles-vertexai)

--- a/docs/docs/Components/bundles-groq.mdx
+++ b/docs/docs/Components/bundles-groq.mdx
@@ -18,7 +18,7 @@ This component generates text using Groq's language models.
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 Specifically, the **Language Model** output is an instance of [`ChatGroq`](https://python.langchain.com/docs/integrations/chat/groq/) configured according to the component's parameters.
 
-Use the **Language Model** output when you want to use a Groq model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use a Groq model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 

--- a/docs/docs/Components/bundles-huggingface.mdx
+++ b/docs/docs/Components/bundles-huggingface.mdx
@@ -4,6 +4,7 @@ slug: /bundles-huggingface
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -19,14 +20,13 @@ Authentication is required.
 This component can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 Specifically, the **Language Model** output is an instance of [`HuggingFaceHub`](https://python.langchain.com/docs/integrations/providers/huggingface/) configured according to the component's parameters.
 
-Use the **Language Model** output when you want to use a Hugging Face model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use a Hugging Face model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### Hugging Face text generation parameters
 
-Many **Hugging Face** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-ibm.mdx
+++ b/docs/docs/Components/bundles-ibm.mdx
@@ -4,6 +4,7 @@ slug: /bundles-ibm
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -20,8 +21,7 @@ You can use this component anywhere you need a language model in a flow.
 
 ### IBM watsonx.ai parameters {#ibm-watsonxai-parameters}
 
-Many **IBM watsonx.ai** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|
@@ -44,7 +44,7 @@ You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden
 
 The **IBM watsonx.ai** component can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use an IBM watsonx.ai model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use an IBM watsonx.ai model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 For more information, see [**Language Model** components](/components-models).
 
 The `LanguageModel` output from the **IBM watsonx.ai** component is an instance of [ChatWatsonx](https://python.langchain.com/docs/integrations/chat/ibm_watsonx/) configured according to the [component's parameters](#ibm-watsonxai-parameters).
@@ -61,8 +61,7 @@ For more information about using embedding model components in flows, see [**Emb
 
 ### IBM watsonx.ai Embeddings parameters
 
-Some **IBM watsonx.ai Embeddings** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|

--- a/docs/docs/Components/bundles-langchain.mdx
+++ b/docs/docs/Components/bundles-langchain.mdx
@@ -110,7 +110,7 @@ This component is different from the [**SQL Database** core component](/componen
 
 ## Text Splitters
 
-The LangChain bundle includes the following text splitter components:
+The **LangChain** bundle includes the following text splitter components:
 
 - **Character Text Splitter**
 - **Language Recursive Text Splitter**
@@ -158,7 +158,7 @@ For more information, see the [LangChain XML Agent documentation](https://python
 
 ## Other LangChain components
 
-Other components in the LangChain bundle include the following:
+Other components in the **LangChain** bundle include the following:
 
 - **Fake Embeddings**
 - **HTML Link Extractor**
@@ -176,48 +176,8 @@ You can still use these components in your flows, but they are no longer maintai
 * **Natural Language to SQL**
 * **Retrieval QA**
 * **Self Query Retriever**
+* **JSON Agent**
+* **Vector Store Info/Agent**
+* **VectorStoreRouterAgent**
 
-<details>
-<summary>JSON Agent</summary>
-
-This component creates a JSON agent from a JSON or YAML file and an LLM.
-
-It accepts the following parameters:
-
-| Name | Type | Description |
-|------|------|-------------|
-| llm | LanguageModel | Input parameter. The language model to use for the agent. |
-| path | File | Input parameter. The path to the JSON or YAML file. |
-| agent | AgentExecutor | Output parameter. The JSON agent instance. |
-
-</details>
-
-<details>
-<summary>Vector Store Info/Agent</summary>
-
-This component creates a Vector Store Agent using LangChain.
-
-It accepts the following parameters:
-
-| Name | Type | Description |
-|------|------|-------------|
-| llm | LanguageModel | Input parameter. The language model to use for the agent. |
-| vectorstore | VectorStoreInfo | Input parameter. The vector store information for the agent to use. |
-| agent | AgentExecutor | Output parameter. The Vector Store Agent instance. |
-
-</details>
-
-<details>
-<summary>VectorStoreRouterAgent</summary>
-
-This component creates a Vector Store Router Agent using LangChain.
-
-It accepts the following parameters:
-
-| Name | Type | Description |
-|------|------|-------------|
-| llm | LanguageModel | Input parameter. The language model to use for the agent. |
-| vectorstores | List[VectorStoreInfo] | Input parameter. The list of vector store information for the agent to route between. |
-| agent | AgentExecutor | Output parameter. The Vector Store Router Agent instance. |
-
-</details>
+To replace these components, consider other components in the **LangChain** bundle or general Langflow components, such as the [**Agent** component](/components-agents) or the [**SQL Database** component](/components-data#sql-database).

--- a/docs/docs/Components/bundles-lmstudio.mdx
+++ b/docs/docs/Components/bundles-lmstudio.mdx
@@ -4,6 +4,7 @@ slug: /bundles-lmstudio
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -16,14 +17,13 @@ The **LM Studio** component generates text using LM Studio's local language mode
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use an LM Studio model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use an LM Studio model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### LM Studio text generation parameters
 
-Many **LM Studio** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|
@@ -45,8 +45,7 @@ For more information about using embedding model components in flows, see [**Emb
 
 ### LM Studio Embeddings parameters
 
-Many **LM Studio Embeddings** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|

--- a/docs/docs/Components/bundles-maritalk.mdx
+++ b/docs/docs/Components/bundles-maritalk.mdx
@@ -4,6 +4,7 @@ slug: /bundles-maritalk
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -17,14 +18,13 @@ The **MariTalk** component generates text using MariTalk LLMs.
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use a MariTalk model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use a MariTalk model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### MariTalk text generation parameters
 
-Many **MariTalk** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-mem0.mdx
+++ b/docs/docs/Components/bundles-mem0.mdx
@@ -4,6 +4,7 @@ slug: /bundles-mem0
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -15,8 +16,7 @@ The **Mem0 Chat Memory** component retrieves and stores chat messages using Mem0
 
 ### Mem0 Chat Memory parameters
 
-Many **Mem0 Chat Memory** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|

--- a/docs/docs/Components/bundles-mistralai.mdx
+++ b/docs/docs/Components/bundles-mistralai.mdx
@@ -4,6 +4,7 @@ slug: /bundles-mistralai
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -17,14 +18,13 @@ The **MistralAI** component generates text using MistralAI LLMs.
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use a MistalAI model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use a MistalAI model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### MistralAI text generation parameters
 
-Many **MistralAI** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|
@@ -48,8 +48,7 @@ For more information about using embedding model components in flows, see [**Emb
 
 ### MistralAI Embeddings parameters
 
-Many **MistralAI Embeddings** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-novita.mdx
+++ b/docs/docs/Components/bundles-novita.mdx
@@ -4,6 +4,7 @@ slug: /bundles-novita
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -21,8 +22,7 @@ For more information, see [**Language Model** components](/components-models).
 
 ### Novita AI parameters
 
-Many **Novita AI** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-nvidia.mdx
+++ b/docs/docs/Components/bundles-nvidia.mdx
@@ -46,7 +46,7 @@ For more information about using embedding model components in flows, see [**Emb
 
 :::tip Tokenization considerations
 Be aware of your embedding model's chunk size limit.
-Tokenization errors can occur if your text chunks are too large. 
+Tokenization errors can occur if your text chunks are too large.
 For more information, see [Tokenization errors due to chunk size](/components-processing#chunk-size).
 :::
 
@@ -59,7 +59,7 @@ This component finds and reranks documents using the NVIDIA API.
 This component uses the NVIDIA `nv-ingest` microservice for data ingestion, processing, and extraction of text files.
 For more information, see [Integrate NVIDIA Retriever Extraction with Langflow](/integrations-nvidia-ingest).
 
-## NVIDIA G-Assist
+## NVIDIA System-Assist
 
 This component requires a specific system environment.
 For information about this component, see [Integrate NVIDIA G-Assist with Langflow](/integrations-nvidia-g-assist).

--- a/docs/docs/Components/bundles-ollama.mdx
+++ b/docs/docs/Components/bundles-ollama.mdx
@@ -32,7 +32,7 @@ To use the **Ollama** component in a flow, connect Langflow to your locally runn
 
 5. Connect the **Ollama** component to other components in the flow, depending on how you want to use the model.
 
-    **Language Model** components can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)). Use the **Language Model** output when you want to use an Ollama model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component. For more information, see [**Language Model** components](/components-models).
+    Language model components can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)). Use the **Language Model** output when you want to use an Ollama model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component. For more information, see [**Language Model** components](/components-models).
 
     In the following example, the flow uses `LanguageModel` output to use an Ollama model as the LLM for an [**Agent** component](/components-agents).
 

--- a/docs/docs/Components/bundles-openai.mdx
+++ b/docs/docs/Components/bundles-openai.mdx
@@ -4,6 +4,7 @@ slug: /bundles-openai
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -19,14 +20,13 @@ It provides access to the same OpenAI models that are available in the core **La
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use a specific OpenAI model configuration as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use a specific OpenAI model configuration as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### OpenAI text generation parameters
 
-Many **OpenAI** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|
@@ -48,8 +48,7 @@ For more information about using embedding model components in flows, see [**Emb
 
 ### OpenAI Embeddings parameters
 
-Many **OpenAI Embeddings** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-openrouter.mdx
+++ b/docs/docs/Components/bundles-openrouter.mdx
@@ -4,6 +4,7 @@ slug: /bundles-openrouter
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -17,14 +18,13 @@ This component generates text using OpenRouter's unified API for multiple AI mod
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use an OpenRouter model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use an OpenRouter model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### OpenRouter text generation parameters
 
-Many **OpenRouter** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-perplexity.mdx
+++ b/docs/docs/Components/bundles-perplexity.mdx
@@ -4,6 +4,7 @@ slug: /bundles-perplexity
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -17,14 +18,13 @@ This component generates text using Perplexity's language models.
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use a Perplexity model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use a Perplexity model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### Perplexity text generation parameters
 
-Many **Perplexity** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-redis.mdx
+++ b/docs/docs/Components/bundles-redis.mdx
@@ -4,6 +4,7 @@ slug: /bundles-redis
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -19,8 +20,7 @@ For more information about using external chat memory in flows, see the [**Messa
 
 ### Redis Chat Memory parameters
 
-Many **Redis Chat Memory** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|

--- a/docs/docs/Components/bundles-sambanova.mdx
+++ b/docs/docs/Components/bundles-sambanova.mdx
@@ -4,6 +4,7 @@ slug: /bundles-sambanova
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -17,14 +18,13 @@ This component generates text using SambaNova LLMs.
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use a SambaNova model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use a SambaNova model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### SambaNova text generation parameters
 
-Many **SambaNova** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-searchapi.mdx
+++ b/docs/docs/Components/bundles-searchapi.mdx
@@ -4,6 +4,7 @@ slug: /bundles-searchapi
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -19,8 +20,7 @@ It returns a list of search results as a [`DataFrame`](/data-types#dataframe).
 
 ### SearchApi web search parameters
 
-Some **SearchApi** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-vertexai.mdx
+++ b/docs/docs/Components/bundles-vertexai.mdx
@@ -4,6 +4,7 @@ slug: /bundles-vertexai
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -19,14 +20,13 @@ The **Vertex AI** component generates text using Google Vertex AI models.
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use a Vertex AI model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use a Vertex AI model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### Vertex AI text generation parameters
 
-Many **Vertex AI** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|
@@ -51,8 +51,7 @@ For more information about using embedding model components in flows, see [**Emb
 
 ### Vertex AI Embeddings parameters
 
-Many **Vertex AI Embeddings** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-wikipedia.mdx
+++ b/docs/docs/Components/bundles-wikipedia.mdx
@@ -4,6 +4,7 @@ slug: /bundles-wikipedia
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -27,8 +28,7 @@ This component searches and retrieves information from Wikipedia with the [WikiM
 
 ### Wikipedia API parameters
 
-Some **Wikipedia API** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/bundles-xai.mdx
+++ b/docs/docs/Components/bundles-xai.mdx
@@ -4,6 +4,7 @@ slug: /bundles-xai
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Bundles](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
 
@@ -17,14 +18,13 @@ The **xAI** component generates text using xAI models like [Grok](https://x.ai/g
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use an xAI model as the LLM for another LLM-driven component, such as a **Language Model** or **Smart Function** component.
+Use the **Language Model** output when you want to use an xAI model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
 
 For more information, see [**Language Model** components](/components-models).
 
 ### xAI text generation parameters
 
-Many **xAI** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/components-agents.mdx
+++ b/docs/docs/Components/components-agents.mdx
@@ -3,27 +3,12 @@ title: Agents
 slug: /components-agents
 ---
 
+import PartialAgentsWork from '@site/docs/_partial-agents-work.mdx';
+
 Langflow's **Agent** and **MCP Tools** components are critical for building agent flows.
 These components define the behavior and capabilities of AI agents in your flows.
 
-<details>
-<summary>How do agents work?</summary>
-
-Agents extend Large Language Models (LLMs) by integrating _tools_, which are functions that provide additional context and enable autonomous task execution.
-These integrations make agents more specialized and powerful than standalone LLMs.
-
-Whereas an LLM might generate acceptable, inert responses to general queries and tasks, an agent can leverage the integrated context and tools to provide more relevant responses and even take action.
-For example, you might create an agent that can access your company's knowledge base, repositories, and other resources to help your team with tasks that require knowledge of your specific products, customers, and code.
-
-Agents use LLMs as a reasoning engine to process input, determine which actions to take to address the query, and then generate a response.
-The response could be a typical text-based LLM response, or it could involve an action, like editing a file, running a script, or calling an external API.
-
-In an agentic context, tools are functions that the agent can run to perform tasks or access external resources.
-A function is wrapped as a `Tool` object with a common interface that the agent understands.
-Agents become aware of tools through tool registration, which is when the agent is provided a list of available tools typically at agent initialization.
-The `Tool` object's description tells the agent what the tool can do so that it can decide whether the tool is appropriate for a given request.
-
-</details>
+<PartialAgentsWork />
 
 ## Examples of agent flows
 
@@ -53,15 +38,15 @@ For more information about using this component, see [Use Langflow agents](/agen
 The **MCP Tools** component connects to a Model Context Protocol (MCP) server and exposes the MCP server's functions as tools for Langflow agents to use to respond to input.
 
 In addition to publicly available MCP servers and your own custom-built MCP servers, you can connect Langflow MCP servers, which allow your agent to use your Langflow flows as tools.
-To do this, use the **MCP Tools** component's [SSE mode](/mcp-client#mcp-sse-mode) to connect to your Langflow MCP server at the `/api/v1/mcp/sse` endpoint.
+To do this, use the **MCP Tools** component's [SSE mode](/mcp-client#mcp-sse-mode) to connect to your Langflow project's MCP server at the `/api/v1/mcp/sse` endpoint.
 
-For more information about using this component and serving flows as MCP tools, see [Use Langflow as an MCP client](/mcp-client) and [Use Langflow as an MCP server](/mcp-server).
+For more information, see [Use Langflow as an MCP client](/mcp-client) and [Use Langflow as an MCP server](/mcp-server).
 
 <details>
 <summary>Earlier versions of the MCP Tools component</summary>
 
 * In Langflow version 1.5, the **MCP Connection** component was renamed to the **MCP Tools** component.
-* In Langflow version 1.3, the **MCP Tools (stdio)** and **MCP Tools (SSE)** components were deprecated and replaced by the unified **MCP Connection** component, which was later renamed to **MCP Tools**.
+* In Langflow version 1.3, the **MCP Tools (stdio)** and **MCP Tools (SSE)** components were removed and replaced by the unified **MCP Connection** component, which was later renamed to **MCP Tools**.
 
 </details>
 

--- a/docs/docs/Components/components-bundles.mdx
+++ b/docs/docs/Components/components-bundles.mdx
@@ -28,8 +28,9 @@ For information about provider-specific features or APIs, see the provider's doc
 
 ## Component parameters
 
-Some component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in each [component's header menu](/concepts-components#component-menus).
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
+
+<PartialParams />
 
 ## Core components and bundles
 

--- a/docs/docs/Components/components-custom-components.mdx
+++ b/docs/docs/Components/components-custom-components.mdx
@@ -39,13 +39,13 @@ class MyCsvReader(Component):
     documentation = "http://docs.example.com/csv_reader"
 ```
 
-* `display_name`: A user-friendly label shown in the **Components** menu and on the component itself when you add it to a flow.
+* `display_name`: A user-friendly label shown in the visual editor.
 * `description`: A brief summary shown in tooltips and printed below the component name when added to a flow.
 * `icon`: A decorative icon from Langflow's icon library, printed next to the name.
 
     Langflow uses [Lucide](https://lucide.dev/icons) for icons. To assign an icon to your component, set the icon attribute to the name of a Lucide icon as a string, such as `icon = "file-text"`. Langflow renders icons from the Lucide library automatically.
 
-* `name`: A unique internal identifier.
+* `name`: A unique internal identifier, typically the same name as the folder containing your component code.
 * `documentation`: An optional link to external documentation, such as API or product documentation.
 
 ### Structure of a custom component

--- a/docs/docs/Components/components-data.mdx
+++ b/docs/docs/Components/components-data.mdx
@@ -4,6 +4,9 @@ slug: /components-data
 ---
 
 import Icon from "@site/src/components/icon";
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 You can use Langflow's **Data** components to bring data into your flows from various sources like files, API endpoints, and URLs.
 For example:
@@ -31,11 +34,11 @@ This can include basic operations, like saving a file in a specific format, or m
 
 **Data** components are used often in flows because they offer a versatile way to perform common, basic functions.
 
-You can use **Data** components to perform their base functions as isolated steps in your flow, or you can connect them to an **Agent** component as tools.
+You can use these components to perform their base functions as isolated steps in your flow, or you can connect them to an **Agent** component as tools.
 
 ![An agent flow with three Data components connected to the agent as tools](/img/connect-data-components-to-agent.png)
 
-For examples of **Data** components in flows, see the following:
+For example flows, see the following:
 
 * [Create a chatbot that can ingest files](/chat-with-files): Learn how to use a **File** component to load a file as context for a chatbot.
 The file and user input are both passed to the LLM so you can ask questions about the file you uploaded.
@@ -63,8 +66,7 @@ For provider-specific API components, see [Bundles](/components-bundle-component
 
 ### API Request parameters
 
-Most **API Request** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|
@@ -90,8 +92,7 @@ Outputs either a [`Data`](/data-types#data) or [`DataFrame`](/data-types#datafra
 
 ### Directory parameters
 
-Many **Directory** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name               | Type             | Description                                        |
 | ------------------ | ---------------- | -------------------------------------------------- |
@@ -157,8 +158,7 @@ For videos, see the **Twelve Labs** and **YouTube** [bundles](/components-bundle
 
 ### File parameters
 
-Most **File** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|
@@ -202,8 +202,7 @@ The agent decides whether to use the **News Search** component based on the user
 
 ### News Search parameters
 
-Most **News Search** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|
@@ -344,8 +343,7 @@ Instead, you only need to provide enough context for the agent to understand tha
 
 ### SQL Database parameters
 
-Some **SQL Database** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|
@@ -362,8 +360,7 @@ It follows links recursively to a given depth, and it supports output in plain t
 
 ### URL parameters
 
-Most **URL** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 Some of the available parameters include the following:
 
@@ -410,7 +407,7 @@ For other search APIs, see [Bundles](/components-bundle-components).
 :::important
 The **Web Search** component uses web scraping that can be subject to rate limits.
 
-For production use, consider using another search component with more robust API support, such as a provider-specific [bundle](/components-bundle-components).
+For production use, consider using another search component with more robust API support, such as provider-specific bundles.
 :::
 
 ### Use the Web Search component in a flow
@@ -519,6 +516,6 @@ Replace these components with the **File** component, which supports loading CSV
 
 ## See also
 
-- [Google components](/bundles-google)
-- [Composio components](/integrations-composio)
+- [**Google** bundle](/bundles-google)
+- [**Composio** bundle](/integrations-composio)
 - [File management](/concepts-file-management)

--- a/docs/docs/Components/components-embedding-models.mdx
+++ b/docs/docs/Components/components-embedding-models.mdx
@@ -22,7 +22,7 @@ This flow loads a text file, splits the text into chunks, generates embeddings f
 1. Create a flow, add a **File** component, and then select a file containing text data, such as a PDF, that you can use to test the flow.
 
 2. Add an **Embedding Model** component, and then provide a valid OpenAI API key.
-You can enter component API keys directly or use Langflow global variables to reference your API keys.
+You can enter the API key directly or use a <Icon name="Globe" aria-hidden="true"/> [global variable](/configuration-global-variables).
 
     :::tip
     If your preferred embedding model provider or model isn't supported by the **Embedding Model** core component, you can use [additional embedding models](#additional-embedding-model-components) in place of the core component.
@@ -49,10 +49,14 @@ This component stores the generated embeddings so they can be used for similarit
 
 7. Click **Playground**, and then enter a search query to retrieve text chunks that are most semantically similar to your query.
 
-## Embedding Model
+## Embedding Model parameters
 
-Some **Embedding Model** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+The following parameters are for the **Embedding Model** core component.
+Other embedding model components can have additional or different parameters.
+
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
+
+<PartialParams />
 
 | Name | Display Name | Type | Description |
 |------|--------------|------|-------------|

--- a/docs/docs/Components/components-helpers.mdx
+++ b/docs/docs/Components/components-helpers.mdx
@@ -117,7 +117,7 @@ Other options include the [**Mem0 Chat Memory** component](/bundles-mem0) and [*
 
 1. Create or edit a flow where you want to use chat memory.
 
-2. At the beginning of the flow, add **Message History** and **Redis Chat Memory** components:
+2. At the beginning of the flow, add a **Message History** component and a **Redis Chat Memory** component:
 
    1. Configure the **Redis Chat Memory** component to connect to your Redis database. For more information, see the [Redis documentation](https://redis.io/docs/latest/).
    2. Set the **Message History** component to **Retrieve** mode.

--- a/docs/docs/Components/components-io.mdx
+++ b/docs/docs/Components/components-io.mdx
@@ -4,6 +4,7 @@ slug: /components-io
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 Langflow's **Input and Output** components define where data enters and exits your flow, but they don't have identical functionality.
 
@@ -31,8 +32,7 @@ Initial input should _not_ be provided as a complete `Message` object because th
 
 #### Chat Input parameters
 
-Most **Chat Input** component input parameters are hidden by default in the visual editor.
-You can enable other parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 For information about the resulting `Message` object, including input parameters that are directly mapped to `Message` attributes, see [`Message` data](/data-types#message).
 
@@ -86,8 +86,7 @@ For an example, see the [Langflow quickstart](/get-started-quickstart).
 
 #### Chat Output parameters
 
-Most **Chat Output** component input parameters are hidden by default in the visual editor.
-You can enable them through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 For information about the resulting `Message` object, including input parameters that are directly mapped to `Message` attributes, see [`Message` data](/data-types#message).
 

--- a/docs/docs/Components/components-logic.mdx
+++ b/docs/docs/Components/components-logic.mdx
@@ -4,6 +4,7 @@ slug: /components-logic
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 Langflow's **Logic** components provide functionalities for routing, conditional processing, and flow management.
 
@@ -82,8 +83,7 @@ The chat output should reflect the instructions in your prompts based on the reg
 
 ### If-Else parameters
 
-Some **If-Else** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name           | Type     | Description                                                       |
 |----------------|----------|-------------------------------------------------------------------|
@@ -182,8 +182,7 @@ When you select a flow for the **Run Flow** component, it uses the target flow's
 
 ### Run Flow parameters
 
-Some **Run Flow** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name              | Type     | Description                                                    |
 |-------------------|----------|----------------------------------------------------------------|

--- a/docs/docs/Components/components-processing.mdx
+++ b/docs/docs/Components/components-processing.mdx
@@ -6,6 +6,7 @@ slug: /components-processing
 import Icon from "@site/src/components/icon";
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 Langflow's **Processing** components process and transform data within a flow.
 They have many uses, including:
@@ -18,7 +19,7 @@ They have many uses, including:
 
 ## Prompt Template
 
-See [Prompt Template](/components-prompts).
+See [**Prompt Template** component](/components-prompts).
 
 ## Batch Run
 
@@ -64,8 +65,7 @@ For example, `Create a business card for each name.`
 
 ### Batch Run parameters
 
-Some **Batch Run** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|
@@ -151,7 +151,7 @@ For more information about the webhook endpoint, see [Trigger flows with webhook
 
 ### Data Operations parameters
 
-Many **Data Operations** component input parameters are conditional based on the selected **Operation** (`operation`).
+Many parameters are conditional based on the selected **Operation** (`operation`).
 
 | Name | Display Name | Info |
 |------|--------------|------|
@@ -196,7 +196,7 @@ The only requirement is that the preceding component must create `DataFrame` out
 1. Create a new flow or use an existing flow.
 
     <details>
-    <summary>API response extraction flow example</summary>
+    <summary>Example: API response extraction flow</summary>
 
     The following example flow uses five components to extract `Data` from an API response, transform it to a `DataFrame`, and then perform further processing on the tabular data using a **DataFrame Operations** component.
     The sixth component, **Chat Output**, is optional in this example.
@@ -380,8 +380,7 @@ The **Chat Input** and **Chat Output** components create a seamless chat interac
 
 ### LLM Router parameters
 
-Some **LLM Router** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|
@@ -428,10 +427,9 @@ The output is a `Message` containing the parsed text.
 This is a versatile component for data extraction and manipulation in your flows.
 For examples of **Parser** components in flows, see the following:
 
-* [**Batch Run** component](#batch-run)
-* [**Structured Output** component](#structured-output)
+* [**Batch Run** component example](#batch-run)
+* [**Structured Output** component example](#structured-output)
 * **Financial Report Parser** template
-* [**Vector Store** components](/components-vector-stores)
 * [Trigger flows with webhooks](/webhook)
 * [Create a vector RAG chatbot](/chat-with-rag)
 
@@ -493,7 +491,7 @@ The resulting text for each row is output as a [`Message`](/data-types#message).
 </details>
 
 The following parameters are available in **Parser** mode.
-To view and edit all available parameters, click <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|
@@ -509,7 +507,7 @@ Use **Stringify** mode to convert the entire input directly to text.
 This mode doesn't support templates or key selection.
 
 The following parameters are available in **Stringify** mode.
-To view and edit all available parameters, click <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|
@@ -718,8 +716,7 @@ From there, the LLM generates a filter function that extracts email addresses fr
 
 ### Smart Function parameters
 
-Some **Smart Function** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|
@@ -748,8 +745,7 @@ The **Split Text** component's parameters control how the text is split into chu
 To test the chunking behavior, add a **Text Input** or **File** component with some sample data to chunk, click <Icon name="Play" aria-hidden="True" /> **Run component** on the **Split Text** component, and then click <Icon name="TextSearch" aria-hidden="True" /> **Inspect output** to view the list of chunks and their metadata. The **text** column contains the actual text chunks created from your chunking settings.
 If the chunks aren't split as you expect, adjust the parameters, rerun the component, and then inspect the new output.
 
-Some **Split Text** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Display Name | Info |
 |------|--------------|------|
@@ -799,10 +795,10 @@ This can come from practically any component, but it is typically a **Chat Input
 
 3. Attach a [**Language Model** component](/components-models) that is set to emit [`LanguageModel`](/data-types#languagemodel) output.
 
-    The **Language Model** component uses the **Input Message** and **Format Instructions** from the **Structured Output** component to extract specific pieces of data from the input text.
+    The LLM uses the **Input Message** and **Format Instructions** from the **Structured Output** component to extract specific pieces of data from the input text.
     The output schema is applied to the model's response to produce the final `Data` or `DataFrame` structured object.
 
-4. Optional: Typically, the structured output is passed to downstream components that use the extracted data for other processes, such as other **Processing** components like the **Parser** or **Data Operations** components.
+4. Optional: Typically, the structured output is passed to downstream components that use the extracted data for other processes, such as the **Parser** or **Data Operations** components.
 
 ![A basic flow with Structured Output, Language Model, Type Convert, and Chat Input and Output components.](/img/component-structured-output.png)
 
@@ -845,8 +841,7 @@ EBITDA: 900 million , Net Income: 500 million , GROSS_PROFIT: 1.2 billion
 
 ### Structured Output parameters
 
-Some **Structured Output** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name | Type | Description |
 |------|------|-------------|

--- a/docs/docs/Components/mcp-client.mdx
+++ b/docs/docs/Components/mcp-client.mdx
@@ -3,8 +3,6 @@ title:  Use Langflow as an MCP client
 slug: /mcp-client
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import Icon from "@site/src/components/icon";
 
 Langflow integrates with the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) as both an MCP server and an MCP client.
@@ -71,7 +69,7 @@ This component has two modes, depending on the type of server you want to access
 ### Connect a Langflow MCP server {#mcp-sse-mode}
 
 Every Langflow project runs a separate MCP server that exposes the project's flows as MCP tools.
-For more information about your projects' MCP servers, including how to manage exposed flows, see [Use Langflow as an MCP server](/mcp-server).
+For more information about your projects' MCP servers, including exposing flows as MCP tools, see [Use Langflow as an MCP server](/mcp-server).
 
 To leverage flows-as-tools, use the **MCP Tools** component in **Server-Sent Events (SSE)** mode to connect to a project's `/api/v1/mcp/sse` endpoint:
 
@@ -100,9 +98,9 @@ In SSE mode, all flows available from the targeted server are treated as tools.
 
 To manage MCP servers connected to your Langflow client, go to **Settings**, and then click **MCP Servers**.
 
-To add a new MCP server, click <Icon name="Plus" aria-hidden="true"/> **Add MCP Server**, and then follow the steps in [Use the MCP Tools component](#use-the-mcp-tools-component) to configure the connection.
+To add a new MCP server, click **Add MCP Server**, and then follow the steps in [Use the MCP Tools component](#use-the-mcp-tools-component) to configure the connection and use the server in a flow.
 
-Click <Icon name="Ellipsis" aria-hidden="true"/> **More** to edit or delete an MCP server.
+Click <Icon name="Ellipsis" aria-hidden="true"/> **More** to edit or delete an MCP server connection.
 
 ## See also
 

--- a/docs/docs/Concepts/concepts-components.mdx
+++ b/docs/docs/Concepts/concepts-components.mdx
@@ -30,7 +30,9 @@ After adding a component to a flow, configure the component's parameters and con
 
 Each component has inputs, outputs, parameters, and controls related to the component's purpose.
 By default, components show only required and common options.
-To access additional settings and controls, including meta settings, use the component's header menu.
+To access additional settings and controls, including meta settings, use the [component's header menu](#component-header-menus).
+
+### Component header menus
 
 To access a component's header menu, click the component in your workspace.
 
@@ -239,7 +241,7 @@ Components are updated to the latest available version, based on the version of 
 
 ## Group components
 
-Multiple components can be grouped into a single component for reuse. This is useful for organizing large flows by combining related components together, such as a RAG **Agent** component and it's associated **Embeddings Model** and **Vector Store** components.
+Multiple components can be grouped into a single component for reuse. This is useful for organizing large flows by combining related components together, such as a RAG **Agent** component and it's associated tools or vector store components.
 
 1. Hold <kbd>Shift</kbd>, and then click and drag to highlight all components you want to merge. Components must be completely within the selection area to be merged.
 

--- a/docs/docs/Concepts/concepts-flows.mdx
+++ b/docs/docs/Concepts/concepts-flows.mdx
@@ -80,7 +80,7 @@ Each node is built and executed sequentially, with results from each built node 
 ## Manage flows in projects {#projects}
 
 The **Projects** page is where you arrive when you launch Langflow.
-It is where you view and manage flows on a high level.
+From here, you can manage flows and your projects' [MCP servers](/mcp-server).
 
 Langflow projects are like folders that you can use to organize related flows.
 The default project is **Starter Project**, and your flows are stored here unless you create another project.
@@ -88,17 +88,20 @@ To create a project, click <Icon name="Plus" aria-hidden="true"/> **Create new p
 
 ![Projects page with multiple flows in a project](/img/my-projects.png)
 
-From the **Projects** page, you can manage flows within each of your projects:
-
-* **View flows in a project**: Select the project name in the **Projects** list.
-* **Create flows**: See [Create a flow](#create-a-flow).
-* **Edit a flow's name and description**: Locate the flow you want to edit, click <Icon name="Ellipsis" aria-hidden="true" /> **More**, and then select **Edit details**.
-* **Delete a flow**: Locate the flow you want to delete, click <Icon name="Ellipsis" aria-hidden="true" /> **More**, and then select **Delete**.
-* **Serve flows as MCP tools**: See [Use Langflow as an MCP server](/mcp-server).
-
 :::tip
 To get back to the **Projects** page after editing a flow, click the project name or Langflow icon in the Langflow header.
 :::
+
+### Edit flow details
+
+1. On the **Projects** page, locate the flow you want to edit.
+2. Click <Icon name="Ellipsis" aria-hidden="true" /> **More**, and then select **Edit details**.
+3. Edit the **Name** and **Description**, and then click **Save**.
+
+### Delete a flow
+
+1. On the **Projects** page, locate the flow you want to delete.
+2. Click <Icon name="Ellipsis" aria-hidden="true" /> **More**, and then select **Delete**.
 
 ## Flow storage and logs
 

--- a/docs/docs/Concepts/concepts-publish.mdx
+++ b/docs/docs/Concepts/concepts-publish.mdx
@@ -521,7 +521,7 @@ export class AppComponent {
 
 Each [Langflow project](/concepts-flows#projects) has an MCP server that exposes the project's flows as [tools](https://modelcontextprotocol.io/docs/concepts/tools) that [MCP clients](https://modelcontextprotocol.io/clients) can use to generate responses.
 
-In addition to serving flows through Langflow MCP servers, you can use Langflow as an MCP client to access any MCP server, including Langflow MCP servers.
+In addition to serving flows through Langflow MCP servers, you can use Langflow as an MCP client to access any MCP server, including your Langflow MCP servers.
 
 Interactions with Langflow MCP servers happen through the Langflow API's `/mcp` endpoints.
 

--- a/docs/docs/Concepts/mcp-server.mdx
+++ b/docs/docs/Concepts/mcp-server.mdx
@@ -9,119 +9,144 @@ import Icon from "@site/src/components/icon";
 
 Langflow integrates with the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) as both an MCP server and an MCP client.
 
-This page describes how to use Langflow as an MCP server.
+This page describes how to use Langflow as an MCP server that exposes your flows as [tools](https://modelcontextprotocol.io/docs/concepts/tools) that [MCP clients](https://modelcontextprotocol.io/clients) can use when generating responses.
 
-For information about using Langflow as an MCP client, see [Use Langflow as an MCP client](/mcp-client).
-
-As an MCP server, Langflow exposes your flows as [tools](https://modelcontextprotocol.io/docs/concepts/tools) that [MCP clients](https://modelcontextprotocol.io/clients) can use to take actions.
+For information about using Langflow as an MCP client and managing MCP server connections within flows, see [Use Langflow as an MCP client](/mcp-client).
 
 ## Prerequisites
 
-* A [Langflow project](/concepts-flows#projects) with at least one flow.
+* A [Langflow project](/concepts-flows#projects) with at least one flow that has a [**Chat Output** component](/components-io#chat-output).
+
+    The **Chat Output** component is required to use a flow as an MCP tool.
 
 * Any LTS version of [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) installed on your computer if you want to use MCP Inspector to [test and debug flows](#test-and-debug-flows).
 
 * [ngrok installed](https://ngrok.com/docs/getting-started/#1-install-ngrok) and an [ngrok authtoken](https://dashboard.ngrok.com/get-started/your-authtoken) if you want to [deploy a public Langflow server](/deployment-public-server).
 
-## Select and configure flows to expose as MCP tools {#select-flows-to-serve}
+## Serve flows as MCP tools {#select-flows-to-serve}
 
 :::important MCP flow requirements
 A flow must contain a [**Chat Output** component](/components-io#chat-output) to be used as a tool by MCP clients.
 :::
 
-Each [Langflow project](/concepts-flows#projects) has an MCP server that exposes the project's flows as tools that MCP clients can use to generate responses.
+Each [Langflow project](/concepts-flows#projects) has an MCP server that exposes the project's flows as tools for use by MCP clients.
 
 By default, all flows in a project are exposed as tools on the project's MCP server.
+You can change the exposed flows and tool metadata by managing the MCP server settings:
 
-The following steps explain how to limit the exposed flows and, optionally, rename flows for agentic use:
-
-1. From the Langflow dashboard, select the project that contains the flows you want to serve as tools, and then click the **MCP Server** tab.
-Alternatively, you can quickly access the **MCP Server** tab from within any flow by selecting **Share > MCP Server**.
-
-    The **Auto install** and **JSON** tabs display options for connecting MCP clients to the project's MCP server.
-
-    The **Flows/Tools** section lists the flows that are currently being served as tools.
+1. Click the **MCP Server** tab on the [**Projects** page](/concepts-flows#projects), or, when editing a flow, click **Share**, and then select **MCP Server**.
 
     ![MCP server projects page](/img/mcp-server.png)
 
-2. Click <Icon name="Settings2" aria-hidden="true"/> **Edit Tools**.
+    The **Flows/Tools** section lists the flows that are currently being served as tools on this MCP server.
 
-3. In the **MCP Server Tools** window, select the flows that you want exposed as tools.
+2. To toggle exposed flows, click <Icon name="Settings2" aria-hidden="true"/> **Edit Tools**, and then select the flows that you want exposed as tools.
+To prevent a flow from being used as a tool, clear the checkbox in the first column.
+
+3. Close the **MCP Server Tools** dialog to save your changes.
 
     ![MCP Server Tools](/img/mcp-server-tools.png)
 
-4. Recommended: Edit the **Tool Name** and **Tool Description** to help MCP clients determine which actions your flows provide and when to use those actions:
+### Edit flow tool names and descriptions
 
-    - **Tool Name**: Enter a name that makes it clear what the flow does when used as a tool by an agent.
+Tool names and descriptions help MCP clients determine which actions your flows provide and when to use those actions.
+It is recommended to provide clear, descriptive names and descriptions for all tools that you serve to MCP clients.
 
-    - **Tool Description**: Enter a description that accurately describes the specific actions the flow performs.
+To edit the names and descriptions of flow tools on a Langflow MCP server, do the following:
 
-    <details>
-    <summary>Name and describe your flows for agentic use</summary>
+1. Click the **MCP Server** tab on the [**Projects** page](/concepts-flows#projects), or, when editing a flow, click **Share**, and then select **MCP Server**.
 
-    MCP clients use the **Tool Name** and **Tool Description** to determine which action to use.
+2. Click <Icon name="Settings2" aria-hidden="true"/> **Edit Tools**.
 
-    MCP clients like [Cursor](https://www.cursor.com/) treat your Langflow project as a single MCP server with all of your enabled flows listed as tools.
+3. Click the **Description** or **Tool** that you want to edit:
 
-    This can confuse agents if the flows have unclear names or descriptions.
-    For example, a flow's default name is the flow ID, such as `adbbf8c7-0a34-493b-90ea-5e8b42f78b66`.
-    This provides no information to an agent about the type of flow or it's purpose.
+    - **Tool name**: Enter a name that makes it clear what the flow does when used as a tool by an agent.
 
-    To provide more context about your flows, make sure to name and describe your flows clearly when configuring your Langflow project's MCP server.
+    - **Tool description**: Enter a description that completely and accurately describes the specific actions the flow performs.
 
-    It's helpful to think of the names and descriptions as function names and code comments, using clear statements describing the problems your flows solve.
+4. Close the **MCP Server Tools** dialog to save your changes.
 
-    For example, assume you create a flow based on the **Document Q&A** template that uses an LLM to chat about resumes, and then you give the flow the following name and description:
+#### Importance of tool names and descriptions
 
-    - **Tool Name**: `document_qa_for_resume`
+MCP clients use tool names and descriptions to determine which actions to use when generating responses.
 
-    - **Tool Description**: `A flow for analyzing Emily's resume.`
+Because MCP clients treat your Langflow project as a single MCP server with all of your enabled flows listed as tools, unclear names and descriptions can cause the agent to select tools incorrectly or inconsistently.
 
-    After connecting your Langflow MCP server to Cursor, you can ask Cursor about the resume, such as `What job experience does Emily have?`.
-    Using the context provided by your tool name and description, the agent can decide to use the `document_qa_for_resume` MCP tool to create a response about Emily's resume.
-    If necessary, the agent asks permission to use the flow tool before generating the response.
+For example, a flow's default tool name is the flow ID, such as `adbbf8c7-0a34-493b-90ea-5e8b42f78b66`.
+This provides no information to an agent about the type of flow or its purpose.
 
-    If you ask about a different resume, such as `What job experience does Alex have?`, the agent can decide that `document_qa_for_resume` isn't relevant to this request, because the tool description specifies that the flow is for Emily's resume.
-    In this case, the agent might use another available tool, or it can inform you that it doesn't have access to information about Alex's.
-    For example:
+To provide more context about your flows, make sure to name and describe your flows clearly when configuring your Langflow project's MCP server.
 
-    ```
-    I notice you're asking about Alex's job experience.
-    Based on the available tools, I can see there is a Document QA for Resume flow that's designed for analyzing resumes.
-    However, the description mentions it's for "Emily's resume" not Alex's. I don't have access to Alex's resume or job experience information.
-    ```
-    </details>
+Think of these names and descriptions as function names and code comments.
+Use clear statements to describe the problems your flows solve.
 
-5. Close the **MCP Server Tools** window to save your changes.
+<details>
+<summary>Example: Tool name and description usage</summary>
+
+For example, assume you create a flow based on the **Document Q&A** template that uses an LLM to chat about resumes, and then you give the flow the following name and description:
+
+- **Tool name**: `document_qa_for_resume`
+
+- **Tool description**: `A flow for analyzing Emily's resume.`
+
+After connecting your Langflow MCP server to Cursor, you can ask Cursor about the resume, such as `What job experience does Emily have?`.
+Using the context provided by your tool name and description, the agent can decide to use the `document_qa_for_resume` MCP tool to create a response about Emily's resume.
+If necessary, the agent asks permission to use the flow tool before generating the response.
+
+If you ask about a different resume, such as `What job experience does Alex have?`, the agent can decide that `document_qa_for_resume` isn't relevant to this request, because the tool description specifies that the flow is for Emily's resume.
+In this case, the agent might use another available tool, or it can inform you that it doesn't have access to information about Alex's.
+For example:
+
+```
+I notice you're asking about Alex's job experience.
+Based on the available tools, I can see there is a Document QA for Resume flow that's designed for analyzing resumes.
+However, the description mentions it's for "Emily's resume" not Alex's. I don't have access to Alex's resume or job experience information.
+```
+
+</details>
 
 {/* The anchor on this section (connect-clients-to-use-the-servers-actions) is currently a link target in the Langflow UI. Do not change. */}
-## Connect clients to Langflow's MCP server {#connect-clients-to-use-the-servers-actions}
+## Connect clients to your Langflow's MCP server {#connect-clients-to-use-the-servers-actions}
 
-The following procedure describes how to connect [Cursor](https://www.cursor.com/) to your Langflow project's MCP server to consume your flows as tools.
-However, you can connect any [MCP-compatible client](https://modelcontextprotocol.io/clients) following similar steps.
+Langflow provides automatic installation and code snippets to help you deploy your Langflow MCP servers to your local MCP clients.
 
 <Tabs>
 <TabItem value="auto" label="Auto install" default>
 
-:::important
-Auto installation only works if your HTTP client and Langflow server are on the same local machine.
-If this isn't the case, use the **JSON** option to configure the MCP server.
+:::info
+The auto install option is available only for specific MCP clients, and the client must be installed locally to your Langflow server.
+If your client isn't supported or installed remotely from your Langflow server, use the **JSON** option.
 :::
 
-1. Install [Cursor](https://docs.cursor.com/get-started/installation).
-2. In the Langflow dashboard, select the project that contains the flows you want to serve, and then click the **MCP Server** tab.
-3. To auto install your current Langflow project as an MCP server, click <Icon name="Plus" aria-hidden="True"/> **Add**.
+1. Install [Cursor](https://docs.cursor.com/get-started/installation), Claude, or Windsurf local to your Langflow instance.
 
-The installation adds the server's configuration file to Cursor's `mcp.json` configuration file.
+2. In Langflow, on the **Projects** page, click the **MCP Server** tab.
+
+3. On the **Auto install** tab, find your MCP client provider, and then click <Icon name="Plus" aria-hidden="True"/> **Add**.
+
+Your Langflow project's MCP server is automatically added to the configuration file for your local Cursor, Claude, or Windsurf client.
+For example, with Cursor, the server configuration is added to the `mcp.json` configuration file.
+
+Langflow attempts to add this configuration even if the selected client isn't installed.
+To verify the installation, check the available MCP servers in your client.
 
 </TabItem>
 <TabItem value="JSON" label="JSON">
 
-1. Install [Cursor](https://docs.cursor.com/get-started/installation).
-2. In Cursor, go to **Cursor Settings > MCP**, and then click **Add New Global MCP Server**.
-This opens Cursor's global MCP configuration file, `mcp.json`.
-3. In the Langflow dashboard, select the project that contains the flows you want to serve, and then click the **MCP Server** tab.
-4. Copy the code template from the **JSON** tab, and then paste it into `mcp.json` in Cursor.
+The JSON option allows you to connect a Langflow MCP server to any local or remote MCP client.
+
+You can modify this process for any [MCP-compatible client](https://modelcontextprotocol.io/clients).
+
+1. Install [Cursor](https://docs.cursor.com/get-started/installation) or any other [MCP-compatible client](https://modelcontextprotocol.io/clients).
+
+    These steps use Cursor as an example.
+    Modify them as needed for other clients.
+
+2. In Cursor, go to **Cursor Settings**, select **MCP**, and then click **Add New Global MCP Server** to open Cursor's global `mcp.json` configuration file.
+
+3. In Langflow, on the **Projects** page, click the **MCP Server** tab.
+
+4. Click the **JSON** tab, copy the code snippet for your operating system, and then paste it into Cursor's `mcp.json` file.
 For example:
 
     ```json
@@ -138,23 +163,24 @@ For example:
     }
     ```
 
-    The **MCP Server** tab automatically includes the correct `PROJECT_NAME`, `LANGFLOW_SERVER_ADDRESS`, and `PROJECT_ID` values.
-    The default Langflow server address is `http://localhost:7860`.
+    The **MCP Server** tab automatically populates the `PROJECT_NAME`, `LANGFLOW_SERVER_ADDRESS`, and `PROJECT_ID` values.
 
-    If you have [deployed a public Langflow server](/deployment-public-server), the address is automatically included.
+    The default Langflow server address is `http://localhost:7860`.
+    If you are using a [public Langflow server](/deployment-public-server), the server address is automatically included.
 
     If your Langflow server requires authentication, you must include your Langflow API key in the configuration.
     For more information, see [MCP server authentication and environment variables](#authentication).
 
-5. Save and close the `mcp.json` file in Cursor.
-The newly added MCP server will appear in the **MCP Servers** section.
+5. In Cursor, save and close the `mcp.json` file.
+
+6. Confirm that your Langflow MCP server is on Cursor's **MCP Servers** list.
 
 </TabItem>
 </Tabs>
 
-Cursor is now connected to your project's MCP server and your flows are registered as tools.
+Once your MCP client is connected to your Langflow project's MCP server, your flows are registered as tools.
 Cursor determines when to use tools based on your queries, and requests permissions when necessary.
-For more information, see the [Cursor's MCP documentation](https://docs.cursor.com/context/model-context-protocol).
+For more information, see the the MCP documentation for your client, such as [Cursor's MCP documentation](https://docs.cursor.com/context/model-context-protocol).
 
 ### MCP server authentication and environment variables {#authentication}
 
@@ -204,9 +230,9 @@ To include other environment variables with your MCP server command, use the `en
 ```
 
 {/* The anchor on this section (deploy-your-server-externally) is currently a link target in the Langflow UI. Do not change. */}
-### Deploy your MCP server externally {#deploy-your-server-externally}
+### Deploy your Langflow MCP server externally {#deploy-your-server-externally}
 
-To deploy your MCP server externally with ngrok, see [Deploy a public Langflow server](/deployment-public-server).
+To deploy your Langflow MCP server externally, see [Deploy a public Langflow server](/deployment-public-server).
 
 ## Use MCP Inspector to test and debug flows {#test-and-debug-flows}
 
@@ -244,7 +270,7 @@ The default address is `http://localhost:6274`.
 
 5. To quit MCP Inspector, press <kbd>Control+C</kbd> in the same terminal window where you started it.
 
-## Troubleshooting MCP server
+## Troubleshoot Langflow MCP servers {#troubleshooting-mcp-server}
 
 If Claude for Desktop isn't using your server's tools correctly, you may need to explicitly define the path to your local `uvx` or `npx` executable file in the `claude_desktop_config.json` configuration file.
 

--- a/docs/docs/Configuration/api-keys-and-authentication.mdx
+++ b/docs/docs/Configuration/api-keys-and-authentication.mdx
@@ -185,7 +185,7 @@ LANGFLOW_SUPERUSER_PASSWORD=securepassword
 They are required if `LANGFLOW_AUTO_LOGIN=False`.
 Otherwise, they aren't relevant.
 
-If required and not set in when you [start a Langflow server with authentication enabled](#start-a-langflow-server-with-authentication-enabled), then the default values are `langflow` and `langflow` for system auto-login behavior.
+When you [start a Langflow server with authentication enabled](#start-a-langflow-server-with-authentication-enabled), if these variables are required but _not_ set, then Langflow uses the default values of `langflow` and `langflow`.
 These defaults don't apply when using the Langflow CLI command [`langflow superuser`](/configuration-cli#langflow-superuser).
 
 ### LANGFLOW_SECRET_KEY {#langflow-secret-key}

--- a/docs/docs/Contributing/contributing-bundles.mdx
+++ b/docs/docs/Contributing/contributing-bundles.mdx
@@ -31,80 +31,93 @@ You can view the [icons folder](https://github.com/langflow-ai/langflow/tree/mai
 To add your icon, create **three** files inside the `icons/darth_vader` folder.
 
 2. In the `icons/darth_vader` folder, add the raw SVG file of your icon, such as `darth_vader-icon.svg`.
-:::tip
-To convert the SVG file to JSX format, you can use an online tool like SVG to JSX.
-It's highly recommended to use the original, lighter version of the SVG.
-:::
+
+    :::tip
+    To convert the SVG file to JSX format, you can use an online tool like SVG to JSX.
+    It's highly recommended to use the original, lighter version of the SVG.
+    :::
+
 3. In the `icons/darth_vader` folder, add the icon as a React component in JSX format, such as `DarthVaderIcon.jsx`.
+
 4. Update the JSX file to include the correct component name and structure.
 Ensure you include the `{...props}` spread operator in your JSX file.
 For example, here is `DarthVaderIcon.jsx`:
-```javascript
-const DarthVaderIcon = (props) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width={24}
-    height={24}
-    viewBox="0 0 32 32"
-    fill="none"
-    style={{ backgroundColor: "#9100ff", borderRadius: "6px" }}
-    {...props}
-  >
-    <g transform="translate(7, 7)">
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M6.27406 0.685082C8.46664 -0.228361 10.9302 -0.228361 13.1229 0.685082C14.6773 1.33267 16.0054 2.40178 16.9702 3.75502C17.6126 4.65574 17.0835 5.84489 16.045 6.21613L13.5108 7.12189C12.9962 7.30585 12.4289 7.26812 11.9429 7.01756C11.8253 6.95701 11.7298 6.86089 11.6696 6.74266L10.2591 3.97469C10.0249 3.51519 9.37195 3.51519 9.13783 3.97469L7.72731 6.74274C7.66714 6.86089 7.57155 6.95701 7.454 7.01756L4.70187 8.43618C4.24501 8.67169 4.24501 9.3284 4.70187 9.56391L7.454 10.9825C7.57155 11.0431 7.66714 11.1392 7.72731 11.2574L9.13783 14.0254C9.37195 14.4849 10.0249 14.4849 10.2591 14.0254L11.6696 11.2574C11.7298 11.1392 11.8253 11.0431 11.9428 10.9825C12.429 10.7319 12.9965 10.6942 13.5112 10.8781L16.045 11.7838C17.0835 12.1551 17.6126 13.3442 16.9704 14.245C16.0054 15.5982"
-        fill={props.isdark === "true" ? "white" : "black"}
-      />
-    </g>
-  </svg>
-);
 
-export default DarthVaderIcon;
-```
+    ```javascript
+    const DarthVaderIcon = (props) => (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={24}
+        height={24}
+        viewBox="0 0 32 32"
+        fill="none"
+        style={{ backgroundColor: "#9100ff", borderRadius: "6px" }}
+        {...props}
+      >
+        <g transform="translate(7, 7)">
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M6.27406 0.685082C8.46664 -0.228361 10.9302 -0.228361 13.1229 0.685082C14.6773 1.33267 16.0054 2.40178 16.9702 3.75502C17.6126 4.65574 17.0835 5.84489 16.045 6.21613L13.5108 7.12189C12.9962 7.30585 12.4289 7.26812 11.9429 7.01756C11.8253 6.95701 11.7298 6.86089 11.6696 6.74266L10.2591 3.97469C10.0249 3.51519 9.37195 3.51519 9.13783 3.97469L7.72731 6.74274C7.66714 6.86089 7.57155 6.95701 7.454 7.01756L4.70187 8.43618C4.24501 8.67169 4.24501 9.3284 4.70187 9.56391L7.454 10.9825C7.57155 11.0431 7.66714 11.1392 7.72731 11.2574L9.13783 14.0254C9.37195 14.4849 10.0249 14.4849 10.2591 14.0254L11.6696 11.2574C11.7298 11.1392 11.8253 11.0431 11.9428 10.9825C12.429 10.7319 12.9965 10.6942 13.5112 10.8781L16.045 11.7838C17.0835 12.1551 17.6126 13.3442 16.9704 14.245C16.0054 15.5982"
+            fill={props.isdark === "true" ? "white" : "black"}
+          />
+        </g>
+      </svg>
+    );
+
+    export default DarthVaderIcon;
+    ```
 
 5. In the `icons/darth_vader` folder, add the React component itself in TypeScript format, such as `index.tsx`.
-Ensure the icon’s React component name corresponds to the JSX component you just created, such as `DarthVaderIcon`.
-```typescript
-import { useDarkStore } from "@/stores/darkStore";
-import React, { forwardRef } from "react";
-import DarthVaderIconSVG from "./DarthVaderIcon";
+Ensure the icon's React component name corresponds to the JSX component you just created, such as `DarthVaderIcon`:
 
-export const DarthVaderIcon = forwardRef<
-  SVGSVGElement,
-  React.PropsWithChildren<{}>
->((props, ref) => {
-  const isdark = useDarkStore((state) => state.dark).toString();
+    ```typescript
+    import { useDarkStore } from "@/stores/darkStore";
+    import React, { forwardRef } from "react";
+    import DarthVaderIconSVG from "./DarthVaderIcon";
 
-  return <DarthVaderIconSVG ref={ref} isdark={isdark} {...props} />;
-});
+    export const DarthVaderIcon = forwardRef<
+      SVGSVGElement,
+      React.PropsWithChildren<{}>
+    >((props, ref) => {
+      const isdark = useDarkStore((state) => state.dark).toString();
 
-export default DarthVaderIcon;
-```
+      return <DarthVaderIconSVG ref={ref} isdark={isdark} {...props} />;
+    });
+
+    export default DarthVaderIcon;
+    ```
 
 6. To link your new bundle to the frontend, open `/src/frontend/src/icons/lazyIconImports.ts`.
 You can view the [lazyIconImports.ts](https://github.com/langflow-ai/langflow/blob/main/src/frontend/src/icons/lazyIconImports.ts) in the Langflow repository.
+
 7. Add the name of your icon, which should match the icon name you used in the `.tsx` file.
 For example:
-```typescript
-  CrewAI: () =>
-    import("@/icons/CrewAI").then((mod) => ({ default: mod.CrewAiIcon })),
-  DarthVader: () =>
-    import("@/icons/DarthVader").then((mod) => ({ default: mod.DarthVaderIcon })),
-  DeepSeek: () =>
-    import("@/icons/DeepSeek").then((mod) => ({ default: mod.DeepSeekIcon })),
-```
 
-8. To update the **Bundles** section in the **Components** menu, add the new icon to the `SIDEBAR_BUNDLES` array in `src > frontend > src > utils > styleUtils.ts`.
-You can view the [SIDEBAR_BUNDLES array](https://github.com/langflow-ai/langflow/blob/main/src/frontend/src/utils/styleUtils.ts#L231) in the Langflow repository.\
-The `name` must point to the folder you created within the `src > backend > base > langflow > components` directory.
-For example:
-```typescript
-{ display_name: "AssemblyAI", name: "assemblyai", icon: "AssemblyAI" },
-{ display_name: "DarthVader", name: "darth_vader", icon: "DarthVader" },
-{ display_name: "DataStax", name: "astra_assistants", icon: "DarthVader" },
-```
+    ```typescript
+      CrewAI: () =>
+        import("@/icons/CrewAI").then((mod) => ({ default: mod.CrewAiIcon })),
+      DarthVader: () =>
+        import("@/icons/DarthVader").then((mod) => ({ default: mod.DarthVaderIcon })),
+      DeepSeek: () =>
+        import("@/icons/DeepSeek").then((mod) => ({ default: mod.DeepSeekIcon })),
+    ```
+
+8. To add your bundle to the **Bundles** menu, edit the [`SIDEBAR_BUNDLES` array](https://github.com/langflow-ai/langflow/blob/main/src/frontend/src/utils/styleUtils.ts#L231) in `/src/frontend/src/utils/styleUtils.ts`.
+
+    Add an object to the array with the following keys:
+
+    * `display_name`: The text label shown in the Langflow visual editor
+    * `name`: The name of the folder you created within the `/src/backend/base/langflow/components` directory
+    * `icon`: The name of the bundle's icon that you defined in the previous steps
+
+    For example:
+
+    ```typescript
+    { display_name: "AssemblyAI", name: "assemblyai", icon: "AssemblyAI" },
+    { display_name: "DarthVader", name: "darth_vader", icon: "DarthVader" },
+    { display_name: "DataStax", name: "astra_assistants", icon: "DarthVader" },
+    ```
 
 ## Update bundle components with icons
 

--- a/docs/docs/Deployment/deployment-architecture.mdx
+++ b/docs/docs/Deployment/deployment-architecture.mdx
@@ -3,9 +3,6 @@ title: Langflow architecture on Kubernetes
 slug: /deployment-architecture
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 There are two broad types of Langflow deployments:
 
 * **Langflow IDE (development)**: Deploy both the Langflow visual editor (frontend) and API (backend). Typically, this is used for development environments where developers use the visual editor to create and manage flows before packaging and serving them through a production runtime deployment.

--- a/docs/docs/Deployment/deployment-overview.mdx
+++ b/docs/docs/Deployment/deployment-overview.mdx
@@ -3,12 +3,9 @@ title: Langflow deployment overview
 slug: /deployment-overview
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 This section includes the different ways to bring your locally-built flows to the world.
 
-* To self-host your local server through an Ngrok gateway, see [Deploy a public Langflow server](/deployment-public-server).
+* To self-host your local server through an ngrok gateway, see [Deploy a public Langflow server](/deployment-public-server).
 This approach uses [ngrok](https://ngrok.com/docs/getting-started/) to forward traffic and share your local Langflow server over the internet, without deploying to a cloud provider or exposing your network directly.
 
 * To build and deploy a Langflow container that includes your flow files, see [Containerize a Langflow application](develop-application).

--- a/docs/docs/Deployment/deployment-public-server.mdx
+++ b/docs/docs/Deployment/deployment-public-server.mdx
@@ -60,6 +60,7 @@ When your Langflow server is public, you can do things like [deploy your Langflo
 After you deploy a public Langflow server, you can also access your Langflow projects' MCP servers publicly.
 
 To do this, use your server's forwarding address when you [connect a client to a Langflow MCP server](/mcp-server#connect-clients-to-use-the-servers-actions).
+
 ### Serve API requests
 
 To send requests to a public Langflow server's [Langflow API](/api-reference-api-examples) endpoints, use the server's domain as the [base URL](/api-reference-api-examples#base-url) for your API requests.

--- a/docs/docs/Develop/Clients/typescript-client.mdx
+++ b/docs/docs/Develop/Clients/typescript-client.mdx
@@ -60,7 +60,7 @@ pnpm add @datastax/langflow-client
     The default Langflow base URL is `http://localhost:7860`.
     To create an API key, see [API keys and authentication](/api-keys-and-authentication).
 
-## Langflow TypeScript client quickstart
+## Connect to your server and get responses
 
 1. With your Langflow client initialized, test the connection by calling your Langflow server.
 
@@ -86,9 +86,10 @@ pnpm add @datastax/langflow-client
 
     Replace the following:
 
-    * `baseUrl`: The URL of your Langflow server
-    * `flowId`: The ID of the flow you want to run
-    * `input`: The chat input message you want to send to trigger the flow
+    * `baseUrl`: The URL of your Langflow server.
+    * `flowId`: The ID of the flow you want to run.
+    * `input`: The chat input message you want to send to trigger the flow.
+    This is only valid for flows with a **Chat Input** component.
 
 
 2. Review the result to confirm that the client connected to your Langflow server.
@@ -104,7 +105,7 @@ pnpm add @datastax/langflow-client
 
     In this case, the response includes a [`sessionID`](/session-id) that is a unique identifier for the client-server session and an `outputs` array that contains information about the flow run.
 
-3. If you want to get full response objects from the server, change `console.log` to stringify the returned JSON object:
+3. Optional: If you want to get full response objects from the server, change `console.log` to stringify the returned JSON object:
 
     ```tsx
     console.log(JSON.stringify(response, null, 2));
@@ -112,7 +113,7 @@ pnpm add @datastax/langflow-client
 
     The exact structure of the returned `inputs` and `outputs` objects depends on the components and configuration of your flow.
 
-4. If you want the response to include only the chat message from the **Chat Output** component, change `console.log` to use the `chatOutputText` convenience function:
+4. Optional: If you want the response to include only the chat message from the **Chat Output** component, change `console.log` to use the `chatOutputText` convenience function:
 
     ```tsx
     console.log(response.chatOutputText());
@@ -122,13 +123,12 @@ pnpm add @datastax/langflow-client
 
 The TypeScript client can do more than just connect to your server and run a flow.
 
-This example builds on the quickstart with additional features for interacting with Langflow.
+This example builds on the quickstart with additional features for interacting with Langflow:
 
-1. Pass tweaks to your code as an object with the request.
+1. Pass [tweaks](/concepts-publish#input-schema) as an object with the request.
+Tweaks are programmatic run-time overrides for component settings.
 
-    Tweaks change values within components for all calls to your flow.
-
-    This example tweaks the **OpenAI** component to enforce using the `gpt-4o-mini` model:
+    This example changes the LLM used by a language model component in a flow::
 
     ```tsx
     const tweaks = { model_name: "gpt-4o-mini" };
@@ -140,7 +140,7 @@ This example builds on the quickstart with additional features for interacting w
     const session_id = "aa5a238b-02c0-4f03-bc5c-cc3a83335cdf";
     ```
 
-3. Instead of calling `run` on the Flow object, call `stream` with the same arguments:
+3. Instead of calling `run` on the Flow object, call `stream` with the same arguments to get a streaming response:
 
     ```tsx
     const response = await client.flow(flowId).stream(input);
@@ -153,9 +153,7 @@ This example builds on the quickstart with additional features for interacting w
     The response is a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) of objects.
     For more information on streaming Langflow responses, see the [`/run` endpoint](/api-flows-run#run-flow).
 
-4. Run the modified TypeScript application to run the flow with `tweaks` and `session_id`, and then stream the response back.
-
-Replace `baseUrl` and `flowId` with values from your deployment.
+4. Run the modified TypeScript application to run the flow with `tweaks`, `session_id`, and streaming:
 
     ```tsx
     import { LangflowClient } from "@datastax/langflow-client";
@@ -182,7 +180,15 @@ Replace `baseUrl` and `flowId` with values from your deployment.
     runFlow().catch(console.error);
     ```
 
-    Replace `baseUrl` and `flowId` with your server URL and flow ID, as you did in the previous run.
+    Replace the following:
+
+    * `baseUrl`: The URL of your Langflow server.
+    * `flowId`: The ID of the flow you want to run.
+    * `input`: The chat input message you want to send to trigger the flow, assuming the flow has a **Chat Input** component.
+    * `tweaks`: Any tweak modifiers to apply to the flow run.
+    This example changes the LLM used by a component in the flow.
+    * `session_id`: Pass a custom session ID.
+    If omitted or empty, the flow ID is the default session ID.
 
     <details>
     <summary>Result</summary>
@@ -265,7 +271,7 @@ Replace `baseUrl` and `flowId` with values from your deployment.
 
 ## Retrieve Langflow logs with the TypeScript client
 
-To retrieve [Langflow logs](/logging), you must enable log retrieval on your Langflow server by including the following values in your server's `.env` file:
+To retrieve [Langflow logs](/logging), you must enable log retrieval on your Langflow server by including the following values in your Langflow `.env` file:
 
 ```text
 LANGFLOW_ENABLE_LOG_RETRIEVAL=True
@@ -304,16 +310,20 @@ async function main() {
 main().catch(console.error);
 ```
 
-Replace `baseUrl` and `flowId` with your server URL and flow ID, as you did in the previous run.
+Replace the following:
+
+* `baseUrl`: The URL of your Langflow server.
+* `flowId`: The ID of the flow you want to run.
+* `input`: The chat input message you want to send to trigger the flow, assuming the flow has a **Chat Input** component.
 
 Logs begin streaming indefinitely, and the flow runs once.
+
+<details>
+<summary>Result</summary>
 
 The following example result is truncated for readability, but you can follow the messages to see how the flow instantiates its components, configures its model, and processes the outputs.
 
 The `FlowResponse` object, at the end of the stream, is returned to the client with the flow result in the `outputs` array.
-
-<details>
-<summary>Result</summary>
 
 ```text
 Starting log stream...

--- a/docs/docs/Integrations/Cleanlab/integrations-cleanlab.mdx
+++ b/docs/docs/Integrations/Cleanlab/integrations-cleanlab.mdx
@@ -4,6 +4,7 @@ slug: /integrations-cleanlab
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 [Cleanlab](https://www.cleanlab.ai/) adds automation and trust to every data point going in and every prediction coming out of AI and RAG solutions.
 
@@ -19,8 +20,7 @@ The **Cleanlab Evaluator** component evaluates and explains the trustworthiness 
 
 ### Cleanlab Evaluator parameters
 
-Some **Cleanlab Evaluator** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name                    | Type       | Description                        |
 |-------------------------|------------|------------------------------------|
@@ -69,8 +69,7 @@ You can pair this component with the [**Cleanlab Remediator** component](#cleanl
 
 ### Cleanlab RAG Evaluator parameters
 
-Some **Cleanlab RAG Evaluator** component input parameters are hidden by default in the visual editor.
-You can toggle parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+<PartialParams />
 
 | Name                        | Type       | Description |
 |-----------------------------|------------|------------|
@@ -113,8 +112,9 @@ You can [download the Evaluate and Remediate flow](./eval_and_remediate_cleanlab
 Or, you can build the flow from scratch by connecting the following components:
 
 * Connect the `Message` output from any **Language Model** or **Agent** component to the **Response** input of the **Cleanlab Evaluator** component.
-* Connect a **Prompt Template** component to **Cleanlab Evaluator** component's **Prompt** input.
-<!-- Components missing -->
+* Connect a **Prompt Template** component to the **Cleanlab Evaluator** component's **Prompt** input.
+
+<!-- Components missing per image -->
 
 ![Evaluate response trustworthiness](./eval_response.png)
 

--- a/docs/docs/Integrations/Notion/notion-agent-conversational.mdx
+++ b/docs/docs/Integrations/Notion/notion-agent-conversational.mdx
@@ -104,7 +104,7 @@ The description has been added as a new text block on the page. Is there anythin
 The flow can be customized to meet your team's specific needs.
 For example:
 
-1. Adjust the system prompt to change the agent's behavior or knowledge base.
+1. Adjust the system prompt to change the agent's behavior or context.
 2. Add or remove Notion tools based on your specific needs.
 3. Modify the OpenAI model parameters (e.g., temperature) to adjust the agent's response style.
 

--- a/docs/docs/Integrations/Notion/notion-agent-meeting-notes.mdx
+++ b/docs/docs/Integrations/Notion/notion-agent-meeting-notes.mdx
@@ -147,7 +147,7 @@ The flow can be customized to meet your team's specific needs.
 
 Customize this flow by:
 
-1. Adjusting the system prompt to change the agent's behavior or knowledge base.
+1. Adjusting the system prompt to change the agent's behavior or context.
 2. Adding or removing Notion tools based on your specific needs.
 3. Modifying the OpenAI model parameters (e.g., temperature) to adjust the agent's response style.
 

--- a/docs/docs/Integrations/Nvidia/integrations-nvidia-g-assist.mdx
+++ b/docs/docs/Integrations/Nvidia/integrations-nvidia-g-assist.mdx
@@ -3,35 +3,35 @@ title: Integrate NVIDIA G-Assist with Langflow
 slug: /integrations-nvidia-g-assist
 ---
 
-:::important
-The **NVIDIA G-Assist** component is available only for Langflow users with NVIDIA GPUs on Windows systems.
-:::
-
-The **NVIDIA G-Assist** component enables interaction with NVIDIA GPU drivers through natural language prompts.
+The **NVIDIA System-Assist** component integrates your flows with NVIDIA G-Assist, enabling interaction with NVIDIA GPU drivers through natural language prompts.
 For example, prompt G-Assist with `"What is my current GPU temperature?"` or `"Show me the available GPU memory"` to get information, and then tell G-Assist to modify your GPU settings.
 For more information, see the [NVIDIA G-Assist repository](https://github.com/NVIDIA/g-assist).
 
 ## Prerequisites
 
-* Windows operating system
-* NVIDIA GPU
-* `gassist.rise` package installed. This package is included in your [Langflow installation](/get-started-installation).
+The **NVIDIA System-Assist** component requires an NVIDIA GPU on a Windows operating system.
 
-## Use the G-Assist component in a flow
+It uses the `gassist.rise` package, which is installed with all Langflow versions that include this component.
 
-1. Create a flow with **Chat Input** component, **G-Assist** component, and **Chat Output** components.
-2. Connect the **Chat Input** component to the **G-Assist** component's **Prompt** input.
-3. Connect the **G-Assist** component's output to the **Chat Output** component.
-4. Open the **Playground**, and then ask a question about your GPU. For example, `"What is my current GPU temperature?"`.
-The **G-Assist** component queries your GPU, and the response appears in the **Playground**.
+## Use NVIDIA G-Assist in a flow
 
-### Inputs
+1. Create a flow with a **Chat Input** component, **NVIDIA System-Assist** component, and **Chat Output** components.
 
-The **NVIDIA G-Assist** component accepts a single input:
+    This is a simplified example that uses only three components.
+    Depending on your use case, your flow might use more components or different inputs and outputs.
 
-- `prompt`: A human-readable prompt processed by NVIDIA G-Assist.
+2. Connect the **Chat Input** component to the **NVIDIA System-Assist** component's **Prompt** input.
 
-### Outputs
+    The **Prompt** parameter accepts a natural language prompt that is processed by the NVIDIA G-Assist AI Assistant.
+    In this example, you'll provide the prompt as chat input.
+    You could also enter a prompt directly in the **Prompt** input or connect another input component.
 
-The **NVIDIA G-Assist** component outputs a [`Message`](/data-types#message) object that contains the NVIDIA G-Assist response.
-The string response with the completed operation result is available in the `text` field of the `Message` object.
+3. Connect the **NVIDIA System-Assist** component's output to the **Chat Output** component.
+
+4. To test the flow, open the **Playground**, and then ask a question about your GPU.
+For example, `"What is my current GPU temperature?"`.
+
+    Through the **NVIDIA System-Assist** component, NVIDIA G-Assist queries your GPU based on the prompt, and then prints the response to the **Playground**.
+
+    The component's output is a [`Message`](/data-types#message) containing the NVIDIA G-Assist response.
+    The string response with the completed operation result is available in the `text` key in the `Message` object.

--- a/docs/docs/Integrations/Nvidia/integrations-nvidia-ingest.mdx
+++ b/docs/docs/Integrations/Nvidia/integrations-nvidia-ingest.mdx
@@ -4,6 +4,7 @@ slug: /integrations-nvidia-ingest
 ---
 
 import Icon from "@site/src/components/icon";
+import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
 The **NVIDIA Retriever Extraction** component integrates with the [NVIDIA nv-ingest](https://github.com/NVIDIA/nv-ingest) microservice for data ingestion, processing, and extraction of text files.
 
@@ -49,9 +50,9 @@ You can also store the URL as a [global variable](/configuration-global-variable
 5. Optional: For PDF files, enable **High Resolution Mode** for better quality extraction from scanned documents.
 6. Select whether to split the text into chunks.
 
-    You can modify the splitting parameters and other hidden settings through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).
+    <PartialParams />
 
-7. Click **Run component** to ingest the file, and then open the **Logs** pane to confirm the component ingested the file.
+7. Click <Icon name="Play" aria-hidden="True" /> **Run component** to ingest the file, and then click **Logs** or <Icon name="TextSearch" aria-hidden="True" /> **Inspect output** to confirm the component ingested the file.
 8. To store the processed data in a vector database, add a **Vector Store** component to your flow, and then connect the **NVIDIA Retriever Extraction** component's `Data` output to the **Vector Store** component's input.
 
     When you run the flow with a **Vector Store** component, the processed data is stored in the vector database.

--- a/docs/docs/Integrations/integrations-langwatch.mdx
+++ b/docs/docs/Integrations/integrations-langwatch.mdx
@@ -38,6 +38,4 @@ To integrate with Langflow, add your LangWatch API key as a Langflow environment
 ## Use the LangWatch Evaluator
 
 In your flows, you can use the **LangWatch Evaluator** component to use LangWatch's evaluation endpoints to assess a model's performance.
-
-This component is available in the **LangWatch** bundle in the **Components** menu.
-For more information, see [Bundles](/components-bundle-components).
+This component is available in the **LangWatch** [bundle](/components-bundle-components).

--- a/docs/docs/Integrations/integrations-opik.mdx
+++ b/docs/docs/Integrations/integrations-opik.mdx
@@ -3,9 +3,6 @@ title: Opik
 slug: /integrations-opik
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 [Opik](https://www.comet.com/site/products/opik/) is an open-source platform designed for evaluating, testing, and monitoring large language model (LLM) applications. Developed by Comet, it aims to facilitate more intuitive collaboration, testing, and monitoring of LLM-based applications.
 
 You can configure Langflow to collect [tracing](https://www.comet.com/docs/opik/tracing/log_traces) data about your flow executions and automatically send the data to Opik.

--- a/docs/docs/Integrations/mcp-component-astra.mdx
+++ b/docs/docs/Integrations/mcp-component-astra.mdx
@@ -3,8 +3,6 @@ title: Connect an Astra DB MCP server to Langflow
 slug: /mcp-component-astra
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import Icon from "@site/src/components/icon";
 
 This guide demonstrates how to [use Langflow as an MCP client](/mcp-client) by using the **MCP Tools** component to run a [DataStax Astra DB MCP server](https://github.com/datastax/astra-db-mcp) in an agent flow.

--- a/docs/docs/Support/release-notes.mdx
+++ b/docs/docs/Support/release-notes.mdx
@@ -59,9 +59,10 @@ For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/rel
 - Centralized **Language Model** and **Embedding Model** components
 
     The [**Language Model** component](/components-models) and [**Embedding Model** component](/components-embedding-models) are now core components for your LLM and embeddings flows. They support multiple models and model providers, and allow you to experiment with different models without swapping out single-provider components.
-    Find them in the **Components** menu in the **Models** category.
+    Find them in the visual editor in the **Models** category.
 
-    The single-provider components are still available for your flows in the **Components** menu in the [**Bundles**](/components-bundle-components) section, and you can use them to replace the **Language Model** and **Embedding Model** core components, or connect them to the **Agent** component with the **Custom** provider option.
+    The single-provider components moved to the [**Bundles**](/components-bundle-components) section.
+    You can use them to replace the **Language Model** and **Embedding Model** core components, or connect them to the **Agent** component with the **Custom** provider option.
 
 - MCP server one-click installation
 
@@ -107,7 +108,7 @@ For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/rel
 - Enhanced file and flow management system with improved bulk capabilities.
 - Added the **BigQuery** component
 - Added the **Twelve Labs** bundle
-- Added the **NVIDIA G-Assist** component
+- Added the **NVIDIA System-Assist** component
 
 ### Deprecations
 

--- a/docs/docs/Tutorials/agent.mdx
+++ b/docs/docs/Tutorials/agent.mdx
@@ -4,8 +4,6 @@ slug: /agent-tutorial
 ---
 
 import Icon from "@site/src/components/icon";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 This tutorial shows you how to connect a JavaScript application to a [Langflow agent](/agents).
 

--- a/docs/docs/Tutorials/chat-with-files.mdx
+++ b/docs/docs/Tutorials/chat-with-files.mdx
@@ -4,8 +4,6 @@ slug: /chat-with-files
 ---
 
 import Icon from "@site/src/components/icon";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 This tutorial shows you how to build a chatbot that can read and answer questions about files you upload, such as meeting notes or job applications.
 

--- a/docs/docs/_partial-agents-work.mdx
+++ b/docs/docs/_partial-agents-work.mdx
@@ -1,0 +1,18 @@
+<details>
+<summary>How do agents work?</summary>
+
+Agents extend Large Language Models (LLMs) by integrating _tools_, which are functions that provide additional context and enable autonomous task execution.
+These integrations make agents more specialized and powerful than standalone LLMs.
+
+Whereas an LLM might generate acceptable, inert responses to general queries and tasks, an agent can leverage the integrated context and tools to provide more relevant responses and even take action.
+For example, you might create an agent that can access your company's documentation, repositories, and other resources to help your team with tasks that require knowledge of your specific products, customers, and code.
+
+Agents use LLMs as a reasoning engine to process input, determine which actions to take to address the query, and then generate a response.
+The response could be a typical text-based LLM response, or it could involve an action, like editing a file, running a script, or calling an external API.
+
+In an agentic context, tools are functions that the agent can run to perform tasks or access external resources.
+A function is wrapped as a `Tool` object with a common interface that the agent understands.
+Agents become aware of tools through tool registration, which is when the agent is provided a list of available tools typically at agent initialization.
+The `Tool` object's description tells the agent what the tool can do so that it can decide whether the tool is appropriate for a given request.
+
+</details>

--- a/docs/docs/_partial-conditional-params.mdx
+++ b/docs/docs/_partial-conditional-params.mdx
@@ -1,0 +1,2 @@
+Some parameters are conditional, and they are only available after you set other parameters or select specific options for other parameters.
+Conditional parameters may not be visible on the **Controls** pane until you set the required dependencies.

--- a/docs/docs/_partial-conditional-params.mdx
+++ b/docs/docs/_partial-conditional-params.mdx
@@ -1,2 +1,0 @@
-Some parameters are conditional, and they are only available after you set other parameters or select specific options for other parameters.
-Conditional parameters may not be visible on the **Controls** pane until you set the required dependencies.

--- a/docs/docs/_partial-hidden-params.mdx
+++ b/docs/docs/_partial-hidden-params.mdx
@@ -1,0 +1,4 @@
+import Icon from "@site/src/components/icon";
+
+Some parameters are hidden by default in the visual editor.
+You can modify all parameters through the <Icon name="SlidersHorizontal" aria-hidden="true"/> **Controls** in the [component's header menu](/concepts-components#component-menus).


### PR DESCRIPTION
Moving low-hanging fruit from docs-1.6 to a new PR to try to reduce the scope of docs-1.6. These are all docs chore/maintenance edits or reflect 1.5.z functionality.