### PR TITLE
fix: propagate upstream provider errors instead of blanket HTTP 500

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -39,7 +39,7 @@ from langflow.api.v1.schemas import (
     UploadFileResponse,
 )
 from langflow.events.event_manager import create_stream_tokens_event_manager
-from langflow.exceptions.api import APIException, InvalidChatInputError
+from langflow.exceptions.api import APIException, InvalidChatInputError, classify_component_error
 from langflow.exceptions.serialization import SerializationError
 from langflow.helpers.flow import get_flow_by_id_or_endpoint_name
 from langflow.interface.initialize.loading import update_params_with_load_from_db_fields
@@ -382,7 +382,14 @@ async def run_flow_generator(
         await client_consumed_queue.get()
     except (ValueError, InvalidChatInputError, SerializationError) as e:
         await logger.aerror(f"Error running flow: {e}")
-        event_manager.on_error(data={"error": str(e)})
+        upstream_status, error_source = classify_component_error(e)
+        event_manager.on_error(
+            data={
+                "error": str(e),
+                "status_code": upstream_status,
+                "source": error_source,
+            }
+        )
     finally:
         await event_manager.queue.put((None, None, time.time))
 
@@ -523,7 +530,13 @@ async def _run_flow_internal(
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
         if "not found" in str(exc):
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-        raise APIException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, exception=exc, flow=flow) from exc
+        # Inspect the exception cause chain to determine if this is an
+        # upstream provider error (e.g. 429 rate-limit) rather than an
+        # internal failure, and return the appropriate HTTP status code.
+        upstream_status, error_source = classify_component_error(exc)
+        raise APIException(
+            status_code=upstream_status, exception=exc, flow=flow
+        ) from exc
     except InvalidChatInputError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
@@ -537,7 +550,10 @@ async def _run_flow_internal(
                 run_id=run_id,
             ),
         )
-        raise APIException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, exception=exc, flow=flow) from exc
+        upstream_status, error_source = classify_component_error(exc)
+        raise APIException(
+            status_code=upstream_status, exception=exc, flow=flow
+        ) from exc
 
     return result
 

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -534,9 +534,7 @@ async def _run_flow_internal(
         # upstream provider error (e.g. 429 rate-limit) rather than an
         # internal failure, and return the appropriate HTTP status code.
         upstream_status, _error_source = classify_component_error(exc)
-        raise APIException(
-            status_code=upstream_status, exception=exc, flow=flow
-        ) from exc
+        raise APIException(status_code=upstream_status, exception=exc, flow=flow) from exc
     except InvalidChatInputError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
@@ -551,9 +549,7 @@ async def _run_flow_internal(
             ),
         )
         upstream_status, _error_source = classify_component_error(exc)
-        raise APIException(
-            status_code=upstream_status, exception=exc, flow=flow
-        ) from exc
+        raise APIException(status_code=upstream_status, exception=exc, flow=flow) from exc
 
     return result
 

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -533,7 +533,7 @@ async def _run_flow_internal(
         # Inspect the exception cause chain to determine if this is an
         # upstream provider error (e.g. 429 rate-limit) rather than an
         # internal failure, and return the appropriate HTTP status code.
-        upstream_status, error_source = classify_component_error(exc)
+        upstream_status, _error_source = classify_component_error(exc)
         raise APIException(
             status_code=upstream_status, exception=exc, flow=flow
         ) from exc
@@ -550,7 +550,7 @@ async def _run_flow_internal(
                 run_id=run_id,
             ),
         )
-        upstream_status, error_source = classify_component_error(exc)
+        upstream_status, _error_source = classify_component_error(exc)
         raise APIException(
             status_code=upstream_status, exception=exc, flow=flow
         ) from exc

--- a/src/backend/base/langflow/exceptions/api.py
+++ b/src/backend/base/langflow/exceptions/api.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
 from fastapi import HTTPException
 from pydantic import BaseModel
 
 from langflow.api.utils import get_suggestion_message
-from langflow.services.database.models.flow.model import Flow
 from langflow.services.database.models.flow.utils import get_outdated_components
+
+if TYPE_CHECKING:
+    from langflow.services.database.models.flow.model import Flow
 
 
 class InvalidChatInputError(Exception):
@@ -34,13 +41,122 @@ class WorkflowServiceUnavailableError(WorkflowExecutionError):
     """Raised when the task queue service is unavailable (e.g., broker down)."""
 
 
