### PR TITLE
feat: add generic AWS API call component

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -229,25 +229,6 @@ jobs:
             image=moby/buildkit:v0.22.0
             network=host
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and Push to Docker Hub
-        uses: Wandalen/wretry.action@master
-        with:
-          action: docker/build-push-action@v6
-          with: |
-            context: .
-            push: true
-            file: ${{ needs.setup.outputs.file }}
-            tags: ${{ needs.setup.outputs.docker_tags }}
-            platforms: linux/amd64,linux/arm64
-            cache-from: type=gha
-            cache-to: type=gha,mode=max
-
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
         with:
@@ -276,16 +257,8 @@ jobs:
     needs: [build, get-version]
     strategy:
       matrix:
-        component: [docker-backend, docker-frontend, ghcr-backend, ghcr-frontend]
+        component: [ghcr-backend, ghcr-frontend]
         include:
-          - component: docker-backend
-            dockerfile: ./docker/build_and_push_backend.Dockerfile
-            tags: langflowai/langflow-backend:${{ needs.get-version.outputs.version }},langflowai/langflow-backend:latest
-            langflow_image: langflowai/langflow:${{ needs.get-version.outputs.version }}
-          - component: docker-frontend
-            dockerfile: ./docker/frontend/build_and_push_frontend.Dockerfile
-            tags: langflowai/langflow-frontend:${{ needs.get-version.outputs.version }},langflowai/langflow-frontend:latest
-            langflow_image: langflowai/langflow:${{ needs.get-version.outputs.version }}
           - component: ghcr-backend
             dockerfile: ./docker/build_and_push_backend.Dockerfile
             tags: ghcr.io/langflow-ai/langflow-backend:${{ needs.get-version.outputs.version }},ghcr.io/langflow-ai/langflow-backend:latest
@@ -322,14 +295,6 @@ jobs:
           driver-opts: |
             image=moby/buildkit:v0.22.0
             network=host
-
-
-      - name: Login to Docker Hub
-        if: ${{ matrix.component == 'docker-backend' }} || ${{ matrix.component == 'docker-frontend' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to Github Container Registry
         if: ${{ matrix.component == 'ghcr-backend' }} || ${{ matrix.component == 'ghcr-frontend' }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -184,6 +184,9 @@ jobs:
           fi
   build:
     runs-on: [self-hosted, linux, ARM64, langflow-ai-arm64-40gb]
+    permissions:
+      contents: read
+      packages: write
     needs: [get-version, setup]
     steps:
       - name: Check out the code at a specific ref
@@ -253,6 +256,7 @@ jobs:
     if: ${{ inputs.release_type == 'main' }}
     runs-on: [self-hosted, linux, ARM64, langflow-ai-arm64-40gb]
     permissions:
+      contents: read
       packages: write
     needs: [build, get-version]
     strategy:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -234,7 +234,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.TEMP_GHCR_TOKEN}}
+          password: ${{ secrets.GITHUB_TOKEN}}
 
       - name: Build and push to Github Container Registry
         uses: Wandalen/wretry.action@master
@@ -302,7 +302,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.TEMP_GHCR_TOKEN}}
+          password: ${{ secrets.GITHUB_TOKEN}}
 
       - name: Wait for propagation (for backend)
         run: sleep 120

--- a/src/lfx/pyproject.toml
+++ b/src/lfx/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pandas>=2.0.0",
     "pydantic>=2.0.0",
     "pillow>=10.0.0",
+    "python-dateutil>=2.8",
     "fastapi>=0.115.13",
     "uvicorn>=0.34.3",
     "typer>=0.16.0",

--- a/src/lfx/src/lfx/components/amazon/__init__.py
+++ b/src/lfx/src/lfx/components/amazon/__init__.py
@@ -8,14 +8,16 @@ if TYPE_CHECKING:
     from lfx.components.amazon.amazon_bedrock_embedding import AmazonBedrockEmbeddingsComponent
     from lfx.components.amazon.amazon_bedrock_model import AmazonBedrockComponent
     from lfx.components.amazon.s3_bucket_uploader import S3BucketUploaderComponent
+    from lfx.components.amazon.aws_api_call import AWSAPICallComponent
 
 _dynamic_imports = {
     "AmazonBedrockEmbeddingsComponent": "amazon_bedrock_embedding",
     "AmazonBedrockComponent": "amazon_bedrock_model",
     "S3BucketUploaderComponent": "s3_bucket_uploader",
+    "AWSAPICallComponent": "aws_api_call",
 }
 
-__all__ = ["AmazonBedrockComponent", "AmazonBedrockEmbeddingsComponent", "S3BucketUploaderComponent"]
+__all__ = ["AmazonBedrockComponent", "AmazonBedrockEmbeddingsComponent", "S3BucketUploaderComponent", "AWSAPICallComponent"]
 
 
 def __getattr__(attr_name: str) -> Any:

