### PR TITLE
docs: fix warning syntax

### DIFF
--- a/docs/docs/Support/release-notes.mdx
+++ b/docs/docs/Support/release-notes.mdx
@@ -57,7 +57,7 @@ For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/rel
 Langflow versions 1.6.0 through 1.6.3 have a critical bug where environment variables from `.env` files aren't read.
 This affects all deployments using environment variables for configuration, including security settings.
 
-:::Warning Potential security vulnerability
+:::warning Potential security vulnerability
 If your `.env` file includes `AUTO_LOGIN=false`, upgrading to the impacted versions causes Langflow to fall back to default settings, potentially giving all users superuser access immediately upon upgrade.
 Additionally, database credentials, API keys, and other sensitive configurations can't be loaded from `.env` files.
 


### PR DESCRIPTION
This pull request makes a minor documentation fix by correcting the markdown syntax for a warning callout in the release notes. This change improves the formatting and visibility of an important security warning for users

<img width="1091" height="468" alt="Screenshot 2025-10-07 at 3 18 43 PM" src="https://github.com/user-attachments/assets/254eb119-f176-4288-be2b-ab61f4452d0f" />
