### PR TITLE
fix(langwatch): prevent trace errors with proper API key validation

### DIFF
--- a/src/backend/base/langflow/services/tracing/langwatch.py
+++ b/src/backend/base/langflow/services/tracing/langwatch.py
@@ -138,7 +138,7 @@ class LangWatchTracer(BaseTracer):
         if metadata and "flow_name" in metadata:
             self.trace.update(metadata=(self.trace.metadata or {}) | {"labels": [f"Flow: {metadata['flow_name']}"]})
 
-        if self.trace.api_key or self._client.api_key:
+        if self.trace.api_key or self._client._api_key:
             try:
                 self.trace.__exit__(None, None, None)
             except ValueError:  # ignoring token was created in a different Context errors


### PR DESCRIPTION
Prevents trace ending errors in LangWatch by validating API keys before operations and catching context errors.
<img width="289" height="21" alt="Screenshot 2025-09-05 at 01 18 32" src="https://github.com/user-attachments/assets/4c268600-53a4-4266-a7b5-8a54c66c56f0" />
