### PR TITLE
fix: preserve Smart Router outputs when Model Provider changes

### DIFF
--- a/src/lfx/src/lfx/components/llm_operations/llm_conditional_router.py
+++ b/src/lfx/src/lfx/components/llm_operations/llm_conditional_router.py
@@ -145,7 +145,7 @@ class SmartRouterComponent(Component):
 
     def update_outputs(self, frontend_node: dict, field_name: str, field_value: Any) -> dict:
         """Create a dynamic output for each category in the categories table."""
-        if field_name in {"routes", "enable_else_output"}:
+        if field_name in {"routes", "enable_else_output", "model"}:
             frontend_node["outputs"] = []
 
             # Get the routes data - either from field_value (if routes field) or from component state


### PR DESCRIPTION
## Summary
- Fixed bug where Smart Router outputs disappear when changing the Model Provider field
- Added `"model"` to the set of field names that trigger output regeneration in `update_outputs()`

## Root Cause
The `update_outputs()` method only regenerated outputs when `field_name` was `"routes"` or `"enable_else_output"`. When Model Provider changed (`field_name="model"`), the condition failed and outputs were not regenerated.

## Test plan
- [ ] Add a Smart Router component to a flow
- [ ] Configure routes in the routing table (add 2-3 categories)
- [ ] Connect outputs to other components
- [ ] Change the Model Provider to a different provider
- [ ] Verify outputs remain visible and connections stay intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model selection now properly triggers output recalculation, ensuring dependent outputs refresh and remain consistent across LLM operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->