### PR TITLE
fix: replace history-based navigation (-1 as To) with dynamic URL using globalThis.location.origin in SettingsPage

### DIFF
--- a/src/frontend/src/pages/SettingsPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/index.tsx
@@ -15,7 +15,7 @@ export default function SettingsPage(): JSX.Element {
   const autoLogin = useAuthStore((state) => state.autoLogin);
   const hasStore = useStoreStore((state) => state.hasStore);
 
-  const flowsUrl = `${window.location.origin}/flows`;
+  const flowsUrl = `${globalThis.location.origin}/flows`;
 
   // Hides the General settings if there is nothing to show
   const showGeneralSettings = ENABLE_PROFILE_ICONS || hasStore || !autoLogin;


### PR DESCRIPTION
This PR replaces history-based navigation `-1 as To` with a dynamic URL using `globalThis.location.origin`. 
This ensures consistent navigation behavior when users access the Settings page directly and click the **Back** button.
The change happens inside the **PageLayout** component, specifically in the `backTo` property.

Motivation
- Fix inconsistent Back button behavior when opening Settings directly.
- Improve user experience.
- Remove dependency on browser history.
- Make navigation environment-independent.

 How to Test
- Open the /settings page directly in the browser like "http://localhost:7860/settings/general".
- Click the Back button.

✅ You should be redirected to the Langflow home page instead of the browser’s default previous page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Settings page back navigation to return users to the Flows page instead of doing nothing.
  * Ensures consistent and predictable back behavior across the app for a smoother UX.
  * Uses the current site URL to build the destination, preventing incorrect redirects across environments.
  * No changes to general settings display or other page behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->