### PR TITLE
fix: removed unnecessary buttons on the flows page

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chat-view-wrapper.tsx
+++ b/src/frontend/src/modals/IOModal/components/chat-view-wrapper.tsx
@@ -13,7 +13,6 @@ export const ChatViewWrapper = ({
   sidebarOpen,
   currentFlowId,
   setSidebarOpen,
-  isPlayground,
   setvisibleSession,
   setSelectedViewField,
   messagesFetched,
@@ -21,7 +20,6 @@ export const ChatViewWrapper = ({
   sendMessage,
   canvasOpen,
   setOpen,
-  playgroundTitle,
   playgroundPage,
 }: ChatViewWrapperProps) => {
   return (

--- a/src/frontend/src/modals/deleteConfirmationModal/index.tsx
+++ b/src/frontend/src/modals/deleteConfirmationModal/index.tsx
@@ -29,9 +29,11 @@ export default function DeleteConfirmationModal({
 }) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild={!children ? true : asChild} tabIndex={-1}>
-        {children ?? <></>}
-      </DialogTrigger>
+      {children && (
+        <DialogTrigger asChild={!children ? true : asChild} tabIndex={-1}>
+          {children}
+        </DialogTrigger>
+      )}
       <DialogContent>
         <DialogHeader>
           <DialogTitle>

--- a/src/frontend/src/pages/MainPage/components/header/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/index.tsx
@@ -184,44 +184,6 @@ const HeaderComponent = ({
                 </div>
               </div>
               <div className="flex items-center">
-                <div
-                  className={cn(
-                    "flex w-0 items-center gap-2 overflow-hidden opacity-0 transition-all duration-300",
-                    selectedFlows.length > 0 && "w-36 opacity-100",
-                  )}
-                >
-                  <Button
-                    variant="outline"
-                    size="iconMd"
-                    className="h-8 w-8"
-                    data-testid="download-bulk-btn"
-                    onClick={handleDownload}
-                    loading={isDownloading}
-                  >
-                    <ForwardedIconComponent name="Download" />
-                  </Button>
-
-                  <DeleteConfirmationModal
-                    onConfirm={handleDelete}
-                    description={"flow" + (selectedFlows.length > 1 ? "s" : "")}
-                    note={
-                      "and " +
-                      (selectedFlows.length > 1 ? "their" : "its") +
-                      " message history"
-                    }
-                  >
-                    <Button
-                      variant="destructive"
-                      size="iconMd"
-                      className="px-2.5 !text-mmd"
-                      data-testid="delete-bulk-btn"
-                      loading={isDeleting}
-                    >
-                      <ForwardedIconComponent name="Trash2" />
-                      Delete
-                    </Button>
-                  </DeleteConfirmationModal>
-                </div>
                 <ShadTooltip content="New Flow" side="bottom">
                   <Button
                     variant="default"


### PR DESCRIPTION
**Description** 
We are seeing a warning in the console when a user lands on the on the [flows](http://localhost:3000/flows). 
The Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>. 

This is happening because of nested buttons that aren't even necessary. We are currently creating a delete button and a download  button that is within the Dialog trigger which is also a button.

We evaluated and saw that it is a bug that these buttons exist. I remove these buttons. Their functionalities we none functional are even erroring out anyways.

Testcase
1. We should be able to delete any individual flow
2. You shouldn't see the buttons on the Download button or the delete button on the page and in the Element console
3. You shouldn't see the above item in the warning in the console

Screenshots

**Before**
<img width="1722" height="1028" alt="Screenshot 2025-11-25 at 3 26 04 PM" src="https://github.com/user-attachments/assets/e21040b8-2c29-4bba-abd6-2d04f69340f8" />

forcing the button to show
After Download button was click and the endpoint request
<img width="1722" height="1028" alt="Screenshot 2025-11-25 at 3 27 40 PM" src="https://github.com/user-attachments/assets/e1f28a15-7531-4103-8970-71dbf76b516e" />

After Delete was clicked and endpoint request
<img width="1722" height="1028" alt="Screenshot 2025-11-25 at 3 28 10 PM" src="https://github.com/user-attachments/assets/716f7b8b-d399-417a-8660-6a0524e69021" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the header by removing bulk action buttons for downloading and deleting selected flows. All other header controls remain available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->