### PR TITLE
ci: Add missing lfx metadata files to Docker build context

### DIFF
--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -41,6 +41,9 @@ COPY ./pyproject.toml /app/pyproject.toml
 COPY ./src/backend/base/README.md /app/src/backend/base/README.md
 COPY ./src/backend/base/uv.lock /app/src/backend/base/uv.lock
 COPY ./src/backend/base/pyproject.toml /app/src/backend/base/pyproject.toml
+# Copy lfx metadata files since it's a workspace member
+COPY ./src/lfx/pyproject.toml /app/src/lfx/pyproject.toml
+COPY ./src/lfx/README.md /app/src/lfx/README.md
 
 # Install the project's dependencies using the lockfile and settings
 # We need to mount the root uv.lock and pyproject.toml to build the base with uv because we're still using uv workspaces

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -23,6 +23,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=src/backend/base/README.md,target=src/backend/base/README.md \
     --mount=type=bind,source=src/backend/base/uv.lock,target=src/backend/base/uv.lock \
     --mount=type=bind,source=src/backend/base/pyproject.toml,target=src/backend/base/pyproject.toml \
+    --mount=type=bind,source=src/lfx/README.md,target=src/lfx/README.md \
+    --mount=type=bind,source=src/lfx/pyproject.toml,target=src/lfx/pyproject.toml \
     uv sync --frozen --no-install-project --no-dev --extra postgresql
 
 EXPOSE 7860


### PR DESCRIPTION
Include lfx metadata files in the Docker build context to ensure they are available during the build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated container builds to include metadata for the lfx component in the base image, aligning it with other workspace modules.
  - Enhanced the dev container setup to mount lfx metadata during dependency installation, ensuring accurate dependency resolution.
  - Improves consistency between local development and containerized environments and reduces rebuild friction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->