### PR TITLE
feat: Add container detection utilities for localhost URL transformation

### DIFF
--- a/src/lfx/src/lfx/components/docling/docling_remote.py
+++ b/src/lfx/src/lfx/components/docling/docling_remote.py
@@ -12,6 +12,7 @@ from lfx.base.data import BaseFileComponent
 from lfx.inputs import IntInput, NestedDictInput, StrInput
 from lfx.inputs.inputs import FloatInput
 from lfx.schema import Data
+from lfx.utils.util import transform_localhost_url
 
 
 class DoclingRemoteComponent(BaseFileComponent):
@@ -103,7 +104,9 @@ class DoclingRemoteComponent(BaseFileComponent):
     ]
 
     def process_files(self, file_list: list[BaseFileComponent.BaseFile]) -> list[BaseFileComponent.BaseFile]:
-        base_url = f"{self.api_url}/v1"
+        # Transform localhost URLs to container-accessible hosts when running in a container
+        transformed_url = transform_localhost_url(self.api_url)
+        base_url = f"{transformed_url}/v1"
 
         def _convert_document(client: httpx.Client, file_path: Path, options: dict[str, Any]) -> Data | None:
             encoded_doc = base64.b64encode(file_path.read_bytes()).decode()

--- a/src/lfx/src/lfx/utils/util.py
+++ b/src/lfx/src/lfx/utils/util.py
@@ -2,6 +2,7 @@ import difflib
 import importlib
 import inspect
 import json
+import os
 import re
 from functools import wraps
 from pathlib import Path
@@ -14,6 +15,140 @@ from lfx.schema.data import Data
 from lfx.services.deps import get_settings_service
 from lfx.template.frontend_node.constants import FORCE_SHOW_FIELDS
 from lfx.utils import constants
+
+
+def detect_container_environment() -> str | None:
+    """Detect if running in a container and return the appropriate container type.
+
+    Returns:
+        'docker' if running in Docker, 'podman' if running in Podman, None otherwise.
+    """
+    # Check for .dockerenv file (Docker)
+    if Path("/.dockerenv").exists():
+        return "docker"
+
+    # Check cgroup for container indicators
+    try:
+        with Path("/proc/self/cgroup").open() as f:
+            content = f.read()
+            if "docker" in content:
+                return "docker"
+            if "podman" in content:
+                return "podman"
+    except (FileNotFoundError, PermissionError):
+        pass
+
+    # Check environment variables (lowercase 'container' is the standard for Podman)
+    if os.getenv("container") == "podman":  # noqa: SIM112
+        return "podman"
+
+    return None
+
+
+def get_container_host() -> str | None:
+    """Get the hostname to access host services from within a container.
+
+    Tries multiple methods to find the correct hostname:
+    1. host.containers.internal (Podman) or host.docker.internal (Docker)
+    2. Gateway IP from routing table (fallback for Linux)
+
+    Returns:
+        The hostname or IP to use, or None if not in a container.
+    """
+    import socket
+
+    # Check if we're in a container first
+    container_type = detect_container_environment()
+    if not container_type:
+        return None
+
+    # Try container-specific hostnames first based on detected type
+    if container_type == "podman":
+        # Podman: try host.containers.internal first
+        try:
+            socket.getaddrinfo("host.containers.internal", None)
+        except socket.gaierror:
+            pass
+        else:
+            return "host.containers.internal"
+
+        # Fallback to host.docker.internal (for Podman Desktop on macOS)
+        try:
+            socket.getaddrinfo("host.docker.internal", None)
+        except socket.gaierror:
+            pass
+        else:
+            return "host.docker.internal"
+    else:
+        # Docker: try host.docker.internal first
+        try:
+            socket.getaddrinfo("host.docker.internal", None)
+        except socket.gaierror:
+            pass
+        else:
+            return "host.docker.internal"
+
+        # Fallback to host.containers.internal (unlikely but possible)
+        try:
+            socket.getaddrinfo("host.containers.internal", None)
+        except socket.gaierror:
+            pass
+        else:
+            return "host.containers.internal"
+
+    # Fallback: try to get gateway IP from routing table (Linux containers)
+    try:
+        with Path("/proc/net/route").open() as f:
+            for line in f:
+                fields = line.strip().split()
+                min_field_count = 3  # Minimum fields needed: interface, destination, gateway
+                if len(fields) >= min_field_count and fields[1] == "00000000":  # Default route
+                    # Gateway is in hex format (little-endian)
+                    gateway_hex = fields[2]
+                    # Convert hex to IP address
+                    # The hex is in little-endian format, so we read it backwards in pairs
+                    octets = [gateway_hex[i : i + 2] for i in range(0, 8, 2)]
+                    return ".".join(str(int(octet, 16)) for octet in reversed(octets))
+    except (FileNotFoundError, PermissionError, IndexError, ValueError):
+        pass
+
+    return None
+
+
+def transform_localhost_url(url: str) -> str:
+    """Transform localhost URLs to container-accessible hosts when running in a container.
+
+    Automatically detects if running inside a container and finds the appropriate host
+    address to replace localhost/127.0.0.1. Tries in order:
+    - host.docker.internal (if resolvable)
+    - host.containers.internal (if resolvable)
+    - Gateway IP from routing table (fallback)
+
+    Args:
+        url: The original URL
+
+    Returns:
+        Transformed URL with container-accessible host if applicable, otherwise the original URL.
+
+    Example:
+        >>> transform_localhost_url("http://localhost:5001")
+        # Returns "http://host.docker.internal:5001" if running in Docker and hostname resolves
+        # Returns "http://172.17.0.1:5001" if running in Docker on Linux (gateway IP fallback)
+        # Returns "http://localhost:5001" if not in a container
+    """
+    container_host = get_container_host()
+
+    if not container_host:
+        return url
+
+    # Replace localhost and 127.0.0.1 with the container host
+    localhost_patterns = ["localhost", "127.0.0.1"]
+
+    for pattern in localhost_patterns:
+        if pattern in url:
+            return url.replace(pattern, container_host)
+
+    return url
 
 
 def unescape_string(s: str):

