### PR TITLE
 fix: correctly pass headers in mcp stdio connections

### DIFF
--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -410,7 +410,7 @@ class TestUpdateToolsStdioHeaders:
         full_command = mock_stdio.connect_to_server.call_args[0][0]
 
         # The injected --headers should appear before the existing --headers
-        assert "--headers authorization Bearer token123 --headers x-api-key sk-existing" in full_command
+        assert "--headers authorization 'Bearer token123' --headers x-api-key sk-existing" in full_command
         # URL should still be at the end
         assert full_command.endswith("http://localhost:7860/api/v1/mcp/project/test/streamable")
 
@@ -503,7 +503,7 @@ class TestUpdateToolsStdioHeaders:
         await update_tools("test-server", server_config, mcp_stdio_client=mock_stdio)
 
         full_command = mock_stdio.connect_to_server.call_args[0][0]
-        assert full_command == "some-tool --verbose --debug --headers authorization Bearer tok"
+        assert full_command == "some-tool --verbose --debug --headers authorization 'Bearer tok'"
 
     @pytest.mark.asyncio
     async def test_stdio_does_not_mutate_original_config(self):

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -5,7 +5,9 @@ import json
 import os
 import platform
 import re
+import shlex
 import shutil
+import subprocess
 import unicodedata
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -1056,7 +1058,7 @@ class MCPStdioClient:
         """Connect to MCP server using stdio transport (SDK style)."""
         from mcp import StdioServerParameters
 
-        command = command_str.split(" ")
+        command = shlex.split(command_str)
         env_data: dict[str, str] = {"DEBUG": "true", "PATH": os.environ["PATH"], **(env or {})}
 
         if platform.system() == "Windows":
@@ -1064,7 +1066,7 @@ class MCPStdioClient:
                 command="cmd",
                 args=[
                     "/c",
-                    f"{command[0]} {' '.join(command[1:])} || echo Command failed with exit code %errorlevel% 1>&2",
+                    f"{subprocess.list2cmdline(command)} || echo Command failed with exit code %errorlevel% 1>&2",
                 ],
                 env=env_data,
             )
@@ -1607,7 +1609,7 @@ async def update_tools(
                 args = args[:-1] + extra_args + [args[-1]]
             else:
                 args.extend(extra_args)
-        full_command = " ".join([command, *args])
+        full_command = shlex.join([command, *args])
         tools = await mcp_stdio_client.connect_to_server(full_command, env)
         client = mcp_stdio_client
     elif mode in ["Streamable_HTTP", "SSE"]:


### PR DESCRIPTION
Correctly passes all custom headers to MCP stdio connections.

Example request in logs:

```
[I 2026-02-11 15:11:10,772.772 mcp_proxy.httpx_client] Request Headers: {'host': 'localhost:7860', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'python-httpx/0.28.1', 'header1': 'value1', 'header2': 'value', 'x-api-key': '***MASKED***', 'accept': 'application/json, text/event-stream', 'content-type': 'application/json', 'mcp-protocol-version': '2025-11-25', 'content-length': '46'}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added input validation component with LLM-based guardrails for detecting harmful content.
  * Introduced SSO configuration support with configurable providers.
  * Enhanced prompt editor with double-bracket (mustache) syntax support and unique variable naming.
  * Added file removal capability to upload inputs.

* **Improvements**
  * Centralized authentication service for streamlined credential handling.
  * Enhanced session renaming with message detection.
  * Improved MCP server configuration with header injection support.
  * Better connected input detection in the inspection panel.

* **Tests**
  * Added comprehensive authentication service test coverage.
  * Introduced guardrails component validation tests.
  * Expanded frontend E2E test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->