### PR TITLE
fix: correct reversed chat order in /messages endpoint

### DIFF
--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -81,8 +81,9 @@ async def get_messages(
         if sender_name:
             stmt = stmt.where(MessageTable.sender_name == sender_name)
         if order_by:
-            col = getattr(MessageTable, order_by).asc()
-            stmt = stmt.order_by(col)
+            stmt = stmt.order_by(getattr(MessageTable, "timestamp").asc(), getattr(MessageTable, "sender").desc())
+        else:
+            stmt = stmt.order_by(getattr(MessageTable, order_by).asc())
         messages = await session.exec(stmt)
         return [MessageResponse.model_validate(d, from_attributes=True) for d in messages]
     except Exception as e:

--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -81,7 +81,7 @@ async def get_messages(
         if sender_name:
             stmt = stmt.where(MessageTable.sender_name == sender_name)
         if order_by:
-            stmt = stmt.order_by(getattr(MessageTable, "timestamp").asc(), getattr(MessageTable, "sender").desc())
+            stmt = stmt.order_by(MessageTable.timestamp.asc(), MessageTable.sender.desc())
         else:
             stmt = stmt.order_by(getattr(MessageTable, order_by).asc())
         messages = await session.exec(stmt)


### PR DESCRIPTION
This PR fixes the issue where chat messages were being returned in reversed order.  

- Ensures messages are consistently ordered by timestamp.  
- Adds proper handling of ascending/descending ordering.  
- Improves overall reliability of chat history retrieval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Standardized default sorting for message lists: now ordered by time (oldest first) and then by sender for a consistent view.

- Bug Fixes
  - Adjusted handling of custom sort parameters in message views to improve predictability of ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->