### PR TITLE
refactor: update skip_auth_auto_login behavior and update messaging timelines for removal

### DIFF
--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -32,7 +32,7 @@ api_key_query = APIKeyQuery(name=API_KEY_NAME, scheme_name="API key query", auto
 api_key_header = APIKeyHeader(name=API_KEY_NAME, scheme_name="API key header", auto_error=False)
 
 MINIMUM_KEY_LENGTH = 32
-AUTO_LOGIN_WARNING = "In v1.6 LANGFLOW_SKIP_AUTH_AUTO_LOGIN will be removed. Please update your authentication method."
+AUTO_LOGIN_WARNING = "In v2.0, LANGFLOW_SKIP_AUTH_AUTO_LOGIN will be removed. Please update your authentication method."
 AUTO_LOGIN_ERROR = (
     "Since v1.5, LANGFLOW_AUTO_LOGIN requires a valid API key. "
     "Set LANGFLOW_SKIP_AUTH_AUTO_LOGIN=true to skip this check. "

--- a/src/backend/base/langflow/services/settings/auth.py
+++ b/src/backend/base/langflow/services/settings/auth.py
@@ -28,7 +28,7 @@ class AuthSettings(BaseSettings):
     API_V1_STR: str = "/api/v1"
 
     AUTO_LOGIN: bool = Field(
-        default=True, # TODO: Set to False in v2.0
+        default=True,  # TODO: Set to False in v2.0
         description=(
             "Enable automatic login with default credentials. "
             "SECURITY WARNING: This bypasses authentication and should only be used in development environments. "

--- a/src/backend/base/langflow/services/settings/auth.py
+++ b/src/backend/base/langflow/services/settings/auth.py
@@ -28,17 +28,17 @@ class AuthSettings(BaseSettings):
     API_V1_STR: str = "/api/v1"
 
     AUTO_LOGIN: bool = Field(
-        default=True,  # TODO: Set to False in v1.6
+        default=True, # TODO: Set to False in v2.0
         description=(
             "Enable automatic login with default credentials. "
             "SECURITY WARNING: This bypasses authentication and should only be used in development environments. "
-            "Set to False in production."
+            "Set to False in production. This will default to False in v2.0."
         ),
     )
     """If True, the application will attempt to log in automatically as a super user."""
-    skip_auth_auto_login: bool = True
+    skip_auth_auto_login: bool = False
     """If True, the application will skip authentication when AUTO_LOGIN is enabled.
-    This will be removed in v1.6"""
+    This will be removed in v2.0"""
 
     ENABLE_SUPERUSER_CLI: bool = Field(
         default=True,

--- a/src/backend/tests/unit/api/v1/test_mcp_projects.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects.py
@@ -678,5 +678,5 @@ async def test_mcp_longterm_token_fails_without_superuser():
 
     # Now attempt to create long-term token -> expect HTTPException 400
     async with get_db_service().with_session() as session:
-        with pytest.raises(HTTPException):
+        with pytest.raises(HTTPException, match="Auto login required to create a long-term token"):
             await create_user_longterm_token(session)

--- a/src/backend/tests/unit/test_load_components.py
+++ b/src/backend/tests/unit/test_load_components.py
@@ -3,7 +3,6 @@ import asyncio
 import time
 
 import pytest
-
 from langflow.interface.components import aget_all_types_dict, import_langflow_components
 from langflow.services.settings.base import BASE_COMPONENTS_PATH
 


### PR DESCRIPTION
Per new discussion, we will not remove the skip_auth variable until v2.0, though the behavior will change from true to false by default. This does result in a breaking change, but as it is a security-related issue and the option exists to revert the value, this is acceptable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - MCP Composer integration with OAuth/API key flows, per-user MCP server configs, and a new composer URL endpoint.
  - Config now exposes voice_mode_available.

- Improvements
  - Safer auth handling (no credential logging).
  - Revamped Knowledge Base components; enhanced File loader with Docling pipelines and OCR options.
  - Better cycle control in Conditional Router; Memory supports session_id and improved retrieval.
  - Clearer UI labels; Groq disabled by default; deprecated Anthropic model hidden; vector store connection output visible.

- Removals
  - Google Serper and deprecated MCP components; chat color/icon inputs; legacy prototype/data components.

- Documentation
  - Default OpenAI model updated to gpt-4.1.

- Chores
  - Version bump; added OCR deps; .gitignore update; renamed MCP composer env flag; Windows script tweaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->