### PR TITLE
docs: update file upload utility link

### DIFF
--- a/docs/docs/Tutorials/chat-with-files.mdx
+++ b/docs/docs/Tutorials/chat-with-files.mdx
@@ -70,7 +70,7 @@ This example uses a local Langflow instance, and it asks the LLM to evaluate a s
 If you don't have a resume on hand, you can download [fake-resume.txt](/files/fake-resume.txt).
 
 :::tip
-For help with constructing file upload requests in Python, JavaScript, and curl, see the [Langflow File Upload Utility](https://langflow-file-upload-examples.onrender.com).
+For help with constructing file upload requests in Python, JavaScript, and curl, see the [Langflow File Upload Utility](https://langflow-file-upload-examples.21cgwws14kdz.us-east.codeengine.appdomain.cloud/).
 :::
 
 1. To construct the request, gather the following information:

--- a/docs/docs/Tutorials/chat-with-rag.mdx
+++ b/docs/docs/Tutorials/chat-with-rag.mdx
@@ -73,7 +73,7 @@ In situations where many users load data or you need to load data programmatical
 To load data programmatically, use the `/v2/files/` and `/v1/run/$FLOW_ID` endpoints. The first endpoint loads a file to your Langflow server, and then returns an uploaded file path. The second endpoint runs the **Load Data Flow**, referencing the uploaded file path, to chunk, embed, and load the data into the vector store.
 
 The following script demonstrates this process.
-For help with creating this script, use the [Langflow File Upload Utility](https://langflow-file-upload-examples.onrender.com/).
+For help with creating this script, use the [Langflow File Upload Utility](https://langflow-file-upload-examples.21cgwws14kdz.us-east.codeengine.appdomain.cloud/).
 
 ```js
 // Node 18+ example using global fetch, FormData, and Blob


### PR DESCRIPTION
The file upload utility is now hosted at https://langflow-file-upload-examples.21cgwws14kdz.us-east.codeengine.appdomain.cloud/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external resource links in tutorial documentation to reference new hosted service endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->