### PR TITLE
fix: resolve `LANGFLOW_CONFIG_DIR` to absolute and update docker compose to use absolute path

### DIFF
--- a/docker_example/docker-compose.yml
+++ b/docker_example/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - LANGFLOW_DATABASE_URL=postgresql://langflow:langflow@postgres:5432/langflow
       # This variable defines where the logs, file storage, monitor data and secret keys are stored.
-      - LANGFLOW_CONFIG_DIR=app/langflow
+      - LANGFLOW_CONFIG_DIR=/app/langflow
     volumes:
       - langflow-data:/app/langflow
 

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -381,6 +381,8 @@ class Settings(BaseSettings):
 
         if isinstance(value, str):
             value = Path(value)
+        # Resolve to absolute path to handle relative paths correctly
+        value = value.resolve()
         if not value.exists():
             value.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Update the LANGFLOW_CONFIG_DIR to an absolute path in the Docker configuration and enhance the Settings class to resolve relative paths to absolute paths. These changes improve reliability and robustness in various deployment environments.