### PR TITLE
fix: Add id field with validation and serialization to Message

### DIFF
--- a/src/lfx/src/lfx/schema/message.py
+++ b/src/lfx/src/lfx/schema/message.py
@@ -35,6 +35,7 @@ class Message(Data):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     # Helper class to deal with image data
     text_key: str = "text"
+    id: str | UUID | None = Field(default=None)
     text: str | AsyncIterator | Iterator | None = Field(default="")
     sender: str | None = None
     sender_name: str | None = None
@@ -52,6 +53,13 @@ class Message(Data):
     category: Literal["message", "error", "warning", "info"] | None = "message"
     content_blocks: list[ContentBlock] = Field(default_factory=list)
     duration: int | None = None
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def validate_id(cls, value):
+        if isinstance(value, UUID):
+            value = str(value)
+        return value
 
     @field_validator("flow_id", mode="before")
     @classmethod
@@ -80,6 +88,12 @@ class Message(Data):
             value = Properties.model_validate_json(value)
         elif isinstance(value, dict):
             value = Properties.model_validate(value)
+        return value
+
+    @field_serializer("id")
+    def serialize_id(self, value):
+        if isinstance(value, UUID):
+            return str(value)
         return value
 
     @field_serializer("flow_id")


### PR DESCRIPTION
Introduces an 'id' field to the Message class, supporting str, UUID, or None types. Includes field validator and serializer to ensure UUIDs are converted to strings for consistency.
_________
This pull request updates the `Message` schema in `src/lfx/src/lfx/schema/message.py` to improve how the `id` field is handled, ensuring better consistency and serialization of UUIDs. The main changes focus on adding validation and serialization logic for the `id` field.

Enhancements to `id` field handling:

* Added an `id` field to the `Message` class, allowing it to be a `str`, `UUID`, or `None`, with a default value of `None`.
* Implemented a field validator for `id` to automatically convert UUIDs to their string representation before assignment.
* Added a field serializer for `id` to ensure UUIDs are serialized as strings when outputting the model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages now include a unique identifier field that is automatically normalized and properly handled during data export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->