### PR TITLE
ci: require main image built before backend/frontend images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,7 +460,7 @@ jobs:
 
   call_docker_build_main_backend:
     name: Call Docker Build Workflow for Langflow Backend
-    if: ${{ inputs.build_docker_main }}
+    if: ${{ inputs.build_docker_main && !inputs.dry_run }}
     needs: [call_docker_build_main]
     uses: ./.github/workflows/docker-build-v2.yml
     with:
@@ -472,7 +472,7 @@ jobs:
 
   call_docker_build_main_frontend:
     name: Call Docker Build Workflow for Langflow Frontend
-    if: ${{ inputs.build_docker_main }}
+    if: ${{ inputs.build_docker_main && !inputs.dry_run }}
     needs: [call_docker_build_main]
     uses: ./.github/workflows/docker-build-v2.yml
     with:


### PR DESCRIPTION
Fixes issue: https://github.com/langflow-ai/langflow/actions/runs/19172919177/job/54811540811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow orchestration to optimize build sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->