-# create a pidantic documentation for this class
+# --------------------------------------------------------------------------- #
+# Upstream / provider error classification
+# --------------------------------------------------------------------------- #
+
+_RATE_LIMIT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"rate.?limit", re.IGNORECASE),
+    re.compile(r"too many requests", re.IGNORECASE),
+    re.compile(r"quota exceeded", re.IGNORECASE),
+    re.compile(r"tokens per min", re.IGNORECASE),
+    re.compile(r"requests per min", re.IGNORECASE),
+]
+
+_AUTH_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"invalid.?api.?key", re.IGNORECASE),
+    re.compile(r"authentication", re.IGNORECASE),
+    re.compile(r"unauthorized", re.IGNORECASE),
+    re.compile(r"permission denied", re.IGNORECASE),
+    re.compile(r"access denied", re.IGNORECASE),
+    re.compile(r"Incorrect API key", re.IGNORECASE),
+]
+
+_TIMEOUT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"timed?\s*out", re.IGNORECASE),
+    re.compile(r"deadline.?exceeded", re.IGNORECASE),
+    re.compile(r"read timeout", re.IGNORECASE),
+    re.compile(r"connect timeout", re.IGNORECASE),
+]
+
+_CONNECTION_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"connection.?(error|refused|reset|aborted)", re.IGNORECASE),
+    re.compile(r"name.?resolution", re.IGNORECASE),
+    re.compile(r"unreachable", re.IGNORECASE),
+]
+
+
+def _exc_status_code(exc: BaseException) -> int | None:
+    """Extract an HTTP status code from an exception if it carries one."""
+    for attr in ("status_code", "code", "http_status"):
+        val = getattr(exc, attr, None)
+        if isinstance(val, int):
+            return val
+    response = getattr(exc, "response", None)
+    if response is not None:
+        code = getattr(response, "status_code", None)
+        if isinstance(code, int):
+            return code
+    return None
+
+
+def _walk_cause_chain(exc: BaseException) -> list[BaseException]:
+    """Collect the full __cause__ / __context__ chain of an exception."""
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        chain.append(current)
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+    return chain
+
+
+def classify_component_error(exc: BaseException) -> tuple[int, str]:
+    """Inspect an exception's cause chain and return (http_status, source).
+
+    Returns:
+        A tuple of (status_code, source) where *source* is one of:
+        ``"upstream"`` for errors originating from an external provider /
+        API, or ``"internal"`` for errors within Langflow itself.
+    """
+    chain = _walk_cause_chain(exc)
+
+    for link in chain:
+        code = _exc_status_code(link)
+        if code is not None and 400 <= code < 600:
+            if code == 429:
+                return 429, "upstream"
+            if code in {401, 403}:
+                return 502, "upstream"
+            if code == 408:
+                return 504, "upstream"
+            if 400 <= code < 500:
+                return 422, "upstream"
+            if 500 <= code < 600:
+                return 502, "upstream"
+
+    all_messages = " ".join(str(link) for link in chain)
+    cls_names = {type(link).__name__ for link in chain}
+
+    if any(p.search(all_messages) for p in _RATE_LIMIT_PATTERNS) or "RateLimitError" in cls_names:
+        return 429, "upstream"
+    if any(p.search(all_messages) for p in _AUTH_PATTERNS) or "AuthenticationError" in cls_names:
+        return 502, "upstream"
+    if any(p.search(all_messages) for p in _TIMEOUT_PATTERNS) or cls_names & {
+        "APITimeoutError",
+        "TimeoutError",
+        "ReadTimeout",
+        "ConnectTimeout",
+    }:
+        return 504, "upstream"
+    if any(p.search(all_messages) for p in _CONNECTION_PATTERNS) or cls_names & {
+        "APIConnectionError",
+        "ConnectionError",
+        "ConnectError",
+    }:
+        return 502, "upstream"
+
+    return 500, "internal"
+
+
 class ExceptionBody(BaseModel):
     message: str | list[str]
     traceback: str | list[str] | None = None
     description: str | list[str] | None = None
     code: str | None = None
     suggestion: str | list[str] | None = None
+    source: str | None = None
 
 
 class APIException(HTTPException):
@@ -49,8 +165,12 @@ class APIException(HTTPException):
         super().__init__(status_code=status_code, detail=body.model_dump_json())
 
     @staticmethod
-    def build_exception_body(exc: str | list[str] | Exception, flow: Flow | None) -> ExceptionBody:
-        body = {"message": str(exc)}
+    def build_exception_body(
+        exc: str | list[str] | Exception, flow: Flow | None, *, source: str | None = None
+    ) -> ExceptionBody:
+        body: dict = {"message": str(exc)}
+        if source is not None:
+            body["source"] = source
         if flow:
             outdated_components = get_outdated_components(flow)
             if outdated_components:

