### PR TITLE
docs: desktop logs include install logs

### DIFF
--- a/docs/docs/Develop/logging.mdx
+++ b/docs/docs/Develop/logging.mdx
@@ -176,8 +176,6 @@ Follow the steps for your operating system.
 
 You can use the log file to investigate the issue on your own, add context to a [GitHub Issue](/contributing-github-issues), or send it to [support](/luna-for-langflow) for debugging assistance.
 
-The log file is only created when Langflow Desktop runs. If you don't see a log file, try starting Langflow Desktop first, then check for the log file.
-
 ## See also
 
 * [Logs endpoints](/api-logs)


### PR DESCRIPTION
Remove outdated information from logging page that Desktop logs need to start the application first to create the logfile - they can also include installation error logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified logging documentation by removing prerequisite requirements for accessing log files, making setup guidance more straightforward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->