### PR TITLE
fix: Update LangflowCounts component to format star and Discord counts

### DIFF
--- a/src/frontend/src/components/core/appHeaderComponent/components/langflow-counts.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/langflow-counts.tsx
@@ -2,12 +2,16 @@ import { FaDiscord, FaGithub } from "react-icons/fa";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
 import { Button } from "@/components/ui/button";
 import { DISCORD_URL, GITHUB_URL } from "@/constants/constants";
+import { Case } from "@/shared/components/caseComponent";
 import { useDarkStore } from "@/stores/darkStore";
 import { formatNumber } from "@/utils/utils";
 
 export const LangflowCounts = () => {
   const stars: number | undefined = useDarkStore((state) => state.stars);
   const discordCount: number = useDarkStore((state) => state.discordCount);
+
+  const formattedStars = formatNumber(stars);
+  const formattedDiscordCount = formatNumber(discordCount);
 
   return (
     <div className="flex items-center gap-3">
@@ -21,11 +25,13 @@ export const LangflowCounts = () => {
           onClick={() => window.open(GITHUB_URL, "_blank")}
           className="hit-area-hover flex items-center gap-2 rounded-md p-1 text-muted-foreground"
         >
-          <div className="hit-area-hover group relative items-center rounded-md px-2 py-1 text-muted-foreground flex">
+          <div className="relative items-center rounded-md px-2 py-1 flex">
             <FaGithub className="h-4 w-4" />
-            <span className="text-xs font-semibold pl-2">
-              {formatNumber(stars)}
-            </span>
+            <Case condition={Boolean(formattedStars) && formattedStars !== "0"}>
+              <span className="text-xs font-semibold pl-2">
+                {formattedStars}
+              </span>
+            </Case>
           </div>
         </Button>
       </ShadTooltip>
@@ -40,11 +46,17 @@ export const LangflowCounts = () => {
           onClick={() => window.open(DISCORD_URL, "_blank")}
           className="hit-area-hover flex items-center gap-2 rounded-md p-1 text-muted-foreground"
         >
-          <div className="hit-area-hover group relative items-center rounded-md px-2 py-1 text-muted-foreground flex">
+          <div className="relative items-center rounded-md px-2 py-1 flex">
             <FaDiscord className="h-4 w-4" />
-            <span className="text-xs font-semibold pl-2">
-              {formatNumber(discordCount || 0)}
-            </span>
+            <Case
+              condition={
+                Boolean(formattedDiscordCount) && formattedDiscordCount !== "0"
+              }
+            >
+              <span className="text-xs font-semibold pl-2">
+                {formattedDiscordCount}
+              </span>
+            </Case>
           </div>
         </Button>
       </ShadTooltip>


### PR DESCRIPTION
This pull request refactors the `LangflowCounts` component to improve code readability, accessibility, and maintainability. The main changes include replacing plain `div` elements with the `Button` component for GitHub and Discord links, introducing conditional rendering for count displays, and using formatted numbers for better presentation.

**Component structure and accessibility improvements:**

* Replaced clickable `div` elements with the `Button` component (with `unstyled` styling) for both GitHub and Discord links, enhancing semantic structure and accessibility.

**Conditional rendering and formatting:**

* Added the `Case` component to conditionally display the GitHub stars and Discord member counts only when they are present and not zero, preventing unnecessary or misleading UI elements.
* Used the `formatNumber` utility to format the counts before rendering, ensuring consistent number presentation.