### PR TITLE
fix: prevent streaming response duplication with custom OpenAI endpoints

### DIFF
--- a/src/backend/base/langflow/api/v1/openai_responses.py
+++ b/src/backend/base/langflow/api/v1/openai_responses.py
@@ -132,6 +132,7 @@ async def run_flow_for_openai_responses(
                 tool_call_counter = 0
                 processed_tools = set()  # Track processed tool calls to avoid duplicates
                 previous_content = ""  # Track content already sent to calculate deltas
+                has_token_events = False  # Track whether token events are being received
 
                 async for event_data in consume_and_yield(asyncio_queue, asyncio_queue_client_consumed):
                     if event_data is None:
@@ -161,6 +162,7 @@ async def run_flow_for_openai_responses(
                                 # Handle add_message events
                                 if event_type == "token":
                                     token_data = data.get("chunk", "")
+                                    has_token_events = True
                                     await logger.adebug(
                                         "[OpenAIResponses][stream] token: token_data=%s",
                                         token_data,
@@ -195,11 +197,18 @@ async def run_flow_for_openai_responses(
                                         message_state,
                                     )
 
-                                    # Skip processing text content if state is "complete"
-                                    # All content has already been streamed via token events
-                                    if message_state == "complete":
+                                    # Skip processing text content when token events are
+                                    # the authoritative source of streamed content.  The
+                                    # component emits both an add_message and a token
+                                    # event for the first chunk, so processing both would
+                                    # cause the same content to appear twice in the
+                                    # response stream (#10719).
+                                    if message_state == "complete" or has_token_events:
                                         await logger.adebug(
-                                            "[OpenAIResponses][stream] skipping add_message with state=complete"
+                                            "[OpenAIResponses][stream] skipping add_message text "
+                                            "(state=%s, has_token_events=%s)",
+                                            message_state,
+                                            has_token_events,
                                         )
                                         # Still process content_blocks for tool calls, but skip text content
                                         text = ""

--- a/src/lfx/src/lfx/base/models/model.py
+++ b/src/lfx/src/lfx/base/models/model.py
@@ -271,16 +271,24 @@ class LCModelComponent(Component):
     async def _handle_stream(self, runnable, inputs):
         """Handle streaming responses from the language model.
 
+        Creates a Message whose ``text`` is the async iterator returned by the
+        model's ``astream`` method and passes it to ``send_message``.  During
+        streaming the component emits *token* events (one per chunk) and a
+        single *add_message* event to initialise the message bubble in the
+        frontend.  The ``add_message`` event intentionally carries **empty**
+        text so that streamed content is delivered exclusively through token
+        events — this avoids duplication in API consumers that process both
+        event types (see #10719).
+
         Args:
-            runnable: The language model configured for streaming
-            inputs: The inputs to send to the model
+            runnable: The language model configured for streaming.
+            inputs: The inputs to send to the model.
 
         Returns:
             tuple: (Message object if connected to chat output, model result)
         """
         lf_message = None
         if self.is_connected_to_chat_output():
-            # Add a Message
             if hasattr(self, "graph"):
                 session_id = self.graph.session_id
             elif hasattr(self, "_session_id"):

--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -1824,9 +1824,13 @@ class Component(CustomComponent):
         complete_message += chunk
         if self._event_manager:
             if first_chunk:
-                # Send the initial message only on the first chunk
+                # Send the initial message event to create the message
+                # bubble in the frontend.  Use empty text so the content
+                # is delivered exclusively through token events — sending
+                # the same text via both channels causes duplication in
+                # consumers like the OpenAI Responses endpoint (#10719).
                 msg_copy = message.model_copy()
-                msg_copy.text = complete_message
+                msg_copy.text = ""
                 await self._send_message_event(msg_copy, id_=message_id)
             await asyncio.to_thread(
                 self._event_manager.on_token,


### PR DESCRIPTION
## Description

When using a custom OpenAI-compatible API endpoint with streaming enabled, the response text appears twice in the Chat Output component. This happens because the streaming pipeline emits both an `add_message` event (to initialise the chat bubble in the frontend) and a `token` event for the first chunk — consumers that process both event types end up yielding the same content twice.

## Related Issue

Fixes #10719

## Root Cause

In `_process_chunk` (component.py), the first chunk triggers:

1. An `add_message` event via `_send_message_event()` — contains the chunk text
2. A `token` event via `event_manager.on_token()` — also contains the chunk text

Any consumer that processes both event types (e.g. the OpenAI Responses API endpoint) yields the first chunk's content twice.

## Changes Made

| File | Change |
|------|--------|
| `src/lfx/src/lfx/custom/custom_component/component.py` | **Root-cause fix**: Set the first-chunk `add_message` text to empty string so streamed content is delivered exclusively through `token` events |
| `src/backend/base/langflow/api/v1/openai_responses.py` | **Defensive fix**: Track whether `token` events have been received; skip `add_message` text content when tokens are active |
| `src/lfx/src/lfx/base/models/model.py` | Updated `_handle_stream` docstring to document the streaming contract: text is delivered via token events, `add_message` only initialises the message bubble |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How It Works

**Before:**
- First chunk → `add_message(text="Hello")` + `token(chunk="Hello")` → "Hello" appears twice
- Subsequent chunks → `token(chunk=" World")` → no duplication

**After:**
- First chunk → `add_message(text="")` + `token(chunk="Hello")` → "Hello" appears once
- Subsequent chunks → `token(chunk=" World")` → no duplication
- OpenAI Responses endpoint also defensively skips `add_message` text when token events are present
