### PR TITLE
fix: Update Bedrock component replacement class name

### DIFF
--- a/src/lfx/src/lfx/components/amazon/amazon_bedrock_model.py
+++ b/src/lfx/src/lfx/components/amazon/amazon_bedrock_model.py
@@ -15,7 +15,7 @@ class AmazonBedrockComponent(LCModelComponent):
     icon = "Amazon"
     name = "AmazonBedrockModel"
     legacy = True
-    replacement = "amazon.AmazonBedrockConverseComponent"
+    replacement = "amazon.AmazonBedrockConverseModel"
 
     inputs = [
         *LCModelComponent.get_base_inputs(),


### PR DESCRIPTION
This pull request updates the replacement class name for the Amazon Bedrock model component to ensure consistency with the intended naming convention.

Component metadata update:

* Changed the `replacement` attribute in the `AmazonBedrockComponent` class from `amazon.AmazonBedrockConverseComponent` to `amazon.AmazonBedrockConverseModel` in `amazon_bedrock_model.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the replacement reference in the Amazon Bedrock component to point to Amazon Bedrock Converse Model, ensuring accurate guidance.

* **Documentation**
  * Updated public-facing references and configuration guidance to use the correct Amazon Bedrock Converse Model name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->