### PR TITLE
fix: Ensure consistent Langflow startup in Windows scripts

### DIFF
--- a/scripts/windows/build_and_run.bat
+++ b/scripts/windows/build_and_run.bat
@@ -85,8 +85,11 @@ echo Step 4: Running Langflow...
 echo.
 echo Attention: Wait until uvicorn is running before opening the browser
 echo.
+REM Change to project root directory for uv
+cd "%PROJECT_ROOT%"
 if defined USE_ENV_FILE (
-    uv run --env-file "%ENV_PATH%" langflow run
+    echo Using env file: .env
+    uv run --env-file ".env" langflow run
 ) else (
     uv run langflow run
 )

--- a/scripts/windows/build_and_run.ps1
+++ b/scripts/windows/build_and_run.ps1
@@ -86,8 +86,11 @@ try {
 Write-Host "`nStep 4: Running Langflow..." -ForegroundColor Yellow
 Write-Host "`nAttention: Wait until uvicorn is running before opening the browser" -ForegroundColor Red
 try {
+    # Change to project root directory for uv
+    Set-Location $projectRoot
     if ($useEnvFile) {
-        & uv run --env-file $envPath langflow run
+        Write-Host "Using env file: .env" -ForegroundColor Cyan
+        & uv run --env-file ".env" langflow run
     } else {
         & uv run langflow run
     }


### PR DESCRIPTION
This pull request updates the Windows build and run scripts to ensure consistent behavior when starting the Langflow application, particularly regarding the use of environment files and the working directory. The changes improve reliability and user feedback during the startup process.

**Script improvements for running Langflow:**

* Both `build_and_run.bat` and `build_and_run.ps1` now explicitly change to the project root directory before executing the `uv` command, ensuring the correct context for running Langflow. [[1]](diffhunk://#diff-e9c784750adf136cff297759596822e02abe928c3d11ac5a9ec8db8a421dcbe4R88-R92) [[2]](diffhunk://#diff-1e052b6485bbc88c566e100f8257a341051bb32579ddebe759d3101ef707501dR89-R93)
* When using an environment file, both scripts now always reference `.env` directly and display a message indicating that `.env` is being used, providing clearer feedback to the user. [[1]](diffhunk://#diff-e9c784750adf136cff297759596822e02abe928c3d11ac5a9ec8db8a421dcbe4R88-R92) [[2]](diffhunk://#diff-1e052b6485bbc88c566e100f8257a341051bb32579ddebe759d3101ef707501dR89-R93)