### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For more information, see [Install and run the Langflow OSS Python package](http
 
 #### Run
 
-To start Langflow, run:
+To start Langflow, run: (For Windows: open terminal with Admin Privileges and run.)
 ```shell
 uv run langflow run
 ```


### PR DESCRIPTION
There was no mention of running the `langflow run` command in an Admin Privileged Terminal. 
Thus, the edit.
Thank you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows-specific guidance to the Run instruction noting that admin privileges are required when running on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->