### PR TITLE
fix(lfx-dev): reload specific modules while preserving index cache

### DIFF
--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -291,6 +291,9 @@ async def _load_from_index_or_cache(
     await logger.adebug("Prebuilt index not available, checking cache")
     try:
         cache_path = _get_cache_path()
+    except Exception as e:  # noqa: BLE001
+        await logger.adebug(f"Cache load failed: {e}")
+    else:
         if cache_path.exists():
             await logger.adebug(f"Attempting to load from cache: {cache_path}")
             index = _read_component_index(str(cache_path))
@@ -302,8 +305,6 @@ async def _load_from_index_or_cache(
                     modules_dict[top_level].update(components)
                 await logger.adebug(f"Loaded {len(modules_dict)} component categories from cache")
                 return modules_dict, "cache"
-    except Exception as e:  # noqa: BLE001
-        await logger.adebug(f"Cache load failed: {e}")
 
     return modules_dict, None
 


### PR DESCRIPTION
This PR fixes a problem where only specific modules were being loaded when setting variables to reload specific modules (i.e. LFX_DEV=agents loaded ONLY agents instead of RELOADING only agents). 

It also refactors the functions for better maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured component loading system to improve separation between development and production modes, enhancing caching and index management for better performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->