### PR TITLE
fix: add back news rss comps

### DIFF
--- a/src/backend/tests/unit/components/data/test_news_search.py
+++ b/src/backend/tests/unit/components/data/test_news_search.py
@@ -1,0 +1,88 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from lfx.components.data.news_search import NewsSearchComponent
+from lfx.schema import DataFrame
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestNewsSearchComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return NewsSearchComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {"query": "OpenAI"}
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    def test_successful_news_search(self):
+        # Mock Google News RSS feed content
+        mock_rss_content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <title>Test News 1</title>
+                    <link>https://example.com/1</link>
+                    <pubDate>2024-03-20</pubDate>
+                    <description>Summary 1</description>
+                </item>
+                <item>
+                    <title>Test News 2</title>
+                    <link>https://example.com/2</link>
+                    <pubDate>2024-03-21</pubDate>
+                    <description>Summary 2</description>
+                </item>
+            </channel>
+        </rss>
+        """
+        mock_response = Mock()
+        mock_response.content = mock_rss_content.encode("utf-8")
+        mock_response.raise_for_status = Mock()
+
+        with patch("requests.get", return_value=mock_response):
+            component = NewsSearchComponent(query="OpenAI")
+            result = component.search_news()
+            assert isinstance(result, DataFrame)
+            news_results_df = result
+            assert len(news_results_df) == 2
+            assert list(news_results_df.columns) == ["title", "link", "published", "summary"]
+            assert news_results_df.iloc[0]["title"] == "Test News 1"
+            assert news_results_df.iloc[1]["title"] == "Test News 2"
+
+    def test_news_search_error(self):
+        with patch("requests.get", side_effect=requests.RequestException("Network error")):
+            component = NewsSearchComponent(query="OpenAI")
+            result = component.search_news()
+            assert isinstance(result, DataFrame)
+            news_results_df = result
+            assert len(news_results_df) == 1
+            assert news_results_df.iloc[0]["title"] == "Error"
+            assert "Network error" in news_results_df.iloc[0]["summary"]
+
+    def test_empty_news_results(self):
+        # Mock empty RSS feed
+        mock_rss_content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+            </channel>
+        </rss>
+        """
+        mock_response = Mock()
+        mock_response.content = mock_rss_content.encode("utf-8")
+        mock_response.raise_for_status = Mock()
+
+        with patch("requests.get", return_value=mock_response):
+            component = NewsSearchComponent(query="OpenAI")
+            result = component.search_news()
+            assert isinstance(result, DataFrame)
+            news_results_df = result
+            assert len(news_results_df) == 1
+            assert news_results_df.iloc[0]["title"] == "No articles found"

