### PR TITLE
docs: fixing the log file path for Langflow Desktop

### DIFF
--- a/docs/docs/Develop/logging.mdx
+++ b/docs/docs/Develop/logging.mdx
@@ -21,7 +21,7 @@ The default config directory location depends on your operating system and insta
 - **Langflow Desktop**:
 
     - **macOS**: `/Users/<username>/Library/Logs/com.LangflowDesktop`
-    - **Windows**: `C:\Users\<username>\AppData\Roaming\com.LangflowDesktop\cache`
+    - **Windows**: `C:\Users\<username>\AppData\Local\com.LangflowDesktop\logs`
 
 - **OSS Langflow**:
 
@@ -61,7 +61,7 @@ To monitor Langflow logs as they are generated, you can follow the log file:
     <TabItem value="Windows" label="Windows">
 
     ```cmd
-    cd C:\Users\**USERNAME**\AppData\Local\langflow\langflow\Cache
+    cd C:\Users\**USERNAME**\AppData\Local\com.LangflowDesktop\logs
     ```
 
     </TabItem>


### PR DESCRIPTION
Updated the documentation to reflect the correct location of the Langflow Desktop logs. The previous path was outdated — the logs were only found at the new directory indicated in this update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Windows log file location for Langflow Desktop. Logs are now stored in the local AppData logs directory instead of the roaming AppData cache location. Updated example commands reflect the new path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->