### PR TITLE
fix: Make sure strings can be parsed in the python interpreter

### DIFF
--- a/src/backend/base/langflow/components/processing/python_repl_core.py
+++ b/src/backend/base/langflow/components/processing/python_repl_core.py
@@ -3,7 +3,7 @@ import importlib
 from langchain_experimental.utilities import PythonREPL
 
 from langflow.custom.custom_component.component import Component
-from langflow.io import CodeInput, Output, StrInput
+from langflow.io import MultilineInput, Output, StrInput
 from langflow.schema.data import Data
 
 
@@ -21,7 +21,7 @@ class PythonREPLComponent(Component):
             value="math,pandas",
             required=True,
         ),
-        CodeInput(
+        MultilineInput(
             name="python_code",
             display_name="Python Code",
             info="The Python code to execute. Only modules specified in Global Imports can be used.",

--- a/src/backend/tests/unit/components/tools/test_python_repl_tool.py
+++ b/src/backend/tests/unit/components/tools/test_python_repl_tool.py
@@ -45,7 +45,8 @@ class TestPythonREPLComponent(ComponentTestBaseWithoutClient):
 
         # Test python_code configuration
         python_code = template["python_code"]
-        assert python_code["type"] == "code"
+        # assert python_code["type"] == "code"  # TODO: Restore when CodeInput is included in component
+        assert python_code["type"] == "str" # TODO: Remove when CodeInput is included in component
         assert python_code["value"] == "print('Hello, World!')"
         assert python_code["required"] is True
 

--- a/src/backend/tests/unit/components/tools/test_python_repl_tool.py
+++ b/src/backend/tests/unit/components/tools/test_python_repl_tool.py
@@ -46,7 +46,7 @@ class TestPythonREPLComponent(ComponentTestBaseWithoutClient):
         # Test python_code configuration
         python_code = template["python_code"]
         # assert python_code["type"] == "code"  # TODO: Restore when CodeInput is included in component
-        assert python_code["type"] == "str" # TODO: Remove when CodeInput is included in component
+        assert python_code["type"] == "str"  # TODO: Remove when CodeInput is included in component
         assert python_code["value"] == "print('Hello, World!')"
         assert python_code["required"] is True
 


### PR DESCRIPTION
This pull request updates the input handling for the `PythonREPLComponent` to better support multi-line Python code input. The main change is replacing the previous code input type with a more flexible multi-line input.

**Input Handling Improvements:**

* Replaced `CodeInput` with `MultilineInput` for the `python_code` parameter in the `PythonREPLComponent` to support multi-line code execution.
* Updated the import statement to use `MultilineInput` instead of `CodeInput` from `langflow.io`.