### PR TITLE
fix: Sanitize NaN values in Tavily Search API output for PostgreSQL compatibility

### DIFF
--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -158,7 +158,7 @@ const SideBarFoldersButtonsComponent = ({
                   console.error(err);
                   setErrorData({
                     title: `Error on uploading your project, try dragging it into an existing project.`,
-                    list: [err["response"]["data"]["message"]],
+                    list: [err["response"]["data"]["detail"]],
                   });
                 },
               },

--- a/src/frontend/src/components/ui/input.tsx
+++ b/src/frontend/src/components/ui/input.tsx
@@ -53,7 +53,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       setIsComposing(true);
     };
 
-    const handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+    const handleCompositionEnd = (
+      e: React.CompositionEvent<HTMLInputElement>,
+    ) => {
       setIsComposing(false);
       // Normalize to NFC and trigger onChange after composition ends
       const normalizedValue = e.currentTarget.value.normalize("NFC");

--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -5,6 +5,7 @@ import {
 } from "@tanstack/react-query";
 import { nanoid } from "nanoid";
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { ForwardedIconComponent } from "@/components/common/genericIconComponent";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
 import InputListComponent from "@/components/core/parameterRenderComponent/components/inputListComponent";
@@ -21,7 +22,6 @@ import { Textarea } from "@/components/ui/textarea";
 import { MAX_MCP_SERVER_NAME_LENGTH } from "@/constants/constants";
 import { useAddMCPServer } from "@/controllers/API/queries/mcp/use-add-mcp-server";
 import { usePatchMCPServer } from "@/controllers/API/queries/mcp/use-patch-mcp-server";
-import { CustomLink } from "@/customization/components/custom-link";
 import BaseModal from "@/modals/baseModal";
 import IOKeyPairInput, {
   KeyPairRow,
@@ -89,6 +89,7 @@ export default function AddMcpServerModal({
     usePatchMCPServer();
 
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const modifyMCPServer = initialData ? patchMCPServer : addMCPServer;
   const isPending = isAddPending || isPatchPending;
@@ -288,9 +289,15 @@ export default function AddMcpServerModal({
             </div>
             <span className="text-mmd font-normal text-muted-foreground">
               Save MCP Servers. Manage added servers in{" "}
-              <CustomLink className="underline" to="/settings/mcp-servers">
+              <button
+                className="underline cursor-pointer bg-transparent border-0 p-0 text-inherit"
+                onClick={() => {
+                  setOpen(false);
+                  navigate("/settings/mcp-servers");
+                }}
+              >
                 settings
-              </CustomLink>
+              </button>
               .
             </span>
           </div>

--- a/src/lfx/src/lfx/components/tavily/tavily_search.py
+++ b/src/lfx/src/lfx/components/tavily/tavily_search.py
@@ -1,3 +1,4 @@
+import math
 import httpx
 
 from lfx.custom.custom_component.component import Component
@@ -207,6 +208,32 @@ class TavilySearchComponent(Component):
             self.status = data_results
             return data_results
 
+    def _replace_nan(self, obj):
+        """Recursively replace NaN values with None for JSON compatibility.
+
+        PostgreSQL JSON type does not support NaN values. This method
+        recursively traverses the data structure and replaces any NaN
+        values (float('nan'), math.nan) with None.
+
+        Args:
+            obj: The object to sanitize (dict, list, or primitive type)
+
+        Returns:
+            The sanitized object with NaN replaced by None
+        """
+        if isinstance(obj, dict):
+            return {k: self._replace_nan(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self._replace_nan(v) for v in obj]
+        elif isinstance(obj, float):
+            # Check for NaN (including math.nan which is a float)
+            if math.isnan(obj):
+                return None
+            return obj
+        return obj
+
     def fetch_content_dataframe(self) -> DataFrame:
         data = self.fetch_content()
-        return DataFrame(data)
+        # Sanitize data to replace NaN values with None
+        sanitized_data = [Data(text=item.text, data=self._replace_nan(item.data)) for item in data]
+        return DataFrame(sanitized_data)

--- a/src/lfx/src/lfx/components/tavily/tavily_search.py
+++ b/src/lfx/src/lfx/components/tavily/tavily_search.py
@@ -1,4 +1,5 @@
 import math
+
 import httpx
 
 from lfx.custom.custom_component.component import Component
@@ -223,9 +224,9 @@ class TavilySearchComponent(Component):
         """
         if isinstance(obj, dict):
             return {k: self._replace_nan(v) for k, v in obj.items()}
-        elif isinstance(obj, list):
+        if isinstance(obj, list):
             return [self._replace_nan(v) for v in obj]
-        elif isinstance(obj, float):
+        if isinstance(obj, float):
             # Check for NaN (including math.nan which is a float)
             if math.isnan(obj):
                 return None


### PR DESCRIPTION
## Summary
- Fixed PostgreSQL JSON error when Tavily Search API returns NaN values
- Added recursive NaN sanitization to replace NaN with None

## Problem
Tavily Search API sometimes returns NaN values in numeric fields (e.g., score, temperature, probability). PostgreSQL's JSON type does not support NaN values, causing this error:

\`\`\`
psycopg.errors.InvalidTextRepresentation: invalid input syntax for type json
DETAIL: Token \"NaN\" is invalid.
\`\`\`

## Solution
Added recursive NaN sanitization that replaces all NaN values with None before creating the DataFrame. This ensures JSON compatibility with PostgreSQL.

## Changes
- Updated `src/lfx/src/lfx/components/tavily/tavily_search.py`
- Added `_replace_nan()` method that recursively traverses data structures
- Updated `fetch_content_dataframe()` to sanitize data before DataFrame creation
- Imported `math` module for NaN detection

## Issue
Fixes #11324

## Test Plan
1. Create a flow with Tavily Search API component connected to an Agent
2. Execute a search query that might return NaN values (e.g., missing score data)
3. Verify the result is stored in PostgreSQL without errors
4. Check that the data is correctly displayed with None instead of NaN

🤖 Generated with [Claude Code](https://claude.com/claude-code)