### PR TITLE
feat(lfx): Add type stubs for IDE autocomplete

### DIFF
--- a/.github/workflows/release-lfx.yml
+++ b/.github/workflows/release-lfx.yml
@@ -164,6 +164,9 @@ jobs:
 
           echo "version=$version" >> $GITHUB_OUTPUT
 
+      - name: Generate type stubs
+        run: uv run python scripts/generate_lfx_stubs.py --inline
+
       - name: Build distribution
         run: |
           cd src/lfx
@@ -176,6 +179,16 @@ jobs:
           ls -la dist/
           # Verify wheel contents
           unzip -l dist/*.whl | grep -E "(lfx/__main__.py|lfx/cli/run.py|lfx/cli/commands.py)"
+          # Verify type stubs are included
+          echo "Checking for type stubs..."
+          unzip -l dist/*.whl | grep -E "\.pyi$" | head -5
+          STUB_COUNT=$(unzip -l dist/*.whl | grep -c "\.pyi$" || true)
+          echo "Found $STUB_COUNT stub files in wheel"
+          if [ "$STUB_COUNT" -lt 100 ]; then
+            echo "❌ Expected at least 100 stub files, found $STUB_COUNT"
+            exit 1
+          fi
+          echo "✅ Type stubs verified"
 
       - name: Test installation from wheel
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -286,5 +286,8 @@ member_servers.json
 # Component index cache (user-specific)
 **/.cache/lfx/
 
+# lfx generated stubs (generated at build time)
+src/lfx/src/lfx/**/*.pyi
+
 # data files used for desktop registration
 data/user

--- a/scripts/generate_lfx_stubs.py
+++ b/scripts/generate_lfx_stubs.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""Generate .pyi stub files for lfx components.
+
+This script generates type stubs for all lfx components, enabling:
+- Autocomplete for set() method parameters in VSCode/PyCharm
+- Type hints for output methods
+- Better IDE integration when building flows from Python
+
+Usage:
+    python scripts/generate_lfx_stubs.py [--inline | output_dir]
+
+Examples:
+    # Generate inline stubs (directly in the lfx package for distribution)
+    python scripts/generate_lfx_stubs.py --inline
+
+    # Generate stubs to typings/ folder (for local development)
+    python scripts/generate_lfx_stubs.py
+
+    # Generate stubs to custom location
+    python scripts/generate_lfx_stubs.py ./my-stubs
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add lfx to path so we can import it
+lfx_path = Path(__file__).parent.parent / "src" / "lfx" / "src"
+sys.path.insert(0, str(lfx_path))
+
+
+def main():
+    from lfx.stubs import generate_stubs
+    from rich.console import Console
+
+    console = Console()
+
+    # Check for --inline flag
+    inline_mode = "--inline" in sys.argv
+
+    if inline_mode:
+        # Generate stubs directly in the lfx package (for distribution)
+        output_dir = Path(__file__).parent.parent / "src" / "lfx" / "src"
+        console.print("[bold]Generating inline stubs (for package distribution)[/bold]")
+    elif len(sys.argv) > 1 and not sys.argv[1].startswith("-"):
+        output_dir = Path(sys.argv[1])
+    else:
+        # Default: typings/ in repo root (for local VSCode development)
+        output_dir = Path(__file__).parent.parent / "typings"
+
+    console.print(f"[bold]Output directory: {output_dir}[/bold]")
+
+    stubs = generate_stubs(output_dir)
+
+    console.print(f"[green]Generated {len(stubs)} stub files[/green]")
+
+    max_display = 10
+    for stub_path in sorted(stubs.keys())[:max_display]:
+        console.print(f"  - {stub_path}")
+
+    if len(stubs) > max_display:
+        console.print(f"  ... and {len(stubs) - max_display} more")
+
+    console.print()
+    if inline_mode:
+        console.print("[dim]Stubs are now part of the lfx package.[/dim]")
+        console.print("[dim]Users will get autocomplete when they 'pip install lfx'.[/dim]")
+    else:
+        console.print("[dim]VSCode should automatically pick up stubs from 'typings/' folder.[/dim]")
+        console.print("[dim]If not, add to .vscode/settings.json:[/dim]")
+        console.print('[blue]  "python.analysis.stubPath": "typings"[/blue]')
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lfx/pyproject.toml
+++ b/src/lfx/pyproject.toml
@@ -53,6 +53,15 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/lfx"]
 
