### PR TITLE
fix: editing feature for custom values in table input

### DIFF
--- a/src/backend/base/langflow/schema/table.py
+++ b/src/backend/base/langflow/schema/table.py
@@ -44,6 +44,8 @@ class Column(BaseModel):
     disable_edit: bool = Field(default=False)
     edit_mode: EditMode | None = Field(default=EditMode.POPOVER)
     hidden: bool = Field(default=False)
+    load_from_db: bool = Field(default=False)
+    allow_custom_value: bool = Field(default=True)
 
     @model_validator(mode="after")
     def set_display_name(self):

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx
@@ -6,8 +6,8 @@ import StringReader from "@/components/common/stringReaderComponent";
 import DateReader from "@/components/core/dateReaderComponent";
 import { Badge } from "@/components/ui/badge";
 import { cn, isTimeStampString } from "@/utils/utils";
-import InputGlobalComponent from "../../../inputGlobalComponent";
 import ToggleShadComponent from "../../../toggleShadComponent";
+import TableGlobalVariableCell from "../tableGlobalVariableCell";
 
 interface CustomCellRender extends CustomCellRendererProps {
   formatter?: "json" | "text" | "boolean" | "number" | "undefined" | "null";
@@ -63,24 +63,12 @@ export default function TableAutoCellRender({
           );
         } else if (colDef?.context?.globalVariable) {
           return (
-            <InputGlobalComponent
-              id="string-reader-global"
+            <TableGlobalVariableCell
               value={value ?? ""}
-              editNode={false}
-              handleOnNewValue={(newValue) => {
-                setValue?.(newValue.value);
-              }}
-              disabled={
-                !colDef?.onCellValueChanged &&
-                !api.getGridOption("onCellValueChanged")
-              }
-              load_from_db={true}
-              allowCustomValue={false}
-              password={false}
-              display_name=""
-              placeholder=""
-              isToolMode={false}
-              hasRefreshButton={false}
+              setValue={setValue}
+              colDef={colDef}
+              api={api}
+              allowCustomValue={colDef?.context?.allowCustomValue ?? true}
             />
           );
         } else {

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableGlobalVariableCell/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableGlobalVariableCell/index.tsx
@@ -1,0 +1,51 @@
+import type { ColDef, GridApi } from "ag-grid-community";
+import { useGetGlobalVariables } from "@/controllers/API/queries/variables";
+import InputGlobalComponent from "../../../inputGlobalComponent";
+import { useGlobalVariableValue } from "../../../inputGlobalComponent/hooks";
+import type { GlobalVariable } from "../../../inputGlobalComponent/types";
+
+interface TableGlobalVariableCellProps {
+  value: string;
+  setValue?: (value: string) => void;
+  colDef: ColDef;
+  api: GridApi;
+  allowCustomValue: boolean;
+}
+
+export default function TableGlobalVariableCell({
+  value,
+  setValue,
+  colDef,
+  api,
+  allowCustomValue,
+}: TableGlobalVariableCellProps) {
+  const { data: globalVariables } = useGetGlobalVariables();
+  const typedGlobalVariables: GlobalVariable[] = globalVariables ?? [];
+
+  // Check if current value is a global variable
+  const valueExists = useGlobalVariableValue(value, typedGlobalVariables);
+
+  // Dynamically determine load_from_db based on whether value is a global variable
+  const loadFromDb = valueExists && value !== "";
+
+  return (
+    <InputGlobalComponent
+      id="string-reader-global"
+      value={value}
+      editNode={false}
+      handleOnNewValue={(newValue) => {
+        setValue?.(newValue.value);
+      }}
+      disabled={
+        !colDef?.onCellValueChanged && !api.getGridOption("onCellValueChanged")
+      }
+      load_from_db={loadFromDb}
+      allowCustomValue={allowCustomValue}
+      password={false}
+      display_name=""
+      placeholder=""
+      isToolMode={false}
+      hasRefreshButton={false}
+    />
+  );
+}

--- a/src/frontend/src/types/utils/functions.ts
+++ b/src/frontend/src/types/utils/functions.ts
@@ -30,4 +30,5 @@ export interface ColumnField {
   edit_mode?: "modal" | "inline" | "popover";
   hidden?: boolean;
   options?: string[];
+  allow_custom_value?: boolean;
 }

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -553,6 +553,9 @@ export function FormatColumns(columns: ColumnField[]): ColDef<any>[] {
       context: {
         ...(col.description ? { info: col.description } : {}),
         ...(col.load_from_db ? { globalVariable: col.load_from_db } : {}),
+        ...(col.allow_custom_value !== undefined
+          ? { allowCustomValue: col.allow_custom_value }
+          : {}),
       },
       cellClass: col.disable_edit ? "cell-disable-edit" : "",
       hide: col.hidden,
@@ -619,7 +622,7 @@ export function FormatColumns(columns: ColumnField[]): ColDef<any>[] {
           newCol.cellClass = "no-border !py-2";
           newCol.type = "boolean";
         } else {
-          if (col.global_variable) {
+          if (col.load_from_db) {
             newCol.editable = false;
             newCol.cellClass = "no-border !p-0";
           }
@@ -646,6 +649,7 @@ export function generateBackendColumnsFromValue(
       filterable: !tableOptions?.block_filter,
       default: null, // Initialize default to null or appropriate value
       hidden: false,
+      allow_custom_value: true, // Default to allowing custom values
     };
 
     // Attempt to infer the default value from the data, if possible

--- a/src/lfx/src/lfx/schema/table.py
+++ b/src/lfx/src/lfx/schema/table.py
@@ -44,6 +44,8 @@ class Column(BaseModel):
     disable_edit: bool = Field(default=False)
     edit_mode: EditMode | None = Field(default=EditMode.POPOVER)
     hidden: bool = Field(default=False)
+    load_from_db: bool = Field(default=False)
+    allow_custom_value: bool = Field(default=True)
 
     @model_validator(mode="after")
     def set_display_name(self):


### PR DESCRIPTION
This pull request introduces support for specifying whether table columns allow custom values and whether their values should be loaded from the database. These changes affect both backend and frontend code, improving the flexibility and accuracy of table rendering and editing, especially for global variable columns.

**Backend schema updates:**

* Added `load_from_db` and `allow_custom_value` fields to the `Column` model in both `src/backend/base/langflow/schema/table.py` and `src/lfx/src/lfx/schema/table.py`, enabling backend configuration of column behavior. [[1]](diffhunk://#diff-66bd9e20d21689c7321905c0c2e5b0e4e5cedb2e92c2f6c00c092a4714f597baR47-R48) [[2]](diffhunk://#diff-ede4f3285bb1cc02a6190265d7ca3dcd7fa7037102198c34383f1755c5bf92cdR47-R48)

**Frontend table rendering and editing:**

* Updated the `ColumnField` interface in `src/frontend/src/types/utils/functions.ts` to include the `allow_custom_value` property, ensuring type safety and consistency.
* Enhanced the `FormatColumns` function in `src/frontend/src/utils/utils.ts` to propagate `allow_custom_value` and `load_from_db` properties into column context, and set their default values when generating columns from data. [[1]](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81R556-R558) [[2]](diffhunk://#diff-b6539a7271a3a6e713a0745ccd15aea9fde0cc556a866fe09cfd7e552dc2bf81R652)
* Refactored cell rendering in `src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx` to use the new `TableGlobalVariableCell` component for global variable columns, passing the relevant props for custom value allowance and database loading. [[1]](diffhunk://#diff-86977b55f6f3573ef83b6ec14ca59c0ae562383d4109c3006320324df35d261cL9-R10) [[2]](diffhunk://#diff-86977b55f6f3573ef83b6ec14ca59c0ae562383d4109c3006320324df35d261cL66-R71)
* Added the `TableGlobalVariableCell` component in `src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableGlobalVariableCell/index.tsx`, which dynamically determines whether to load values from the database and whether custom values are allowed, based on the column context and current value.

**Column editing behavior:**

* Adjusted logic in the `FormatColumns` function to set editing and styling rules for columns with `load_from_db`, ensuring global variable columns are not editable and styled appropriately.