### PR TITLE
chore: upgrade pyproject versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow"
-version = "1.7.2"
+version = "1.8.0"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.14"
 license = "MIT"
@@ -17,7 +17,7 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
-    "langflow-base~=0.7.2",
+    "langflow-base~=0.8.0",
     "beautifulsoup4==4.12.3",
     "google-search-results>=2.4.1,<3.0.0",
     "google-api-python-client==2.154.0",

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-base"
-version = "0.7.2"
+version = "0.8.0"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.14"
 license = "MIT"
@@ -17,7 +17,7 @@ maintainers = [
 ]
 
 dependencies = [
-    "lfx~=0.2.1",
+    "lfx~=0.3.0", 
     "fastapi>=0.115.2,<1.0.0",
     "httpx[http2]>=0.27,<1.0.0",
     "aiofile>=3.9.0,<4.0.0",

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langflow",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langflow",
-      "version": "1.7.2",
+      "version": "1.8.0",
       "dependencies": {
         "@chakra-ui/number-input": "^2.1.2",
         "@chakra-ui/system": "^2.6.2",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langflow",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "private": true,
   "engines": {
     "node": ">=20.19.0"

--- a/src/lfx/pyproject.toml
+++ b/src/lfx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx"
-version = "0.2.1"
+version = "0.3.0"
 description = "Langflow Executor - A lightweight CLI tool for executing and serving Langflow AI flows"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin'",
@@ -5530,7 +5530,7 @@ wheels = [
 
 [[package]]
 name = "langflow"
-version = "1.7.2"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-lifecycle-toolkit" },
@@ -5935,7 +5935,7 @@ dev = [
 
 [[package]]
 name = "langflow-base"
-version = "0.7.2"
+version = "0.8.0"
 source = { editable = "src/backend/base" }
 dependencies = [
     { name = "aiofile" },
@@ -6394,7 +6394,7 @@ wheels = [
 
 [[package]]
 name = "lfx"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "src/lfx" }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
Upgrades to v1.8.0 main, v0.8.0 base, v0.3.0 lfx.

Bumping the minor version ensures that nightly builds from main represent development toward the next release (v1.8.0), rather than appearing as development builds of an already published version (v1.7.x).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.8.0 across project packages
  * Backend package version updated to 0.8.0
  * Frontend package version synchronized to 1.8.0
  * Dependency versions updated for compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->