### PR TITLE
fix(FlowBuildingComponent): remove layout shift when timer updates

### DIFF
--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/utils/format-run-time.ts
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/utils/format-run-time.ts
@@ -16,7 +16,7 @@ export function normalizeTimeString(input) {
   // Check for seconds
   if (patterns.seconds.test(cleanInput)) {
     const [, seconds] = cleanInput.match(patterns.seconds);
-    return `${parseFloat(seconds)}s`;
+    return `${Number(seconds).toFixed(1)}s`;
   }
 
   // Check for milliseconds


### PR DESCRIPTION
This PR makes the timer a bit less janky while a flow is running by preserving the whitespace by keeping the decimal place in seconds.


## Before

https://github.com/user-attachments/assets/ea05f97a-63ba-49f5-9e2f-6c82f4f46a77



## After
https://github.com/user-attachments/assets/00e356b5-70b8-4a77-ba3d-9296044fa1ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved run time display formatting to show consistent decimal precision across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->