### PR TITLE
fix: adjust tools title and description padding

### DIFF
--- a/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
+++ b/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
@@ -104,8 +104,8 @@ export default function ToolsTable({
             name !== "" && name !== display_name
               ? name
               : isAction
-              ? sanitizeMcpName(display_name || row.name, 46)
-              : display_name
+                ? sanitizeMcpName(display_name || row.name, 46)
+                : display_name
           ).slice(0, 46);
 
           const processedDescription =
@@ -113,8 +113,8 @@ export default function ToolsTable({
             row.description !== row.display_description
               ? row.description
               : isAction
-              ? ""
-              : row.display_description;
+                ? ""
+                : row.display_description;
 
           return selectedRows?.some(
             (selected) =>
@@ -182,11 +182,11 @@ export default function ToolsTable({
               "uppercase",
             ])
           : isAction
-          ? sanitizeMcpName(params.data.display_name, 46).toUpperCase()
-          : parseString(params.data.tags.join(", "), [
-              "snake_case",
-              "uppercase",
-            ]),
+            ? sanitizeMcpName(params.data.display_name, 46).toUpperCase()
+            : parseString(params.data.tags.join(", "), [
+                "snake_case",
+                "uppercase",
+              ]),
       cellClass: "text-muted-foreground",
     },
     {


### PR DESCRIPTION
This pull request makes minor UI improvements to the `ToolsTable` component in the tools modal. The updates focus on refining layout spacing and improving conditional rendering for separators.

UI and layout improvements:

* Added padding (`p-4`) to the sidebar header container for better visual spacing in `toolsTable/index.tsx`.
* Updated the condition for rendering the `Separator` component so it only appears when there are action arguments, preventing unnecessary separators.