### PR TITLE
docs: connect to postgresql with SSL

### DIFF
--- a/docs/docs/Develop/configuration-custom-database.mdx
+++ b/docs/docs/Develop/configuration-custom-database.mdx
@@ -59,7 +59,7 @@ Langflow can more efficiently handle multiple users and larger workloads by usin
         LANGFLOW_DATABASE_URL="postgresql://user@db.example.com:5432/dbname?sslmode=verify-full&sslcert=/path/to/client.crt&sslkey=/path/to/client.key&sslrootcert=/path/to/ca.crt"
         ```
 
-        Do not use the Langflow environment variables [`LANGFLOW_SSL_CERT_FILE_PATH`](/environment-variables#server) and [`LANGFLOW_SSL_KEY_FILE_PATH`](/environment-variables#server) for your PostgreSQL certificates: these variables are for enabling HTTPS on the Langflow server, not for PostgreSQL database connections.
+        Do not use the Langflow environment variables [`LANGFLOW_SSL_CERT_FILE`](/environment-variables#server) and [`LANGFLOW_SSL_KEY_FILE`](/environment-variables#server) for your PostgreSQL certificates: these variables are for enabling HTTPS on the Langflow server, not for PostgreSQL database connections.
 
         For more on managing SSL certificates in PostgreSQL, see the [PostgreSQL documentation](https://www.postgresql.org/docs/9.1/ssl-tcp.html).
 

--- a/docs/docs/Develop/environment-variables.mdx
+++ b/docs/docs/Develop/environment-variables.mdx
@@ -452,8 +452,8 @@ The following environment variables set base Langflow server configuration, such
 | `LANGFLOW_HEALTH_CHECK_MAX_RETRIES` | Integer | `5` | Set the maximum number of retries for Langflow's server status health checks. |
 | `LANGFLOW_WORKERS` | Integer | `1` | Number of worker processes. |
 | `LANGFLOW_WORKER_TIMEOUT` | Integer | `300` | Worker timeout in seconds. |
-| `LANGFLOW_SSL_CERT_FILE_PATH` | String | Not set | Path to the SSL certificate file for enabling HTTPS on the Langflow web server. This is separate from [database SSL connections](/configuration-custom-database#configuring-postgresql-with-ssl). |
-| `LANGFLOW_SSL_KEY_FILE_PATH` | String | Not set | Path to the SSL key file for enabling HTTPS on the Langflow web server. This is separate from [database SSL connections](/configuration-custom-database#configuring-postgresql-with-ssl). |
+| `LANGFLOW_SSL_CERT_FILE` | String | Not set | Path to the SSL certificate file for enabling HTTPS on the Langflow web server. This is separate from [database SSL connections](/configuration-custom-database#connect-langflow-to-a-local-postgresql-database). |
+| `LANGFLOW_SSL_KEY_FILE` | String | Not set | Path to the SSL key file for enabling HTTPS on the Langflow web server. This is separate from [database SSL connections](/configuration-custom-database#connect-langflow-to-a-local-postgresql-database). |
 | `LANGFLOW_DEACTIVATE_TRACING` | Boolean | `False` | Deactivate tracing functionality. |
 | `LANGFLOW_CELERY_ENABLED` | Boolean | `False` | Enable Celery for distributed task processing. |
 


### PR DESCRIPTION
[Preview](https://d5rxiv0do0q3v.cloudfront.net/langflow-drafts/docs-postgres-ssl/configuration-custom-database#connect-langflow-to-a-local-postgresql-database)
Clarify PostgreSQL connection values for connecting Langflow to a PostgreSQL database.
1. What parameters are supported?
2. How do I pass the cert files for my connection?
3. Difference between SSL certs env vars and Postgresql cert files?
4. Where can I get more information?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a detailed guide for configuring SSL with PostgreSQL in the external database setup, including SSL modes (require, verify-ca, verify-full), client certificate options, connection parameters for SQLAlchemy/psycopg, and a link to PostgreSQL SSL docs. Includes a warning not to reuse web server HTTPS variables for database certificates.
  * Clarified that LANGFLOW_SSL_CERT_FILE and LANGFLOW_SSL_KEY_FILE are for enabling HTTPS on the web server only and are separate from database SSL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->