### PR TITLE
fix: ci test failure

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           timeout_minutes: 12
           max_attempts: 2
-          command: make unit_tests args="-x -vv --splits ${{ matrix.splitCount }} --group ${{ matrix.group }} --reruns 5 --cov --cov-config=src/backend/.coveragerc --cov-report=xml --cov-report=html"
+          command: DO_NOT_TRACK=true make unit_tests args="-x -vv --splits ${{ matrix.splitCount }} --group ${{ matrix.group }} --reruns 5 --cov --cov-config=src/backend/.coveragerc --cov-report=xml --cov-report=html"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/src/backend/tests/unit/api/v2/test_files.py
+++ b/src/backend/tests/unit/api/v2/test_files.py
@@ -112,7 +112,7 @@ async def files_client_fixture(
         app, db_path = await asyncio.to_thread(init_app)
 
         async with (
-            LifespanManager(app, startup_timeout=None, shutdown_timeout=None) as manager,
+            LifespanManager(app, startup_timeout=None, shutdown_timeout=30) as manager,
             AsyncClient(transport=ASGITransport(app=manager.app), base_url="http://testserver/") as client,
         ):
             yield client


### PR DESCRIPTION
This pull request introduces improvements to test reliability and CLI progress output behavior, especially in CI and test environments. The most significant changes include making progress output in the CLI configurable via environment variables and automatically disabling it in CI and pytest contexts, as well as disabling telemetry and external service calls during tests to avoid CI stalls. Additionally, test client shutdown timeouts have been standardized for more robust test execution.

**Progress output configurability and CI/test detection:**

* The `Progress` class in `progress.py` now determines whether to enable progress output based on a new environment variable (`LANGFLOW_PROGRESS`), TTY detection, and heuristics for CI/pytest environments. This ensures progress animations and prints are disabled when running in CI or tests, preventing noisy logs and improving compatibility. [[1]](diffhunk://#diff-2526f275df05466aa702e2d4e5ab6439edb134be38d75f63d5ef2ea13ef5572cR1) [[2]](diffhunk://#diff-2526f275df05466aa702e2d4e5ab6439edb134be38d75f63d5ef2ea13ef5572cR43-R60)
* All methods in `Progress` that print output now respect the new `enabled` flag, ensuring no output is produced when disabled. [[1]](diffhunk://#diff-2526f275df05466aa702e2d4e5ab6439edb134be38d75f63d5ef2ea13ef5572cR75-R76) [[2]](diffhunk://#diff-2526f275df05466aa702e2d4e5ab6439edb134be38d75f63d5ef2ea13ef5572cR112) [[3]](diffhunk://#diff-2526f275df05466aa702e2d4e5ab6439edb134be38d75f63d5ef2ea13ef5572cR134-R137) [[4]](diffhunk://#diff-2526f275df05466aa702e2d4e5ab6439edb134be38d75f63d5ef2ea13ef5572cR160-R161) [[5]](diffhunk://#diff-2526f275df05466aa702e2d4e5ab6439edb134be38d75f63d5ef2ea13ef5572cL151-R179) [[6]](diffhunk://#diff-2526f275df05466aa702e2d4e5ab6439edb134be38d75f63d5ef2ea13ef5572cL167-R195)

**Test reliability and CI stability:**

* Added a global pytest fixture in `conftest.py` to disable telemetry and external MCP composer calls during tests, preventing CI stalls and removing external dependencies from test runs.
* The GitHub Actions workflow for Python tests now sets `DO_NOT_TRACK=true` to further ensure telemetry is disabled in CI.

**Test client timeout standardization:**

* Updated `LifespanManager` shutdown timeouts to `30` seconds in test client setup for both general and file API tests, improving reliability of test teardown and preventing premature shutdowns. [[1]](diffhunk://#diff-2f574640999ddf5d1e3c1d4217f1d8d3018710f2801838edea87078a919ca77eL441-R450) [[2]](diffhunk://#diff-4a30feb41700eb6cd449ed31b29e06a833214bc80b1c7da884744b87392cb8afL115-R115)