### PR TITLE
docs: update LF Desktop logging path

### DIFF
--- a/docs/docs/Develop/logging.mdx
+++ b/docs/docs/Develop/logging.mdx
@@ -160,7 +160,7 @@ Follow the steps for your operating system.
 1. Open the Command Prompt (CMD), and then run the following command:
 
    ```cmd
-   cd %APPDATA%\com.LangflowDesktop\cache
+   cd %LOCALAPPDATA%\com.LangflowDesktop\cache
    ```
 
 2. Open the folder and view the log files:


### PR DESCRIPTION
LF Desktop log storage paths:

    - **macOS**: `/Users/<username>/Library/Logs/com.LangflowDesktop`
    - **Windows**: `C:\Users\<username>\AppData\Roaming\com.LangflowDesktop\cache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated logging docs to reflect Langflow Desktop naming across macOS and Windows.
  - Revised log directory and cache paths; refreshed example commands in “Log storage” and “Access Langflow Desktop logs.”
  - Corrected path notation to match OS conventions for each platform.
  - Improves clarity and consistency when locating and accessing desktop logs.
  - No functional changes for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->