### PR TITLE
ci: make docs deployment manual-only

### DIFF
--- a/.github/workflows/deploy_gh-pages.yml
+++ b/.github/workflows/deploy_gh-pages.yml
@@ -1,13 +1,13 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
-    # Review gh actions docs if you want to further define triggers, paths, etc
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to deploy docs from"
+        required: false
+        default: "main"
+        type: string
 
 jobs:
   deploy:
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
       - uses: actions/setup-node@v6
         with:
           node-version: 22


### PR DESCRIPTION
## Summary
- Changed docs deployment from auto-deploy on push to main to manual workflow dispatch
- Allows docs PRs to merge freely without triggering immediate production deploys
- Added optional branch input (defaults to main) for flexibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to support manual triggering with configurable branch selection. Implemented Node dependency caching to improve build performance and streamline the website deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->