### PR TITLE
feat: Add PUT endpoint for projects upsert

### DIFF
--- a/src/backend/base/langflow/services/database/models/folder/model.py
+++ b/src/backend/base/langflow/services/database/models/folder/model.py
@@ -37,6 +37,7 @@ class Folder(FolderBase, table=True):  # type: ignore[call-arg]
 
 
 class FolderCreate(FolderBase):
+    parent_id: UUID | None = None
     components_list: list[UUID] | None = None
     flows_list: list[UUID] | None = None
 


### PR DESCRIPTION
## Summary

- Adds `PUT /api/v1/projects/{project_id}` endpoint with upsert semantics (create or update)
- Returns `201 Created` for new projects, `200 OK` for updates
- Returns `404` for other user's projects (avoids leaking resource existence)
- Returns `409 Conflict` on name uniqueness violations
- Adds `parent_id` field to `FolderCreate` schema for consistency with the model

## Changes

**API endpoint** (`src/backend/base/langflow/api/v1/projects.py`):
- `_check_name_uniqueness()` - reusable helper for name validation
- `_update_existing_project()` - handles UPDATE path
- `_create_new_project()` - handles CREATE path with specified ID
- `upsert_project()` - main PUT endpoint

**Model** (`src/backend/base/langflow/services/database/models/folder/model.py`):
- Added `parent_id` to `FolderCreate` schema

**Tests** (`src/backend/tests/unit/api/v1/test_projects.py`):
- 8 new tests covering create, update, ownership, and conflict scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified project creation and update operation: create new projects or update existing ones through a single endpoint with appropriate status responses (201 for creation, 200 for updates).
  * Projects can now be organized hierarchically with parent-child relationships for better structure.
  * Enhanced error handling provides specific HTTP status codes for naming conflicts and authorization scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->