### PR TITLE
feat: Add auto type coercion for Data, Message, and DataFrame types

### DIFF
--- a/src/backend/base/langflow/api/utils/core.py
+++ b/src/backend/base/langflow/api/utils/core.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 
 from fastapi import Depends, HTTPException, Path, Query
 from fastapi_pagination import Params
+from lfx.graph.coercion import CoercionSettings
 from lfx.graph.graph.base import Graph
 from lfx.log.logger import logger
 from lfx.services.deps import injectable_session_scope, injectable_session_scope_readonly, session_scope
@@ -179,7 +180,12 @@ async def _get_flow_name(flow_id: uuid.UUID) -> str:
     return flow.name
 
 
-async def build_graph_from_data(flow_id: uuid.UUID | str, payload: dict, **kwargs):
+async def build_graph_from_data(
+    flow_id: uuid.UUID | str,
+    payload: dict,
+    coercion_settings: CoercionSettings | None = None,
+    **kwargs,
+):
     """Build and cache the graph."""
     # Get flow name
     if "flow_name" not in kwargs:
@@ -189,7 +195,13 @@ async def build_graph_from_data(flow_id: uuid.UUID | str, payload: dict, **kwarg
     str_flow_id = str(flow_id)
     session_id = kwargs.get("session_id") or str_flow_id
 
-    graph = Graph.from_payload(payload, str_flow_id, flow_name, kwargs.get("user_id"))
+    graph = Graph.from_payload(
+        payload,
+        str_flow_id,
+        flow_name,
+        kwargs.get("user_id"),
+        coercion_settings=coercion_settings,
+    )
     for vertex_id in graph.has_session_id_vertices:
         vertex = graph.get_vertex(vertex_id)
         if vertex is None:

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -30,6 +30,7 @@ from langflow.api.utils import (
 )
 from langflow.api.v1.schemas import (
     CancelFlowResponse,
+    CoercionSettingsRequest,
     FlowDataRequest,
     ResultDataResponse,
     StreamData,
@@ -145,6 +146,7 @@ async def build_flow(
     queue_service: Annotated[JobQueueService, Depends(get_queue_service)],
     flow_name: str | None = None,
     event_delivery: EventDeliveryType = EventDeliveryType.POLLING,
+    coercion_settings: Annotated[CoercionSettingsRequest | None, Body(embed=True)] = None,
 ):
     """Build and process a flow, returning a job ID for event polling.
 
@@ -186,6 +188,7 @@ async def build_flow(
         current_user=current_user,
         queue_service=queue_service,
         flow_name=flow_name,
+        coercion_settings=coercion_settings,
     )
 
     # This is required to support FE tests - we need to be able to set the event delivery to direct

--- a/src/backend/base/langflow/api/v1/schemas.py
+++ b/src/backend/base/langflow/api/v1/schemas.py
@@ -353,6 +353,13 @@ class SimplifiedAPIRequest(BaseModel):
 #     viewport: Viewport;
 # }
 # import ReactFlowJsonObject
+class CoercionSettingsRequest(BaseModel):
+    """Settings for auto-coercion between Data, Message, and DataFrame types."""
+
+    enabled: bool = False
+    auto_parse: bool = False
+
+
 class FlowDataRequest(BaseModel):
     nodes: list[dict]
     edges: list[dict]

--- a/src/frontend/src/pages/SettingsPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/index.tsx
@@ -89,6 +89,16 @@ export default function SettingsPage(): JSX.Element {
         />
       ),
     },
+    {
+      title: "Type Coercion",
+      href: "/settings/type-coercion",
+      icon: (
+        <ForwardedIconComponent
+          name="Repeat"
+          className="w-4 flex-shrink-0 justify-start stroke-[1.5]"
+        />
+      ),
+    },
   );
 
   // TODO: Remove this on cleanup

--- a/src/frontend/src/pages/SettingsPage/pages/TypeCoercionPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/TypeCoercionPage/index.tsx
@@ -1,0 +1,136 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useCoercionStore } from "@/stores/coercionStore";
+
+export default function TypeCoercionPage() {
+  const { coercionSettings, setCoercionEnabled, setAutoParse } =
+    useCoercionStore();
+
+  return (
+    <div className="flex h-full w-full flex-col gap-6">
+      <div className="flex w-full items-start justify-between gap-6">
+        <div className="flex w-full flex-col">
+          <h2
+            className="flex items-center text-lg font-semibold tracking-tight"
+            data-testid="settings_menu_header"
+          >
+            Type Coercion
+            <ForwardedIconComponent
+              name="Repeat"
+              className="ml-2 h-5 w-5 text-primary"
+            />
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Configure automatic type conversion between Data, Message, and
+            DataFrame types.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-6 pb-8">
+        {/* Enable Auto-Coercion */}
+        <div className="flex flex-col space-y-4 rounded-lg border border-border p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col space-y-1">
+              <Label
+                htmlFor="auto-coercion-toggle"
+                className="text-sm font-medium"
+              >
+                Enable Auto-Coercion
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Allow Data, Message, and DataFrame types to connect
+                interchangeably. When enabled, handles for these types will
+                display with a unified violet color.
+              </p>
+            </div>
+            <Switch
+              id="auto-coercion-toggle"
+              checked={coercionSettings.enabled}
+              onCheckedChange={setCoercionEnabled}
+              data-testid="auto-coercion-toggle"
+            />
+          </div>
+
+          {/* Visual indicator */}
+          {coercionSettings.enabled && (
+            <div className="flex items-center gap-2 rounded-md bg-accent/50 p-3 text-sm">
+              <ForwardedIconComponent
+                name="Info"
+                className="h-4 w-4 text-pink-500"
+              />
+              <span>
+                Coercible types (Data, Message, DataFrame) will now show{" "}
+                <span className="font-medium text-pink-500">pink</span>{" "}
+                colored handles and can connect to each other.
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Auto Parse (only shown when coercion is enabled) */}
+        {coercionSettings.enabled && (
+          <div className="flex flex-col space-y-4 rounded-lg border border-border p-4">
+            <div className="flex items-center justify-between">
+              <div className="flex flex-col space-y-1">
+                <Label htmlFor="auto-parse-toggle" className="text-sm font-medium">
+                  Auto Parse
+                </Label>
+                <p className="text-sm text-muted-foreground">
+                  Automatically detect and convert JSON/CSV strings when
+                  transforming between types. This mirrors the behavior of the
+                  Type Convert component&apos;s auto_parse option.
+                </p>
+              </div>
+              <Switch
+                id="auto-parse-toggle"
+                checked={coercionSettings.autoParse}
+                onCheckedChange={setAutoParse}
+                data-testid="auto-parse-toggle"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Information Card */}
+        <div className="rounded-lg border border-border bg-muted/30 p-4">
+          <h3 className="mb-2 flex items-center gap-2 text-sm font-medium">
+            <ForwardedIconComponent name="HelpCircle" className="h-4 w-4" />
+            How Auto-Coercion Works
+          </h3>
+          <div className="space-y-2 text-sm text-muted-foreground">
+            <p>
+              When auto-coercion is enabled, the following conversions happen
+              automatically at runtime:
+            </p>
+            <ul className="list-inside list-disc space-y-1 pl-2">
+              <li>
+                <strong>Data → Message:</strong> Converts using the{" "}
+                <code className="rounded bg-muted px-1">to_message()</code>{" "}
+                method
+              </li>
+              <li>
+                <strong>Message → Data:</strong> Extracts text content into a
+                Data object
+              </li>
+              <li>
+                <strong>DataFrame → Message:</strong> Converts to a markdown
+                table representation
+              </li>
+              <li>
+                <strong>Data → DataFrame:</strong> Creates a single-row
+                DataFrame
+              </li>
+            </ul>
+            <p className="mt-3">
+              <strong>Note:</strong> Other types (LanguageModel, Tool,
+              Embeddings, etc.) remain strictly typed and are not affected by
+              this setting.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/pages/SettingsPage/pages/TypeCoercionPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/TypeCoercionPage/index.tsx
@@ -62,8 +62,8 @@ export default function TypeCoercionPage() {
               />
               <span>
                 Coercible types (Data, Message, DataFrame) will now show{" "}
-                <span className="font-medium text-pink-500">pink</span>{" "}
-                colored handles and can connect to each other.
+                <span className="font-medium text-pink-500">pink</span> colored
+                handles and can connect to each other.
               </span>
             </div>
           )}
@@ -74,7 +74,10 @@ export default function TypeCoercionPage() {
           <div className="flex flex-col space-y-4 rounded-lg border border-border p-4">
             <div className="flex items-center justify-between">
               <div className="flex flex-col space-y-1">
-                <Label htmlFor="auto-parse-toggle" className="text-sm font-medium">
+                <Label
+                  htmlFor="auto-parse-toggle"
+                  className="text-sm font-medium"
+                >
                   Auto Parse
                 </Label>
                 <p className="text-sm text-muted-foreground">

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -37,6 +37,7 @@ import MCPServersPage from "./pages/SettingsPage/pages/MCPServersPage";
 import ModelProvidersPage from "./pages/SettingsPage/pages/ModelProvidersPage";
 import MessagesPage from "./pages/SettingsPage/pages/messagesPage";
 import ShortcutsPage from "./pages/SettingsPage/pages/ShortcutsPage";
+import TypeCoercionPage from "./pages/SettingsPage/pages/TypeCoercionPage";
 import ViewPage from "./pages/ViewPage";
 
 const AdminPage = lazy(() => import("./pages/AdminPage"));
@@ -157,6 +158,10 @@ const router = createBrowserRouter(
                   />
                   <Route path="shortcuts" element={<ShortcutsPage />} />
                   <Route path="messages" element={<MessagesPage />} />
+                  <Route
+                    path="type-coercion"
+                    element={<TypeCoercionPage />}
+                  />
                   {CustomRoutesStore()}
                 </Route>
                 {CustomRoutesStorePages()}

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -158,10 +158,7 @@ const router = createBrowserRouter(
                   />
                   <Route path="shortcuts" element={<ShortcutsPage />} />
                   <Route path="messages" element={<MessagesPage />} />
-                  <Route
-                    path="type-coercion"
-                    element={<TypeCoercionPage />}
-                  />
+                  <Route path="type-coercion" element={<TypeCoercionPage />} />
                   {CustomRoutesStore()}
                 </Route>
                 {CustomRoutesStorePages()}

--- a/src/frontend/src/stores/coercionStore.ts
+++ b/src/frontend/src/stores/coercionStore.ts
@@ -1,0 +1,103 @@
+import { create } from "zustand";
+
+/**
+ * Types that are interchangeable when auto-coercion is enabled.
+ * Only these three types can be coerced to each other.
+ * All other types (LanguageModel, Tool, Embeddings, etc.) remain strictly typed.
+ */
+export const COERCIBLE_TYPES = ["Data", "Message", "DataFrame"];
+
+type CoercionSettings = {
+  enabled: boolean;
+  autoParse: boolean; // Detect and convert JSON/CSV strings (mirrors Type Convert component)
+};
+
+type CoercionStoreType = {
+  coercionSettings: CoercionSettings;
+  setCoercionEnabled: (value: boolean) => void;
+  setAutoParse: (value: boolean) => void;
+  isCoercibleType: (type: string) => boolean;
+  areTypesCoercible: (sourceTypes: string[], targetTypes: string[]) => boolean;
+};
+
+const DEFAULT_SETTINGS: CoercionSettings = {
+  enabled: false,
+  autoParse: false,
+};
+
+const STORAGE_KEY = "coercionSettings";
+
+const loadSettings = (): CoercionSettings => {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      // Validate the parsed object has the expected shape
+      if (
+        typeof parsed.enabled === "boolean" &&
+        typeof parsed.autoParse === "boolean"
+      ) {
+        return parsed;
+      }
+    }
+  } catch (e) {
+    console.warn("Failed to load coercion settings from localStorage:", e);
+  }
+  return DEFAULT_SETTINGS;
+};
+
+const saveSettings = (settings: CoercionSettings) => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch (e) {
+    console.warn("Failed to save coercion settings to localStorage:", e);
+  }
+};
+
+export const useCoercionStore = create<CoercionStoreType>((set, get) => ({
+  coercionSettings: loadSettings(),
+
+  setCoercionEnabled: (value: boolean) => {
+    const newSettings = { ...get().coercionSettings, enabled: value };
+    saveSettings(newSettings);
+    set({ coercionSettings: newSettings });
+  },
+
+  setAutoParse: (value: boolean) => {
+    const newSettings = { ...get().coercionSettings, autoParse: value };
+    saveSettings(newSettings);
+    set({ coercionSettings: newSettings });
+  },
+
+  /**
+   * Check if a single type is coercible (Data, Message, or DataFrame)
+   */
+  isCoercibleType: (type: string): boolean => {
+    return COERCIBLE_TYPES.includes(type);
+  },
+
+  /**
+   * Check if two sets of types can be coerced to each other.
+   * Returns true only if auto-coercion is enabled AND both have at least one coercible type.
+   */
+  areTypesCoercible: (
+    sourceTypes: string[],
+    targetTypes: string[],
+  ): boolean => {
+    const { coercionSettings } = get();
+    if (!coercionSettings.enabled) {
+      return false;
+    }
+
+    const sourceHasCoercible = sourceTypes.some((t) =>
+      COERCIBLE_TYPES.includes(t),
+    );
+    const targetHasCoercible = targetTypes.some((t) =>
+      COERCIBLE_TYPES.includes(t),
+    );
+
+    return sourceHasCoercible && targetHasCoercible;
+  },
+}));
+
+export default useCoercionStore;

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -7,6 +7,7 @@ import {
   POLLING_MESSAGES,
 } from "@/constants/constants";
 import { performStreamingRequest } from "@/controllers/API/api";
+import { useCoercionStore } from "@/stores/coercionStore";
 import {
   customBuildUrl,
   customCancelBuildUrl,
@@ -257,6 +258,15 @@ export async function buildFlowVertices({
   inputs["client_request_time"] = Date.now();
   if (Object.keys(inputs).length > 0) {
     postData["inputs"] = inputs;
+  }
+
+  // Add coercion settings if enabled
+  const coercionSettings = useCoercionStore.getState().coercionSettings;
+  if (coercionSettings.enabled) {
+    postData["coercion_settings"] = {
+      enabled: coercionSettings.enabled,
+      auto_parse: coercionSettings.autoParse,
+    };
   }
 
   try {

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -188,6 +188,27 @@ export const nodeColorsName: { [char: string]: string } = {
   DataFrame: "pink",
 };
 
+/**
+ * Colors that correspond to coercible types (Data, Message, DataFrame):
+ * - Data = "red"
+ * - Message = "indigo"
+ * - DataFrame = "pink"
+ */
+const COERCIBLE_COLORS = new Set(["red", "indigo", "pink"]);
+
+/**
+ * Unified color for coercible types when auto-coercion is enabled.
+ */
+export const COERCION_UNIFIED_COLOR_NAME = "pink";
+
+/**
+ * Check if any color in the array is a coercible type's color.
+ * Used to determine if a handle should show the unified coercion color.
+ */
+export const hasCoercibleColor = (colors: string[]): boolean => {
+  return colors.some((c) => COERCIBLE_COLORS.has(c));
+};
+
 export const FILE_ICONS = {
   json: {
     icon: "FileJson",

--- a/src/lfx/src/lfx/graph/__init__.py
+++ b/src/lfx/src/lfx/graph/__init__.py
@@ -1,6 +1,16 @@
+from lfx.graph.coercion import COERCIBLE_TYPES, CoercionSettings
 from lfx.graph.edge.base import Edge
 from lfx.graph.graph.base import Graph
 from lfx.graph.vertex.base import Vertex
 from lfx.graph.vertex.vertex_types import CustomComponentVertex, InterfaceVertex, StateVertex
 
-__all__ = ["CustomComponentVertex", "Edge", "Graph", "InterfaceVertex", "StateVertex", "Vertex"]
+__all__ = [
+    "COERCIBLE_TYPES",
+    "CoercionSettings",
+    "CustomComponentVertex",
+    "Edge",
+    "Graph",
+    "InterfaceVertex",
+    "StateVertex",
+    "Vertex",
+]

--- a/src/lfx/src/lfx/graph/coercion.py
+++ b/src/lfx/src/lfx/graph/coercion.py
@@ -1,0 +1,230 @@
+"""Auto-coercion utilities for converting between Data, Message, and DataFrame types.
+
+This module provides utilities for automatic type coercion between Langflow's
+three primary data types: Data, Message, and DataFrame. The coercion is enabled
+via settings and uses the same conversion logic as the Type Convert component.
+
+IMPORTANT: Auto-coercion ONLY applies to these three types:
+- Data
+- Message
+- DataFrame
+
+All other types (LanguageModel, Tool, Embeddings, Retriever, Memory, etc.)
+remain strictly typed with no coercion, regardless of the setting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lfx.schema import Data, DataFrame, Message
+
+# Types that can be coerced to each other
+COERCIBLE_TYPES = frozenset({"Data", "Message", "DataFrame"})
+
+
+@dataclass
+class CoercionSettings:
+    """Settings for auto-coercion behavior.
+
+    Attributes:
+        enabled: Whether auto-coercion is enabled
+        auto_parse: Whether to automatically parse JSON/CSV strings during conversion
+    """
+
+    enabled: bool = False
+    auto_parse: bool = False
+
+
+def is_coercible_type(type_name: str) -> bool:
+    """Check if a type name is a coercible type.
+
+    Args:
+        type_name: The type name to check
+
+    Returns:
+        True if the type is coercible (Data, Message, or DataFrame)
+    """
+    return type_name in COERCIBLE_TYPES
+
+
+def are_types_coercible(source_types: list[str], target_types: list[str]) -> bool:
+    """Check if source and target types can be coerced.
+
+    Args:
+        source_types: List of source output types
+        target_types: List of target input types
+
+    Returns:
+        True if both have at least one coercible type
+    """
+    source_coercible = any(t in COERCIBLE_TYPES for t in source_types)
+    target_coercible = any(t in COERCIBLE_TYPES for t in target_types)
+    return source_coercible and target_coercible
+
+
+def convert_to_message(value: Any) -> Message:
+    """Convert input to Message type.
+
+    Uses the same logic as the Type Convert component.
+
+    Args:
+        value: Input to convert (Message, Data, DataFrame, or dict)
+
+    Returns:
+        Message: Converted Message object
+    """
+    from lfx.schema import Message
+
+    if isinstance(value, Message):
+        return value
+
+    # For Data and DataFrame, use their to_message() method
+    if hasattr(value, "to_message"):
+        return value.to_message()
+
+    # For dicts, create a Message from text if present
+    if isinstance(value, dict):
+        text = value.get("text", str(value))
+        return Message(text=text)
+
+    # Fallback: convert to string
+    return Message(text=str(value))
+
+
+def convert_to_data(value: Any, *, auto_parse: bool = False) -> Data:
+    """Convert input to Data type.
+
+    Uses the same logic as the Type Convert component.
+
+    Args:
+        value: Input to convert (Message, Data, DataFrame, or dict)
+        auto_parse: Enable automatic parsing of structured data (JSON/CSV)
+
+    Returns:
+        Data: Converted Data object
+    """
+    from lfx.components.processing.converter import parse_structured_data
+    from lfx.schema import Data, DataFrame, Message
+
+    if isinstance(value, Data) and not isinstance(value, (Message, DataFrame)):
+        return value
+
+    if isinstance(value, dict):
+        return Data(value)
+
+    if isinstance(value, Message):
+        data = Data(data={"text": value.data.get("text", "")})
+        return parse_structured_data(data) if auto_parse else data
+
+    if isinstance(value, DataFrame):
+        return value.to_data()
+
+    # For other types with to_data method
+    if hasattr(value, "to_data"):
+        return value.to_data()
+
+    # Fallback
+    return Data(data={"value": value})
+
+
+def convert_to_dataframe(value: Any, *, auto_parse: bool = False) -> DataFrame:
+    """Convert input to DataFrame type.
+
+    Uses the same logic as the Type Convert component.
+
+    Args:
+        value: Input to convert (Message, Data, DataFrame, or dict)
+        auto_parse: Enable automatic parsing of structured data (JSON/CSV)
+
+    Returns:
+        DataFrame: Converted DataFrame object
+    """
+    import pandas as pd
+
+    from lfx.components.processing.converter import parse_structured_data
+    from lfx.schema import Data, DataFrame, Message
+
+    if isinstance(value, DataFrame):
+        return value
+
+    if isinstance(value, dict):
+        return DataFrame([value])
+
+    # Handle pandas DataFrame
+    if isinstance(value, pd.DataFrame):
+        return DataFrame(data=value)
+
+    if isinstance(value, Message):
+        data = Data(data={"text": value.data.get("text", "")})
+        if auto_parse:
+            return parse_structured_data(data).to_dataframe()
+        return data.to_dataframe()
+
+    if isinstance(value, Data):
+        return value.to_dataframe()
+
+    # For other types with to_dataframe method
+    if hasattr(value, "to_dataframe"):
+        return value.to_dataframe()
+
+    # Fallback
+    return DataFrame([{"value": value}])
+
+
+def auto_coerce_value(value: Any, expected_type: str, settings: CoercionSettings) -> Any:
+    """Auto-convert between Data, Message, DataFrame when types differ.
+
+    Uses the same conversion logic as the Type Convert component.
+    Only coerces if:
+    1. Settings are enabled
+    2. Expected type is a coercible type
+    3. Actual value type is also a coercible type
+
+    Args:
+        value: The value to potentially coerce
+        expected_type: The expected type name (e.g., "Message", "Data", "DataFrame")
+        settings: The coercion settings
+
+    Returns:
+        The coerced value if coercion applies, otherwise the original value
+    """
+    if not settings.enabled:
+        return value
+
+    if expected_type not in COERCIBLE_TYPES:
+        return value
+
+    # Get actual type name
+    actual_type = type(value).__name__
+    if actual_type == expected_type:
+        return value
+
+    if actual_type not in COERCIBLE_TYPES:
+        return value
+
+    # Apply conversion based on expected type
+    if expected_type == "Message":
+        return convert_to_message(value)
+    if expected_type == "Data":
+        return convert_to_data(value, auto_parse=settings.auto_parse)
+    if expected_type == "DataFrame":
+        return convert_to_dataframe(value, auto_parse=settings.auto_parse)
+
+    return value
+
+
+def auto_coerce_list(values: list, expected_type: str, settings: CoercionSettings) -> list:
+    """Coerce a list of values to the expected type.
+
+    Args:
+        values: List of values to coerce
+        expected_type: The expected type for each value
+        settings: The coercion settings
+
+    Returns:
+        List of coerced values
+    """
+    return [auto_coerce_value(v, expected_type, settings) for v in values]


### PR DESCRIPTION
## Summary

- Adds a global setting (Settings > Type Coercion) that allows Data, Message, and DataFrame types to connect interchangeably
- When enabled, handles show unified pink color for visual feedback
- Runtime automatically converts values using Type Convert component logic
- Includes "Auto Parse" option to detect and convert JSON/CSV strings

## Test plan

- [ ] Toggle OFF (default): Verify Data cannot connect to Message input
- [ ] Toggle ON: Verify Data/Message/DataFrame can connect to each other
- [ ] Verify handles show pink color when coercion is enabled
- [ ] Verify runtime conversion works (e.g., Data → Message connection executes correctly)
- [ ] Verify setting persists after browser refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)