### PR TITLE
fix: make input clickable on chat 

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/input-wrapper.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/input-wrapper.tsx
@@ -55,15 +55,23 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
   // Check if voice mode is available
   const { data: config } = useGetConfig();
 
-  const onClick = () => {
-    () => {
-      if (inputRef.current && inputRef.current !== document.activeElement) {
-        inputRef.current?.focus();
-      }
-    };
+  const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.closest("textarea")) {
+      return;
+    }
+    inputRef.current?.focus();
+    inputRef.current?.setSelectionRange(
+      inputRef.current.value.length,
+      inputRef.current.value.length,
+    );
   };
 
   const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.closest("textarea")) {
+      return;
+    }
     e.stopPropagation();
     e.preventDefault();
   };
@@ -73,8 +81,8 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
       <div
         data-testid="input-wrapper"
         className="flex w-full flex-col rounded-md border cursor-text border-input p-4 hover:border-muted-foreground focus:border-[1.75px] has-[:focus]:border-primary"
-        onMouseDown={onMouseDown}
         onClick={onClick}
+        onMouseDown={onMouseDown}
       >
         <TextAreaWrapper
           isBuilding={isBuilding}


### PR DESCRIPTION
This pull request refines the behavior of the `InputWrapper` component in the chat input area to improve focus management and event handling. The changes ensure that clicking outside the textarea within the input wrapper properly focuses the textarea and places the cursor at the end, while preventing unintended side effects when interacting directly with the textarea.

**Focus and event handling improvements:**

* Updated the `onClick` handler to focus the textarea and move the cursor to the end only when clicking outside the textarea, preventing unnecessary focus changes when the textarea itself is clicked.
* Modified the `onMouseDown` handler to prevent default behavior and stop propagation only when clicking outside the textarea, improving event handling and avoiding interference with textarea interactions.
* Reordered the `onMouseDown` and `onClick` props on the input wrapper `div` to ensure correct event handling order.