### PR TITLE
fix(frontend): fix and improvement to templates section - scrolling and UX

### DIFF
--- a/src/frontend/src/modals/templatesModal/components/GetStartedComponent/index.tsx
+++ b/src/frontend/src/modals/templatesModal/components/GetStartedComponent/index.tsx
@@ -49,9 +49,11 @@ export default function GetStartedComponent() {
 
   return (
     <div className="flex flex-1 flex-col gap-4 md:gap-8">
-      <BaseModal.Header description="Start with templates showcasing Langflow's Prompting, RAG, and Agent use cases.">
-        Get started
-      </BaseModal.Header>
+      <div className="sticky top-[-24px] z-10 -mx-6 -mt-6 bg-background/80 px-6 pb-4 pt-6 backdrop-blur-sm">
+        <BaseModal.Header description="Start with templates showcasing Langflow's Prompting, RAG, and Agent use cases.">
+          Get started
+        </BaseModal.Header>
+      </div>
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 lg:grid-cols-3">
         {cardData.map((card, index) => (
           <TemplateGetStartedCardComponent key={index} {...card} />

--- a/src/frontend/src/modals/templatesModal/components/TemplateContentComponent/index.tsx
+++ b/src/frontend/src/modals/templatesModal/components/TemplateContentComponent/index.tsx
@@ -38,7 +38,6 @@ export default function TemplateContentComponent({
   const navigate = useCustomNavigate();
   const { folderId } = useParams();
   const myCollectionId = useFolderStore((state) => state.myCollectionId);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const folderIdUrl = folderId ?? myCollectionId;
 
@@ -58,10 +57,6 @@ export default function TemplateContentComponent({
     } else {
       const searchResults = fuse.search(searchQuery);
       setFilteredExamples(searchResults.map((result) => result.item));
-    }
-    // Scroll to the top when search query changes
-    if (scrollContainerRef.current) {
-      scrollContainerRef.current.scrollTop = 0;
     }
   }, [searchQuery, currentTab, examples, fuse]);
 
@@ -85,27 +80,26 @@ export default function TemplateContentComponent({
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <div className="flex flex-1 flex-col gap-6 overflow-hidden">
-      <div className="relative mx-3 flex-1 grow-0 py-px">
-        <ForwardedIconComponent
-          name="Search"
-          className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-        />
-        <Input
-          type="search"
-          placeholder="Search..."
-          icon={"SearchIcon"}
-          data-testid="search-input-template"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          ref={searchInputRef}
-          className="w-3/4 rounded-lg bg-background lg:w-2/3"
-        />
+    <>
+      <div className="sticky top-[-24px] z-10 -mx-6 -mt-6 bg-background/80 px-6 pb-4 pt-6 backdrop-blur-sm">
+        <div className="relative py-px">
+          <ForwardedIconComponent
+            name="Search"
+            className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            type="search"
+            placeholder="Search..."
+            icon={"SearchIcon"}
+            data-testid="search-input-template"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            ref={searchInputRef}
+            className="w-3/4 rounded-lg bg-background lg:w-2/3"
+          />
+        </div>
       </div>
-      <div
-        ref={scrollContainerRef}
-        className="flex flex-1 flex-col gap-6 overflow-auto scrollbar-hide"
-      >
+      <div className="flex flex-col gap-6">
         {currentTabItem && filteredExamples.length > 0 ? (
           <TemplateCategoryComponent
             examples={filteredExamples}
@@ -126,6 +120,6 @@ export default function TemplateContentComponent({
           </div>
         )}
       </div>
-    </div>
+    </>
   );
 }

--- a/src/frontend/src/modals/templatesModal/index.tsx
+++ b/src/frontend/src/modals/templatesModal/index.tsx
@@ -58,54 +58,66 @@ export default function TemplatesModal({
   ];
 
   return (
-    <BaseModal size="templates" open={open} setOpen={setOpen} className="p-0">
+    <BaseModal
+      size="templates"
+      open={open}
+      setOpen={setOpen}
+      className="p-0"
+      closeButtonClassName="z-20"
+    >
       <BaseModal.Content className="flex flex-col p-0">
-        <div className="flex h-full">
+        <div className="flex h-full min-h-0 flex-col">
           <SidebarProvider width="15rem" defaultOpen={false}>
-            <Nav
-              categories={categories}
-              currentTab={currentTab}
-              setCurrentTab={setCurrentTab}
-            />
-            <main className="flex flex-1 flex-col gap-4 overflow-auto p-6 md:gap-8">
-              {currentTab === "get-started" ? (
-                <GetStartedComponent />
-              ) : (
-                <TemplateContentComponent
-                  currentTab={currentTab}
-                  categories={categories.flatMap((category) => category.items)}
-                />
-              )}
-              <BaseModal.Footer>
-                <div className="flex w-full flex-col justify-between gap-4 pb-4 sm:flex-row sm:items-center">
-                  <div className="flex flex-col items-start justify-center">
-                    <div className="font-semibold">Start from scratch</div>
-                    <div className="text-sm text-muted-foreground">
-                      Begin with a fresh flow to build from scratch.
-                    </div>
-                  </div>
-                  <Button
-                    onClick={() => {
-                      addFlow().then((id) => {
-                        navigate(
-                          `/flow/${id}${folderId ? `/folder/${folderId}` : ""}`,
-                        );
-                      });
-                      track("New Flow Created", { template: "Blank Flow" });
-                    }}
-                    size="sm"
-                    data-testid="blank-flow"
-                    className="shrink-0"
-                  >
-                    <ForwardedIconComponent
-                      name="Plus"
-                      className="h-4 w-4 shrink-0"
+            <div className="flex h-full min-h-0 flex-1">
+              <Nav
+                categories={categories}
+                currentTab={currentTab}
+                setCurrentTab={setCurrentTab}
+              />
+              <div className="flex min-h-0 flex-1 flex-col">
+                <main className="flex min-h-0 flex-1 flex-col overflow-auto scrollbar-hide p-6">
+                  {currentTab === "get-started" ? (
+                    <GetStartedComponent />
+                  ) : (
+                    <TemplateContentComponent
+                      currentTab={currentTab}
+                      categories={categories.flatMap(
+                        (category) => category.items,
+                      )}
                     />
-                    Blank Flow
-                  </Button>
+                  )}
+                </main>
+                <div className="shrink-0 border-t bg-background px-6 py-4">
+                  <div className="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-center">
+                    <div className="flex flex-col items-start justify-center">
+                      <div className="font-semibold">Start from scratch</div>
+                      <div className="text-sm text-muted-foreground">
+                        Begin with a fresh flow to build from scratch.
+                      </div>
+                    </div>
+                    <Button
+                      onClick={() => {
+                        addFlow().then((id) => {
+                          navigate(
+                            `/flow/${id}${folderId ? `/folder/${folderId}` : ""}`,
+                          );
+                        });
+                        track("New Flow Created", { template: "Blank Flow" });
+                      }}
+                      size="sm"
+                      data-testid="blank-flow"
+                      className="shrink-0"
+                    >
+                      <ForwardedIconComponent
+                        name="Plus"
+                        className="h-4 w-4 shrink-0"
+                      />
+                      Blank Flow
+                    </Button>
+                  </div>
                 </div>
-              </BaseModal.Footer>
-            </main>
+              </div>
+            </div>
           </SidebarProvider>
         </div>
       </BaseModal.Content>


### PR DESCRIPTION
- Fix glitchy scrolling behavior by removing nested scroll containers
- Add sticky header with blur effect for search bar and titles
- Fix footer positioning to stay at bottom without scrolling

Before

https://github.com/user-attachments/assets/d0ce8fbf-e37a-4bdc-be0d-99a13181d741


After

https://github.com/user-attachments/assets/e698fd0e-b103-457a-bef3-b0b98cbae3ee




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Introduced sticky headers in the templates modal so the title and search stay visible while scrolling.
  - Updated to a cleaner two-column layout (navigation + content) with improved spacing and hidden scrollbars.
  - Added a consistent bottom footer with clearer placement for the “Blank Flow” action.

- Bug Fixes
  - Ensured the modal close button stays visible above content.
  - Smoothed scrolling by preventing unexpected scroll resets during search.

- Refactor
  - Simplified modal structure for more predictable sizing and scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->