### PR TITLE
feat: add customization layer for duplicate file functionality

### DIFF
--- a/src/frontend/src/customization/hooks/use-custom-duplicate-file.ts
+++ b/src/frontend/src/customization/hooks/use-custom-duplicate-file.ts
@@ -1,0 +1,3 @@
+import { useDuplicateFileV2 } from "../../controllers/API/queries/file-management/use-duplicate-file";
+
+export { useDuplicateFileV2 };

--- a/src/frontend/src/modals/fileManagerModal/components/filesContextMenuComponent/index.tsx
+++ b/src/frontend/src/modals/fileManagerModal/components/filesContextMenuComponent/index.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useDeleteFileV2 } from "@/controllers/API/queries/file-management/use-delete-file";
-import { useDuplicateFileV2 } from "@/controllers/API/queries/file-management/use-duplicate-file";
+import { useDuplicateFileV2 } from "@/customization/hooks/use-custom-duplicate-file";
 import { useCustomHandleSingleFileDownload } from "@/customization/hooks/use-custom-handle-single-file-download";
 import ConfirmationModal from "@/modals/confirmationModal";
 import useAlertStore from "@/stores/alertStore";


### PR DESCRIPTION
- Create use-custom-duplicate-file.ts in customization/hooks
- Update import path in filesContextMenuComponent to use customization layer
- Maintains original functionality while enabling desktop-specific overrides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined the Duplicate File action by routing it through the customization hooks layer for improved extensibility and consistency. No functional changes.
  - Users should experience the same Duplicate action without interruptions.

- Chores
  - Updated internal imports in the file manager context menu to use the new hook location, aligning with the customization namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->