### PR TITLE
unique locking key for postgres alembic migration

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -50,3 +50,9 @@ C_FORCE_ROOT="true"
 # PGAdmin configuration
 PGADMIN_DEFAULT_EMAIL=admin@admin.com
 PGADMIN_DEFAULT_PASSWORD=admin
+
+# Database Migration Lock Namespace (optional)
+# Used for PostgreSQL advisory locks during migrations
+# Examples: "blue", "green", "ci", "staging", "production"
+# Leave empty or unset for default behavior (lock per DB/role without namespace)
+LANGFLOW_MIGRATION_LOCK_NAMESPACE=

--- a/src/backend/base/langflow/alembic/env.py
+++ b/src/backend/base/langflow/alembic/env.py
@@ -1,5 +1,6 @@
 # noqa: INP001
 import asyncio
+import hashlib
 from logging.config import fileConfig
 from typing import Any
 
@@ -99,8 +100,11 @@ def _do_run_migrations(connection):
 
     with context.begin_transaction():
         if connection.dialect.name == "postgresql":
+            # Hash the database URL to create a unique lock key per database
+            db_url = str(connection.engine.url)
+            lock_key = int(hashlib.sha256(db_url.encode()).hexdigest()[:16], 16) % (2**63 - 1)
             connection.execute(text("SET LOCAL lock_timeout = '60s';"))
-            connection.execute(text("SELECT pg_advisory_xact_lock(112233);"))
+            connection.execute(text(f"SELECT pg_advisory_xact_lock({lock_key});"))
         context.run_migrations()
 
 

--- a/src/backend/base/langflow/alembic/env.py
+++ b/src/backend/base/langflow/alembic/env.py
@@ -86,6 +86,7 @@ def _i63_from_sha256(s: str) -> int:
 
 def _canonical_db_identity(url) -> str:
     """Build a non-sensitive, stable identity string for the target DB/role.
+
     Avoids password and driver noise, normalizes case and default port.
     """
     # SQLAlchemy URL object
@@ -99,7 +100,8 @@ def _canonical_db_identity(url) -> str:
     return f"{host}:{port}/{dbname}:{user}"
 
 def _compute_lock_key(engine, namespace: str | None) -> int:
