### PR TITLE
fix: Check org membership for community label workflow

### DIFF
--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -11,17 +11,31 @@ jobs:
       pull-requests: write
     steps:
       - name: Add community label
-        if: github.event.pull_request.author_association != 'MEMBER' && github.event.pull_request.author_association != 'OWNER' && github.event.pull_request.author_association != 'COLLABORATOR'
         uses: actions/github-script@v8
         with:
           script: |
-            const pullRequestNumber = context.payload.pull_request.number;
-            const repoDetails = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pullRequestNumber
-            };
+            const prNumber = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Re-fetch the PR to get a fresh author_association
+            // instead of relying on the event payload which can be stale.
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            const association = pr.author_association;
+            if (['MEMBER', 'OWNER', 'COLLABORATOR'].includes(association)) {
+              console.log(`Skipping community label: ${pr.user.login} is ${association}`);
+              return;
+            }
+
+            console.log(`Adding community label: ${pr.user.login} is ${association}`);
             await github.rest.issues.addLabels({
-              ...repoDetails,
+              owner,
+              repo,
+              issue_number: prNumber,
               labels: ['community']
             });


### PR DESCRIPTION
## Summary
The workflow was incorrectly adding the community label to PRs from org members. The author_association field in pull_request_target events doesn't reliably identify org members.

This change queries the GitHub API directly to check if the PR author is a member of the organization before deciding whether to add the community label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated pull request labeling workflow to apply the "community" label only to contributors who are not organization members. Previously, all pull requests received this label. This change enhances contribution categorization, better distinguishing community-submitted requests from those authored by organization members.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->