### PR TITLE
fix: disable keys when flow is locked

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -309,6 +309,7 @@ export default function Page({
   }
 
   function handleDelete(e: KeyboardEvent) {
+    if (isLocked) return;
     if (!isWrappedWithClass(e, "nodelete") && lastSelection) {
       e.preventDefault();
       (e as unknown as Event).stopImmediatePropagation();
@@ -481,6 +482,7 @@ export default function Page({
   const onDrop = useCallback(
     (event: React.DragEvent) => {
       event.preventDefault();
+      if (isLocked) return;
       const grabbingElement =
         document.getElementsByClassName("cursor-grabbing");
       if (grabbingElement.length > 0) {

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx
@@ -638,6 +638,13 @@ export default function Page({
     reactFlowWrapper.current?.style.setProperty("--selected", accentColor);
   };
 
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (isLocked) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
   useEffect(() => {
     const handleGlobalMouseMove = (event) => {
       if (isAddingNote) {
@@ -694,6 +701,8 @@ export default function Page({
             onEdgesChange={onEdgesChange}
             onConnect={isLocked ? undefined : onConnectMod}
             disableKeyboardA11y={true}
+            nodesFocusable={!isLocked}
+            edgesFocusable={!isLocked}
             onInit={setReactFlowInstance}
             nodeTypes={nodeTypes}
             onReconnect={isLocked ? undefined : onEdgeUpdate}
@@ -716,6 +725,7 @@ export default function Page({
             fitView={isEmptyFlow.current ? false : true}
             fitViewOptions={fitViewOptions}
             className="theme-attribution"
+            tabIndex={isLocked ? -1 : undefined}
             minZoom={MIN_ZOOM}
             maxZoom={MAX_ZOOM}
             zoomOnScroll={!view}
@@ -725,6 +735,7 @@ export default function Page({
             proOptions={{ hideAttribution: true }}
             onPaneClick={onPaneClick}
             onEdgeClick={handleEdgeClick}
+            onKeyDown={handleKeyDown}
           >
             <FlowBuildingComponent />
             <UpdateAllComponents />

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -391,6 +391,7 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
     track("Component Connection Deleted", { edgeId });
   },
   paste: (selection, position) => {
+    if (get().currentFlow?.locked) return;
     // Collect IDs of nodes in the selection
     const selectedNodeIds = new Set(selection.nodes.map((node) => node.id));
     // Find existing edges in the flow that connect nodes within the selection


### PR DESCRIPTION
This pull request adds comprehensive locking logic to the flow editor page, ensuring that when a flow is locked (`isLocked`), users cannot perform destructive or editing actions such as deleting, dragging, pasting, or focusing nodes and edges. These changes help prevent unintended modifications in locked mode and improve the overall user experience.

**Locking and interaction prevention:**

* Prevent deletion of nodes or edges when the flow is locked by checking `isLocked` in the `handleDelete` function (`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`).
* Prevent drag-and-drop operations when the flow is locked by checking `isLocked` in the `onDrop` handler (`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`).
* Prevent keyboard interactions when the flow is locked by adding a `handleKeyDown` handler that blocks events if `isLocked` is true, and wiring it to the main flow component (`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`). [[1]](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eR643-R649) [[2]](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eR740)
* Prevent pasting of nodes and edges when the flow is locked by checking the `locked` property in the `paste` method of the flow store (`src/frontend/src/stores/flowStore.ts`).

**UI accessibility and focus management:**

* Disable focusability of nodes and edges, and set `tabIndex` to `-1` on the main flow component when locked, ensuring users cannot interact with flow elements via keyboard navigation (`src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx`). [[1]](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eR706-R707) [[2]](diffhunk://#diff-58f6af33afc15c24e3df56ce2169081e35e5fe005f6281ebc5d7156b2eaa7d0eR730)