--- a/src/backend/base/langflow/exceptions/api.py
+++ b/src/backend/base/langflow/exceptions/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from http import HTTPStatus
 from typing import TYPE_CHECKING
 
 from fastapi import HTTPException
@@ -102,6 +103,22 @@ def _walk_cause_chain(exc: BaseException) -> list[BaseException]:
     return chain
 
 
+# SDK-specific timeout class names that are unambiguously from an upstream
+# provider.  Built-in ``TimeoutError`` / ``asyncio.TimeoutError`` are
+# intentionally excluded because they can be raised by Langflow's own
+# internal task management and do not indicate an upstream failure.
+_SDK_TIMEOUT_CLASSES: set[str] = {"APITimeoutError", "ReadTimeout", "ConnectTimeout"}
+
+# Attributes that indicate an exception originated from an HTTP SDK rather
+# than from internal Python / asyncio code.
+_UPSTREAM_INDICATOR_ATTRS: tuple[str, ...] = ("response", "headers", "request", "metadata")
+
+
+def _has_upstream_indicator(exc: BaseException) -> bool:
+    """Return True if *exc* carries attributes typical of an HTTP SDK error."""
+    return any(getattr(exc, attr, None) is not None for attr in _UPSTREAM_INDICATOR_ATTRS)
+
+
 def classify_component_error(exc: BaseException) -> tuple[int, str]:
     """Inspect an exception's cause chain and return (http_status, source).
 
@@ -112,42 +129,49 @@ def classify_component_error(exc: BaseException) -> tuple[int, str]:
     """
     chain = _walk_cause_chain(exc)
 
+    # --- Phase 1: look for an explicit HTTP status code on the exception ---
     for link in chain:
         code = _exc_status_code(link)
-        if code is not None and 400 <= code < 600:
-            if code == 429:
-                return 429, "upstream"
-            if code in {401, 403}:
-                return 502, "upstream"
-            if code == 408:
-                return 504, "upstream"
-            if 400 <= code < 500:
-                return 422, "upstream"
-            if 500 <= code < 600:
-                return 502, "upstream"
+        if code is None:
+            continue
+        if code == HTTPStatus.TOO_MANY_REQUESTS:
+            return HTTPStatus.TOO_MANY_REQUESTS, "upstream"
+        if code in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}:
+            return HTTPStatus.BAD_GATEWAY, "upstream"
+        if code == HTTPStatus.REQUEST_TIMEOUT:
+            return HTTPStatus.GATEWAY_TIMEOUT, "upstream"
+        if HTTPStatus.BAD_REQUEST <= code < HTTPStatus.INTERNAL_SERVER_ERROR:
+            return HTTPStatus.UNPROCESSABLE_ENTITY, "upstream"
+        if HTTPStatus.INTERNAL_SERVER_ERROR <= code < 600:  # noqa: PLR2004
+            return HTTPStatus.BAD_GATEWAY, "upstream"
 
+    # --- Phase 2: heuristic pattern / class-name matching -----------------
     all_messages = " ".join(str(link) for link in chain)
     cls_names = {type(link).__name__ for link in chain}
 
     if any(p.search(all_messages) for p in _RATE_LIMIT_PATTERNS) or "RateLimitError" in cls_names:
-        return 429, "upstream"
+        return HTTPStatus.TOO_MANY_REQUESTS, "upstream"
     if any(p.search(all_messages) for p in _AUTH_PATTERNS) or "AuthenticationError" in cls_names:
-        return 502, "upstream"
-    if any(p.search(all_messages) for p in _TIMEOUT_PATTERNS) or cls_names & {
-        "APITimeoutError",
-        "TimeoutError",
-        "ReadTimeout",
-        "ConnectTimeout",
-    }:
-        return 504, "upstream"
+        return HTTPStatus.BAD_GATEWAY, "upstream"
+
+    # Timeout: only classify as upstream when the exception is from an SDK
+    # (has response/request/headers) or uses an SDK-specific class name.
+    # Plain ``TimeoutError`` / ``asyncio.TimeoutError`` are internal.
+    if cls_names & _SDK_TIMEOUT_CLASSES:
+        return HTTPStatus.GATEWAY_TIMEOUT, "upstream"
+    if any(p.search(all_messages) for p in _TIMEOUT_PATTERNS) and any(
+        _has_upstream_indicator(link) for link in chain
+    ):
+        return HTTPStatus.GATEWAY_TIMEOUT, "upstream"
+
     if any(p.search(all_messages) for p in _CONNECTION_PATTERNS) or cls_names & {
         "APIConnectionError",
         "ConnectionError",
         "ConnectError",
     }:
