### PR TITLE
fix(tests): Update copy-code-button click to target first element

### DIFF
--- a/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
+++ b/src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts
@@ -103,7 +103,7 @@ test(
       timeout: 30000,
     });
 
-    await page.getByTestId("copy-code-button").last().click();
+    await page.getByTestId("copy-code-button").first().click();
 
     const handle = await page.evaluateHandle(() =>
       navigator.clipboard.readText(),


### PR DESCRIPTION
This pull request makes a minor adjustment to a test in `generalBugs-shard-3.spec.ts`. The change ensures that the test clicks the first "copy-code-button" instead of the last one, which may improve test reliability or accuracy.

* Updated the test to click the first "copy-code-button" instead of the last, potentially addressing a test bug or aligning with expected UI behavior. (`src/frontend/tests/extended/regression/generalBugs-shard-3.spec.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted regression test for code copying functionality in the playground modal to target the correct copy button element.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->