### PR TITLE
feat: create env variable flag for mcp streamable-http stateless mode

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -1205,8 +1205,10 @@ class ProjectMCPServer:
     def __init__(self, project_id: UUID):
         self.project_id = project_id
         self.server = Server(f"langflow-mcp-project-{project_id}")
-        # TODO: implement an environment variable to enable/disable stateless mode
-        self.session_manager = StreamableHTTPSessionManager(self.server, stateless=True)
+        settings = get_settings_service().settings
+        self.session_manager = StreamableHTTPSessionManager(
+            app=self.server, stateless=settings.mcp_streamable_http_stateless
+        )
         # since we lazily initialize the session manager's lifecycle
         # via .run(), which can only be called once, otherwise an error is raised,
         # we use the lock to prevent race conditions on concurrent requests to prevent such an error

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -307,6 +307,8 @@ class Settings(BaseSettings):
     """If set to False, Langflow will not start the MCP Composer service."""
     mcp_composer_version: str = "==0.1.0.8.10"
     """Version constraint for mcp-composer when using uvx. Uses PEP 440 syntax."""
+    mcp_streamable_http_stateless: bool = True
+    """If set to True, the Langflow MCP server will use its Streamable HTTP Session Manager in stateless mode."""
 
     # Agentic Experience
     agentic_experience: bool = False


### PR DESCRIPTION
introduce an environment variable to expose and set the streamable-http session manager's stateless flag in langflow's mcp server implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration setting to control MCP Streamable HTTP stateless mode.

* **Chores**
  * Enhanced per-project MCP server management with improved lifecycle coordination and centralized error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->