### PR TITLE
docs: docling dependency on macOS x86

### DIFF
--- a/docs/docs/Components/components-data.mdx
+++ b/docs/docs/Components/components-data.mdx
@@ -175,6 +175,7 @@ For videos, see the **Twelve Labs** and **YouTube** <Icon name="Blocks" aria-hid
 ### Advanced parsing
 
 In Langflow version 1.6 and later, the **File** component supports advanced document parsing using the [Docling](https://docling-project.github.io/docling/) library for supported file types.
+No installation is required, except for macOS systems with x86_64 architecture where the Docling dependency is not automatically installed. For more information, see [Docling prerequisites](/integrations-docling#prerequisites).
 
 <details>
 <summary>Enable Developer Mode for Windows</summary>

--- a/docs/docs/Integrations/Docling/integrations-docling.mdx
+++ b/docs/docs/Integrations/Docling/integrations-docling.mdx
@@ -21,9 +21,7 @@ If you are running Langflow Desktop on Windows, you must [enable Developer Mode]
 
 * **Install Docling dependency in earlier versions of Langflow**:
 In Langflow version 1.6 and later, the Docling dependency is included by default.
-No installation is required.
-
-    In Langflow versions earlier than 1.6, you must install the Docling dependency to use the Docling components in Langflow.
+No installation is required, except for macOS systems with x86_64 architecture where the Docling dependency is not automatically installed.
 
     <details>
     <summary>Install Docling dependency in earlier versions</summary>

--- a/docs/docs/Integrations/Docling/integrations-docling.mdx
+++ b/docs/docs/Integrations/Docling/integrations-docling.mdx
@@ -20,8 +20,8 @@ If you are running Langflow Desktop on Windows, you must [enable Developer Mode]
     You might need to restart your computer or Langflow to apply the change.
 
 * **Install Docling dependency in earlier versions of Langflow**:
-In Langflow version 1.6 and later, the Docling dependency is included by default.
-No installation is required, except for macOS systems with x86_64 architecture where the Docling dependency is not automatically installed.
+In Langflow version 1.6 and later, the Docling dependency is included by default, except for macOS systems with x86_64 architecture.
+In Langflow versions earlier than 1.6, and on macOS systems with x86_64 architecture, you must install the Docling dependency to use the Docling components in Langflow.
 
     <details>
     <summary>Install Docling dependency in earlier versions</summary>

--- a/docs/docs/Support/release-notes.mdx
+++ b/docs/docs/Support/release-notes.mdx
@@ -80,6 +80,12 @@ For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/rel
   The **File** component supports [advanced parsing with the Docling library](/components-data#advanced-parsing).
   Additionally, the Docling dependency is now included with Langflow, making it easier to use the **Docling** components and the **File** component's new advanced parsing feature.
 
+  :::note macOS x86_64 limitation
+  The Docling dependency is not automatically installed on macOS systems with x86_64 architecture.
+  Users on macOS with x86_64 architecture who want to use Docling features must manually install the Docling dependency.
+  For more information, see [Docling prerequisites](/integrations-docling#prerequisites).
+  :::
+
 - Reorganized component menus and visual editor controls
 
   - The [workspace](/concepts-overview#workspace) sidebar is divided into separate sections for <Icon name="Search" aria-hidden="true" /> **Search**, <Icon name="Component" aria-hidden="true" /> **Core components**, <McpIcon /> [**MCP servers**](/mcp-server), <Icon name="Blocks" aria-hidden="true" /> [**Bundles**](/components-bundle-components), and <Icon name="StickyNote" aria-hidden="true"/> **Add Note**.


### PR DESCRIPTION
Users on macOS with x86 architecture must manually install the Docling dependency.

Might do this as a partial instead.

See #9944