### PR TITLE
fix: Broaden exception handling in API connection

### DIFF
--- a/src/lfx/src/lfx/components/nvidia/nvidia.py
+++ b/src/lfx/src/lfx/components/nvidia/nvidia.py
@@ -27,7 +27,7 @@ class NVIDIAModelComponent(LCModelComponent):
     except ImportError as e:
         msg = "Please install langchain-nvidia-ai-endpoints to use the NVIDIA model."
         raise ImportError(msg) from e
-    except (ConnectionError, MaxRetryError, NameResolutionError):
+    except (ConnectionError, MaxRetryError, NameResolutionError, Exception):
         logger.warning(
             "Failed to connect to NVIDIA API. Model list may be unavailable."
             " Please check your internet connection and API credentials."


### PR DESCRIPTION
This pull request makes a small change to the exception handling in the `NVIDIAModelComponent` class. The change broadens the exception handling to catch all exceptions, not just specific connection-related ones, when attempting to connect to the NVIDIA API. This ensures that any unexpected errors during the connection process are logged with a warning, making the component more robust.


2025-09-30T00:29:12.192921Z [error    ] [503] Service Temporarily Unavailable
{'_content': b'<html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n</body>\r\n</html>\r\n', '_content_consumed': True, '_next': None, 'status_code': 503, 'headers': {'Server': 'awselb/2.0', 'Date': 'Tue, 30 Sep 2025 00:29:12 GMT', 'Content-Type': 'text/html', 'Content-Length': '162', 'Connection': 'keep-alive'}, 'raw': <urllib3.response.HTTPResponse object at 0x77afe63a0040>, 'url': 'https://integrate.api.nvidia.com/v1/models', 'encoding': 'ISO-8859-1', 'history': [], 'reason': 'Service Temporarily Unavailable', 'cookies': <RequestsCookieJar[]>, 'elapsed': datetime.timedelta(microseconds=87202), 'request': <PreparedRequest [GET]>, 'connection': <requests.adapters.HTTPAdapter object at 0x77afe65fffe0>}
