### PR TITLE
fix: formatting of curl command in get-curl-code.tsx

### DIFF
--- a/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
+++ b/src/frontend/src/modals/apiModal/utils/get-curl-code.tsx
@@ -113,7 +113,7 @@ curl.exe --request POST \`
         .join("\n\t\t");
 
       const authHeader = shouldDisplayApiKey
-        ? `     --header "x-api-key: YOUR_API_KEY_HERE" \\ `
+        ? `     --header "x-api-key: YOUR_API_KEY_HERE" \\`
         : "";
 
       return `curl --request POST \\


### PR DESCRIPTION
Currently, the curl command breaks due to the escape of a space, rather than a newline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Corrected formatting of generated cURL commands for Unix-like shells by removing an extra space before line-continuation backslashes. This prevents shell parsing issues and improves copy-paste reliability from the API modal.

- Style
  - Harmonized whitespace in generated multi-line cURL snippets for clearer display and consistency across platforms within the API modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->