### PR TITLE
ci: ensure nightly docker builds are published when running via cron job

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -221,7 +221,9 @@ jobs:
       nightly_tag_main: ${{ needs.create-nightly-tag.outputs.main_tag }}
       nightly_tag_base: ${{ needs.create-nightly-tag.outputs.base_tag }}
       nightly_tag_lfx: ${{ needs.create-nightly-tag.outputs.lfx_tag }}
-      push_to_registry: ${{ inputs.push_to_registry != false }}
+      # When triggered by schedule, inputs.push_to_registry is not set, so default to true
+      # When triggered manually, use the provided value (default is also true)
+      push_to_registry: ${{ github.event_name == 'schedule' || inputs.push_to_registry != false }}
     secrets: inherit
 
   slack-notification:


### PR DESCRIPTION
Ensures that the push flag is set when run via schedule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly build workflow to default to pushing artifacts to the registry on scheduled runs; manual runs now honor the specified push setting.
  * Improves consistency of nightly artifacts and reduces manual configuration for routine builds.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->