### PR TITLE
fix(auth): Disallow refresh token access to API endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -755,16 +755,6 @@
         "is_secret": false
       }
     ],
-    "src/backend/base/langflow/inputs/input_mixin.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/base/langflow/inputs/input_mixin.py",
-        "hashed_secret": "3442496b96dd01591a8cd44b1eec1368ab728aba",
-        "is_verified": false,
-        "line_number": 22,
-        "is_secret": false
-      }
-    ],
     "src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json": [
       {
         "type": "Hex High Entropy String",
@@ -881,6 +871,16 @@
         "is_secret": false
       }
     ],
+    "src/backend/base/langflow/inputs/input_mixin.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/inputs/input_mixin.py",
+        "hashed_secret": "3442496b96dd01591a8cd44b1eec1368ab728aba",
+        "is_verified": false,
+        "line_number": 22,
+        "is_secret": false
+      }
+    ],
     "src/backend/base/langflow/schema/table.py": [
       {
         "type": "Secret Keyword",
@@ -897,7 +897,7 @@
         "filename": "src/backend/base/langflow/services/auth/utils.py",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 31,
         "is_secret": false
       }
     ],
@@ -1528,5 +1528,5 @@
       }
     ]
   },
-  "generated_at": "2025-11-19T18:36:04Z"
+  "generated_at": "2025-12-02T04:40:43Z"
 }

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -3,7 +3,7 @@ import random
 import warnings
 from collections.abc import Coroutine
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Final
 from uuid import UUID
 
 from cryptography.fernet import Fernet
@@ -40,6 +40,9 @@ AUTO_LOGIN_ERROR = (
     "Set LANGFLOW_SKIP_AUTH_AUTO_LOGIN=true to skip this check. "
     "Please update your authentication method."
 )
+
+REFRESH_TOKEN_TYPE: Final[str] = "refresh"  # noqa: S105
+ACCESS_TOKEN_TYPE: Final[str] = "access"  # noqa: S105
 
 
 # Source: https://github.com/mrtolkien/fastapi_simple_security/blob/master/fastapi_simple_security/security_api_key.py
@@ -185,6 +188,14 @@ async def get_current_user_by_jwt(
             payload = jwt.decode(token, secret_key, algorithms=[settings_service.auth_settings.ALGORITHM])
         user_id: UUID = payload.get("sub")  # type: ignore[assignment]
         token_type: str = payload.get("type")  # type: ignore[assignment]
+
+        if token_type != ACCESS_TOKEN_TYPE:
+            logger.error(f"Token type is invalid: {token_type}. Expected: {ACCESS_TOKEN_TYPE}.")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token is invalid.",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
         if expires := payload.get("exp", None):
             expires_datetime = datetime.fromtimestamp(expires, timezone.utc)
             if datetime.now(timezone.utc) > expires_datetime:
@@ -413,7 +424,7 @@ async def create_user_longterm_token(db: AsyncSession) -> tuple[UUID, dict]:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Super user hasn't been created")
     access_token_expires_longterm = timedelta(days=365)
     access_token = create_token(
-        data={"sub": str(super_user.id), "type": "access"},
+        data={"sub": str(super_user.id), "type": ACCESS_TOKEN_TYPE},
         expires_delta=access_token_expires_longterm,
     )
 
@@ -449,13 +460,13 @@ async def create_user_tokens(user_id: UUID, db: AsyncSession, *, update_last_log
 
     access_token_expires = timedelta(seconds=settings_service.auth_settings.ACCESS_TOKEN_EXPIRE_SECONDS)
     access_token = create_token(
-        data={"sub": str(user_id), "type": "access"},
+        data={"sub": str(user_id), "type": ACCESS_TOKEN_TYPE},
         expires_delta=access_token_expires,
     )
 
     refresh_token_expires = timedelta(seconds=settings_service.auth_settings.REFRESH_TOKEN_EXPIRE_SECONDS)
     refresh_token = create_token(
-        data={"sub": str(user_id), "type": "refresh"},
+        data={"sub": str(user_id), "type": REFRESH_TOKEN_TYPE},
         expires_delta=refresh_token_expires,
     )
 
@@ -485,7 +496,7 @@ async def create_refresh_token(refresh_token: str, db: AsyncSession):
         user_id: UUID = payload.get("sub")  # type: ignore[assignment]
         token_type: str = payload.get("type")  # type: ignore[assignment]
 
-        if user_id is None or token_type != "refresh":  # noqa: S105
+        if user_id is None or token_type != REFRESH_TOKEN_TYPE:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
 
         user_exists = await get_user_by_id(db, user_id)


### PR DESCRIPTION
## Problem

- BUG: Able to successfully invoke the new `api/v1/run/session` API endpoint using a refresh token

```shell
curl --location 'http://9.46.81.78:3000/api/v1/run/session/206831f5-dce8-471d-b4f2-fc54cde4a41a' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <refresh-token>' \
--data '{
   "output_type": "chat",
   "input_type": "chat",
   "input_value": "build a house"
}'
```
- EXPECTED: Should only be able to invoke the new `api/v1/run/session` API endpoint using an access token

## Work Done

- ✅  Restrict JWT access to all API endpoints to access tokens only
- ✅  Defined constants for `access` and `refresh` token types
- ⚠️  There are open questions regarding whether the proposed fix will cause any regressions (see PR comments)
- 🚧  Push this fix to the `1.7.0` branch

## Research

<img width="854" height="1029" alt="image" src="https://github.com/user-attachments/assets/f27684f5-5876-4531-bc2c-48f05395c4ff" />

<img width="889" height="845" alt="image" src="https://github.com/user-attachments/assets/01162564-12fc-40a9-b291-5e85f4f3a702" />

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced token type validation in authentication to ensure proper token classification and validation during user authentication requests.

* **Chores**
  * Updated internal security baseline configuration with refreshed timestamps and line number adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->