### PR TITLE
feat: Add visual progress bar for component execution

### DIFF
--- a/src/backend/base/langflow/services/job_queue/service.py
+++ b/src/backend/base/langflow/services/job_queue/service.py
@@ -345,6 +345,7 @@ class JobQueueService(Service):
             ("on_end_vertex", "end_vertex"),
             ("on_build_start", "build_start"),
             ("on_build_end", "build_end"),
+            ("on_progress", "progress"),
         ]
         for name, event_type in event_names_types:
             manager.register_event(name, event_type)

--- a/src/frontend/src/CustomNodes/GenericNode/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/index.tsx
@@ -32,6 +32,7 @@ import NodeUpdateComponent from "./components/NodeUpdateComponent";
 import { NodeIcon } from "./components/nodeIcon";
 import RenderInputParameters from "./components/RenderInputParameters";
 import { useBuildStatus } from "./hooks/use-get-build-status";
+import { BuildStatus } from "@/constants/enums";
 
 const MemoizedRenderInputParameters = memo(RenderInputParameters);
 const MemoizedNodeIcon = memo(NodeIcon);
@@ -88,6 +89,7 @@ function GenericNode({
   const setEdges = useFlowStore((state) => state.setEdges);
   const shortcuts = useShortcutsStore((state) => state.shortcuts);
   const buildStatus = useBuildStatus(data, data.id);
+  const nodeProgress = useFlowStore((state) => state.nodeProgress[data.id]);
   const dismissedNodes = useFlowStore((state) => state.dismissedNodes);
   const addDismissedNodes = useFlowStore((state) => state.addDismissedNodes);
   const removeDismissedNodes = useFlowStore(
@@ -663,6 +665,18 @@ function GenericNode({
                 handleSelectOutput={handleSelectOutput}
               />
             </>
+          </div>
+        )}
+        {/* Progress bar - only render when building with progress */}
+        {buildStatus === BuildStatus.BUILDING && nodeProgress && (
+          <div
+            className="pointer-events-none absolute bottom-0 left-0 right-0 h-3 overflow-hidden"
+            style={{ borderRadius: '0 0 11px 11px' }}
+          >
+            <div
+              className="absolute bottom-0 left-0 h-1 bg-accent-indigo-foreground transition-all duration-300 ease-out"
+              style={{ width: `${(nodeProgress.current / nodeProgress.total) * 100}%` }}
+            />
           </div>
         )}
       </div>

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -58,6 +58,24 @@ import { useTypesStore } from "./typesStore";
 
 // this is our useStore hook that we can use in our components to get parts of the store and call actions
 const useFlowStore = create<FlowStoreType>((set, get) => ({
+  nodeProgress: {},
+  setNodeProgress: (nodeId, progress) => {
+    if (progress === null) {
+      const newProgress = { ...get().nodeProgress };
+      delete newProgress[nodeId];
+      set({ nodeProgress: newProgress });
+    } else {
+      set({
+        nodeProgress: {
+          ...get().nodeProgress,
+          [nodeId]: progress,
+        },
+      });
+    }
+  },
+  clearAllNodeProgress: () => {
+    set({ nodeProgress: {} });
+  },
   playgroundPage: false,
   setPlaygroundPage: (playgroundPage) => {
     set({ playgroundPage });
@@ -1076,6 +1094,7 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
       positionDictionary: {},
       componentsToUpdate: [],
       rightClickedNodeId: null,
+      nodeProgress: {},
     });
   },
   dismissedNodes: [],

--- a/src/frontend/src/types/zustand/flow/index.ts
+++ b/src/frontend/src/types/zustand/flow/index.ts
@@ -61,7 +61,16 @@ export type ComponentsToUpdateType = {
   userEdited: boolean;
 };
 
+export type NodeProgressType = {
+  current: number;
+  total: number;
+  message?: string;
+};
+
 export type FlowStoreType = {
+  nodeProgress: { [nodeId: string]: NodeProgressType };
+  setNodeProgress: (nodeId: string, progress: NodeProgressType | null) => void;
+  clearAllNodeProgress: () => void;
   dismissedNodes: string[];
   addDismissedNodes: (dismissedNodes: string[]) => void;
   removeDismissedNodes: (dismissedNodes: string[]) => void;

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -499,6 +499,9 @@ async function onEvent(
     }
     case "end_vertex": {
       const buildData = data.build_data;
+      // Clear progress for this node when it finishes
+      useFlowStore.getState().setNodeProgress(buildData.id, null);
+
       const startTimeMs = verticesStartTimeMs.get(buildData.id);
       if (startTimeMs) {
         const delta = Date.now() - startTimeMs;
@@ -577,6 +580,8 @@ async function onEvent(
       const allNodesValid = buildResults.every((result) => result);
       onBuildComplete && onBuildComplete(allNodesValid);
       useFlowStore.getState().setIsBuilding(false);
+      // Clear all progress when build ends
+      useFlowStore.getState().clearAllNodeProgress();
       return true;
     }
     case "error": {
@@ -598,6 +603,14 @@ async function onEvent(
     case "build_end":
       useFlowStore.getState().updateBuildStatus([data.id], BuildStatus.BUILT);
       break;
+    case "progress": {
+      // Handle progress events from components (e.g., batch processing)
+      const { id, current, total, message } = data;
+      if (id && typeof current === "number" && typeof total === "number") {
+        useFlowStore.getState().setNodeProgress(id, { current, total, message });
+      }
+      return true;
+    }
     default:
       return true;
   }

--- a/src/lfx/src/lfx/_assets/stable_hash_history.json
+++ b/src/lfx/src/lfx/_assets/stable_hash_history.json
@@ -1773,5 +1773,10 @@
     "versions": {
       "0.3.0": "ec825c33caf6"
     }
+  },
+  "ProgressTest": {
+    "versions": {
+      "0.3.0": "48a384dd6fbb"
+    }
   }
 }

--- a/src/lfx/src/lfx/components/processing/__init__.py
+++ b/src/lfx/src/lfx/components/processing/__init__.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from lfx.components.processing.output_parser import OutputParserComponent
     from lfx.components.processing.parse_data import ParseDataComponent
     from lfx.components.processing.parser import ParserComponent
+    from lfx.components.processing.progress_test import ProgressTestComponent
     from lfx.components.processing.regex import RegexExtractorComponent
     from lfx.components.processing.split_text import SplitTextComponent
     from lfx.components.processing.store_message import MessageStoreComponent
@@ -30,6 +31,7 @@ _dynamic_imports = {
     "OutputParserComponent": "output_parser",
     "ParseDataComponent": "parse_data",
     "ParserComponent": "parser",
+    "ProgressTestComponent": "progress_test",
     "RegexExtractorComponent": "regex",
     "SplitTextComponent": "split_text",
     "MessageStoreComponent": "store_message",
@@ -45,6 +47,7 @@ __all__ = [
     "OutputParserComponent",
     "ParseDataComponent",
     "ParserComponent",
+    "ProgressTestComponent",
     "RegexExtractorComponent",
     "SplitTextComponent",
     "TypeConverterComponent",

--- a/src/lfx/src/lfx/components/processing/progress_test.py
+++ b/src/lfx/src/lfx/components/processing/progress_test.py
@@ -1,0 +1,54 @@
+"""Test component for progress bar functionality."""
+
+import time
+
+from lfx.custom import Component
+from lfx.io import IntInput, Output
+from lfx.schema.data import Data
+
+
+class ProgressTestComponent(Component):
+    """Test component to demonstrate progress bar functionality."""
+
+    display_name = "Progress Test"
+    description = "Test component that simulates a long-running task with progress."
+    icon = "loader"
+    name = "ProgressTest"
+
+    inputs = [
+        IntInput(
+            name="num_steps",
+            display_name="Number of Steps",
+            info="Number of steps to simulate.",
+            value=10,
+        ),
+        IntInput(
+            name="delay_ms",
+            display_name="Delay (ms)",
+            info="Delay between steps in milliseconds.",
+            value=500,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(
+            name="result",
+            display_name="Result",
+            method="run_test",
+        ),
+    ]
+
+    def run_test(self) -> Data:
+        """Run test loop with progress updates."""
+        total_steps = self.num_steps
+        delay_seconds = self.delay_ms / 1000
+
+        for step in range(1, total_steps + 1):
+            # Send progress update to frontend
+            self.set_progress(step, total_steps, f"Step {step}/{total_steps}")
+
+            # Simulate work
+            time.sleep(delay_seconds)
+
+        return Data(data={"completed_steps": total_steps, "status": "done"})

--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -1539,6 +1539,25 @@ class Component(CustomComponent):
             data["component_id"] = self._id
             self._event_manager.on_log(data=data)
 
+    def set_progress(self, current: int, total: int, message: str | None = None) -> None:
+        """Set progress for long-running operations (like batch processing).
+
+        Sends a progress event to the frontend to display a progress bar.
+
+        Args:
+            current: Current step number (1-indexed).
+            total: Total number of steps.
+            message: Optional message to display (e.g., "Processing batch 3/10").
+        """
+        if self._event_manager is not None:
+            progress_data = {
+                "id": self._id,
+                "current": current,
+                "total": total,
+                "message": message or f"Step {current}/{total}",
+            }
+            self._event_manager.on_progress(data=progress_data)
+
     def _append_tool_output(self) -> None:
         if next((output for output in self.outputs if output.name == TOOL_OUTPUT_NAME), None) is None:
             self.outputs.append(

--- a/src/lfx/src/lfx/events/event_manager.py
+++ b/src/lfx/src/lfx/events/event_manager.py
@@ -99,6 +99,7 @@ def create_default_event_manager(queue=None):
     manager.register_event("on_end_vertex", "end_vertex")
     manager.register_event("on_build_start", "build_start")
     manager.register_event("on_build_end", "build_end")
+    manager.register_event("on_progress", "progress")
     return manager
 
 


### PR DESCRIPTION
## Summary
- Adds a visual progress bar at the bottom of component nodes during long-running operations
- Components can call `self.set_progress(current, total)` to report progress (e.g., batch processing)
- Progress bar clips properly to rounded corners without affecting handles

## Changes
- **Frontend**: Progress bar UI in `GenericNode`, state management in `flowStore`, event handling in `buildUtils`
- **Backend**: `set_progress()` method in Component class, `on_progress` event registration

## Usage
```python
# In any component method
for i, item in enumerate(items, 1):
    self.set_progress(i, len(items))
    # process item...
```