### PR TITLE
ci: Increase memory limit and disable concurrent builds for esbuild in docker

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -53,7 +53,7 @@ COPY src/frontend /tmp/src/frontend
 WORKDIR /tmp/src/frontend
 RUN --mount=type=cache,target=/root/.npm \
     npm ci \
-    && NODE_OPTIONS="--max-old-space-size=4096" npm run build \
+    && NODE_OPTIONS="--max-old-space-size=8192" JOBS=1 npm run build \
     && cp -r build /app/src/backend/langflow/frontend \
     && rm -rf /tmp/src/frontend
 

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -55,8 +55,9 @@ COPY ./src /app/src
 
 COPY src/frontend /tmp/src/frontend
 WORKDIR /tmp/src/frontend
+# Increase memory and disable concurrent builds to avoid esbuild crashes on emulated architectures
 RUN npm install \
-    && NODE_OPTIONS="--max-old-space-size=4096" npm run build \
+    && NODE_OPTIONS="--max-old-space-size=8192" JOBS=1 npm run build \
     && cp -r build /app/src/backend/base/langflow/frontend \
     && rm -rf /tmp/src/frontend
 

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -53,7 +53,7 @@ COPY src/frontend /tmp/src/frontend
 WORKDIR /tmp/src/frontend
 RUN --mount=type=cache,target=/root/.npm \
     npm ci \
-    && NODE_OPTIONS="--max-old-space-size=4096" npm run build \
+    && NODE_OPTIONS="--max-old-space-size=8192" JOBS=1 npm run build \
     && cp -r build /app/src/backend/langflow/frontend \
     && rm -rf /tmp/src/frontend
 

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -53,7 +53,7 @@ COPY src/frontend /tmp/src/frontend
 WORKDIR /tmp/src/frontend
 RUN --mount=type=cache,target=/root/.npm \
     npm ci \
-    && NODE_OPTIONS="--max-old-space-size=4096" npm run build \
+    && NODE_OPTIONS="--max-old-space-size=8192" JOBS=1 npm run build \
     && cp -r build /app/src/backend/langflow/frontend \
     && rm -rf /tmp/src/frontend
 


### PR DESCRIPTION
Adjust the memory limit to prevent esbuild crashes and disable concurrent builds across multiple Dockerfiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Reduced frontend build failures during Docker image creation by increasing memory allocation and limiting build concurrency, improving reliability across platforms (including emulated architectures).

- Chores
  - Standardized Docker build configuration for the frontend across images to enhance stability and consistency.
  - No changes to runtime behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->