### PR TITLE
fix: Support tool mode in components without inputs

### DIFF
--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -2217,13 +2217,13 @@ export function checkHasToolMode(template: APITemplateType): boolean {
   if (!template) return false;
 
   const templateKeys = Object.keys(template);
-  
+
   // System/metadata fields that are not actual input fields
-  const systemFields = ['code', 'is_refresh', 'tools_metadata'];
-  
+  const systemFields = ["code", "is_refresh", "tools_metadata"];
+
   // Count only fields that are actual inputs (not internal, not system fields)
   const inputFields = templateKeys.filter(
-    key => !key.startsWith('_') && !systemFields.includes(key)
+    (key) => !key.startsWith("_") && !systemFields.includes(key),
   );
 
   // Check if the template has no input fields
@@ -2237,7 +2237,7 @@ export function checkHasToolMode(template: APITemplateType): boolean {
   const hasToolModeFields = Object.values(template).some((field) =>
     Boolean(field.tool_mode),
   );
-  
+
   // Check if the component is already in tool mode
   // This occurs when the template has tools_metadata field
   const isInToolMode = Boolean(template.tools_metadata);


### PR DESCRIPTION
This pull request refactors the logic in the `checkHasToolMode` function in `src/frontend/src/utils/reactflowUtils.ts` to improve how tool mode eligibility is determined for templates. The changes clarify which fields are considered system/metadata fields and simplify the checks for input fields and tool mode status.

Improvements to tool mode detection logic:

* Updated the function to explicitly filter out system/metadata fields (`code`, `is_refresh`, `tools_metadata`) and internal fields (those starting with `_`) when determining if a template has input fields.
* Changed the logic to check for tool mode eligibility by ensuring there are no input fields, rather than relying on a fixed field count.
* Simplified the check for whether a component is already in tool mode to only require the presence of the `tools_metadata` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced tool mode detection to more accurately identify when the application is operating in tool mode based on input field composition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->