+[tool.hatch.build.targets.wheel.shared-data]
+
+[tool.hatch.build]
+include = [
+    "src/lfx/**/*.py",
+    "src/lfx/**/*.pyi",
+    "src/lfx/py.typed",
+]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/src/lfx/src/lfx/stubs/__init__.py
+++ b/src/lfx/src/lfx/stubs/__init__.py
@@ -1,0 +1,5 @@
+"""Stub generation for IDE autocomplete support."""
+
+from lfx.stubs.generator import generate_stubs, generate_stubs_for_component
+
+__all__ = ["generate_stubs", "generate_stubs_for_component"]

--- a/src/lfx/src/lfx/stubs/generator.py
+++ b/src/lfx/src/lfx/stubs/generator.py
@@ -1,0 +1,406 @@
+"""Generate .pyi stub files for components to enable IDE autocomplete."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lfx.custom.custom_component.component import Component
+
+# Mapping from input class names to Python types
+# These are the "native" types that each input stores/expects
+INPUT_TYPE_MAP: dict[str, str] = {
+    "StrInput": "str",
+    "MessageTextInput": "str | Message",  # Accepts Message but stores str
+    "MultilineInput": "str | Message",
+    "MultilineSecretInput": "str",  # pragma: allowlist secret
+    "SecretStrInput": "str",  # pragma: allowlist secret
+    "IntInput": "int",
+    "FloatInput": "float",
+    "BoolInput": "bool",
+    "DictInput": "dict[str, Any]",
+    "NestedDictInput": "dict[str, Any]",
+    "TableInput": "list[dict[str, Any]]",
+    "DropdownInput": "str",
+    "HandleInput": "Any",
+    "DataInput": "Data",
+    "DataFrameInput": "DataFrame",
+    "MessageInput": "Message",
+    "PromptInput": "str",
+    "CodeInput": "str",
+    "FileInput": "str",
+    "LinkInput": "str",
+    "SliderInput": "float",
+    "ToolsInput": "list[dict]",
+    "ConnectionInput": "Any",
+}
+
+# Input types where we should NOT use input_types for the type hint
+# because input_types describes what can be connected, not what value type is stored
+IGNORE_INPUT_TYPES_FOR: set[str] = {
+    "MessageTextInput",
+    "MultilineInput",
+}
+
+
+def _get_python_type_for_input(inp: Any) -> str:
+    """Get the Python type annotation string for an input."""
+    input_class_name = type(inp).__name__
+
+    # For certain input types, use the explicit mapping instead of input_types
+    if input_class_name in IGNORE_INPUT_TYPES_FOR:
+        return INPUT_TYPE_MAP.get(input_class_name, "Any")
+
+    # Check if it has input_types defined (like HandleInput)
+    if hasattr(inp, "input_types") and inp.input_types:
+        types = inp.input_types
+        if len(types) == 1:
+            return types[0]
+        return f"{' | '.join(types)}"
+
+    return INPUT_TYPE_MAP.get(input_class_name, "Any")
+
+
+def _get_default_repr(value: Any) -> str:
+    """Get a string representation of a default value for stub files."""
+    if value is None:
+        return "None"
+    if isinstance(value, str):
+        # Escape quotes in string
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, int | float):
+        return str(value)
+    if isinstance(value, list):
+        if not value:
+            return "[]"
+        return "..."
+    if isinstance(value, dict):
+        if not value:
+            return "{}"
+        return "..."
+    return "..."
+
+
+def _get_output_return_type(output: Any, component_class: type | None = None) -> str:
+    """Get the return type for an output method.
+
+    Args:
+        output: The Output object.
+        component_class: The component class to inspect for method return type annotations.
+
+    Returns:
+        The return type as a string.
+    """
+    # First, try to get the return type from output.types
+    if hasattr(output, "types") and output.types:
+        types = output.types
+        if len(types) == 1:
+            return types[0]
+        return f"{' | '.join(types)}"
+
+    # If no types defined, try to get from method's return type annotation
+    if component_class and hasattr(output, "method") and output.method:
+        method = getattr(component_class, output.method, None)
+        if method:
+            hints = getattr(method, "__annotations__", {})
+            return_hint = hints.get("return")
+            if return_hint is not None:
+                return _type_to_str(return_hint)
+
+    return "Any"
+
+
+def _type_to_str(type_hint: Any) -> str:
+    """Convert a type hint to a string representation for stubs."""
+    import typing
+
+    # Handle None type
+    if type_hint is type(None):
+        return "None"
+
+    # Handle string annotations (forward references)
+    if isinstance(type_hint, str):
+        return type_hint
+
+    # Handle typing module types (Union, Optional, etc.)
+    origin = getattr(type_hint, "__origin__", None)
+
+    if origin is typing.Union:
+        args = getattr(type_hint, "__args__", ())
+        # Check if it's Optional (Union with None)
+        if len(args) == 2 and type(None) in args:  # noqa: PLR2004
+            non_none = next(a for a in args if a is not type(None))
+            return f"{_type_to_str(non_none)} | None"
+        return " | ".join(_type_to_str(a) for a in args)
+
+    if origin is list:
+        args = getattr(type_hint, "__args__", ())
+        if args:
+            return f"list[{_type_to_str(args[0])}]"
+        return "list"
+
+    if origin is dict:
+        args = getattr(type_hint, "__args__", ())
+        if len(args) == 2:  # noqa: PLR2004
+            return f"dict[{_type_to_str(args[0])}, {_type_to_str(args[1])}]"
+        return "dict"
+
+    # Handle regular types
+    if hasattr(type_hint, "__name__"):
+        return type_hint.__name__
+
+    # Fallback to string representation
+    return str(type_hint).replace("typing.", "").replace("lfx.schema.", "")
+
+
+def generate_stubs_for_component(component_class: type[Component]) -> str:
+    """Generate stub content for a single component class.
+
+    Args:
+        component_class: The component class to generate stubs for.
+
+    Returns:
+        String containing the .pyi stub content for the class.
+    """
+    lines = []
+
+    # Get the class name and parent
+    class_name = component_class.__name__
+
+    # Find base class
+    bases = [b.__name__ for b in component_class.__bases__ if b.__name__ != "object"]
+    base_str = ", ".join(bases) if bases else "Component"
+
+    lines.append(f"class {class_name}({base_str}):")
+
+    # Get inputs from class attribute
+    inputs = getattr(component_class, "inputs", [])
+    outputs = getattr(component_class, "outputs", [])
+
+    if not inputs and not outputs:
+        lines.append("    ...")
+        return "\n".join(lines)
+
+    # Generate set() method signature
+    lines.append("    def set(")
+    lines.append("        self,")
+    lines.append("        *,")
+
+    seen_names: set[str] = set()
+    for inp in inputs:
+        if inp.name in seen_names:
+            continue
+        seen_names.add(inp.name)
+
+        py_type = _get_python_type_for_input(inp)
+        default = _get_default_repr(inp.value) if inp.value is not None else "..."
+
+        lines.append(f"        {inp.name}: {py_type} = {default},")
+
+    lines.append("    ) -> Self: ...")
+
+    # Generate output method stubs
+    for output in outputs:
+        if not hasattr(output, "method") or not output.method:
+            continue
+
+        method_name = output.method
+        return_type = _get_output_return_type(output, component_class)
+
+        # Check if the method is async by inspecting the class
+        method = getattr(component_class, method_name, None)
+        if method and inspect.iscoroutinefunction(method):
+            lines.append(f"    async def {method_name}(self) -> {return_type}: ...")
+        else:
+            lines.append(f"    def {method_name}(self) -> {return_type}: ...")
+
+    return "\n".join(lines)
+
+
+def _collect_imports(component_classes: list[type[Component]]) -> set[str]:
+    """Collect all imports needed for the stub file."""
+    imports: set[str] = set()
+    imports.add("from typing import Any")
+    imports.add("from typing_extensions import Self")
+
+    for component_class in component_classes:
+        inputs = getattr(component_class, "inputs", [])
+        outputs = getattr(component_class, "outputs", [])
+
+        for inp in inputs:
+            py_type = _get_python_type_for_input(inp)
+            if "Data" in py_type:
+                imports.add("from lfx.schema.data import Data")
+            if "DataFrame" in py_type:
+                imports.add("from lfx.schema.dataframe import DataFrame")
+            if "Message" in py_type:
+                imports.add("from lfx.schema.message import Message")
+
+        for output in outputs:
+            return_type = _get_output_return_type(output, component_class)
+            if "Data" in return_type:
+                imports.add("from lfx.schema.data import Data")
+            if "DataFrame" in return_type:
+                imports.add("from lfx.schema.dataframe import DataFrame")
+            if "Message" in return_type:
+                imports.add("from lfx.schema.message import Message")
+
+    return imports
+
+
+def generate_stubs_for_module(module_path: str) -> dict[str, str]:
+    """Generate stubs for all components in a module.
+
+    Args:
+        module_path: The import path to the module (e.g., 'lfx.components.input_output').
+
+    Returns:
+        Dict mapping relative file paths to stub content.
+    """
+    from lfx.custom.custom_component.component import Component
+
+    stubs: dict[str, str] = {}
+
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError:
+        return stubs
+
+    # Find all Component subclasses in the module
+    component_classes: list[type[Component]] = []
+    for name in dir(module):
+        obj = getattr(module, name)
+        if isinstance(obj, type) and issubclass(obj, Component) and obj is not Component:
+            component_classes.append(obj)
+
+    if not component_classes:
+        return stubs
+
+    # Generate imports
+    imports = _collect_imports(component_classes)
+
+    # Generate stub content
+    lines = list(imports)
+    lines.append("")
+    lines.append("")
+
+    for component_class in sorted(component_classes, key=lambda c: c.__name__):
+        lines.append(generate_stubs_for_component(component_class))
+        lines.append("")
+        lines.append("")
+
+    # Determine output path
+    module_parts = module_path.split(".")
+    stub_path = "/".join(module_parts) + ".pyi"
+
+    stubs[stub_path] = "\n".join(lines)
+
+    return stubs
+
+
+def generate_stubs(output_dir: str | Path | None = None) -> dict[str, str]:
+    """Generate stubs for all lfx components.
+
+    Args:
+        output_dir: Optional directory to write stub files to.
+            If None, returns the stubs as a dict without writing.
+
+    Returns:
+        Dict mapping file paths to stub content.
+    """
+    from lfx.custom.custom_component.component import Component
+
+    all_stubs: dict[str, str] = {}
+
+    # Import the components package to discover submodules
+    try:
+        import lfx.components as components_pkg
+    except ImportError:
+        return all_stubs
+
+    # Walk through all submodules
+    package_path = Path(components_pkg.__file__).parent
+
+    for module_info in pkgutil.walk_packages([str(package_path)], prefix="lfx.components."):
+        try:
+            module = importlib.import_module(module_info.name)
+        except Exception:  # noqa: BLE001, S112
+            # Skip modules that can't be imported (missing optional dependencies, key errors, etc.)
+            continue
+
+        # Find Component subclasses
+        component_classes: list[type[Component]] = []
+        for name in dir(module):
+            try:
+                obj = getattr(module, name)
+            except Exception:  # noqa: BLE001, S112
+                # Skip attributes that can't be accessed (lazy loading failures, missing deps)
+                continue
+
+            try:
+                if (
+                    isinstance(obj, type)
+                    and issubclass(obj, Component)
+                    and obj is not Component
+                    and obj.__module__ == module_info.name
+                ):
+                    component_classes.append(obj)
+            except (TypeError, Exception):  # noqa: BLE001, S112
+                # issubclass can fail for some types
+                continue
+
+        if not component_classes:
+            continue
+
+        # Generate imports
+        imports = _collect_imports(component_classes)
+
+        # Generate stub content
+        lines = sorted(imports)
+        lines.append("")
+        lines.append("")
+
+        for component_class in sorted(component_classes, key=lambda c: c.__name__):
+            lines.append(generate_stubs_for_component(component_class))
+            lines.append("")
+            lines.append("")
+
+        # Determine output path
+        module_parts = module_info.name.split(".")
+        stub_path = "/".join(module_parts) + ".pyi"
+
+        all_stubs[stub_path] = "\n".join(lines)
+
+    # Write files if output_dir is specified
+    if output_dir:
+        output_path = Path(output_dir)
+
+        # Track directories that need __init__.pyi
+        init_dirs: set[Path] = set()
+
+        for stub_path, content in all_stubs.items():
+            full_path = output_path / stub_path
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            full_path.write_text(content)
+
+            # Track all parent directories for __init__.pyi
+            parent = full_path.parent
+            while parent not in (output_path, output_path.parent):
+                init_dirs.add(parent)
+                parent = parent.parent
+
+        # Create __init__.pyi files for all package directories
+        for init_dir in init_dirs:
+            init_file = init_dir / "__init__.pyi"
+            if not init_file.exists():
+                # Create stub that re-exports from submodules
+                init_file.write_text("# Auto-generated stub\n")
+
+    return all_stubs

--- a/src/lfx/tests/unit/custom/component/test_component_dx.py
+++ b/src/lfx/tests/unit/custom/component/test_component_dx.py
@@ -1,0 +1,181 @@
+"""Tests for Component developer experience (DX) features.
+
+Tests for __dir__, describe(), and set() signature features.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from lfx.components.input_output.chat import ChatInput
+from lfx.components.input_output.chat_output import ChatOutput
+from lfx.custom.custom_component.component import Component
+from lfx.inputs.inputs import MessageTextInput
+from lfx.io import Output
+
+
+class SimpleTestComponent(Component):
+    """A simple component for testing DX features."""
+
+    display_name = "Simple Test"
+    description = "A test component"
+
+    inputs = [
+        MessageTextInput(name="text_input", display_name="Text", info="Input text"),
+        MessageTextInput(name="prefix", display_name="Prefix", value="Hello"),
+    ]
+    outputs = [
+        Output(display_name="Result", name="result", method="process_text"),
+    ]
+
+    def process_text(self) -> str:
+        return f"{self.prefix} {self.text_input}"
+
+
+class TestComponentDir:
+    """Tests for __dir__ method."""
+
+    def test_dir_includes_input_names(self):
+        """__dir__ includes input names for autocomplete."""
+        comp = SimpleTestComponent()
+        dir_items = dir(comp)
+
+        assert "text_input" in dir_items
+        assert "prefix" in dir_items
+
+    def test_dir_includes_output_methods(self):
+        """__dir__ includes output method names for connection."""
+        comp = SimpleTestComponent()
+        dir_items = dir(comp)
+
+        assert "process_text" in dir_items
+
+    def test_dir_includes_standard_attributes(self):
+        """__dir__ still includes standard class attributes."""
+        comp = SimpleTestComponent()
+        dir_items = dir(comp)
+
+        # Should include standard methods
+        assert "set" in dir_items
+        assert "describe" in dir_items
+        assert "list_inputs" in dir_items
+        assert "list_outputs" in dir_items
+
+    def test_dir_with_chat_input(self):
+        """__dir__ works with built-in ChatInput component."""
+        chat_input = ChatInput()
+        dir_items = dir(chat_input)
+
+        # Should include the output method
+        assert "message_response" in dir_items
+        # Should include input names
+        assert "input_value" in dir_items
+
+    def test_dir_with_chat_output(self):
+        """__dir__ works with built-in ChatOutput component."""
+        chat_output = ChatOutput()
+        dir_items = dir(chat_output)
+
+        # Should include input names
+        assert "input_value" in dir_items
+
+
+class TestSetSignature:
+    """Tests for dynamic set() method signature."""
+
+    def test_set_signature_shows_inputs(self):
+        """set() signature includes input parameter names."""
+        comp = SimpleTestComponent()
+        sig = inspect.signature(comp.set)
+        param_names = list(sig.parameters.keys())
+
+        # Should include input names (self is not shown for bound methods)
+        assert "text_input" in param_names
+        assert "prefix" in param_names
+
+    def test_set_signature_shows_defaults(self):
+        """set() signature includes default values."""
+        comp = SimpleTestComponent()
+        sig = inspect.signature(comp.set)
+
+        # prefix has default "Hello"
+        prefix_param = sig.parameters["prefix"]
+        assert prefix_param.default == "Hello"
+
+    def test_set_signature_keyword_only(self):
+        """set() parameters are keyword-only."""
+        comp = SimpleTestComponent()
+        sig = inspect.signature(comp.set)
+
+        for name, param in sig.parameters.items():
+            if name != "self":
+                assert param.kind == inspect.Parameter.KEYWORD_ONLY
+
+    def test_set_signature_with_chat_input(self):
+        """set() signature works with ChatInput."""
+        chat_input = ChatInput()
+        sig = inspect.signature(chat_input.set)
+        param_names = list(sig.parameters.keys())
+
+        assert "input_value" in param_names
+        assert "session_id" in param_names
+
+
+class TestDescribe:
+    """Tests for describe() method."""
+
+    def test_describe_returns_string(self):
+        """describe() returns a string."""
+        comp = SimpleTestComponent()
+        result = comp.describe()
+
+        assert isinstance(result, str)
+
+    def test_describe_includes_class_name(self):
+        """describe() includes the class name."""
+        comp = SimpleTestComponent()
+        result = comp.describe()
+
+        assert "SimpleTestComponent" in result
+
+    def test_describe_includes_display_name(self):
+        """describe() includes the display name."""
+        comp = SimpleTestComponent()
+        result = comp.describe()
+
+        assert "Simple Test" in result
+
+    def test_describe_lists_inputs(self):
+        """describe() lists input names."""
+        comp = SimpleTestComponent()
+        result = comp.describe()
+
+        assert "Inputs:" in result
+        assert "text_input" in result
+        assert "prefix" in result
+
+    def test_describe_lists_outputs(self):
+        """describe() lists outputs with method names."""
+        comp = SimpleTestComponent()
+        result = comp.describe()
+
+        assert "Outputs:" in result
+        assert "result" in result
+        assert "process_text" in result
+
+    def test_describe_shows_output_types(self):
+        """describe() shows output types."""
+        chat_input = ChatInput()
+        result = chat_input.describe()
+
+        assert "Message" in result
+
+    def test_describe_with_chat_input(self):
+        """describe() works with ChatInput."""
+        chat_input = ChatInput()
+        result = chat_input.describe()
+
+        assert "ChatInput" in result
+        assert "Chat Input" in result
+        assert "input_value" in result
+        assert "message_response" in result

