### PR TITLE
feat: Add pagination support to ToolsTable with configurable page sizes

### DIFF
--- a/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
+++ b/src/frontend/src/modals/toolsModal/components/toolsTable/index.tsx
@@ -53,7 +53,9 @@ export default function ToolsTable({
   const { setOpen: setSidebarOpen } = useSidebar();
 
   const getRowId = useMemo(() => {
-    return (params: any) => params.data._uniqueId || `${params.data.name}_${params.data.display_name}`;
+    return (params: any) =>
+      params.data._uniqueId ||
+      `${params.data.name}_${params.data.display_name}`;
   }, []);
 
   useEffect(() => {
@@ -237,7 +239,11 @@ export default function ToolsTable({
     if (!focusedRow) return;
 
     const originalUniqueId = focusedRow._uniqueId;
-    const updatedRow = { ...focusedRow, [field]: value, _uniqueId: originalUniqueId };
+    const updatedRow = {
+      ...focusedRow,
+      [field]: value,
+      _uniqueId: originalUniqueId,
+    };
 
     setFocusedRow(updatedRow);
 
@@ -256,10 +262,11 @@ export default function ToolsTable({
       setData(updatedData);
 
       // Update selectedRows to reflect the updated data
-      setSelectedRows((prevSelected) =>
-        prevSelected?.map((row) =>
-          row._uniqueId === originalUniqueId ? updatedRow : row,
-        ) || null,
+      setSelectedRows(
+        (prevSelected) =>
+          prevSelected?.map((row) =>
+            row._uniqueId === originalUniqueId ? updatedRow : row,
+          ) || null,
       );
     }
   };

--- a/src/frontend/tests/extended/features/edit-tools.spec.ts
+++ b/src/frontend/tests/extended/features/edit-tools.spec.ts
@@ -27,7 +27,7 @@ test(
       '[data-testid="generic-node-title-arrangement"]',
       {
         timeout: 3000,
-      }
+      },
     );
 
     await page.getByTestId("generic-node-title-arrangement").click();
@@ -52,11 +52,11 @@ test(
     expect(rowsCount).toBeGreaterThan(2);
 
     expect(
-      await page.locator('input[data-ref="eInput"]').nth(0).isChecked()
+      await page.locator('input[data-ref="eInput"]').nth(0).isChecked(),
     ).toBe(true);
 
     expect(
-      await page.locator('input[data-ref="eInput"]').nth(3).isChecked()
+      await page.locator('input[data-ref="eInput"]').nth(3).isChecked(),
     ).toBe(true);
 
     await page.locator('input[data-ref="eInput"]').nth(0).click();
@@ -64,7 +64,7 @@ test(
     await page.waitForTimeout(500);
 
     expect(
-      await page.locator('input[data-ref="eInput"]').nth(3).isChecked()
+      await page.locator('input[data-ref="eInput"]').nth(3).isChecked(),
     ).toBe(false);
 
     await page.locator('input[data-ref="eInput"]').nth(0).click();
@@ -76,21 +76,23 @@ test(
     await page.waitForTimeout(500);
 
     expect(
-      await page.locator('[data-testid="sidebar_header_name"]').isHidden()
+      await page.locator('[data-testid="sidebar_header_name"]').isHidden(),
     ).toBe(true);
 
     expect(
       await page
         .locator('[data-testid="sidebar_header_description"]')
-        .isHidden()
+        .isHidden(),
     ).toBe(true);
 
     expect(
-      await page.locator('[data-testid="input_update_name"]').isVisible()
+      await page.locator('[data-testid="input_update_name"]').isVisible(),
     ).toBe(true);
 
     expect(
-      await page.locator('[data-testid="input_update_description"]').isVisible()
+      await page
+        .locator('[data-testid="input_update_description"]')
+        .isVisible(),
     ).toBe(true);
 
     await page.locator('[data-testid="input_update_name"]').fill("test name");
@@ -113,7 +115,7 @@ test(
       '[data-testid="generic-node-title-arrangement"]',
       {
         timeout: 3000,
-      }
+      },
     );
 
     await page.waitForSelector('[data-testid="div-tools_tools_metadata"]', {
@@ -121,7 +123,9 @@ test(
     });
 
     expect(
-      await page.locator('[data-testid="div-tools_tools_metadata"]').isVisible()
+      await page
+        .locator('[data-testid="div-tools_tools_metadata"]')
+        .isVisible(),
     ).toBe(true);
 
     await page.getByTestId("button_open_actions").click();
@@ -129,7 +133,7 @@ test(
     await page.waitForTimeout(500);
 
     expect(
-      await page.locator('input[data-ref="eInput"]').nth(3).isChecked()
+      await page.locator('input[data-ref="eInput"]').nth(3).isChecked(),
     ).toBe(true);
 
     await page.waitForTimeout(500);
@@ -139,31 +143,33 @@ test(
     await page.waitForTimeout(500);
 
     expect(
-      await page.locator('[data-testid="sidebar_header_name"]').isHidden()
+      await page.locator('[data-testid="sidebar_header_name"]').isHidden(),
     ).toBe(true);
 
     expect(
       await page
         .locator('[data-testid="sidebar_header_description"]')
-        .isHidden()
+        .isHidden(),
     ).toBe(true);
 
     expect(
-      await page.locator('[data-testid="input_update_name"]').isVisible()
+      await page.locator('[data-testid="input_update_name"]').isVisible(),
     ).toBe(true);
 
     expect(
-      await page.locator('[data-testid="input_update_description"]').isVisible()
+      await page
+        .locator('[data-testid="input_update_description"]')
+        .isVisible(),
     ).toBe(true);
 
     expect(
-      await page.locator('[data-testid="input_update_name"]').inputValue()
+      await page.locator('[data-testid="input_update_name"]').inputValue(),
     ).toBe("test_name");
 
     expect(
       await page
         .locator('[data-testid="input_update_description"]')
-        .inputValue()
+        .inputValue(),
     ).toBe("test description");
 
     await page.locator('[data-testid="input_update_name"]').fill("");
@@ -185,7 +191,7 @@ test(
     await page.getByText("Close").last().click();
 
     expect(
-      await page.locator('[data-testid="tool_fetch_content"]').isVisible()
+      await page.locator('[data-testid="tool_fetch_content"]').isVisible(),
     ).toBe(true);
-  }
+  },
 );


### PR DESCRIPTION
This pull request introduces comprehensive improvements to the `ToolsTable` component, focusing on robust pagination support and more reliable selection management. It also adds a dedicated test suite to validate pagination behavior across various dataset sizes and edge cases. The main themes are enhanced pagination, improved selection logic, and expanded test coverage.

**Pagination and Table Options**

* Pagination is now always enabled in `ToolsTable`, with automatic page size calculation for better performance and usability on both small and large datasets. This is reflected in the table options and the props passed to the underlying table component. [[1]](diffhunk://#diff-74c8a3a7d322d9e3c2682246b095581a079f097b77acf319fd19a7922a39c7baR279-L268) [[2]](diffhunk://#diff-74c8a3a7d322d9e3c2682246b095581a079f097b77acf319fd19a7922a39c7baL306-R325)
* The `tableOptions` object is updated to explicitly set `hide_options: false`, ensuring table controls are consistently available.

**Selection Management**

* Selection logic is refactored to use `useRef` hooks (`editedSelection`, `applyingSelection`, and `previousRowsCount`) to better track and preserve user selections, especially when the dataset changes or the modal is reopened. This prevents unwanted selection resets and ensures selections are only applied when appropriate. [[1]](diffhunk://#diff-74c8a3a7d322d9e3c2682246b095581a079f097b77acf319fd19a7922a39c7baR49-R50) [[2]](diffhunk://#diff-74c8a3a7d322d9e3c2682246b095581a079f097b77acf319fd19a7922a39c7baR59-R107) [[3]](diffhunk://#diff-74c8a3a7d322d9e3c2682246b095581a079f097b77acf319fd19a7922a39c7baL200-L204)
* The selection matching now uses a fallback to `name` if `display_name` is not present, improving robustness for tools with missing display names.

**Testing Enhancements**

* A new test file `toolsTable-pagination.test.tsx` is added, providing thorough coverage of pagination behavior, including large and small datasets, edge cases, and integration with search and action modes. Mocking is used to isolate and validate pagination-related props and interactions.


https://www.loom.com/share/6250c80b2ecc4b88942d343cfc0033ec?sid=8554815e-b2ae-40d9-8197-e01a5bccfb04