### PR TITLE
fix: broadly catch exceptions when building components

### DIFF
--- a/src/backend/base/langflow/components/nvidia/nvidia.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia.py
@@ -1,8 +1,5 @@
 from typing import Any
 
-from requests.exceptions import ConnectionError  # noqa: A004
-from urllib3.exceptions import MaxRetryError, NameResolutionError
-
 from langflow.base.models.model import LCModelComponent
 from langflow.field_typing import LanguageModel
 from langflow.field_typing.range_spec import RangeSpec
@@ -27,10 +24,9 @@ class NVIDIAModelComponent(LCModelComponent):
     except ImportError as e:
         msg = "Please install langchain-nvidia-ai-endpoints to use the NVIDIA model."
         raise ImportError(msg) from e
-    except (ConnectionError, MaxRetryError, NameResolutionError):
+    except Exception as e:  # noqa: BLE001
         logger.warning(
-            "Failed to connect to NVIDIA API. Model list may be unavailable."
-            " Please check your internet connection and API credentials."
+            f"Failed to fetch NVIDIA models during initialization: {e}. Model list will be unavailable."
         )
         all_models = []
 

--- a/src/backend/base/langflow/components/nvidia/nvidia.py
+++ b/src/backend/base/langflow/components/nvidia/nvidia.py
@@ -25,9 +25,7 @@ class NVIDIAModelComponent(LCModelComponent):
         msg = "Please install langchain-nvidia-ai-endpoints to use the NVIDIA model."
         raise ImportError(msg) from e
     except Exception as e:  # noqa: BLE001
-        logger.warning(
-            f"Failed to fetch NVIDIA models during initialization: {e}. Model list will be unavailable."
-        )
+        logger.warning(f"Failed to fetch NVIDIA models during initialization: {e}. Model list will be unavailable.")
         all_models = []
 
     inputs = [

--- a/src/backend/base/langflow/interface/components.py
+++ b/src/backend/base/langflow/interface/components.py
@@ -101,6 +101,10 @@ def _process_single_module(modname: str) -> tuple[str, dict] | None:
     except (ImportError, AttributeError) as e:
         logger.error(f"Error importing module {modname}: {e}", exc_info=True)
         return None
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"Error building module {modname}: {e}", exc_info=True)
+        return None
+
     # Extract the top-level subpackage name after "langflow.components."
     # e.g., "langflow.components.Notion.add_content_to_page" -> "Notion"
     mod_parts = modname.split(".")

