### PR TITLE
Fix: lfx run agent _noopresult not iterable error

### DIFF
--- a/src/backend/base/langflow/memory.py
+++ b/src/backend/base/langflow/memory.py
@@ -190,9 +190,7 @@ async def aadd_messagetables(messages: list[MessageTable], session: AsyncSession
     try:
         try:
             for message in messages:
-                result = session.add(message)
-                if asyncio.iscoroutine(result):
-                    await result
+                session.add(message)
             await session.commit()
             # This is a hack.
             # We are doing this because build_public_tmp causes the CancelledError to be raised

--- a/src/lfx/src/lfx/services/session.py
+++ b/src/lfx/src/lfx/services/session.py
@@ -24,7 +24,7 @@ class NoopSession:
 
     bind = NoopBind()
 
-    async def add(self, *args, **kwargs):
+    def add(self, *args, **kwargs):
         pass
 
     async def commit(self):


### PR DESCRIPTION
From #10892.

`lfx run [path-to-flow-containing-agent] [user-prompt-input]` throws the following exception

```sh
Error running method "message_response": '_NoopResult' object is not iterable
{"success": false, "type": "error", "exception_type": "ComponentBuildError", "exception_message": "Error building Component Agent: \n\nError running method \"message_response\": '_NoopResult' object is not iterable"}
```

which is fixed but adding an __iter__ method to the _NoopResult class.

After which the same command throws the following warning:
```sh
/workspace/src/backend/base/langflow/memory.py:193: RuntimeWarning: coroutine 'NoopSession.add' was never awaited..."
```


which is fixed by checking if the `add` method is async, and if true, awaiting its result. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of asynchronous message operations to ensure messages are properly queued and processed
  * Fixed iteration support for session result objects to prevent errors when traversing results

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

