### PR TITLE
docs: auto-add projects as MCP servers 

### DIFF
--- a/docs/docs/Agents/mcp-server.mdx
+++ b/docs/docs/Agents/mcp-server.mdx
@@ -25,10 +25,13 @@ For information about using Langflow as an MCP client and managing MCP server co
 
 ## Serve flows as MCP tools {#select-flows-to-serve}
 
-Each [Langflow project](/concepts-flows#projects) has an MCP server that exposes the project's flows as tools for use by MCP clients.
+When you create a [Langflow project](/concepts-flows#projects), Langflow automatically adds the project to your MCP server's configuration and makes the project's flows available as MCP tools.
 
-By default, all flows in a project are exposed as tools on the project's MCP server.
-You can change the exposed flows and tool metadata by managing the MCP server settings:
+If your Langflow server has authentication enabled (`AUTO_LOGIN=false`), the project's MCP server is automatically configured with API key authentication, and a new API key is generated specifically for accessing the new project's flows. See [MCP server authentication](#authentication).
+
+To disable automatic MCP server configuration for new projects, set the `LANGFLOW_ADD_PROJECTS_TO_MCP_SERVERS` environment variable to `false`. See [MCP server environment variables](#mcp-server-environment-variables).
+
+Even with automatic configuration enabled, you can still manually select which projects are exposed as MCP tools:
 
 1. Click the **MCP Server** tab on the [**Projects** page](/concepts-flows#projects), or, when editing a flow, click **Share**, and then select **MCP Server**.
 
@@ -207,6 +210,8 @@ For more information, see the MCP documentation for your client, such as [Cursor
 
 Each [Langflow project](/concepts-flows#projects) has its own MCP server with its own MCP server authentication settings.
 
+When you create a new project, Langflow automatically configures authentication for the project's MCP server based on your Langflow server's authentication settings. If authentication is enabled (`AUTO_LOGIN=false`), the project is automatically configured with API key authentication, and a new API key is generated for accessing the project's flows.
+
 To configure authentication for a Langflow MCP server, go to the **Projects** page in Langflow, click the **MCP Server** tab, click <Icon name="Fingerprint" aria-hidden="true"/> **Edit Auth**, and then select your preferred authentication method:
 
 <Tabs groupId="auth-type">
@@ -287,6 +292,7 @@ The following environment variables set behaviors related to your Langflow proje
 | `LANGFLOW_MCP_SERVER_ENABLE_PROGRESS_NOTIFICATIONS` | Boolean | `False` | If `true`, Langflow MCP servers send progress notifications. |
 | `LANGFLOW_MCP_SERVER_TIMEOUT` | Integer | `20` | The number of seconds to wait before an MCP server operation expires due to poor connectivity or long-running requests. |
 | `LANGFLOW_MCP_MAX_SESSIONS_PER_SERVER` | Integer | `10` | Maximum number of MCP sessions to keep per unique server. |
+| `LANGFLOW_ADD_PROJECTS_TO_MCP_SERVERS` | Boolean | `True` | Whether to automatically add newly created projects to the user's MCP servers configuration. If `false`, projects must be manually added to MCP servers. |
 
 {/* The anchor on this section (deploy-your-server-externally) is currently a link target in the Langflow UI. Do not change. */}
 ### Deploy your Langflow MCP server externally {#deploy-your-server-externally}


### PR DESCRIPTION
This is the default behavior for 1.7.

See #9891 