### PR TITLE
docs(opik): Opik intergration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - **Multi-agent orchestration** with conversation management and retrieval.
 - **Deploy as an API** or export as JSON for Python apps.
 - **Deploy as an MCP server** and turn your flows into tools for MCP clients.
-- **Observability** with LangSmith, LangFuse and other integrations.
+- **Observability** with LangSmith, LangFuse, Opik, and other integrations.
 - **Enterprise-ready** security and scalability.
 
 ## 🖥️  Langflow Desktop

--- a/docs/docs/Develop/integrations-langfuse.mdx
+++ b/docs/docs/Develop/integrations-langfuse.mdx
@@ -155,3 +155,4 @@ As an alternative to the previous setup, particularly for self-hosted Langfuse, 
 ## See also
 
 * [Langfuse GitHub repository](https://github.com/langfuse/langfuse)
+* [Opik integration for Langflow](/integrations-opik)

--- a/docs/docs/Develop/integrations-opik.mdx
+++ b/docs/docs/Develop/integrations-opik.mdx
@@ -68,7 +68,7 @@ export OPIK_URL_OVERRIDE=https://www.comet.com/opik/api
 </TabItem>
 <TabItem value="windows" label="Windows">
 
-```
+```batch
 set OPIK_API_KEY=YOUR_API_KEY
 set OPIK_WORKSPACE=YOUR_WORKSPACE
 set OPIK_PROJECT_NAME=YOUR_PROJECT

--- a/docs/docs/Develop/integrations-opik.mdx
+++ b/docs/docs/Develop/integrations-opik.mdx
@@ -105,6 +105,8 @@ For deployment options and configuration details, see the [Opik + Langflow integ
 
 Remove Opik environment variables (or update/remove `~/.opik.config`), then restart Langflow.
 
+On Windows, this file is typically located at `%USERPROFILE%\\.opik.config` (for example, `C:\\Users\\<username>\\.opik.config`).
+
 ## See also
 
 * [Opik + Langflow integration](https://www.comet.com/docs/opik/integrations/langflow)

--- a/docs/docs/Develop/integrations-opik.mdx
+++ b/docs/docs/Develop/integrations-opik.mdx
@@ -68,7 +68,7 @@ export OPIK_URL_OVERRIDE=https://www.comet.com/opik/api
 </TabItem>
 <TabItem value="windows" label="Windows">
 
-```bash
+```
 set OPIK_API_KEY=YOUR_API_KEY
 set OPIK_WORKSPACE=YOUR_WORKSPACE
 set OPIK_PROJECT_NAME=YOUR_PROJECT

--- a/docs/docs/Develop/integrations-opik.mdx
+++ b/docs/docs/Develop/integrations-opik.mdx
@@ -3,9 +3,12 @@ title: Opik
 slug: /integrations-opik
 ---
 
-[Opik](https://www.comet.com/site/products/opik/) is an open-source platform designed for evaluating, testing, and monitoring large language model (LLM) applications. Developed by Comet, it aims to facilitate more intuitive collaboration, testing, and monitoring of LLM-based applications.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-You can configure Langflow to collect [tracing](https://www.comet.com/docs/opik/tracing/log_traces) data about your flow executions and automatically send the data to Opik.
+[Opik](https://www.comet.com/site/products/opik/) is an open-source platform for evaluating, testing, and monitoring LLM applications. You can configure Langflow to collect tracing data about flow executions and send it to Opik automatically.
+
+For end-to-end integration details, see the official [Opik + Langflow guide](https://www.comet.com/docs/opik/integrations/langflow).
 
 ## Prerequisites
 
@@ -16,7 +19,9 @@ You can configure Langflow to collect [tracing](https://www.comet.com/docs/opik/
 If you need a flow to test the Opik integration, see the [Langflow quickstart](/get-started-quickstart).
 :::
 
-## Integrate Opik with Langflow
+## Configure Opik for Langflow
+
+### Option 1: Use `opik configure` (recommended)
 
 1. If you use Opik Cloud, get an [Opik API key](https://www.comet.com/docs/opik/faq#where-can-i-find-my-opik-api-key-).
 
@@ -36,16 +41,71 @@ If you need a flow to test the Opik integration, see the [Langflow quickstart](/
 
     For more information, see the [Opik SDK configuration documentation](https://www.comet.com/docs/opik/tracing/sdk_configuration).
 
-3. Start Langflow in the same terminal or environment where you set the environment variables:
+3. Start Langflow in the same terminal or environment where Opik was configured:
 
     ```bash
     uv run langflow run
     ```
 
-4. In Langflow, run a flow to produce activity for Opik to trace.
+4. Run a flow in Langflow to produce activity for Opik to trace.
 
-5. Navigate to your Opik project dashboard and view the collected tracing data.
+5. Open your Opik project dashboard to view collected traces.
 
-## Disable the Opik integration
+### Option 2: Set Opik environment variables manually
 
-To disable the Opik integration, remove the environment variables you set with `opik configure`, and then restart Langflow.
+You can also configure Opik via environment variables:
+
+<Tabs>
+<TabItem value="linux-macos" label="Linux or macOS" default>
+
+```bash
+export OPIK_API_KEY=YOUR_API_KEY
+export OPIK_WORKSPACE=YOUR_WORKSPACE
+export OPIK_PROJECT_NAME=YOUR_PROJECT
+export OPIK_URL_OVERRIDE=https://www.comet.com/opik/api
+```
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```bash
+set OPIK_API_KEY=YOUR_API_KEY
+set OPIK_WORKSPACE=YOUR_WORKSPACE
+set OPIK_PROJECT_NAME=YOUR_PROJECT
+set OPIK_URL_OVERRIDE=https://www.comet.com/opik/api
+```
+
+</TabItem>
+</Tabs>
+
+Then start Langflow:
+
+```bash
+uv run langflow run
+```
+
+## Run Langflow + Opik with Docker Compose
+
+If you run Langflow in Docker, pass Opik settings as container environment variables:
+
+```yaml
+services:
+  langflow:
+    image: langflowai/langflow:latest
+    environment:
+      - OPIK_API_KEY=${OPIK_API_KEY}
+      - OPIK_WORKSPACE=${OPIK_WORKSPACE}
+      - OPIK_PROJECT_NAME=langflow
+      - OPIK_URL_OVERRIDE=https://www.comet.com/opik/api
+```
+
+For deployment options and configuration details, see the [Opik + Langflow integration guide](https://www.comet.com/docs/opik/integrations/langflow).
+
+## Disable Opik tracing
+
+Remove Opik environment variables (or update/remove `~/.opik.config`), then restart Langflow.
+
+## See also
+
+* [Opik + Langflow integration](https://www.comet.com/docs/opik/integrations/langflow)
+* [Opik SDK configuration](https://www.comet.com/docs/opik/tracing/sdk_configuration)

--- a/docs/docs/Develop/integrations-opik.mdx
+++ b/docs/docs/Develop/integrations-opik.mdx
@@ -29,13 +29,13 @@ If you need a flow to test the Opik integration, see the [Langflow quickstart](/
 
 2. Call the `opik configure` CLI to save your Opik configuration in the same environment where you run Langflow:
 
-    ```bash
+    ```bash title="Configure Opik"
     opik configure
     ```
 
     For self-hosted Opik, you can also use the following Opik CLI command:
 
-    ```bash
+    ```bash title="Configure Opik (self-hosted)"
     opik configure --use_local
     ```
 
@@ -43,7 +43,7 @@ If you need a flow to test the Opik integration, see the [Langflow quickstart](/
 
 3. Start Langflow in the same terminal or environment where Opik was configured:
 
-    ```bash
+    ```bash title="Start Langflow"
     uv run langflow run
     ```
 
@@ -58,7 +58,7 @@ You can also configure Opik via environment variables:
 <Tabs>
 <TabItem value="linux-macos" label="Linux or macOS" default>
 
-```bash
+```bash title="Set Opik environment variables (Linux/macOS)"
 export OPIK_API_KEY=YOUR_API_KEY
 export OPIK_WORKSPACE=YOUR_WORKSPACE
 export OPIK_PROJECT_NAME=YOUR_PROJECT
@@ -68,7 +68,7 @@ export OPIK_URL_OVERRIDE=https://www.comet.com/opik/api
 </TabItem>
 <TabItem value="windows" label="Windows">
 
-```batch
+```batch title="Set Opik environment variables (Windows)"
 set OPIK_API_KEY=YOUR_API_KEY
 set OPIK_WORKSPACE=YOUR_WORKSPACE
 set OPIK_PROJECT_NAME=YOUR_PROJECT
@@ -80,7 +80,7 @@ set OPIK_URL_OVERRIDE=https://www.comet.com/opik/api
 
 Then start Langflow:
 
-```bash
+```bash title="Start Langflow"
 uv run langflow run
 ```
 
@@ -88,7 +88,7 @@ uv run langflow run
 
 If you run Langflow in Docker, pass Opik settings as container environment variables:
 
-```yaml
+```yaml title="docker-compose.yml"
 services:
   langflow:
     image: langflowai/langflow:latest
@@ -105,7 +105,7 @@ For deployment options and configuration details, see the [Opik + Langflow integ
 
 Remove Opik environment variables (or update/remove `~/.opik.config`), then restart Langflow.
 
-On Windows, this file is typically located at `%USERPROFILE%\\.opik.config` (for example, `C:\\Users\\<username>\\.opik.config`).
+On Windows, this file is typically located at `%USERPROFILE%\.opik.config` (for example, `C:\Users\<username>\.opik.config`).
 
 ## See also
 


### PR DESCRIPTION
## Summary
- update README observability highlight to explicitly include Opik
- keep wording aligned with existing LangSmith/LangFuse positioning

## Test Plan
- docs-only change
- verified README renders with the updated bullet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Opik to the observability integrations list and linked it from related integration pages.
  * Reworked Opik integration docs into a tabbed "Configure Opik" guide with two setup options (recommended CLI configure and manual environment variables), platform-specific examples, Docker Compose usage, and steps to enable/disable tracing.
  * Added cross-references to Opik + Langflow and Opik SDK configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->