### PR TITLE
fix: ensure running edges re-render by using immutable edge updates

### DIFF
--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -933,21 +933,21 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
   },
   updateEdgesRunningByNodes: (ids: string[], running: boolean) => {
     const edges = get().edges;
+    const stopNodeId = get().stopNodeId;
 
     const newEdges = edges.map((edge) => {
-      if (
+      const shouldRun =
         edge.data?.sourceHandle &&
         ids.includes(edge.data.sourceHandle.id ?? "") &&
-        edge.data.sourceHandle.id !== get().stopNodeId
-      ) {
-        edge.animated = running;
-        edge.className = running ? "running" : "";
-      } else {
-        edge.animated = false;
-        edge.className = "not-running";
-      }
-      return edge;
+        edge.data.sourceHandle.id !== stopNodeId;
+
+      return {
+        ...edge,
+        animated: shouldRun ? running : false,
+        className: shouldRun && running ? "running" : "not-running",
+      };
     });
+
     set({ edges: newEdges });
   },
   clearEdgesRunningByNodes: async (): Promise<void> => {


### PR DESCRIPTION
What does this PR do?
Fixes the delayed animation update on running edges.
Refactors edge state updates to use immutable objects, ensuring React Flow re-renders correctly.

Why is this needed?
Previously, edge animation states were updated by mutating existing edge objects. Since React Flow performs shallow comparison on edge references, these mutations did not trigger a re-render immediately. As a result, the running animation appeared with noticeable delay.
This PR ensures that edges are updated immutably, allowing React Flow to detect changes instantly and apply the animation state correctly.

How to test?
Start the application and trigger a node execution that should set edges to running state.
Observe the connecting edges: the animation should appear immediately without requiring zoom or canvas interaction.
Stop the execution and confirm that animations stop and styles revert as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal edge animation handling with enhanced code maintainability and stability through better data handling patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->