### PR TITLE
ci: Add configurable runner options for CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      runs-on:
+        description: "Runner to use for the tests"
+        required: false
+        type: string
+        default: "ubuntu-latest"
   workflow_dispatch:
     inputs:
       branch:
@@ -37,6 +42,14 @@ on:
         required: false
         type: string
         default: "['3.10']"
+      runs-on:
+        description: "Runner to use for the tests"
+        required: false
+        type: choice
+        options:
+          - ubuntu-latest
+          - self-hosted
+        default: ubuntu-latest
   pull_request:
     types: [opened, synchronize, labeled]
   merge_group:
@@ -179,6 +192,7 @@ jobs:
     uses: ./.github/workflows/python_test.yml
     with:
       python-versions: ${{ inputs.python-versions || '["3.10"]' }}
+      runs-on: ${{ inputs.runs-on || 'ubuntu-latest' }}
     secrets:
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
       ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}"
@@ -200,6 +214,7 @@ jobs:
     with:
       tests_folder: ${{ inputs.frontend-tests-folder }}
       release: ${{ inputs.release || false }}
+      runs-on: ${{ inputs.runs-on || 'ubuntu-latest' }}
     secrets:
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
       STORE_API_KEY: "${{ secrets.STORE_API_KEY }}"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -2,6 +2,15 @@ name: Nightly Build
 
 on:
   workflow_dispatch:
+    inputs:
+      runs_on:
+        description: "Runner to use for tests (use self-hosted for safe/release code)"
+        required: false
+        type: choice
+        options:
+          - ubuntu-latest
+          - self-hosted
+        default: self-hosted
   schedule:
     # Run job at 00:00 UTC (4:00 PM PST / 5:00 PM PDT)
     - cron: "0 0 * * *"
@@ -145,6 +154,7 @@ jobs:
     with:
       tests_folder: "tests"
       release: true
+      runs-on: ${{ inputs.runs_on || 'ubuntu-latest' }}
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       STORE_API_KEY: ${{ secrets.STORE_API_KEY }}
@@ -158,6 +168,7 @@ jobs:
     uses: ./.github/workflows/python_test.yml
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      runs-on: ${{ inputs.runs_on || 'ubuntu-latest' }}
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      runs-on:
+        description: "Runner to use for the tests"
+        required: false
+        type: string
+        default: "ubuntu-latest"
   workflow_dispatch:
     inputs:
       python-versions:
@@ -31,6 +36,14 @@ on:
         required: true
         type: string
         default: "['3.10', '3.11', '3.12', '3.13']"
+      runs-on:
+        description: "Runner to use for the tests"
+        required: false
+        type: choice
+        options:
+          - ubuntu-latest
+          - self-hosted
+        default: ubuntu-latest
 env:
   POETRY_VERSION: "1.8.2"
   NODE_VERSION: "21"
@@ -42,7 +55,7 @@ jobs:
   build:
 
     name: Unit Tests - Python ${{ matrix.python-version }} - Group ${{ matrix.group }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on || 'ubuntu-latest' }}
     strategy:
       matrix:
         python-version: ${{ fromJson(inputs.python-versions || '["3.10", "3.11", "3.12", "3.13"]' ) }}
@@ -108,7 +121,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests - Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on || 'ubuntu-latest' }}
     strategy:
       matrix:
         python-version: ${{ fromJson(inputs.python-versions || '["3.10", "3.11", "3.12", "3.13"]' ) }}
@@ -133,7 +146,7 @@ jobs:
 
   lfx-tests:
     name: LFX Tests - Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on || 'ubuntu-latest' }}
     strategy:
       matrix:
         python-version: ${{ fromJson(inputs.python-versions || '["3.10", "3.11", "3.12", "3.13"]' ) }}
@@ -155,7 +168,7 @@ jobs:
 
   test-cli:
     name: Test CLI - Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on || 'ubuntu-latest' }}
     strategy:
       matrix:
         python-version: ${{ fromJson(inputs.python-versions || '["3.10", "3.11", "3.12", "3.13"]') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,14 @@ on:
         required: false
         type: boolean
         default: false
+      runs_on:
+        description: "Runner to use for CI tests (use self-hosted for safe/release code)"
+        required: false
+        type: choice
+        options:
+          - ubuntu-latest
+          - self-hosted
+        default: self-hosted
 
 
 
@@ -56,6 +64,7 @@ jobs:
       python-versions: "['3.10', '3.11', '3.12', '3.13']"
       frontend-tests-folder: "tests"
       release: true
+      runs-on: ${{ inputs.runs_on || 'ubuntu-latest' }}
     secrets: inherit
 
 

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -31,6 +31,11 @@ on:
         description: "(Optional) ref to checkout"
         required: false
         type: string
+      runs-on:
+        description: "Runner to use for the tests"
+        required: false
+        type: string
+        default: "ubuntu-latest"
   workflow_dispatch:
     inputs:
       suites:
@@ -48,6 +53,14 @@ on:
         required: false
         type: string
         default: "tests"
+      runs-on:
+        description: "Runner to use for the tests"
+        required: false
+        type: choice
+        options:
+          - ubuntu-latest
+          - self-hosted
+        default: ubuntu-latest
 
 env:
   NODE_VERSION: "21"
@@ -60,7 +73,7 @@ env:
 jobs:
   determine-test-suite:
     name: Determine Test Suites and Shard Distribution
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on || 'ubuntu-latest' }}
     outputs:
       matrix: ${{ steps.setup-matrix.outputs.matrix }}
       test_grep: ${{ steps.set-matrix.outputs.test_grep }}
@@ -246,7 +259,7 @@ jobs:
 
   setup-and-test:
     name: Playwright Tests - Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on || 'ubuntu-latest' }}
     if: ${{ needs.determine-test-suite.outputs.test_grep != '' }}
     needs: determine-test-suite
     strategy:
@@ -341,7 +354,7 @@ jobs:
     # We need to repeat the condition at every step
     # https://github.com/actions/runner/issues/662
     needs: setup-and-test
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on || 'ubuntu-latest' }}
     if: always()
     env:
       EXIT_CODE: ${{!contains(needs.setup-and-test.result, 'failure') && !contains(needs.setup-and-test.result, 'cancelled') && '0' || '1'}}


### PR DESCRIPTION
Introduce options for selecting the runner in CI workflows, allowing users to choose between `ubuntu-latest` and `self-hosted` for test execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - CI workflows now support choosing the runner (ubuntu-latest or self-hosted) when triggered manually or by dependent workflows.
  - Default runner remains ubuntu-latest if none is specified, ensuring backward compatibility.
  - Runner selection is propagated through backend and frontend test workflows for consistent execution.
  - Nightly build and release workflows also support configurable runners, enabling alignment with environment and security needs.
  - No changes to test logic or sequencing; only execution environment selection is now configurable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->