### PR TITLE
feat:The JSON snippet is causing an error in the workflow's prompt co…

### DIFF
--- a/src/lfx/src/lfx/schema/message.py
+++ b/src/lfx/src/lfx/schema/message.py
@@ -235,7 +235,22 @@ class Message(Data):
         return cls(prompt=prompt_json)
 
     def format_text(self):
-        prompt_template = PromptTemplate.from_template(self.template)
+        # Escape any non-identifier placeholders so braces from JSON/examples are treated as literals
+        def _escape_non_identifier_placeholders(template: str) -> str:
+            parts: list[str] = []
+            identifier_pattern = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+            for literal_text, field_name, _, _ in StrFormatter().parse(template):
+                parts.append(literal_text)
+                if field_name is None:
+                    continue
+                if identifier_pattern.match(field_name or ""):
+                    parts.append("{" + field_name + "}")
+                else:
+                    parts.append("{{" + (field_name or "") + "}}")
+            return "".join(parts)
+
+        safe_template = _escape_non_identifier_placeholders(self.template)
+        prompt_template = PromptTemplate.from_template(safe_template)
         variables_with_str_values = dict_values_to_string(self.variables)
         formatted_prompt = prompt_template.format(**variables_with_str_values)
         self.text = formatted_prompt


### PR DESCRIPTION
This avoids interpreting JSON fragments or other brace usages as variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when formatting messages containing braces or non-identifier placeholders (e.g., from JSON/examples). Such content is now treated as literal text instead of causing formatting failures.
  * Improved robustness of message rendering to avoid crashes and unexpected substitutions in templates with mixed or malformed placeholder syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->