### PR TITLE
fix: handle pandas Series in get_message boolean evaluation

### DIFF
--- a/src/backend/base/langflow/schema/schema.py
+++ b/src/backend/base/langflow/schema/schema.py
@@ -2,6 +2,7 @@ from collections.abc import Generator
 from enum import Enum
 from typing import Literal
 
+from pandas import Series
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
@@ -77,6 +78,9 @@ def get_message(payload):
 
     if message is None and isinstance(payload, dict | str | Data):
         message = payload.data if isinstance(payload, Data) else payload
+
+    if isinstance(message, Series):
+        return message if not message.empty else payload
 
     return message or payload
 


### PR DESCRIPTION
Resolves ValueError when message is pandas Series by checking .empty instead of relying on ambiguous truth value evaluation.
<img width="1628" height="1328" alt="bug" src="https://github.com/user-attachments/assets/5ca2999e-652d-4c79-873a-9ebacefe16da" />
Flow: [sample.json](https://github.com/user-attachments/files/22233670/sample.json)