--- a/src/backend/tests/unit/test_load_components.py
+++ b/src/backend/tests/unit/test_load_components.py
@@ -578,6 +578,7 @@ class TestComponentLoading:
         missing dependencies, or initialization failures), it doesn't crash Langflow startup.
         """
         from unittest.mock import patch
+
         from langflow.interface.components import _process_single_module
 
         print("\n" + "=" * 80)
@@ -586,21 +587,21 @@ class TestComponentLoading:
 
         # Test 1: ImportError during module import
         print("\n1. Testing ImportError handling...")
-        with patch('importlib.import_module', side_effect=ImportError("Missing dependency: some_package")):
+        with patch("importlib.import_module", side_effect=ImportError("Missing dependency: some_package")):
             result = _process_single_module("lfx.components.test_module")
             assert result is None, "Should return None when ImportError occurs"
             print("   ✓ ImportError handled correctly")
 
         # Test 2: AttributeError during module import
         print("\n2. Testing AttributeError handling...")
-        with patch('importlib.import_module', side_effect=AttributeError("Module has no attribute 'something'")):
+        with patch("importlib.import_module", side_effect=AttributeError("Module has no attribute 'something'")):
             result = _process_single_module("lfx.components.test_module")
             assert result is None, "Should return None when AttributeError occurs"
             print("   ✓ AttributeError handled correctly")
 
         # Test 3: ConnectionError (e.g., HTTP 503 from external API)
         print("\n3. Testing ConnectionError handling (simulating HTTP 503)...")
-        with patch('importlib.import_module', side_effect=ConnectionError("503 Service Unavailable")):
+        with patch("importlib.import_module", side_effect=ConnectionError("503 Service Unavailable")):
             result = _process_single_module("lfx.components.nvidia.nvidia")
             assert result is None, "Should return None when ConnectionError occurs"
             print("   ✓ ConnectionError handled correctly")
@@ -608,35 +609,36 @@ class TestComponentLoading:
         # Test 4: Generic HTTPError
         print("\n4. Testing HTTPError handling...")
         from urllib3.exceptions import MaxRetryError
-        with patch('importlib.import_module', side_effect=MaxRetryError(None, "", reason="Connection timeout")):
+
+        with patch("importlib.import_module", side_effect=MaxRetryError(None, "", reason="Connection timeout")):
             result = _process_single_module("lfx.components.test_module")
             assert result is None, "Should return None when HTTPError occurs"
             print("   ✓ HTTPError handled correctly")
 
         # Test 5: TimeoutError
         print("\n5. Testing TimeoutError handling...")
-        with patch('importlib.import_module', side_effect=TimeoutError("Request timed out")):
+        with patch("importlib.import_module", side_effect=TimeoutError("Request timed out")):
             result = _process_single_module("lfx.components.test_module")
             assert result is None, "Should return None when TimeoutError occurs"
             print("   ✓ TimeoutError handled correctly")
 
         # Test 6: Generic Exception
         print("\n6. Testing generic Exception handling...")
-        with patch('importlib.import_module', side_effect=Exception("Unexpected error during import")):
+        with patch("importlib.import_module", side_effect=Exception("Unexpected error during import")):
             result = _process_single_module("lfx.components.test_module")
             assert result is None, "Should return None when generic Exception occurs"
             print("   ✓ Generic Exception handled correctly")
 
         # Test 7: RuntimeError (e.g., from component initialization)
         print("\n7. Testing RuntimeError handling...")
-        with patch('importlib.import_module', side_effect=RuntimeError("Component initialization failed")):
+        with patch("importlib.import_module", side_effect=RuntimeError("Component initialization failed")):
             result = _process_single_module("lfx.components.test_module")
             assert result is None, "Should return None when RuntimeError occurs"
             print("   ✓ RuntimeError handled correctly")
 
         # Test 8: ValueError (e.g., from invalid configuration)
         print("\n8. Testing ValueError handling...")
-        with patch('importlib.import_module', side_effect=ValueError("Invalid configuration")):
+        with patch("importlib.import_module", side_effect=ValueError("Invalid configuration")):
             result = _process_single_module("lfx.components.test_module")
             assert result is None, "Should return None when ValueError occurs"
             print("   ✓ ValueError handled correctly")

--- a/src/backend/tests/unit/test_load_components.py
+++ b/src/backend/tests/unit/test_load_components.py
@@ -568,3 +568,80 @@ class TestComponentLoading:
     async def test_component_loading_performance(self):
         """Test the performance of component loading."""
         await import_langflow_components()
+
+    @pytest.mark.no_blockbuster
+    @pytest.mark.asyncio
+    async def test_process_single_module_exception_handling(self):
+        """Test that _process_single_module catches all exceptions during module import and component building.
+
+        This ensures that if a component fails to import or build (e.g., due to network errors,
+        missing dependencies, or initialization failures), it doesn't crash Langflow startup.
+        """
+        from unittest.mock import patch
+        from langflow.interface.components import _process_single_module
+
+        print("\n" + "=" * 80)
+        print("TESTING EXCEPTION HANDLING IN _process_single_module")
+        print("=" * 80)
+
+        # Test 1: ImportError during module import
+        print("\n1. Testing ImportError handling...")
+        with patch('importlib.import_module', side_effect=ImportError("Missing dependency: some_package")):
+            result = _process_single_module("lfx.components.test_module")
+            assert result is None, "Should return None when ImportError occurs"
+            print("   ✓ ImportError handled correctly")
+
+        # Test 2: AttributeError during module import
+        print("\n2. Testing AttributeError handling...")
+        with patch('importlib.import_module', side_effect=AttributeError("Module has no attribute 'something'")):
+            result = _process_single_module("lfx.components.test_module")
+            assert result is None, "Should return None when AttributeError occurs"
+            print("   ✓ AttributeError handled correctly")
+
+        # Test 3: ConnectionError (e.g., HTTP 503 from external API)
+        print("\n3. Testing ConnectionError handling (simulating HTTP 503)...")
+        with patch('importlib.import_module', side_effect=ConnectionError("503 Service Unavailable")):
+            result = _process_single_module("lfx.components.nvidia.nvidia")
+            assert result is None, "Should return None when ConnectionError occurs"
+            print("   ✓ ConnectionError handled correctly")
+
+        # Test 4: Generic HTTPError
+        print("\n4. Testing HTTPError handling...")
+        from urllib3.exceptions import MaxRetryError
+        with patch('importlib.import_module', side_effect=MaxRetryError(None, "", reason="Connection timeout")):
+            result = _process_single_module("lfx.components.test_module")
+            assert result is None, "Should return None when HTTPError occurs"
+            print("   ✓ HTTPError handled correctly")
+
+        # Test 5: TimeoutError
+        print("\n5. Testing TimeoutError handling...")
+        with patch('importlib.import_module', side_effect=TimeoutError("Request timed out")):
+            result = _process_single_module("lfx.components.test_module")
+            assert result is None, "Should return None when TimeoutError occurs"
+            print("   ✓ TimeoutError handled correctly")
+
+        # Test 6: Generic Exception
+        print("\n6. Testing generic Exception handling...")
+        with patch('importlib.import_module', side_effect=Exception("Unexpected error during import")):
+            result = _process_single_module("lfx.components.test_module")
+            assert result is None, "Should return None when generic Exception occurs"
+            print("   ✓ Generic Exception handled correctly")
+
+        # Test 7: RuntimeError (e.g., from component initialization)
+        print("\n7. Testing RuntimeError handling...")
+        with patch('importlib.import_module', side_effect=RuntimeError("Component initialization failed")):
+            result = _process_single_module("lfx.components.test_module")
+            assert result is None, "Should return None when RuntimeError occurs"
+            print("   ✓ RuntimeError handled correctly")
+
+        # Test 8: ValueError (e.g., from invalid configuration)
+        print("\n8. Testing ValueError handling...")
+        with patch('importlib.import_module', side_effect=ValueError("Invalid configuration")):
+            result = _process_single_module("lfx.components.test_module")
+            assert result is None, "Should return None when ValueError occurs"
+            print("   ✓ ValueError handled correctly")
+
+        print("\n" + "=" * 80)
+        print("ALL EXCEPTION HANDLING TESTS PASSED")
+        print("Component failures will not crash Langflow startup")
+        print("=" * 80)


### PR DESCRIPTION
Broadly catch exception when building components on startups. This prevents a single component from crashing Langflow.

For example, if an HTTP request is made to list models from a provider, but that provider is down, we should continue.

Later on, we'll want to surface these errors to the UI somehow, but that's a larger solution.

Patch of https://github.com/langflow-ai/langflow/pull/10037