### PR TITLE
security: use HKDF for Fernet key derivation instead of insecure methods

### DIFF
--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import random
 import warnings
 from collections.abc import Coroutine
 from datetime import datetime, timedelta, timezone
@@ -10,6 +9,8 @@ from uuid import UUID
 
 import jwt
 from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from fastapi import HTTPException, Request, WebSocketException, status
 from jwt import InvalidTokenError
 from lfx.log.logger import logger
@@ -42,8 +43,6 @@ if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
     from langflow.services.database.models.api_key.model import ApiKey
-
-MINIMUM_KEY_LENGTH = 32
 
 
 class AuthService(BaseAuthService):
@@ -644,23 +643,19 @@ class AuthService(BaseAuthService):
 
         return user if self.verify_password(password, user.password) else None
 
-    def _add_padding(self, value: str) -> str:
-        padding_needed = 4 - len(value) % 4
-        return value + "=" * padding_needed
-
-    def _ensure_valid_key(self, raw_key: str) -> bytes:
-        if len(raw_key) < MINIMUM_KEY_LENGTH:
-            random.seed(raw_key)
-            key = bytes(random.getrandbits(8) for _ in range(32))
-            key = base64.urlsafe_b64encode(key)
-        else:
-            key = self._add_padding(raw_key).encode()
-        return key
+    @staticmethod
+    def _derive_fernet_key(raw_key: str) -> bytes:
+        derived = HKDF(
+            algorithm=SHA256(),
+            length=32,
+            salt=None,
+            info=b"langflow-fernet-key",
+        ).derive(raw_key.encode())
+        return base64.urlsafe_b64encode(derived)
 
     def _get_fernet(self) -> Fernet:
         secret_key: str = self.settings.auth_settings.SECRET_KEY.get_secret_value()
-        valid_key = self._ensure_valid_key(secret_key)
-        return Fernet(valid_key)
+        return Fernet(self._derive_fernet_key(secret_key))
 
     def encrypt_api_key(self, api_key: str) -> str:
         fernet = self._get_fernet()

--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import warnings
 from collections.abc import Coroutine
 from datetime import datetime, timedelta, timezone
@@ -9,8 +8,6 @@ from uuid import UUID
 
 import jwt
 from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives.hashes import SHA256
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from fastapi import HTTPException, Request, WebSocketException, status
 from jwt import InvalidTokenError
 from lfx.log.logger import logger
@@ -643,19 +640,11 @@ class AuthService(BaseAuthService):
 
         return user if self.verify_password(password, user.password) else None
 
-    @staticmethod
-    def _derive_fernet_key(raw_key: str) -> bytes:
-        derived = HKDF(
-            algorithm=SHA256(),
-            length=32,
-            salt=None,
-            info=b"langflow-fernet-key",
-        ).derive(raw_key.encode())
-        return base64.urlsafe_b64encode(derived)
-
     def _get_fernet(self) -> Fernet:
+        from langflow.services.auth.utils import _derive_fernet_key
+
         secret_key: str = self.settings.auth_settings.SECRET_KEY.get_secret_value()
-        return Fernet(self._derive_fernet_key(secret_key))
+        return Fernet(_derive_fernet_key(secret_key))
 
     def encrypt_api_key(self, api_key: str) -> str:
         fernet = self._get_fernet()

--- a/src/backend/base/langflow/services/auth/utils.py
+++ b/src/backend/base/langflow/services/auth/utils.py
@@ -4,6 +4,8 @@ import base64
 from typing import TYPE_CHECKING, Annotated, Final
 
 from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from fastapi import Depends, HTTPException, Request, Security, WebSocket, WebSocketException, status
 from fastapi.security import APIKeyHeader, APIKeyQuery, OAuth2PasswordBearer
 from fastapi.security.utils import get_authorization_scheme_param
@@ -246,6 +248,16 @@ async def get_current_active_superuser(user: User = Depends(get_current_user)) -
     return result
 
 
+def _derive_fernet_key(raw_key: str) -> bytes:
+    derived = HKDF(
+        algorithm=SHA256(),
+        length=32,
+        salt=None,
+        info=b"langflow-fernet-key",
+    ).derive(raw_key.encode())
+    return base64.urlsafe_b64encode(derived)
+
+
 def get_fernet(settings_service: SettingsService) -> Fernet:
     """Get a Fernet instance for encryption/decryption.
 
@@ -255,24 +267,8 @@ def get_fernet(settings_service: SettingsService) -> Fernet:
     Returns:
         Fernet instance for encryption/decryption
     """
