### PR TITLE
docs: make help command

### DIFF
--- a/docs/docs/Contributing/contributing-how-to-contribute.mdx
+++ b/docs/docs/Contributing/contributing-how-to-contribute.mdx
@@ -133,7 +133,7 @@ The Langflow frontend is served at `http://localhost:7860`.
 ### Set up your Langflow development environment
 
 :::tip
-Run `make help` to see all available make commands.
+Run `make help` to display all available make commands.
 :::
 
 This section is for contributors who want to develop and test code changes with hot reload enabled.


### PR DESCRIPTION
This pull request adds a tip to the contributor documentation, reminding users to run `make help` to view all available make commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the contributing guide with a new tip in the development environment setup section, recommending running “make help” to list available make commands.
  * Improves onboarding by helping contributors quickly discover common tasks and workflows without digging through scripts.
  * Clarifies available developer commands, reducing setup friction and increasing productivity for new and returning contributors.
  * No behavioral or functional changes to the product; this update is purely informational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->