### PR TITLE
docs: clarify superuser flow run behavior

### DIFF
--- a/docs/docs/Develop/api-keys-and-authentication.mdx
+++ b/docs/docs/Develop/api-keys-and-authentication.mdx
@@ -39,6 +39,7 @@ A Langflow API key cannot be used to access resources outside of your own Langfl
 In single-user environments, you are always a superuser, and your Langflow API keys always have superuser privileges.
 
 In multi-user environments, users who aren't superusers cannot use their API keys to access other users' resources.
+Superusers can only run their own flows, and cannot run flows owned by other users.
 You must [start your Langflow server with authentication enabled](#start-a-langflow-server-with-authentication-enabled) to allow user management and creation of non-superuser accounts.
 
 ### Create a Langflow API key


### PR DESCRIPTION
Clarify that superusers can only run their own flows and cannot run flows owned by other users.