### PR TITLE
Component improvements: unified Operations, tool_mode defaults, enhancements

### DIFF
--- a/src/lfx/src/lfx/components/data_source/web_search.py
+++ b/src/lfx/src/lfx/components/data_source/web_search.py
@@ -13,7 +13,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from lfx.custom import Component
-from lfx.io import IntInput, MessageTextInput, Output, TabInput
+from lfx.io import BoolInput, IntInput, MessageTextInput, Output, TabInput
 from lfx.schema import DataFrame
 from lfx.utils.request_utils import get_user_agent
 
@@ -88,6 +88,13 @@ class WebSearchComponent(Component):
             required=False,
             advanced=True,
         ),
+        BoolInput(
+            name="include_content",
+            display_name="Include Content",
+            info="When enabled, fetches the full page content for each search result. Disabling makes searches faster.",
+            value=True,
+            advanced=True,
+        ),
         IntInput(
             name="timeout",
             display_name="Timeout",
@@ -121,8 +128,8 @@ class WebSearchComponent(Component):
                 build_config["query"]["info"] = "Keywords to search for"
                 build_config["query"]["display_name"] = "Search Query"
 
-            # Keep news-specific fields as advanced (matching original News Search component)
-            # They remain advanced=True in all modes, just like in the original component
+            # Show "Include Content" only in Web mode
+            build_config["include_content"]["show"] = not is_news and not is_rss
 
         return build_config
 
@@ -187,14 +194,17 @@ class WebSearchComponent(Component):
                 uddg = parse_qs(parsed.query).get("uddg", [""])[0]
                 decoded_link = unquote(uddg) if uddg else raw_link
 
-                try:
-                    final_url = self.ensure_url(decoded_link)
-                    page = requests.get(final_url, headers=headers, timeout=self.timeout)
-                    page.raise_for_status()
-                    content = BeautifulSoup(page.text, "lxml").get_text(separator=" ", strip=True)
-                except requests.RequestException as e:
-                    final_url = decoded_link
-                    content = f"(Failed to fetch: {e!s}"
+                content = ""
+                final_url = decoded_link
+                if self.include_content:
+                    try:
+                        final_url = self.ensure_url(decoded_link)
+                        page = requests.get(final_url, headers=headers, timeout=self.timeout)
+                        page.raise_for_status()
+                        content = BeautifulSoup(page.text, "lxml").get_text(separator=" ", strip=True)
+                    except requests.RequestException as e:
+                        final_url = decoded_link
+                        content = f"(Failed to fetch: {e!s}"
 
                 results.append(
                     {

--- a/src/lfx/src/lfx/components/deactivated/mcp_sse.py
+++ b/src/lfx/src/lfx/components/deactivated/mcp_sse.py
@@ -15,6 +15,7 @@ from lfx.io import MessageTextInput, Output
 
 
 class MCPSse(Component):
+    tool_mode = True
     client = MCPSseClient()
     tools = types.ListToolsResult
     tool_names = [str]

--- a/src/lfx/src/lfx/components/deactivated/mcp_stdio.py
+++ b/src/lfx/src/lfx/components/deactivated/mcp_stdio.py
@@ -15,6 +15,7 @@ from lfx.io import MessageTextInput, Output
 
 
 class MCPStdio(Component):
+    tool_mode = True
     client = MCPStdioClient()
     tools = types.ListToolsResult
     tool_names = [str]

--- a/src/lfx/src/lfx/components/files_and_knowledge/ingestion.py
+++ b/src/lfx/src/lfx/components/files_and_knowledge/ingestion.py
@@ -31,6 +31,7 @@ from lfx.io import (
     StrInput,
     TableInput,
 )
+from lfx.log.logger import logger
 from lfx.schema.data import Data
 from lfx.schema.table import EditMode
 from lfx.services.deps import (
@@ -49,23 +50,21 @@ HUGGINGFACE_MODEL_NAMES = [
 ]
 COHERE_MODEL_NAMES = ["embed-english-v3.0", "embed-multilingual-v3.0"]
 
-_KNOWLEDGE_BASES_ROOT_PATH: Path | None = None
-
 # Error message to raise if we're in Astra cloud environment and the component is not supported.
 astra_error_msg = "Knowledge ingestion is not supported in Astra cloud environment."
 
 
 def _get_knowledge_bases_root_path() -> Path:
-    """Lazy load the knowledge bases root path from settings."""
-    global _KNOWLEDGE_BASES_ROOT_PATH  # noqa: PLW0603
-    if _KNOWLEDGE_BASES_ROOT_PATH is None:
+    """Get the knowledge bases root path from settings with caching."""
+    # Use function attribute for caching instead of global variable
+    if not hasattr(_get_knowledge_bases_root_path, "_cached_path"):
         settings = get_settings_service().settings
         knowledge_directory = settings.knowledge_bases_dir
         if not knowledge_directory:
             msg = "Knowledge bases directory is not set in the settings."
             raise ValueError(msg)
-        _KNOWLEDGE_BASES_ROOT_PATH = Path(knowledge_directory).expanduser()
-    return _KNOWLEDGE_BASES_ROOT_PATH
+        _get_knowledge_bases_root_path._cached_path = Path(knowledge_directory).expanduser()
+    return _get_knowledge_bases_root_path._cached_path
 
 
 class KnowledgeIngestionComponent(Component):
@@ -406,10 +405,21 @@ class KnowledgeIngestionComponent(Component):
                 doc = data_obj.to_lc_document()
                 documents.append(doc)
 
-            # Add documents to vector store
+            # Add documents to vector store in batches (Chroma limit is ~5461)
             if documents:
-                chroma.add_documents(documents)
-                self.log(f"Added {len(documents)} documents to vector store '{self.knowledge_base}'")
+                batch_size = 5000
+                total_docs = len(documents)
+                total_batches = (total_docs + batch_size - 1) // batch_size
+                logger.info(f"Knowledge Ingestion: Adding {total_docs} documents in {total_batches} batches")
+                for i in range(0, total_docs, batch_size):
+                    batch_num = i // batch_size + 1
+                    batch = documents[i : i + batch_size]
+                    logger.info(
+                        f"Knowledge Ingestion: Processing batch {batch_num}/{total_batches} ({len(batch)} docs)"
+                    )
+                    chroma.add_documents(batch)
+                    logger.info(f"Knowledge Ingestion: Batch {batch_num}/{total_batches} completed")
+                logger.info(f"Knowledge Ingestion: All {total_docs} documents added to '{self.knowledge_base}'")
 
         except (OSError, ValueError, RuntimeError) as e:
             self.log(f"Error creating vector store: {e}")

--- a/src/lfx/src/lfx/components/files_and_knowledge/retrieval.py
+++ b/src/lfx/src/lfx/components/files_and_knowledge/retrieval.py
@@ -1,4 +1,5 @@
 import json
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -10,30 +11,28 @@ from pydantic import SecretStr
 
 from lfx.base.knowledge_bases.knowledge_base_utils import get_knowledge_bases
 from lfx.custom import Component
-from lfx.io import BoolInput, DropdownInput, IntInput, MessageTextInput, Output, SecretStrInput
+from lfx.io import BoolInput, DropdownInput, IntInput, MessageTextInput, Output, SecretStrInput, TabInput
 from lfx.log.logger import logger
 from lfx.schema.data import Data
 from lfx.schema.dataframe import DataFrame
 from lfx.services.deps import get_settings_service, session_scope
 from lfx.utils.validate_cloud import raise_error_if_astra_cloud_disable_component
 
-_KNOWLEDGE_BASES_ROOT_PATH: Path | None = None
-
 # Error message to raise if we're in Astra cloud environment and the component is not supported.
 astra_error_msg = "Knowledge retrieval is not supported in Astra cloud environment."
 
 
 def _get_knowledge_bases_root_path() -> Path:
-    """Lazy load the knowledge bases root path from settings."""
-    global _KNOWLEDGE_BASES_ROOT_PATH  # noqa: PLW0603
-    if _KNOWLEDGE_BASES_ROOT_PATH is None:
+    """Get the knowledge bases root path from settings with caching."""
+    # Use function attribute for caching instead of global variable
+    if not hasattr(_get_knowledge_bases_root_path, "_cached_path"):
         settings = get_settings_service().settings
         knowledge_directory = settings.knowledge_bases_dir
         if not knowledge_directory:
             msg = "Knowledge bases directory is not set in the settings."
             raise ValueError(msg)
-        _KNOWLEDGE_BASES_ROOT_PATH = Path(knowledge_directory).expanduser()
-    return _KNOWLEDGE_BASES_ROOT_PATH
+        _get_knowledge_bases_root_path._cached_path = Path(knowledge_directory).expanduser()
+    return _get_knowledge_bases_root_path._cached_path
 
 
 class KnowledgeRetrievalComponent(Component):
@@ -43,6 +42,14 @@ class KnowledgeRetrievalComponent(Component):
     name = "KnowledgeRetrieval"
 
     inputs = [
+        TabInput(
+            name="search_mode",
+            display_name="Search Mode",
+            info="Choose between similarity (vector) search or exact match (text) search.",
+            options=["Similarity", "Exact Match"],
+            value="Similarity",
+            tool_mode=True,
+        ),
         DropdownInput(
             name="knowledge_base",
             display_name="Knowledge",
@@ -52,18 +59,18 @@ class KnowledgeRetrievalComponent(Component):
             refresh_button=True,
             real_time_refresh=True,
         ),
-        SecretStrInput(
-            name="api_key",
-            display_name="Embedding Provider API Key",
-            info="API key for the embedding provider to generate embeddings.",
-            advanced=True,
-            required=False,
-        ),
         MessageTextInput(
             name="search_query",
             display_name="Search Query",
-            info="Optional search query to filter knowledge base data.",
+            info="Search query to filter knowledge base data.",
             tool_mode=True,
+        ),
+        BoolInput(
+            name="search_metadata",
+            display_name="Also Search Metadata",
+            info="When using Exact Match, also search in metadata fields (not just content).",
+            value=False,
+            advanced=True,
         ),
         IntInput(
             name="top_k",
@@ -87,6 +94,13 @@ class KnowledgeRetrievalComponent(Component):
             value=False,
             advanced=True,
         ),
+        SecretStrInput(
+            name="api_key",
+            display_name="Embedding Provider API Key",
+            info="API key for the embedding provider to generate embeddings. Only required for Similarity search.",
+            advanced=True,
+            required=False,
+        ),
     ]
 
     outputs = [
@@ -95,6 +109,13 @@ class KnowledgeRetrievalComponent(Component):
             display_name="Results",
             method="retrieve_data",
             info="Returns the data from the selected knowledge base.",
+        ),
+        Output(
+            name="get_kb_info",
+            display_name="Info",
+            method="get_kb_info",
+            info="Returns structure and statistics about the knowledge base.",
+            tool_mode=True,
         ),
     ]
 
@@ -186,6 +207,73 @@ class KnowledgeRetrievalComponent(Component):
         msg = f"Embedding provider '{provider}' is not supported for retrieval."
         raise NotImplementedError(msg)
 
+    def _exact_match_search(self, chroma: Chroma, query: str) -> list[tuple]:
+        """Perform exact match search on content and optionally metadata.
+
+        Args:
+            chroma: The Chroma vector store instance.
+            query: The search query string.
+
+        Returns:
+            List of (Document, score) tuples matching the query.
+        """
+        collection = chroma._collection  # noqa: SLF001
+
+        # Use Chroma's where_document for content search
+        # $contains does a substring match on the document content
+        logger.info(f"Performing exact match search with query: {query}")
+
+        try:
+            # Search in document content
+            content_results = collection.get(
+                where_document={"$contains": query},
+                include=["documents", "metadatas"],
+                limit=self.top_k,
+            )
+
+            # Build results list from content matches
+            results = []
+            for i, doc_content in enumerate(content_results.get("documents", [])):
+                from langchain_core.documents import Document
+
+                metadata = content_results["metadatas"][i] if content_results.get("metadatas") else {}
+                doc = Document(page_content=doc_content or "", metadata=metadata or {})
+                results.append((doc, 0))  # Score 0 for exact match (no similarity score)
+
+            # If search_metadata is enabled, also search in metadata fields
+            if self.search_metadata:
+                logger.info("Also searching in metadata fields")
+                # Get all documents to search metadata (Chroma doesn't support $contains on metadata)
+                all_docs = collection.get(include=["documents", "metadatas"])
+
+                existing_ids = {r[0].metadata.get("_id") for r in results if r[0].metadata.get("_id")}
+
+                for i, metadata in enumerate(all_docs.get("metadatas", [])):
+                    if not metadata:
+                        continue
+                    # Skip if already in results
+                    if metadata.get("_id") in existing_ids:
+                        continue
+                    # Check if query appears in any metadata value
+                    for value in metadata.values():
+                        if value and query.lower() in str(value).lower():
+                            from langchain_core.documents import Document
+
+                            doc_content = all_docs["documents"][i] if all_docs.get("documents") else ""
+                            doc = Document(page_content=doc_content or "", metadata=metadata)
+                            results.append((doc, 0))
+                            existing_ids.add(metadata.get("_id"))
+                            break
+
+                # Limit to top_k
+                results = results[: self.top_k]
+
+            return results
+
+        except Exception as e:
+            logger.error(f"Error during exact match search: {e}")
+            return []
+
     async def retrieve_data(self) -> DataFrame:
         """Retrieve data from the selected knowledge base by reading the Chroma collection.
 
@@ -211,8 +299,13 @@ class KnowledgeRetrievalComponent(Component):
             msg = f"Metadata not found for knowledge base: {self.knowledge_base}. Ensure it has been indexed."
             raise ValueError(msg)
 
-        # Build the embedder for the knowledge base
-        embedding_function = self._build_embeddings(metadata)
+        # Determine if we need embeddings (only for similarity search)
+        use_similarity = self.search_mode == "Similarity"
+
+        # Build the embedder only if needed for similarity search
+        embedding_function = None
+        if use_similarity:
+            embedding_function = self._build_embeddings(metadata)
 
         # Load vector store
         chroma = Chroma(
@@ -221,22 +314,34 @@ class KnowledgeRetrievalComponent(Component):
             collection_name=self.knowledge_base,
         )
 
-        # If a search query is provided, perform a similarity search
-        if self.search_query:
-            # Use the search query to perform a similarity search
-            logger.info(f"Performing similarity search with query: {self.search_query}")
-            results = chroma.similarity_search_with_score(
-                query=self.search_query or "",
-                k=self.top_k,
-            )
-        else:
-            results = chroma.similarity_search(
-                query=self.search_query or "",
-                k=self.top_k,
-            )
+        results: list[tuple] = []
 
-            # For each result, make it a tuple to match the expected output format
-            results = [(doc, 0) for doc in results]  # Assign a dummy score of 0
+        if self.search_query:
+            if use_similarity:
+                # Use the search query to perform a similarity search
+                logger.info(f"Performing similarity search with query: {self.search_query}")
+                results = chroma.similarity_search_with_score(
+                    query=self.search_query,
+                    k=self.top_k,
+                )
+            else:
+                # Exact match search
+                results = self._exact_match_search(chroma, self.search_query)
+        else:
+            # No query - just return top_k documents
+            if use_similarity:
+                docs = chroma.similarity_search(query="", k=self.top_k)
+                results = [(doc, 0) for doc in docs]
+            else:
+                # For exact match without query, just get documents
+                collection = chroma._collection  # noqa: SLF001
+                all_docs = collection.get(include=["documents", "metadatas"], limit=self.top_k)
+                from langchain_core.documents import Document
+
+                for i, doc_content in enumerate(all_docs.get("documents", [])):
+                    meta = all_docs["metadatas"][i] if all_docs.get("metadatas") else {}
+                    doc = Document(page_content=doc_content or "", metadata=meta or {})
+                    results.append((doc, 0))
 
         # If include_embeddings is enabled, get embeddings for the results
         id_to_embedding = {}
@@ -250,9 +355,9 @@ class KnowledgeRetrievalComponent(Component):
                 embeddings_result = collection.get(where={"_id": {"$in": doc_ids}}, include=["metadatas", "embeddings"])
 
                 # Create a mapping from document ID to embedding
-                for i, metadata in enumerate(embeddings_result.get("metadatas", [])):
-                    if metadata and "_id" in metadata:
-                        id_to_embedding[metadata["_id"]] = embeddings_result["embeddings"][i]
+                for i, meta in enumerate(embeddings_result.get("metadatas", [])):
+                    if meta and "_id" in meta:
+                        id_to_embedding[meta["_id"]] = embeddings_result["embeddings"][i]
 
         # Build output data based on include_metadata setting
         data_list = []
@@ -260,7 +365,7 @@ class KnowledgeRetrievalComponent(Component):
             kwargs = {
                 "content": doc[0].page_content,
             }
-            if self.search_query:
+            if self.search_query and use_similarity:
                 kwargs["_score"] = -1 * doc[1]
             if self.include_metadata:
                 # Include all metadata, embeddings, and content
@@ -272,3 +377,78 @@ class KnowledgeRetrievalComponent(Component):
 
         # Return the DataFrame containing the data
         return DataFrame(data=data_list)
+
+    async def get_kb_info(self) -> Data:
+        """Get structure and statistics about the selected knowledge base."""
+        raise_error_if_astra_cloud_disable_component(astra_error_msg)
+
+        async with session_scope() as db:
+            if not self.user_id:
+                msg = "User ID is required."
+                raise ValueError(msg)
+            current_user = await get_user_by_id(db, self.user_id)
+            if not current_user:
+                msg = f"User with ID {self.user_id} not found."
+                raise ValueError(msg)
+            kb_user = current_user.username
+
+        kb_path = _get_knowledge_bases_root_path() / kb_user / self.knowledge_base
+        kb_metadata = self._get_kb_metadata(kb_path)
+
+        chroma = Chroma(
+            persist_directory=str(kb_path),
+            collection_name=self.knowledge_base,
+        )
+        collection = chroma._collection  # noqa: SLF001
+        all_data = collection.get(include=["metadatas", "documents"])
+
+        total_documents = len(all_data.get("ids", []))
+        metadatas = all_data.get("metadatas", [])
+        documents = all_data.get("documents", [])
+
+        all_fields: set[str] = set()
+        for meta in metadatas:
+            if meta:
+                all_fields.update(meta.keys())
+
+        display_fields = sorted([f for f in all_fields if not f.startswith("_")])
+
+        # Analyze each field
+        describe: dict[str, Any] = {}
+        for field in all_fields:
+            values = [meta.get(field) if meta else None for meta in metadatas]
+            non_null = [v for v in values if v is not None]
+            if not non_null:
+                describe[field] = {"count": 0, "unique": 0}
+                continue
+            str_values = [str(v) for v in non_null]
+            counter = Counter(str_values)
+            describe[field] = {
+                "count": len(non_null),
+                "unique": len(counter),
+                "top_values": [{"value": val, "count": cnt} for val, cnt in counter.most_common(10)],
+            }
+
+        # Sample documents
+        sample_size = min(5, total_documents)
+        sample: list[dict[str, Any]] = []
+        for i in range(sample_size):
+            s: dict[str, Any] = {"content": documents[i] if documents and i < len(documents) else None}
+            if metadatas and i < len(metadatas) and metadatas[i]:
+                s["metadata"] = metadatas[i]
+            sample.append(s)
+
+        info_data: dict[str, Any] = {
+            "collection_name": self.knowledge_base,
+            "total_documents": total_documents,
+            "embedding_provider": kb_metadata.get("embedding_provider"),
+            "embedding_model": kb_metadata.get("embedding_model"),
+            "created_at": kb_metadata.get("created_at"),
+            "metadata_fields": display_fields,
+            "describe": describe,
+            "sample": sample,
+        }
+
+        self.status = f"KB '{self.knowledge_base}': {total_documents} documents, {len(display_fields)} metadata fields"
+
+        return Data(data=info_data)

--- a/src/lfx/src/lfx/components/files_and_knowledge/retrieval.py
+++ b/src/lfx/src/lfx/components/files_and_knowledge/retrieval.py
@@ -327,21 +327,20 @@ class KnowledgeRetrievalComponent(Component):
             else:
                 # Exact match search
                 results = self._exact_match_search(chroma, self.search_query)
+        # No query - just return top_k documents
+        elif use_similarity:
+            docs = chroma.similarity_search(query="", k=self.top_k)
+            results = [(doc, 0) for doc in docs]
         else:
-            # No query - just return top_k documents
-            if use_similarity:
-                docs = chroma.similarity_search(query="", k=self.top_k)
-                results = [(doc, 0) for doc in docs]
-            else:
-                # For exact match without query, just get documents
-                collection = chroma._collection  # noqa: SLF001
-                all_docs = collection.get(include=["documents", "metadatas"], limit=self.top_k)
-                from langchain_core.documents import Document
+            # For exact match without query, just get documents
+            collection = chroma._collection  # noqa: SLF001
+            all_docs = collection.get(include=["documents", "metadatas"], limit=self.top_k)
+            from langchain_core.documents import Document
 
-                for i, doc_content in enumerate(all_docs.get("documents", [])):
-                    meta = all_docs["metadatas"][i] if all_docs.get("metadatas") else {}
-                    doc = Document(page_content=doc_content or "", metadata=meta or {})
-                    results.append((doc, 0))
+            for i, doc_content in enumerate(all_docs.get("documents", [])):
+                meta = all_docs["metadatas"][i] if all_docs.get("metadatas") else {}
+                doc = Document(page_content=doc_content or "", metadata=meta or {})
+                results.append((doc, 0))
 
         # If include_embeddings is enabled, get embeddings for the results
         id_to_embedding = {}

--- a/src/lfx/src/lfx/components/input_output/__init__.py
+++ b/src/lfx/src/lfx/components/input_output/__init__.py
@@ -7,6 +7,7 @@ from lfx.components._importing import import_mod
 if TYPE_CHECKING:
     from lfx.components.input_output.chat import ChatInput
     from lfx.components.input_output.chat_output import ChatOutput
+    from lfx.components.input_output.request_payload import JSONInputComponent
     from lfx.components.input_output.text import TextInputComponent
     from lfx.components.input_output.text_output import TextOutputComponent
     from lfx.components.input_output.webhook import WebhookComponent
@@ -14,12 +15,20 @@ if TYPE_CHECKING:
 _dynamic_imports = {
     "ChatInput": "chat",
     "ChatOutput": "chat_output",
+    "JSONInputComponent": "request_payload",
     "TextInputComponent": "text",
     "TextOutputComponent": "text_output",
     "WebhookComponent": "webhook",
 }
 
-__all__ = ["ChatInput", "ChatOutput", "TextInputComponent", "TextOutputComponent", "WebhookComponent"]
+__all__ = [
+    "ChatInput",
+    "ChatOutput",
+    "JSONInputComponent",
+    "TextInputComponent",
+    "TextOutputComponent",
+    "WebhookComponent",
+]
 
 
 def __getattr__(attr_name: str) -> Any:

--- a/src/lfx/src/lfx/components/input_output/request_payload.py
+++ b/src/lfx/src/lfx/components/input_output/request_payload.py
@@ -1,0 +1,94 @@
+import json
+
+from lfx.base.io.text import TextComponent
+from lfx.io import MultilineInput, Output
+from lfx.schema.data import Data
+from lfx.schema.message import Message
+
+
+class JSONInputComponent(TextComponent):
+    display_name = "JSON Input"
+    description = "Receives and destructures an HTTP request JSON payload."
+    icon = "braces"
+    name = "JSONInput"
+
+    inputs = [
+        MultilineInput(
+            name="payload",
+            display_name="Payload",
+            info="Manual JSON payload for testing (will be overridden by actual HTTP request when used via API)",
+            value=(
+                '{\n  "method": "POST",\n  "headers": {"Content-Type": "application/json"},'
+                '\n  "body": {"name": "test", "value": 123},\n  "query": {"page": "1"},'
+                '\n  "path": {"id": "456"},\n  "url": "/api/test/456"\n}'
+            ),
+            advanced=False,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Method", name="method", method="get_method"),
+        Output(display_name="Headers", name="headers", method="get_headers"),
+        Output(display_name="Body", name="body", method="get_body"),
+        Output(display_name="Query Params", name="query", method="get_query"),
+        Output(display_name="Path Params", name="path", method="get_path"),
+        Output(display_name="URL", name="url", method="get_url"),
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # These will be populated by the API endpoint
+        self.request_data = None
+
+    def set_request_data(self, request_data: dict):
+        """Called by the API endpoint to inject request data."""
+        self.request_data = request_data
+
+    def _get_payload_data(self) -> dict:
+        """Get payload data from either API injection or manual input."""
+        if self.request_data is not None:
+            # Use injected data from API endpoint
+            return self.request_data
+
+        try:
+            # Parse manual payload input for testing
+            payload_text = getattr(self, "payload", "{}")
+            return json.loads(payload_text)
+        except (json.JSONDecodeError, AttributeError):
+            # Fallback to default values
+            return {"method": "GET", "headers": {}, "body": {}, "query": {}, "path": {}, "url": "/"}
+
+    def get_method(self) -> Message:
+        """Returns the HTTP method as a Message."""
+        data = self._get_payload_data()
+        return Message(text=data.get("method", "GET"))
+
+    def get_headers(self) -> Data:
+        """Returns request headers as Data."""
+        data = self._get_payload_data()
+        headers = data.get("headers", {})
+        return Data(data=headers)
+
+    def get_body(self) -> Data:
+        """Returns request body as Data."""
+        data = self._get_payload_data()
+        body = data.get("body", {})
+        return Data(data=body)
+
+    def get_query(self) -> Data:
+        """Returns query parameters as Data."""
+        data = self._get_payload_data()
+        query = data.get("query", {})
+        return Data(data=query)
+
+    def get_path(self) -> Data:
+        """Returns path parameters as Data."""
+        data = self._get_payload_data()
+        path = data.get("path", {})
+        return Data(data=path)
+
+    def get_url(self) -> Message:
+        """Returns the request URL as a Message."""
+        data = self._get_payload_data()
+        url = data.get("url", "/")
+        return Message(text=url)

--- a/src/lfx/src/lfx/components/models_and_agents/mcp_component.py
+++ b/src/lfx/src/lfx/components/models_and_agents/mcp_component.py
@@ -49,6 +49,7 @@ def resolve_mcp_config(
 
 
 class MCPToolsComponent(ComponentWithCache):
+    legacy = True
     schema_inputs: list = []
     tools: list[StructuredTool] = []
     _not_load_actions: bool = False
@@ -95,6 +96,7 @@ class MCPToolsComponent(ComponentWithCache):
     documentation: str = "https://docs.langflow.org/mcp-tools"
     icon = "Mcp"
     name = "MCPTools"
+    tool_mode = True
 
     inputs = [
         McpInput(

--- a/src/lfx/src/lfx/components/processing/__init__.py
+++ b/src/lfx/src/lfx/components/processing/__init__.py
@@ -12,7 +12,9 @@ if TYPE_CHECKING:
     from lfx.components.processing.create_list import CreateListComponent
     from lfx.components.processing.data_operations import DataOperationsComponent
     from lfx.components.processing.dataframe_operations import DataFrameOperationsComponent
+    from lfx.components.processing.dynamic_create_data import DynamicCreateDataComponent
     from lfx.components.processing.json_cleaner import JSONCleaner
+    from lfx.components.processing.operations import Operations
     from lfx.components.processing.output_parser import OutputParserComponent
     from lfx.components.processing.parse_data import ParseDataComponent
     from lfx.components.processing.parser import ParserComponent
@@ -26,7 +28,9 @@ _dynamic_imports = {
     "CreateListComponent": "create_list",
     "DataOperationsComponent": "data_operations",
     "DataFrameOperationsComponent": "dataframe_operations",
+    "DynamicCreateDataComponent": "dynamic_create_data",
     "JSONCleaner": "json_cleaner",
+    "Operations": "operations",
     "OutputParserComponent": "output_parser",
     "ParseDataComponent": "parse_data",
     "ParserComponent": "parser",
@@ -40,8 +44,10 @@ __all__ = [
     "CreateListComponent",
     "DataFrameOperationsComponent",
     "DataOperationsComponent",
+    "DynamicCreateDataComponent",
     "JSONCleaner",
     "MessageStoreComponent",
+    "Operations",
     "OutputParserComponent",
     "ParseDataComponent",
     "ParserComponent",

--- a/src/lfx/src/lfx/components/processing/data_operations.py
+++ b/src/lfx/src/lfx/components/processing/data_operations.py
@@ -41,6 +41,8 @@ class DataOperationsComponent(Component):
     description = "Perform various operations on a Data object."
     icon = "file-json"
     name = "DataOperations"
+    legacy = True
+    replacement = ["processing.Operations"]
     default_keys = ["operations", "data"]
     metadata = {
         "keywords": [

--- a/src/lfx/src/lfx/components/processing/dataframe_operations.py
+++ b/src/lfx/src/lfx/components/processing/dataframe_operations.py
@@ -13,6 +13,8 @@ class DataFrameOperationsComponent(Component):
     documentation: str = "https://docs.langflow.org/dataframe-operations"
     icon = "table"
     name = "DataFrameOperations"
+    legacy = True
+    replacement = ["processing.Operations"]
 
     OPERATION_CHOICES = [
         "Add Column",

--- a/src/lfx/src/lfx/components/processing/dynamic_create_data.py
+++ b/src/lfx/src/lfx/components/processing/dynamic_create_data.py
@@ -3,305 +3,145 @@ from typing import Any
 from lfx.custom import Component
 from lfx.io import (
     BoolInput,
-    FloatInput,
     HandleInput,
     IntInput,
     MultilineInput,
     Output,
-    StrInput,
     TableInput,
 )
 from lfx.schema.data import Data
-from lfx.schema.message import Message
+from lfx.schema.table import EditMode
 
 
 class DynamicCreateDataComponent(Component):
-    display_name: str = "Dynamic Create Data"
-    description: str = "Dynamically create a Data with a specified number of fields."
-    name: str = "DynamicCreateData"
-    MAX_FIELDS = 15  # Define a constant for maximum number of fields
+    display_name: str = "Combine Inputs"
+    description: str = "Define custom inputs and combine them into a single output."
+    name: str = "CombineInputs"
     icon = "ListFilter"
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    metadata = {
+        "previous_names": ["Dynamic Inputs", "DynamicInputs", "Dynamic Create Data", "DynamicCreateData"],
+        "previous_params": ["form_fields", "field_name", "field_type"],
+    }
 
     inputs = [
         TableInput(
-            name="form_fields",
-            display_name="Input Configuration",
-            info=(
-                "Define the dynamic form fields. Each row creates a new input field "
-                "that can connect to other components."
-            ),
+            name="inputs_config",
+            display_name="Inputs",
+            info="Define custom inputs. Each row creates a new input handle.",
             table_schema=[
                 {
-                    "name": "field_name",
-                    "display_name": "Field Name",
+                    "name": "input_name",
+                    "display_name": "Input Name",
                     "type": "str",
-                    "description": "Name for the field (used as both internal name and display label)",
+                    "description": "Name for the input (used as both internal name and display label)",
+                    "edit_mode": EditMode.INLINE,
                 },
                 {
-                    "name": "field_type",
-                    "display_name": "Field Type",
+                    "name": "input_type",
+                    "display_name": "Input Type",
                     "type": "str",
-                    "description": "Type of input field to create",
+                    "description": "Type of input to create",
                     "options": ["Text", "Data", "Number", "Handle", "Boolean"],
-                    "value": "Text",
+                    "default": "Text",
+                    "edit_mode": EditMode.INLINE,
                 },
             ],
             value=[],
             real_time_refresh=True,
         ),
-        BoolInput(
-            name="include_metadata",
-            display_name="Include Metadata",
-            info="Include form configuration metadata in the output.",
-            value=False,
-            advanced=True,
-        ),
     ]
 
     outputs = [
-        Output(display_name="Data", name="form_data", method="process_form"),
-        Output(display_name="Message", name="message", method="get_message"),
+        Output(display_name="Data", name="data_output", method="process_inputs"),
     ]
 
     def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:
         """Update build configuration to add dynamic inputs that can connect to other components."""
-        if field_name == "form_fields":
-            # Clear existing dynamic inputs from build config
-            keys_to_remove = [key for key in build_config if key.startswith("dynamic_")]
-            for key in keys_to_remove:
-                del build_config[key]
+        if field_name != "inputs_config":
+            return build_config
 
-            # Add dynamic inputs based on table configuration
-            # Safety check to ensure field_value is not None and is iterable
-            if field_value is None:
-                field_value = []
+        # Clear existing dynamic inputs from build config
+        keys_to_remove = [key for key in build_config if key.startswith("dynamic_")]
+        for key in keys_to_remove:
+            del build_config[key]
 
-            for i, field_config in enumerate(field_value):
-                # Safety check to ensure field_config is not None
-                if field_config is None:
-                    continue
+        if field_value is None:
+            return build_config
 
-                field_name = field_config.get("field_name", f"field_{i}")
-                display_name = field_name  # Use field_name as display_name
-                field_type_option = field_config.get("field_type", "Text")
-                default_value = ""  # All fields have empty default value
-                required = False  # All fields are optional by default
-                help_text = ""  # All fields have empty help text
+        # Map input type options to input class and accepted types
+        input_type_mapping = {
+            "Text": {"class": MultilineInput, "input_types": ["Text", "Message"]},
+            "Data": {"class": HandleInput, "input_types": ["Data"]},
+            "Number": {"class": IntInput, "input_types": ["Text", "Message"]},
+            "Handle": {"class": HandleInput, "input_types": ["Text", "Data", "Message"]},
+            "Boolean": {"class": BoolInput, "input_types": []},
+        }
 
-                # Map field type options to actual field types and input types
-                field_type_mapping = {
-                    "Text": {"field_type": "multiline", "input_types": ["Text", "Message"]},
-                    "Data": {"field_type": "data", "input_types": ["Data"]},
-                    "Number": {"field_type": "number", "input_types": ["Text", "Message"]},
-                    "Handle": {"field_type": "handle", "input_types": ["Text", "Data", "Message"]},
-                    "Boolean": {"field_type": "boolean", "input_types": None},
-                }
+        for i, input_config in enumerate(field_value):
+            if input_config is None:
+                continue
 
-                field_config_mapped = field_type_mapping.get(
-                    field_type_option, {"field_type": "text", "input_types": []}
-                )
-                if not isinstance(field_config_mapped, dict):
-                    field_config_mapped = {"field_type": "text", "input_types": []}
-                field_type = field_config_mapped["field_type"]
-                input_types_list = field_config_mapped["input_types"]
+            input_name = input_config.get("input_name", f"input_{i}")
+            input_type_option = input_config.get("input_type", "Text")
+            dynamic_input_name = f"dynamic_{input_name}"
 
-                # Create the appropriate input type based on field_type
-                dynamic_input_name = f"dynamic_{field_name}"
+            mapping = input_type_mapping.get(input_type_option, input_type_mapping["Text"])
+            input_class = mapping["class"]
+            input_types = mapping["input_types"]
 
-                if field_type == "text":
-                    if input_types_list:
-                        build_config[dynamic_input_name] = StrInput(
-                            name=dynamic_input_name,
-                            display_name=display_name,
-                            info=f"{help_text} (Can connect to: {', '.join(input_types_list)})",
-                            value=default_value,
-                            required=required,
-                            input_types=input_types_list,
-                        )
-                    else:
-                        build_config[dynamic_input_name] = StrInput(
-                            name=dynamic_input_name,
-                            display_name=display_name,
-                            info=help_text,
-                            value=default_value,
-                            required=required,
-                        )
+            # Build common kwargs
+            kwargs = {
+                "name": dynamic_input_name,
+                "display_name": input_name,
+                "input_types": input_types,
+            }
 
-                elif field_type == "multiline":
-                    if input_types_list:
-                        build_config[dynamic_input_name] = MultilineInput(
-                            name=dynamic_input_name,
-                            display_name=display_name,
-                            info=f"{help_text} (Can connect to: {', '.join(input_types_list)})",
-                            value=default_value,
-                            required=required,
-                            input_types=input_types_list,
-                        )
-                    else:
-                        build_config[dynamic_input_name] = MultilineInput(
-                            name=dynamic_input_name,
-                            display_name=display_name,
-                            info=help_text,
-                            value=default_value,
-                            required=required,
-                        )
+            # Add type-specific defaults
+            if input_class == BoolInput:
+                kwargs["value"] = False
+            elif input_class == MultilineInput:
+                kwargs["value"] = ""
+            elif input_class == IntInput:
+                kwargs["value"] = 0
 
-                elif field_type == "number":
-                    try:
-                        default_int = int(default_value) if default_value else 0
-                    except ValueError:
-                        default_int = 0
-
-                    if input_types_list:
-                        build_config[dynamic_input_name] = IntInput(
-                            name=dynamic_input_name,
-                            display_name=display_name,
-                            info=f"{help_text} (Can connect to: {', '.join(input_types_list)})",
-                            value=default_int,
-                            required=required,
-                            input_types=input_types_list,
-                        )
-                    else:
-                        build_config[dynamic_input_name] = IntInput(
-                            name=dynamic_input_name,
-                            display_name=display_name,
-                            info=help_text,
-                            value=default_int,
-                            required=required,
-                        )
-
-                elif field_type == "float":
-                    try:
-                        default_float = float(default_value) if default_value else 0.0
-                    except ValueError:
-                        default_float = 0.0
-
-                    if input_types_list:
-                        build_config[dynamic_input_name] = FloatInput(
-                            name=dynamic_input_name,
-                            display_name=display_name,
-                            info=f"{help_text} (Can connect to: {', '.join(input_types_list)})",
-                            value=default_float,
-                            required=required,
-                            input_types=input_types_list,
-                        )
-                    else:
-                        build_config[dynamic_input_name] = FloatInput(
-                            name=dynamic_input_name,
-                            display_name=display_name,
-                            info=help_text,
-                            value=default_float,
-                            required=required,
-                        )
-
-                elif field_type == "boolean":
-                    default_bool = default_value.lower() in ["true", "1", "yes"] if default_value else False
-
-                    # Boolean fields don't use input_types parameter to avoid errors
-                    build_config[dynamic_input_name] = BoolInput(
-                        name=dynamic_input_name,
-                        display_name=display_name,
-                        info=help_text,
-                        value=default_bool,
-                        input_types=[],
-                        required=required,
-                    )
-
-                elif field_type == "handle":
-                    # HandleInput for generic data connections
-                    build_config[dynamic_input_name] = HandleInput(
-                        name=dynamic_input_name,
-                        display_name=display_name,
-                        info=f"{help_text} (Accepts: {', '.join(input_types_list) if input_types_list else 'Any'})",
-                        input_types=input_types_list if input_types_list else ["Data", "Text", "Message"],
-                        required=required,
-                    )
-
-                elif field_type == "data":
-                    # Specialized for Data type connections
-                    build_config[dynamic_input_name] = HandleInput(
-                        name=dynamic_input_name,
-                        display_name=display_name,
-                        info=f"{help_text} (Data input)",
-                        input_types=input_types_list if input_types_list else ["Data"],
-                        required=required,
-                    )
-
-                else:
-                    # Default to text input for unknown types
-                    build_config[dynamic_input_name] = StrInput(
-                        name=dynamic_input_name,
-                        display_name=display_name,
-                        info=f"{help_text} (Unknown type '{field_type}', defaulting to text)",
-                        value=default_value,
-                        required=required,
-                    )
+            build_config[dynamic_input_name] = input_class(**kwargs)
 
         return build_config
 
     def get_dynamic_values(self) -> dict[str, Any]:
-        """Extract simple values from all dynamic inputs, handling both manual and connected inputs."""
+        """Extract values from all dynamic inputs."""
         dynamic_values = {}
-        connection_info = {}
-        form_fields = getattr(self, "form_fields", [])
+        inputs_config = getattr(self, "inputs_config", [])
 
-        for field_config in form_fields:
-            # Safety check to ensure field_config is not None
-            if field_config is None:
+        for input_config in inputs_config:
+            if input_config is None:
                 continue
 
-            field_name = field_config.get("field_name", "")
-            if field_name:
-                dynamic_input_name = f"dynamic_{field_name}"
-                value = getattr(self, dynamic_input_name, None)
+            input_name = input_config.get("input_name", "")
+            if not input_name:
+                continue
 
-                # Extract simple values from connections or manual input
-                if value is not None:
-                    try:
-                        extracted_value = self._extract_simple_value(value)
-                        dynamic_values[field_name] = extracted_value
+            dynamic_input_name = f"dynamic_{input_name}"
+            value = getattr(self, dynamic_input_name, None)
 
-                        # Determine connection type for status
-                        if hasattr(value, "text") and hasattr(value, "timestamp"):
-                            connection_info[field_name] = "Connected (Message)"
-                        elif hasattr(value, "data"):
-                            connection_info[field_name] = "Connected (Data)"
-                        elif isinstance(value, (str, int, float, bool, list, dict)):
-                            connection_info[field_name] = "Manual input"
-                        else:
-                            connection_info[field_name] = "Connected (Object)"
+            if value is not None:
+                dynamic_values[input_name] = self._extract_simple_value(value)
+            else:
+                dynamic_values[input_name] = ""
 
-                    except (AttributeError, TypeError, ValueError):
-                        # Fallback to string representation if all else fails
-                        dynamic_values[field_name] = str(value)
-                        connection_info[field_name] = "Error"
-                else:
-                    # Use empty default value if nothing connected
-                    dynamic_values[field_name] = ""
-                    connection_info[field_name] = "Empty default"
-
-        # Store connection info for status output
-        self._connection_info = connection_info
         return dynamic_values
 
     def _extract_simple_value(self, value: Any) -> Any:
         """Extract the simplest, most useful value from any input type."""
-        # Handle None
         if value is None:
             return None
 
-        # Handle simple types directly
         if isinstance(value, (str, int, float, bool)):
             return value
 
-        # Handle lists and tuples - keep simple
         if isinstance(value, (list, tuple)):
             return [self._extract_simple_value(item) for item in value]
 
-        # Handle dictionaries - keep simple
         if isinstance(value, dict):
             return {str(k): self._extract_simple_value(v) for k, v in value.items()}
 
@@ -313,45 +153,10 @@ class DynamicCreateDataComponent(Component):
         if hasattr(value, "data") and value.data is not None:
             return self._extract_simple_value(value.data)
 
-        # For any other object, convert to string
         return str(value)
 
-    def process_form(self) -> Data:
-        """Process all dynamic form inputs and return clean data with just field values."""
-        # Get all dynamic values (just the key:value pairs)
+    def process_inputs(self) -> Data:
+        """Process all dynamic inputs and return combined data."""
         dynamic_values = self.get_dynamic_values()
-
-        # Update status with connection info
-        connected_fields = len([v for v in getattr(self, "_connection_info", {}).values() if "Connected" in v])
-        total_fields = len(dynamic_values)
-
-        self.status = f"Form processed successfully. {connected_fields}/{total_fields} fields connected to components."
-
-        # Return clean Data object with just the field values
+        self.status = f"Combined {len(dynamic_values)} inputs."
         return Data(data=dynamic_values)
-
-    def get_message(self) -> Message:
-        """Return form data as a formatted text message."""
-        # Get all dynamic values
-        dynamic_values = self.get_dynamic_values()
-
-        if not dynamic_values:
-            return Message(text="No form data available")
-
-        # Format as text message
-        message_lines = ["📋 Form Data:"]
-        message_lines.append("=" * 40)
-
-        for field_name, value in dynamic_values.items():
-            # Use field_name as display_name
-            display_name = field_name
-
-            message_lines.append(f"• {display_name}: {value}")
-
-        message_lines.append("=" * 40)
-        message_lines.append(f"Total fields: {len(dynamic_values)}")
-
-        message_text = "\n".join(message_lines)
-        self.status = f"Message formatted with {len(dynamic_values)} fields"
-
-        return Message(text=message_text)

--- a/src/lfx/src/lfx/components/processing/operations.py
+++ b/src/lfx/src/lfx/components/processing/operations.py
@@ -1,0 +1,1357 @@
+import ast
+import contextlib
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+import jq
+import pandas as pd
+from json_repair import repair_json
+
+from lfx.custom import Component
+from lfx.field_typing import RangeSpec
+from lfx.inputs import (
+    BoolInput,
+    DictInput,
+    DropdownInput,
+    HandleInput,
+    IntInput,
+    MessageTextInput,
+    MultilineInput,
+    SortableListInput,
+    StrInput,
+    TabInput,
+)
+from lfx.io import DataFrameInput, DataInput, Output
+from lfx.log.logger import logger
+from lfx.schema import Data
+from lfx.schema.dataframe import DataFrame
+from lfx.schema.message import Message
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# Operation registry: maps operation name to its configuration
+OPERATIONS_BY_TYPE = {
+    "Text": [
+        {"name": "Word Count", "icon": "hash"},
+        {"name": "Case Conversion", "icon": "type"},
+        {"name": "Text Replace", "icon": "replace"},
+        {"name": "Text Extract", "icon": "search"},
+        {"name": "Text Head", "icon": "chevron-left"},
+        {"name": "Text Tail", "icon": "chevron-right"},
+        {"name": "Text Strip", "icon": "minus"},
+        {"name": "Text Join", "icon": "link"},
+        {"name": "Text Clean", "icon": "sparkles"},
+        {"name": "Text to DataFrame", "icon": "table"},
+    ],
+    "Data": [
+        {"name": "Select Keys", "icon": "lasso-select"},
+        {"name": "Literal Eval", "icon": "braces"},
+        {"name": "Combine", "icon": "merge"},
+        {"name": "Filter Values", "icon": "filter"},
+        {"name": "Append or Update", "icon": "circle-plus"},
+        {"name": "Remove Keys", "icon": "eraser"},
+        {"name": "Rename Keys", "icon": "pencil-line"},
+        {"name": "Path Selection", "icon": "mouse-pointer"},
+        {"name": "JQ Expression", "icon": "terminal"},
+    ],
+    "DataFrame": [
+        {"name": "Add Column", "icon": "plus"},
+        {"name": "Drop Column", "icon": "minus"},
+        {"name": "Filter Rows", "icon": "filter"},
+        {"name": "Head Rows", "icon": "arrow-up"},
+        {"name": "Rename Column", "icon": "pencil"},
+        {"name": "Replace Value", "icon": "replace"},
+        {"name": "Select Columns", "icon": "columns"},
+        {"name": "Sort", "icon": "arrow-up-down"},
+        {"name": "Tail Rows", "icon": "arrow-down"},
+        {"name": "Drop Duplicates", "icon": "copy-x"},
+    ],
+}
+
+# Fields required for each operation
+OPERATION_FIELDS = {
+    # Text operations
+    "Word Count": ["text_input", "count_words", "count_characters", "count_lines"],
+    "Case Conversion": ["text_input", "case_type"],
+    "Text Replace": ["text_input", "search_pattern", "replacement_text", "use_regex"],
+    "Text Extract": ["text_input", "extract_pattern", "max_matches"],
+    "Text Head": ["text_input", "head_characters"],
+    "Text Tail": ["text_input", "tail_characters"],
+    "Text Strip": ["text_input", "strip_mode", "strip_characters"],
+    "Text Join": ["text_input", "text_input_2"],
+    "Text Clean": ["text_input", "remove_extra_spaces", "remove_special_chars", "remove_empty_lines"],
+    "Text to DataFrame": ["text_input", "table_separator", "has_header"],
+    # Data operations
+    "Select Keys": ["data_input", "select_keys_input"],
+    "Literal Eval": ["data_input"],
+    "Combine": ["data_input"],
+    "Filter Values": ["data_input", "filter_key", "operator", "filter_values"],
+    "Append or Update": ["data_input", "append_update_data"],
+    "Remove Keys": ["data_input", "remove_keys_input"],
+    "Rename Keys": ["data_input", "rename_keys_input"],
+    "Path Selection": ["data_input", "mapped_json_display", "selected_key"],
+    "JQ Expression": ["data_input", "query"],
+    # DataFrame operations
+    "Add Column": ["df_input", "new_column_name", "new_column_value"],
+    "Drop Column": ["df_input", "column_name"],
+    "Filter Rows": ["df_input", "column_name", "filter_value", "filter_operator"],
+    "Head Rows": ["df_input", "num_rows"],
+    "Rename Column": ["df_input", "column_name", "new_column_name"],
+    "Replace Value": ["df_input", "column_name", "replace_value", "replacement_value"],
+    "Select Columns": ["df_input", "columns_to_select"],
+    "Sort": ["df_input", "column_name", "ascending"],
+    "Tail Rows": ["df_input", "num_rows"],
+    "Drop Duplicates": ["df_input", "column_name"],
+}
+
+# All dynamic fields that can be shown/hidden
+ALL_DYNAMIC_FIELDS = [
+    # Input fields
+    "text_input",
+    "data_input",
+    "df_input",
+    # Text operation fields
+    "table_separator",
+    "has_header",
+    "count_words",
+    "count_characters",
+    "count_lines",
+    "case_type",
+    "search_pattern",
+    "replacement_text",
+    "use_regex",
+    "extract_pattern",
+    "max_matches",
+    "head_characters",
+    "tail_characters",
+    "strip_mode",
+    "strip_characters",
+    "text_input_2",
+    "remove_extra_spaces",
+    "remove_special_chars",
+    "remove_empty_lines",
+    # Data operation fields
+    "select_keys_input",
+    "filter_key",
+    "operator",
+    "filter_values",
+    "append_update_data",
+    "remove_keys_input",
+    "rename_keys_input",
+    "mapped_json_display",
+    "selected_key",
+    "query",
+    # DataFrame operation fields
+    "column_name",
+    "filter_value",
+    "filter_operator",
+    "ascending",
+    "new_column_name",
+    "new_column_value",
+    "columns_to_select",
+    "num_rows",
+    "replace_value",
+    "replacement_value",
+]
+
+# Data operations comparison operators
+DATA_OPERATORS = {
+    "equals": lambda a, b: str(a) == str(b),
+    "not equals": lambda a, b: str(a) != str(b),
+    "contains": lambda a, b: str(b) in str(a),
+    "starts with": lambda a, b: str(a).startswith(str(b)),
+    "ends with": lambda a, b: str(a).endswith(str(b)),
+}
+
+# Case converters for text operations
+CASE_CONVERTERS = {
+    "uppercase": str.upper,
+    "lowercase": str.lower,
+    "title": str.title,
+    "capitalize": str.capitalize,
+    "swapcase": str.swapcase,
+}
+
+
+class Operations(Component):
+    """Unified component for Text, Data, and DataFrame operations."""
+
+    display_name = "Operations"
+    description = "Perform various operations on Text, Data, or DataFrame inputs."
+    icon = "workflow"
+    name = "Operations"
+
+    inputs = [
+        # Input type selection (tabs)
+        TabInput(
+            name="input_type",
+            display_name="Input Type",
+            options=["Text", "Data", "DataFrame"],
+            value="Text",
+            info="Select the type of input to operate on.",
+            real_time_refresh=True,
+        ),
+        # === TEXT INPUT ===
+        HandleInput(
+            name="text_input",
+            display_name="Text Input",
+            info="The input text to process.",
+            input_types=["Message"],
+            show=True,
+        ),
+        # === DATA INPUT ===
+        DataInput(
+            name="data_input",
+            display_name="Data",
+            info="Data object to operate on.",
+            is_list=True,
+            show=False,
+        ),
+        # === DATAFRAME INPUT ===
+        DataFrameInput(
+            name="df_input",
+            display_name="DataFrame",
+            info="The input DataFrame to operate on.",
+            show=False,
+        ),
+        # === TEXT OPERATION FIELDS ===
+        StrInput(
+            name="table_separator",
+            display_name="Table Separator",
+            info="Separator used in the table (default: '|').",
+            value="|",
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="has_header",
+            display_name="Has Header",
+            info="Whether the table has a header row.",
+            value=True,
+            dynamic=True,
+            advanced=True,
+            show=False,
+        ),
+        BoolInput(
+            name="count_words",
+            display_name="Count Words",
+            info="Include word count in analysis.",
+            value=True,
+            dynamic=True,
+            advanced=True,
+            show=False,
+        ),
+        BoolInput(
+            name="count_characters",
+            display_name="Count Characters",
+            info="Include character count in analysis.",
+            value=True,
+            dynamic=True,
+            advanced=True,
+            show=False,
+        ),
+        BoolInput(
+            name="count_lines",
+            display_name="Count Lines",
+            info="Include line count in analysis.",
+            value=True,
+            dynamic=True,
+            advanced=True,
+            show=False,
+        ),
+        DropdownInput(
+            name="case_type",
+            display_name="Case Type",
+            options=["uppercase", "lowercase", "title", "capitalize", "swapcase"],
+            value="lowercase",
+            info="Type of case conversion to apply.",
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="use_regex",
+            display_name="Use Regex",
+            info="Whether to treat search pattern as regex.",
+            value=False,
+            dynamic=True,
+            show=False,
+        ),
+        StrInput(
+            name="search_pattern",
+            display_name="Search Pattern",
+            info="Text pattern to search for (supports regex).",
+            dynamic=True,
+            show=False,
+        ),
+        StrInput(
+            name="replacement_text",
+            display_name="Replacement Text",
+            info="Text to replace the search pattern with.",
+            dynamic=True,
+            show=False,
+        ),
+        StrInput(
+            name="extract_pattern",
+            display_name="Extract Pattern",
+            info="Regex pattern to extract from text.",
+            dynamic=True,
+            show=False,
+        ),
+        IntInput(
+            name="max_matches",
+            display_name="Max Matches",
+            info="Maximum number of matches to extract.",
+            value=10,
+            dynamic=True,
+            show=False,
+        ),
+        IntInput(
+            name="head_characters",
+            display_name="Characters from Start",
+            info="Number of characters to extract from the beginning of text.",
+            value=100,
+            dynamic=True,
+            show=False,
+            range_spec=RangeSpec(min=0, max=1000000, step=1, step_type="int"),
+        ),
+        IntInput(
+            name="tail_characters",
+            display_name="Characters from End",
+            info="Number of characters to extract from the end of text.",
+            value=100,
+            dynamic=True,
+            show=False,
+            range_spec=RangeSpec(min=0, max=1000000, step=1, step_type="int"),
+        ),
+        DropdownInput(
+            name="strip_mode",
+            display_name="Strip Mode",
+            options=["both", "left", "right"],
+            value="both",
+            info="Which sides to strip whitespace from.",
+            dynamic=True,
+            show=False,
+        ),
+        StrInput(
+            name="strip_characters",
+            display_name="Characters to Strip",
+            info="Specific characters to remove (leave empty for whitespace).",
+            value="",
+            dynamic=True,
+            show=False,
+        ),
+        HandleInput(
+            name="text_input_2",
+            display_name="Second Text Input",
+            info="Second text to join with the first text.",
+            input_types=["Message"],
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="remove_extra_spaces",
+            display_name="Remove Extra Spaces",
+            info="Remove multiple consecutive spaces.",
+            value=True,
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="remove_special_chars",
+            display_name="Remove Special Characters",
+            info="Remove special characters except alphanumeric and spaces.",
+            value=False,
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="remove_empty_lines",
+            display_name="Remove Empty Lines",
+            info="Remove empty lines from text.",
+            value=False,
+            dynamic=True,
+            show=False,
+        ),
+        # === DATA OPERATION FIELDS ===
+        MessageTextInput(
+            name="select_keys_input",
+            display_name="Select Keys",
+            info="List of keys to select from the data.",
+            show=False,
+            is_list=True,
+        ),
+        MessageTextInput(
+            name="filter_key",
+            display_name="Filter Key",
+            info="Name of the key containing the list to filter.",
+            is_list=True,
+            show=False,
+        ),
+        DropdownInput(
+            name="operator",
+            display_name="Comparison Operator",
+            options=["equals", "not equals", "contains", "starts with", "ends with"],
+            info="The operator to apply for comparing the values.",
+            value="equals",
+            show=False,
+        ),
+        DictInput(
+            name="filter_values",
+            display_name="Filter Values",
+            info="Key-value pairs to filter by.",
+            show=False,
+            is_list=True,
+        ),
+        DictInput(
+            name="append_update_data",
+            display_name="Append or Update",
+            info="Data to append or update the existing data with.",
+            show=False,
+            value={"key": "value"},
+            is_list=True,
+        ),
+        MessageTextInput(
+            name="remove_keys_input",
+            display_name="Remove Keys",
+            info="List of keys to remove from the data.",
+            show=False,
+            is_list=True,
+        ),
+        DictInput(
+            name="rename_keys_input",
+            display_name="Rename Keys",
+            info="Mapping of old keys to new keys.",
+            show=False,
+            is_list=True,
+            value={"old_key": "new_key"},
+        ),
+        MultilineInput(
+            name="mapped_json_display",
+            display_name="JSON to Map",
+            info="Paste JSON here to explore its structure and select a path.",
+            required=False,
+            refresh_button=True,
+            real_time_refresh=True,
+            placeholder="Add a JSON example.",
+            show=False,
+        ),
+        DropdownInput(
+            name="selected_key",
+            display_name="Select Path",
+            options=[],
+            required=False,
+            dynamic=True,
+            show=False,
+        ),
+        MessageTextInput(
+            name="query",
+            display_name="JQ Expression",
+            info="JQ expression to query the data.",
+            placeholder="e.g., .properties.id",
+            show=False,
+        ),
+        # === DATAFRAME OPERATION FIELDS ===
+        StrInput(
+            name="column_name",
+            display_name="Column Name",
+            info="The column name to use for the operation.",
+            dynamic=True,
+            show=False,
+        ),
+        MessageTextInput(
+            name="filter_value",
+            display_name="Filter Value",
+            info="The value to filter rows by.",
+            dynamic=True,
+            show=False,
+        ),
+        DropdownInput(
+            name="filter_operator",
+            display_name="Filter Operator",
+            options=[
+                "equals",
+                "not equals",
+                "contains",
+                "not contains",
+                "starts with",
+                "ends with",
+                "greater than",
+                "less than",
+            ],
+            value="equals",
+            info="The operator to apply for filtering rows.",
+            dynamic=True,
+            show=False,
+        ),
+        BoolInput(
+            name="ascending",
+            display_name="Sort Ascending",
+            info="Whether to sort in ascending order.",
+            dynamic=True,
+            show=False,
+            value=True,
+        ),
+        StrInput(
+            name="new_column_name",
+            display_name="New Column Name",
+            info="The new column name when renaming or adding a column.",
+            dynamic=True,
+            show=False,
+        ),
+        MessageTextInput(
+            name="new_column_value",
+            display_name="New Column Value",
+            info="The value to populate the new column with.",
+            dynamic=True,
+            show=False,
+        ),
+        StrInput(
+            name="columns_to_select",
+            display_name="Columns to Select",
+            dynamic=True,
+            is_list=True,
+            show=False,
+        ),
+        IntInput(
+            name="num_rows",
+            display_name="Number of Rows",
+            info="Number of rows to return.",
+            dynamic=True,
+            show=False,
+            value=5,
+        ),
+        MessageTextInput(
+            name="replace_value",
+            display_name="Value to Replace",
+            info="The value to replace in the column.",
+            dynamic=True,
+            show=False,
+        ),
+        MessageTextInput(
+            name="replacement_value",
+            display_name="Replacement Value",
+            info="The value to replace with.",
+            dynamic=True,
+            show=False,
+        ),
+        # === OPERATION SELECTION (last) ===
+        SortableListInput(
+            name="operation",
+            display_name="Operation",
+            placeholder="Select Operation",
+            info="Select the operation to perform.",
+            options=OPERATIONS_BY_TYPE["Text"],  # Default to Text operations
+            real_time_refresh=True,
+            limit=1,
+        ),
+    ]
+
+    outputs = []
+
+    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:
+        """Update build configuration based on input type and operation selection."""
+        # Hide all dynamic fields first
+        for field in ALL_DYNAMIC_FIELDS:
+            if field in build_config:
+                build_config[field]["show"] = False
+
+        # Handle input_type change - update operation options
+        if field_name == "input_type":
+            input_type = field_value
+            build_config["operation"]["options"] = OPERATIONS_BY_TYPE.get(input_type, [])
+            build_config["operation"]["value"] = []  # Clear selection when type changes
+
+            # Show the appropriate input field
+            if input_type == "Text":
+                build_config["text_input"]["show"] = True
+            elif input_type == "Data":
+                build_config["data_input"]["show"] = True
+                # Set is_list based on operation (default to False)
+                build_config["data_input"]["is_list"] = False
+            elif input_type == "DataFrame":
+                build_config["df_input"]["show"] = True
+
+            return build_config
+
+        # Handle operation change - show relevant fields
+        if field_name == "operation":
+            operation_name = self._extract_operation_name(field_value)
+            if not operation_name:
+                # Still show the input field based on current input_type
+                input_type = build_config.get("input_type", {}).get("value", "Text")
+                if input_type == "Text":
+                    build_config["text_input"]["show"] = True
+                elif input_type == "Data":
+                    build_config["data_input"]["show"] = True
+                elif input_type == "DataFrame":
+                    build_config["df_input"]["show"] = True
+                return build_config
+
+            # Get fields for this operation
+            fields_to_show = OPERATION_FIELDS.get(operation_name, [])
+            for field in fields_to_show:
+                if field in build_config:
+                    build_config[field]["show"] = True
+
+            # Special handling for Data operations that need is_list=True
+            if operation_name == "Combine":
+                build_config["data_input"]["is_list"] = True
+            elif "data_input" in fields_to_show:
+                build_config["data_input"]["is_list"] = False
+
+            return build_config
+
+        # Handle mapped_json_display change for Path Selection
+        if field_name == "mapped_json_display":
+            try:
+                parsed_json = json.loads(field_value)
+                keys = self._extract_all_paths(parsed_json)
+                build_config["selected_key"]["options"] = keys
+                build_config["selected_key"]["show"] = True
+            except (json.JSONDecodeError, TypeError, ValueError) as e:
+                logger.error(f"Error parsing mapped JSON: {e}")
+                build_config["selected_key"]["show"] = False
+
+        # Preserve current visibility state for fields not being changed
+        if field_name not in ("input_type", "operation"):
+            input_type = build_config.get("input_type", {}).get("value", "Text")
+            operation_value = build_config.get("operation", {}).get("value", [])
+            operation_name = self._extract_operation_name(operation_value)
+
+            # Show input field
+            if input_type == "Text":
+                build_config["text_input"]["show"] = True
+            elif input_type == "Data":
+                build_config["data_input"]["show"] = True
+            elif input_type == "DataFrame":
+                build_config["df_input"]["show"] = True
+
+            # Show operation fields
+            if operation_name:
+                fields_to_show = OPERATION_FIELDS.get(operation_name, [])
+                for field in fields_to_show:
+                    if field in build_config:
+                        build_config[field]["show"] = True
+
+        return build_config
+
+    def update_outputs(self, frontend_node: dict, field_name: str, field_value: Any) -> dict:
+        """Create dynamic outputs based on selected operation."""
+        # Always update outputs when input_type or operation changes
+        # Also update when operation-related fields change (for Path Selection, etc.)
+        if field_name not in ("input_type", "operation", "mapped_json_display", "selected_key"):
+            return frontend_node
+
+        frontend_node["outputs"] = []
+
+        # Get current input type and operation
+        input_type = None
+        operation_name = None
+
+        if field_name == "input_type":
+            input_type = field_value
+            # When input type changes, no operation is selected yet
+            operation_name = None
+        elif field_name == "operation":
+            operation_name = self._extract_operation_name(field_value)
+            # Get input_type from the node template
+            input_type = frontend_node.get("template", {}).get("input_type", {}).get("value", "Text")
+        else:
+            # For other fields (mapped_json_display, selected_key), get current values from template
+            operation_value = frontend_node.get("template", {}).get("operation", {}).get("value", [])
+            operation_name = self._extract_operation_name(operation_value)
+            input_type = frontend_node.get("template", {}).get("input_type", {}).get("value", "Text")
+
+        # If no operation selected, show default output based on input type
+        if not operation_name:
+            if input_type == "Text":
+                frontend_node["outputs"].append(Output(display_name="Message", name="message", method="get_message"))
+            elif input_type == "Data":
+                frontend_node["outputs"].append(Output(display_name="Data", name="data_output", method="get_data"))
+            elif input_type == "DataFrame":
+                frontend_node["outputs"].append(
+                    Output(display_name="DataFrame", name="dataframe", method="get_dataframe")
+                )
+            return frontend_node
+
+        # First, explicitly check for Path Selection to ensure it always gets output
+        if operation_name == "Path Selection":
+            frontend_node["outputs"].append(Output(display_name="Data", name="data_output", method="get_data"))
+            return frontend_node
+
+        # Then check if it's a Data operation by checking OPERATION_FIELDS
+        # This ensures all Data operations get the correct output
+        if operation_name in OPERATION_FIELDS and "data_input" in OPERATION_FIELDS.get(operation_name, []):
+            frontend_node["outputs"].append(Output(display_name="Data", name="data_output", method="get_data"))
+            return frontend_node
+
+        # Text operations outputs
+        if operation_name == "Word Count":
+            frontend_node["outputs"].append(Output(display_name="Data", name="data_output", method="get_data"))
+        elif operation_name == "Text to DataFrame":
+            frontend_node["outputs"].append(Output(display_name="DataFrame", name="dataframe", method="get_dataframe"))
+        elif operation_name == "Text Join":
+            frontend_node["outputs"].append(Output(display_name="Text", name="text", method="get_text"))
+            frontend_node["outputs"].append(Output(display_name="Message", name="message", method="get_message"))
+        elif operation_name in (
+            "Case Conversion",
+            "Text Replace",
+            "Text Extract",
+            "Text Head",
+            "Text Tail",
+            "Text Strip",
+            "Text Clean",
+        ):
+            frontend_node["outputs"].append(Output(display_name="Message", name="message", method="get_message"))
+        # DataFrame operations outputs
+        elif operation_name in OPERATION_FIELDS and "df_input" in OPERATION_FIELDS.get(operation_name, []):
+            frontend_node["outputs"].append(Output(display_name="DataFrame", name="dataframe", method="get_dataframe"))
+        # Final fallback: use input_type to determine output
+        elif not frontend_node["outputs"]:
+            if input_type == "Text":
+                frontend_node["outputs"].append(Output(display_name="Message", name="message", method="get_message"))
+            elif input_type == "Data":
+                frontend_node["outputs"].append(Output(display_name="Data", name="data_output", method="get_data"))
+            elif input_type == "DataFrame":
+                frontend_node["outputs"].append(
+                    Output(display_name="DataFrame", name="dataframe", method="get_dataframe")
+                )
+
+        return frontend_node
+
+    def _extract_operation_name(self, field_value: Any) -> str:
+        """Extract operation name from SortableListInput value."""
+        if isinstance(field_value, list) and len(field_value) > 0:
+            return field_value[0].get("name", "")
+        return ""
+
+    def get_operation_name(self) -> str:
+        """Get the selected operation name."""
+        operation_input = getattr(self, "operation", [])
+        return self._extract_operation_name(operation_input)
+
+    # ==================== OUTPUT METHODS ====================
+
+    def get_message(self) -> Message:
+        """Return result as Message."""
+        result = self._process()
+        return Message(text=self._format_result_as_text(result))
+
+    def get_text(self) -> Message:
+        """Return result as Message (text output)."""
+        result = self._process()
+        return Message(text=self._format_result_as_text(result))
+
+    def get_data(self) -> Data:
+        """Return result as Data object."""
+        result = self._process()
+        if result is None:
+            return Data(data={})
+        if isinstance(result, Data):
+            return result
+        if isinstance(result, dict):
+            return Data(data=result)
+        if isinstance(result, list):
+            return Data(data={"items": result})
+        return Data(data={"result": str(result)})
+
+    def get_dataframe(self) -> DataFrame:
+        """Return result as DataFrame."""
+        result = self._process()
+        if result is None:
+            return DataFrame(pd.DataFrame())
+        if isinstance(result, DataFrame):
+            return result
+        if isinstance(result, pd.DataFrame):
+            return DataFrame(result)
+        return DataFrame(pd.DataFrame())
+
+    def _format_result_as_text(self, result: Any) -> str:
+        """Format result as text string."""
+        if result is None:
+            return ""
+        if isinstance(result, list):
+            return "\n".join(str(item) for item in result)
+        if isinstance(result, dict):
+            return json.dumps(result, indent=2)
+        return str(result)
+
+    def _process(self) -> Any:
+        """Process based on the selected operation."""
+        operation = self.get_operation_name()
+        if not operation:
+            return None
+
+        # Text operations
+        text_handlers = {
+            "Word Count": self._word_count,
+            "Case Conversion": self._case_conversion,
+            "Text Replace": self._text_replace,
+            "Text Extract": self._text_extract,
+            "Text Head": self._text_head,
+            "Text Tail": self._text_tail,
+            "Text Strip": self._text_strip,
+            "Text Join": self._text_join,
+            "Text Clean": self._text_clean,
+            "Text to DataFrame": self._text_to_dataframe,
+        }
+
+        # Data operations
+        data_handlers: dict[str, Callable[[], Data]] = {
+            "Select Keys": self._select_keys,
+            "Literal Eval": self._evaluate_data,
+            "Combine": self._combine_data,
+            "Filter Values": self._multi_filter_data,
+            "Append or Update": self._append_update,
+            "Remove Keys": self._remove_keys,
+            "Rename Keys": self._rename_keys,
+            "Path Selection": self._json_path,
+            "JQ Expression": self._json_query,
+        }
+
+        # DataFrame operations
+        df_handlers = {
+            "Add Column": self._df_add_column,
+            "Drop Column": self._df_drop_column,
+            "Filter Rows": self._df_filter_rows,
+            "Head Rows": self._df_head,
+            "Rename Column": self._df_rename_column,
+            "Replace Value": self._df_replace_value,
+            "Select Columns": self._df_select_columns,
+            "Sort": self._df_sort,
+            "Tail Rows": self._df_tail,
+            "Drop Duplicates": self._df_drop_duplicates,
+        }
+
+        # Try each handler category
+        if operation in text_handlers:
+            return text_handlers[operation]()
+        if operation in data_handlers:
+            return data_handlers[operation]()
+        if operation in df_handlers:
+            return df_handlers[operation]()
+
+        return None
+
+    # ==================== TEXT OPERATIONS ====================
+
+    def _extract_text(self, value: Any) -> str:
+        """Extract text from a value, handling both string and Message types."""
+        if value is None:
+            return ""
+        if hasattr(value, "text"):
+            return str(value.text) if value.text else ""
+        return str(value)
+
+    def _get_text_input(self) -> str:
+        """Get text from text_input."""
+        return self._extract_text(getattr(self, "text_input", ""))
+
+    def _word_count(self) -> dict[str, Any]:
+        """Count words, characters, and lines in text."""
+        text_str = self._get_text_input()
+        is_empty = not text_str or not text_str.strip()
+        result: dict[str, Any] = {}
+
+        if getattr(self, "count_words", True):
+            if is_empty:
+                result["word_count"] = 0
+                result["unique_words"] = 0
+            else:
+                words = text_str.split()
+                result["word_count"] = len(words)
+                result["unique_words"] = len(set(words))
+
+        if getattr(self, "count_characters", True):
+            if is_empty:
+                result["character_count"] = 0
+                result["character_count_no_spaces"] = 0
+            else:
+                result["character_count"] = len(text_str)
+                result["character_count_no_spaces"] = len(text_str.replace(" ", ""))
+
+        if getattr(self, "count_lines", True):
+            if is_empty:
+                result["line_count"] = 0
+                result["non_empty_lines"] = 0
+            else:
+                lines = text_str.split("\n")
+                result["line_count"] = len(lines)
+                result["non_empty_lines"] = len([line for line in lines if line.strip()])
+
+        return result
+
+    def _case_conversion(self) -> str:
+        """Convert text case."""
+        text = self._get_text_input()
+        case_type = getattr(self, "case_type", "lowercase")
+        converter = CASE_CONVERTERS.get(case_type)
+        return converter(text) if converter else text
+
+    def _text_replace(self) -> str:
+        """Replace text patterns."""
+        text = self._get_text_input()
+        search_pattern = getattr(self, "search_pattern", "")
+        if not search_pattern:
+            return text
+
+        replacement_text = getattr(self, "replacement_text", "")
+        use_regex = getattr(self, "use_regex", False)
+
+        if use_regex:
+            try:
+                return re.sub(search_pattern, replacement_text, text)
+            except re.error as e:
+                self.log(f"Invalid regex pattern: {e}")
+                return text
+
+        return text.replace(search_pattern, replacement_text)
+
+    def _text_extract(self) -> list[str]:
+        """Extract text matching patterns."""
+        text = self._get_text_input()
+        extract_pattern = getattr(self, "extract_pattern", "")
+        if not extract_pattern:
+            return []
+
+        max_matches = getattr(self, "max_matches", 10)
+
+        try:
+            matches = re.findall(extract_pattern, text)
+        except re.error as e:
+            msg = f"Invalid regex pattern '{extract_pattern}': {e}"
+            raise ValueError(msg) from e
+
+        return matches[:max_matches] if max_matches > 0 else matches
+
+    def _text_head(self) -> str:
+        """Extract characters from the beginning of text."""
+        text = self._get_text_input()
+        head_characters = getattr(self, "head_characters", 100)
+        if head_characters < 0:
+            msg = f"Characters from Start must be non-negative, got {head_characters}"
+            raise ValueError(msg)
+        return text[:head_characters] if head_characters > 0 else ""
+
+    def _text_tail(self) -> str:
+        """Extract characters from the end of text."""
+        text = self._get_text_input()
+        tail_characters = getattr(self, "tail_characters", 100)
+        if tail_characters < 0:
+            msg = f"Characters from End must be non-negative, got {tail_characters}"
+            raise ValueError(msg)
+        return text[-tail_characters:] if tail_characters > 0 else ""
+
+    def _text_strip(self) -> str:
+        """Remove whitespace or specific characters from text edges."""
+        text = self._get_text_input()
+        strip_mode = getattr(self, "strip_mode", "both")
+        strip_characters = getattr(self, "strip_characters", "")
+        chars_to_strip = strip_characters if strip_characters else None
+
+        if strip_mode == "left":
+            return text.lstrip(chars_to_strip)
+        if strip_mode == "right":
+            return text.rstrip(chars_to_strip)
+        return text.strip(chars_to_strip)
+
+    def _text_join(self) -> str:
+        """Join two texts with line break separator."""
+        text1 = self._get_text_input()
+        text2 = self._extract_text(getattr(self, "text_input_2", ""))
+
+        if text1 and text2:
+            return f"{text1}\n{text2}"
+        return text1 or text2
+
+    def _text_clean(self) -> str:
+        """Clean text by removing extra spaces, special chars, etc."""
+        text = self._get_text_input()
+        result = text
+
+        if getattr(self, "remove_extra_spaces", True):
+            result = re.sub(r"\s+", " ", result)
+
+        if getattr(self, "remove_special_chars", False):
+            result = re.sub(r"[^\w\s]", "", result)
+
+        if getattr(self, "remove_empty_lines", False):
+            lines = [line for line in result.split("\n") if line.strip()]
+            result = "\n".join(lines)
+
+        return result
+
+    def _text_to_dataframe(self) -> DataFrame:
+        """Convert markdown-style table text to DataFrame."""
+        text = self._get_text_input()
+        lines = [line.strip() for line in text.strip().split("\n") if line.strip()]
+        if not lines:
+            return DataFrame(pd.DataFrame())
+
+        separator = getattr(self, "table_separator", "|")
+        has_header = getattr(self, "has_header", True)
+
+        rows = []
+        for line in lines:
+            cleaned_line = line.strip(separator)
+            cells = [cell.strip() for cell in cleaned_line.split(separator)]
+            rows.append(cells)
+
+        if not rows:
+            return DataFrame(pd.DataFrame())
+
+        if has_header and len(rows) > 1:
+            header = rows[0]
+            data_rows = rows[1:]
+            df = pd.DataFrame(data_rows, columns=header)
+        else:
+            max_cols = max(len(row) for row in rows) if rows else 0
+            columns = [f"col_{i}" for i in range(max_cols)]
+            df = pd.DataFrame(rows, columns=columns)
+
+        # Convert numeric columns
+        for col in df.columns:
+            with contextlib.suppress(ValueError, TypeError):
+                df[col] = pd.to_numeric(df[col])
+
+        self.log(f"Converted text to DataFrame: {len(df)} rows, {len(df.columns)} columns")
+        return DataFrame(df)
+
+    # ==================== DATA OPERATIONS ====================
+
+    def _get_data_dict(self) -> dict:
+        """Extract data dictionary from Data object."""
+        data = self.data_input
+        if isinstance(data, list) and len(data) == 1:
+            data = data[0]
+        return data.model_dump() if hasattr(data, "model_dump") else {}
+
+    def _get_normalized_data(self) -> dict:
+        """Get normalized data dictionary, handling the 'data' key if present."""
+        data_dict = self._get_data_dict()
+        return data_dict.get("data", data_dict)
+
+    def _data_is_list(self) -> bool:
+        """Check if data contains multiple items."""
+        data = getattr(self, "data_input", None)
+        return isinstance(data, list) and len(data) > 1
+
+    def _validate_single_data(self, operation: str) -> None:
+        """Validate that the operation is being performed on a single data object."""
+        if self._data_is_list():
+            msg = f"{operation} operation is not supported for multiple data objects."
+            raise ValueError(msg)
+
+    def _select_keys(self) -> Data:
+        """Select specific keys from the data dictionary."""
+        self._validate_single_data("Select Keys")
+        data_dict = self._get_normalized_data()
+        filter_criteria: list[str] = getattr(self, "select_keys_input", [])
+
+        if len(filter_criteria) == 1 and filter_criteria[0] == "data":
+            filtered = data_dict["data"]
+        else:
+            if not all(key in data_dict for key in filter_criteria):
+                msg = f"Select key not found in data. Available keys: {list(data_dict.keys())}"
+                raise ValueError(msg)
+            filtered = {key: value for key, value in data_dict.items() if key in filter_criteria}
+
+        return Data(data=filtered)
+
+    def _evaluate_data(self) -> Data:
+        """Evaluate string values in the data dictionary."""
+        self._validate_single_data("Literal Eval")
+        return Data(**self._recursive_eval(self._get_data_dict()))
+
+    def _recursive_eval(self, data: Any) -> Any:
+        """Recursively evaluate string values."""
+        if isinstance(data, dict):
+            return {k: self._recursive_eval(v) for k, v in data.items()}
+        if isinstance(data, list):
+            return [self._recursive_eval(item) for item in data]
+        if isinstance(data, str):
+            try:
+                if (
+                    data.strip().startswith(("{", "[", "(", "'", '"'))
+                    or data.strip().lower() in ("true", "false", "none")
+                    or data.strip().replace(".", "").isdigit()
+                ):
+                    return ast.literal_eval(data)
+            except (ValueError, SyntaxError, TypeError, MemoryError):
+                return data
+            else:
+                return data
+        return data
+
+    def _combine_data(self) -> Data:
+        """Combine multiple data objects into one."""
+        data = getattr(self, "data_input", [])
+        if not self._data_is_list():
+            return data[0] if data else Data(data={})
+
+        data_dicts = [d.model_dump().get("data", d.model_dump()) for d in data]
+        combined_data = {}
+
+        for data_dict in data_dicts:
+            for key, value in data_dict.items():
+                if key not in combined_data:
+                    combined_data[key] = value
+                elif isinstance(combined_data[key], list):
+                    if isinstance(value, list):
+                        combined_data[key].extend(value)
+                    else:
+                        combined_data[key].append(value)
+                else:
+                    combined_data[key] = (
+                        [combined_data[key], value] if not isinstance(value, list) else [combined_data[key], *value]
+                    )
+
+        return Data(**combined_data)
+
+    def _multi_filter_data(self) -> Data:
+        """Apply multiple filters to the data."""
+        self._validate_single_data("Filter Values")
+        data_filtered = self._get_normalized_data()
+        filter_key_list = getattr(self, "filter_key", [])
+        filter_values_dict = getattr(self, "filter_values", {})
+        operator = getattr(self, "operator", "equals")
+
+        for filter_key in filter_key_list:
+            if filter_key not in data_filtered:
+                msg = f"Filter key '{filter_key}' not found in data. Available keys: {list(data_filtered.keys())}"
+                raise ValueError(msg)
+
+            if isinstance(data_filtered[filter_key], list):
+                for filter_data_key, filter_value in filter_values_dict.items():
+                    if filter_value is not None:
+                        filtered_list = []
+                        for item in data_filtered[filter_key]:
+                            if isinstance(item, dict) and filter_data_key in item:
+                                comparison_func = DATA_OPERATORS.get(operator)
+                                if comparison_func and comparison_func(item[filter_data_key], filter_value):
+                                    filtered_list.append(item)
+                        data_filtered[filter_key] = filtered_list
+            else:
+                msg = f"Filter key '{filter_key}' is not a list."
+                raise TypeError(msg)
+
+        return Data(**data_filtered)
+
+    def _append_update(self) -> Data:
+        """Append or Update with new key-value pairs."""
+        self._validate_single_data("Append or Update")
+        data_filtered = self._get_normalized_data()
+        append_data = getattr(self, "append_update_data", {})
+
+        for key, value in append_data.items():
+            data_filtered[key] = value
+
+        return Data(**data_filtered)
+
+    def _remove_keys(self) -> Data:
+        """Remove specified keys from the data dictionary, recursively."""
+        self._validate_single_data("Remove Keys")
+        data_dict = self._get_normalized_data()
+        remove_keys = set(getattr(self, "remove_keys_input", []))
+
+        def remove_recursive(obj: Any) -> Any:
+            if isinstance(obj, dict):
+                return {k: remove_recursive(v) for k, v in obj.items() if k not in remove_keys}
+            if isinstance(obj, list):
+                return [remove_recursive(item) for item in obj]
+            return obj
+
+        return Data(data=remove_recursive(data_dict))
+
+    def _rename_keys(self) -> Data:
+        """Rename keys in the data dictionary, recursively."""
+        self._validate_single_data("Rename Keys")
+        data_dict = self._get_normalized_data()
+        rename_map = getattr(self, "rename_keys_input", {})
+
+        def rename_recursive(obj: Any) -> Any:
+            if isinstance(obj, dict):
+                return {rename_map.get(k, k): rename_recursive(v) for k, v in obj.items()}
+            if isinstance(obj, list):
+                return [rename_recursive(item) for item in obj]
+            return obj
+
+        return Data(data=rename_recursive(data_dict))
+
+    def _json_path(self) -> Data:
+        """Select data by JSON path."""
+        try:
+            data = getattr(self, "data_input", None)
+            selected_key = getattr(self, "selected_key", None)
+            if not data or not selected_key:
+                msg = "Missing input data or selected key."
+                raise ValueError(msg)
+            input_payload = data[0].data if isinstance(data, list) else data.data
+            compiled = jq.compile(selected_key)
+            result = compiled.input(input_payload).first()
+            if isinstance(result, dict):
+                return Data(data=result)
+            return Data(data={"result": result})
+        except (ValueError, TypeError, KeyError) as e:
+            self.status = f"Error: {e!s}"
+            self.log(self.status)
+            return Data(data={"error": str(e)})
+
+    def _json_query(self) -> Data:
+        """Query data using JQ expression."""
+        query = getattr(self, "query", "")
+        if not query or not query.strip():
+            msg = "JQ Expression is required and cannot be blank."
+            raise ValueError(msg)
+
+        raw_data = self._get_data_dict()
+        try:
+            input_str = json.dumps(raw_data)
+            repaired = repair_json(input_str)
+            data_json = json.loads(repaired)
+            jq_input = data_json["data"] if isinstance(data_json, dict) and "data" in data_json else data_json
+            results = jq.compile(query).input(jq_input).all()
+            if not results:
+                msg = "No result from JQ query."
+                raise ValueError(msg)
+            result = results[0] if len(results) == 1 else results
+            if result is None or result == "None":
+                msg = "JQ query returned null/None. Check if the path exists in your data."
+                raise ValueError(msg)
+            if isinstance(result, dict):
+                return Data(data=result)
+            return Data(data={"result": result})
+        except (ValueError, TypeError, KeyError, json.JSONDecodeError) as e:
+            logger.error(f"JQ Query failed: {e}")
+            msg = f"JQ Query error: {e}"
+            raise ValueError(msg) from e
+
+    @staticmethod
+    def _extract_all_paths(obj: Any, path: str = "") -> list[str]:
+        """Extract all JSON paths from an object."""
+        paths = []
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                new_path = f"{path}.{k}" if path else f".{k}"
+                paths.append(new_path)
+                paths.extend(Operations._extract_all_paths(v, new_path))
+        elif isinstance(obj, list) and obj:
+            new_path = f"{path}[0]"
+            paths.append(new_path)
+            paths.extend(Operations._extract_all_paths(obj[0], new_path))
+        return paths
+
+    # ==================== DATAFRAME OPERATIONS ====================
+
+    def _get_df(self) -> pd.DataFrame:
+        """Get the input DataFrame."""
+        df = getattr(self, "df_input", None)
+        if df is None:
+            return pd.DataFrame()
+        if isinstance(df, DataFrame):
+            return df.copy()
+        if isinstance(df, pd.DataFrame):
+            return df.copy()
+        return pd.DataFrame()
+
+    def _df_add_column(self) -> DataFrame:
+        """Add a new column to the DataFrame."""
+        df = self._get_df()
+        new_column_name = getattr(self, "new_column_name", "")
+        new_column_value = getattr(self, "new_column_value", "")
+        df[new_column_name] = [new_column_value] * len(df)
+        return DataFrame(df)
+
+    def _df_drop_column(self) -> DataFrame:
+        """Drop a column from the DataFrame."""
+        df = self._get_df()
+        column_name = getattr(self, "column_name", "")
+        return DataFrame(df.drop(columns=[column_name]))
+
+    def _df_filter_rows(self) -> DataFrame:
+        """Filter rows by value."""
+        df = self._get_df()
+        column_name = getattr(self, "column_name", "")
+        filter_value = getattr(self, "filter_value", "")
+        operator = getattr(self, "filter_operator", "equals")
+
+        column = df[column_name]
+
+        if operator == "equals":
+            mask = column == filter_value
+        elif operator == "not equals":
+            mask = column != filter_value
+        elif operator == "contains":
+            mask = column.astype(str).str.contains(str(filter_value), na=False)
+        elif operator == "not contains":
+            mask = ~column.astype(str).str.contains(str(filter_value), na=False)
+        elif operator == "starts with":
+            mask = column.astype(str).str.startswith(str(filter_value), na=False)
+        elif operator == "ends with":
+            mask = column.astype(str).str.endswith(str(filter_value), na=False)
+        elif operator == "greater than":
+            try:
+                numeric_value = pd.to_numeric(filter_value)
+                mask = column > numeric_value
+            except (ValueError, TypeError):
+                mask = column.astype(str) > str(filter_value)
+        elif operator == "less than":
+            try:
+                numeric_value = pd.to_numeric(filter_value)
+                mask = column < numeric_value
+            except (ValueError, TypeError):
+                mask = column.astype(str) < str(filter_value)
+        else:
+            mask = column == filter_value
+
+        return DataFrame(df[mask])
+
+    def _df_head(self) -> DataFrame:
+        """Get the first N rows."""
+        df = self._get_df()
+        num_rows = getattr(self, "num_rows", 5)
+        return DataFrame(df.head(num_rows))
+
+    def _df_tail(self) -> DataFrame:
+        """Get the last N rows."""
+        df = self._get_df()
+        num_rows = getattr(self, "num_rows", 5)
+        return DataFrame(df.tail(num_rows))
+
+    def _df_rename_column(self) -> DataFrame:
+        """Rename a column."""
+        df = self._get_df()
+        column_name = getattr(self, "column_name", "")
+        new_column_name = getattr(self, "new_column_name", "")
+        return DataFrame(df.rename(columns={column_name: new_column_name}))
+
+    def _df_replace_value(self) -> DataFrame:
+        """Replace values in a column."""
+        df = self._get_df()
+        column_name = getattr(self, "column_name", "")
+        replace_value = getattr(self, "replace_value", "")
+        replacement_value = getattr(self, "replacement_value", "")
+        df[column_name] = df[column_name].replace(replace_value, replacement_value)
+        return DataFrame(df)
+
+    def _df_select_columns(self) -> DataFrame:
+        """Select specific columns."""
+        df = self._get_df()
+        columns = [col.strip() for col in getattr(self, "columns_to_select", [])]
+        return DataFrame(df[columns])
+
+    def _df_sort(self) -> DataFrame:
+        """Sort by column."""
+        df = self._get_df()
+        column_name = getattr(self, "column_name", "")
+        ascending = getattr(self, "ascending", True)
+        return DataFrame(df.sort_values(by=column_name, ascending=ascending))
+
+    def _df_drop_duplicates(self) -> DataFrame:
+        """Drop duplicate rows based on a column."""
+        df = self._get_df()
+        column_name = getattr(self, "column_name", "")
+        return DataFrame(df.drop_duplicates(subset=column_name))

--- a/src/lfx/src/lfx/components/processing/text_operations.py
+++ b/src/lfx/src/lfx/components/processing/text_operations.py
@@ -25,6 +25,8 @@ class TextOperations(Component):
     description = "Perform various text processing operations including text-to-DataFrame conversion."
     icon = "type"
     name = "TextOperations"
+    legacy = True
+    replacement = ["processing.Operations"]
 
     # Configuration for operation-specific input fields
     OPERATION_FIELDS: dict[str, list[str]] = {

--- a/src/lfx/src/lfx/components/utilities/calculator_core.py
+++ b/src/lfx/src/lfx/components/utilities/calculator_core.py
@@ -13,6 +13,7 @@ class CalculatorComponent(Component):
     description = "Perform basic arithmetic operations on a given expression."
     documentation: str = "https://docs.langflow.org/calculator"
     icon = "calculator"
+    tool_mode = True
 
     # Cache operators dictionary as a class variable
     OPERATORS: dict[type[ast.operator], Callable] = {

--- a/src/lfx/src/lfx/components/utilities/current_date.py
+++ b/src/lfx/src/lfx/components/utilities/current_date.py
@@ -13,6 +13,7 @@ class CurrentDateComponent(Component):
     documentation: str = "https://docs.langflow.org/current-date"
     icon = "clock"
     name = "CurrentDate"
+    tool_mode = True
 
     inputs = [
         DropdownInput(

--- a/src/lfx/src/lfx/components/utilities/id_generator.py
+++ b/src/lfx/src/lfx/components/utilities/id_generator.py
@@ -15,6 +15,7 @@ class IDGeneratorComponent(Component):
     icon = "fingerprint"
     name = "IDGenerator"
     legacy = True
+    tool_mode = True
 
     inputs = [
         MessageTextInput(

--- a/src/lfx/src/lfx/components/utilities/python_repl_core.py
+++ b/src/lfx/src/lfx/components/utilities/python_repl_core.py
@@ -12,6 +12,7 @@ class PythonREPLComponent(Component):
     description = "Run Python code with optional imports. Use print() to see the output."
     documentation: str = "https://docs.langflow.org/python-interpreter"
     icon = "square-terminal"
+    tool_mode = True
 
     inputs = [
         StrInput(


### PR DESCRIPTION
## Summary

- **Unified Operations component**: New `Operations` component (tab-based: Text/Data/DataFrame) replacing `DataOperations`, `DataFrameOperations`, and `TextOperations` with ~29 operations (word count, case conversion, select keys, JQ, add column, filter rows, etc.)
- **Legacy markers**: `DataOperations`, `DataFrameOperations`, `TextOperations` marked `legacy=True` with replacement pointing to `Operations`
- **DynamicCreateData → Combine Inputs**: Renamed, simplified table schema, collapsed verbose per-type input creation into mapping-based approach
- **JSONInputComponent**: New component that destructures HTTP request JSON payloads into 6 separate outputs (Method, Headers, Body, Query Params, Path Params, URL)
- **tool_mode=True by default**: Enabled on `Calculator`, `CurrentDate`, `IDGenerator`, `PythonREPL`, `MCPTools`, `MCP SSE`, and `MCP stdio` so they appear with Toolset toggle already on when added to flows
- **WebSearch**: Added `include_content` toggle (default True) making full page content fetch optional
- **KnowledgeIngestion**: Replaced global variable cache with function-attribute cache; added batch processing (batch size 5000) for `chroma.add_documents()` to work around Chroma's ~5461 doc limit
- **Retrieval**: Added Similarity vs Exact Match tab, `search_metadata` BoolInput for metadata substring matching, `get_kb_info` output with collection statistics

## Test plan

- [ ] Verify `Operations` component renders with Text/Data/DataFrame tabs and operations work correctly
- [ ] Confirm legacy components (`DataOperations`, `DataFrameOperations`, `TextOperations`) still load but show legacy indicator
- [ ] Verify `Combine Inputs` (formerly Dynamic Create Data) works with simplified schema
- [ ] Test `JSONInputComponent` with an HTTP request payload
- [ ] Confirm `Calculator`, `CurrentDate`, `IDGenerator`, `PythonREPL`, and MCP components appear with tool_mode enabled by default
- [ ] Test `WebSearch` with `include_content` toggled off — should return results without fetching page content
- [ ] Test `KnowledgeIngestion` with a large document set (>5000 chunks) to verify batch processing
- [ ] Test `Retrieval` with Exact Match mode and metadata search

🤖 Generated with [Claude Code](https://claude.com/claude-code)