### PR TITLE
fix: make file button clickable after focusing on chat

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/input-wrapper.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/input-wrapper.tsx
@@ -64,12 +64,9 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
           e.stopPropagation();
           e.preventDefault();
         }}
-        onClick={(e) => {
+        onClick={() => {
           if (inputRef.current && inputRef.current !== document.activeElement) {
             inputRef.current?.focus();
-          } else {
-            e.stopPropagation();
-            e.preventDefault();
           }
         }}
       >


### PR DESCRIPTION
This pull request makes a minor update to the click handler in the `InputWrapper` component to simplify its logic. The change removes unnecessary event handling when the input is already focused, making the code cleaner and easier to maintain.

* Simplified the `onClick` handler in `input-wrapper.tsx` by removing redundant event stopping and preventing logic when the input is already focused.