### PR TITLE
chore: remove debug console.log from search input check

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
@@ -475,7 +475,6 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
   const hasMcpServers = Boolean(mcpServers && mcpServers.length > 0);
 
   const hasSearchInput = search !== "" || filterType !== undefined;
-  console.log("hasSearchInput", hasSearchInput);
 
   const showComponents =
     (ENABLE_NEW_SIDEBAR &&


### PR DESCRIPTION
Removed leftover console.log("hasSearchInput", hasSearchInput); used for debugging. This cleans up the code and avoids unnecessary console noise in production.