### PR TITLE
docs: troubleshooting for pydantic request body mismatch

### DIFF
--- a/docs/docs/Support/troubleshooting.mdx
+++ b/docs/docs/Support/troubleshooting.mdx
@@ -179,6 +179,18 @@ Earlier versions can't automatically detect or apply updates.
 
 To resolve this issue, uninstall Langflow Desktop, and then [download and install the latest version of Langflow Desktop](https://langflow.org/desktop).
 
+### 422 error when freezing components after upgrading Pydantic/FastAPI dependencies
+
+If you locally upgrade your Pydantic and FastAPI dependencies, you may encounter a 422 error when trying to freeze components.
+
+This error occurs due to changes in how request bodies are handled in newer versions of these dependencies.
+
+If you're experiencing this issue, update your Langflow installation to version 1.6.5 or later, which includes a fix for this issue.
+
+```bash
+uv pip install langflow -U
+```
+
 ## Langflow uninstall issues
 
 The following issues can occur when uninstalling Langflow.


### PR DESCRIPTION
Troubleshooting documentation for #10248 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting subsection addressing 422 errors when freezing components after upgrading Pydantic/FastAPI.
  * Explains the cause related to request body handling changes and how it affects users.
  * Recommends updating to Langflow 1.6.5 or later and provides a simple upgrade command.
  * Helps users quickly resolve errors without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->