### PR TITLE
fix: Correct ElevenLabs API key access for Vite

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx
@@ -116,7 +116,7 @@ export function VoiceAssistant({
   }, [globalVariables]);
 
   const hasElevenLabsApiKeyEnv = useMemo(() => {
-    return Boolean(process.env?.ELEVENLABS_API_KEY);
+    return Boolean(import.meta?.env?.ELEVENLABS_API_KEY);
   }, [variables, addKey]);
 
   useEffect(() => {


### PR DESCRIPTION
This pull request updates the way the ElevenLabs API key is accessed in the `VoiceAssistant` component. The change ensures that the API key is retrieved using the correct Vite environment variable syntax for frontend code.

* API Key Access Update:
  * In `voice-assistant.tsx`, replaced `process.env.ELEVENLABS_API_KEY` with `import.meta.env.ELEVENLABS_API_KEY` to properly access the API key in a Vite-based frontend environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated voice assistant configuration handling to support modern build system practices.

---

**Note:** This release contains primarily technical updates with no new user-facing features or bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->