--- a/src/lfx/src/lfx/components/amazon/__init__.py
+++ b/src/lfx/src/lfx/components/amazon/__init__.py
@@ -7,8 +7,8 @@ from lfx.components._importing import import_mod
 if TYPE_CHECKING:
     from lfx.components.amazon.amazon_bedrock_embedding import AmazonBedrockEmbeddingsComponent
     from lfx.components.amazon.amazon_bedrock_model import AmazonBedrockComponent
-    from lfx.components.amazon.s3_bucket_uploader import S3BucketUploaderComponent
     from lfx.components.amazon.aws_api_call import AWSAPICallComponent
+    from lfx.components.amazon.s3_bucket_uploader import S3BucketUploaderComponent
 
 _dynamic_imports = {
     "AmazonBedrockEmbeddingsComponent": "amazon_bedrock_embedding",
@@ -17,7 +17,12 @@ _dynamic_imports = {
     "AWSAPICallComponent": "aws_api_call",
 }
 
-__all__ = ["AmazonBedrockComponent", "AmazonBedrockEmbeddingsComponent", "S3BucketUploaderComponent", "AWSAPICallComponent"]
+__all__ = [
+    "AWSAPICallComponent",
+    "AmazonBedrockComponent",
+    "AmazonBedrockEmbeddingsComponent",
+    "S3BucketUploaderComponent",
+]
 
 
 def __getattr__(attr_name: str) -> Any:

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -2,8 +2,8 @@ import re
 from typing import TYPE_CHECKING, Any
 
 import aiofiles
-
 from dateutil import parser
+
 from lfx.base.models.aws_constants import AWS_REGIONS
 from lfx.custom.custom_component.component import Component
 from lfx.io import (
@@ -331,7 +331,7 @@ class AWSAPICallComponent(Component):
             elif hasattr(self, "method_timefield_" + param_name):
                 field_value = getattr(self, "method_timefield_" + param_name)
                 if field_value is not None and hasattr(field_value, "text"):
-                        returns[param_name] = parser.parse(field_value.text)
+                    returns[param_name] = parser.parse(field_value.text)
 
         result = method(**returns)
 

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -338,9 +338,8 @@ class AWSAPICallComponent(Component):
                         try:
                             from dateutil import parser as _dateparser
                         except ImportError as e:
-                            raise ImportError(
-                                "python-dateutil is required to parse timestamps. Install with `pip install python-dateutil`."
-                            ) from e
+                            msg = "python-dateutil is required. Install with `pip install python-dateutil`."
+                            raise ImportError(msg) from e
                         returns[param_name] = _dateparser.parse(val)
 
         import asyncio

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -1,25 +1,24 @@
-from pathlib import Path
+import re
 from typing import Any
 
-from lfx.base.models.aws_constants import AWS_REGIONS
+import aiofiles
 
+from lfx.base.models.aws_constants import AWS_REGIONS
 from lfx.custom.custom_component.component import Component
-from lfx.schema.data import Data
 from lfx.io import (
     BoolInput,
+    DataInput,
     DropdownInput,
+    FileInput,
+    FloatInput,
+    IntInput,
+    MessageInput,
+    MessageTextInput,
     Output,
     SecretStrInput,
-    DataInput,
-    MessageTextInput,
-    MessageInput,
-    FileInput,
-    IntInput,
-    FloatInput,
 )
+from lfx.schema.data import Data
 
-import aiofiles
-import re
 
 class AWSAPICallComponent(Component):
     """A component that can dynamically determine fields for a specific service method, and execute the AWS API call within a flow."""
@@ -90,13 +89,13 @@ class AWSAPICallComponent(Component):
             options=[""],
             info="The AWS method to make a call to.",
             required=True,
-        )
+        ),
     ]
 
     outputs = [
         Output(display_name="Result", name="result", method="execute_call"),
     ]
-    
+
     def _get_session(self) -> Any:
         try:
             import boto3
@@ -113,9 +112,9 @@ class AWSAPICallComponent(Component):
             session = boto3.Session(profile_name=self.credentials_profile_name)
         else:
             session = boto3.Session()
-        
+
         return session
-        
+
     def _get_client(self, session) -> Any:
         client_params = {}
         if self.endpoint_url:
@@ -124,133 +123,141 @@ class AWSAPICallComponent(Component):
             client_params["region_name"] = self.region_name
 
         return session.client(self.aws_service, **client_params)
-    
+
     def update_build_config(self, build_config: dict, field_value: str, field_name: str | None = None) -> dict:
         session = self._get_session()
         build_config["aws_service"]["options"] = session.get_available_services()
