### PR TITLE
fix: add back in macOS amd64 runners

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -89,10 +89,15 @@ jobs:
             arch: amd64
             runner: ubuntu-latest
             python-version: "3.12"
-          # macOS-13 Brown out
-          # TODO add macos-15-intel
-          # https://github.com/actions/runner-images/issues/13046
-          # https://github.com/godot-rust/gdext/pull/1402
+          # macOS AMD64
+          - os: macos
+            arch: amd64
+            runner: macos-latest-large
+            python-version: "3.10"
+          - os: macos
+            arch: amd64
+            runner: macos-latest-large
+            python-version: "3.12"
           # macOS ARM64 (Apple Silicon)
           - os: macos
             arch: arm64
@@ -387,15 +392,17 @@ jobs:
             arch: amd64
             runner: ubuntu-latest
             python-version: "3.13"
-          # macOS-13 Brown out
-          # TODO add macos-15-intel
-          - os: macos
-            arch: arm64
-            runner: macos-latest
-            python-version: "3.13"
           - os: windows
             arch: amd64
             runner: windows-latest
+            python-version: "3.13"
+          - os: macos
+            arch: amd64
+            runner: macos-latest-large
+            python-version: "3.13"
+          - os: macos
+            arch: arm64
+            runner: macos-latest
             python-version: "3.13"
 
     steps:


### PR DESCRIPTION
macos-13 runners are depricated adding back in macOS-latest

refs:
https://github.com/actions/runner-images
https://github.com/actions/partner-runner-images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cross-platform test infrastructure by adding dedicated macOS AMD64 runners with improved hardware resources for Python 3.10 and 3.12 testing, ensuring better test coverage and performance across different architectures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->