### PR TITLE
fix: decode percent-encoded headers

### DIFF
--- a/src/backend/base/langflow/api/utils/core.py
+++ b/src/backend/base/langflow/api/utils/core.py
@@ -5,6 +5,7 @@ from ast import literal_eval
 from datetime import timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, Annotated, Any
+from urllib.parse import unquote
 
 from fastapi import Depends, HTTPException, Path, Query
 from fastapi_pagination import Params
@@ -412,9 +413,9 @@ def extract_global_variables_from_headers(headers) -> dict[str, str]:
         Dictionary mapping variable names (uppercase) to their values
 
     Example:
-        headers = {"X-LANGFLOW-GLOBAL-VAR-API-KEY": "secret", "Content-Type": "application/json"}
+        headers = {"X-LANGFLOW-GLOBAL-VAR-FILE-NAME": "document.pdf", "Content-Type": "application/json"}
         result = extract_global_variables_from_headers(headers)
-        # Returns: {"API_KEY": "secret"}
+        # Returns: {"FILE-NAME": "document.pdf"}
     """
     variables: dict[str, str] = {}
 
@@ -423,7 +424,7 @@ def extract_global_variables_from_headers(headers) -> dict[str, str]:
             header_lower = header_name.lower()
             if header_lower.startswith(LANGFLOW_GLOBAL_VAR_HEADER_PREFIX):
                 var_name = header_lower[len(LANGFLOW_GLOBAL_VAR_HEADER_PREFIX) :].upper()
-                variables[var_name] = header_value
+                variables[var_name] = unquote(header_value)
     except Exception as exc:  # noqa: BLE001
         # Log the error but don't raise - we want to continue execution
         logger.exception("Failed to extract global variables from headers: %s", exc)

--- a/src/backend/base/langflow/tests/api/utils/test_core.py
+++ b/src/backend/base/langflow/tests/api/utils/test_core.py
@@ -1,0 +1,104 @@
+from langflow.api.utils.core import extract_global_variables_from_headers
+from starlette.datastructures import Headers
+
+
+def test_extract_global_variables_from_headers_regular_strings():
+    """Test that regular strings are returned correctly as values when converted from headers to a dict."""
+    headers = Headers(
+        headers={
+            "X-LANGFLOW-GLOBAL-VAR-API-KEY": "secret123",
+            "X-LANGFLOW-GLOBAL-VAR-DATABASE-URL": "postgresql://localhost:5432/db",
+            "Content-Type": "application/json",
+            "Authorization": "Bearer token",
+        }
+    )
+
+    result = extract_global_variables_from_headers(headers)
+
+    assert result == {
+        "API-KEY": "secret123",
+        "DATABASE-URL": "postgresql://localhost:5432/db",
+    }
+    # Non-matching headers should not be included
+    assert "CONTENT-TYPE" not in result
+    assert "AUTHORIZATION" not in result
+
+
+def test_extract_global_variables_from_headers_percent_encoded():
+    """Test that percent-encoded strings are decoded before being returned."""
+    headers = Headers(
+        headers={
+            "X-LANGFLOW-GLOBAL-VAR-MESSAGE": "hello%20world",
+            "X-LANGFLOW-GLOBAL-VAR-PATH": "/path/with%20spaces/and%2Fslash",
+            "X-LANGFLOW-GLOBAL-VAR-SPECIAL": "value%21%40%23%24%25",  # !@#$%
+            "X-LANGFLOW-GLOBAL-VAR-UNICODE": "caf%C3%A9",  # café
+        }
+    )
+
+    result = extract_global_variables_from_headers(headers)
+
+    assert result == {
+        "MESSAGE": "hello world",
+        "PATH": "/path/with spaces/and/slash",
+        "SPECIAL": "value!@#$%",
+        "UNICODE": "café",
+    }
+
+
+def test_extract_global_variables_from_headers_mixed():
+    """Test with a mix of regular and percent-encoded values."""
+    headers = Headers(
+        headers={
+            "X-LANGFLOW-GLOBAL-VAR-REGULAR": "simple_value",
+            "X-LANGFLOW-GLOBAL-VAR-ENCODED": "value%20with%20spaces",
+            "X-LANGFLOW-GLOBAL-VAR-EMPTY": "",
+        }
+    )
+
+    result = extract_global_variables_from_headers(headers)
+
+    assert result == {
+        "REGULAR": "simple_value",
+        "ENCODED": "value with spaces",
+        "EMPTY": "",
+    }
+
+
+def test_extract_global_variables_from_headers_case_insensitive():
+    """Test that header names are case-insensitive."""
+    headers = Headers(
+        headers={
+            "x-langflow-global-var-lowercase": "value1",
+            "X-LANGFLOW-GLOBAL-VAR-UPPERCASE": "value2",
+            "X-Langflow-Global-Var-MixedCase": "value3",
+        }
+    )
+
+    result = extract_global_variables_from_headers(headers)
+
+    assert result == {
+        "LOWERCASE": "value1",
+        "UPPERCASE": "value2",
+        "MIXEDCASE": "value3",
+    }
+
+
+def test_extract_global_variables_from_headers_empty():
+    """Test with no matching headers."""
+    headers = Headers(
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer token",
+        }
+    )
+
+    result = extract_global_variables_from_headers(headers)
+
+    assert result == {}
+
+
+def test_extract_global_variables_from_headers_error_handling():
+    """Test that errors are handled gracefully."""
+    # Test with None (should handle gracefully)
+    result = extract_global_variables_from_headers(Headers())
+    assert result == {}


### PR DESCRIPTION
In OpenRAG we discovered that uploading a file with non-ASCII characters in the filename caused an error (https://github.com/langflow-ai/openrag/issues/769).

This was because the filename was not being percent-encoded. Updating the OpenRAG implementation to encode the headers led to filenames arriving in Langflow as percent-encoded strings. It turns out that Langflow was not decoding these headers, and thus setting flow variables to percent-encoded strings, which flowed through to many places where the filename was displayed with percent-encoded characters instead of the original.

This updates `extract_global_variables_from_headers` to decode the headers, and adds unit tests.

(Oh, I renamed the example in the docstring because the secrets checker thought that `"API_KEY": "secret"` was dangerous.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP header values are now properly URL-decoded when extracting global variables, ensuring special characters and percent-encoded values are interpreted correctly.

* **Tests**
  * Added comprehensive test coverage for HTTP header extraction, including percent-encoded values, mixed formats, case-insensitive matching, and various edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->