### PR TITLE
fix s3 implementation of storage service

### DIFF
--- a/src/backend/base/langflow/services/storage/s3.py
+++ b/src/backend/base/langflow/services/storage/s3.py
@@ -1,4 +1,5 @@
 import os
+
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 

--- a/src/backend/base/langflow/services/storage/s3.py
+++ b/src/backend/base/langflow/services/storage/s3.py
@@ -1,3 +1,4 @@
+import os
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 
@@ -105,9 +106,8 @@ class S3StorageService(StorageService):
         """Get the size of a file in the S3 bucket."""
         try:
             response = self.s3_client.head_object(Bucket=self.bucket, Key=f"{flow_id}/{file_name}")
+            await logger.ainfo(f"File {file_name} retrieved successfully from folder {flow_id}.")
             return response["ContentLength"]
-        except ClientError as e:
-            if e.response["Error"]["Code"] == "404":
-                raise FileNotFoundError(f"File {file_name} not found in flow_id {flow_id}")
-            logger.exception(f"Error getting file size for {file_name} in flow_id {flow_id}: {e}")
+        except ClientError:
+            logger.aexception(f"Error getting file size for {file_name} in flow_id {flow_id}: {e}")
             raise

--- a/src/backend/base/langflow/services/storage/s3.py
+++ b/src/backend/base/langflow/services/storage/s3.py
@@ -110,5 +110,5 @@ class S3StorageService(StorageService):
             await logger.ainfo(f"File {file_name} retrieved successfully from folder {flow_id}.")
             return response["ContentLength"]
         except ClientError:
-            logger.aexception(f"Error getting file size for {file_name} in flow_id {flow_id}: {e}")
+            logger.aexception(f"Error getting file size for {file_name} in flow_id {flow_id}")
             raise

--- a/src/backend/base/langflow/services/storage/s3.py
+++ b/src/backend/base/langflow/services/storage/s3.py
@@ -12,7 +12,7 @@ class S3StorageService(StorageService):
     def __init__(self, session_service, settings_service) -> None:
         """Initialize the S3 storage service with session and settings services."""
         super().__init__(session_service, settings_service)
-        self.bucket = "langflow"
+        self.bucket = os.getenv("LANGFLOW_S3_BUCKET", "langflow")
         self.s3_client = boto3.client("s3")
         self.set_ready()
 

--- a/src/backend/base/langflow/services/storage/s3.py
+++ b/src/backend/base/langflow/services/storage/s3.py
@@ -105,9 +105,9 @@ class S3StorageService(StorageService):
         """Get the size of a file in the S3 bucket."""
         try:
             response = self.s3_client.head_object(Bucket=self.bucket, Key=f"{flow_id}/{file_name}")
-            return response['ContentLength']
+            return response["ContentLength"]
         except ClientError as e:
-            if e.response['Error']['Code'] == '404':
+            if e.response["Error"]["Code"] == "404":
                 raise FileNotFoundError(f"File {file_name} not found in flow_id {flow_id}")
             logger.exception(f"Error getting file size for {file_name} in flow_id {flow_id}: {e}")
             raise

--- a/src/backend/base/langflow/services/storage/s3.py
+++ b/src/backend/base/langflow/services/storage/s3.py
@@ -1,6 +1,7 @@
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
-from lfx.log.logger import logger
+
+from langflow.logging.logger import logger
 
 from .service import StorageService
 
@@ -15,11 +16,11 @@ class S3StorageService(StorageService):
         self.s3_client = boto3.client("s3")
         self.set_ready()
 
-    async def save_file(self, folder: str, file_name: str, data) -> None:
+    async def save_file(self, flow_id: str, file_name: str, data) -> None:
         """Save a file to the S3 bucket.
 
         Args:
-            folder: The folder in the bucket to save the file.
+            flow_id: The folder in the bucket to save the file.
             file_name: The name of the file to be saved.
             data: The byte content of the file.
 
@@ -27,20 +28,20 @@ class S3StorageService(StorageService):
             Exception: If an error occurs during file saving.
         """
         try:
-            self.s3_client.put_object(Bucket=self.bucket, Key=f"{folder}/{file_name}", Body=data)
-            await logger.ainfo(f"File {file_name} saved successfully in folder {folder}.")
+            self.s3_client.put_object(Bucket=self.bucket, Key=f"{flow_id}/{file_name}", Body=data)
+            await logger.ainfo(f"File {file_name} saved successfully in folder {flow_id}.")
         except NoCredentialsError:
             await logger.aexception("Credentials not available for AWS S3.")
             raise
         except ClientError:
-            await logger.aexception(f"Error saving file {file_name} in folder {folder}")
+            await logger.aexception(f"Error saving file {file_name} in folder {flow_id}")
             raise
 
