### PR TITLE
fix: avoid request auto_login when AUTO_LOGIN disabled

### DIFF
--- a/src/frontend/src/controllers/API/queries/auth/use-get-autologin.ts
+++ b/src/frontend/src/controllers/API/queries/auth/use-get-autologin.ts
@@ -38,6 +38,9 @@ export const useGetAutoLogin: useQueryFunctionType<undefined, undefined> = (
 
   async function getAutoLoginFn(): Promise<null> {
     try {
+      if (!IS_AUTO_LOGIN) {
+        return null;
+      }
       const response = await api.get<Users>(`${getURL("AUTOLOGIN")}`);
       const user = response.data;
       if (user && user["access_token"]) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-login is now correctly bypassed when the feature is disabled, preventing unintended sign-in attempts. This reduces unnecessary network calls and improves startup responsiveness.
  * Users should see fewer transient login states (e.g., brief loading or flicker) on app launch when auto-login is off, resulting in a more stable and predictable sign-in experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->