### PR TITLE
docs: 1.7 release branch

### DIFF
--- a/docs/docs/Develop/api-keys-and-authentication.mdx
+++ b/docs/docs/Develop/api-keys-and-authentication.mdx
@@ -27,6 +27,7 @@ You can use Langflow API keys to interact with Langflow programmatically.
 
 By default, most Langflow API endpoints, such as `/v1/run/$FLOW_ID`, require authentication with a Langflow API key.
 
+To require API key authentication for flow webhook endpoints, use the [`LANGFLOW_WEBHOOK_AUTH_ENABLE`](/webhook#require-authentication-for-webhooks) environment variable.
 To configure authentication for Langflow MCP servers, see [Use Langflow as an MCP server](/mcp-server).
 
 ### Langflow API key permissions

--- a/docs/docs/Flows/webhook.mdx
+++ b/docs/docs/Flows/webhook.mdx
@@ -88,6 +88,12 @@ For the preceding example, the parsed payload would be a string like `ID: 12345 
 Typically, you won't manually trigger the **Webhook** component.
 To learn about triggering flows with payloads from external applications, see the video tutorial [How to Use Webhooks in Langflow](https://www.youtube.com/watch?v=IC1CAtzFRE0).
 
+## Require authentication for webhooks {#require-authentication-for-webhooks}
+
+By default, webhooks run as the flow owner without authentication (`LANGFLOW_WEBHOOK_AUTH_ENABLE=False`).
+
+If you want to require API key authentication for webhooks, set `LANGFLOW_WEBHOOK_AUTH_ENABLE=True`.
+
 ## Troubleshoot flows with Webhook components
 
 Use the following information to help address common issues that can occur with the **Webhook** component.

--- a/docs/docs/Support/release-notes.mdx
+++ b/docs/docs/Support/release-notes.mdx
@@ -47,6 +47,22 @@ To avoid the impact of potential breaking changes and test new versions, the Lan
 
     If you made changes to your flows in the isolated installation, you might want to export and import those flows back to your upgraded primary installation so you don't have to repeat the component upgrade process.
 
+## 1.7.0
+
+Highlights of this release include the following changes.
+For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/releases).
+
+### New features and enhancements
+
+- Webhook authentication
+
+    Added the `LANGFLOW_WEBHOOK_AUTH_ENABLE` environment variable for authenticating requests to the [/webhook endpoint](/api-flows-run#webhook-run-flow). When `LANGFLOW_WEBHOOK_AUTH_ENABLE=TRUE`, webhook endpoints require API key authentication and validate that the authenticated user owns the flow being executed. When `FALSE`, no Langflow API key is required.
+
+- New integrations and bundles:
+
+### Deprecations
+
+
 ## 1.6.0
 
 Highlights of this release include the following changes.


### PR DESCRIPTION
This branch accepts docs PRs for Langflow v1.7 features, and will merge at release.

[Preview build](https://d5rxiv0do0q3v.cloudfront.net/langflow-drafts/docs-1.6/index.html)

[Release notes](https://d5rxiv0do0q3v.cloudfront.net/langflow-drafts/docs-1.6/release-notes.html)

Preview links:


Before release, check:

    Links from release notes to added feature.
    Parity with main.