-    import random
-
     secret_key: str = settings_service.auth_settings.SECRET_KEY.get_secret_value()
-
-    # Replicate the original _ensure_valid_key logic from AuthService
-    MINIMUM_KEY_LENGTH = 32  # noqa: N806
-    if len(secret_key) < MINIMUM_KEY_LENGTH:
-        # Generate deterministic key from seed for short keys
-        random.seed(secret_key)
-        key = bytes(random.getrandbits(8) for _ in range(32))
-        key = base64.urlsafe_b64encode(key)
-    else:
-        # Add padding for longer keys
-        padding_needed = 4 - len(secret_key) % 4
-        padded_key = secret_key + "=" * padding_needed
-        key = padded_key.encode()
-
-    return Fernet(key)
+    return Fernet(_derive_fernet_key(secret_key))
 
 
 def encrypt_api_key(api_key: str, settings_service: SettingsService | None = None) -> str:  # noqa: ARG001


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## Insecure Fernet Key Padding Implementation

## Location
`src/backend/base/langflow/services/auth/utils.py` (`get_fernet()`) and `src/backend/base/langflow/services/auth/service.py` (`_ensure_valid_key()`, `_add_padding()`, `_get_fernet()`)

## Description
The `ensure_valid_key()` and `get_fernet()` functions implemented a custom, non-standard Fernet key handling with two significant cryptographic issues:

1. **For keys < 32 chars**: Used `random.seed()` with the secret as seed, then generated 32 random bytes. Python's `random` module is **not cryptographically secure** — it uses a Mersenne Twister PRNG. The same seed always produces identical output, making key derivation predictable to anyone who knows or can guess the secret.

2. **For keys >= 32 chars**: Simply added `=` padding and encoded to bytes. Fernet expects a 32-byte URL-safe base64-encoded key, but this approach doesn't properly derive a key — it can produce invalid Fernet keys or keys of incorrect length after base64 decoding.

## Analysis Notes
This vulnerability existed in two locations: the `AuthService._ensure_valid_key()` method in `service.py` and the `get_fernet()` standalone function in `utils.py` (which replicated the same logic). Both code paths are used for encrypting/decrypting API keys stored in the database.

## Fix Applied
Replaced both insecure key derivation implementations with HKDF-SHA256 (HMAC-based Key Derivation Function) from the `cryptography` library, which is already a project dependency. HKDF properly derives a cryptographically strong 32-byte key from any input secret regardless of length, which is then base64url-encoded for Fernet. This is deterministic (same input produces same key, required for encrypt/decrypt consistency) while being cryptographically sound.

**Note**: This is a key-derivation change. Existing encrypted API keys in the database were encrypted with the old derivation method and will not be decryptable with the new derivation. The existing `decrypt_api_key()` method already handles decryption failures gracefully (returns empty string and logs a warning), and the API key check logic falls back to plaintext comparison. Deployments may need to re-encrypt stored API keys after this change.

## Tests/Linters Ran
- `uv run ruff check --fix` and `uv run ruff format` on both changed files — all checks passed
- `uv run pytest src/backend/tests/unit/services/auth/` — 57 tests passed
- `uv run pytest src/backend/tests/unit/test_get_api_key.py` — 1 test passed  
- `uv run pytest src/backend/tests/unit/test_auth_settings.py` — 10 tests passed
- `uv run pytest src/backend/tests/unit/test_auth_jwt_algorithms.py` — 52 tests passed
- **Total: 120 tests passed, 0 failures**

## Contribution Notes
- PR title follows [semantic commit conventions](https://www.conventionalcommits.org/) as required by CONTRIBUTING.md
- Code style matches existing project patterns (verified via ruff check + format)
- The `cryptography` library (already a dependency at `>=43.0.1,<44.0.0`) provides HKDF natively — no new dependencies added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Strengthened API key encryption by implementing cryptographic key derivation using HKDF-SHA256 standards
* Enhanced key management security infrastructure with improved cryptographic practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->