### PR TITLE
ref: obfuscate openai api key

### DIFF
--- a/src/lfx/src/lfx/components/openai/openai_chat_model.py
+++ b/src/lfx/src/lfx/components/openai/openai_chat_model.py
@@ -98,7 +98,7 @@ class OpenAIModelComponent(LCModelComponent):
         # Handle api_key - it can be string or SecretStr
         api_key_value = None
         if self.api_key:
-            logger.debug(f"API key type: {type(self.api_key)}, value: {self.api_key!r}")
+            logger.debug(f"API key type: {type(self.api_key)}, value: {'***' if self.api_key else None}")
             if isinstance(self.api_key, SecretStr):
                 api_key_value = self.api_key.get_secret_value()
             else:


### PR DESCRIPTION
Obfuscates openai api key from debug logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI API keys are now masked as "***" in debug logging to prevent accidental exposure of sensitive credentials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->