### PR TITLE
chore: remove webhook auth docs that aren not in 1.6

### DIFF
--- a/docs/docs/Configuration/api-keys-and-authentication.mdx
+++ b/docs/docs/Configuration/api-keys-and-authentication.mdx
@@ -26,7 +26,7 @@ There are three types of credentials that you use in Langflow:
 You can use Langflow API keys to interact with Langflow programmatically.
 
 By default, most Langflow API endpoints, such as `/v1/run/$FLOW_ID`, require authentication with a Langflow API key.
-To require API key authentication for flow webhook endpoints, use the [`LANGFLOW_WEBHOOK_AUTH_ENABLE`](/webhook#require-authentication-for-webhooks) environment variable.
+
 To configure authentication for Langflow MCP servers, see [Use Langflow as an MCP server](/mcp-server).
 
 ### Langflow API key permissions

--- a/docs/docs/Develop/webhook.mdx
+++ b/docs/docs/Develop/webhook.mdx
@@ -88,11 +88,6 @@ For the preceding example, the parsed payload would be a string like `ID: 12345 
 Typically, you won't manually trigger the **Webhook** component.
 To learn about triggering flows with payloads from external applications, see the video tutorial [How to Use Webhooks in Langflow](https://www.youtube.com/watch?v=IC1CAtzFRE0).
 
-## Require authentication for webhooks {#require-authentication-for-webhooks}
-
-By default, webhooks run as the flow owner without authentication (`LANGFLOW_WEBHOOK_AUTH_ENABLE=False`).
-If you want to require API key authentication for webhooks, set `LANGFLOW_WEBHOOK_AUTH_ENABLE=True`.
-
 ## Troubleshoot flows with Webhook components
 
 Use the following information to help address common issues that can occur with the **Webhook** component.


### PR DESCRIPTION
Remove the webhook_auth documentation that is not in v 1.6