### PR TITLE
test: Fix race condition in rename flow test

### DIFF
--- a/src/frontend/tests/utils/rename-flow.ts
+++ b/src/frontend/tests/utils/rename-flow.ts
@@ -40,8 +40,6 @@ export const renameFlow = async (
       timeout: 30000,
     });
 
-    // Wait for the header to be updated with the new name
-    // This ensures the store has been updated before we return
     if (flowName) {
       await page.waitForFunction(
         (expected) => {


### PR DESCRIPTION
OBJECTIVE: Fix flaky edit-flow-name test by waiting for header update after saving flow name.                                  
                                                                                                                                 
CHANGES:                                                                                                                       
  - Add explicit wait for header to reflect new flow name after save                                                             
  - Ensure store state is synchronized before reading input value                                                                
  - Fix timing issue introduced by Playwright 1.57 update 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test synchronization for rename flow operations by adding an explicit wait condition that verifies the flow header element displays the correct updated name before proceeding, using a 30-second timeout. This enhancement increases test reliability and reduces potential false failures caused by race conditions or timing issues in test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->