### PR TITLE
docs: amazon bedrock converse

### DIFF
--- a/docs/docs/Components/bundles-amazon.mdx
+++ b/docs/docs/Components/bundles-amazon.mdx
@@ -30,7 +30,7 @@ For more information, see [Language model components](/components-models).
 | input_value | String | Input parameter. The input string for text generation. |
 | system_message | String | Input parameter. A system message to pass to the model. |
 | stream | Boolean | Input parameter. Whether to stream the response. Only works in chat. Default: `false`. |
-| model_id | String | Input parameter. The Amazon Bedrock model to use. Default: `anthropic.claude-3-5-sonnet-20241022-v2:0`. |
+| model_id | String | Input parameter. The Amazon Bedrock model to use.|
 | aws_access_key_id | SecretString | Input parameter. AWS Access Key for authentication. Required. |
 | aws_secret_access_key | SecretString | Input parameter. AWS Secret Key for authentication. Required. |
 | aws_session_token | SecretString | Input parameter. The session key for your AWS account. Only needed for temporary credentials. |


### PR DESCRIPTION
* Bedrock model is now legacy
* Bedrock Converse should be used instead.

#9901 