-    async def get_file(self, folder: str, file_name: str):
+    async def get_file(self, flow_id: str, file_name: str):
         """Retrieve a file from the S3 bucket.
 
         Args:
-            folder: The folder in the bucket where the file is stored.
+            flow_id: The folder in the bucket where the file is stored.
             file_name: The name of the file to be retrieved.
 
         Returns:
@@ -50,18 +51,18 @@ class S3StorageService(StorageService):
             Exception: If an error occurs during file retrieval.
         """
         try:
-            response = self.s3_client.get_object(Bucket=self.bucket, Key=f"{folder}/{file_name}")
-            await logger.ainfo(f"File {file_name} retrieved successfully from folder {folder}.")
+            response = self.s3_client.get_object(Bucket=self.bucket, Key=f"{flow_id}/{file_name}")
+            await logger.ainfo(f"File {file_name} retrieved successfully from folder {flow_id}.")
             return response["Body"].read()
         except ClientError:
-            await logger.aexception(f"Error retrieving file {file_name} from folder {folder}")
+            await logger.aexception(f"Error retrieving file {file_name} from folder {flow_id}")
             raise
 
-    async def list_files(self, folder: str):
+    async def list_files(self, flow_id: str):
         """List all files in a specified folder of the S3 bucket.
 
         Args:
-            folder: The folder in the bucket to list files from.
+            flow_id: The folder in the bucket to list files from.
 
         Returns:
             A list of file names.
@@ -70,30 +71,30 @@ class S3StorageService(StorageService):
             Exception: If an error occurs during file listing.
         """
         try:
-            response = self.s3_client.list_objects_v2(Bucket=self.bucket, Prefix=folder)
+            response = self.s3_client.list_objects_v2(Bucket=self.bucket, Prefix=str(flow_id))
         except ClientError:
-            await logger.aexception(f"Error listing files in folder {folder}")
+            await logger.aexception(f"Error listing files in folder {flow_id}")
             raise
 
-        files = [item["Key"] for item in response.get("Contents", []) if "/" not in item["Key"][len(folder) :]]
-        await logger.ainfo(f"{len(files)} files listed in folder {folder}.")
+        files = [item["Key"] for item in response.get("Contents", []) if "/" not in item["Key"][len(flow_id) :]]
+        await logger.ainfo(f"{len(files)} files listed in folder {flow_id}.")
         return files
 
-    async def delete_file(self, folder: str, file_name: str) -> None:
+    async def delete_file(self, flow_id: str, file_name: str) -> None:
         """Delete a file from the S3 bucket.
 
         Args:
-            folder: The folder in the bucket where the file is stored.
+            flow_id: The folder in the bucket where the file is stored.
             file_name: The name of the file to be deleted.
 
         Raises:
             Exception: If an error occurs during file deletion.
         """
         try:
-            self.s3_client.delete_object(Bucket=self.bucket, Key=f"{folder}/{file_name}")
-            await logger.ainfo(f"File {file_name} deleted successfully from folder {folder}.")
+            self.s3_client.delete_object(Bucket=self.bucket, Key=f"{flow_id}/{file_name}")
+            await logger.ainfo(f"File {file_name} deleted successfully from folder {flow_id}.")
         except ClientError:
-            await logger.aexception(f"Error deleting file {file_name} from folder {folder}")
+            await logger.aexception(f"Error deleting file {file_name} from folder {flow_id}")
             raise
 
     async def teardown(self) -> None:
@@ -101,4 +102,12 @@ class S3StorageService(StorageService):
         # No specific teardown actions required for S3 storage at the moment.
 
     async def get_file_size(self, flow_id: str, file_name: str):
-        raise NotImplementedError
+        """Get the size of a file in the S3 bucket."""
+        try:
+            response = self.s3_client.head_object(Bucket=self.bucket, Key=f"{flow_id}/{file_name}")
+            return response['ContentLength']
+        except ClientError as e:
+            if e.response['Error']['Code'] == '404':
+                raise FileNotFoundError(f"File {file_name} not found in flow_id {flow_id}")
+            logger.exception(f"Error getting file size for {file_name} in flow_id {flow_id}: {e}")
+            raise


### PR DESCRIPTION
Also fix issue with boto3 s3_client.list_objects_v2 - as it accepts str, not Path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added ability to retrieve file size for stored files.

* Configuration
  * S3 bucket can be set via LANGFLOW_S3_BUCKET; defaults to "langflow".

* API Changes
  * Storage operations now use flow_id instead of folder.
  * Updated file path conventions to use "{flow_id}/{file_name}".
  * Listing now scoped by flow_id.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->