### PR TITLE
Clarify log message when starter project crestion is skipped due to lock

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -219,7 +219,9 @@ def get_lifespan(*, fix_migration=False, version=None):
                     )
             except TimeoutError:
                 # Another process has the lock
-                await logger.adebug("Another worker is creating starter projects, skipping")
+                await logger.debug(
+    "Starter project creation skipped (lock held by another worker)"
+)        
             except Exception as e:  # noqa: BLE001
                 await logger.awarning(
                     f"Failed to acquire lock for starter projects: {e}. Starter projects may not be created or updated."

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -219,9 +219,7 @@ def get_lifespan(*, fix_migration=False, version=None):
                     )
             except TimeoutError:
                 # Another process has the lock
-                await logger.debug(
-    "Starter project creation skipped (lock held by another worker)"
-)        
+                await logger.debug("Starter project creation skipped (lock held by another worker)")
             except Exception as e:  # noqa: BLE001
                 await logger.awarning(
                     f"Failed to acquire lock for starter projects: {e}. Starter projects may not be created or updated."


### PR DESCRIPTION
Clarifies the debug log message emitted when starter project creation is skipped because another worker already holds the file lock .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging messages for starter project initialization to provide clearer debugging information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->