### PR TITLE
docs: yanked version and known issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Langflow is available at http://localhost:7860/.
 For configuration options, see the [Docker deployment guide](https://docs.langflow.org/deployment-docker).
 
 > [!CAUTION]
+> - Langflow version 1.7.0 has a critical bug where persisted state (flows, projects, and global variables) cannot be found when upgrading from versions 1.6.8 or 1.6.9. Version 1.7.0 was yanked and replaced with version 1.7.1, which includes a fix for this bug. **DO NOT** upgrade to version 1.7.0. Instead, upgrade directly to version 1.7.1.
 > - Langflow versions 1.6.0 through 1.6.3 have a critical bug where `.env` files are not read, potentially causing security vulnerabilities. **DO NOT** upgrade to these versions if you use `.env` files for configuration. Instead, upgrade to 1.6.4, which includes a fix for this bug.
 > - Windows users of Langflow Desktop should **not** use the in-app update feature to upgrade to Langflow version 1.6.0. For upgrade instructions, see [Windows Desktop update issue](https://docs.langflow.org/release-notes#windows-desktop-update-issue).
 > - Users must update to Langflow >= 1.3 to protect against [CVE-2025-3248](https://nvd.nist.gov/vuln/detail/CVE-2025-3248)

--- a/docs/docs/Support/release-notes.mdx
+++ b/docs/docs/Support/release-notes.mdx
@@ -47,10 +47,39 @@ To avoid the impact of potential breaking changes and test new versions, the Lan
 
     If you made changes to your flows in the isolated installation, you might want to export and import those flows back to your upgraded primary installation so you don't have to repeat the component upgrade process.
 
-## 1.7.0
+## 1.7.x
+
+:::warning Version yanked
+Version 1.7.0 was yanked due to a critical bug. Version 1.7.0 has been replaced with version 1.7.1, which includes a fix for this issue.
+:::
 
 Highlights of this release include the following changes.
 For all changes, see the [Changelog](https://github.com/langflow-ai/langflow/releases).
+
+### Known issue: Data not accessible when upgrading to version 1.7.0 {#v170-data-loss}
+
+A critical issue was identified during the upgrade process to version 1.7.0. While the package updates correctly, there is a total loss of persisted state, including flows, projects, and global variables.
+
+Flows, projects, and global variables are **not** deleted or corrupted. The data still exists, but version 1.7.0 cannot find it due to a path change in how flows are located.
+Only Langflow versions 1.6.8 and 1.6.9 upgrading to 1.7.0 are affected.
+
+Don't upgrade to Langflow version 1.7.0 if you are upgrading from version 1.6.8 or 1.6.9. Instead, upgrade directly to version 1.7.1, which includes a fix for this bug.
+
+If you installed version 1.7.0 before the fix was released, follow these steps to recover your flows:
+
+1. Revert Langflow to version 1.6.9:
+
+   ```bash
+   uv pip install langflow==1.6.9
+   ```
+
+2. Verify that your flows, projects, and global variables are accessible.
+
+3. Upgrade directly to version 1.7.1, which includes the fix for this issue:
+
+   ```bash
+   uv pip install langflow==1.7.1
+   ```
 
 ### New features and enhancements
 


### PR DESCRIPTION
Warn users not to upgrade to yanked 1.7.0, use 1.7.1, and provide instructions for recovery if already affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added warning about critical bug affecting version 1.7.0; users must upgrade directly to version 1.7.1
  * Documented known issue regarding data access loss during upgrade to 1.7.0 with recovery steps provided

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->