### PR TITLE
fix: add iter method to noopresult

### DIFF
--- a/src/backend/base/langflow/services/database/session.py
+++ b/src/backend/base/langflow/services/database/session.py
@@ -59,4 +59,7 @@ class NoopSession:
             def one_or_none(self):
                 return None
 
+            def __iter__(self):
+                return iter([])
+
         return _NoopResult()

--- a/src/lfx/src/lfx/services/session.py
+++ b/src/lfx/src/lfx/services/session.py
@@ -68,6 +68,9 @@ class NoopSession:
             def one_or_none(self):
                 return None
 
+            def __iter__(self):
+                return iter([])
+
         return _NoopResult()
 
     @property


### PR DESCRIPTION
 ```bash
 uv run lfx run [Some flow containing the agent component] [input]
 ```
 throws the following exception:
 ```bash
 "Error building Component Agent: \n\nError running method \"message_response\": '_NoopResult' object is not iterable"
 ```
 as the agent component iterates through chat history while the _NoopResult is not iterable. This is fixed by adding an iter method to the class.

This is largely a port of a [PR that was already merged for 1.7](https://github.com/langflow-ai/langflow/pull/10914): 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced iteration support for database session results to prevent potential errors when processing query results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->