-        
+
         if self.aws_service and self.aws_service != "":
             client = self._get_client(session)
             build_config["aws_method"]["options"] = list(client._service_model.operation_names)
-            
+
         if field_name == "aws_method":
             # dynamically add top-level parameters
             for key in list(build_config.keys()):
                 if key.startswith("method_field_") or key.startswith("method_filefield_"):
                     del build_config[key]
-            
+
             params = []
-            
+
             try:
                 import boto3
                 from botocore.model import Shape
             except ImportError as e:
                 msg = "boto3 or botocore is not installed. Please install it with `pip install boto3`."
                 raise ImportError(msg) from e
-            
+
             client = self._get_client(session)
             operation_model = client._service_model.operation_model(self.aws_method)
-        
+
             input_shape: Shape = operation_model.input_shape
             if input_shape is not None:
                 members = input_shape.members
                 required = set(input_shape.required_members)
-                
+
                 for name, shape in members.items():
-                    doc = re.sub(r"<.*?>", "", shape.documentation) if hasattr(shape, 'documentation') else ''
+                    doc = re.sub(r"<.*?>", "", shape.documentation) if hasattr(shape, "documentation") else ""
                     if len(doc) > 1000:
                         doc = doc[:1000] + "..."
-                    
-                    params.append({
-                        "name": name,
-                        "type": shape.type_name,
-                        "required": name in required,
-                        "sensitive": shape.sensitive if hasattr(shape, 'sensitive') else False,
-                        "description": doc
-                    })
-            
+
+                    params.append(
+                        {
+                            "name": name,
+                            "type": shape.type_name,
+                            "required": name in required,
+                            "sensitive": shape.sensitive if hasattr(shape, "sensitive") else False,
+                            "description": doc,
+                        }
+                    )
+
             for param in params:
                 if param["type"] == "string":
                     field = MessageInput(
                         display_name=param["name"],
-                        name="method_field_"+param["name"],
+                        name="method_field_" + param["name"],
                         info=param["description"],
                         required=param["required"],
-                        advanced=not param["required"]
+                        advanced=not param["required"],
                     )
                     if param["sensitive"]:
                         field = SecretStrInput(
                             display_name=param["name"],
-                            name="method_field_"+param["name"],
+                            name="method_field_" + param["name"],
                             info=param["description"],
                             required=param["required"],
-                            advanced=not param["required"]
+                            advanced=not param["required"],
                         )
-                    build_config["method_field_"+param["name"]] = field.to_dict()
+                    build_config["method_field_" + param["name"]] = field.to_dict()
                 elif param["type"] == "boolean":
                     field = BoolInput(
                         display_name=param["name"],
-                        name="method_field_"+param["name"],
-                        info=param["description"],
-                        required=param["required"],
-                        advanced=not param["required"]
-                    )
-                    build_config["method_field_"+param["name"]] = field.to_dict()
-                elif param["type"] == "blob":
-                    field = FileInput(
-                        display_name=param["name"],
-                        name="method_filefield_"+param["name"],
+                        name="method_field_" + param["name"],
                         info=param["description"],
                         required=param["required"],
                         advanced=not param["required"],
-                        file_types=["txt", "json", "jpg", "png"] # TODO: fix me to support all types - https://github.com/langflow-ai/langflow/issues/9933
                     )
-                    build_config["method_filefield_"+param["name"]] = field.to_dict()
+                    build_config["method_field_" + param["name"]] = field.to_dict()
+                elif param["type"] == "blob":
+                    field = FileInput(
+                        display_name=param["name"],
+                        name="method_filefield_" + param["name"],
+                        info=param["description"],
+                        required=param["required"],
+                        advanced=not param["required"],
+                        file_types=[
+                            "txt",
+                            "json",
+                            "jpg",
+                            "png",
+                        ],  # TODO: fix me to support all types - https://github.com/langflow-ai/langflow/issues/9933
+                    )
+                    build_config["method_filefield_" + param["name"]] = field.to_dict()
                 elif param["type"] == "integer" or param["type"] == "long":
                     field = IntInput(
                         display_name=param["name"],
-                        name="method_field_"+param["name"],
+                        name="method_field_" + param["name"],
                         info=param["description"],
                         required=param["required"],
-                        advanced=not param["required"]
+                        advanced=not param["required"],
                     )
-                    build_config["method_field_"+param["name"]] = field.to_dict()
+                    build_config["method_field_" + param["name"]] = field.to_dict()
                 elif param["type"] == "double":
                     field = FloatInput(
                         display_name=param["name"],
-                        name="method_field_"+param["name"],
+                        name="method_field_" + param["name"],
                         info=param["description"],
                         required=param["required"],
-                        advanced=not param["required"]
+                        advanced=not param["required"],
                     )
