### PR TITLE
Fix: disable mem0 to prevent excessive chat memory (OOM error)

### DIFF
--- a/src/backend/base/langflow/components/mem0/mem0_chat_memory.py
+++ b/src/backend/base/langflow/components/mem0/mem0_chat_memory.py
@@ -7,6 +7,7 @@ from langflow.inputs.inputs import DictInput, HandleInput, MessageTextInput, Nes
 from langflow.io import Output
 from langflow.logging.logger import logger
 from langflow.schema.data import Data
+from langflow.services.deps import get_settings_service
 
 
 class Mem0MemoryComponent(LCChatMemoryComponent):
@@ -80,6 +81,15 @@ class Mem0MemoryComponent(LCChatMemoryComponent):
 
     def build_mem0(self) -> Memory:
         """Initializes a Mem0 memory instance based on provided configuration and API keys."""
+        # Check if we're in S3 mode - Mem0 memory not supported in cloud
+        settings = get_settings_service().settings
+        if settings.storage_type == "s3":
+            msg = (
+                "Mem0 memory is not supported in S3/cloud mode. "
+                "Mem0 memory requires local file system access for persistence. "
+                "Please use local storage mode."
+            )
+            raise ValueError(msg)
         if self.openai_api_key:
             os.environ["OPENAI_API_KEY"] = self.openai_api_key
 
@@ -95,6 +105,15 @@ class Mem0MemoryComponent(LCChatMemoryComponent):
 
     def ingest_data(self) -> Memory:
         """Ingests a new message into Mem0 memory and returns the updated memory instance."""
+        # Check if we're in S3 mode - Mem0 memory not supported in cloud
+        settings = get_settings_service().settings
+        if settings.storage_type == "s3":
+            msg = (
+                "Mem0 memory is not supported in S3/cloud mode. "
+                "Mem0 memory requires local file system access for persistence. "
+                "Please use local storage mode."
+            )
+            raise ValueError(msg)
         mem0_memory = self.existing_memory or self.build_mem0()
 
         if not self.ingest_message or not self.user_id:
@@ -115,6 +134,15 @@ class Mem0MemoryComponent(LCChatMemoryComponent):
 
     def build_search_results(self) -> Data:
         """Searches the Mem0 memory for related messages based on the search query and returns the results."""
+        # Check if we're in S3 mode - Mem0 memory not supported in cloud
+        settings = get_settings_service().settings
+        if settings.storage_type == "s3":
+            msg = (
+                "Mem0 memory is not supported in S3/cloud mode. "
+                "Mem0 memory requires local file system access for persistence. "
+                "Please use local storage mode."
+            )
+            raise ValueError(msg)
         mem0_memory = self.ingest_data()
         search_query = self.search_query
         user_id = self.user_id


### PR DESCRIPTION
Adds validation to each method in the mem0 component to check if s3 storage_type is being used. If true, raises a ValueError. This is a temporary fix for the OOM issue faced in production (the data volume). We note that the initialization of a mem0 instance is also disabled to prevent bloat in the container, as it can be used to arbitrarily create directories containing .sqlite files.