### PR TITLE
docs: add tool shortlisting and remove web_apps from CUGA component

### DIFF
--- a/docs/docs/Components/bundles-cuga.mdx
+++ b/docs/docs/Components/bundles-cuga.mdx
@@ -19,7 +19,7 @@ Like the core **Agent** component, the **CUGA** component can use tools connecte
 It also includes some additional features:
 
 * Browser automation for web scraping with [Playwright](https://playwright.dev/docs/intro).
-To enable web scraping, set the component's `browser_enabled` parameter to `true`, and specify a single URL in the `web_apps` parameter, in the format `https://example.com`.
+To enable web scraping, set the component's `browser_enabled` parameter to `true`.
 * Load custom instructions for the agent to execute.
 To use this feature, use the component's **Instructions** input to attach markdown files containing agent instructions.
 
@@ -90,6 +90,6 @@ This example asked about the sales data provided by the MCP Server, such as `Whi
 | add_current_date_tool | Boolean | If true, adds a tool that returns the current date. Default: `true`. |
 | lite_mode | Boolean | Set to `true` to enable CugaLite mode for faster execution when using a smaller number of tools. Default: `true`. |
 | lite_mode_tool_threshold | Integer | The threshold to automatically enable CugaLite. If the CUGA component has fewer tools connected than this threshold, CugaLite is activated. Default: `25`. |
+| shortlisting_tool_threshold | Integer | The threshold for tool shortlisting. When the total number of tools exceeds this threshold, the CUGA component enables its `find_tools` feature to filter tools down to a smaller subset before making tool selection decisions. This helps reduce token usage and improve performance when working with large numbers of tools. Default: `35`. |
 | decomposition_strategy | Dropdown | Strategy for task decomposition. `flexible` allows multiple subtasks per app. `exact` enforces one subtask per app. Default: `flexible`. |
 | browser_enabled | Boolean | Enable a built-in browser for web scraping and search. Allows the agent to use general web search in its responses. Disable (`false`) to restrict the agent to the context provided in the flow. Default: `false`. |
-| web_apps | Multiline String | When `browser_enabled` is `true`, specify a single URL such as `https://example.com` that the agent can open with the built-in browser. The CUGA component can access both public and private internet resources. There is no built-in mechanism in the CUGA component to restrict access to only public internet resources. |


### PR DESCRIPTION
Remove `web_apps` parameter and add tool shortlisting to the CUGA component.

#11585 