### PR TITLE
chore: Update pip and setuptools version constraints

### DIFF
--- a/src/lfx/pyproject.toml
+++ b/src/lfx/pyproject.toml
@@ -40,8 +40,6 @@ dependencies = [
     "langchain~=0.3.23",
     "validators>=0.34.0,<1.0.0",
     "filelock>=3.20.0",
-    "pip>=25.3,<26.0.0",
-    "setuptools>=78.1.1,<79.0.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin'",
@@ -5923,6 +5923,7 @@ dependencies = [
     { name = "pandas" },
     { name = "passlib" },
     { name = "pillow" },
+    { name = "pip" },
     { name = "platformdirs" },
     { name = "prometheus-client" },
     { name = "pydantic" },
@@ -6063,6 +6064,7 @@ requires-dist = [
     { name = "pandas", specifier = "==2.2.3" },
     { name = "passlib", specifier = ">=1.7.4,<2.0.0" },
     { name = "pillow", specifier = ">=11.1.0,<12.0.0" },
+    { name = "pip", specifier = ">=25.3,<26.0.0" },
     { name = "platformdirs", specifier = ">=4.2.0,<5.0.0" },
     { name = "prometheus-client", specifier = ">=0.20.0,<1.0.0" },
     { name = "pydantic", specifier = "~=2.11.0" },
@@ -6077,7 +6079,7 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "sentence-transformers", marker = "extra == 'local'", specifier = ">=2.0.0" },
     { name = "sentry-sdk", extras = ["fastapi", "loguru"], specifier = ">=2.5.1,<3.0.0" },
-    { name = "setuptools", specifier = ">=78.1.0,<79.0.0" },
+    { name = "setuptools", specifier = ">=78.1.1,<79.0.0" },
     { name = "spider-client", specifier = ">=0.0.27,<1.0.0" },
     { name = "sqlalchemy", extras = ["aiosqlite"], specifier = ">=2.0.38,<3.0.0" },
     { name = "sqlalchemy", extras = ["postgresql-psycopg"], marker = "extra == 'postgresql'", specifier = ">=2.0.38,<3.0.0" },
@@ -9518,6 +9520,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f4/fb/e8a4063264953ead9e2b24d9b390152c60f042c951c47f4592e9996e57ff/pinecone_plugin_interface-0.0.7.tar.gz", hash = "sha256:b8e6675e41847333aa13923cc44daa3f85676d7157324682dc1640588a982846", size = 3370, upload-time = "2024-06-05T01:57:52.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/1d/a21fdfcd6d022cb64cef5c2a29ee6691c6c103c4566b41646b080b7536a5/pinecone_plugin_interface-0.0.7-py3-none-any.whl", hash = "sha256:875857ad9c9fc8bbc074dbe780d187a2afd21f5bfe0f3b08601924a61ef1bba8", size = 6249, upload-time = "2024-06-05T01:57:50.583Z" },
+]
+
+[[package]]
+name = "pip"
+version = "25.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/6e/74a3f0179a4a73a53d66ce57fdb4de0080a8baa1de0063de206d6167acc2/pip-25.3.tar.gz", hash = "sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343", size = 1803014, upload-time = "2025-10-25T00:55:41.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/3c/d717024885424591d5376220b5e836c2d5293ce2011523c9de23ff7bf068/pip-25.3-py3-none-any.whl", hash = "sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd", size = 1778622, upload-time = "2025-10-25T00:55:39.247Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request updates the Python package dependencies for both the backend and LFX components to ensure compatibility and address potential issues with package management. The most important changes are grouped below:

**Dependency updates for package management:**

* Added `pip>=25.3,<26.0.0` as a required dependency in both `src/backend/base/pyproject.toml` and `src/lfx/pyproject.toml` to ensure a minimum version of pip is used. [[1]](diffhunk://#diff-791e429538b782db78051d7dc01bf66022b585810db3f20b644e26ce5d1cce48L69-R70) [[2]](diffhunk://#diff-d8ce811c4d427c9a2040e08aac6a13a11c502abe1f9fc92bf2f76825c66a9535R43-R44)
* Updated the `setuptools` dependency to `>=78.1.1,<79.0.0` in both files, replacing the previous version constraint. [[1]](diffhunk://#diff-791e429538b782db78051d7dc01bf66022b585810db3f20b644e26ce5d1cce48L69-R70) [[2]](diffhunk://#diff-d8ce811c4d427c9a2040e08aac6a13a11c502abe1f9fc92bf2f76825c66a9535R43-R44)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Updated project dependencies to ensure compatibility and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->