### PR TITLE
ci: Change docker build jobs to run on self-hosted runners

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -183,7 +183,7 @@ jobs:
             fi
           fi
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: [get-version, setup]
     steps:
       - name: Check out the code at a specific ref
@@ -256,7 +256,7 @@ jobs:
 
   build_components:
     if: ${{ inputs.release_type == 'main' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       packages: write
     needs: [build, get-version]


### PR DESCRIPTION
Update the GitHub Actions workflow to use self-hosted runners for build jobs instead of the default Ubuntu environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated continuous integration build jobs to self-hosted runners, improving build performance, reliability, and control over the environment used to produce release artifacts. Enhances deployment cadence and consistency across branches and pull requests. This change affects only the CI infrastructure; end-users will not notice differences in features, performance, or compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->