### PR TITLE
fix: Reduce toggle button size

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/featureTogglesComponent.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/featureTogglesComponent.tsx
@@ -40,6 +40,7 @@ const FeatureToggles = ({
             checked={toggle.checked}
             onCheckedChange={toggle.onChange}
             data-testid={toggle.testId}
+            className="scale-90"
           />
         </div>
       ))}


### PR DESCRIPTION
Reduces Beta and Legacy toggle switches to 90% size for better visual consistency.

🤖 Generated with [Claude Code](https://claude.ai/code)