### PR TITLE
feat: Add multiple handles support for list inputs

### DIFF
--- a/src/lfx/src/lfx/components/data/url.py
+++ b/src/lfx/src/lfx/components/data/url.py
@@ -61,7 +61,7 @@ class URLComponent(Component):
             tool_mode=True,
             placeholder="Enter a URL...",
             list_add_label="Add URL",
-            input_types=[],
+            input_types=["Message"],
         ),
         SliderInput(
             name="max_depth",


### PR DESCRIPTION
## Summary
- Enable multiple handles for list inputs with input_types defined
- Each list item gets its own connection handle for granular input control
- Maintain backward compatibility with existing single-handle behavior

## Key Changes
1. **URL Component**: Added `input_types=["Message"]` to enable multiple handles
2. **NodeInputField**: Added detection and rendering logic for multiple handles
3. **Handle Positioning**: Implemented precise positioning with 55px base + 45.8px spacing
4. **Unique Handle IDs**: Generate unique IDs using `${id.id}_${i}` pattern
5. **Dynamic Container Height**: Adjust container height based on number of handles

## Technical Details
- Only applies to inputs with both `is_list=True` AND `input_types` defined
- Maintains compatibility with existing validation logic
- Uses absolute positioning with transform for precise handle placement
- Added constants for maintainable positioning values

## Test Plan
- [ ] Verify URL component shows multiple handles for each URL input
- [ ] Test connections from different Message sources to each handle
- [ ] Confirm existing single-handle inputs remain unchanged
- [ ] Validate no frontend crashes or console errors
- [ ] Check that handle tooltips show correct input types
- [ ] Check possible impact in every other component handles

🤖 Generated with [Claude Code](https://claude.ai/code)