### PR TITLE
fix: Correct LANGFLOW_CONFIG_DIR path for langflow service

### DIFF
--- a/docker_example/docker-compose.yml
+++ b/docker_example/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - LANGFLOW_DATABASE_URL=postgresql://langflow:langflow@postgres:5432/langflow
       # This variable defines where the logs, file storage, monitor data and secret keys are stored.
-      - LANGFLOW_CONFIG_DIR=/app/langflow
+      - LANGFLOW_CONFIG_DIR=app/langflow
     volumes:
       - langflow-data:/app/langflow
 


### PR DESCRIPTION
Fix error when running docker-compose.
changed LANGFLOW_CONFIG_DIR path from /app/langflow to app/langflow .

```
langflow-1  | │                                                                              │
langflow-1  | │ /usr/local/lib/python3.12/pathlib.py:1013 in open                            │
langflow-1  | │                                                                              │
langflow-1  | │   1010 │   │   """                                                           │
langflow-1  | │   1011 │   │   if "b" not in mode:                                           │
langflow-1  | │   1012 │   │   │   encoding = io.text_encoding(encoding)                     │
langflow-1  | │ ❱ 1013 │   │   return io.open(self, mode, buffering, encoding, errors, newli │
langflow-1  | │   1014 │                                                                     │
langflow-1  | │   1015 │   def read_bytes(self):                                             │
langflow-1  | │   1016 │   │   """                                                           │
langflow-1  | │                                                                              │
langflow-1  | │ ╭───────────────────── locals ──────────────────────╮                        │
langflow-1  | │ │ buffering = -1                                    │                        │
langflow-1  | │ │  encoding = 'utf-8'                               │                        │
langflow-1  | │ │    errors = None                                  │                        │
langflow-1  | │ │      mode = 'w'                                   │                        │
langflow-1  | │ │   newline = None                                  │                        │
langflow-1  | │ │      self = PosixPath('/app/langflow/secret_key') │                        │
langflow-1  | │ ╰───────────────────────────────────────────────────╯                        │
langflow-1  | ╰──────────────────────────────────────────────────────────────────────────────╯
langflow-1  | PermissionError: [Errno 13] Permission denied: '/app/langflow/secret_key'
langflow-1 exited with code 1
``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker deployment configuration path for improved environment setup consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->