### PR TITLE
fix: Set agentic_experience default to False

### DIFF
--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -309,7 +309,7 @@ class Settings(BaseSettings):
     """Version constraint for mcp-composer when using uvx. Uses PEP 440 syntax."""
 
     # Agentic Experience
-    agentic_experience: bool = True
+    agentic_experience: bool = False
     """If set to True, Langflow will start the agentic MCP server that provides tools for
     flow/component operations, template search, and graph visualization."""
 


### PR DESCRIPTION
Changed the default value of the agentic_experience setting from True to False to prevent the agentic MCP server from starting by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Agentic experience feature is now disabled by default. Users can enable it in settings if desired.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->