### PR TITLE
fix: Ensure `log_level` is set correctly

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -261,10 +261,7 @@ def run(
 
     # Must set as env var for child process to pick up
     env_log_level = os.environ.get("LANGFLOW_LOG_LEVEL")
-    if env_log_level is None:
-        os.environ["LANGFLOW_LOG_LEVEL"] = log_level_str
-    else:
-        os.environ["LANGFLOW_LOG_LEVEL"] = env_log_level.lower()
+    log_level = log_level_str if env_log_level is None else env_log_level.lower()
 
     configure(log_level=log_level, log_file=log_file, log_rotation=log_rotation)
 

--- a/src/backend/base/langflow/base/data/base_file.py
+++ b/src/backend/base/langflow/base/data/base_file.py
@@ -265,7 +265,7 @@ class BaseFileComponent(Component, ABC):
                     parts.append(str(data_text))
                 elif isinstance(d.data, dict):
                     # convert the data dict to a readable string
-                    parts.append(orjson.dumps(d.data, indent=2, default=str))
+                    parts.append(orjson.dumps(d.data, option=orjson.OPT_INDENT_2, default=str).decode())
                 else:
                     parts.append(str(d))
             except Exception:  # noqa: BLE001


### PR DESCRIPTION
Set the `log_level` variable to avoid it being None which caused the `configure` call to fail making the default `langflow run` to fail.