### PR TITLE
docs: hide cometAPI bundle until release-1.7

### DIFF
--- a/docs/docs/Components/_bundles-cometapi.mdx
+++ b/docs/docs/Components/_bundles-cometapi.mdx
@@ -18,7 +18,7 @@ This component generates text using CometAPI's language models through the Comet
 
 It can output either a **Model Response** ([`Message`](/data-types#message)) or a **Language Model** ([`LanguageModel`](/data-types#languagemodel)).
 
-Use the **Language Model** output when you want to use a CometAPI model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Function** component.
+Use the **Language Model** output when you want to use a CometAPI model as the LLM for another LLM-driven component, such as an **Agent** or **Smart Transform** component.
 
 For more information, see [Language model components](/components-models).
 
@@ -55,4 +55,4 @@ import PartialParams from '@site/docs/_partial-hidden-params.mdx';
 
     To perform a basic test, add **Chat Input** and **Chat Output** components to your flow, connect them to the **CometAPI** component accordingly, and then click **Playground** to test the connection and chat with your model.
 
-    For more advanced use cases, you can connect the CometAPI component to other components like **Prompt Template**, **Agent**, or **Smart Function** components.
+    For more advanced use cases, you can connect the CometAPI component to other components like **Prompt Template**, **Agent**, or **Smart Transform** components.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -305,7 +305,6 @@ module.exports = {
             "Components/bundles-clickhouse",
             "Components/bundles-cloudflare",
             "Components/bundles-cohere",
-            "Components/bundles-cometapi",
             "Components/bundles-couchbase",
             "Components/bundles-datastax",
             "Components/bundles-deepseek",


### PR DESCRIPTION
Hide CometAPI bundle until it is released in 1.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated component documentation terminology throughout bundle descriptions and advanced integration examples for consistency.
  * Removed CometAPI bundle from the documentation sidebar navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->