### PR TITLE
Fix: Always fetch withCounts from inside the canvas

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/mcpComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/mcpComponent/index.tsx
@@ -17,7 +17,7 @@ export default function McpComponent({
   id = "",
 }: InputProps<string, any>): JSX.Element {
   const [open, setOpen] = useState(false);
-  const { data: mcpServers } = useGetMCPServers({ withCounts: open });
+  const { data: mcpServers } = useGetMCPServers({ withCounts: true });
   const { mutate: addMcpServer } = useAddMCPServer();
   const setErrorData = useAlertStore((state) => state.setErrorData);
   const options = useMemo(


### PR DESCRIPTION
When making the `mcp/servers` call from the canvas always load the tools list