### PR TITLE
fix: update sidebar icon styles to maintain backward compatibility

### DIFF
--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -231,6 +231,22 @@ export const SIDEBAR_CATEGORIES = [
   { display_name: "Utilities", name: "utilities", icon: "Wand2" },
   { display_name: "Prototypes", name: "prototypes", icon: "FlaskConical" },
   { display_name: "Tools", name: "tools", icon: "Hammer" },
+  { display_name: "Agents", name: "agents", icon: "Bot" },
+  { display_name: "Data", name: "data", icon: "Database" },
+  { display_name: "Logic", name: "logic", icon: "ArrowRightLeft" },
+  { display_name: "Helpers", name: "helpers", icon: "Wand2" },
+  { display_name: "Models", name: "models", icon: "BrainCog" },
+  { display_name: "Vector Stores", name: "vectorstores", icon: "Layers" },
+  { display_name: "Inputs", name: "inputs", icon: "Download" },
+  { display_name: "Outputs", name: "outputs", icon: "Upload" },
+  { display_name: "Prompts", name: "prompts", icon: "braces" },
+  { display_name: "Chains", name: "chains", icon: "Link" },
+  { display_name: "Loaders", name: "documentloaders", icon: "Paperclip" },
+  { display_name: "Link Extractors", name: "link_extractors", icon: "Link2" },
+  { display_name: "Output Parsers", name: "output_parsers", icon: "Compass" },
+  { display_name: "Retrievers", name: "retrievers", icon: "FileSearch" },
+  { display_name: "Text Splitters", name: "textsplitters", icon: "Scissors" },
+  { display_name: "Toolkits", name: "toolkits", icon: "Package2" },
 ];
 
 export const SIDEBAR_BUNDLES = [


### PR DESCRIPTION
This pull request adds several new categories to the `SIDEBAR_CATEGORIES` array in `src/frontend/src/utils/styleUtils.ts`. These additions expand the sidebar options, providing more granular organization and icon representation for different types of components in the application.

New sidebar categories and icons:

* Added categories for `Agents`, `Data`, `Logic`, `Helpers`, `Models`, `Vector Stores`, `Inputs`, `Outputs`, `Prompts`, `Chains`, `Loaders`, `Link Extractors`, `Output Parsers`, `Retrievers`, `Text Splitters`, and `Toolkits`, each with a corresponding icon for improved navigation and clarity.