### PR TITLE
fix: make cache default in MCP component

### DIFF
--- a/src/lfx/src/lfx/components/agents/mcp_component.py
+++ b/src/lfx/src/lfx/components/agents/mcp_component.py
@@ -76,7 +76,7 @@ class MCPToolsComponent(ComponentWithCache):
                 "Enable caching of MCP Server and tools to improve performance. "
                 "Disable to always fetch fresh tools and server updates."
             ),
-            value=False,
+            value=True,
             advanced=True,
         ),
         DropdownInput(


### PR DESCRIPTION
This pull request makes a small configuration change to the caching behavior in the MCP component. The default value for enabling caching of the MCP server and tools has been switched from `False` to `True`, which will improve performance by using cached data unless explicitly disabled.

* Default value for `enable_cache` in `_ensure_cache_structure` has been changed to `True` to improve performance.