### PR TITLE
fix(inputs): default IntInput to 0

### DIFF
--- a/src/lfx/src/lfx/inputs/inputs.py
+++ b/src/lfx/src/lfx/inputs/inputs.py
@@ -477,7 +477,7 @@ class IntInput(BaseInputMixin, ListableInputMixin, RangeMixin, MetadataTraceMixi
     field_type: SerializableFieldTypes = FieldTypes.INTEGER
     track_in_telemetry: CoalesceBool = True  # Safe numeric parameter
 
-    value: int = 0
+    value: Any = 0
 
     @field_validator("value")
     @classmethod


### PR DESCRIPTION
set IntInput default value to 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integer input fields now include configurable default values for enhanced form initialization and user input management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->