### PR TITLE
feat: Add stopNodeId tracking for improved validation and edge control

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
@@ -475,7 +475,6 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
   const hasMcpServers = Boolean(mcpServers && mcpServers.length > 0);
 
   const hasSearchInput = search !== "" || filterType !== undefined;
-  console.log("hasSearchInput", hasSearchInput);
 
   const showComponents =
     (ENABLE_NEW_SIDEBAR &&

--- a/src/frontend/src/types/zustand/flow/index.ts
+++ b/src/frontend/src/types/zustand/flow/index.ts
@@ -289,4 +289,6 @@ export type FlowStoreType = {
   setHelperLineEnabled: (helperLineEnabled: boolean) => void;
   newChatOnPlayground: boolean;
   setNewChatOnPlayground: (newChat: boolean) => void;
+  stopNodeId: string | undefined;
+  setStopNodeId: (nodeId: string | undefined) => void;
 };


### PR DESCRIPTION
This pull request introduces improvements to the flow state management in the frontend, primarily by adding support for tracking and updating the `stopNodeId` in the flow store. This change enables more precise control over flow validation and edge animation, particularly when a stop node is specified. Additionally, some code cleanup was performed.

**Flow store enhancements:**

* Added `stopNodeId` and `setStopNodeId` to the `FlowStoreType` interface and store implementation, allowing the flow to track which node is designated as the stopping point and update it as needed. [[1]](diffhunk://#diff-fcc3956aca8d6605f996046e0619bac8c9e8b2a3b5318a32921588a6b5592ba7R292-R293) [[2]](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357R1084-R1087)
* Updated validation logic to set or clear `stopNodeId` during flow validation, ensuring the store accurately reflects the current stopping node. [[1]](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357R682) [[2]](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357R692-R694)

**Edge animation logic:**

* Modified edge animation updates to exclude edges connected to the `stopNodeId`, preventing running animations on edges beyond the stop node.

**Code cleanup:**

* Removed a console log from the sidebar component for cleaner output.
* Minor formatting and whitespace improvements in the flow store. [[1]](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357L933) [[2]](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357R819) [[3]](diffhunk://#diff-c0be28c27c2bdb8f48b4b4efacde87f9bdceccd4b979600e9f7b38dcd7ffc357L824)