### PR TITLE
feat: add allowlist and blocklist filtering for component categories

### DIFF
--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -261,19 +261,86 @@ async def _send_telemetry(
         await logger.adebug(f"Failed to send component index telemetry: {e}")
 
 
+def _is_category_excluded(
+    category_lower: str,
+    category_allowlist: frozenset[str] | None,
+    category_blocklist: frozenset[str] | None,
+) -> bool:
+    """Check if a category should be excluded based on allowlist/blocklist."""
+    if category_allowlist is not None and category_lower not in category_allowlist:
+        return True
+    return category_blocklist is not None and category_lower in category_blocklist
+
+
+def _all_category_names(entries: list[list]) -> frozenset[str]:
+    """Extract all valid category names (lowercased) from index entries."""
+    return frozenset(
+        entry[0].lower()
+        for entry in entries
+        if isinstance(entry, (list, tuple)) and len(entry) == 2 and isinstance(entry[0], str)  # noqa: PLR2004
+    )
+
+
+def _get_all_known_categories(settings_service: Optional["SettingsService"] = None) -> frozenset[str]:
+    """Get all category names from the built-in index (for validation only).
+
+    This reads the index to extract category names without applying any filters.
+    Used at startup to validate allowlist/blocklist entries against known categories.
+    """
+    custom_path = None
+    if settings_service and settings_service.settings.components_index_path:
+        custom_path = settings_service.settings.components_index_path
+    index = _read_component_index(custom_path)
+    if index and "entries" in index:
+        return _all_category_names(index["entries"])
+    return frozenset()
+
+
+def _entries_to_dict(
+    entries: list[list],
+    category_allowlist: frozenset[str] | None = None,
+    category_blocklist: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    """Convert index entries to a modules dict, applying optional allowlist/blocklist filtering.
+
+    Args:
+        entries: List of [category_name, components_dict] pairs from the index.
+        category_allowlist: If set, only include categories whose lowercase name is in this set.
+        category_blocklist: If set, exclude categories whose lowercase name is in this set.
+
+    Returns:
+        Dictionary mapping category names to their components.
+    """
+    modules_dict: dict[str, Any] = {}
+    for entry in entries:
+        if not isinstance(entry, (list, tuple)) or len(entry) != 2:  # noqa: PLR2004
+            continue
+        top_level, components = entry
+        if not isinstance(top_level, str) or not isinstance(components, dict):
+            continue
+        if _is_category_excluded(top_level.lower(), category_allowlist, category_blocklist):
+            continue
+        if top_level not in modules_dict:
+            modules_dict[top_level] = {}
+        modules_dict[top_level].update(components)
+    return filter_disabled_components_from_dict(modules_dict)
+
+
 async def _load_from_index_or_cache(
     settings_service: Optional["SettingsService"] = None,
+    category_allowlist: frozenset[str] | None = None,
+    category_blocklist: frozenset[str] | None = None,
 ) -> tuple[dict[str, Any], str | None]:
     """Load components from prebuilt index or cache.
 
     Args:
         settings_service: Optional settings service to get custom index path
+        category_allowlist: If set, only include categories whose lowercase name is in this set.
+        category_blocklist: If set, exclude categories whose lowercase name is in this set.
 
     Returns:
         Tuple of (modules_dict, index_source) where index_source is "builtin", "cache", or None if failed
     """
-    modules_dict: dict[str, Any] = {}
-
     # Try to load from prebuilt index first
     custom_index_path = None
     if settings_service and settings_service.settings.components_index_path:
@@ -284,13 +351,7 @@ async def _load_from_index_or_cache(
     if index and "entries" in index:
         source = custom_index_path or "built-in index"
         await logger.adebug(f"Loading components from {source}")
-        # Reconstruct modules_dict from index entries
-        for top_level, components in index["entries"]:
-            if top_level not in modules_dict:
-                modules_dict[top_level] = {}
-            modules_dict[top_level].update(components)
-        # Filter disabled components for Astra cloud
-        modules_dict = filter_disabled_components_from_dict(modules_dict)
+        modules_dict = _entries_to_dict(index["entries"], category_allowlist, category_blocklist)
         await logger.adebug(f"Loaded {len(modules_dict)} component categories from index")
         return modules_dict, "builtin"
 
@@ -306,25 +367,24 @@ async def _load_from_index_or_cache(
             index = _read_component_index(str(cache_path))
             if index and "entries" in index:
                 await logger.adebug("Loading components from cached index")
-                for top_level, components in index["entries"]:
-                    if top_level not in modules_dict:
-                        modules_dict[top_level] = {}
-                    modules_dict[top_level].update(components)
-                # Filter disabled components for Astra cloud
-                modules_dict = filter_disabled_components_from_dict(modules_dict)
+                modules_dict = _entries_to_dict(index["entries"], category_allowlist, category_blocklist)
                 await logger.adebug(f"Loaded {len(modules_dict)} component categories from cache")
                 return modules_dict, "cache"
 
-    return modules_dict, None
+    return {}, None
 
 
 async def _load_components_dynamically(
     target_modules: list[str] | None = None,
+    category_allowlist: frozenset[str] | None = None,
+    category_blocklist: frozenset[str] | None = None,
 ) -> dict[str, Any]:
     """Load components dynamically by scanning and importing modules.
 
     Args:
         target_modules: Optional list of specific module names to load (e.g., ["mistral", "openai"])
+        category_allowlist: If set, only include categories whose lowercase name is in this set.
+        category_blocklist: If set, exclude categories whose lowercase name is in this set.
 
     Returns:
         Dictionary mapping top-level module names to their components
@@ -348,15 +408,20 @@ async def _load_components_dynamically(
         parts = modname.split(".")
         if len(parts) > MIN_MODULE_PARTS:
             component_type = parts[2]
+            component_type_lower = component_type.lower()
+
+            # Skip excluded categories (avoids expensive module imports)
+            if _is_category_excluded(component_type_lower, category_allowlist, category_blocklist):
+                continue
 
             # Skip disabled components when ASTRA_CLOUD_DISABLE_COMPONENT is true
             if len(parts) >= MIN_MODULE_PARTS_WITH_FILENAME:
                 module_filename = parts[3]
-                if is_component_disabled_in_astra_cloud(component_type.lower(), module_filename):
+                if is_component_disabled_in_astra_cloud(component_type_lower, module_filename):
                     continue
 
             # If specific modules requested, filter by top-level module name
-            if target_modules and component_type.lower() not in target_modules:
+            if target_modules and component_type_lower not in target_modules:
                 continue
 
         module_names.append(modname)
@@ -393,35 +458,32 @@ async def _load_components_dynamically(
     return modules_dict
 
 
-async def _load_full_dev_mode() -> tuple[dict[str, Any], str]:
-    """Load all components dynamically in full dev mode.
-
-    Returns:
-        Tuple of (modules_dict, index_source)
-    """
-    await logger.adebug("LFX_DEV full mode: loading all modules dynamically")
-    modules_dict = await _load_components_dynamically(target_modules=None)
-    return modules_dict, "dynamic"
-
-
 async def _load_selective_dev_mode(
     settings_service: Optional["SettingsService"],
     target_modules: list[str],
+    category_allowlist: frozenset[str] | None = None,
+    category_blocklist: frozenset[str] | None = None,
 ) -> tuple[dict[str, Any], str]:
     """Load index and selectively reload specific modules.
 
     Args:
         settings_service: Settings service for custom index path
         target_modules: List of module names to reload
+        category_allowlist: If set, only include categories whose lowercase name is in this set.
+        category_blocklist: If set, exclude categories whose lowercase name is in this set.
 
     Returns:
         Tuple of (modules_dict, index_source)
     """
     await logger.adebug(f"LFX_DEV selective mode: reloading {target_modules}")
-    modules_dict, _ = await _load_from_index_or_cache(settings_service)
+    modules_dict, _ = await _load_from_index_or_cache(
+        settings_service, category_allowlist=category_allowlist, category_blocklist=category_blocklist
+    )
 
     # Reload specific modules dynamically
-    dynamic_modules = await _load_components_dynamically(target_modules=target_modules)
+    dynamic_modules = await _load_components_dynamically(
+        target_modules=target_modules, category_allowlist=category_allowlist, category_blocklist=category_blocklist
+    )
 
     # Merge/replace the targeted modules
     for top_level, components in dynamic_modules.items():
@@ -435,6 +497,8 @@ async def _load_selective_dev_mode(
 
 async def _load_production_mode(
     settings_service: Optional["SettingsService"],
+    category_allowlist: frozenset[str] | None = None,
+    category_blocklist: frozenset[str] | None = None,
 ) -> tuple[dict[str, Any], str]:
     """Load components in production mode with fallback chain.
 
@@ -442,20 +506,26 @@ async def _load_production_mode(
 
     Args:
         settings_service: Settings service for custom index path
+        category_allowlist: If set, only include categories whose lowercase name is in this set.
+        category_blocklist: If set, exclude categories whose lowercase name is in this set.
 
     Returns:
         Tuple of (modules_dict, index_source)
     """
-    modules_dict, index_source = await _load_from_index_or_cache(settings_service)
+    modules_dict, index_source = await _load_from_index_or_cache(
+        settings_service, category_allowlist=category_allowlist, category_blocklist=category_blocklist
+    )
 
     if not index_source:
         # No index or cache available - build dynamically and save
         await logger.adebug("Falling back to dynamic loading")
-        modules_dict = await _load_components_dynamically(target_modules=None)
+        modules_dict = await _load_components_dynamically(
+            target_modules=None, category_allowlist=category_allowlist, category_blocklist=category_blocklist
+        )
         index_source = "dynamic"
 
-        # Save to cache for future use
-        if modules_dict:
+        # Save to cache for future use (skip when filtering is active to avoid caching a filtered subset)
+        if modules_dict and category_allowlist is None and category_blocklist is None:
             await logger.adebug("Saving generated component index to cache")
             _save_generated_index(modules_dict)
 
@@ -483,13 +553,78 @@ async def import_langflow_components(
     start_time_ms: int = int(time.time() * 1000)
     dev_mode_enabled, target_modules = _parse_dev_mode()
 
-    # Strategy pattern: map dev mode state to loading function
+    # Build allowlist/blocklist sets once — passed into every loading path to skip work early
+    category_allowlist: frozenset[str] | None = None
+    if settings_service and settings_service.settings.component_category_allowlist:
+        cleaned = [cat.lower().strip() for cat in settings_service.settings.component_category_allowlist if cat.strip()]
+        if cleaned:
+            category_allowlist = frozenset(cleaned)
+            await logger.adebug(f"component_category_allowlist active: {sorted(category_allowlist)}")
+
+    category_blocklist: frozenset[str] | None = None
+    if settings_service and settings_service.settings.component_category_blocklist:
+        cleaned = [cat.lower().strip() for cat in settings_service.settings.component_category_blocklist if cat.strip()]
+        if cleaned:
+            category_blocklist = frozenset(cleaned)
+            await logger.adebug(f"component_category_blocklist active: {sorted(category_blocklist)}")
+
+    if category_allowlist is not None and category_blocklist is not None:
+        overlap = category_allowlist & category_blocklist
+        if overlap:
+            await logger.aerror(
+                f"component_category_blocklist contains categories also in allowlist: "
+                f"{', '.join(sorted(overlap))}. These categories will be excluded."
+            )
+        if category_allowlist <= category_blocklist:
+            await logger.aerror(
+                "component_category_blocklist completely overrides component_category_allowlist — "
+                "no categories will be loaded. Check your configuration."
+            )
+
     if dev_mode_enabled and not target_modules:
-        modules_dict, index_source = await _load_full_dev_mode()
+        await logger.adebug("LFX_DEV full mode: loading all modules dynamically")
+        modules_dict = await _load_components_dynamically(
+            category_allowlist=category_allowlist, category_blocklist=category_blocklist
+        )
+        index_source = "dynamic"
     elif dev_mode_enabled and target_modules:
-        modules_dict, index_source = await _load_selective_dev_mode(settings_service, target_modules)
+        modules_dict, index_source = await _load_selective_dev_mode(
+            settings_service,
+            target_modules,
+            category_allowlist=category_allowlist,
+            category_blocklist=category_blocklist,
+        )
     else:
-        modules_dict, index_source = await _load_production_mode(settings_service)
+        modules_dict, index_source = await _load_production_mode(
+            settings_service, category_allowlist=category_allowlist, category_blocklist=category_blocklist
+        )
+
+    # Validate allowlist/blocklist entries against what was actually loaded
+    if category_allowlist is not None or category_blocklist is not None:
+        loaded = frozenset(k.lower() for k in modules_dict)
+
+        if category_allowlist is not None:
+            unmatched = category_allowlist - loaded
+            if unmatched:
+                await logger.aerror(
+                    f"component_category_allowlist contains categories not found in the index: "
+                    f"{', '.join(sorted(unmatched))}. Check for typos in "
+                    f"LANGFLOW_COMPONENT_CATEGORY_ALLOWLIST. "
+                    f"Available: {', '.join(sorted(loaded)) or '(none)'}"
+                )
+
+        if category_blocklist is not None:
+            # To detect typos in the blocklist we need the full set of categories before
+            # the blocklist was applied.  The cheapest way is to re-derive it from the index.
+            all_known = _get_all_known_categories(settings_service)
+            effective_known = all_known if category_allowlist is None else all_known & category_allowlist
+            unmatched_block = category_blocklist - effective_known
+            if unmatched_block:
+                await logger.aerror(
+                    f"component_category_blocklist contains categories not found in the index: "
+                    f"{', '.join(sorted(unmatched_block))}. These entries have no effect. "
+                    f"Check for typos in LANGFLOW_COMPONENT_CATEGORY_BLOCKLIST."
+                )
 
     # Send telemetry
     await _send_telemetry(

--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -281,11 +281,14 @@ def _all_category_names(entries: list[list]) -> frozenset[str]:
     )
 
 
-def _get_all_known_categories(settings_service: Optional["SettingsService"] = None) -> frozenset[str]:
+def _get_all_known_categories(settings_service: Optional["SettingsService"] = None) -> frozenset[str] | None:
     """Get all category names from the built-in index (for validation only).
 
     This reads the index to extract category names without applying any filters.
     Used at startup to validate allowlist/blocklist entries against known categories.
+
+    Returns:
+        frozenset of category names, or None if the index could not be loaded.
     """
     custom_path = None
     if settings_service and settings_service.settings.components_index_path:
@@ -293,7 +296,7 @@ def _get_all_known_categories(settings_service: Optional["SettingsService"] = No
     index = _read_component_index(custom_path)
     if index and "entries" in index:
         return _all_category_names(index["entries"])
-    return frozenset()
+    return None
 
 
 def _entries_to_dict(
@@ -312,17 +315,22 @@ def _entries_to_dict(
         Dictionary mapping category names to their components.
     """
     modules_dict: dict[str, Any] = {}
+    skipped = 0
     for entry in entries:
         if not isinstance(entry, (list, tuple)) or len(entry) != 2:  # noqa: PLR2004
+            skipped += 1
             continue
         top_level, components = entry
         if not isinstance(top_level, str) or not isinstance(components, dict):
+            skipped += 1
             continue
         if _is_category_excluded(top_level.lower(), category_allowlist, category_blocklist):
             continue
         if top_level not in modules_dict:
             modules_dict[top_level] = {}
         modules_dict[top_level].update(components)
+    if skipped:
+        logger.warning(f"Skipped {skipped} malformed entries in component index")
     return filter_disabled_components_from_dict(modules_dict)
 
 
@@ -617,14 +625,15 @@ async def import_langflow_components(
             # To detect typos in the blocklist we need the full set of categories before
             # the blocklist was applied.  The cheapest way is to re-derive it from the index.
             all_known = _get_all_known_categories(settings_service)
-            effective_known = all_known if category_allowlist is None else all_known & category_allowlist
-            unmatched_block = category_blocklist - effective_known
-            if unmatched_block:
-                await logger.aerror(
-                    f"component_category_blocklist contains categories not found in the index: "
-                    f"{', '.join(sorted(unmatched_block))}. These entries have no effect. "
-                    f"Check for typos in LANGFLOW_COMPONENT_CATEGORY_BLOCKLIST."
-                )
+            if all_known is not None:
+                effective_known = all_known if category_allowlist is None else all_known & category_allowlist
+                unmatched_block = category_blocklist - effective_known
+                if unmatched_block:
+                    await logger.aerror(
+                        f"component_category_blocklist contains categories not found in the index: "
+                        f"{', '.join(sorted(unmatched_block))}. These entries have no effect. "
+                        f"Check for typos in LANGFLOW_COMPONENT_CATEGORY_BLOCKLIST."
+                    )
 
     # Send telemetry
     await _send_telemetry(

--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -26,6 +26,39 @@ MIN_MODULE_PARTS = 2
 MIN_MODULE_PARTS_WITH_FILENAME = 4  # Minimum parts needed to have a module filename (lfx.components.type.filename)
 EXPECTED_RESULT_LENGTH = 2  # Expected length of the tuple returned by _process_single_module
 
+# Core component categories — mirrors SIDEBAR_CATEGORIES in the frontend (styleUtils.ts).
+# The virtual keyword "core" in allowlist/blocklist expands to these names.
+CORE_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "input_output",
+        "data_source",
+        "models_and_agents",
+        "llm_operations",
+        "files_and_knowledge",
+        "processing",
+        "flow_controls",
+        "utilities",
+        "prototypes",
+        "tools",
+        "agents",
+        "data",
+        "logic",
+        "helpers",
+        "models",
+        "vectorstores",
+        "inputs",
+        "outputs",
+        "prompts",
+        "chains",
+        "documentloaders",
+        "link_extractors",
+        "output_parsers",
+        "retrievers",
+        "textsplitters",
+        "toolkits",
+    }
+)
+
 
 # Create a class to manage component cache instead of using globals
 class ComponentCache:
@@ -259,6 +292,17 @@ async def _send_telemetry(
     except Exception as e:  # noqa: BLE001
         # Don't fail component loading if telemetry fails
         await logger.adebug(f"Failed to send component index telemetry: {e}")
+
+
+def _expand_virtual_keywords(categories: list[str]) -> list[str]:
+    """Expand virtual keywords like 'core' into their constituent category names."""
+    expanded: list[str] = []
+    for cat in categories:
+        if cat.lower().strip() == "core":
+            expanded.extend(CORE_CATEGORIES)
+        else:
+            expanded.append(cat)
+    return expanded
 
 
 def _is_category_excluded(
@@ -564,14 +608,16 @@ async def import_langflow_components(
     # Build allowlist/blocklist sets once — passed into every loading path to skip work early
     category_allowlist: frozenset[str] | None = None
     if settings_service and settings_service.settings.component_category_allowlist:
-        cleaned = [cat.lower().strip() for cat in settings_service.settings.component_category_allowlist if cat.strip()]
+        expanded = _expand_virtual_keywords(settings_service.settings.component_category_allowlist)
+        cleaned = [cat.lower().strip() for cat in expanded if cat.strip()]
         if cleaned:
             category_allowlist = frozenset(cleaned)
             await logger.adebug(f"component_category_allowlist active: {sorted(category_allowlist)}")
 
     category_blocklist: frozenset[str] | None = None
     if settings_service and settings_service.settings.component_category_blocklist:
-        cleaned = [cat.lower().strip() for cat in settings_service.settings.component_category_blocklist if cat.strip()]
+        expanded = _expand_virtual_keywords(settings_service.settings.component_category_blocklist)
+        cleaned = [cat.lower().strip() for cat in expanded if cat.strip()]
         if cleaned:
             category_blocklist = frozenset(cleaned)
             await logger.adebug(f"component_category_blocklist active: {sorted(category_blocklist)}")

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -169,6 +169,16 @@ class Settings(BaseSettings):
     Set to a file path (e.g., '/path/to/index.json') or URL (e.g., 'https://example.com/index.json')
     to use a custom index.
     """
+    component_category_allowlist: list[str] = []
+    """Comma-separated list of component category names to include from the component index.
+    If empty (default), all categories are included. If set, only the listed categories
+    will be available. Category names are case-insensitive.
+    Example: LANGFLOW_COMPONENT_CATEGORY_ALLOWLIST=openai,anthropic,google,processing"""
+    component_category_blocklist: list[str] = []
+    """Comma-separated list of component category names to exclude from the component index.
+    If empty (default), no categories are excluded. Applied after the allowlist.
+    Category names are case-insensitive.
+    Example: LANGFLOW_COMPONENT_CATEGORY_BLOCKLIST=prototypes,langchain_utilities"""
     langchain_cache: str = "InMemoryCache"
     load_flows_path: str | None = None
     bundle_urls: list[str] = []

--- a/src/lfx/tests/unit/test_component_index.py
+++ b/src/lfx/tests/unit/test_component_index.py
@@ -1,18 +1,32 @@
 """Unit tests for component index system."""
 
+import functools
 import hashlib
+import inspect
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import orjson
 import pytest
 from lfx.interface.components import (
+    _entries_to_dict,
     _get_cache_path,
+    _is_category_excluded,
     _parse_dev_mode,
     _read_component_index,
     _save_generated_index,
     import_langflow_components,
 )
+
+
+@functools.lru_cache(maxsize=1)
+def _load_real_index() -> dict:
+    """Load the real built-in component index (cached across calls)."""
+    import lfx
+
+    pkg_dir = Path(inspect.getfile(lfx)).parent
+    index_path = pkg_dir / "_assets" / "component_index.json"
+    return orjson.loads(index_path.read_bytes())
 
 
 class TestParseDevMode:
@@ -383,6 +397,8 @@ class TestImportLangflowComponents:
 
         mock_settings = Mock()
         mock_settings.settings.components_index_path = str(custom_file)
+        mock_settings.settings.component_category_allowlist = []
+        mock_settings.settings.component_category_blocklist = []
 
         with (
             patch("lfx.interface.components._read_component_index") as mock_read,
@@ -413,3 +429,341 @@ class TestImportLangflowComponents:
         # Should return empty dict, not raise
         assert "components" in result
         assert len(result["components"]) == 0
+
+
+class TestCategoryAllowlist:
+    """Tests for component_category_allowlist filtering using the real component index."""
+
+    def test_no_allowlist_keeps_all(self):
+        index = _load_real_index()
+        all_categories = _entries_to_dict(index["entries"])
+        assert len(all_categories) > 50  # sanity: real index has many categories
+
+    def test_allowlist_filters_to_requested_categories(self):
+        index = _load_real_index()
+        result = _entries_to_dict(index["entries"], category_allowlist=frozenset(["openai", "anthropic"]))
+        assert set(result.keys()) == {"openai", "anthropic"}
+
+    def test_allowlist_case_insensitive_with_real_categories(self):
+        index = _load_real_index()
+        # Real index has "FAISS" and "Notion" (mixed case)
+        result = _entries_to_dict(index["entries"], category_allowlist=frozenset(["faiss", "notion"]))
+        assert len(result) == 2
+        # Original casing from the index is preserved
+        result_lower = {k.lower() for k in result}
+        assert result_lower == {"faiss", "notion"}
+
+    def test_allowlist_single_category_has_components(self):
+        index = _load_real_index()
+        result = _entries_to_dict(index["entries"], category_allowlist=frozenset(["openai"]))
+        assert "openai" in result
+        assert len(result["openai"]) > 0  # openai has actual components
+
+    def test_allowlist_nonexistent_category_returns_empty(self):
+        index = _load_real_index()
+        result = _entries_to_dict(index["entries"], category_allowlist=frozenset(["nonexistent_category"]))
+        assert result == {}
+
+    def test_empty_allowlist_differs_from_none(self):
+        """frozenset() (empty) filters everything out; None keeps everything."""
+        index = _load_real_index()
+        with_none = _entries_to_dict(index["entries"], category_allowlist=None)
+        with_empty = _entries_to_dict(index["entries"], category_allowlist=frozenset())
+        assert len(with_none) > 50
+        assert with_empty == {}
+
+    def test_allowlist_preserves_component_data(self):
+        """Filtered components have the same data as unfiltered ones."""
+        index = _load_real_index()
+        all_categories = _entries_to_dict(index["entries"])
+        filtered = _entries_to_dict(index["entries"], category_allowlist=frozenset(["openai"]))
+        assert filtered["openai"] == all_categories["openai"]
+
+
+class TestCategoryBlocklist:
+    """Tests for component_category_blocklist filtering using the real component index."""
+
+    def test_no_blocklist_keeps_all(self):
+        index = _load_real_index()
+        all_categories = _entries_to_dict(index["entries"])
+        with_none = _entries_to_dict(index["entries"], category_blocklist=None)
+        assert with_none == all_categories
+
+    def test_blocklist_removes_specified_categories(self):
+        index = _load_real_index()
+        all_categories = _entries_to_dict(index["entries"])
+        result = _entries_to_dict(index["entries"], category_blocklist=frozenset(["openai", "anthropic"]))
+        assert "openai" not in result
+        assert "anthropic" not in result
+        assert len(result) == len(all_categories) - 2
+
+    def test_blocklist_case_insensitive(self):
+        index = _load_real_index()
+        # Real index has "FAISS" (uppercase)
+        result = _entries_to_dict(index["entries"], category_blocklist=frozenset(["faiss"]))
+        result_lower = {k.lower() for k in result}
+        assert "faiss" not in result_lower
+
+    def test_blocklist_nonexistent_category_is_noop(self):
+        index = _load_real_index()
+        all_categories = _entries_to_dict(index["entries"])
+        result = _entries_to_dict(index["entries"], category_blocklist=frozenset(["nonexistent_category"]))
+        assert result == all_categories
+
+    def test_empty_blocklist_keeps_all(self):
+        """frozenset() (empty) removes nothing."""
+        index = _load_real_index()
+        all_categories = _entries_to_dict(index["entries"])
+        with_empty = _entries_to_dict(index["entries"], category_blocklist=frozenset())
+        assert with_empty == all_categories
+
+    def test_blocklist_preserves_remaining_component_data(self):
+        index = _load_real_index()
+        all_categories = _entries_to_dict(index["entries"])
+        result = _entries_to_dict(index["entries"], category_blocklist=frozenset(["openai"]))
+        # anthropic should still have the same data
+        assert result["anthropic"] == all_categories["anthropic"]
+
+
+class TestAllowlistAndBlocklistCombined:
+    """Tests for allowlist + blocklist interaction using the real component index."""
+
+    def test_allowlist_then_blocklist(self):
+        """Blocklist removes from the allowlist result."""
+        index = _load_real_index()
+        result = _entries_to_dict(
+            index["entries"],
+            category_allowlist=frozenset(["openai", "anthropic", "google"]),
+            category_blocklist=frozenset(["anthropic"]),
+        )
+        assert set(result.keys()) == {"openai", "google"}
+
+    def test_blocklist_overrides_allowlist_for_same_category(self):
+        """If a category is in both, blocklist wins (excluded)."""
+        index = _load_real_index()
+        result = _entries_to_dict(
+            index["entries"],
+            category_allowlist=frozenset(["openai"]),
+            category_blocklist=frozenset(["openai"]),
+        )
+        assert result == {}
+
+    def test_both_none_keeps_all(self):
+        index = _load_real_index()
+        all_categories = _entries_to_dict(index["entries"])
+        result = _entries_to_dict(index["entries"], category_allowlist=None, category_blocklist=None)
+        assert result == all_categories
+
+
+class TestIsCategoryExcluded:
+    """Truth-table tests for _is_category_excluded."""
+
+    def test_no_filters(self):
+        assert _is_category_excluded("openai", None, None) is False
+
+    def test_allowlist_match(self):
+        assert _is_category_excluded("openai", frozenset(["openai"]), None) is False
+
+    def test_allowlist_no_match(self):
+        assert _is_category_excluded("anthropic", frozenset(["openai"]), None) is True
+
+    def test_blocklist_match(self):
+        assert _is_category_excluded("openai", None, frozenset(["openai"])) is True
+
+    def test_blocklist_no_match(self):
+        assert _is_category_excluded("anthropic", None, frozenset(["openai"])) is False
+
+    def test_in_both_blocklist_wins(self):
+        assert _is_category_excluded("openai", frozenset(["openai"]), frozenset(["openai"])) is True
+
+    def test_in_allowlist_not_in_blocklist(self):
+        assert _is_category_excluded("openai", frozenset(["openai", "anthropic"]), frozenset(["anthropic"])) is False
+
+    def test_empty_allowlist_excludes_everything(self):
+        assert _is_category_excluded("openai", frozenset(), None) is True
+
+    def test_empty_blocklist_excludes_nothing(self):
+        assert _is_category_excluded("openai", None, frozenset()) is False
+
+
+class TestEntriesToDictDefensive:
+    """Tests for _entries_to_dict defensive handling of malformed entries."""
+
+    def test_malformed_entry_wrong_length(self):
+        entries = [["valid", {"comp": {}}], ["only_one_element"], ["a", "b", "c"]]
+        result = _entries_to_dict(entries)
+        assert set(result.keys()) == {"valid"}
+
+    def test_entry_with_non_string_category(self):
+        entries = [[123, {"comp": {}}], ["valid", {"comp": {}}]]
+        result = _entries_to_dict(entries)
+        assert set(result.keys()) == {"valid"}
+
+    def test_entry_with_non_dict_components(self):
+        entries = [["bad", "not_a_dict"], ["valid", {"comp": {}}]]
+        result = _entries_to_dict(entries)
+        assert set(result.keys()) == {"valid"}
+
+    def test_empty_entries(self):
+        assert _entries_to_dict([]) == {}
+
+    def test_none_in_entries(self):
+        entries = [None, ["valid", {"comp": {}}]]
+        result = _entries_to_dict(entries)
+        assert set(result.keys()) == {"valid"}
+
+
+@pytest.mark.asyncio
+class TestImportLangflowComponentsFiltering:
+    """Integration tests for allowlist/blocklist through import_langflow_components."""
+
+    async def test_allowlist_filters_via_settings(self, monkeypatch):
+        """Settings with allowlist=['category1'] returns only category1."""
+        monkeypatch.delenv("LFX_DEV", raising=False)
+
+        index = {
+            "version": "0.1.12",
+            "entries": [
+                ["category1", {"comp1": {"template": {}}}],
+                ["category2", {"comp2": {"template": {}}}],
+                ["category3", {"comp3": {"template": {}}}],
+            ],
+        }
+        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
+        index["sha256"] = hashlib.sha256(payload).hexdigest()
+
+        mock_settings = Mock()
+        mock_settings.settings.components_index_path = None
+        mock_settings.settings.component_category_allowlist = ["category1"]
+        mock_settings.settings.component_category_blocklist = []
+
+        with patch("lfx.interface.components._read_component_index", return_value=index):
+            result = await import_langflow_components(mock_settings)
+
+        assert set(result["components"].keys()) == {"category1"}
+
+    async def test_blocklist_filters_via_settings(self, monkeypatch):
+        """Settings with blocklist=['category2'] excludes category2."""
+        monkeypatch.delenv("LFX_DEV", raising=False)
+
+        index = {
+            "version": "0.1.12",
+            "entries": [
+                ["category1", {"comp1": {"template": {}}}],
+                ["category2", {"comp2": {"template": {}}}],
+                ["category3", {"comp3": {"template": {}}}],
+            ],
+        }
+        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
+        index["sha256"] = hashlib.sha256(payload).hexdigest()
+
+        mock_settings = Mock()
+        mock_settings.settings.components_index_path = None
+        mock_settings.settings.component_category_allowlist = []
+        mock_settings.settings.component_category_blocklist = ["category2"]
+
+        with patch("lfx.interface.components._read_component_index", return_value=index):
+            result = await import_langflow_components(mock_settings)
+
+        assert "category1" in result["components"]
+        assert "category2" not in result["components"]
+        assert "category3" in result["components"]
+
+    async def test_empty_list_settings_means_no_filtering(self, monkeypatch):
+        """Empty lists [] in settings mean no filtering (not 'block everything')."""
+        monkeypatch.delenv("LFX_DEV", raising=False)
+
+        index = {
+            "version": "0.1.12",
+            "entries": [
+                ["category1", {"comp1": {"template": {}}}],
+                ["category2", {"comp2": {"template": {}}}],
+            ],
+        }
+        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
+        index["sha256"] = hashlib.sha256(payload).hexdigest()
+
+        mock_settings = Mock()
+        mock_settings.settings.components_index_path = None
+        mock_settings.settings.component_category_allowlist = []
+        mock_settings.settings.component_category_blocklist = []
+
+        with patch("lfx.interface.components._read_component_index", return_value=index):
+            result = await import_langflow_components(mock_settings)
+
+        assert set(result["components"].keys()) == {"category1", "category2"}
+
+    async def test_empty_string_entries_are_ignored(self, monkeypatch):
+        """Allowlist with empty strings (from ALLOWLIST='') doesn't filter everything."""
+        monkeypatch.delenv("LFX_DEV", raising=False)
+
+        index = {
+            "version": "0.1.12",
+            "entries": [
+                ["category1", {"comp1": {"template": {}}}],
+                ["category2", {"comp2": {"template": {}}}],
+            ],
+        }
+        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
+        index["sha256"] = hashlib.sha256(payload).hexdigest()
+
+        mock_settings = Mock()
+        mock_settings.settings.components_index_path = None
+        mock_settings.settings.component_category_allowlist = [""]  # parsed from ALLOWLIST=""
+        mock_settings.settings.component_category_blocklist = []
+
+        with patch("lfx.interface.components._read_component_index", return_value=index):
+            result = await import_langflow_components(mock_settings)
+
+        # Empty string should be stripped, resulting in no filtering
+        assert set(result["components"].keys()) == {"category1", "category2"}
+
+    async def test_cache_not_saved_when_allowlist_active(self, tmp_path, monkeypatch):
+        """Cache is skipped when allowlist filters the result."""
+        monkeypatch.delenv("LFX_DEV", raising=False)
+        cache_file = tmp_path / "component_index.json"
+        monkeypatch.setattr("lfx.interface.components._get_cache_path", lambda: cache_file)
+
+        mock_settings = Mock()
+        mock_settings.settings.components_index_path = None
+        mock_settings.settings.component_category_allowlist = ["category1"]
+        mock_settings.settings.component_category_blocklist = []
+
+        with (
+            patch("lfx.interface.components._read_component_index", return_value=None),
+            patch("lfx.interface.components._process_single_module") as mock_process,
+            patch("lfx.interface.components.pkgutil.walk_packages") as mock_walk,
+            patch("importlib.metadata.version", return_value="0.1.12"),
+        ):
+            mock_process.return_value = ("category1", {"comp1": {"template": {}}})
+            mock_walk.return_value = [(None, "lfx.components.category1", False)]
+
+            await import_langflow_components(mock_settings)
+
+        # Cache should NOT exist because allowlist was active
+        assert not cache_file.exists()
+
+    async def test_cache_not_saved_when_blocklist_active(self, tmp_path, monkeypatch):
+        """Cache is skipped when blocklist filters the result."""
+        monkeypatch.delenv("LFX_DEV", raising=False)
+        cache_file = tmp_path / "component_index.json"
+        monkeypatch.setattr("lfx.interface.components._get_cache_path", lambda: cache_file)
+
+        mock_settings = Mock()
+        mock_settings.settings.components_index_path = None
+        mock_settings.settings.component_category_allowlist = []
+        mock_settings.settings.component_category_blocklist = ["category1"]
+
+        with (
+            patch("lfx.interface.components._read_component_index", return_value=None),
+            patch("lfx.interface.components._process_single_module") as mock_process,
+            patch("lfx.interface.components.pkgutil.walk_packages") as mock_walk,
+            patch("importlib.metadata.version", return_value="0.1.12"),
+        ):
+            mock_process.return_value = ("category1", {"comp1": {"template": {}}})
+            mock_walk.return_value = [(None, "lfx.components.category1", False)]
+
+            await import_langflow_components(mock_settings)
+
+        # Cache should NOT exist because blocklist was active
+        assert not cache_file.exists()

--- a/src/lfx/tests/unit/test_component_index.py
+++ b/src/lfx/tests/unit/test_component_index.py
@@ -4,12 +4,15 @@ import functools
 import hashlib
 import inspect
 from pathlib import Path
-from unittest.mock import Mock, patch
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import orjson
 import pytest
 from lfx.interface.components import (
+    _all_category_names,
     _entries_to_dict,
+    _get_all_known_categories,
     _get_cache_path,
     _is_category_excluded,
     _parse_dev_mode,
@@ -27,6 +30,41 @@ def _load_real_index() -> dict:
     pkg_dir = Path(inspect.getfile(lfx)).parent
     index_path = pkg_dir / "_assets" / "component_index.json"
     return orjson.loads(index_path.read_bytes())
+
+
+def _get_lfx_version() -> str:
+    """Get the installed lfx package version."""
+    from importlib.metadata import version
+
+    return version("lfx")
+
+
+def _build_index(entries, *, version=None):
+    """Build a valid component index dict with correct SHA256."""
+    if version is None:
+        version = _get_lfx_version()
+    index = {"version": version, "entries": entries}
+    payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
+    index["sha256"] = hashlib.sha256(payload).hexdigest()
+    return index
+
+
+def _write_index(path, entries, *, version=None):
+    """Write a valid component index file to disk."""
+    index = _build_index(entries, version=version)
+    path.write_bytes(orjson.dumps(index, option=orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2))
+    return index
+
+
+def _make_settings(*, index_path=None, allowlist=None, blocklist=None):
+    """Create a settings-like object without mocking."""
+    return SimpleNamespace(
+        settings=SimpleNamespace(
+            components_index_path=index_path,
+            component_category_allowlist=allowlist or [],
+            component_category_blocklist=blocklist or [],
+        )
+    )
 
 
 class TestParseDevMode:
@@ -126,140 +164,78 @@ class TestReadComponentIndex:
     """Tests for _read_component_index() function."""
 
     def test_read_index_file_not_found(self):
-        """Test reading index when file doesn't exist."""
-        mock_path = Mock()
-        mock_path.exists.return_value = False
-
-        with patch("lfx.interface.components.Path") as mock_path_class:
-            mock_path_class.return_value = mock_path
-            result = _read_component_index()
-
+        """Test reading index when custom path doesn't exist."""
+        result = _read_component_index("/nonexistent/path/component_index.json")
         assert result is None
 
     def test_read_index_valid(self, tmp_path):
-        """Test reading valid index file."""
-        # Create valid index
-        index = {
-            "version": "0.1.12",
-            "entries": [["category1", {"comp1": {"template": {}}}]],
-        }
-        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
-        index["sha256"] = hashlib.sha256(payload).hexdigest()
-
+        """Test reading valid index file via custom path."""
+        entries = [["category1", {"comp1": {"template": {}}}]]
         index_file = tmp_path / "component_index.json"
-        index_file.write_bytes(orjson.dumps(index, option=orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2))
+        _write_index(index_file, entries)
 
-        # Mock the path resolution
-        with (
-            patch("lfx.interface.components.inspect.getfile") as mock_getfile,
-            patch("importlib.metadata.version") as mock_version,
-        ):
-            mock_getfile.return_value = str(tmp_path / "lfx" / "__init__.py")
-            mock_version.return_value = "0.1.12"
-
-            # Create the directory structure
-            (tmp_path / "lfx" / "_assets").mkdir(parents=True)
-            (tmp_path / "lfx" / "_assets" / "component_index.json").write_bytes(
-                orjson.dumps(index, option=orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2)
-            )
-
-            result = _read_component_index()
+        result = _read_component_index(str(index_file))
 
         assert result is not None
-        assert result["version"] == "0.1.12"
+        assert result["version"] == _get_lfx_version()
         assert "entries" in result
-        assert result["sha256"] == index["sha256"]
+        assert len(result["entries"]) == 1
 
     def test_read_index_invalid_sha256(self, tmp_path):
         """Test reading index with invalid SHA256."""
-        # Create index with bad hash
         index = {
-            "version": "0.1.12",
+            "version": _get_lfx_version(),
             "entries": [["category1", {"comp1": {"template": {}}}]],
             "sha256": "invalid_hash",
         }
-
         index_file = tmp_path / "component_index.json"
         index_file.write_bytes(orjson.dumps(index))
 
-        with (
-            patch("lfx.interface.components.inspect.getfile") as mock_getfile,
-            patch("importlib.metadata.version") as mock_version,
-        ):
-            mock_getfile.return_value = str(tmp_path / "lfx" / "__init__.py")
-            mock_version.return_value = "0.1.12"
-
-            (tmp_path / "lfx" / "_assets").mkdir(parents=True)
-            (tmp_path / "lfx" / "_assets" / "component_index.json").write_bytes(orjson.dumps(index))
-
-            result = _read_component_index()
-
+        result = _read_component_index(str(index_file))
         assert result is None
 
     def test_read_index_version_mismatch(self, tmp_path):
         """Test reading index with mismatched version."""
-        index = {
-            "version": "0.1.11",
-            "entries": [["category1", {"comp1": {"template": {}}}]],
-        }
-        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
-        index["sha256"] = hashlib.sha256(payload).hexdigest()
+        index_file = tmp_path / "component_index.json"
+        _write_index(index_file, [["category1", {"comp1": {"template": {}}}]], version="0.0.0-fake")
 
-        with (
-            patch("lfx.interface.components.inspect.getfile") as mock_getfile,
-            patch("importlib.metadata.version") as mock_version,
-        ):
-            mock_getfile.return_value = str(tmp_path / "lfx" / "__init__.py")
-            mock_version.return_value = "0.1.12"  # Different version
-
-            (tmp_path / "lfx" / "_assets").mkdir(parents=True)
-            (tmp_path / "lfx" / "_assets" / "component_index.json").write_bytes(
-                orjson.dumps(index, option=orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2)
-            )
-
-            result = _read_component_index()
-
+        result = _read_component_index(str(index_file))
         assert result is None
 
     def test_read_index_custom_path_file(self, tmp_path):
         """Test reading index from custom file path."""
-        index = {
-            "version": "0.1.12",
-            "entries": [["category1", {"comp1": {"template": {}}}]],
-        }
-        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
-        index["sha256"] = hashlib.sha256(payload).hexdigest()
-
+        entries = [["category1", {"comp1": {"template": {}}}]]
         custom_file = tmp_path / "custom_index.json"
-        custom_file.write_bytes(orjson.dumps(index, option=orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2))
+        _write_index(custom_file, entries)
 
-        with patch("importlib.metadata.version") as mock_version:
-            mock_version.return_value = "0.1.12"
-            result = _read_component_index(str(custom_file))
+        result = _read_component_index(str(custom_file))
 
         assert result is not None
-        assert result["version"] == "0.1.12"
+        assert result["version"] == _get_lfx_version()
 
     def test_read_index_custom_path_url(self):
         """Test reading index from URL."""
-        index = {
-            "version": "0.1.12",
-            "entries": [["category1", {"comp1": {"template": {}}}]],
-        }
-        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
-        index["sha256"] = hashlib.sha256(payload).hexdigest()
+        entries = [["category1", {"comp1": {"template": {}}}]]
+        index = _build_index(entries)
 
-        mock_response = Mock()
-        mock_response.content = orjson.dumps(index)
+        mock_response = SimpleNamespace(
+            content=orjson.dumps(index),
+            raise_for_status=lambda: None,
+        )
 
-        with (
-            patch("httpx.get", return_value=mock_response),
-            patch("importlib.metadata.version", return_value="0.1.12"),
-        ):
+        with patch("httpx.get", return_value=mock_response):
             result = _read_component_index("https://example.com/index.json")
 
         assert result is not None
-        assert result["version"] == "0.1.12"
+        assert result["version"] == _get_lfx_version()
+
+    def test_read_builtin_index_returns_valid_data(self):
+        """Test that the real built-in index loads successfully."""
+        result = _read_component_index()
+
+        assert result is not None
+        assert "entries" in result
+        assert len(result["entries"]) > 50
 
 
 class TestCachePath:
@@ -274,7 +250,12 @@ class TestCachePath:
 
 
 class TestSaveGeneratedIndex:
-    """Tests for _save_generated_index() function."""
+    """Tests for _save_generated_index() function.
+
+    Note: _save_generated_index calls version("langflow") internally,
+    and langflow is not installed in the lfx test environment, so the
+    version mock is required here.
+    """
 
     def test_save_generated_index(self, tmp_path, monkeypatch):
         """Test saving generated index to cache."""
@@ -337,27 +318,15 @@ class TestImportLangflowComponents:
         assert not mock_save.called
 
     async def test_import_with_builtin_index(self, monkeypatch):
-        """Test import with valid built-in index."""
+        """Test import with the real built-in index — no mocking."""
         monkeypatch.delenv("LFX_DEV", raising=False)
 
-        index = {
-            "version": "0.1.12",
-            "entries": [["category1", {"comp1": {"template": {}}}]],
-        }
-        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
-        index["sha256"] = hashlib.sha256(payload).hexdigest()
-
-        with (
-            patch("lfx.interface.components._read_component_index") as mock_read,
-            patch("importlib.metadata.version", return_value="0.1.12"),
-        ):
-            mock_read.return_value = index
-
-            result = await import_langflow_components()
+        result = await import_langflow_components()
 
         assert "components" in result
-        assert "category1" in result["components"]
-        assert "comp1" in result["components"]["category1"]
+        assert len(result["components"]) > 50
+        categories_lower = {k.lower() for k in result["components"]}
+        assert "openai" in categories_lower
 
     async def test_import_with_missing_index_creates_cache(self, tmp_path, monkeypatch):
         """Test import with missing index falls back to dynamic and caches."""
@@ -385,32 +354,17 @@ class TestImportLangflowComponents:
         """Test import with custom index path from settings."""
         monkeypatch.delenv("LFX_DEV", raising=False)
 
-        index = {
-            "version": "0.1.12",
-            "entries": [["category1", {"comp1": {"template": {}}}]],
-        }
-        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
-        index["sha256"] = hashlib.sha256(payload).hexdigest()
-
+        entries = [["category1", {"comp1": {"template": {}}}]]
         custom_file = tmp_path / "custom_index.json"
-        custom_file.write_bytes(orjson.dumps(index))
+        _write_index(custom_file, entries)
 
-        mock_settings = Mock()
-        mock_settings.settings.components_index_path = str(custom_file)
-        mock_settings.settings.component_category_allowlist = []
-        mock_settings.settings.component_category_blocklist = []
+        settings = _make_settings(index_path=str(custom_file))
 
-        with (
-            patch("lfx.interface.components._read_component_index") as mock_read,
-            patch("importlib.metadata.version", return_value="0.1.12"),
-        ):
-            mock_read.return_value = index
-
-            result = await import_langflow_components(mock_settings)
+        result = await import_langflow_components(settings)
 
         assert "components" in result
-        # Verify custom path was used
-        mock_read.assert_called_with(str(custom_file))
+        assert "category1" in result["components"]
+        assert "comp1" in result["components"]["category1"]
 
     async def test_import_handles_import_errors(self, monkeypatch):
         """Test import handles component import errors gracefully."""
@@ -613,107 +567,122 @@ class TestEntriesToDictDefensive:
         assert set(result.keys()) == {"valid"}
 
 
+class TestAllCategoryNames:
+    """Tests for _all_category_names helper."""
+
+    def test_extracts_lowered_names(self):
+        entries = [["OpenAI", {"c": {}}], ["Anthropic", {"c": {}}]]
+        assert _all_category_names(entries) == frozenset(["openai", "anthropic"])
+
+    def test_skips_malformed_entries(self):
+        entries = [["valid", {"c": {}}], [123, {"c": {}}], None, ["also_valid", {"c": {}}]]
+        assert _all_category_names(entries) == frozenset(["valid", "also_valid"])
+
+    def test_empty_entries(self):
+        assert _all_category_names([]) == frozenset()
+
+    def test_returns_frozenset(self):
+        result = _all_category_names([["a", {}]])
+        assert isinstance(result, frozenset)
+
+
+class TestGetAllKnownCategories:
+    """Tests for _get_all_known_categories."""
+
+    def test_returns_categories_from_real_index(self):
+        result = _get_all_known_categories()
+        assert result is not None
+        assert len(result) > 50
+        assert "openai" in result
+
+    def test_returns_categories_from_custom_path(self, tmp_path):
+        entries = [["custom1", {"c": {}}], ["custom2", {"c": {}}]]
+        index_file = tmp_path / "index.json"
+        _write_index(index_file, entries)
+        settings = _make_settings(index_path=str(index_file))
+        result = _get_all_known_categories(settings)
+        assert result == frozenset(["custom1", "custom2"])
+
+    def test_returns_none_when_index_fails(self):
+        """When the index can't be loaded, return None (not empty frozenset)."""
+        with patch("lfx.interface.components._read_component_index", return_value=None):
+            result = _get_all_known_categories()
+        assert result is None
+
+
 @pytest.mark.asyncio
 class TestImportLangflowComponentsFiltering:
     """Integration tests for allowlist/blocklist through import_langflow_components."""
 
-    async def test_allowlist_filters_via_settings(self, monkeypatch):
+    async def test_allowlist_filters_via_settings(self, tmp_path, monkeypatch):
         """Settings with allowlist=['category1'] returns only category1."""
         monkeypatch.delenv("LFX_DEV", raising=False)
 
-        index = {
-            "version": "0.1.12",
-            "entries": [
-                ["category1", {"comp1": {"template": {}}}],
-                ["category2", {"comp2": {"template": {}}}],
-                ["category3", {"comp3": {"template": {}}}],
-            ],
-        }
-        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
-        index["sha256"] = hashlib.sha256(payload).hexdigest()
+        entries = [
+            ["category1", {"comp1": {"template": {}}}],
+            ["category2", {"comp2": {"template": {}}}],
+            ["category3", {"comp3": {"template": {}}}],
+        ]
+        index_file = tmp_path / "index.json"
+        _write_index(index_file, entries)
 
-        mock_settings = Mock()
-        mock_settings.settings.components_index_path = None
-        mock_settings.settings.component_category_allowlist = ["category1"]
-        mock_settings.settings.component_category_blocklist = []
+        settings = _make_settings(index_path=str(index_file), allowlist=["category1"])
 
-        with patch("lfx.interface.components._read_component_index", return_value=index):
-            result = await import_langflow_components(mock_settings)
+        result = await import_langflow_components(settings)
 
         assert set(result["components"].keys()) == {"category1"}
 
-    async def test_blocklist_filters_via_settings(self, monkeypatch):
+    async def test_blocklist_filters_via_settings(self, tmp_path, monkeypatch):
         """Settings with blocklist=['category2'] excludes category2."""
         monkeypatch.delenv("LFX_DEV", raising=False)
 
-        index = {
-            "version": "0.1.12",
-            "entries": [
-                ["category1", {"comp1": {"template": {}}}],
-                ["category2", {"comp2": {"template": {}}}],
-                ["category3", {"comp3": {"template": {}}}],
-            ],
-        }
-        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
-        index["sha256"] = hashlib.sha256(payload).hexdigest()
+        entries = [
+            ["category1", {"comp1": {"template": {}}}],
+            ["category2", {"comp2": {"template": {}}}],
+            ["category3", {"comp3": {"template": {}}}],
+        ]
+        index_file = tmp_path / "index.json"
+        _write_index(index_file, entries)
 
-        mock_settings = Mock()
-        mock_settings.settings.components_index_path = None
-        mock_settings.settings.component_category_allowlist = []
-        mock_settings.settings.component_category_blocklist = ["category2"]
+        settings = _make_settings(index_path=str(index_file), blocklist=["category2"])
 
-        with patch("lfx.interface.components._read_component_index", return_value=index):
-            result = await import_langflow_components(mock_settings)
+        result = await import_langflow_components(settings)
 
         assert "category1" in result["components"]
         assert "category2" not in result["components"]
         assert "category3" in result["components"]
 
-    async def test_empty_list_settings_means_no_filtering(self, monkeypatch):
+    async def test_empty_list_settings_means_no_filtering(self, tmp_path, monkeypatch):
         """Empty lists [] in settings mean no filtering (not 'block everything')."""
         monkeypatch.delenv("LFX_DEV", raising=False)
 
-        index = {
-            "version": "0.1.12",
-            "entries": [
-                ["category1", {"comp1": {"template": {}}}],
-                ["category2", {"comp2": {"template": {}}}],
-            ],
-        }
-        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
-        index["sha256"] = hashlib.sha256(payload).hexdigest()
+        entries = [
+            ["category1", {"comp1": {"template": {}}}],
+            ["category2", {"comp2": {"template": {}}}],
+        ]
+        index_file = tmp_path / "index.json"
+        _write_index(index_file, entries)
 
-        mock_settings = Mock()
-        mock_settings.settings.components_index_path = None
-        mock_settings.settings.component_category_allowlist = []
-        mock_settings.settings.component_category_blocklist = []
+        settings = _make_settings(index_path=str(index_file))
 
-        with patch("lfx.interface.components._read_component_index", return_value=index):
-            result = await import_langflow_components(mock_settings)
+        result = await import_langflow_components(settings)
 
         assert set(result["components"].keys()) == {"category1", "category2"}
 
-    async def test_empty_string_entries_are_ignored(self, monkeypatch):
+    async def test_empty_string_entries_are_ignored(self, tmp_path, monkeypatch):
         """Allowlist with empty strings (from ALLOWLIST='') doesn't filter everything."""
         monkeypatch.delenv("LFX_DEV", raising=False)
 
-        index = {
-            "version": "0.1.12",
-            "entries": [
-                ["category1", {"comp1": {"template": {}}}],
-                ["category2", {"comp2": {"template": {}}}],
-            ],
-        }
-        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
-        index["sha256"] = hashlib.sha256(payload).hexdigest()
+        entries = [
+            ["category1", {"comp1": {"template": {}}}],
+            ["category2", {"comp2": {"template": {}}}],
+        ]
+        index_file = tmp_path / "index.json"
+        _write_index(index_file, entries)
 
-        mock_settings = Mock()
-        mock_settings.settings.components_index_path = None
-        mock_settings.settings.component_category_allowlist = [""]  # parsed from ALLOWLIST=""
-        mock_settings.settings.component_category_blocklist = []
+        settings = _make_settings(index_path=str(index_file), allowlist=[""])
 
-        with patch("lfx.interface.components._read_component_index", return_value=index):
-            result = await import_langflow_components(mock_settings)
+        result = await import_langflow_components(settings)
 
         # Empty string should be stripped, resulting in no filtering
         assert set(result["components"].keys()) == {"category1", "category2"}
@@ -724,10 +693,7 @@ class TestImportLangflowComponentsFiltering:
         cache_file = tmp_path / "component_index.json"
         monkeypatch.setattr("lfx.interface.components._get_cache_path", lambda: cache_file)
 
-        mock_settings = Mock()
-        mock_settings.settings.components_index_path = None
-        mock_settings.settings.component_category_allowlist = ["category1"]
-        mock_settings.settings.component_category_blocklist = []
+        settings = _make_settings(allowlist=["category1"])
 
         with (
             patch("lfx.interface.components._read_component_index", return_value=None),
@@ -738,7 +704,7 @@ class TestImportLangflowComponentsFiltering:
             mock_process.return_value = ("category1", {"comp1": {"template": {}}})
             mock_walk.return_value = [(None, "lfx.components.category1", False)]
 
-            await import_langflow_components(mock_settings)
+            await import_langflow_components(settings)
 
         # Cache should NOT exist because allowlist was active
         assert not cache_file.exists()
@@ -749,10 +715,7 @@ class TestImportLangflowComponentsFiltering:
         cache_file = tmp_path / "component_index.json"
         monkeypatch.setattr("lfx.interface.components._get_cache_path", lambda: cache_file)
 
-        mock_settings = Mock()
-        mock_settings.settings.components_index_path = None
-        mock_settings.settings.component_category_allowlist = []
-        mock_settings.settings.component_category_blocklist = ["category1"]
+        settings = _make_settings(blocklist=["category1"])
 
         with (
             patch("lfx.interface.components._read_component_index", return_value=None),
@@ -763,7 +726,7 @@ class TestImportLangflowComponentsFiltering:
             mock_process.return_value = ("category1", {"comp1": {"template": {}}})
             mock_walk.return_value = [(None, "lfx.components.category1", False)]
 
-            await import_langflow_components(mock_settings)
+            await import_langflow_components(settings)
 
         # Cache should NOT exist because blocklist was active
         assert not cache_file.exists()

--- a/src/lfx/tests/unit/test_component_index.py
+++ b/src/lfx/tests/unit/test_component_index.py
@@ -10,8 +10,10 @@ from unittest.mock import patch
 import orjson
 import pytest
 from lfx.interface.components import (
+    CORE_CATEGORIES,
     _all_category_names,
     _entries_to_dict,
+    _expand_virtual_keywords,
     _get_all_known_categories,
     _get_cache_path,
     _is_category_excluded,
@@ -608,6 +610,103 @@ class TestGetAllKnownCategories:
         with patch("lfx.interface.components._read_component_index", return_value=None):
             result = _get_all_known_categories()
         assert result is None
+
+
+class TestExpandVirtualKeywords:
+    """Tests for _expand_virtual_keywords helper."""
+
+    def test_core_expands(self):
+        result = _expand_virtual_keywords(["core"])
+        assert set(result) == CORE_CATEGORIES
+
+    def test_core_case_insensitive(self):
+        result = _expand_virtual_keywords(["Core"])
+        assert set(result) == CORE_CATEGORIES
+
+    def test_non_keyword_passthrough(self):
+        assert _expand_virtual_keywords(["openai", "anthropic"]) == ["openai", "anthropic"]
+
+    def test_core_plus_bundle(self):
+        result = _expand_virtual_keywords(["core", "openai"])
+        expanded = set(result)
+        assert expanded >= CORE_CATEGORIES
+        assert "openai" in expanded
+
+    def test_empty_list(self):
+        assert _expand_virtual_keywords([]) == []
+
+    def test_core_with_whitespace(self):
+        result = _expand_virtual_keywords([" core "])
+        assert set(result) == CORE_CATEGORIES
+
+
+@pytest.mark.asyncio
+class TestCoreKeywordIntegration:
+    """Integration tests for the 'core' virtual keyword through import_langflow_components."""
+
+    async def test_core_allowlist_includes_core_categories(self, tmp_path, monkeypatch):
+        """ALLOWLIST=core loads only core categories, not bundles."""
+        monkeypatch.delenv("LFX_DEV", raising=False)
+
+        entries = [
+            ["input_output", {"comp1": {"template": {}}}],
+            ["processing", {"comp2": {"template": {}}}],
+            ["openai", {"comp3": {"template": {}}}],
+            ["anthropic", {"comp4": {"template": {}}}],
+        ]
+        index_file = tmp_path / "index.json"
+        _write_index(index_file, entries)
+
+        settings = _make_settings(index_path=str(index_file), allowlist=["core"])
+
+        result = await import_langflow_components(settings)
+
+        assert "input_output" in result["components"]
+        assert "processing" in result["components"]
+        assert "openai" not in result["components"]
+        assert "anthropic" not in result["components"]
+
+    async def test_core_plus_bundle_allowlist(self, tmp_path, monkeypatch):
+        """ALLOWLIST=core,openai loads core categories + openai."""
+        monkeypatch.delenv("LFX_DEV", raising=False)
+
+        entries = [
+            ["input_output", {"comp1": {"template": {}}}],
+            ["processing", {"comp2": {"template": {}}}],
+            ["openai", {"comp3": {"template": {}}}],
+            ["anthropic", {"comp4": {"template": {}}}],
+        ]
+        index_file = tmp_path / "index.json"
+        _write_index(index_file, entries)
+
+        settings = _make_settings(index_path=str(index_file), allowlist=["core", "openai"])
+
+        result = await import_langflow_components(settings)
+
+        assert "input_output" in result["components"]
+        assert "processing" in result["components"]
+        assert "openai" in result["components"]
+        assert "anthropic" not in result["components"]
+
+    async def test_core_blocklist_removes_core_categories(self, tmp_path, monkeypatch):
+        """BLOCKLIST=core removes core categories, keeps bundles."""
+        monkeypatch.delenv("LFX_DEV", raising=False)
+
+        entries = [
+            ["input_output", {"comp1": {"template": {}}}],
+            ["processing", {"comp2": {"template": {}}}],
+            ["openai", {"comp3": {"template": {}}}],
+        ]
+        index_file = tmp_path / "index.json"
+        _write_index(index_file, entries)
+
+        settings = _make_settings(index_path=str(index_file), blocklist=["core"])
+
+        result = await import_langflow_components(settings)
+
+        assert "input_output" not in result["components"]
+        assert "processing" not in result["components"]
+        assert "openai" in result["components"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add `LANGFLOW_COMPONENT_CATEGORY_ALLOWLIST` and `LANGFLOW_COMPONENT_CATEGORY_BLOCKLIST` environment variables to control which component categories are loaded from the component index
- Allowlist restricts to only listed categories; blocklist excludes listed categories. Both are case-insensitive comma-separated lists
- Filtering is applied at the earliest point in each loading path (index, cache, dynamic) for maximum speed
- Includes configuration validation with error-level logging for typos, overlaps, and contradictions between allowlist and blocklist
- Adds defensive handling for malformed index entries
- 62 tests total (31 new), all using the real component index with no mocking

## Test plan

- [x] All 62 lfx unit tests pass (`cd src/lfx && uv sync && uv run pytest`)
- [x] `make format_backend` passes (ruff check + format)
- [x] Pre-commit hooks pass
- [ ] Verify allowlist works: `LANGFLOW_COMPONENT_CATEGORY_ALLOWLIST=openai,anthropic` loads only those categories
- [ ] Verify blocklist works: `LANGFLOW_COMPONENT_CATEGORY_BLOCKLIST=prototypes` excludes that category
- [ ] Verify combined: allowlist + blocklist filters correctly (allowlist first, then blocklist removes from result)
- [ ] Verify typo detection: misspelled category names produce error-level log messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added component category filtering with allowlist and blocklist configuration options. Users can now selectively include or exclude component categories when loading components, providing granular control over component availability.

* **Tests**
  * Added comprehensive unit tests for category filtering logic and settings-driven component loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->