--- a/src/backend/tests/unit/components/data/test_rss.py
+++ b/src/backend/tests/unit/components/data/test_rss.py
@@ -1,0 +1,129 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from lfx.components.data.rss import RSSReaderComponent
+from lfx.schema import DataFrame
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestRSSReaderComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        """Return the component class to test."""
+        return RSSReaderComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        """Return the default kwargs for the component."""
+        return {
+            "rss_url": "https://example.com/feed.xml",
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        """Return an empty list since this component doesn't have version-specific files."""
+        return []
+
+    def test_successful_rss_fetch(self):
+        # Mock RSS feed content
+        mock_rss_content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <title>Test Article 1</title>
+                    <link>https://example.com/1</link>
+                    <pubDate>2024-03-20</pubDate>
+                    <description>Test summary 1</description>
+                </item>
+                <item>
+                    <title>Test Article 2</title>
+                    <link>https://example.com/2</link>
+                    <pubDate>2024-03-21</pubDate>
+                    <description>Test summary 2</description>
+                </item>
+            </channel>
+        </rss>
+        """
+
+        # Mock the requests.get response
+        mock_response = Mock()
+        mock_response.content = mock_rss_content.encode("utf-8")
+        mock_response.raise_for_status = Mock()
+
+        with patch("requests.get", return_value=mock_response):
+            component = RSSReaderComponent(rss_url="https://example.com/feed.xml")
+            result = component.read_rss()
+
+            assert isinstance(result, DataFrame)
+            assert len(result) == 2
+            assert list(result.columns) == ["title", "link", "published", "summary"]
+            assert result.iloc[0]["title"] == "Test Article 1"
+            assert result.iloc[1]["title"] == "Test Article 2"
+
+    def test_rss_fetch_with_missing_fields(self):
+        # Mock RSS feed content with missing fields
+        mock_rss_content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <title>Test Article</title>
+                    <!-- Missing link -->
+                    <pubDate>2024-03-20</pubDate>
+                    <!-- Missing description -->
+                </item>
+            </channel>
+        </rss>
+        """
+
+        mock_response = Mock()
+        mock_response.content = mock_rss_content.encode("utf-8")
+        mock_response.raise_for_status = Mock()
+
+        with patch("requests.get", return_value=mock_response):
+            component = RSSReaderComponent(rss_url="https://example.com/feed.xml")
+            result = component.read_rss()
+
+            assert isinstance(result, DataFrame)
+            assert len(result) == 1
+            assert result.iloc[0]["title"] == "Test Article"
+            assert result.iloc[0]["link"] == ""
+            assert result.iloc[0]["summary"] == ""
+
+    def test_rss_fetch_error(self):
+        # Mock a failed request
+        with patch("requests.get", side_effect=requests.RequestException("Network error")):
+            component = RSSReaderComponent(rss_url="https://example.com/feed.xml")
+            result = component.read_rss()
+
+            assert isinstance(result, DataFrame)
+            assert len(result) == 1
+            assert result.iloc[0]["title"] == "Error"
+            assert result.iloc[0]["link"] == ""
+            assert result.iloc[0]["published"] == ""
+            assert "Network error" in result.iloc[0]["summary"]
+
+    def test_empty_rss_feed(self):
+        # Mock empty RSS feed
+        mock_rss_content = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+            </channel>
+        </rss>
+        """
+
+        mock_response = Mock()
+        mock_response.content = mock_rss_content.encode("utf-8")
+        mock_response.raise_for_status = Mock()
+
+        with patch("requests.get", return_value=mock_response):
+            component = RSSReaderComponent(rss_url="https://example.com/feed.xml")
+            result = component.read_rss()
+
+            assert isinstance(result, DataFrame)
+            assert len(result) == 0
+            assert list(result.columns) == ["title", "link", "published", "summary"]

--- a/src/lfx/src/lfx/components/data/news_search.py
+++ b/src/lfx/src/lfx/components/data/news_search.py
@@ -1,0 +1,164 @@
+from urllib.parse import quote_plus
+
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+
+from lfx.custom import Component
+from lfx.io import IntInput, MessageTextInput, Output
+from lfx.schema import DataFrame
+
+
+class NewsSearchComponent(Component):
+    display_name = "News Search"
+    description = "Searches Google News via RSS. Returns clean article data."
+    documentation: str = "https://docs.langflow.org/components-data#news-search"
+    icon = "newspaper"
+    name = "NewsSearch"
+
+    inputs = [
+        MessageTextInput(
+            name="query",
+            display_name="Search Query",
+            info="Search keywords for news articles.",
+            tool_mode=True,
+            required=True,
+        ),
+        MessageTextInput(
+            name="hl",
+            display_name="Language (hl)",
+            info="Language code, e.g. en-US, fr, de. Default: en-US.",
+            tool_mode=False,
+            input_types=[],
+            required=False,
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="gl",
+            display_name="Country (gl)",
+            info="Country code, e.g. US, FR, DE. Default: US.",
+            tool_mode=False,
+            input_types=[],
+            required=False,
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="ceid",
+            display_name="Country:Language (ceid)",
+            info="e.g. US:en, FR:fr. Default: US:en.",
+            tool_mode=False,
+            value="US:en",
+            input_types=[],
+            required=False,
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="topic",
+            display_name="Topic",
+            info="One of: WORLD, NATION, BUSINESS, TECHNOLOGY, ENTERTAINMENT, SCIENCE, SPORTS, HEALTH.",
+            tool_mode=False,
+            input_types=[],
+            required=False,
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="location",
+            display_name="Location (Geo)",
+            info="City, state, or country for location-based news. Leave blank for keyword search.",
+            tool_mode=False,
+            input_types=[],
+            required=False,
+            advanced=True,
+        ),
+        IntInput(
+            name="timeout",
+            display_name="Timeout",
+            info="Timeout for the request in seconds.",
+            value=5,
+            required=False,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [Output(name="articles", display_name="News Articles", method="search_news")]
+
+    def search_news(self) -> DataFrame:
+        # Defaults
+        hl = getattr(self, "hl", None) or "en-US"
+        gl = getattr(self, "gl", None) or "US"
+        ceid = getattr(self, "ceid", None) or f"{gl}:{hl.split('-')[0]}"
+        topic = getattr(self, "topic", None)
+        location = getattr(self, "location", None)
+        query = getattr(self, "query", None)
+
+        # Build base URL
+        if topic:
+            # Topic-based feed
+            base_url = f"https://news.google.com/rss/headlines/section/topic/{quote_plus(topic.upper())}"
+            params = f"?hl={hl}&gl={gl}&ceid={ceid}"
+            rss_url = base_url + params
+        elif location:
+            # Location-based feed
+            base_url = f"https://news.google.com/rss/headlines/section/geo/{quote_plus(location)}"
+            params = f"?hl={hl}&gl={gl}&ceid={ceid}"
+            rss_url = base_url + params
+        elif query:
+            # Keyword search feed
+            base_url = "https://news.google.com/rss/search?q="
+            query_parts = [query]
+            query_encoded = quote_plus(" ".join(query_parts))
+            params = f"&hl={hl}&gl={gl}&ceid={ceid}"
+            rss_url = f"{base_url}{query_encoded}{params}"
+        else:
+            self.status = "No search query, topic, or location provided."
+            self.log(self.status)
+            return DataFrame(
+                pd.DataFrame(
+                    [
+                        {
+                            "title": "Error",
+                            "link": "",
+                            "published": "",
+                            "summary": "No search query, topic, or location provided.",
+                        }
+                    ]
+                )
+            )
+
+        try:
+            response = requests.get(rss_url, timeout=self.timeout)
+            response.raise_for_status()
+            soup = BeautifulSoup(response.content, "xml")
+            items = soup.find_all("item")
+        except requests.RequestException as e:
+            self.status = f"Failed to fetch news: {e}"
+            self.log(self.status)
+            return DataFrame(pd.DataFrame([{"title": "Error", "link": "", "published": "", "summary": str(e)}]))
+        except (AttributeError, ValueError, TypeError) as e:
+            self.status = f"Unexpected error: {e!s}"
+            self.log(self.status)
+            return DataFrame(pd.DataFrame([{"title": "Error", "link": "", "published": "", "summary": str(e)}]))
+
+        if not items:
+            self.status = "No news articles found."
+            self.log(self.status)
+            return DataFrame(pd.DataFrame([{"title": "No articles found", "link": "", "published": "", "summary": ""}]))
+
+        articles = []
+        for item in items:
+            try:
+                title = self.clean_html(item.title.text if item.title else "")
+                link = item.link.text if item.link else ""
+                published = item.pubDate.text if item.pubDate else ""
+                summary = self.clean_html(item.description.text if item.description else "")
+                articles.append({"title": title, "link": link, "published": published, "summary": summary})
+            except (AttributeError, ValueError, TypeError) as e:
+                self.log(f"Error parsing article: {e!s}")
+                continue
+
+        df_articles = pd.DataFrame(articles)
+        self.log(f"Found {len(df_articles)} articles.")
+        return DataFrame(df_articles)
+
+    def clean_html(self, html_string: str) -> str:
+        return BeautifulSoup(html_string, "html.parser").get_text(separator=" ", strip=True)

--- a/src/lfx/src/lfx/components/data/news_search.py
+++ b/src/lfx/src/lfx/components/data/news_search.py
@@ -15,6 +15,9 @@ class NewsSearchComponent(Component):
     documentation: str = "https://docs.langflow.org/components-data#news-search"
     icon = "newspaper"
     name = "NewsSearch"
+    legacy = True
+    replacement = "data.WebSearch"
+
 
     inputs = [
         MessageTextInput(

--- a/src/lfx/src/lfx/components/data/rss.py
+++ b/src/lfx/src/lfx/components/data/rss.py
@@ -1,0 +1,69 @@
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+
+from lfx.custom import Component
+from lfx.io import IntInput, MessageTextInput, Output
+from lfx.log.logger import logger
+from lfx.schema import DataFrame
+
+
+class RSSReaderComponent(Component):
+    display_name = "RSS Reader"
+    description = "Fetches and parses an RSS feed."
+    documentation: str = "https://docs.langflow.org/components-data#rss-reader"
+    icon = "rss"
+    name = "RSSReaderSimple"
+
+    inputs = [
+        MessageTextInput(
+            name="rss_url",
+            display_name="RSS Feed URL",
+            info="URL of the RSS feed to parse.",
+            tool_mode=True,
+            required=True,
+        ),
+        IntInput(
+            name="timeout",
+            display_name="Timeout",
+            info="Timeout for the RSS feed request.",
+            value=5,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [Output(name="articles", display_name="Articles", method="read_rss")]
+
+    def read_rss(self) -> DataFrame:
+        try:
+            response = requests.get(self.rss_url, timeout=self.timeout)
+            response.raise_for_status()
+            if not response.content.strip():
+                msg = "Empty response received"
+                raise ValueError(msg)
+            # Check if the response is valid XML
+            try:
+                BeautifulSoup(response.content, "xml")
+            except Exception as e:
+                msg = f"Invalid XML response: {e}"
+                raise ValueError(msg) from e
+            soup = BeautifulSoup(response.content, "xml")
+            items = soup.find_all("item")
+        except (requests.RequestException, ValueError) as e:
+            self.status = f"Failed to fetch RSS: {e}"
+            return DataFrame(pd.DataFrame([{"title": "Error", "link": "", "published": "", "summary": str(e)}]))
+
+        articles = [
+            {
+                "title": item.title.text if item.title else "",
+                "link": item.link.text if item.link else "",
+                "published": item.pubDate.text if item.pubDate else "",
+                "summary": item.description.text if item.description else "",
+            }
+            for item in items
+        ]
+
+        # Ensure the DataFrame has the correct columns even if empty
+        df_articles = pd.DataFrame(articles, columns=["title", "link", "published", "summary"])
+        logger.info(f"Fetched {len(df_articles)} articles.")
+        return DataFrame(df_articles)

--- a/src/lfx/src/lfx/components/data/rss.py
+++ b/src/lfx/src/lfx/components/data/rss.py
@@ -14,6 +14,8 @@ class RSSReaderComponent(Component):
     documentation: str = "https://docs.langflow.org/components-data#rss-reader"
     icon = "rss"
     name = "RSSReaderSimple"
+    legacy = True
+    replacement = "data.WebSearch"
 
     inputs = [
         MessageTextInput(


### PR DESCRIPTION
These components were accidentally removed instead of being deprecated first; this just adds them back until we decide to eventually clean up the deprecated components. 

Original PR: https://github.com/langflow-ai/langflow/pull/9975