### PR TITLE
fix: Look globally for duplicate file names in case of uniqueness constraint present

### DIFF
--- a/src/backend/base/langflow/api/v2/files.py
+++ b/src/backend/base/langflow/api/v2/files.py
@@ -132,9 +132,7 @@ async def upload_user_file(
         else:
             # For normal files, ensure unique name by appending a count if necessary
             # TODO: If we can remove the unique constraint on name, we should filter to user_id
-            stmt = select(UserFile).where(
-                col(UserFile.name).like(f"{root_filename}%")
-            )
+            stmt = select(UserFile).where(col(UserFile.name).like(f"{root_filename}%"))
             existing_files = await session.exec(stmt)
             files = existing_files.all()  # Fetch all matching records
 

--- a/src/backend/base/langflow/api/v2/files.py
+++ b/src/backend/base/langflow/api/v2/files.py
@@ -131,8 +131,9 @@ async def upload_user_file(
             unique_filename = new_filename
         else:
             # For normal files, ensure unique name by appending a count if necessary
+            # TODO: If we can remove the unique constraint on name, we should filter to user_id
             stmt = select(UserFile).where(
-                col(UserFile.name).like(f"{root_filename}%"), UserFile.user_id == current_user.id
+                col(UserFile.name).like(f"{root_filename}%")
             )
             existing_files = await session.exec(stmt)
             files = existing_files.all()  # Fetch all matching records


### PR DESCRIPTION
This pull request makes a minor adjustment to the file upload logic in `files.py`. Specifically, it updates the SQL query that checks for existing files with similar names by removing the filter that restricts results to the current user. A TODO comment is also added to indicate that filtering by `user_id` may be restored if the unique constraint on file names is removed in the future.

- File upload logic:
  * In `src/backend/base/langflow/api/v2/files.py`, the SQL query for checking existing filenames no longer filters by `user_id`, and a TODO comment is added regarding the unique constraint on file names.