### PR TITLE
feat: get python dependencies from flow

### DIFF
--- a/src/lfx/src/lfx/custom/dependency_analyzer.py
+++ b/src/lfx/src/lfx/custom/dependency_analyzer.py
@@ -192,7 +192,7 @@ def get_versioned_package_distributions(package_name: str, version: str | None =
     for dist_name in dist_names:
         try:
             versioned_names.append(f"{dist_name}=={md.distribution(dist_name).version}")
-        except Exception: # noqa: BLE001
+        except Exception:  # noqa: BLE001
             versioned_names.append(dist_name)
 
     return versioned_names

--- a/src/lfx/src/lfx/custom/utils.py
+++ b/src/lfx/src/lfx/custom/utils.py
@@ -881,8 +881,8 @@ def get_flow_dependencies(
     flow: dict,
     trusted_versions: dict[str, str] | None = None,
     trusted_packages: set[str] | None = None,
-    enable_unsafe_packages: bool = False, # noqa: FBT001, FBT002
-    ) -> set[str]:
+    enable_unsafe_packages: bool = False,  # noqa: FBT001, FBT002
+) -> set[str]:
     """Get the Python dependencies of a flow.
 
     Prioritizes installed packages.
@@ -990,13 +990,12 @@ def get_flow_dependencies(
 
     for component in flow.get("data", {}).get("nodes", []):
         deps = (
-            component
-            .get("data", {})
+            component.get("data", {})
             .get("node", {})
             .get("metadata", {})
             .get("dependencies", {})
             .get("dependencies", [])
-            )
+        )
 
         if not deps:
             continue
@@ -1007,14 +1006,10 @@ def get_flow_dependencies(
 
             if dep_version := dep.get("version"):
                 # first matching distribution with the provided version
-                versioned_names = get_versioned_package_distributions(
-                        package_name=dep_name, version=dep_version
-                        )
+                versioned_names = get_versioned_package_distributions(package_name=dep_name, version=dep_version)
             else:
                 # all matching distributions
-                versioned_names = get_versioned_package_distributions(
-                    dep_name, version=None
-                    )
+                versioned_names = get_versioned_package_distributions(dep_name, version=None)
             if not versioned_names:
                 logger.warning(f"Package {dep_name} has no matching distribution.")
 
@@ -1023,13 +1018,7 @@ def get_flow_dependencies(
                 elif dep_name in trusted_packages:
                     versioned_names = [dep_name]
                 elif enable_unsafe_packages:
-                    versioned_names = (
-                        [f"{dep_name}=={v}"]
-
-                        if (v := dep.get("version"))
-
-                        else [dep_name]
-                    )
+                    versioned_names = [f"{dep_name}=={v}"] if (v := dep.get("version")) else [dep_name]
 
             dependencies.update(versioned_names)
 

--- a/src/lfx/tests/unit/custom/test_utils_metadata.py
+++ b/src/lfx/tests/unit/custom/test_utils_metadata.py
@@ -638,13 +638,7 @@ class TestGetFlowDependencies:
 
     @staticmethod
     def _flow_with_deps(deps):
-        return {
-            "data": {
-                "nodes": [
-                    {"data": {"node": {"metadata": {"dependencies": {"dependencies": deps}}}}}
-                ]
-            }
-        }
+        return {"data": {"nodes": [{"data": {"node": {"metadata": {"dependencies": {"dependencies": deps}}}}}]}}
 
     def test_empty_flow_returns_empty_set(self):
         assert get_flow_dependencies({}) == set()
@@ -702,25 +696,19 @@ class TestGetFlowDependencies:
     def test_trusted_versions_take_priority_over_trusted_packages(self):
         flow = self._flow_with_deps([{"name": "demo"}])
         with patch("lfx.custom.utils.get_versioned_package_distributions", return_value=[]):
-            result = get_flow_dependencies(
-                flow, trusted_versions={"demo": "9.9.9"}, trusted_packages={"demo"}
-            )
+            result = get_flow_dependencies(flow, trusted_versions={"demo": "9.9.9"}, trusted_packages={"demo"})
         assert result == {"demo==9.9.9"}
 
     def test_trusted_versions_take_priority_over_unsafe(self):
         flow = self._flow_with_deps([{"name": "demo", "version": "1.0.0"}])
         with patch("lfx.custom.utils.get_versioned_package_distributions", return_value=[]):
-            result = get_flow_dependencies(
-                flow, trusted_versions={"demo": "9.9.9"}, enable_unsafe_packages=True
-            )
+            result = get_flow_dependencies(flow, trusted_versions={"demo": "9.9.9"}, enable_unsafe_packages=True)
         assert result == {"demo==9.9.9"}
 
     def test_trusted_packages_take_priority_over_unsafe(self):
         flow = self._flow_with_deps([{"name": "demo", "version": "1.0.0"}])
         with patch("lfx.custom.utils.get_versioned_package_distributions", return_value=[]):
-            result = get_flow_dependencies(
-                flow, trusted_packages={"demo"}, enable_unsafe_packages=True
-            )
+            result = get_flow_dependencies(flow, trusted_packages={"demo"}, enable_unsafe_packages=True)
         assert result == {"demo"}
 
     def test_installed_distribution_overrides_trusted_versions(self):


### PR DESCRIPTION
Uses existing work on component-level package resolution to surface Python dependencies at the flow level and the current environment. Prioritizes installed distributions, followed by trusted overrides, and allows unsafe fall backs (using the package names from the flow json/dict). Adds unit tests to cover edge cases surrounding precedence and distribution resolution behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved package dependency resolution capabilities, including versioned distribution lookups and flow-based dependency computation with support for trusted versions and packages.

* **Tests**
  * Added comprehensive test coverage for dependency analysis, including edge cases for multiple versions, missing dependencies, and various resolution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->