-                    build_config["method_field_"+param["name"]] = field.to_dict()
+                    build_config["method_field_" + param["name"]] = field.to_dict()
                 elif param["type"] == "timestamp":
                     field = FloatInput(
                         display_name=param["name"],
-                        name="method_field_"+param["name"],
+                        name="method_field_" + param["name"],
                         info=param["description"] + "\n\nThis accepts a timestamp as epoch.",
                         required=param["required"],
-                        advanced=not param["required"]
+                        advanced=not param["required"],
                     )
-                    build_config["method_field_"+param["name"]] = field.to_dict()
+                    build_config["method_field_" + param["name"]] = field.to_dict()
                 elif param["type"] == "structure" or param["type"] == "map" or param["type"] == "list":
                     field = DataInput(
                         display_name=param["name"],
-                        name="method_field_"+param["name"],
-                        info=param["description"] + "\n\nAccepts JSON Data as parameters input. Uses boto3-conformant parameters.",
+                        name="method_field_" + param["name"],
+                        info=param["description"]
+                        + "\n\nAccepts JSON Data as parameters input. Uses boto3-conformant parameters.",
                         required=param["required"],
-                        advanced=not param["required"]
+                        advanced=not param["required"],
                     )
-                    build_config["method_field_"+param["name"]] = field.to_dict()
-        
+                    build_config["method_field_" + param["name"]] = field.to_dict()
+
         return build_config
 
     async def execute_call(self) -> Data:
         session = self._get_session()
         client = self._get_client(session)
-        
+
         try:
-            from botocore import xform_name # this_type_of_casing function
+            from botocore import xform_name  # this_type_of_casing function
             from botocore.model import Shape
         except ImportError as e:
             msg = "botocore is not installed. Please install it with `pip install botocore`."
@@ -259,42 +266,44 @@ class AWSAPICallComponent(Component):
 
         # retrieve for method
         params = []
-        
+
         client = self._get_client(session)
         operation_model = client._service_model.operation_model(self.aws_method)
-    
+
         input_shape: Shape = operation_model.input_shape
         if input_shape is not None:
             members = input_shape.members
             required = set(input_shape.required_members)
-            
+
             for name, shape in members.items():
-                doc = re.sub(r"<.*?>", "", shape.documentation) if hasattr(shape, 'documentation') else ''
+                doc = re.sub(r"<.*?>", "", shape.documentation) if hasattr(shape, "documentation") else ""
                 if len(doc) > 1000:
                     doc = doc[:1000] + "..."
-                
-                params.append({
-                    "name": name,
-                    "type": shape.type_name,
-                    "required": name in required,
-                    "sensitive": shape.sensitive if hasattr(shape, 'sensitive') else False,
-                    "description": doc
-                })
-        
+
+                params.append(
+                    {
+                        "name": name,
+                        "type": shape.type_name,
+                        "required": name in required,
+                        "sensitive": shape.sensitive if hasattr(shape, "sensitive") else False,
+                        "description": doc,
+                    }
+                )
+
         returns = {}
         for param in params:
-            param_name = param['name']
-            if hasattr(self, "method_field_"+param_name):
-                field_value = getattr(self, "method_field_"+param_name)
+            param_name = param["name"]
+            if hasattr(self, "method_field_" + param_name):
+                field_value = getattr(self, "method_field_" + param_name)
                 if field_value is not None:
                     if isinstance(field_value, bool):
                         if field_value == True:
                             returns[param_name] = True
                     elif isinstance(field_value, (int, float)):
                         returns[param_name] = field_value
-                    elif hasattr(field_value, 'text'):
+                    elif hasattr(field_value, "text"):
                         returns[param_name] = field_value.text
-                    elif hasattr(field_value, 'data'):
+                    elif hasattr(field_value, "data"):
                         returns[param_name] = field_value.data
                     elif isinstance(field_value, str):
                         if field_value != "":
@@ -302,12 +311,12 @@ class AWSAPICallComponent(Component):
                     else:
                         msg = f"Unsupported type for parameter '{param_name}': {type(field_value)}"
                         raise ValueError(msg)
-            elif hasattr(self, "method_filefield_"+param_name):
-                field_value = getattr(self, "method_filefield_"+param_name)
+            elif hasattr(self, "method_filefield_" + param_name):
+                field_value = getattr(self, "method_filefield_" + param_name)
                 if field_value is not None and field_value != "":
                     async with aiofiles.open(str(field_value), "rb") as f:
                         returns[param_name] = await f.read()
-        
+
         result = method(**returns)
-        
+
         return Data(text=str(result), data=result)

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -331,7 +331,18 @@ class AWSAPICallComponent(Component):
             elif hasattr(self, "method_timefield_" + param_name):
                 field_value = getattr(self, "method_timefield_" + param_name)
                 if field_value is not None and hasattr(field_value, "text"):
