### PR TITLE
test: Increase loading performance test timeout

### DIFF
--- a/src/backend/tests/unit/test_load_components.py
+++ b/src/backend/tests/unit/test_load_components.py
@@ -3,6 +3,7 @@ import asyncio
 import time
 
 import pytest
+
 from langflow.interface.components import aget_all_types_dict, import_langflow_components
 from langflow.services.settings.base import BASE_COMPONENTS_PATH
 
@@ -65,7 +66,7 @@ class TestComponentLoading:
         print(f"Ratio (langflow/all_types): {langflow_duration / max(all_types_duration, 0.0001):.2f}")
 
         # Both should complete in reasonable time (< 5s for langflow, < 15s for all_types)
-        assert langflow_duration < 5.0, f"get_langflow_components_list took too long: {langflow_duration}s"
+        assert langflow_duration < 15.0, f"get_langflow_components_list took too long: {langflow_duration}s"
         assert all_types_duration < 15.0, f"aget_all_types_dict took too long: {all_types_duration}s"
 
         # Store results for further analysis

--- a/src/backend/tests/unit/test_load_components.py
+++ b/src/backend/tests/unit/test_load_components.py
@@ -65,8 +65,8 @@ class TestComponentLoading:
         print(f"aget_all_types_dict: {all_types_duration:.4f}s")
         print(f"Ratio (langflow/all_types): {langflow_duration / max(all_types_duration, 0.0001):.2f}")
 
-        # Both should complete in reasonable time (< 5s for langflow, < 15s for all_types)
-        assert langflow_duration < 15.0, f"get_langflow_components_list took too long: {langflow_duration}s"
+        # Both should complete in reasonable time (< 10s for langflow, < 15s for all_types)
+        assert langflow_duration < 10.0, f"get_langflow_components_list took too long: {langflow_duration}s"
         assert all_types_duration < 15.0, f"aget_all_types_dict took too long: {all_types_duration}s"
 
         # Store results for further analysis


### PR DESCRIPTION
This pull request makes a minor adjustment to the unit test for component loading performance. The main change is an update to the time threshold for the `get_langflow_components_list` function to allow for a longer execution time.

* Increased the allowed duration for the `get_langflow_components_list` performance test from 5 seconds to 15 seconds in `test_load_components.py`, making the test less strict about execution time.