### PR TITLE
fix(variables): Update decryption logic to only apply to CREDENTIAL_TYPE

### DIFF
--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -11,7 +11,7 @@ from langflow.services.auth import utils as auth_utils
 from langflow.services.base import Service
 from langflow.services.database.models.variable.model import Variable, VariableCreate, VariableRead, VariableUpdate
 from langflow.services.variable.base import VariableService
-from langflow.services.variable.constants import CREDENTIAL_TYPE, GENERIC_TYPE
+from langflow.services.variable.constants import CREDENTIAL_TYPE
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -193,9 +193,7 @@ class DatabaseVariableService(VariableService, Service):
                 try:
                     value = auth_utils.decrypt_api_key(variable.value, settings_service=self.settings_service)
                 except Exception as e:  # noqa: BLE001
-                    await logger.adebug(
-                        f"Decryption of {variable.type} failed for variable '{variable.name}': {e}."
-                    )
+                    await logger.adebug(f"Decryption of {variable.type} failed for variable '{variable.name}': {e}.")
                     value = None  # Don't expose potentially corrupted credential data
             else:
                 # Generic and other types are stored as plaintext


### PR DESCRIPTION
Update decryption logic to only apply to CREDENTIAL_TYPE variables, ensuring other types are treated as plaintext.

# Bug Fix: Langflow Variable Decryption Mismatch (InvalidToken)

**Date**: 2025-12-21
**Status**: Resolved

## 1. Issue Description
*   **Symptoms**: 
    *   Backend logs showing `InvalidToken` errors: `Decryption using UTF-8 encoded API key failed. Error: . Retrying decryption using the raw string input.`
    *   `Decryption of Generic failed for variable ... Assuming plaintext.`
    *   `POST /api/v1/custom_component/update HTTP/1.1" 400` errors during component updates.
    *   Error: `Invalid base64-encoded string: number of data characters (21) cannot be 1 more than a multiple of 4`.
*   **Context**: Occurred when `update_params_with_load_from_db_fields` was called, triggering `get_variable` or `get_all` in `DatabaseVariableService`. This happens frequently when the UI tries to load variable values for components.

## 2. Root Cause Analysis
*   **Investigation**: 
    *   Analyzed the `DatabaseVariableService.get_variable` and `get_all` methods in `service.py`.
    *   Observed that `get_variable` was unconditionally calling `auth_utils.decrypt_api_key(variable.value)` regardless of the variable type.
    *   Observed that `get_all` was attempting to decrypt `GENERIC_TYPE` variables (labeled as "attempt to decrypt") but failing because they were plaintext.
*   **The Cause**: 
    *   Symmetry violation: `create_variable` and `update_variable` **only** encrypt variables if `type == CREDENTIAL_TYPE`.
    *   However, `get_variable` and `get_all` tried to decrypt **everything**.
    *   When a `GENERIC_TYPE` variable (stored as plaintext) was passed to the Fernet decryptor, it raised `InvalidToken` because the plaintext string was not a valid Fernet token (base64 encoded).

## 3. The Fix
*   **Changes Made**:
    *   Modified `src/backend/base/langflow/services/variable/service.py`.
    *   Updated `get_variable` to check `if variable.type == CREDENTIAL_TYPE` before decrypting.
    *   Updated `get_all` to check `if variable.type == CREDENTIAL_TYPE` before decrypting, and treat others as plaintext.
*   **Code Snippet**:
    ```python
    # After change in get_variable
    # Only decrypt CREDENTIAL_TYPE variables - others are stored as plaintext
    if variable.type == CREDENTIAL_TYPE:
        return auth_utils.decrypt_api_key(variable.value, settings_service=self.settings_service)
    return variable.value
    ```

## 4. Verification
*   **Test Case**: 
    1.  Rebuilt the container with the code fix.
    2.  Monitored logs during startup and API interactions.
*   **Outcome**: 
    *   The `InvalidToken` and `Decryption failed` error logs disappeared.
    *   The 400 errors on `custom_component/update` should now be resolved as the variables are correctly returned as plaintext without throwing exceptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable handling to properly distinguish between credential and non-credential types during decryption.
  * Enhanced security by preventing exposure of corrupted data when decryption fails; affected values are now safely treated as inaccessible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->