### PR TITLE
chore: replace 40gb runner with ephemeral

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,7 @@ on:
         options:
           - ubuntu-latest
           - self-hosted
-          - >-
-            ["self-hosted", "linux", "ARM64", "langflow-arm64-runners-group-ephemeral"]
+          - '["self-hosted", "linux", "ARM64", "langflow-arm64-runners-group-ephemeral"]'
         default: ubuntu-latest
   pull_request:
     types: [opened, synchronize, labeled]

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -10,8 +10,7 @@ on:
         options:
           - ubuntu-latest
           - self-hosted
-          - >-
-            ["self-hosted", "linux", "ARM64", "langflow-arm64-runners-group-ephemeral"]
+          - '["self-hosted", "linux", "ARM64", "langflow-arm64-runners-group-ephemeral"]'
         default: ubuntu-latest
       skip_frontend_tests:
         description: "Skip frontend tests. Only do this for testing purposes."

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -43,8 +43,7 @@ on:
         options:
           - ubuntu-latest
           - self-hosted
-          - >-
-            ["self-hosted", "linux", "ARM64", "langflow-arm64-runners-group-ephemeral"]
+          - '["self-hosted", "linux", "ARM64", "langflow-arm64-runners-group-ephemeral"]'
         default: ubuntu-latest
 env:
   POETRY_VERSION: "1.8.2"

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -60,8 +60,7 @@ on:
         options:
           - ubuntu-latest
           - self-hosted
-          - >-
-            ["self-hosted", "linux", "ARM64", "langflow-arm64-runners-group-ephemeral"]
+          - '["self-hosted", "linux", "ARM64", "langflow-arm64-runners-group-ephemeral"]'
         default: ubuntu-latest
 
 env:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -153,7 +153,7 @@
         "filename": ".github/workflows/nightly_build.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 233,
+        "line_number": 232,
         "is_secret": false
       }
     ],
@@ -1528,5 +1528,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-01T22:49:10Z"
+  "generated_at": "2025-12-01T23:03:21Z"
 }


### PR DESCRIPTION
replace langflow-ai-arm64-40gb with langflow-arm64-runners-group-ephemeral

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions CI/CD workflows to use improved runner infrastructure configurations across continuous integration and test pipelines.
  * Standardized Python version syntax formatting in workflow configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->