### PR TITLE
fix: await adebug logs in agentic_mcp.py

### DIFF
--- a/src/backend/base/langflow/api/utils/mcp/agentic_mcp.py
+++ b/src/backend/base/langflow/api/utils/mcp/agentic_mcp.py
@@ -322,12 +322,12 @@ async def initialize_agentic_user_variables(user_id: UUID | str, session: AsyncS
 
         # Create a dict with agentic variable names and default values as empty strings
         agentic_variables = dict.fromkeys(AGENTIC_VARIABLES, DEFAULT_AGENTIC_VARIABLE_VALUE)
-        logger.adebug(f"Agentic variables: {agentic_variables}")
+        await logger.adebug(f"Agentic variables: {agentic_variables}")
 
         existing_vars = await variable_service.list_variables(user_id, session)
 
         for var_name, default_value in agentic_variables.items():
-            logger.adebug(f"Checking if agentic variable {var_name} exists for user {user_id}")
+            await logger.adebug(f"Checking if agentic variable {var_name} exists for user {user_id}")
             if var_name not in existing_vars:
                 try:
                     await variable_service.create_variable(


### PR DESCRIPTION
awaits a couple of logger.adebug calls in agentic_mcp.py to prevent `coroutine [x] was never awaited` warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging behavior in the agentic MCP initialization process to improve asynchronous handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->