### PR TITLE
fix: Move docling dependency into core dependencies instead of dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ dependencies = [
     "cleanlab-tlm>=1.1.2",
     'gassist>=0.0.1; sys_platform == "win32"',
     "twelvelabs>=0.4.7",
-    "docling_core>=2.36.1",
+    "docling>=2.36.1",
     "filelock>=3.18.0",
     "jigsawstack==0.2.7",
     "structlog>=25.4.0",
@@ -181,7 +181,6 @@ dev = [
     "pytest-timeout>=2.3.1",
     "pyyaml>=6.0.2",
     "pyleak>=0.1.14",
-    "docling>=2.36.1"
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version < '3.11' and platform_python_implementation == 'PyPy' and sys_platform == 'darwin'",
@@ -4992,7 +4992,7 @@ dependencies = [
     { name = "composio" },
     { name = "composio-langchain" },
     { name = "datasets" },
-    { name = "docling-core" },
+    { name = "docling" },
     { name = "dspy-ai" },
     { name = "duckduckgo-search" },
     { name = "easyocr" },
@@ -5132,7 +5132,6 @@ dev = [
     { name = "blockbuster" },
     { name = "codeflash" },
     { name = "dictdiffer" },
-    { name = "docling" },
     { name = "elevenlabs", version = "1.58.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
     { name = "elevenlabs", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
     { name = "faker" },
@@ -5199,8 +5198,8 @@ requires-dist = [
     { name = "couchbase", marker = "extra == 'couchbase'", specifier = ">=4.2.1" },
     { name = "ctransformers", marker = "extra == 'local'", specifier = ">=0.2.10" },
     { name = "datasets", specifier = ">2.14.7" },
+    { name = "docling", specifier = ">=2.36.1" },
     { name = "docling", marker = "extra == 'docling'", specifier = ">=2.36.1" },
-    { name = "docling-core", specifier = ">=2.36.1" },
     { name = "dspy-ai", specifier = "==2.5.41" },
     { name = "duckduckgo-search", specifier = "==7.2.1" },
     { name = "easyocr", specifier = ">=1.7.2" },
@@ -5316,7 +5315,6 @@ dev = [
     { name = "blockbuster", specifier = ">=1.5.20,<1.6" },
     { name = "codeflash", specifier = ">=0.8.4" },
     { name = "dictdiffer", specifier = ">=0.9.0" },
-    { name = "docling", specifier = ">=2.36.1" },
     { name = "elevenlabs", marker = "python_full_version != '3.12.*'", specifier = ">=1.52.0" },
     { name = "elevenlabs", marker = "python_full_version == '3.12.*'", specifier = "==1.58.1" },
     { name = "faker", specifier = ">=37.0.0" },


### PR DESCRIPTION
This pull request updates the dependencies in `pyproject.toml` to use the correct package name for `docling` in both the main and development dependency lists.

Dependency updates:

* Changed the main dependency from `docling_core` to `docling` to ensure the correct package is installed.
* Removed the duplicate `docling` entry from the development dependencies to avoid redundancy.