### PR TITLE
fix: correct typo 'recieved' to 'received'

### DIFF
--- a/src/lfx/src/lfx/components/cuga/cuga_agent.py
+++ b/src/lfx/src/lfx/components/cuga/cuga_agent.py
@@ -282,7 +282,7 @@ class CugaComponent(ToolCallingAgentComponent):
                 async for event in cuga_agent.run_task_generic_yield(
                     eval_mode=False, goal=current_input, chat_messages=lc_messages
                 ):
-                    logger.debug(f"[CUGA] recieved event {event}")
+                    logger.debug(f"[CUGA] received event {event}")
                     if last_event is not None and tool_run_id is not None:
                         logger.debug(f"[CUGA] last event {last_event}")
                         try:


### PR DESCRIPTION
Fix spelling error in cuga_agent.py log message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected a spelling error in a debug log message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->