### PR TITLE
fix: Backport macOS specific ver reqs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,10 @@ dependencies = [
     "cleanlab-tlm>=1.1.2,<2.0.0",
     'gassist>=0.0.1; sys_platform == "win32"',
     "twelvelabs>=0.4.7,<1.0.0",
-    "docling>=2.36.1,<3.0.0",
+    "docling-core>=2.36.1,<3.0.0",
+    "docling>=2.36.1,<3.0.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+    "easyocr>=1.7.2,<2.0.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+    "opencv-python>=4.11,<5.0.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
     "filelock>=3.18.0,<4.0.0",
     "jigsawstack==0.2.7",
     "structlog>=25.4.0,<26.0.0",
@@ -129,8 +132,6 @@ dependencies = [
     "aiosqlite==0.21.0",
     "fastparquet>=2024.11.0,<2025.0.0",
     "traceloop-sdk>=0.43.1,<1.0.0",
-    "easyocr>=1.7.2,<2.0.0",
-    "opencv-python>=4.11,<5.0.0",
 ]
 
 [dependency-groups]
@@ -246,7 +247,7 @@ postgresql = [
 [tool.uv]
 override-dependencies = [
     # temporary force a newer python-pptx
-    "python-pptx>=1.0.2"
+    "python-pptx>=1.0.2",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'darwin'",
@@ -4919,10 +4919,11 @@ dependencies = [
     { name = "composio-langchain" },
     { name = "cryptography" },
     { name = "datasets" },
-    { name = "docling" },
+    { name = "docling", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "docling-core" },
     { name = "dspy-ai" },
     { name = "duckduckgo-search" },
-    { name = "easyocr" },
+    { name = "easyocr", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "elasticsearch" },
     { name = "faiss-cpu" },
     { name = "fake-useragent" },
@@ -4983,7 +4984,7 @@ dependencies = [
     { name = "nltk" },
     { name = "numexpr" },
     { name = "openai" },
-    { name = "opencv-python" },
+    { name = "opencv-python", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "openinference-instrumentation-langchain" },
     { name = "opensearch-py" },
     { name = "opik" },
@@ -5123,10 +5124,11 @@ requires-dist = [
     { name = "cryptography", specifier = ">=43.0.1,<44.0.0" },
     { name = "ctransformers", marker = "extra == 'local'", specifier = ">=0.2.10" },
     { name = "datasets", specifier = ">2.14.7,<4.0.0" },
-    { name = "docling", specifier = ">=2.36.1,<3.0.0" },
+    { name = "docling", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=2.36.1,<3.0.0" },
+    { name = "docling-core", specifier = ">=2.36.1,<3.0.0" },
     { name = "dspy-ai", specifier = "==2.5.41" },
     { name = "duckduckgo-search", specifier = "==7.2.1" },
-    { name = "easyocr", specifier = ">=1.7.2,<2.0.0" },
+    { name = "easyocr", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=1.7.2,<2.0.0" },
     { name = "elasticsearch", specifier = "==8.16.0" },
     { name = "faiss-cpu", specifier = "==1.9.0.post1" },
     { name = "fake-useragent", specifier = "==1.5.1" },
@@ -5192,7 +5194,7 @@ requires-dist = [
     { name = "nv-ingest-client", marker = "python_full_version >= '3.12' and extra == 'nv-ingest'", specifier = "==25.6.3,<26.0.0" },
     { name = "ocrmac", marker = "sys_platform == 'darwin' and extra == 'docling'", specifier = ">=1.0.0" },
     { name = "openai", specifier = ">=1.68.2,<2.0.0" },
-    { name = "opencv-python", specifier = ">=4.11,<5.0.0" },
+    { name = "opencv-python", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=4.11,<5.0.0" },
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.29,<0.1.52" },
     { name = "opensearch-py", specifier = "==2.8.0" },
     { name = "opik", specifier = ">=1.6.3,<2.0.0" },


### PR DESCRIPTION
This pull request updates the dependency configuration in `pyproject.toml` to improve compatibility with different platforms, especially addressing issues for macOS on x86_64 architecture. The main changes involve conditional dependencies for certain packages and the introduction of a new core package.

Dependency updates and platform-specific adjustments:

* Replaced the unconditional `docling` dependency with `docling-core` for all platforms, and made `docling` conditional so it is only installed on platforms other than macOS x86_64.
* Made `easyocr` and `opencv-python` dependencies conditional so they are not installed on macOS x86_64, improving compatibility for that platform.

Minor changes:

* Added a trailing comma to the `python-pptx` override dependency for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform installation reliability, especially on macOS (Intel), by refining platform-specific dependency rules.

* **Chores**
  * Updated core document-processing dependency and aligned related libraries.
  * Applied platform-conditional installs to reduce download size and avoid unnecessary packages on macOS (Intel).
  * Maintained existing dependencies without functional changes.
  * Minor formatting tidy-up in dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->