### PR TITLE
fix: add debounce functionality to search input in FlowSidebarComponent

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx
@@ -1,5 +1,5 @@
 import Fuse from "fuse.js";
-import { cloneDeep } from "lodash";
+import { cloneDeep, debounce } from "lodash";
 import {
   createContext,
   memo,
@@ -234,6 +234,19 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
   const showBetaStorage = getBooleanFromStorage("showBeta", true);
   const showLegacyStorage = getBooleanFromStorage("showLegacy", false);
 
+  // Debounced search value for filtering
+  const [debouncedSearch, setDebouncedSearch] = useState(search);
+
+  const debouncedSetSearch = useMemo(
+    () => debounce((value: string) => setDebouncedSearch(value), 300),
+    [],
+  );
+
+  useEffect(() => {
+    debouncedSetSearch(search);
+    return () => debouncedSetSearch.cancel();
+  }, [search, debouncedSetSearch]);
+
   // State
   const [fuse, setFuse] = useState<Fuse<any> | null>(null);
   const [openCategories, setOpenCategories] = useState<string[]>([]);
@@ -296,10 +309,10 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
   }, [data]);
 
   const searchResults = useMemo(() => {
-    if (!search || !fuse) return null;
+    if (!debouncedSearch || !fuse) return null;
 
-    const searchTerm = normalizeString(search);
-    const fuseResults = fuse.search(search).map((result) => ({
+    const searchTerm = normalizeString(debouncedSearch);
+    const fuseResults = fuse.search(debouncedSearch).map((result) => ({
       ...result,
       item: { ...result.item, score: result.score },
     }));
@@ -314,10 +327,10 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
       combinedResults,
       traditionalResults,
     };
-  }, [search, fuse, baseData]);
+  }, [debouncedSearch, fuse, baseData]);
 
   const searchFilteredData = useMemo(() => {
-    if (!search || !searchResults) return cloneDeep(baseData);
+    if (!debouncedSearch || !searchResults) return cloneDeep(baseData);
 
     const filteredData = filteredDataFn(
       baseData,
@@ -326,7 +339,7 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
     );
 
     return filteredData;
-  }, [baseData, search, searchResults]);
+  }, [baseData, debouncedSearch, searchResults]);
 
   const sortedCategories = useMemo(() => {
     if (!searchResults || !searchFilteredData) return [];
@@ -408,7 +421,7 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
     setFilterData(finalFilteredData);
 
     if (
-      search !== "" ||
+      debouncedSearch !== "" ||
       filterType ||
       getFilterEdge.length > 0 ||
       getFilterComponent !== ""
@@ -420,7 +433,7 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
     }
   }, [
     finalFilteredData,
-    search,
+    debouncedSearch,
     filterType,
     getFilterEdge,
     setFilterComponent,
@@ -485,13 +498,13 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
 
   useEffect(() => {
     if (
-      search === "" &&
+      debouncedSearch === "" &&
       getFilterEdge.length === 0 &&
       getFilterComponent === ""
     ) {
       setOpenCategories([]);
     }
-  }, [search, getFilterEdge, getFilterComponent]);
+  }, [debouncedSearch, getFilterEdge, getFilterComponent]);
 
   const searchComponentsSidebar = useShortcutsStore(
     (state) => state.searchComponentsSidebar,
@@ -565,7 +578,9 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
   const hasMcpServers = Boolean(mcpServers && mcpServers.length > 0);
 
   const hasSearchInput =
-    search !== "" || filterType !== undefined || getFilterComponent !== "";
+    debouncedSearch !== "" ||
+    filterType !== undefined ||
+    getFilterComponent !== "";
 
   const showComponents =
     (ENABLE_NEW_SIDEBAR &&
@@ -660,7 +675,7 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
                         CATEGORIES={CATEGORIES}
                         openCategories={openCategories}
                         setOpenCategories={setOpenCategories}
-                        search={search}
+                        search={debouncedSearch}
                         nodeColors={nodeColors}
                         onDragStart={onDragStart}
                         sensitiveSort={sensitiveSort}
@@ -680,7 +695,7 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
                         openCategories={openCategories}
                         mcpLoading={mcpLoading}
                         mcpSuccess={mcpSuccess}
-                        search={search}
+                        search={debouncedSearch}
                         hasMcpServers={hasMcpServers}
                         showSearchConfigTrigger={
                           activeSection !== "mcp" &&
@@ -694,7 +709,7 @@ export function FlowSidebarComponent({ isLoading }: FlowSidebarComponentProps) {
                     {showBundles && (
                       <MemoizedSidebarGroup
                         BUNDLES={BUNDLES}
-                        search={search}
+                        search={debouncedSearch}
                         sortedCategories={sortedCategories}
                         dataFilter={dataFilter}
                         nodeColors={nodeColors}


### PR DESCRIPTION
https://datastax.jira.com/browse/LFOSS-3293

This pull request improves the search functionality in the `FlowSidebarComponent` by introducing debounced search input handling. This helps optimize performance and user experience by reducing unnecessary re-renders and search computations as the user types. The most important changes are grouped below:

**Search Input Debouncing:**

* Added a debounced version of the `search` state using `lodash`'s `debounce`, ensuring that search filtering only triggers after the user pauses typing for 300ms. [[1]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL2-R2) [[2]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aR237-R249)
* Replaced all direct usages of `search` with `debouncedSearch` throughout the component, including in memoized computations, effect dependencies, and prop passing to child components. [[1]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL299-R315) [[2]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL317-R333) [[3]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL329-R342) [[4]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL411-R424) [[5]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL423-R436) [[6]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL488-R507) [[7]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL568-R583) [[8]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL663-R678) [[9]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL683-R698) [[10]](diffhunk://#diff-a7aca77bca849cb42f3874557f429ffda61a62df6a1af3fdeaf3b9b9aad9a30aL697-R712)

Before, it takes some time for the text to appear on the screen after typing it.
https://github.com/user-attachments/assets/0f692c54-e21c-4902-8404-4725c4d4ac34

After.
https://github.com/user-attachments/assets/1d1af609-e039-4fea-8ae2-9ca4ef5585dc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized search filtering logic to significantly reduce unnecessary computations while users are typing, improving overall responsiveness and delivering smoother search interactions.
  * Enhanced the efficiency and responsiveness of item and category filtering operations throughout the application sidebar.
  * Implemented improvements to minimize the performance impact of search-related operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->