-    """Compute a transaction advisory lock key:
+    """Compute a transaction advisory lock key.
+
     base = SHA256(canonical(host,port,db,user)) -> 63-bit
     if namespace: XOR with SHA256(namespace) -> 63-bit
     """
@@ -163,8 +165,8 @@ def _do_run_migrations(connection):
             connection.exec_driver_sql(f"SET LOCAL lock_timeout = '{PG_LOCK_TIMEOUT}'")
             try:
                 connection.exec_driver_sql(f"SELECT pg_advisory_xact_lock({lock_key})")
-            except Exception as e:
-                logger.error(f"Failed to acquire advisory lock: {e}")
+            except Exception :
+                logger.exception("Failed to acquire advisory lock")
                 raise
 
         # Run migrations only once

--- a/src/backend/base/langflow/alembic/env.py
+++ b/src/backend/base/langflow/alembic/env.py
@@ -1,11 +1,13 @@
 # noqa: INP001
 import asyncio
 import hashlib
+import os
+import logging
 from logging.config import fileConfig
-from typing import Any
+from typing import Any, Optional
 
 from alembic import context
-from sqlalchemy import pool, text
+from sqlalchemy import pool
 from sqlalchemy.event import listen
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
@@ -15,10 +17,17 @@ from langflow.services.database.service import SQLModel
 # access to the values within the .ini file in use.
 config = context.config
 
+# Configuration constants
+SQLITE_BUSY_TIMEOUT_MS = 60000  # 60 seconds
+PG_LOCK_TIMEOUT = "60s"
+SHA256_BYTES_FOR_KEY = 8
+
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
+    
+logger = logging.getLogger("alembic.env")
 
 NAMING_CONVENTION = {
     "ix": "ix_%(column_0_label)s",
@@ -37,7 +46,6 @@ target_metadata.naming_convention = NAMING_CONVENTION
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
-
 
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode.
@@ -69,22 +77,57 @@ def run_migrations_offline() -> None:
     with context.begin_transaction():
         context.run_migrations()
 
+MAX_I63 = (1 << 63) - 1
+
+def _i63_from_sha256(s: str) -> int:
+    """Return a positive 63-bit int from the first 8 bytes of SHA-256(s)."""
+    h8 = hashlib.sha256(s.encode("utf-8")).digest()[:SHA256_BYTES_FOR_KEY]  # 64 bits
+    return int.from_bytes(h8, "big") & MAX_I63
+
+def _canonical_db_identity(url) -> str:
+    """
+    Build a non-sensitive, stable identity string for the target DB/role.
+    Avoids password and driver noise, normalizes case and default port.
+    """
+    # SQLAlchemy URL object
+    host = (url.host or "").lower()
+    # Normalize default port to 5432 for postgres
+    port = url.port or 5432
+    dbname = (url.database or "").lower()
+    user = (url.username or "").lower()
+    # Driver differences (postgresql vs postgresqlpsycopg) should not split identities
+    # so we intentionally exclude drivername from the identity.
+    return f"{host}:{port}/{dbname}:{user}"
+
+def _compute_lock_key(engine, namespace: Optional[str]) -> int:
+    """
+    Compute a transaction advisory lock key:
+      base = SHA256(canonical(host,port,db,user)) -> 63-bit
+      if namespace: XOR with SHA256(namespace) -> 63-bit
+    """
+    url = engine.url
+    base_key = _i63_from_sha256(_canonical_db_identity(url))
+    if namespace:
+        ns = namespace.strip().lower()
+        if ns:
+            ns_key = _i63_from_sha256(ns)
+            return (base_key ^ ns_key) & MAX_I63
+    return base_key
 
 def _sqlite_do_connect(
-    dbapi_connection,
-    connection_record,  # noqa: ARG001
+    dbapi_connection: Any,
+    connection_record: Any,  # noqa: ARG001
 ):
     # disable pysqlite's emitting of the BEGIN statement entirely.
     # also stops it from emitting COMMIT before any DDL.
     dbapi_connection.isolation_level = None
-
-
+    # Set busy timeout at connection time to avoid race conditions
+    dbapi_connection.execute(f"PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}")
+    
 def _sqlite_do_begin(conn):
     # emit our own BEGIN
-    conn.exec_driver_sql("PRAGMA busy_timeout = 60000")
     conn.exec_driver_sql("BEGIN EXCLUSIVE")
-
-
+    
 def _do_run_migrations(connection):
     configure_kwargs = {
         "connection": connection,
@@ -100,14 +143,35 @@ def _do_run_migrations(connection):
 
     with context.begin_transaction():
         if connection.dialect.name == "postgresql":
-            # Hash the database URL to create a unique lock key per database
-            db_url = str(connection.engine.url)
-            lock_key = int(hashlib.sha256(db_url.encode()).hexdigest()[:16], 16) % (2**63 - 1)
-            connection.execute(text("SET LOCAL lock_timeout = '60s';"))
-            connection.execute(text(f"SELECT pg_advisory_xact_lock({lock_key});"))
+            # Serialize migrations per DB/role, optionally namespaced by env.
+            # Optional: LANGFLOW_MIGRATION_LOCK_NAMESPACE (e.g., "blue", "green", "ci")
+            namespace = os.getenv("LANGFLOW_MIGRATION_LOCK_NAMESPACE")
+            lock_key = _compute_lock_key(connection.engine, namespace)
+
+            # It can be handy for ops to know which namespace is active (no secrets).
+            # (Log the namespace string, NOT the computed bigint.)
+            if namespace:
+                logger.info(
+                    "Alembic: using advisory lock namespace=%r (per-DB/role key namespaced)",
+                    namespace,
+                )
+            else:
+                logger.warning("Empty LANGFLOW_MIGRATION_LOCK_NAMESPACE, ignoring...")
+                logger.info(
+                    "Alembic: using advisory lock per-DB/role (no namespace)"
+                )
+
+            # Set lock timeout and acquire advisory lock
+            connection.exec_driver_sql(f"SET LOCAL lock_timeout = '{PG_LOCK_TIMEOUT}'")
+            try:
+                connection.exec_driver_sql(f"SELECT pg_advisory_xact_lock({lock_key})")
+            except Exception as e:
+                logger.error(f"Failed to acquire advisory lock: {e}")
+                raise 
+ 
+        # Run migrations only once
         context.run_migrations()
-
-
+        
 async def _run_async_migrations() -> None:
     # Get database URL to determine dialect
     url = config.get_main_option("sqlalchemy.url")
@@ -149,3 +213,4 @@ if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
+    


### PR DESCRIPTION
Langflow has hard coded a lock key for its alembic migration on Postgres. Postgres advisory locks are cluster wide, not per schema or per search_path. So technically, if I have multiple langflow share the same database that shares the same key and blocking one another. The fix is to hash connection string as the lock key because locking needs to be based on per database and per role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by using a unique advisory lock per database, preventing cross-environment lock conflicts.
  * Added a 60s lock timeout to avoid indefinite waits during migrations.
  * Ensures concurrent instances targeting different databases no longer block each other.
  * Results in smoother startups and deploys, with quicker feedback if a migration is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->