### PR TITLE
fix(ci): handle PEP 440 normalized versions in pre-release tag script

### DIFF
--- a/scripts/ci/langflow_pre_release_tag.py
+++ b/scripts/ci/langflow_pre_release_tag.py
@@ -18,14 +18,13 @@ def create_tag(package_version: str, latest_released_version: str | None) -> str
     new_pre_release_version = f"{pkg}.rc0"
 
     if latest:
-        # match either exact pkg or pkg.rcN
-        m = re.match(rf"^{re.escape(pkg)}(?:\.rc(\d+))?$", latest)
+        # match either exact pkg or pkg.rcN (with or without dot before rc, per PEP 440 normalization)
+        m = re.match(rf"^{re.escape(pkg)}\.?rc(\d+)$", latest)
         if m:
-            if m.group(1):
-                rc_number = int(m.group(1)) + 1
-                new_pre_release_version = f"{pkg}.rc{rc_number}"
-            else:
-                new_pre_release_version = f"{pkg}.rc1"
+            rc_number = int(m.group(1)) + 1
+            new_pre_release_version = f"{pkg}.rc{rc_number}"
+        elif latest == pkg:
+            new_pre_release_version = f"{pkg}.rc1"
 
     return new_pre_release_version
 


### PR DESCRIPTION
The regex in langflow_pre_release_tag.py expected a dot before `rc` (e.g. `1.8.0.rc0`), but PyPI returns PEP 440-normalized versions without the dot (e.g. `1.8.0rc0`). This caused the script to recompute the same version instead of incrementing, and `uv publish` silently skipped the duplicate upload.

Update the regex to accept both formats with `\.?rc`.