### PR TITLE
ci: Update Docker Hub login condition in workflow to avoid login in community PRs

### DIFF
--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -49,7 +49,7 @@ jobs:
             docker buildx du || true
           fi
       - name: Login to Docker Hub
-        if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Added a conditional check to the Docker Hub login step in the GitHub Actions workflow, allowing login only during manual dispatch or when the pull request originates from the same repository. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized workflow configuration to improve efficiency in internal testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->