### PR TITLE
Adding the new input type CheckboxInput.

### DIFF
--- a/src/backend/base/langflow/inputs/inputs.py
+++ b/src/backend/base/langflow/inputs/inputs.py
@@ -8,6 +8,7 @@ All input classes have been migrated to lfx and this file serves as a compatibil
 from lfx.inputs.inputs import (
     AuthInput,
     BoolInput,
+    CheckboxInput,
     CodeInput,
     DataFrameInput,
     DataInput,
@@ -43,6 +44,7 @@ from lfx.inputs.inputs import (
 __all__ = [
     "AuthInput",
     "BoolInput",
+    "CheckboxInput",
     "CodeInput",
     "DataFrameInput",
     "DataInput",

--- a/src/frontend/src/components/core/parameterRenderComponent/components/checkboxComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/checkboxComponent/index.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { cn } from "@/utils/utils";
+import type { CheckboxComponentType, InputProps } from "../../types";
+
+export default function CheckboxComponent({
+  disabled,
+  value,
+  options = [],
+  handleOnNewValue,
+  editNode = false,
+  id = "",
+}: InputProps<string[], CheckboxComponentType>): JSX.Element {
+  // Ensure value is always an array
+  const treatedValue = Array.isArray(value) ? value : value ? [value] : [];
+
+  useEffect(() => {
+    if (disabled && treatedValue.length > 0) {
+      handleOnNewValue({ value: [] }, { skipSnapshot: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disabled]);
+
+  const handleCheckboxChange = (option: string, checked: boolean) => {
+    if (checked) {
+      // Add option to the array if not already present
+      if (!treatedValue.includes(option)) {
+        handleOnNewValue({ value: [...treatedValue, option] });
+      }
+    } else {
+      // Remove option from the array
+      handleOnNewValue({ value: treatedValue.filter((v) => v !== option) });
+    }
+  };
+
+  if (options.length === 0) {
+    return (
+      <div>
+        <span className="text-sm italic">
+          No checkbox options are available for display.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-2 gap-2",
+        editNode ? "input-edit-node" : "",
+      )}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {options.map((option, index) => {
+        const isChecked = treatedValue.includes(option);
+        return (
+          <div
+            key={`${option}-${index}`}
+            className="flex items-center space-x-2"
+          >
+            <Checkbox
+              id={`${id}-checkbox-${index}`}
+              data-testid={`${id}-checkbox-${index}`}
+              checked={isChecked}
+              disabled={disabled}
+              onCheckedChange={(checked) =>
+                handleCheckboxChange(option, checked as boolean)
+              }
+            />
+            <label
+              htmlFor={`${id}-checkbox-${index}`}
+              className={cn(
+                "text-sm font-medium leading-none cursor-pointer",
+                disabled && "cursor-not-allowed opacity-50",
+                !isChecked && "text-muted-foreground",
+              )}
+            >
+              {option}
+            </label>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/frontend/src/components/core/parameterRenderComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/index.tsx
@@ -1,14 +1,16 @@
 import type { handleOnNewValueType } from "@/CustomNodes/hooks/use-handle-new-value";
+import TableNodeComponent from "@/components/core/parameterRenderComponent/components/TableNodeComponent";
 import CodeAreaComponent from "@/components/core/parameterRenderComponent/components/codeAreaComponent";
 import ModelInputComponent from "@/components/core/parameterRenderComponent/components/modelInputComponent";
 import SliderComponent from "@/components/core/parameterRenderComponent/components/sliderComponent";
-import TableNodeComponent from "@/components/core/parameterRenderComponent/components/TableNodeComponent";
 import TabComponent from "@/components/core/parameterRenderComponent/components/tabComponent";
 import { TEXT_FIELD_TYPES } from "@/constants/constants";
 import CustomConnectionComponent from "@/customization/components/custom-connectionComponent";
 import CustomInputFileComponent from "@/customization/components/custom-input-file";
 import CustomLinkComponent from "@/customization/components/custom-linkComponent";
 import type { APIClassType, InputFieldType } from "@/types/api";
+import ToolsComponent from "./components/ToolsComponent";
+import CheckboxComponent from "./components/checkboxComponent";
 import DictComponent from "./components/dictComponent";
 import { EmptyParameterComponent } from "./components/emptyParameterComponent";
 import FloatComponent from "./components/floatComponent";
@@ -21,7 +23,6 @@ import PromptAreaComponent from "./components/promptComponent";
 import QueryComponent from "./components/queryComponent";
 import SortableListComponent from "./components/sortableListComponent";
 import { StrRenderComponent } from "./components/strRenderComponent";
-import ToolsComponent from "./components/ToolsComponent";
 import ToggleShadComponent from "./components/toggleShadComponent";
 import type { InputProps, NodeInfoType } from "./types";
 
@@ -300,6 +301,18 @@ export function ParameterRenderComponent({
             options={templateData?.options || []}
             placeholder={templateData?.placeholder}
             externalOptions={templateData?.external_options}
+          />
+        );
+      case "checkbox":
+        return (
+          <CheckboxComponent
+            {...baseInputProps}
+            options={
+              (Array.isArray(templateData.options)
+                ? templateData.options
+                : [templateData.options]) || []
+            }
+            id={`checkbox_${id}`}
           />
         );
       default:

--- a/src/frontend/src/components/core/parameterRenderComponent/types.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/types.ts
@@ -143,6 +143,10 @@ export type MultiselectComponentType = {
   combobox?: boolean;
 };
 
+export type CheckboxComponentType = {
+  options: string[];
+};
+
 export type TabComponentType = {
   options: string[];
 };

--- a/src/lfx/src/lfx/graph/vertex/param_handler.py
+++ b/src/lfx/src/lfx/graph/vertex/param_handler.py
@@ -309,6 +309,17 @@ class ParameterHandler:
                 else:
                     msg = f"Invalid value type {type(val)} for field {field_name}"
                     raise ValueError(msg)
+            case "checkbox":
+                # Checkbox returns a list of selected option strings
+                match val:
+                    case list():
+                        params[field_name] = [unescape_string(v) if isinstance(v, str) else v for v in val]
+                    case str():
+                        # Single string value, convert to list
+                        params[field_name] = [unescape_string(val)]
+                    case _:
+                        # Default to empty list if None or invalid
+                        params[field_name] = []
             case _:
                 if val:
                     params[field_name] = val

--- a/src/lfx/src/lfx/inputs/__init__.py
+++ b/src/lfx/src/lfx/inputs/__init__.py
@@ -1,6 +1,7 @@
 from .inputs import (
     AuthInput,
     BoolInput,
+    CheckboxInput,
     CodeInput,
     ConnectionInput,
     DataFrameInput,
@@ -36,6 +37,7 @@ from .inputs import (
 __all__ = [
     "AuthInput",
     "BoolInput",
+    "CheckboxInput",
     "CodeInput",
     "ConnectionInput",
     "DataFrameInput",

--- a/src/lfx/src/lfx/inputs/input_mixin.py
+++ b/src/lfx/src/lfx/inputs/input_mixin.py
@@ -38,6 +38,7 @@ class FieldTypes(str, Enum):
     TOOLS = "tools"
     MCP = "mcp"
     MODEL = "model"
+    CHECKBOX = "checkbox"
 
 
 SerializableFieldTypes = Annotated[FieldTypes, PlainSerializer(lambda v: v.value, return_type=str)]

--- a/src/lfx/src/lfx/inputs/inputs.py
+++ b/src/lfx/src/lfx/inputs/inputs.py
@@ -713,6 +713,40 @@ class MultiselectInput(BaseInputMixin, ListableInputMixin, DropDownMixin, Metada
         return v
 
 
+class CheckboxInput(BaseInputMixin, ListableInputMixin, DropDownMixin, MetadataTraceMixin, ToolModeMixin):
+    """Represents a checkbox input field.
+
+    This class represents a checkbox input field that displays a list of checkboxes in the UI.
+    The selected checkboxes are passed as an array of strings.
+
+    Attributes:
+        field_type (SerializableFieldTypes): The field type of the input. Defaults to FieldTypes.CHECKBOX.
+        options (list[str]): List of checkbox options to display. Default is an empty list.
+        value (list[str]): The selected checkbox values as a list of strings. Default is an empty list.
+    """
+
+    field_type: SerializableFieldTypes = FieldTypes.CHECKBOX
+    options: list[str] = Field(default_factory=list)
+    value: list[str] = Field(default_factory=list)
+    is_list: bool = Field(default=True, serialization_alias="list")
+    track_in_telemetry: CoalesceBool = True  # Safe predefined choices
+
+    @field_validator("value")
+    @classmethod
+    def validate_value(cls, v: Any, _info):
+        """Validates that the value is a list of strings."""
+        if v is None:
+            return []
+        if not isinstance(v, list):
+            msg = f"CheckboxInput value must be a list. Value: '{v}'"
+            raise ValueError(msg)  # noqa: TRY004
+        for item in v:
+            if not isinstance(item, str):
+                msg = f"CheckboxInput value must be a list of strings. Item: '{item}' is not a string"
+                raise ValueError(msg)  # noqa: TRY004
+        return v
+
+
 class FileInput(BaseInputMixin, ListableInputMixin, FileMixin, MetadataTraceMixin, ToolModeMixin):
     """Represents a file field.
 
@@ -775,6 +809,7 @@ InputTypes: TypeAlias = (
     | DictInput
     | DropdownInput
     | MultiselectInput
+    | CheckboxInput
     | SortableListInput
     | ConnectionInput
     | FileInput

--- a/src/lfx/src/lfx/io/__init__.py
+++ b/src/lfx/src/lfx/io/__init__.py
@@ -1,5 +1,6 @@
 from lfx.inputs import (
     BoolInput,
+    CheckboxInput,
     CodeInput,
     DataFrameInput,
     DataInput,
@@ -32,6 +33,7 @@ from lfx.template import Output
 
 __all__ = [
     "BoolInput",
+    "CheckboxInput",
     "CodeInput",
     "DataFrameInput",
     "DataInput",

--- a/src/lfx/src/lfx/io/schema.py
+++ b/src/lfx/src/lfx/io/schema.py
@@ -29,6 +29,7 @@ _convert_field_type_to_type: dict[FieldTypes, type] = {
     FieldTypes.OTHER: str,
     FieldTypes.TAB: str,
     FieldTypes.QUERY: str,
+    FieldTypes.CHECKBOX: str,
 }
 
 

--- a/src/lfx/src/lfx/utils/constants.py
+++ b/src/lfx/src/lfx/utils/constants.py
@@ -83,6 +83,7 @@ DIRECT_TYPES = [
     "tools",
     "mcp",
     "model",
+    "checkbox",
 ]
 
 


### PR DESCRIPTION
Adding a new input type `CheckboxInput` to facilitate the configuration of components that require multiple predefined selections, such as: Processing components, guardrail components, logic components, among others.

<img width="611" height="749" alt="image" src="https://github.com/user-attachments/assets/142396d8-a453-46d8-878c-d869f57b9063" />