-        return 502, "upstream"
+        return HTTPStatus.BAD_GATEWAY, "upstream"
 
-    return 500, "internal"
+    return HTTPStatus.INTERNAL_SERVER_ERROR, "internal"
 
 
 class ExceptionBody(BaseModel):

--- a/src/backend/base/langflow/exceptions/api.py
+++ b/src/backend/base/langflow/exceptions/api.py
@@ -159,9 +159,7 @@ def classify_component_error(exc: BaseException) -> tuple[int, str]:
     # Plain ``TimeoutError`` / ``asyncio.TimeoutError`` are internal.
     if cls_names & _SDK_TIMEOUT_CLASSES:
         return HTTPStatus.GATEWAY_TIMEOUT, "upstream"
-    if any(p.search(all_messages) for p in _TIMEOUT_PATTERNS) and any(
-        _has_upstream_indicator(link) for link in chain
-    ):
+    if any(p.search(all_messages) for p in _TIMEOUT_PATTERNS) and any(_has_upstream_indicator(link) for link in chain):
         return HTTPStatus.GATEWAY_TIMEOUT, "upstream"
 
     if any(p.search(all_messages) for p in _CONNECTION_PATTERNS) or cls_names & {

--- a/src/backend/tests/unit/exceptions/test_error_classification.py
+++ b/src/backend/tests/unit/exceptions/test_error_classification.py
@@ -1,0 +1,535 @@
+"""Tests for upstream / provider error classification.
+
+Covers ``classify_component_error`` and its helper functions introduced to
+propagate meaningful HTTP status codes from component failures instead of
+always returning 500.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from http import HTTPStatus
+from types import SimpleNamespace
+
+import pytest
+from langflow.exceptions.api import (
+    ExceptionBody,
+    _exc_status_code,
+    _has_upstream_indicator,
+    _walk_cause_chain,
+    classify_component_error,
+)
+
+# ------------------------------------------------------------------ helpers --
+
+
+def _make_exc_with_status(status_code: int, msg: str = "err") -> Exception:
+    """Return an exception carrying a ``status_code`` attribute."""
+    exc = Exception(msg)
+    exc.status_code = status_code  # type: ignore[attr-defined]
+    return exc
+
+
+def _make_exc_with_response(status_code: int, msg: str = "err") -> Exception:
+    """Return an exception whose ``.response.status_code`` is set."""
+    exc = Exception(msg)
+    exc.response = SimpleNamespace(status_code=status_code)  # type: ignore[attr-defined]
+    return exc
+
+
+def _chain(outer_msg: str, cause: BaseException) -> BaseException:
+    """Build ``ValueError(outer_msg)`` chained to *cause* via ``raise … from``."""
+    try:
+        raise ValueError(outer_msg) from cause
+    except ValueError as wrapper:
+        return wrapper
+
+
+def _make_sdk_timeout(msg: str = "Request timed out") -> Exception:
+    """Return a timeout exception that looks like it came from an SDK."""
+    exc = Exception(msg)
+    exc.request = SimpleNamespace(url="https://api.openai.com/v1/chat")  # type: ignore[attr-defined]
+    return exc
+
+
+# ======================================================================== #
+#  _exc_status_code
+# ======================================================================== #
+
+
+class TestExcStatusCode:
+    def test_status_code_attribute(self):
+        exc = _make_exc_with_status(429)
+        assert _exc_status_code(exc) == 429
+
+    def test_code_attribute(self):
+        exc = Exception("err")
+        exc.code = 503  # type: ignore[attr-defined]
+        assert _exc_status_code(exc) == 503
+
+    def test_http_status_attribute(self):
+        exc = Exception("err")
+        exc.http_status = 401  # type: ignore[attr-defined]
+        assert _exc_status_code(exc) == 401
+
+    def test_response_status_code(self):
+        exc = _make_exc_with_response(502)
+        assert _exc_status_code(exc) == 502
+
+    def test_no_status_code(self):
+        assert _exc_status_code(Exception("plain")) is None
+
+    def test_non_int_status_code_ignored(self):
+        exc = Exception("err")
+        exc.status_code = "429"  # type: ignore[attr-defined]
+        assert _exc_status_code(exc) is None
+
+
+# ======================================================================== #
+#  _walk_cause_chain
+# ======================================================================== #
+
+
+class TestWalkCauseChain:
+    def test_single_exception(self):
+        exc = ValueError("only one")
+        chain = _walk_cause_chain(exc)
+        assert chain == [exc]
+
+    def test_chained_cause(self):
+        root = RuntimeError("root")
+        wrapper = _chain("wrapper", root)
+        chain = _walk_cause_chain(wrapper)
+        assert len(chain) == 2
+        assert chain[0] is wrapper
+        assert chain[1] is root
+
+    def test_deep_chain(self):
+        a = RuntimeError("a")
+        b = _chain("b", a)
+        c = _chain("c", b)
+        chain = _walk_cause_chain(c)
+        assert len(chain) == 3
+
+    def test_circular_chain_protection(self):
+        """Ensure the walker doesn't loop on a pathological circular chain."""
+        a = Exception("a")
+        b = Exception("b")
+        a.__cause__ = b
+        b.__cause__ = a  # circular
+        chain = _walk_cause_chain(a)
+        assert len(chain) == 2
+
+
+# ======================================================================== #
+#  _has_upstream_indicator
+# ======================================================================== #
+
+
+class TestHasUpstreamIndicator:
+    def test_plain_exception_has_no_indicator(self):
+        assert _has_upstream_indicator(Exception("err")) is False
+
+    def test_response_attribute(self):
+        exc = Exception("err")
+        exc.response = SimpleNamespace(status_code=200)  # type: ignore[attr-defined]
+        assert _has_upstream_indicator(exc) is True
+
+    def test_request_attribute(self):
+        exc = Exception("err")
+        exc.request = SimpleNamespace(url="https://example.com")  # type: ignore[attr-defined]
+        assert _has_upstream_indicator(exc) is True
+
+    def test_headers_attribute(self):
+        exc = Exception("err")
+        exc.headers = {"x-request-id": "abc"}  # type: ignore[attr-defined]
+        assert _has_upstream_indicator(exc) is True
+
+    def test_metadata_attribute(self):
+        exc = Exception("err")
+        exc.metadata = {"key": "val"}  # type: ignore[attr-defined]
+        assert _has_upstream_indicator(exc) is True
+
+    def test_none_valued_attribute_ignored(self):
+        exc = Exception("err")
+        exc.response = None  # type: ignore[attr-defined]
+        assert _has_upstream_indicator(exc) is False
+
+
+# ======================================================================== #
+#  classify_component_error  —  Phase 1: explicit HTTP status codes
+# ======================================================================== #
+
+
+class TestClassifyPhase1StatusCodes:
+    """Phase 1 detection: the exception (or its cause) carries an HTTP code."""
+
+    def test_429_on_exception(self):
+        exc = _make_exc_with_status(429, "Rate limit exceeded")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.TOO_MANY_REQUESTS
+        assert source == "upstream"
+
+    def test_429_on_chained_cause(self):
+        root = _make_exc_with_status(429, "too many requests")
+        wrapper = _chain("Error running graph: too many requests", root)
+        status_code, source = classify_component_error(wrapper)
+        assert status_code == HTTPStatus.TOO_MANY_REQUESTS
+        assert source == "upstream"
+
+    def test_401_returns_502(self):
+        exc = _make_exc_with_status(401, "Unauthorized")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.BAD_GATEWAY
+        assert source == "upstream"
+
+    def test_403_returns_502(self):
+        exc = _make_exc_with_status(403, "Forbidden")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.BAD_GATEWAY
+        assert source == "upstream"
+
+    def test_408_returns_504(self):
+        exc = _make_exc_with_status(408, "Request Timeout")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.GATEWAY_TIMEOUT
+        assert source == "upstream"
+
+    def test_generic_4xx_returns_422(self):
+        exc = _make_exc_with_status(422, "Unprocessable Entity")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert source == "upstream"
+
+    def test_400_returns_422(self):
+        exc = _make_exc_with_status(400, "Bad Request from provider")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert source == "upstream"
+
+    def test_500_upstream_returns_502(self):
+        exc = _make_exc_with_status(500, "Internal Server Error from provider")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.BAD_GATEWAY
+        assert source == "upstream"
+
+    def test_503_upstream_returns_502(self):
+        exc = _make_exc_with_status(503, "Service Unavailable")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.BAD_GATEWAY
+        assert source == "upstream"
+
+    def test_response_status_code_detected(self):
+        exc = _make_exc_with_response(429, "rate limited")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.TOO_MANY_REQUESTS
+        assert source == "upstream"
+
+
+# ======================================================================== #
+#  classify_component_error  —  Phase 2: heuristic / pattern matching
+# ======================================================================== #
+
+
+class TestClassifyPhase2Patterns:
+    """Phase 2 detection: no explicit status code, fallback to patterns."""
+
+    # -- Rate-limit patterns --
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Error: Rate limit exceeded",
+            "Too many requests, please retry after 60s",
+            "Quota exceeded for model gpt-4o",
+            "tokens per min limit reached",
+            "requests per min exceeded",
+        ],
+    )
+    def test_rate_limit_messages(self, msg: str):
+        exc = Exception(msg)
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.TOO_MANY_REQUESTS
+        assert source == "upstream"
+
+    def test_rate_limit_class_name(self):
+        class RateLimitError(Exception):
+            pass
+
+        exc = RateLimitError("slow down")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.TOO_MANY_REQUESTS
+        assert source == "upstream"
+
+    # -- Auth patterns --
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Invalid API key provided",
+            "Authentication failed",
+            "Unauthorized access",
+            "Permission denied for resource",
+            "Access denied",
+            "Incorrect API key",
+        ],
+    )
+    def test_auth_messages(self, msg: str):
+        exc = Exception(msg)
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.BAD_GATEWAY
+        assert source == "upstream"
+
+    def test_auth_class_name(self):
+        class AuthenticationError(Exception):
+            pass
+
+        exc = AuthenticationError("bad key")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.BAD_GATEWAY
+        assert source == "upstream"
+
+    # -- Connection patterns --
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Connection error: refused",
+            "Connection refused",
+            "Connection reset by peer",
+            "Connection aborted",
+            "Name resolution failed",
+            "Host unreachable",
+        ],
+    )
+    def test_connection_messages(self, msg: str):
+        exc = Exception(msg)
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.BAD_GATEWAY
+        assert source == "upstream"
+
+    @pytest.mark.parametrize("cls_name", ["APIConnectionError", "ConnectionError", "ConnectError"])
+    def test_connection_class_names(self, cls_name: str):
+        exc_cls = type(cls_name, (Exception,), {})
+        exc = exc_cls("connection lost")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.BAD_GATEWAY
+        assert source == "upstream"
+
+
+# ======================================================================== #
+#  classify_component_error  —  Timeout guarding
+# ======================================================================== #
+
+
+class TestClassifyTimeoutGuard:
+    """Builtin TimeoutError must NOT be classified as upstream.
+
+    Only SDK-specific timeout classes or timeout messages with upstream
+    indicators should be classified as upstream.
+    """
+
+    def test_builtin_timeout_error_is_internal(self):
+        """Plain ``TimeoutError`` is an internal error, not upstream."""
+        exc = TimeoutError("internal task timed out")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert source == "internal"
+
+    def test_asyncio_timeout_error_is_internal(self):
+        """``asyncio.TimeoutError`` is the same as ``TimeoutError`` in modern Python."""
+        exc = asyncio.TimeoutError()
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert source == "internal"
+
+    def test_sdk_api_timeout_error_is_upstream(self):
+        """An exception named ``APITimeoutError`` is unambiguously upstream."""
+
+        class APITimeoutError(Exception):
+            pass
+
+        exc = APITimeoutError("request timed out")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.GATEWAY_TIMEOUT
+        assert source == "upstream"
+
+    def test_sdk_read_timeout_is_upstream(self):
+        class ReadTimeout(Exception):  # noqa: N818
+            pass
+
+        exc = ReadTimeout("read timed out")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.GATEWAY_TIMEOUT
+        assert source == "upstream"
+
+    def test_sdk_connect_timeout_is_upstream(self):
+        class ConnectTimeout(Exception):  # noqa: N818
+            pass
+
+        exc = ConnectTimeout("connect timed out")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.GATEWAY_TIMEOUT
+        assert source == "upstream"
+
+    def test_timeout_message_with_sdk_indicator_is_upstream(self):
+        """A timeout message from an exception with SDK attributes -> upstream."""
+        exc = _make_sdk_timeout("Request timed out after 30s")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.GATEWAY_TIMEOUT
+        assert source == "upstream"
+
+    def test_timeout_message_without_sdk_indicator_is_internal(self):
+        """A timeout message from a plain exception (no SDK attrs) -> internal."""
+        exc = Exception("Operation timed out")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert source == "internal"
+
+    def test_deadline_exceeded_with_sdk_indicator(self):
+        exc = Exception("Deadline exceeded waiting for response")
+        exc.response = SimpleNamespace(status_code=200)  # type: ignore[attr-defined]
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.GATEWAY_TIMEOUT
+        assert source == "upstream"
+
+    def test_deadline_exceeded_without_sdk_indicator(self):
+        exc = Exception("Deadline exceeded")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert source == "internal"
+
+    def test_chained_timeout_with_sdk_cause(self):
+        """Timeout message on wrapper, SDK indicator on chained cause -> upstream."""
+        sdk_cause = Exception("underlying timeout")
+        sdk_cause.request = SimpleNamespace(url="https://api.openai.com")  # type: ignore[attr-defined]
+        wrapper = _chain("Error running graph: request timed out", sdk_cause)
+        status_code, source = classify_component_error(wrapper)
+        assert status_code == HTTPStatus.GATEWAY_TIMEOUT
+        assert source == "upstream"
+
+
+# ======================================================================== #
+#  classify_component_error  —  Default / internal
+# ======================================================================== #
+
+
+class TestClassifyDefault:
+    def test_plain_exception_is_internal(self):
+        exc = Exception("something broke")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert source == "internal"
+
+    def test_value_error_is_internal(self):
+        exc = ValueError("bad value")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert source == "internal"
+
+    def test_key_error_is_internal(self):
+        exc = KeyError("missing_key")
+        status_code, source = classify_component_error(exc)
+        assert status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert source == "internal"
+
+
+# ======================================================================== #
+#  classify_component_error  —  Realistic end-to-end chains
+# ======================================================================== #
+
+
+class TestClassifyRealisticChains:
+    """Simulate the real exception chain: component error → graph ValueError."""
+
+    def test_openai_rate_limit_chain(self):
+        """Simulate openai.RateLimitError chained to graph ValueError."""
+
+        class RateLimitError(Exception):
+            pass
+
+        root = RateLimitError("You exceeded your current quota")
+        root.status_code = 429  # type: ignore[attr-defined]
+        wrapper = _chain("Error running graph (component: OpenAIModel): You exceeded your current quota", root)
+        status_code, source = classify_component_error(wrapper)
+        assert status_code == HTTPStatus.TOO_MANY_REQUESTS
+        assert source == "upstream"
+
+    def test_openai_auth_error_chain(self):
+        class AuthenticationError(Exception):
+            pass
+
+        root = AuthenticationError("Incorrect API key provided")
+        root.status_code = 401  # type: ignore[attr-defined]
+        wrapper = _chain("Error running graph (component: OpenAIModel): Incorrect API key provided", root)
+        status_code, source = classify_component_error(wrapper)
+        assert status_code == HTTPStatus.BAD_GATEWAY
+        assert source == "upstream"
+
+    def test_httpx_status_error_chain(self):
+        """Simulate httpx.HTTPStatusError with .response.status_code."""
+        root = Exception("Server error")
+        root.response = SimpleNamespace(status_code=503)  # type: ignore[attr-defined]
+        wrapper = _chain("Error running graph: Server error", root)
+        status_code, source = classify_component_error(wrapper)
+        assert status_code == HTTPStatus.BAD_GATEWAY
+        assert source == "upstream"
+
+    def test_generic_internal_error_chain(self):
+        root = TypeError("unsupported operand type(s)")
+        wrapper = _chain("Error running graph (component: TextSplitter): unsupported operand type(s)", root)
+        status_code, source = classify_component_error(wrapper)
+        assert status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert source == "internal"
+
+
+# ======================================================================== #
+#  ExceptionBody.source field
+# ======================================================================== #
+
+
+class TestExceptionBodySource:
+    def test_source_field_defaults_to_none(self):
+        body = ExceptionBody(message="err")
+        assert body.source is None
+
+    def test_source_field_set(self):
+        body = ExceptionBody(message="err", source="upstream")
+        assert body.source == "upstream"
+
+    def test_source_serialised_in_json(self):
+        body = ExceptionBody(message="err", source="upstream")
+        data = body.model_dump()
+        assert data["source"] == "upstream"
+
+    def test_source_absent_in_json_when_none(self):
+        body = ExceptionBody(message="err")
+        data = body.model_dump()
+        assert data["source"] is None
+
+
+# ======================================================================== #
+#  APIException.build_exception_body with source
+# ======================================================================== #
+
+
+class TestBuildExceptionBodySource:
+    def test_source_kwarg_included(self):
+        from langflow.exceptions.api import APIException
+
+        body = APIException.build_exception_body(Exception("err"), flow=None, source="upstream")
+        assert body.source == "upstream"
+
+    def test_source_kwarg_omitted_defaults_none(self):
+        from langflow.exceptions.api import APIException
+
+        body = APIException.build_exception_body(Exception("err"), flow=None)
+        assert body.source is None
+
+    def test_backward_compat_no_source(self):
+        """Existing callers that don't pass source still work."""
+        from langflow.exceptions.api import APIException
+
+        body = APIException.build_exception_body("simple string", flow=None)
+        assert body.message == "simple string"
+        assert body.source is None

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -671,6 +671,15 @@ class Graph:
                 session_id=self.session_id,
             )
 
