### PR TITLE
chore: fix main-frotnend typo

### DIFF
--- a/.github/workflows/docker-build-v2.yml
+++ b/.github/workflows/docker-build-v2.yml
@@ -31,7 +31,7 @@ on:
         options:
           - main
           - main-backend
-          - main-frotnend
+          - main-frontend
           - main-ep
           - base
           - main-all


### PR DESCRIPTION
main-frotnend -> main-frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration option naming in deployment workflow to ensure proper release type processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->