### PR TITLE
fix: Correct error key reference in project upload error handling

### DIFF
--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -158,7 +158,7 @@ const SideBarFoldersButtonsComponent = ({
                   console.error(err);
                   setErrorData({
                     title: `Error on uploading your project, try dragging it into an existing project.`,
-                    list: [err["response"]["data"]["message"]],
+                    list: [err["response"]["data"]["detail"]],
                   });
                 },
               },


### PR DESCRIPTION
Fixes #11293

## Summary
- Fixed incorrect key reference in project upload error handler
- Changed from 'message' to 'detail' to match API response structure

## Test plan
- [ ] Verified build succeeds without TypeScript errors
- [ ] Manually tested uploading invalid JSON file
- [ ] Confirmed error message displays correctly

