### PR TITLE
fix: make file component zoomable on canvas

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx
@@ -152,11 +152,11 @@ export default function InputFileComponent({
       ? Array.isArray(file_path)
         ? file_path.filter((value) => value !== "")
         : typeof file_path === "string"
-          ? [file_path]
-          : []
+        ? [file_path]
+        : []
       : Array.isArray(file_path)
-        ? (file_path ?? [])
-        : [file_path ?? ""]
+      ? file_path ?? []
+      : [file_path ?? ""]
   ).filter((value) => value !== "");
 
   useEffect(() => {
@@ -182,15 +182,15 @@ export default function InputFileComponent({
       }
       handleOnNewValue({
         value: isList
-          ? (files
+          ? files
               ?.filter((f) => selectedFiles.includes(f.path))
-              .map((f) => f.name) ?? [])
-          : (files?.find((f) => selectedFiles.includes(f.path))?.name ?? ""),
+              .map((f) => f.name) ?? []
+          : files?.find((f) => selectedFiles.includes(f.path))?.name ?? "",
         file_path: isList
-          ? (files
+          ? files
               ?.filter((f) => selectedFiles.includes(f.path))
-              .map((f) => f.path) ?? [])
-          : (files?.find((f) => selectedFiles.includes(f.path))?.path ?? ""),
+              .map((f) => f.path) ?? []
+          : files?.find((f) => selectedFiles.includes(f.path))?.path ?? "",
       });
     }
   }, [files, value, file_path]);
@@ -202,7 +202,7 @@ export default function InputFileComponent({
           {ENABLE_FILE_MANAGEMENT && !tempFile ? (
             files && (
               <div className="relative flex w-full flex-col gap-2">
-                <div className="nopan nowheel flex max-h-44 flex-col overflow-y-auto">
+                <div className="flex max-h-44 flex-col overflow-y-auto">
                   <FilesRendererComponent
                     files={files.filter((file) =>
                       selectedFiles.includes(file.path),
@@ -217,11 +217,11 @@ export default function InputFileComponent({
                               (file) =>
                                 files.find((f) => f.path === file)?.name,
                             )
-                          : (files.find((f) => f.path == newSelectedFiles[0]) ??
-                            ""),
+                          : files.find((f) => f.path == newSelectedFiles[0]) ??
+                            "",
                         file_path: isList
                           ? newSelectedFiles
-                          : (newSelectedFiles[0] ?? ""),
+                          : newSelectedFiles[0] ?? "",
                       });
                     }}
                   />
@@ -235,10 +235,10 @@ export default function InputFileComponent({
                         ? selectedFiles.map(
                             (file) => files.find((f) => f.path === file)?.name,
                           )
-                        : (files.find((f) => f.path == selectedFiles[0]) ?? ""),
+                        : files.find((f) => f.path == selectedFiles[0]) ?? "",
                       file_path: isList
                         ? selectedFiles
-                        : (selectedFiles[0] ?? ""),
+                        : selectedFiles[0] ?? "",
                     });
                   }}
                   disabled={isDisabled}


### PR DESCRIPTION
This pull request makes several small improvements to the `InputFileComponent` in `index.tsx`, focusing on code clarity and consistency in handling file selection and value updates. The changes primarily simplify ternary expressions and remove unnecessary parentheses, making the code easier to read and maintain.

UI and code cleanup:

* Removed unused `nopan nowheel` classes from the file list container to allow scrolling and panning with cursor on files.