### PR TITLE
 fix(frontend): prevent Message Logs table from dropping columns with falsy values

### DIFF
--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -410,7 +410,7 @@ export function extractColumnsFromRows(
     }
     for (const row of rows) {
       for (const key in columnsKeys) {
-        if (!row[key]) {
+        if (!(key in row)) {
           delete columnsKeys[key];
         }
       }


### PR DESCRIPTION
Description
Fix Message Logs table dropping "text" column when session contains image messages

What
The Message Logs table was inconsistently displaying columns based on message content. When a session contained image messages (with or without text), the "text" column would disappear from the table, making it impossible to view message text content.

Why
The root cause was in the extractColumnsFromRows function's intersection mode logic. The function was checking if (!row[key]) to determine if a column should be removed, which incorrectly treated falsy values (empty strings, null, undefined) as missing properties. When an image-only message had an empty or null text field, the entire "text" column was removed from the table.

Testing
Manually tested both scenarios:

Scenario 1: Text → Image+Text → Text (column reappears) ✅
Scenario 2: Image-only → Text (column now appears correctly) ✅

<img width="3076" height="1532" alt="image" src="https://github.com/user-attachments/assets/9c3acec0-ea4b-4bfd-8f35-19785a935fb2" />
