### PR TITLE
fix: exclude docs folder from local biome check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
         language: system
         types: [text]
         files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+        exclude: ^docs/
       - id: validate-starter-projects
         name: Validate Starter Project Templates
         entry: uv run python src/backend/tests/unit/template/test_starter_projects.py


### PR DESCRIPTION
The local biome check is causing docs PRs to be blocked when changes to `sidebars.js` are made.
I don't think the docs folder has any need of the biome check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted local pre-commit checks to exclude the documentation directory from style/lint validation, reducing noise and speeding up developer workflows.
  * Improves commit performance and keeps documentation-only edits unblocked by code-quality tooling.
  * No changes to application features, UI, or behavior, and no impact on production builds.
  * Continuous integration and release artifacts remain unchanged; this affects only local development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->