### PR TITLE
feat: add playwright test simulating Composio's GmailFetchEmails action.

### DIFF
--- a/src/frontend/tests/core/integrations/Composio Gmail Fetch Emails.spec.ts
+++ b/src/frontend/tests/core/integrations/Composio Gmail Fetch Emails.spec.ts
@@ -1,9 +1,13 @@
 import { expect, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import * as dotenv from "dotenv";
 import path from "path";
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env") });
+test.use({ trace: "off", video: "off" });
+
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { removeOldApiKeys } from "../../utils/remove-old-api-keys";
-
 test(
   "Gmail Fetch Emails",
   { tag: ["@release", "@components", "@composio"] },


### PR DESCRIPTION
Added a simulation to test an action(Gmail fetch email) using playwright.
**Frontend**: `langflow/src/frontend/tests/core/integrations/Composio Gmail Fetch Emails.spec.ts`

Steps to run test:

```bash
# Add your Composio API key in root dir
echo "COMPOSIO_API_KEY=your-key-here" >> .env

# Install Playwright
bunx playwright install

# Run the test with Playwright UI
bunx playwright test --ui

https://github.com/user-attachments/assets/9512fd39-ad49-4d66-8701-ba00468a252f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added an end-to-end Playwright test for the Gmail “Fetch emails” action via the Composio integration. The test covers connecting the integration, running the action, optionally configuring parameters, and verifying that results render in the output view. This strengthens coverage of the end-user flow, improves reliability, and helps prevent regressions in Gmail email fetching functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->