### PR TITLE
fix(test): Skip Tavily API key fill when global variable is loaded                                                         

### DIFF
--- a/src/frontend/tests/core/integrations/Market Research.spec.ts
+++ b/src/frontend/tests/core/integrations/Market Research.spec.ts
@@ -44,9 +44,7 @@ withEventDeliveryModes(
     // environment (see VARIABLES_TO_GET_FROM_ENVIRONMENT in constants.py).
     // When loaded, the input is replaced by a badge and fill() would fail.
     // Only fill manually when the input is still present.
-    const tavilyApiKeyInput = page.getByTestId(
-      "popover-anchor-input-api_key",
-    );
+    const tavilyApiKeyInput = page.getByTestId("popover-anchor-input-api_key");
     if ((await tavilyApiKeyInput.count()) > 0) {
       await tavilyApiKeyInput.fill(process.env.TAVILY_API_KEY || "");
     }


### PR DESCRIPTION
OBJECTIVE: Fix flaky Market Research E2E test that fails in CI because TAVILY_API_KEY is auto-loaded as a global variable, replacing the input field with a badge.                                                                                                      
                                                                                                                                      
CHANGES:
  - Add count() check before fill() to skip when input is replaced by global variable badge
  - Add comment explaining the race condition root cause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of Market Research integration tests by adding safeguards to prevent input-filling failures when elements are dynamically replaced during environment variable loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->