### PR TITLE
ci: Fix checkout ref in nightly release

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Check out the code at a specific ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.nightly_tag_main }}
+          ref: ${{ github.ref }}
           persist-credentials: true
       - name: "Setup Environment"
         uses: astral-sh/setup-uv@v6
@@ -148,7 +148,7 @@ jobs:
       - name: Check out the code at a specific ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.nightly_tag_main}}
+          ref: ${{ github.ref }}
           persist-credentials: true
       - name: "Setup Environment"
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
This pull request updates the code checkout step in the nightly release GitHub Actions workflow to use the current GitHub reference (`github.ref`) instead of an input variable for the ref. This change ensures that the workflow always checks out the correct commit or branch that triggered the workflow.

Workflow improvements:

* Updated the `actions/checkout@v4` step in `.github/workflows/release_nightly.yml` to use `${{ github.ref }}` instead of `${{ inputs.nightly_tag_main }}` or `${{ inputs.nightly_tag_main}}`, ensuring the workflow checks out the triggering ref. [[1]](diffhunk://#diff-3e9627631213861db56751e801ce149ca7974e5559af73fb36f9216013875006L74-R74) [[2]](diffhunk://#diff-3e9627631213861db56751e801ce149ca7974e5559af73fb36f9216013875006L151-R151)