-                    returns[param_name] = parser.parse(field_value.text)
+                    val = field_value.text.strip()
+                    from datetime import datetime, timezone
+                    if val.isdigit():
+                        returns[param_name] = datetime.fromtimestamp(int(val), tz=timezone.utc)
+                    else:
+                        try:
+                            from dateutil import parser as _dateparser
+                        except ImportError as e:
+                            raise ImportError(
+                                "python-dateutil is required to parse timestamps. Install with `pip install python-dateutil`."
+                            ) from e
+                        returns[param_name] = _dateparser.parse(val)
 
         import asyncio
         result = await asyncio.to_thread(method, **returns)

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -2,7 +2,6 @@ import re
 from typing import TYPE_CHECKING, Any
 
 import aiofiles
-from dateutil import parser
 
 from lfx.base.models.aws_constants import AWS_REGIONS
 from lfx.custom.custom_component.component import Component
@@ -332,6 +331,7 @@ class AWSAPICallComponent(Component):
                 if field_value is not None and hasattr(field_value, "text"):
                     val = field_value.text.strip()
                     from datetime import datetime, timezone
+
                     if val.isdigit():
                         returns[param_name] = datetime.fromtimestamp(int(val), tz=timezone.utc)
                     else:
@@ -344,6 +344,7 @@ class AWSAPICallComponent(Component):
                         returns[param_name] = _dateparser.parse(val)
 
         import asyncio
+
         result = await asyncio.to_thread(method, **returns)
 
         return Data(text=str(result), data=result)

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiofiles
 
@@ -21,9 +21,11 @@ from lfx.schema.data import Data
 
 MAX_DOC_LENGTH = 1000  # Maximum length for documentation strings
 