--- a/src/lfx/tests/unit/stubs/test_stub_generator.py
+++ b/src/lfx/tests/unit/stubs/test_stub_generator.py
@@ -1,0 +1,62 @@
+"""Tests for stub generator."""
+
+from __future__ import annotations
+
+from lfx.components.input_output.chat import ChatInput
+from lfx.components.input_output.chat_output import ChatOutput
+from lfx.stubs.generator import generate_stubs_for_component
+
+
+class TestGenerateStubsForComponent:
+    """Tests for generate_stubs_for_component."""
+
+    def test_generates_set_method(self):
+        """Generated stub includes set() method."""
+        stub = generate_stubs_for_component(ChatOutput)
+
+        assert "def set(" in stub
+        assert "self," in stub
+
+    def test_includes_input_parameters(self):
+        """Generated stub includes input parameter names."""
+        stub = generate_stubs_for_component(ChatOutput)
+
+        assert "input_value:" in stub
+        assert "should_store_message:" in stub
+        assert "sender:" in stub
+
+    def test_includes_output_methods(self):
+        """Generated stub includes output method signatures."""
+        stub = generate_stubs_for_component(ChatOutput)
+
+        assert "def message_response(self)" in stub
+
+    def test_set_returns_self(self):
+        """set() method returns Self for chaining."""
+        stub = generate_stubs_for_component(ChatOutput)
+
+        assert ") -> Self:" in stub
+
+    def test_chat_input_stub(self):
+        """ChatInput generates valid stub."""
+        stub = generate_stubs_for_component(ChatInput)
+
+        assert "class ChatInput" in stub
+        assert "def set(" in stub
+        assert "input_value:" in stub
+
+    def test_includes_type_annotations(self):
+        """Generated stub includes type annotations."""
+        stub = generate_stubs_for_component(ChatOutput)
+
+        # Bool inputs should have bool type
+        assert "bool" in stub
+        # String inputs should have str type
+        assert "str" in stub
+
+    def test_includes_default_values(self):
+        """Generated stub includes default values."""
+        stub = generate_stubs_for_component(ChatOutput)
+
+        # should_store_message has default True
+        assert "= True" in stub


