### PR TITLE
fix: mask value to hide null field being returned

### DIFF
--- a/src/frontend/src/pages/SettingsPage/pages/GlobalVariablesPage/__tests__/GlobalVariablesPage.test.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GlobalVariablesPage/__tests__/GlobalVariablesPage.test.tsx
@@ -1,0 +1,159 @@
+import type { ColDef, ValueFormatterParams } from "ag-grid-community";
+import type { GlobalVariable } from "@/types/global_variables";
+
+describe("GlobalVariablesPage - valueFormatter Tests", () => {
+  const valueFormatter = (
+    params: Partial<ValueFormatterParams<GlobalVariable>>,
+  ): string => {
+    const isCreditential = params.data?.type === "Credential";
+    if (isCreditential) {
+      return "*****";
+    }
+    return params.value ?? "";
+  };
+
+  const arrayFormatter = (
+    params: Partial<ValueFormatterParams<GlobalVariable>>,
+  ): string => params.value?.join(", ") ?? "";
+
+  it("should mask credential type with actual value", () => {
+    const result = valueFormatter({
+      value: "secret-password",
+      data: { type: "Credential" } as unknown as GlobalVariable,
+    });
+    expect(result).toBe("*****");
+  });
+
+  it("should display actual string value for generic type", () => {
+    const result = valueFormatter({
+      value: "https://api.example.com",
+      data: { type: "Generic" } as unknown as GlobalVariable,
+    });
+    expect(result).toBe("https://api.example.com");
+  });
+
+  it("should mask credential type regardless of value (null, empty, etc)", () => {
+    expect(
+      valueFormatter({
+        value: null,
+        data: { type: "Credential" } as unknown as GlobalVariable,
+      }),
+    ).toBe("*****");
+    expect(
+      valueFormatter({
+        value: "",
+        data: { type: "Credential" } as unknown as GlobalVariable,
+      }),
+    ).toBe("*****");
+    expect(
+      valueFormatter({
+        value: undefined,
+        data: { type: "Credential" } as unknown as GlobalVariable,
+      }),
+    ).toBe("*****");
+  });
+
+  it("should display generic type with various values (null, zero, false)", () => {
+    expect(
+      valueFormatter({
+        value: null,
+        data: { type: "Generic" } as unknown as GlobalVariable,
+      }),
+    ).toBe("");
+    expect(
+      valueFormatter({
+        value: 0,
+        data: { type: "Generic" } as unknown as GlobalVariable,
+      }),
+    ).toBe(0);
+    expect(
+      valueFormatter({
+        value: false,
+        data: { type: "Generic" } as unknown as GlobalVariable,
+      }),
+    ).toBe(false);
+  });
+
+  it("should handle mixed credential and generic variables in table", () => {
+    const credentialVar: GlobalVariable = {
+      id: "1",
+      name: "PASSWORD",
+      value: "secret",
+      type: "Credential",
+      default_fields: [],
+    };
+    const genericVar: GlobalVariable = {
+      id: "2",
+      name: "ENDPOINT",
+      value: "https://api.com",
+      type: "Generic",
+      default_fields: [],
+    };
+
+    expect(
+      valueFormatter({ value: credentialVar.value, data: credentialVar }),
+    ).toBe("*****");
+    expect(valueFormatter({ value: genericVar.value, data: genericVar })).toBe(
+      "https://api.com",
+    );
+  });
+
+  it("should have value column with valueFormatter applied", () => {
+    const colDefs = [
+      {
+        field: "value",
+        valueFormatter: valueFormatter,
+      },
+    ];
+
+    const valueColumn = colDefs.find((col) => col.field === "value");
+    expect(valueColumn).toBeDefined();
+    expect(typeof valueColumn?.valueFormatter).toBe("function");
+  });
+
+  it("should have all required column definitions", () => {
+    const colDefs: ColDef<GlobalVariable>[] = [
+      { headerName: "Variable Name", field: "name", flex: 2 },
+      { headerName: "Type", field: "type", cellRenderer: jest.fn() },
+      { field: "value", valueFormatter },
+      {
+        headerName: "Apply To Fields",
+        field: "default_fields",
+        valueFormatter: arrayFormatter,
+      },
+    ];
+
+    expect(colDefs.map((c) => c.field)).toEqual([
+      "name",
+      "type",
+      "value",
+      "default_fields",
+    ]);
+    expect(colDefs.length).toBe(4);
+  });
+
+  it("should format array fields with comma separator", () => {
+    expect(arrayFormatter({ value: ["field1", "field2", "field3"] })).toBe(
+      "field1, field2, field3",
+    );
+    expect(arrayFormatter({ value: ["field1"] })).toBe("field1");
+    expect(arrayFormatter({ value: [] })).toBe("");
+    expect(arrayFormatter({ value: null })).toBe("");
+  });
+
+  it("should handle edge cases with unknown type and special characters", () => {
+    expect(
+      valueFormatter({
+        value: "some-value",
+        data: { type: "Unknown" } as unknown as GlobalVariable,
+      }),
+    ).toBe("some-value");
+    expect(
+      valueFormatter({
+        value: "p@ss!word#$%",
+        data: { type: "Credential" } as unknown as GlobalVariable,
+      }),
+    ).toBe("*****");
+    expect(valueFormatter({ value: "test", data: undefined })).toBe("test");
+  });
+});

--- a/src/frontend/src/pages/SettingsPage/pages/GlobalVariablesPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GlobalVariablesPage/index.tsx
@@ -2,6 +2,7 @@ import type {
   ColDef,
   RowClickedEvent,
   SelectionChangedEvent,
+  ValueFormatterParams,
 } from "ag-grid-community";
 import { useRef, useState } from "react";
 
@@ -62,8 +63,13 @@ export default function GlobalVariablesPage() {
     },
     {
       field: "value",
-      valueFormatter: (params) => {
-        return params.value == null ? "*****" : params.value;
+      valueFormatter: (params: ValueFormatterParams<GlobalVariable>) => {
+        const isCreditential = params.data?.type === "Credential";
+
+        if (isCreditential) {
+          return "*****";
+        }
+        return params.value ?? "";
       },
     },
     {


### PR DESCRIPTION
**Description**

When a user create a global variable, and the type is credential, the value is persisted to the BE. The BE however doesn't send the credential back to the FE  to protect the key. On the FE we receive a null for the value field which is why the index is empty. My change simply ensures that when a null is seen we just used a masked string "*****" to simulate that fact that a key was inserted.

Testcase
1. Add a new variable (credential) under the global variable tab on the setting page
2. Ensure that we see the masked key when the key as the been saved
3. Add a new variable (generic) under the global variable tab on the setting page
4. Ensure that we see the value previously inserted when the key as the been saved

**Screenshot**
Before
<img width="1201" height="806" alt="Screenshot 2025-11-28 at 10 30 31 AM" src="https://github.com/user-attachments/assets/8f92dd42-c190-49bb-ada2-5f02988e6b2b" />

After
<img width="1201" height="806" alt="Screenshot 2025-11-28 at 10 31 15 AM" src="https://github.com/user-attachments/assets/6963828b-2ad0-4656-a286-edef85749171" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Global Variables table now masks null or undefined values, displaying them as asterisks for improved clarity and visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->