### PR TITLE
fix(deps): Pin langchain-mcp-adapters to resolve langchain-core compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ dependencies = [
     "traceloop-sdk>=0.43.1,<1.0.0",
     "vlmrun[all]>=0.2.0",
     "cuga~=0.2.6",
+    "langchain-mcp-adapters>=0.1.14,<0.2.0",  # Pin to avoid incompatibility with langchain-core<1.0.0
     "agent-lifecycle-toolkit~=0.4.4",
     "astrapy>=2.1.0,<3.0.0",
     "aioboto3>=15.2.0,<16.0.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin'",
@@ -5595,6 +5595,7 @@ dependencies = [
     { name = "langchain-groq" },
     { name = "langchain-huggingface" },
     { name = "langchain-ibm" },
+    { name = "langchain-mcp-adapters" },
     { name = "langchain-milvus" },
     { name = "langchain-mistralai" },
     { name = "langchain-mongodb" },
@@ -5808,6 +5809,7 @@ requires-dist = [
     { name = "langchain-groq", specifier = "==0.2.1" },
     { name = "langchain-huggingface", specifier = "==0.3.1" },
     { name = "langchain-ibm", specifier = ">=0.3.8" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.1.14,<0.2.0" },
     { name = "langchain-milvus", specifier = "==0.1.7" },
     { name = "langchain-mistralai", specifier = "==0.2.3" },
     { name = "langchain-mongodb", specifier = "==0.7.0" },


### PR DESCRIPTION
This pull request introduces a new dependency to the project to address compatibility issues with `langchain-core`. The new package is pinned to a specific version range to prevent incompatibilities.

Dependency management:

* Added `langchain-mcp-adapters` (version `>=0.1.14,<0.2.0`) to the `dependencies` list in `pyproject.toml` to avoid incompatibility with `langchain-core<1.0.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new project dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->