### PR TITLE
docs: custom components input types

### DIFF
--- a/docs/docs/Components/components-custom-components.mdx
+++ b/docs/docs/Components/components-custom-components.mdx
@@ -282,10 +282,10 @@ The `build_df` method processes data and returns a `DataFrame`. The `-> DataFram
 For a complete list of all available parameters, see the [Output class definition](https://github.com/langflow-ai/langflow/blob/main/src/lfx/src/lfx/template/field/base.py) in the Langflow codebase. Common parameters include:
 
 **Additional return types:**
-* **`Message`** - Structured chat messages
-* **`Data`** - Flexible object with `.data` and optional `.text`
-* **`DataFrame`** - Tabular data (pandas DataFrame subclass)
-* **Primitive types** - `str`, `int`, `bool`, not recommended for type consistency
+* **`Message`**: Structured chat messages
+* **`Data`**: Flexible object with `.data` and optional `.text`
+* **`DataFrame`**: Tabular data (pandas DataFrame subclass)
+* **Primitive types**: `str`, `int`, `bool`, not recommended for type consistency
 
 #### Associated methods
 


### PR DESCRIPTION
Add links to additional input and output types.
Use lfx input in examples.
The import partial clarifies that the langflow.io path is still backwards compatible.