### PR TITLE
chore: Bump `lfx` version to 0.1.12

### DIFF
--- a/src/lfx/pyproject.toml
+++ b/src/lfx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx"
-version = "0.1.11"
+version = "0.1.12"
 description = "Langflow Executor - A lightweight CLI tool for executing and serving Langflow AI flows"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -5774,7 +5774,7 @@ wheels = [
 
 [[package]]
 name = "lfx"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "src/lfx" }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
Update the version number in `pyproject.toml` and `uv.lock` to reflect the new release.