### PR TITLE
fix(code-editor): prevent modal from closing when escape is pressed in search box

### DIFF
--- a/src/frontend/src/modals/codeAreaModal/index.tsx
+++ b/src/frontend/src/modals/codeAreaModal/index.tsx
@@ -170,16 +170,15 @@ export default function CodeAreaModal({
 
   return (
     <BaseModal
-      onEscapeKeyDown={(e) => {        
+      onEscapeKeyDown={(e) => {
         e.preventDefault();
 
         // Check if AceEditor search box input is in the viewport
         const searchInput = document.querySelector(
-          'input.ace_search_field',
+          "input.ace_search_field",
         ) as HTMLInputElement;
         const isSearchBoxVisible =
-          searchInput &&
-          searchInput.offsetParent !== null; // Check if element is visible
+          searchInput && searchInput.offsetParent !== null; // Check if element is visible
 
         // If search box is visible, don't close the modal - let AceEditor handle escape
         if (isSearchBoxVisible) {


### PR DESCRIPTION
## Problem
Pressing Escape inside the AceEditor search text field was closing the code editor modal, preventing users from closing the search box with Escape.

## Solution
Added a check in the modal's escape handler to detect if the AceEditor search box input (`input.ace_search_field`) is visible in the viewport. If the search box is visible, the escape handler returns early, allowing AceEditor to handle the Escape key to close the search box instead of closing the modal.

## Changes
- Modified `onEscapeKeyDown` handler in `CodeAreaModal` to check for visible search box input before processing escape key
- If search box is visible, escape key is handled by AceEditor (closes search box)
- If search box is not visible, normal modal close behavior applies (with confirmation dialog for unsaved changes)

## Testing
- Open code editor modal
- Press Ctrl+F (or Cmd+F) to open search box
- Press Escape - search box should close, modal should remain open
- Press Escape again - modal should close (or show confirmation if there are unsaved changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Escape key behavior in the code editor. The search box now properly handles Escape key presses without closing the modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->