--- a/src/lfx/tests/unit/utils/__init__.py
+++ b/src/lfx/tests/unit/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for utility functions."""

--- a/src/lfx/tests/unit/utils/test_container_utils.py
+++ b/src/lfx/tests/unit/utils/test_container_utils.py
@@ -1,0 +1,260 @@
+"""Test container detection and URL transformation utilities."""
+
+import socket
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+from lfx.utils.util import detect_container_environment, get_container_host, transform_localhost_url
+
+
+class TestDetectContainerEnvironment:
+    """Test the detect_container_environment function."""
+
+    def test_detects_docker_via_dockerenv(self):
+        """Test detection of Docker via .dockerenv file."""
+        with patch.object(Path, "exists", return_value=True):
+            result = detect_container_environment()
+            assert result == "docker"
+
+    def test_detects_docker_via_cgroup(self):
+        """Test detection of Docker via /proc/self/cgroup."""
+        mock_cgroup_content = """12:cpuset:/docker/abc123
+11:memory:/docker/abc123
+10:devices:/docker/abc123"""
+
+        mock_file = mock_open(read_data=mock_cgroup_content)
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch.object(Path, "open", mock_file),
+        ):
+            result = detect_container_environment()
+            assert result == "docker"
+
+    def test_detects_podman_via_cgroup(self):
+        """Test detection of Podman via /proc/self/cgroup."""
+        mock_cgroup_content = """12:cpuset:/podman/xyz789
+11:memory:/podman/xyz789"""
+
+        mock_file = mock_open(read_data=mock_cgroup_content)
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch.object(Path, "open", mock_file),
+        ):
+            result = detect_container_environment()
+            assert result == "podman"
+
+    def test_detects_podman_via_env_var(self):
+        """Test detection of Podman via container environment variable."""
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch("os.getenv", return_value="podman"),
+        ):
+            result = detect_container_environment()
+            assert result == "podman"
+
+    def test_returns_none_when_not_in_container(self):
+        """Test returns None when not running in a container."""
+        mock_cgroup_content = """12:cpuset:/
+11:memory:/"""
+
+        mock_file = mock_open(read_data=mock_cgroup_content)
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch.object(Path, "open", mock_file),
+            patch("os.getenv", return_value=None),
+        ):
+            result = detect_container_environment()
+            assert result is None
+
+    def test_handles_missing_cgroup_file(self):
+        """Test gracefully handles missing /proc/self/cgroup file."""
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch.object(Path, "open", side_effect=FileNotFoundError),
+            patch("os.getenv", return_value=None),
+        ):
+            result = detect_container_environment()
+            assert result is None
+
+    def test_handles_permission_error_on_cgroup(self):
+        """Test gracefully handles permission error on /proc/self/cgroup."""
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch.object(Path, "open", side_effect=PermissionError),
+            patch("os.getenv", return_value=None),
+        ):
+            result = detect_container_environment()
+            assert result is None
+
+
+class TestGetContainerHost:
+    """Test the get_container_host function."""
+
+    def test_returns_none_when_not_in_container(self):
+        """Test returns None when not in a container."""
+        with patch("lfx.utils.util.detect_container_environment", return_value=None):
+            result = get_container_host()
+            assert result is None
+
+    def test_returns_docker_internal_when_resolvable(self):
+        """Test returns host.docker.internal when it resolves (Docker Desktop)."""
+        with (
+            patch("lfx.utils.util.detect_container_environment", return_value="docker"),
+            patch("socket.getaddrinfo") as mock_getaddrinfo,
+        ):
+            # First call succeeds (host.docker.internal resolves)
+            mock_getaddrinfo.return_value = [("dummy", "data")]
+
+            result = get_container_host()
+            assert result == "host.docker.internal"
+            mock_getaddrinfo.assert_called_once_with("host.docker.internal", None)
+
+    def test_returns_containers_internal_when_docker_internal_fails(self):
+        """Test returns host.containers.internal when host.docker.internal doesn't resolve."""
+        with (
+            patch("lfx.utils.util.detect_container_environment", return_value="podman"),
+            patch("socket.getaddrinfo") as mock_getaddrinfo,
+        ):
+            # First call fails (host.docker.internal doesn't resolve)
+            # Second call succeeds (host.containers.internal resolves)
+            def side_effect(hostname, _port):
+                msg = "Name or service not known"
+                if hostname == "host.docker.internal":
+                    raise socket.gaierror(msg)
+                return [("dummy", "data")]
+
+            mock_getaddrinfo.side_effect = side_effect
+
+            result = get_container_host()
+            assert result == "host.containers.internal"
+
+    def test_returns_gateway_ip_when_no_special_hosts_resolve(self):
+        """Test returns gateway IP from routing table when special hostnames don't resolve (Linux)."""
+        # Mock routing table with gateway 172.17.0.1
+        # Gateway hex 0111A8C0 = 01 11 A8 C0 in little-endian = C0.A8.11.01 = 192.168.17.1
+        # Format: Iface Destination Gateway Flags RefCnt Use Metric Mask MTU Window IRTT
+        mock_route_content = """Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+eth0	00000000	0111A8C0	0003	0	0	0	00000000	0	0	0
+eth0	0011A8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0"""
+
+        mock_file = mock_open(read_data=mock_route_content)
+        with (
+            patch("lfx.utils.util.detect_container_environment", return_value="docker"),
+            patch("socket.getaddrinfo", side_effect=socket.gaierror),
+            patch.object(Path, "open", mock_file),
+        ):
+            result = get_container_host()
+            # 0111A8C0 reversed in pairs: C0.A8.11.01 = 192.168.17.1
+            assert result == "192.168.17.1"
+
+    def test_returns_none_when_all_methods_fail(self):
+        """Test returns None when all detection methods fail."""
+        with (
+            patch("lfx.utils.util.detect_container_environment", return_value="docker"),
+            patch("socket.getaddrinfo", side_effect=socket.gaierror),
+            patch.object(Path, "open", side_effect=FileNotFoundError),
+        ):
+            result = get_container_host()
+            assert result is None
+
+    def test_handles_malformed_routing_table(self):
+        """Test gracefully handles malformed routing table."""
+        mock_route_content = """invalid data here"""
+
+        mock_file = mock_open(read_data=mock_route_content)
+        with (
+            patch("lfx.utils.util.detect_container_environment", return_value="docker"),
+            patch("socket.getaddrinfo", side_effect=socket.gaierror),
+            patch.object(Path, "open", mock_file),
+        ):
+            result = get_container_host()
+            assert result is None
+
+
+class TestTransformLocalhostUrl:
+    """Test the transform_localhost_url function."""
+
+    def test_returns_original_url_when_not_in_container(self):
+        """Test returns original URL when not in a container."""
+        with patch("lfx.utils.util.get_container_host", return_value=None):
+            url = "http://localhost:5001/api"
+            result = transform_localhost_url(url)
+            assert result == url
+
+    def test_transforms_localhost_to_docker_internal(self):
+        """Test transforms localhost to host.docker.internal in Docker."""
+        with patch("lfx.utils.util.get_container_host", return_value="host.docker.internal"):
+            url = "http://localhost:5001/api"
+            result = transform_localhost_url(url)
+            assert result == "http://host.docker.internal:5001/api"
+
+    def test_transforms_127001_to_docker_internal(self):
+        """Test transforms 127.0.0.1 to host.docker.internal in Docker."""
+        with patch("lfx.utils.util.get_container_host", return_value="host.docker.internal"):
+            url = "http://127.0.0.1:5001/api"
+            result = transform_localhost_url(url)
+            assert result == "http://host.docker.internal:5001/api"
+
+    def test_transforms_localhost_to_containers_internal(self):
+        """Test transforms localhost to host.containers.internal in Podman."""
+        with patch("lfx.utils.util.get_container_host", return_value="host.containers.internal"):
+            url = "http://localhost:5001/api"
+            result = transform_localhost_url(url)
+            assert result == "http://host.containers.internal:5001/api"
+
+    def test_transforms_127001_to_containers_internal(self):
+        """Test transforms 127.0.0.1 to host.containers.internal in Podman."""
+        with patch("lfx.utils.util.get_container_host", return_value="host.containers.internal"):
+            url = "http://127.0.0.1:5001/api"
+            result = transform_localhost_url(url)
+            assert result == "http://host.containers.internal:5001/api"
+
+    def test_transforms_localhost_to_gateway_ip_on_linux(self):
+        """Test transforms localhost to gateway IP on Linux containers."""
+        with patch("lfx.utils.util.get_container_host", return_value="172.17.0.1"):
+            url = "http://localhost:5001/api"
+            result = transform_localhost_url(url)
+            assert result == "http://172.17.0.1:5001/api"
+
+    def test_transforms_127001_to_gateway_ip_on_linux(self):
+        """Test transforms 127.0.0.1 to gateway IP on Linux containers."""
+        with patch("lfx.utils.util.get_container_host", return_value="172.17.0.1"):
+            url = "http://127.0.0.1:5001/api"
+            result = transform_localhost_url(url)
+            assert result == "http://172.17.0.1:5001/api"
+
+    def test_does_not_transform_non_localhost_urls(self):
+        """Test does not transform URLs that don't contain localhost or 127.0.0.1."""
+        with patch("lfx.utils.util.get_container_host", return_value="host.docker.internal"):
+            url = "http://example.com:5001/api"
+            result = transform_localhost_url(url)
+            assert result == url
+
+    def test_transforms_url_without_path(self):
+        """Test transforms URL without path."""
+        with patch("lfx.utils.util.get_container_host", return_value="host.docker.internal"):
+            url = "http://localhost:5001"
+            result = transform_localhost_url(url)
+            assert result == "http://host.docker.internal:5001"
+
+    def test_transforms_url_with_complex_path(self):
+        """Test transforms URL with complex path and query parameters."""
+        with patch("lfx.utils.util.get_container_host", return_value="host.docker.internal"):
+            url = "http://localhost:5001/api/v1/convert?format=json&timeout=30"
+            result = transform_localhost_url(url)
+            assert result == "http://host.docker.internal:5001/api/v1/convert?format=json&timeout=30"
+
+    def test_transforms_https_url(self):
+        """Test transforms HTTPS URLs."""
+        with patch("lfx.utils.util.get_container_host", return_value="host.docker.internal"):
+            url = "https://localhost:5001/api"
+            result = transform_localhost_url(url)
+            assert result == "https://host.docker.internal:5001/api"
+
+    def test_transforms_url_without_port(self):
+        """Test transforms URL without explicit port."""
+        with patch("lfx.utils.util.get_container_host", return_value="host.docker.internal"):
+            url = "http://localhost/api"
+            result = transform_localhost_url(url)
+            assert result == "http://host.docker.internal/api"


### PR DESCRIPTION
Adds a util to detect if we're running in a container and updates the localhost address accordingly
host.containers.internal for podman
host.docker.internal for docker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically adjusts localhost API URLs when running inside containers, improving connectivity in Docker/Podman environments without manual configuration.
  - More robust host resolution with fallbacks to ensure reliable API access across platforms.

- Tests
  - Added comprehensive unit tests covering container detection, host resolution, routing fallbacks, and URL transformation, including edge cases and failure paths.

- Documentation
  - Added descriptive docstring to utility test module for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->