### PR TITLE
fix: docling OCR selector with None option

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1176,7 +1176,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/lfx/src/lfx/base/data/docling_utils.py
+++ b/src/lfx/src/lfx/base/data/docling_utils.py
@@ -133,7 +133,7 @@ def docling_worker(file_paths: list[str], queue, pipeline: str, ocr_engine: str)
         check_shutdown()  # Check before heavy operations
 
         pipeline_options = PdfPipelineOptions()
-        pipeline_options.do_ocr = ocr_engine != ""
+        pipeline_options.do_ocr = ocr_engine not in {"", "None"}
         if pipeline_options.do_ocr:
             ocr_factory = get_ocr_factory(
                 allow_external_plugins=False,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added explicit control to disable OCR by setting the OCR engine to "None" or leaving it blank.
  - OCR now activates only when a valid engine is specified, improving configurability.

- Bug Fixes
  - Prevents unintended OCR activation when the engine field is empty, reducing unnecessary processing and resource usage.
  - Ensures more predictable OCR behavior across configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->