### PR TITLE
docs: exclude docs directory from pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
+        exclude: ^docs/
   - repo: local
     hooks:
       - id: local-biome-check


### PR DESCRIPTION
Exclude the `docs/` directory  from the `detect-secrets` hook, because it blocks commits and pollutes code samples if you need to add `# pragma: allowlist secret`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secret scanning configuration to exclude the documentation directory, reducing false positives and speeding up pre-commit checks for contributors.
  * Improves developer workflow without affecting application behavior or user-facing functionality.
  * No changes to features, performance, or compatibility for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->