### PR TITLE
ci: add Docker Hub authentication to test workflow to avoid rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,9 @@ jobs:
     name: Test Docker Images
     if: ${{ needs.path-filter.outputs.docker == 'true' && needs.set-ci-condition.outputs.should-run-tests == 'true' }}
     uses: ./.github/workflows/docker_test.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   # https://github.com/langchain-ai/langchain/blob/master/.github/workflows/check_diffs.yml
   ci_success:

--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -2,6 +2,11 @@ name: Test Docker images
 
 on:
   workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

Fixes Docker Hub rate limit errors in the "Test Docker Images" workflow.

## Problem

The workflow was failing with:
```
ERROR: failed to build: failed to solve: failed to copy: 
httpReadSeeker: failed open: unexpected status from GET request to 
https://registry-1.docker.io/v2/library/python/manifests/...: 429 Too Many Requests
toomanyrequests: You have reached your unauthenticated pull rate limit.
```

## Solution

Added Docker Hub login step (using existing `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets) before building images, matching the pattern used in `docker-build.yml`.

## Changes

- Added Docker Hub authentication step to `.github/workflows/docker_test.yml`
- Placed after cleanup and before build steps
- Uses same credentials as other Docker workflows

## Result

- Authenticated pulls have higher rate limits
- No more 429 errors (hopefully)
- Consistent with other Docker workflows in the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by authenticating with the container registry before building container images. This reduces rate limiting, enables better use of cached layers, and helps ensure consistent builds across environments.
  * No functional changes to the application; end-user experience remains unchanged, but release processes should be more stable and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->