+    def _find_failed_vertex(self) -> str | None:
+        """Return the display name of the first vertex that failed to build."""
+        for vertex in self.vertices:
+            if vertex.built and hasattr(vertex, "result") and vertex.result is not None:
+                continue
+            if not vertex.built:
+                return vertex.display_name
+        return None
+
     def _end_all_traces_async(self, outputs: dict[str, Any] | None = None, error: Exception | None = None) -> None:
         # Subgraphs don't end traces - the parent graph owns the trace lifecycle
         if self._is_subgraph:
@@ -816,7 +825,12 @@ class Graph:
             self.increment_run_count()
         except Exception as exc:
             self._end_all_traces_async(error=exc)
-            msg = f"Error running graph: {exc}"
+            # Preserve the original exception via chaining so the API layer
+            # can inspect the root cause and return a meaningful HTTP status
+            # (e.g. 429 for rate-limit errors instead of a blanket 500).
+            failed_vertex = self._find_failed_vertex()
+            component_hint = f" (component: {failed_vertex})" if failed_vertex else ""
+            msg = f"Error running graph{component_hint}: {exc}"
             raise ValueError(msg) from exc
 
         self._end_all_traces_async()


### PR DESCRIPTION
## Summary

Resolves #11534

When a flow component fails due to an upstream provider error (e.g. an LLM returning **429 Too Many Requests**), the run API currently always responds with **HTTP 500 Internal Server Error**. This makes it impossible for API consumers to distinguish rate-limit errors, authentication failures, or timeouts from genuine Langflow bugs.

