### PR TITLE
fix(launch.json): correct CLI argument from --path to --frontend-path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,7 @@
       "module": "langflow",
       "args": [
         "run",
-        "--path",
+        "--frontend-path",
         "${workspaceFolder}/src/backend/base/langflow/frontend",
         "--env-file",
         "${workspaceFolder}/.env"


### PR DESCRIPTION
The debug configuration "Debug CLI" failed to start because `--path` is not a valid option
(`No such option: --path (Possible options: --cache, --port)`).  
Replaced it with the correct `--frontend-path` argument so that the CLI launches properly
with the frontend and env file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the IDE debug configuration to align with the latest CLI options, improving compatibility with current tooling.
  - Streamlined local debugging to ensure consistent startup parameters and reduce setup friction for developers.
  - No impact on application features or UI; end users are unaffected.
  - Enhances stability and consistency across development environments during debug sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->