### PR TITLE
test: update lock flow playwright test

### DIFF
--- a/src/frontend/tests/extended/features/lock-flow.spec.ts
+++ b/src/frontend/tests/extended/features/lock-flow.spec.ts
@@ -65,19 +65,28 @@ test(
     await page.waitForTimeout(500);
 
     await tryDeleteEdge(page);
-    await page.locator(".react-flow__edge-path").nth(0).click();
-    await page.keyboard.press("Delete");
-    let numberOfEdges = await page.locator(".react-flow__edge-path").count();
+    await page.waitForTimeout(500);
+
+    // Delete edges one by one (when unlocked, should work)
+    await page.locator(".react-flow__edge").nth(0).click();
+    await page.waitForTimeout(200);
+    await page.keyboard.press("Backspace");
+    await page.waitForTimeout(300);
+    let numberOfEdges = await page.locator(".react-flow__edge").count();
     expect(numberOfEdges).toBe(2);
 
-    await page.locator(".react-flow__edge-path").nth(0).click();
-    await page.keyboard.press("Delete");
-    numberOfEdges = await page.locator(".react-flow__edge-path").count();
+    await page.locator(".react-flow__edge").nth(0).click();
+    await page.waitForTimeout(200);
+    await page.keyboard.press("Backspace");
+    await page.waitForTimeout(300);
+    numberOfEdges = await page.locator(".react-flow__edge").count();
     expect(numberOfEdges).toBe(1);
 
-    await page.locator(".react-flow__edge-path").nth(0).click();
-    await page.keyboard.press("Delete");
-    numberOfEdges = await page.locator(".react-flow__edge-path").count();
+    await page.locator(".react-flow__edge").nth(0).click();
+    await page.waitForTimeout(200);
+    await page.keyboard.press("Backspace");
+    await page.waitForTimeout(300);
+    numberOfEdges = await page.locator(".react-flow__edge").count();
     expect(numberOfEdges).toBe(0);
 
     await tryConnectNodes(page);
@@ -100,7 +109,8 @@ test(
       )
       .click();
     await page.getByTestId("handle-chatoutput-shownode-inputs-left").click();
-    numberOfEdges = await page.locator(".react-flow__edge-path").count();
+    await page.waitForTimeout(300);
+    numberOfEdges = await page.locator(".react-flow__edge").count();
 
     expect(numberOfEdges).toBe(3);
   },
@@ -110,7 +120,7 @@ async function tryConnectNodes(page: Page) {
   await lockFlow(page);
 
   const numberOfTries = 5;
-  let numberOfEdges = await page.locator(".react-flow__edge-path").count();
+  let numberOfEdges = await page.locator(".react-flow__edge").count();
 
   for (let i = 0; i < numberOfTries; i++) {
     try {
@@ -118,7 +128,7 @@ async function tryConnectNodes(page: Page) {
         timeout: 500,
       });
     } catch (_e) {
-      numberOfEdges = await page.locator(".react-flow__edge-path").count();
+      numberOfEdges = await page.locator(".react-flow__edge").count();
       expect(numberOfEdges).toBe(0);
     }
 
@@ -131,7 +141,7 @@ async function tryConnectNodes(page: Page) {
           timeout: 500,
         });
     } catch (_e) {
-      numberOfEdges = await page.locator(".react-flow__edge-path").count();
+      numberOfEdges = await page.locator(".react-flow__edge").count();
       expect(numberOfEdges).toBe(0);
     }
   }
@@ -141,20 +151,18 @@ async function tryConnectNodes(page: Page) {
 async function tryDeleteEdge(page: Page) {
   await lockFlow(page);
 
-  const numberOfEdges = await page.locator(".react-flow__edge-path").count();
+  let numberOfEdges = await page.locator(".react-flow__edge").count();
   expect(numberOfEdges).toBe(3);
   const numberOfTries = 5;
 
+  // When locked, clicking edges and pressing delete should not remove them
   for (let i = 0; i < numberOfTries; i++) {
-    await expect(
-      page.locator(".react-flow__edge-path").nth(0).click({ timeout: 500 }),
-    ).rejects.toThrow();
-    await expect(
-      page.locator(".react-flow__edge-path").nth(1).click({ timeout: 500 }),
-    ).rejects.toThrow();
-    await expect(
-      page.locator(".react-flow__edge-path").nth(2).click({ timeout: 500 }),
-    ).rejects.toThrow();
+    await page.locator(".react-flow__edge").nth(0).click();
+    await page.waitForTimeout(200);
+    await page.keyboard.press("Backspace");
+    await page.waitForTimeout(200);
+
+    numberOfEdges = await page.locator(".react-flow__edge").count();
     expect(numberOfEdges).toBe(3);
   }
   await unlockFlow(page);


### PR DESCRIPTION
This pull request updates the lock-flow feature tests to use the `.react-flow__edge` selector instead of `.react-flow__edge-path` for locating and interacting with edges in the flow. The changes also update the edge deletion logic to use the `Backspace` key and add appropriate waits to ensure test stability.

**Test selector and interaction updates:**

* Replaced all occurrences of `.react-flow__edge-path` with `.react-flow__edge` for edge selection and counting, ensuring compatibility with the current DOM structure. [[1]](diffhunk://#diff-f0ac0c30832123ae0a2ae5aeee3c9de21ff17105e2c37d0682bc1fcc6534bb90L68-R89) [[2]](diffhunk://#diff-f0ac0c30832123ae0a2ae5aeee3c9de21ff17105e2c37d0682bc1fcc6534bb90L103-R113) [[3]](diffhunk://#diff-f0ac0c30832123ae0a2ae5aeee3c9de21ff17105e2c37d0682bc1fcc6534bb90L113-R131) [[4]](diffhunk://#diff-f0ac0c30832123ae0a2ae5aeee3c9de21ff17105e2c37d0682bc1fcc6534bb90L134-R144) [[5]](diffhunk://#diff-f0ac0c30832123ae0a2ae5aeee3c9de21ff17105e2c37d0682bc1fcc6534bb90L144-R165)

**Edge deletion and flow lock logic improvements:**

* Updated edge deletion steps to use the `Backspace` key instead of `Delete`, and added `waitForTimeout` calls to improve test reliability.
* Modified the locked flow test logic so that clicking and attempting to delete edges (while locked) does not remove them, and verifies the edge count remains unchanged.