### PR TITLE
Fix: update lfx serve tests to mock the .serve() to prevent hanging 

### DIFF
--- a/src/lfx/tests/unit/cli/test_serve.py
+++ b/src/lfx/tests/unit/cli/test_serve.py
@@ -187,7 +187,7 @@ def test_serve_command_json_file():
         # Mock the necessary dependencies
         with (
             patch("lfx.cli.commands.load_graph_from_path") as mock_load,
-            patch("lfx.cli.commands.uvicorn.run") as mock_uvicorn,
+            patch("lfx.cli.commands.uvicorn.Server.serve", new=AsyncMock(return_value=None)) as mock_uvicorn,
             patch.dict(os.environ, {"LANGFLOW_API_KEY": "test-key"}),  # pragma: allowlist secret
         ):
             import typer
@@ -245,7 +245,7 @@ def test_serve_command_inline_json():
 
     with (
         patch("lfx.cli.commands.load_graph_from_path") as mock_load,
-        patch("lfx.cli.commands.uvicorn.run") as mock_uvicorn,
+        patch("lfx.cli.commands.uvicorn.Server.serve", new=AsyncMock(return_value=None)) as mock_uvicorn,
         patch.dict(os.environ, {"LANGFLOW_API_KEY": "test-key"}),  # pragma: allowlist secret
     ):
         import typer


### PR DESCRIPTION
from #10904

updates `test_serve_command_json_file` and `test_serve_command_inline_json` to mock the .serve() call to prevent hanging / blocking ci. keeps the tests up to date with #10888