### PR TITLE
feat(api): add exclude_flows_data query param to GET /projects/{id}

### DIFF
--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -38,13 +38,13 @@ from langflow.services.database.models.api_key.model import ApiKeyCreate
 from langflow.services.database.models.flow.model import Flow, FlowCreate, FlowRead
 from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NAME
 from langflow.services.database.models.folder.model import (
+    FlowReadNoData,
     Folder,
     FolderCreate,
     FolderRead,
     FolderReadWithFlows,
     FolderReadWithFlowsNoData,
     FolderUpdate,
-    FlowReadNoData,
 )
 from langflow.services.database.models.folder.pagination_model import FolderWithPaginatedFlows
 from langflow.services.deps import get_service, get_settings_service, get_storage_service

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -254,13 +254,12 @@ async def read_project(
     is_component: bool = False,
     is_flow: bool = False,
     search: str = "",
-    exclude_flows_data: bool = Query(
-        default=False,
+    exclude_flows_data: Annotated[bool, Query(
         description=(
             "When true, omits the flow graph data from each flow in the response. "
             "Useful for listing flows or performing existence checks without fetching heavy graph data."
         ),
-    ),
+    )] = False,
 ):
     try:
         project = (

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -254,12 +254,15 @@ async def read_project(
     is_component: bool = False,
     is_flow: bool = False,
     search: str = "",
-    exclude_flows_data: Annotated[bool, Query(
-        description=(
-            "When true, omits the flow graph data from each flow in the response. "
-            "Useful for listing flows or performing existence checks without fetching heavy graph data."
+    exclude_flows_data: Annotated[
+        bool,
+        Query(
+            description=(
+                "When true, omits the flow graph data from each flow in the response. "
+                "Useful for listing flows or performing existence checks without fetching heavy graph data."
+            ),
         ),
-    )] = False,
+    ] = False,
 ):
     try:
         project = (

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -42,7 +42,9 @@ from langflow.services.database.models.folder.model import (
     FolderCreate,
     FolderRead,
     FolderReadWithFlows,
+    FolderReadWithFlowsNoData,
     FolderUpdate,
+    FlowReadNoData,
 )
 from langflow.services.database.models.folder.pagination_model import FolderWithPaginatedFlows
 from langflow.services.deps import get_service, get_settings_service, get_storage_service
@@ -236,7 +238,11 @@ async def read_projects(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@router.get("/{project_id}", response_model=FolderWithPaginatedFlows | FolderReadWithFlows, status_code=200)
+@router.get(
+    "/{project_id}",
+    response_model=FolderWithPaginatedFlows | FolderReadWithFlows | FolderReadWithFlowsNoData,
+    status_code=200,
+)
 async def read_project(
     *,
     session: DbSession,
@@ -248,6 +254,13 @@ async def read_project(
     is_component: bool = False,
     is_flow: bool = False,
     search: str = "",
+    exclude_flows_data: bool = Query(
+        default=False,
+        description=(
+            "When true, omits the flow graph data from each flow in the response. "
+            "Useful for listing flows or performing existence checks without fetching heavy graph data."
+        ),
+    ),
 ):
     try:
         project = (
@@ -292,6 +305,18 @@ async def read_project(
         # If no pagination requested, return all flows for the current user
         flows_from_current_user_in_project = [flow for flow in project.flows if flow.user_id == current_user.id]
         project.flows = flows_from_current_user_in_project
+
+        # When exclude_flows_data is requested, return flows without the heavy graph data field
+        if exclude_flows_data:
+            flows_no_data = [FlowReadNoData.model_validate(flow, from_attributes=True) for flow in project.flows]
+            return FolderReadWithFlowsNoData(
+                id=project.id,
+                name=project.name,
+                description=project.description,
+                parent_id=project.parent_id,
+                auth_settings=project.auth_settings,
+                flows=flows_no_data,
+            )
 
         # Convert to FolderReadWithFlows while session is still active to avoid detached instance errors
         return FolderReadWithFlows.model_validate(project, from_attributes=True)

--- a/src/backend/base/langflow/services/database/models/folder/model.py
+++ b/src/backend/base/langflow/services/database/models/folder/model.py
@@ -1,10 +1,11 @@
+from datetime import datetime
 from typing import Optional
 from uuid import UUID, uuid4
 
 from sqlalchemy import Text, UniqueConstraint
 from sqlmodel import JSON, Column, Field, Relationship, SQLModel
 
-from langflow.services.database.models.flow.model import Flow, FlowRead
+from langflow.services.database.models.flow.model import AccessTypeEnum, Flow, FlowRead
 from langflow.services.database.models.user.model import User
 
 
@@ -50,6 +51,34 @@ class FolderReadWithFlows(FolderBase):
     id: UUID
     parent_id: UUID | None = Field()
     flows: list[FlowRead] = Field(default=[])
+
+
+class FlowReadNoData(SQLModel):
+    """Lightweight flow read model that omits the heavy graph data field."""
+
+    id: UUID
+    name: str
+    description: str | None = None
+    folder_id: UUID | None = None
+    user_id: UUID | None = None
+    is_component: bool | None = None
+    updated_at: datetime | None = None
+    endpoint_name: str | None = None
+    tags: list[str] | None = None
+    access_type: AccessTypeEnum = AccessTypeEnum.PRIVATE
+    icon: str | None = None
+    icon_bg_color: str | None = None
+    locked: bool | None = None
+    mcp_enabled: bool | None = None
+    webhook: bool | None = None
+
+
+class FolderReadWithFlowsNoData(FolderBase):
+    """Folder read model whose flows list omits the heavy graph data field from each flow."""
+
+    id: UUID
+    parent_id: UUID | None = Field(default=None)
+    flows: list[FlowReadNoData] = Field(default=[])
 
 
 class FolderUpdate(SQLModel):

--- a/src/backend/base/langflow/services/database/models/folder/model.py
+++ b/src/backend/base/langflow/services/database/models/folder/model.py
@@ -68,9 +68,12 @@ class FlowReadNoData(SQLModel):
     access_type: AccessTypeEnum = AccessTypeEnum.PRIVATE
     icon: str | None = None
     icon_bg_color: str | None = None
+    gradient: str | None = None
     locked: bool | None = None
     mcp_enabled: bool | None = None
     webhook: bool | None = None
+    action_name: str | None = None
+    action_description: str | None = None
 
 
 class FolderReadWithFlowsNoData(FolderBase):

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -1775,9 +1775,8 @@ async def test_read_project_exclude_flows_data(client: AsyncClient, logged_in_he
     assert len(full_flows) == 1, "Expected one non-component flow"
 
     full_flow_entry = full_flows[0]
-    assert "data" in full_flow_entry and full_flow_entry["data"] is not None, (
-        "Flow graph data must be present when exclude_flows_data is not set"
-    )
+    assert "data" in full_flow_entry, "Flow data key must be present when exclude_flows_data is not set"
+    assert full_flow_entry["data"] is not None, "Flow graph data must not be None when exclude_flows_data is not set"
     assert "nodes" in full_flow_entry["data"], "Nodes must be present in flow data"
 
     # --- Test with exclude_flows_data=false explicitly: should behave as default ---

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -1719,3 +1719,79 @@ async def test_download_file_starter_project(client: AsyncClient, logged_in_head
     # Clean up: delete the project (which will cascade delete flows)
     delete_response = await client.delete(f"api/v1/projects/{starter_project_id}", headers=logged_in_headers)
     assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+
+async def test_read_project_exclude_flows_data(client: AsyncClient, logged_in_headers):
+    """Test that exclude_flows_data=true omits the graph data field from flows in the response."""
+    # Create a project
+    project_payload = {
+        "name": "Test Exclude Flows Data Project",
+        "description": "Testing exclude_flows_data parameter",
+        "flows_list": [],
+        "components_list": [],
+    }
+    create_resp = await client.post("api/v1/projects/", json=project_payload, headers=logged_in_headers)
+    assert create_resp.status_code == status.HTTP_201_CREATED
+    project_id = create_resp.json()["id"]
+
+    # Create a flow with non-trivial graph data inside the project
+    flow_payload = {
+        "name": "Graph Flow",
+        "description": "Flow with graph data",
+        "folder_id": project_id,
+        "data": {
+            "nodes": [{"id": "node-1", "type": "genericNode", "data": {"type": "OpenAI", "node": {}}}],
+            "edges": [],
+        },
+        "is_component": False,
+    }
+    flow_resp = await client.post("api/v1/flows/", json=flow_payload, headers=logged_in_headers)
+    assert flow_resp.status_code == status.HTTP_201_CREATED
+
+    # --- Test with exclude_flows_data=true: graph data should be absent ---
+    no_data_resp = await client.get(
+        f"api/v1/projects/{project_id}?exclude_flows_data=true", headers=logged_in_headers
+    )
+    assert no_data_resp.status_code == status.HTTP_200_OK
+    no_data_result = no_data_resp.json()
+
+    assert "flows" in no_data_result, "Response must contain flows list"
+    actual_flows = [f for f in no_data_result["flows"] if not f.get("is_component", False)]
+    assert len(actual_flows) == 1, "Expected one non-component flow"
+
+    flow_entry = actual_flows[0]
+    assert "data" not in flow_entry or flow_entry.get("data") is None, (
+        "Flow graph data must be absent when exclude_flows_data=true"
+    )
+    assert "id" in flow_entry, "Flow id must be present"
+    assert "name" in flow_entry, "Flow name must be present"
+    assert flow_entry["name"] == "Graph Flow"
+
+    # --- Test without exclude_flows_data (default): graph data should be present ---
+    full_resp = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert full_resp.status_code == status.HTTP_200_OK
+    full_result = full_resp.json()
+
+    assert "flows" in full_result, "Response must contain flows list"
+    full_flows = [f for f in full_result["flows"] if not f.get("is_component", False)]
+    assert len(full_flows) == 1, "Expected one non-component flow"
+
+    full_flow_entry = full_flows[0]
+    assert "data" in full_flow_entry and full_flow_entry["data"] is not None, (
+        "Flow graph data must be present when exclude_flows_data is not set"
+    )
+    assert "nodes" in full_flow_entry["data"], "Nodes must be present in flow data"
+
+    # --- Test with exclude_flows_data=false explicitly: should behave as default ---
+    explicit_false_resp = await client.get(
+        f"api/v1/projects/{project_id}?exclude_flows_data=false", headers=logged_in_headers
+    )
+    assert explicit_false_resp.status_code == status.HTTP_200_OK
+    explicit_false_result = explicit_false_resp.json()
+    explicit_false_flows = [f for f in explicit_false_result["flows"] if not f.get("is_component", False)]
+    assert len(explicit_false_flows) == 1
+    assert explicit_false_flows[0].get("data") is not None, "Data must be present when exclude_flows_data=false"
+
+    # Clean up
+    delete_resp = await client.delete(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert delete_resp.status_code == status.HTTP_204_NO_CONTENT

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -1749,9 +1749,7 @@ async def test_read_project_exclude_flows_data(client: AsyncClient, logged_in_he
     assert flow_resp.status_code == status.HTTP_201_CREATED
 
     # --- Test with exclude_flows_data=true: graph data should be absent ---
-    no_data_resp = await client.get(
-        f"api/v1/projects/{project_id}?exclude_flows_data=true", headers=logged_in_headers
-    )
+    no_data_resp = await client.get(f"api/v1/projects/{project_id}?exclude_flows_data=true", headers=logged_in_headers)
     assert no_data_resp.status_code == status.HTTP_200_OK
     no_data_result = no_data_resp.json()
 


### PR DESCRIPTION
## Summary

The `GET /api/v1/projects/{project_id}` endpoint currently always returns the full graph data for every flow in a project. For projects with many complex flows, this payload can be several megabytes — even when the caller only needs lightweight metadata such as flow IDs, names, or descriptions.

This PR adds an optional boolean query parameter `exclude_flows_data` (default `false`) that, when set to `true`, strips the `data` field from each flow in the response. The `data` field contains the full node-and-edge graph, which is the dominant contributor to response size. All other flow metadata (id, name, description, timestamps, endpoint name, access type, tags, etc.) is still returned.

The default value is `false`, so the change is fully backward-compatible — existing callers are unaffected.

Closes #11463.

---

## Problem

Every call to `GET /api/v1/projects/{project_id}` loads and serializes the complete flow graph for every flow in the project, regardless of whether the caller needs it. This is wasteful in several common scenarios:

- **Sidebar / project listing UI** — the UI only needs flow IDs, names, and descriptions to render the sidebar; it does not render graph nodes until the user opens a flow.
- **Existence and ownership checks** — external systems that verify a project or flow exists incur full graph deserialization even though they only use the ID.
- **API integrations** — integrations that enumerate flows to build lookup maps don't need graph data.
- **Health checks and monitoring** — periodic checks that validate accessibility should not bear the cost of full graph payloads.

For a project with 20 flows, each with a moderately complex graph (~50 nodes), the difference in response size can be on the order of hundreds of kilobytes to a few megabytes.

---

## Changes

### `src/backend/base/langflow/services/database/models/folder/model.py`

Two new Pydantic response models:

- **`FlowReadNoData`** — mirrors `FlowRead` but omits the `data` field. Includes all other flow fields: `id`, `name`, `description`, `folder_id`, `user_id`, `is_component`, `updated_at`, `endpoint_name`, `tags`, `access_type`, `icon`, `icon_bg_color`, `locked`, `mcp_enabled`, `webhook`.
- **`FolderReadWithFlowsNoData`** — mirrors `FolderReadWithFlows` but uses `FlowReadNoData` for its `flows` list.

### `src/backend/base/langflow/api/v1/projects.py`

- Added `exclude_flows_data: bool = Query(default=False, ...)` parameter to the `read_project` endpoint.
- Updated the `response_model` annotation to include `FolderReadWithFlowsNoData` as a valid return type.
- When `exclude_flows_data=True` and no pagination is requested, the endpoint validates each flow into `FlowReadNoData` (which omits `data`) and returns a `FolderReadWithFlowsNoData` instance.
- The paginated path (`page` + `size`) is unaffected by this parameter in this PR — pagination already returns `FolderWithPaginatedFlows` which does not serialize `data` by default; graph-level exclusion there can be addressed in a follow-up if needed.

### `src/backend/tests/unit/api/v1/test_projects.py`

Added `test_read_project_exclude_flows_data` covering three cases:

1. `exclude_flows_data=true` — asserts `data` is absent from flow entries in the response.
2. No parameter (default) — asserts `data` is present and contains `nodes`.
3. `exclude_flows_data=false` explicitly — asserts `data` is present (same as default, explicit opt-in to full payload).

---

## API Usage

### Before (always returns full graph data)

```http
GET /api/v1/projects/{project_id}
```

```json
{
  "id": "3fa85f64-...",
  "name": "My Project",
  "flows": [
    {
      "id": "flow-uuid-1",
      "name": "My Flow",
      "data": {
        "nodes": [ ... ],
        "edges": [ ... ]
      }
    }
  ]
}
```

### After (lightweight metadata only)

```http
GET /api/v1/projects/{project_id}?exclude_flows_data=true
```

```json
{
  "id": "3fa85f64-...",
  "name": "My Project",
  "flows": [
    {
      "id": "flow-uuid-1",
      "name": "My Flow",
      "description": "...",
      "updated_at": "2026-02-17T00:00:00Z",
      "is_component": false,
      "access_type": "PRIVATE"
    }
  ]
}
```

---

## Backward Compatibility

- Default value is `false` — all existing callers receive the same response as before.
- No database schema changes.
- No changes to any other endpoint.
- The new response models are additive only.

---

## Testing

```bash
# Run the projects unit tests
cd src/backend
pytest tests/unit/api/v1/test_projects.py -v -k "test_read_project"
```

To manually verify against a running instance:

```bash
# Full response (default)
curl -H "x-api-key: <KEY>" \
  "http://localhost:7860/api/v1/projects/<PROJECT_ID>"

# Lightweight metadata only
curl -H "x-api-key: <KEY>" \
  "http://localhost:7860/api/v1/projects/<PROJECT_ID>?exclude_flows_data=true"
```

The new `exclude_flows_data` query parameter also appears in the interactive API docs at `/docs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exclude_flows_data query parameter to project read endpoints to optionally exclude flow graph data from responses and return lightweight flow representations instead.

* **Tests**
  * Added comprehensive test coverage for the exclude_flows_data parameter, validating correct data inclusion/exclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->