### PR TITLE
fix(launch): correct CLI arg from --path to --frontend-path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,7 @@
       "module": "langflow",
       "args": [
         "run",
-        "--path",
+        "--frontend-path",
         "${workspaceFolder}/src/backend/base/langflow/frontend",
         "--env-file",
         "${workspaceFolder}/.env"


### PR DESCRIPTION
The "Debug CLI" launch configuration failed to start because
`--path` is not a valid option.

Error:
No such option: --path (Possible options: --cache, --port)

Replaced it with the correct `--frontend-path` argument so that
the debugger can launch Langflow with the frontend and env file.