+
 class AWSAPICallComponent(Component):
     """A component that can dynamically determine fields for a specific service method
-    and execute the AWS API call within a flow."""
+    and execute the AWS API call within a flow.
+    """
 
     display_name: str = "AWS API Call"
     description: str = "Makes an API call to an AWS service."
@@ -260,6 +262,7 @@ class AWSAPICallComponent(Component):
 
         try:
             from botocore import xform_name  # this_type_of_casing function
+
             if TYPE_CHECKING:
                 from botocore.model import Shape
         except ImportError as e:

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -23,9 +23,7 @@ MAX_DOC_LENGTH = 1000  # Maximum length for documentation strings
 
 
 class AWSAPICallComponent(Component):
-    """A component that can dynamically determine fields for a specific service method
-    and execute the AWS API call within a flow.
-    """
+    """A component that executes an AWS API call."""
 
     display_name: str = "AWS API Call"
     description: str = "Makes an API call to an AWS service."
@@ -139,7 +137,7 @@ class AWSAPICallComponent(Component):
         if field_name == "aws_method":
             # dynamically add top-level parameters
             for key in list(build_config.keys()):
-                if key.startswith("method_field_") or key.startswith("method_filefield_"):
+                if key.startswith(("method_field_","method_filefield_")):
                     del build_config[key]
 
             params = []

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -248,7 +248,7 @@ class AWSAPICallComponent(Component):
                             required=param["required"],
                             advanced=not param["required"],
                         )
-                        build_config["method_field_" + param["name"]] = field.to_dict()
+                        build_config["method_timefield_" + param["name"]] = field.to_dict()
                     elif param["type"] == "structure" or param["type"] == "map" or param["type"] == "list":
                         field = DataInput(
                             display_name=param["name"],

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -1,0 +1,313 @@
+from pathlib import Path
+from typing import Any
+
+from lfx.base.models.aws_constants import AWS_REGIONS
+
+from lfx.custom.custom_component.component import Component
+from lfx.schema.data import Data
+from lfx.io import (
+    BoolInput,
+    DropdownInput,
+    Output,
+    SecretStrInput,
+    DataInput,
+    MessageTextInput,
+    MessageInput,
+    FileInput,
+    IntInput,
+    FloatInput,
+)
+
+import aiofiles
+import re
+
+class AWSAPICallComponent(Component):
+    """A component that can dynamically determine fields for a specific service method, and execute the AWS API call within a flow."""
+
+    display_name: str = "AWS API Call"
+    description: str = "Makes an API call to an AWS service."
+    icon: str = "Amazon"
+    name: str = "AWSAPICall"
+
+    inputs = [
+        SecretStrInput(
+            name="aws_access_key_id",
+            display_name="AWS Access Key ID",
+            info="The access key for your AWS account."
+            "Usually set in Python code as the environment variable 'AWS_ACCESS_KEY_ID'.",
+            required=True,
+        ),
+        SecretStrInput(
+            name="aws_secret_access_key",
+            display_name="AWS Secret Access Key",
+            info="The secret key for your AWS account. "
+            "Usually set in Python code as the environment variable 'AWS_SECRET_ACCESS_KEY'.",
+            required=True,
+        ),
+        SecretStrInput(
+            name="aws_session_token",
+            display_name="AWS Session Token",
+            advanced=False,
+            info="The session key for your AWS account. "
+            "Only needed for temporary credentials. "
+            "Usually set in Python code as the environment variable 'AWS_SESSION_TOKEN'.",
+        ),
+        SecretStrInput(
+            name="credentials_profile_name",
+            display_name="Credentials Profile Name",
+            advanced=True,
+            info="The name of the profile to use from your "
+            "~/.aws/credentials file. "
+            "If not provided, the default profile will be used.",
+        ),
+        DropdownInput(
+            name="region_name",
+            display_name="Region Name",
+            value="us-east-1",
+            options=AWS_REGIONS,
+            info="The AWS region to execute the call in.",
+        ),
+        MessageTextInput(
+            name="endpoint_url",
+            display_name="Endpoint URL",
+            advanced=True,
+            info="The URL of the AWS endpoint to use.",
+        ),
+        DropdownInput(
+            name="aws_service",
+            display_name="Service",
+            real_time_refresh=True,
+            refresh_button=True,
+            options=[""],
+            info="The AWS service to make a call to.",
+            required=True,
+        ),
+        DropdownInput(
+            name="aws_method",
+            display_name="Method",
+            real_time_refresh=True,
+            refresh_button=True,
+            options=[""],
+            info="The AWS method to make a call to.",
+            required=True,
+        )
+    ]
+
+    outputs = [
+        Output(display_name="Result", name="result", method="execute_call"),
+    ]
+    
+    def _get_session(self) -> Any:
+        try:
+            import boto3
+        except ImportError as e:
+            msg = "boto3 is not installed. Please install it with `pip install boto3`."
+            raise ImportError(msg) from e
+        if self.aws_access_key_id or self.aws_secret_access_key:
+            session = boto3.Session(
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key,
+                aws_session_token=self.aws_session_token,
+            )
+        elif self.credentials_profile_name:
+            session = boto3.Session(profile_name=self.credentials_profile_name)
+        else:
+            session = boto3.Session()
+        
+        return session
+        
+    def _get_client(self, session) -> Any:
+        client_params = {}
+        if self.endpoint_url:
+            client_params["endpoint_url"] = self.endpoint_url
+        if self.region_name:
+            client_params["region_name"] = self.region_name
+
+        return session.client(self.aws_service, **client_params)
+    
+    def update_build_config(self, build_config: dict, field_value: str, field_name: str | None = None) -> dict:
+        session = self._get_session()
+        build_config["aws_service"]["options"] = session.get_available_services()
+        
+        if self.aws_service and self.aws_service != "":
+            client = self._get_client(session)
+            build_config["aws_method"]["options"] = list(client._service_model.operation_names)
+            
+        if field_name == "aws_method":
+            # dynamically add top-level parameters
+            for key in list(build_config.keys()):
+                if key.startswith("method_field_") or key.startswith("method_filefield_"):
+                    del build_config[key]
+            
+            params = []
+            
+            try:
+                import boto3
+                from botocore.model import Shape
+            except ImportError as e:
+                msg = "boto3 or botocore is not installed. Please install it with `pip install boto3`."
+                raise ImportError(msg) from e
+            
+            client = self._get_client(session)
+            operation_model = client._service_model.operation_model(self.aws_method)
+        
+            input_shape: Shape = operation_model.input_shape
+            if input_shape is not None:
+                members = input_shape.members
+                required = set(input_shape.required_members)
+                
+                for name, shape in members.items():
+                    doc = re.sub(r"<.*?>", "", shape.documentation) if hasattr(shape, 'documentation') else ''
+                    if len(doc) > 1000:
+                        doc = doc[:1000] + "..."
+                    
+                    params.append({
+                        "name": name,
+                        "type": shape.type_name,
+                        "required": name in required,
+                        "sensitive": shape.sensitive if hasattr(shape, 'sensitive') else False,
+                        "description": doc
+                    })
+            
+            for param in params:
+                if param["type"] == "string":
+                    field = MessageInput(
+                        display_name=param["name"],
+                        name="method_field_"+param["name"],
+                        info=param["description"],
+                        required=param["required"],
+                        advanced=not param["required"]
+                    )
+                    if param["sensitive"]:
+                        field = SecretStrInput(
+                            display_name=param["name"],
+                            name="method_field_"+param["name"],
+                            info=param["description"],
+                            required=param["required"],
+                            advanced=not param["required"]
+                        )
+                    build_config["method_field_"+param["name"]] = field.to_dict()
+                elif param["type"] == "boolean":
+                    field = BoolInput(
+                        display_name=param["name"],
+                        name="method_field_"+param["name"],
+                        info=param["description"],
+                        required=param["required"],
+                        advanced=not param["required"]
+                    )
+                    build_config["method_field_"+param["name"]] = field.to_dict()
+                elif param["type"] == "blob":
+                    field = FileInput(
+                        display_name=param["name"],
+                        name="method_filefield_"+param["name"],
+                        info=param["description"],
+                        required=param["required"],
+                        advanced=not param["required"],
+                        file_types=["txt", "json", "jpg", "png"] # TODO: fix me to support all types - https://github.com/langflow-ai/langflow/issues/9933
+                    )
+                    build_config["method_filefield_"+param["name"]] = field.to_dict()
+                elif param["type"] == "integer" or param["type"] == "long":
+                    field = IntInput(
+                        display_name=param["name"],
+                        name="method_field_"+param["name"],
+                        info=param["description"],
+                        required=param["required"],
+                        advanced=not param["required"]
+                    )
+                    build_config["method_field_"+param["name"]] = field.to_dict()
+                elif param["type"] == "double":
+                    field = FloatInput(
+                        display_name=param["name"],
+                        name="method_field_"+param["name"],
+                        info=param["description"],
+                        required=param["required"],
+                        advanced=not param["required"]
+                    )
+                    build_config["method_field_"+param["name"]] = field.to_dict()
+                elif param["type"] == "timestamp":
+                    field = FloatInput(
+                        display_name=param["name"],
+                        name="method_field_"+param["name"],
+                        info=param["description"] + "\n\nThis accepts a timestamp as epoch.",
+                        required=param["required"],
+                        advanced=not param["required"]
+                    )
+                    build_config["method_field_"+param["name"]] = field.to_dict()
+                elif param["type"] == "structure" or param["type"] == "map" or param["type"] == "list":
+                    field = DataInput(
+                        display_name=param["name"],
+                        name="method_field_"+param["name"],
+                        info=param["description"] + "\n\nAccepts JSON Data as parameters input. Uses boto3-conformant parameters.",
+                        required=param["required"],
+                        advanced=not param["required"]
+                    )
+                    build_config["method_field_"+param["name"]] = field.to_dict()
+        
+        return build_config
+
+    async def execute_call(self) -> Data:
+        session = self._get_session()
+        client = self._get_client(session)
+        
+        try:
+            from botocore import xform_name # this_type_of_casing function
+            from botocore.model import Shape
+        except ImportError as e:
+            msg = "botocore is not installed. Please install it with `pip install botocore`."
+            raise ImportError(msg) from e
+        method = getattr(client, xform_name(self.aws_method))
+
+        # retrieve for method
+        params = []
+        
+        client = self._get_client(session)
+        operation_model = client._service_model.operation_model(self.aws_method)
+    
+        input_shape: Shape = operation_model.input_shape
+        if input_shape is not None:
+            members = input_shape.members
+            required = set(input_shape.required_members)
+            
+            for name, shape in members.items():
+                doc = re.sub(r"<.*?>", "", shape.documentation) if hasattr(shape, 'documentation') else ''
+                if len(doc) > 1000:
+                    doc = doc[:1000] + "..."
+                
+                params.append({
+                    "name": name,
+                    "type": shape.type_name,
+                    "required": name in required,
+                    "sensitive": shape.sensitive if hasattr(shape, 'sensitive') else False,
+                    "description": doc
+                })
+        
+        returns = {}
+        for param in params:
+            param_name = param['name']
+            if hasattr(self, "method_field_"+param_name):
+                field_value = getattr(self, "method_field_"+param_name)
+                if field_value is not None:
+                    if isinstance(field_value, bool):
+                        if field_value == True:
+                            returns[param_name] = True
+                    elif isinstance(field_value, (int, float)):
+                        returns[param_name] = field_value
+                    elif hasattr(field_value, 'text'):
+                        returns[param_name] = field_value.text
+                    elif hasattr(field_value, 'data'):
+                        returns[param_name] = field_value.data
+                    elif isinstance(field_value, str):
+                        if field_value != "":
+                            returns[param_name] = field_value
+                    else:
+                        msg = f"Unsupported type for parameter '{param_name}': {type(field_value)}"
+                        raise ValueError(msg)
+            elif hasattr(self, "method_filefield_"+param_name):
+                field_value = getattr(self, "method_filefield_"+param_name)
+                if field_value is not None and field_value != "":
+                    async with aiofiles.open(str(field_value), "rb") as f:
+                        returns[param_name] = await f.read()
+        
+        result = method(**returns)
+        
+        return Data(text=str(result), data=result)

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -137,7 +137,7 @@ class AWSAPICallComponent(Component):
         if field_name == "aws_method":
             # dynamically add top-level parameters
             for key in list(build_config.keys()):
-                if key.startswith(("method_field_","method_filefield_")):
+                if key.startswith(("method_field_", "method_filefield_")):
                     del build_config[key]
 
             params = []

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -158,8 +158,7 @@ class AWSAPICallComponent(Component):
                     raise ImportError(msg) from e
 
                 client = self._get_client(session)
-                operation_model = client._service_model.operation_model(self.aws_method)
-
+                operation_model = client.meta.service_model.operation_model(self.aws_method)
                 input_shape: Shape = operation_model.input_shape
                 if input_shape is not None:
                     members = input_shape.members

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -131,9 +131,12 @@ class AWSAPICallComponent(Component):
         build_config["aws_service"]["options"] = session.get_available_services()
 
         if (
-            self.aws_service and self.aws_service != "" and
-            self.aws_access_key_id and self.aws_access_key_id != "" and
-            self.aws_secret_access_key and self.aws_secret_access_key != ""
+            self.aws_service
+            and self.aws_service != ""
+            and self.aws_access_key_id
+            and self.aws_access_key_id != ""
+            and self.aws_secret_access_key
+            and self.aws_secret_access_key != ""
         ):
             client = self._get_client(session)
             build_config["aws_method"]["options"] = list(client._service_model.operation_names)

--- a/src/lfx/src/lfx/components/amazon/aws_api_call.py
+++ b/src/lfx/src/lfx/components/amazon/aws_api_call.py
@@ -333,6 +333,7 @@ class AWSAPICallComponent(Component):
                 if field_value is not None and hasattr(field_value, "text"):
                     returns[param_name] = parser.parse(field_value.text)
 
-        result = method(**returns)
+        import asyncio
+        result = await asyncio.to_thread(method, **returns)
 
         return Data(text=str(result), data=result)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version < '3.11' and platform_python_implementation == 'PyPy' and sys_platform == 'darwin'",
@@ -5815,6 +5815,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "structlog" },
@@ -5861,6 +5862,7 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
+    { name = "python-dateutil", specifier = ">=2.8" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "structlog" },


### PR DESCRIPTION
This pull request creates a new component within the existing Amazon bundle which allows for a user to perform an arbitrary AWS API call.

## Screenshots

<img width="802" height="606" alt="screenshot1" src="https://github.com/user-attachments/assets/2a2be651-70b1-42d2-940e-1407097684da" />

<img width="1429" height="691" alt="screenshot2" src="https://github.com/user-attachments/assets/b75c1d53-c26f-4495-9421-9b986a12cc3e" />

<img width="913" height="658" alt="screenshot3" src="https://github.com/user-attachments/assets/bdb7fbb3-b909-40c0-a885-1bab4d3fe230" />

## Features

- Dynamic listing of AWS services from boto3 library
- Dynamic listing of methods within the previously selected service
- Dynamic **creation** of top-level fields for the method call
- Dynamic fields are set to advanced if not a required field for the call (users can enable optional fields)
- Support `MessageInput` for any string-based fields (unless it is a secret, where `SecretStrInput` is used)
- Support for float, int and bool (toggle) inputs for those fields
- Support `Data` for any list or object parameter fields
- Support `File` for any fields that take bytes (asyncio used to read bytes)
- Dynamic fields (call parameters) support a description of the use of said field
- Outputs JSON to `Data`

## Current Bugs (requesting help!)

- When exiting the Code for the component, the fields reset as the options for the service/method field are dynamically set in `update_build_config()`, so the existing value does not exist in the default `[""]`. Any patterns for this?
- Similarly, this will likely not work well for exported / imported flows with the dynamic fields
- <strike>For FileInput fields, if omitting the file types filter, the user cannot upload and accept any file (related https://github.com/langflow-ai/langflow/issues/9933)</strike> Unlikely to be fixed, there's a generic list there that'll work and users can manually override in Python
- <strike>Date/Time fields aren't fully supported yet, was looking for an appropriate input field type?</strike> Parsing `Message` for this for now
- Need to add tests - [current documentation](https://docs.langflow.org/contributing-component-tests) is confusing as to where to add as location of most components don't match the documentation (says `src > backend > base > langflow > components` but that doesn't seem to be correct)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AWS API Call component to execute AWS operations.
  * Supports authentication via access keys, profiles, or default credentials, plus region and optional endpoint selection.
  * Dynamically lists services and methods and auto-generates typed parameter fields (strings, numbers, booleans, files, timestamps, lists/maps/structures).
  * Returns readable results along with raw data output.
  * Provides clear messages when required AWS SDK dependencies are not installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->