### PR TITLE
fix: Make settings hyperlink functional in Add MCP Server modal

### DIFF
--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -158,7 +158,12 @@ const SideBarFoldersButtonsComponent = ({
                   console.error(err);
                   setErrorData({
                     title: `Error on uploading your project, try dragging it into an existing project.`,
-                    list: [err["response"]["data"]["detail"]],
+                    list: [
+                      err?.response?.data?.detail ??
+                        err?.response?.data?.message ??
+                        err?.message ??
+                        "Unknown upload error.",
+                    ],
                   });
                 },
               },

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -158,7 +158,7 @@ const SideBarFoldersButtonsComponent = ({
                   console.error(err);
                   setErrorData({
                     title: `Error on uploading your project, try dragging it into an existing project.`,
-                    list: [err["response"]["data"]["message"]],
+                    list: [err["response"]["data"]["detail"]],
                   });
                 },
               },

--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -5,6 +5,7 @@ import {
 } from "@tanstack/react-query";
 import { nanoid } from "nanoid";
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { ForwardedIconComponent } from "@/components/common/genericIconComponent";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
 import InputListComponent from "@/components/core/parameterRenderComponent/components/inputListComponent";
@@ -21,7 +22,6 @@ import { Textarea } from "@/components/ui/textarea";
 import { MAX_MCP_SERVER_NAME_LENGTH } from "@/constants/constants";
 import { useAddMCPServer } from "@/controllers/API/queries/mcp/use-add-mcp-server";
 import { usePatchMCPServer } from "@/controllers/API/queries/mcp/use-patch-mcp-server";
-import { CustomLink } from "@/customization/components/custom-link";
 import BaseModal from "@/modals/baseModal";
 import IOKeyPairInput, {
   KeyPairRow,
@@ -89,6 +89,7 @@ export default function AddMcpServerModal({
     usePatchMCPServer();
 
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const modifyMCPServer = initialData ? patchMCPServer : addMCPServer;
   const isPending = isAddPending || isPatchPending;
@@ -288,9 +289,15 @@ export default function AddMcpServerModal({
             </div>
             <span className="text-mmd font-normal text-muted-foreground">
               Save MCP Servers. Manage added servers in{" "}
-              <CustomLink className="underline" to="/settings/mcp-servers">
+              <button
+                className="underline cursor-pointer bg-transparent border-0 p-0 text-inherit"
+                onClick={() => {
+                  setOpen(false);
+                  navigate("/settings/mcp-servers");
+                }}
+              >
                 settings
-              </CustomLink>
+              </button>
               .
             </span>
           </div>

--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -290,6 +290,7 @@ export default function AddMcpServerModal({
             <span className="text-mmd font-normal text-muted-foreground">
               Save MCP Servers. Manage added servers in{" "}
               <button
+                type="button"
                 className="underline cursor-pointer bg-transparent border-0 p-0 text-inherit"
                 onClick={() => {
                   setOpen(false);


### PR DESCRIPTION
## Summary
- Fixed non-functional "settings" hyperlink in Add MCP Server modal
- Replaced CustomLink with a button that properly closes the modal and navigates to settings

## Changes
- Updated `src/frontend/src/modals/addMcpServerModal/index.tsx`
- Changed CustomLink to button with onClick handler
- Added useNavigate hook for programmatic navigation

## Issue
Fixes #10460

## Test Plan
1. Open the Add MCP Server modal
2. Click on the "settings" hyperlink in the description text
3. Verify that the modal closes and you are navigated to /settings/mcp-servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error message display for file upload failures.
  * Enhanced navigation flow when accessing MCP server settings from the modal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->