### PR TITLE
chore(docker): Upgrade Node.js from 18 to 20 LTS

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -33,6 +33,9 @@ RUN apt-get update \
     npm \
     # gcc
     gcc \
+    curl \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -75,7 +78,7 @@ FROM python:3.12.3-slim AS runtime
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y curl git libpq5 gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
This pull request updates the Node.js version used in the Docker build and runtime environments from Node.js 18 to Node.js 20. This ensures that the Docker images are built and run with the latest long-term support version of Node.js.

Dependency updates:

* Updated the Node.js installation script in the build stage to use Node.js 20 instead of Node.js 18 (`docker/build_and_push.Dockerfile`).
* Updated the Node.js installation script in the runtime stage to use Node.js 20 instead of Node.js 18 (`docker/build_and_push.Dockerfile`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Node.js version upgraded from 18.x to 20.x in the application's Docker runtime environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->