### PR DESCRIPTION
## Summary

- Add type stub generator for lfx components to enable IDE autocomplete (VSCode/PyCharm)
- Add Component DX methods (`__dir__`, `describe()`, dynamic `set()` signature) for runtime introspection
- Configure CI to generate stubs at build time before release
- Stubs are gitignored and generated fresh each release

## What this enables

Users installing `lfx` via pip will get:
- Autocomplete for `component.set(...)` parameters
- Type hints for output method return types (e.g., `-> Message` instead of `-> Any`)
- `py.typed` marker for PEP 561 compliance

## Test plan

- [x] Run stub generator tests: `cd src/lfx && uv sync && uv run pytest tests/unit/stubs/`
- [x] Run component DX tests: `cd src/lfx && uv sync && uv run pytest tests/unit/custom/component/test_component_dx.py`
- [x] Build wheel and verify stubs included: `uv run python scripts/generate_lfx_stubs.py --inline && cd src/lfx && uv build --wheel`
- [ ] Verify IDE autocomplete works after installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced IDE support with dynamic autocomplete for component inputs and method signatures.
  * Added component introspection capabilities to explore available inputs and outputs programmatically.

* **Build & Distribution**
  * Type stub files now included in package distributions for improved type checking compatibility.

* **Tests**
  * Added tests for type stub generation and IDE integration features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->