### PR TITLE
test: Fix flaky If-Else component reset regression test

### DIFF
--- a/src/frontend/tests/extended/regression/general-bugs-reset-flow-run.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-reset-flow-run.spec.ts
@@ -8,7 +8,7 @@ import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { zoomOut } from "../../utils/zoom-out";
 
 test(
-  "user must be able to send images in the playground with the agent component",
+  "user can run flow with If-Else component multiple times with different branches",
   { tag: ["@release", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
@@ -142,8 +142,14 @@ test(
 
     // retest to make sure we can run again the flow with the first branch of the If-Else component
 
+    await page.waitForTimeout(500);
+
     await page.getByTestId("popover-anchor-input-input_text").fill("1");
+    await page.waitForTimeout(500);
+
     await page.getByTestId("button_run_text output").click();
+
+    await page.waitForTimeout(500);
 
     await page.waitForSelector("text=built successfully", { timeout: 30000 });
 


### PR DESCRIPTION
This pull request updates the regression test for the flow run reset functionality, focusing on the If-Else component. The changes improve test reliability and better reflect the intended user flow when running the component multiple times with different branches.

Test scenario update:

* Changed the test description to clarify that it now verifies running a flow with the If-Else component multiple times, rather than sending images in the playground.

Test stability improvements:

* Added multiple `waitForTimeout` calls to ensure UI elements and state are ready before performing actions, reducing flakiness in the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced regression testing for If-Else flow execution across multiple branch scenarios with improved test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->