### PR TITLE
fix(frontend): reset playground state when navigating between flows

### DIFF
--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -141,6 +141,9 @@ export default function FlowPage({ view }: { view?: boolean }): JSX.Element {
       console.warn("unmounting");
 
       setCurrentFlow(undefined);
+      // Reset playground state when leaving the flow
+      setSlidingContainerOpen(false);
+      setIsFullscreen(false);
     };
   }, [id]);
 


### PR DESCRIPTION
What does this PR do?
Fixes a bug where the Playground state (open/closed, sidebar/fullscreen mode) persisted globally when navigating between different flows, causing the Playground to remain open inappropriately.

Why is this important?
When users switched flows, the Playground would remain open even for flows without Chat Input/Output components, blocking access to the canvas and requiring manual closure. This violated the fundamental prerequisite that a flow must contain at least one Chat Input or Chat Output component for the Playground to be enabled.

How does it work?
Added cleanup logic to reset Playground state (isOpen and isFullscreen) when the FlowPage component unmounts (i.e., when navigating away from a flow). This ensures the Playground always starts closed when opening any flow.

Testing
Steps to reproduce the original bug:

Open a flow with Chat Input/Output components
Open the Playground (sidebar or fullscreen)
Navigate to Dashboard
Open a different flow or create a blank flow
❌ Playground incorrectly remains open
Expected behavior after fix:

Open a flow with Chat Input/Output components
Open the Playground (sidebar or fullscreen)
Navigate to Dashboard
Open a different flow or create a blank flow
✅ Playground is closed and must be explicitly opened by user