This PR introduces exception-chain classification so the API returns the most appropriate HTTP status code:

| Upstream error | HTTP response |
|---|---|
| 429 rate-limit | **429** Too Many Requests |
| 401 / 403 auth failure | **502** Bad Gateway |
| Timeout / deadline exceeded | **504** Gateway Timeout |
| Connection refused / unreachable | **502** Bad Gateway |
| Other upstream 4xx | **422** Unprocessable Entity |
| Other upstream 5xx | **502** Bad Gateway |
| Internal Langflow error | **500** (unchanged) |

### Changes

- **`src/backend/base/langflow/exceptions/api.py`** — Added `classify_component_error()` which walks the full `__cause__` / `__context__` exception chain. It checks for HTTP status codes on exception attributes, pattern-matches error messages (rate limit, auth, timeout, connection), and recognises well-known exception class names from common LLM SDKs. The `ExceptionBody` model now includes an optional `source` field (`"upstream"` or `"internal"`).

- **`src/backend/base/langflow/api/v1/endpoints.py`** — Both the synchronous and streaming error paths in `_run_flow_internal()` / `run_flow_generator()` now call `classify_component_error()` to determine the correct HTTP status. SSE error events include `status_code` and `source` fields so streaming clients can also programmatically handle upstream failures.

- **`src/lfx/src/lfx/graph/graph/base.py`** — The graph execution layer now identifies which component failed and includes its display name in the error message (e.g. `Error running graph (component: AmazonBedrockModel): ...`). Added `_find_failed_vertex()` helper for this.

### How it works

The classifier is provider-agnostic — it does not import any LLM SDK. Instead it inspects:
1. `status_code` / `response.status_code` attributes on any exception in the chain
2. String patterns in error messages (e.g. "rate limit", "too many requests")
3. Exception class names (e.g. `RateLimitError`, `APITimeoutError`)

This covers OpenAI, Anthropic, AWS Bedrock, Google, Azure, and any httpx-based client.

## Test plan

- [ ] Run a flow with an invalid API key → verify API returns **502** instead of 500
- [ ] Run a flow exceeding rate limits → verify API returns **429** instead of 500
- [ ] Run a flow with unreachable provider → verify API returns **502** instead of 500
- [ ] Run a flow with valid config → verify API still returns **200** (no regression)
- [ ] Verify streaming error events include `status_code` and `source` fields
- [ ] Existing unit tests in `test_api.py` still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now identify the specific component that failed during execution
  * Enhanced error responses include status codes and source classification for better diagnostics
  * Improved error classification system for provider and upstream-related failures
  * Consistent error reporting across all API and streaming execution paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->