### PR TITLE
refactor: Update AgentComponent to utilize MODEL_OPTIONS_METADATA from constants

### DIFF
--- a/src/lfx/src/lfx/base/models/model_input_constants.py
+++ b/src/lfx/src/lfx/base/models/model_input_constants.py
@@ -305,3 +305,7 @@ ALL_PROVIDER_FIELDS: list[str] = [field for prov in ACTIVE_MODEL_PROVIDERS_DICT.
 MODEL_DYNAMIC_UPDATE_FIELDS = ["api_key", "model", "tool_model_enabled", "base_url", "model_name"]
 
 MODELS_METADATA = {name: {"icon": prov["icon"]} for name, prov in ACTIVE_MODEL_PROVIDERS_DICT.items()}
+
+MODEL_PROVIDERS_LIST = ["Anthropic", "Google Generative AI", "OpenAI"]
+
+MODEL_OPTIONS_METADATA = [MODELS_METADATA[key] for key in MODEL_PROVIDERS_LIST if key in MODELS_METADATA]

--- a/src/lfx/src/lfx/components/agents/agent.py
+++ b/src/lfx/src/lfx/components/agents/agent.py
@@ -9,7 +9,9 @@ from lfx.base.agents.events import ExceptionWithMessageError
 from lfx.base.models.model_input_constants import (
     ALL_PROVIDER_FIELDS,
     MODEL_DYNAMIC_UPDATE_FIELDS,
+    MODEL_OPTIONS_METADATA,
     MODEL_PROVIDERS_DICT,
+    MODEL_PROVIDERS_LIST,
     MODELS_METADATA,
 )
 from lfx.base.models.model_utils import get_model_name
@@ -31,9 +33,6 @@ from lfx.schema.table import EditMode
 def set_advanced_true(component_input):
     component_input.advanced = True
     return component_input
-
-
-MODEL_PROVIDERS_LIST = ["Anthropic", "Google Generative AI", "OpenAI"]
 
 
 class AgentComponent(ToolCallingAgentComponent):
@@ -66,8 +65,7 @@ class AgentComponent(ToolCallingAgentComponent):
             real_time_refresh=True,
             refresh_button=False,
             input_types=[],
-            options_metadata=[MODELS_METADATA[key] for key in MODEL_PROVIDERS_LIST if key in MODELS_METADATA]
-            + [{"icon": "brain"}],
+            options_metadata=[*MODEL_OPTIONS_METADATA, {"icon": "brain"}],
             external_options={
                 "fields": {
                     "data": {


### PR DESCRIPTION
Having the list in the AgentComponent caused outdated components to check for models that could have been made inactive. Since `Groq` was made inactive in `1.6.0`  flows built in 1.5.0 broke.

- Removed the hardcoded `MODEL_PROVIDERS_LIST` and replaced it with `MODEL_OPTIONS_METADATA` for improved flexibility in options metadata handling.
- Enhanced the `options_metadata` in the AgentComponent to streamline the integration of model provider options, ensuring better alignment with the existing metadata structure.