### PR TITLE
feat: Add ModelsLab LLM and image generation components

### DIFF
--- a/src/backend/base/langflow/components/models/modelslab.py
+++ b/src/backend/base/langflow/components/models/modelslab.py
@@ -1,5 +1,4 @@
-"""
-ModelsLab LLM component for Langflow.
+"""ModelsLab LLM component for Langflow.
 
 Provides uncensored Llama 3.1 8B and 70B models via ModelsLab's
 OpenAI-compatible API endpoint.
@@ -31,8 +30,7 @@ MODELSLAB_CHAT_BASE_URL = "https://modelslab.com/uncensored-chat/v1"
 
 
 class ModelsLabModelComponent(LCModelComponent):
-    """
-    ModelsLab LLM component for Langflow.
+    """ModelsLab LLM component for Langflow.
 
     Connects to ModelsLab's OpenAI-compatible endpoint to provide uncensored
     Llama 3.1 models with 128K token context windows.
@@ -123,14 +121,9 @@ class ModelsLabModelComponent(LCModelComponent):
     ]
 
     def build_model(self) -> LanguageModel:
-        """
-        Instantiate and return a ChatOpenAI model configured for ModelsLab.
-        """
+        """Instantiate and return a ChatOpenAI model configured for ModelsLab."""
         if not self.api_key:
-            msg = (
-                "ModelsLab API key is required. "
-                "Get yours at https://modelslab.com"
-            )
+            msg = "ModelsLab API key is required. Get yours at https://modelslab.com"
             raise ValueError(msg)
 
         params: dict = {

--- a/src/backend/base/langflow/components/models/modelslab.py
+++ b/src/backend/base/langflow/components/models/modelslab.py
@@ -1,0 +1,149 @@
+"""
+ModelsLab LLM component for Langflow.
+
+Provides uncensored Llama 3.1 8B and 70B models via ModelsLab's
+OpenAI-compatible API endpoint.
+
+Get your API key at: https://modelslab.com
+API docs: https://docs.modelslab.com/uncensored-chat
+"""
+
+from langchain_openai import ChatOpenAI
+from langflow.base.models.model import LCModelComponent
+from langflow.field_typing import LanguageModel
+from langflow.io import (
+    BoolInput,
+    DropdownInput,
+    FloatInput,
+    IntInput,
+    MessageTextInput,
+    Output,
+    SecretStrInput,
+    SliderInput,
+)
+
+MODELSLAB_CHAT_MODELS = [
+    "llama-3.1-8b-uncensored",
+    "llama-3.1-70b-uncensored",
+]
+
+MODELSLAB_CHAT_BASE_URL = "https://modelslab.com/uncensored-chat/v1"
+
+
+class ModelsLabModelComponent(LCModelComponent):
+    """
+    ModelsLab LLM component for Langflow.
+
+    Connects to ModelsLab's OpenAI-compatible endpoint to provide uncensored
+    Llama 3.1 models with 128K token context windows.
+    """
+
+    display_name: str = "ModelsLab"
+    description: str = (
+        "Chat with ModelsLab's uncensored Llama 3.1 models (8B & 70B) via an "
+        "OpenAI-compatible API. Ideal for creative writing, research, and use cases "
+        "where standard content restrictions are too limiting. 128K context window."
+    )
+    documentation: str = "https://docs.modelslab.com/uncensored-chat"
+    icon: str = "ModelsLab"
+    name: str = "ModelsLabModel"
+
+    inputs = [
+        *LCModelComponent._base_inputs,
+        SecretStrInput(
+            name="api_key",
+            display_name="ModelsLab API Key",
+            info="Your ModelsLab API key. Get one at https://modelslab.com",
+            real_time_refresh=True,
+            required=True,
+        ),
+        DropdownInput(
+            name="model_name",
+            display_name="Model",
+            info="The ModelsLab model to use for generation.",
+            options=MODELSLAB_CHAT_MODELS,
+            value=MODELSLAB_CHAT_MODELS[0],
+            refresh_button=True,
+        ),
+        SliderInput(
+            name="temperature",
+            display_name="Temperature",
+            info="Controls randomness. Lower = more deterministic, higher = more creative.",
+            value=0.7,
+            range_spec={"min": 0.0, "max": 2.0, "step": 0.1},
+        ),
+        IntInput(
+            name="max_tokens",
+            display_name="Max Tokens",
+            info="Maximum number of tokens to generate. Leave at 0 for model default.",
+            value=0,
+            advanced=True,
+        ),
+        FloatInput(
+            name="top_p",
+            display_name="Top P",
+            info="Nucleus sampling probability. 1.0 = no filtering.",
+            value=1.0,
+            advanced=True,
+        ),
+        IntInput(
+            name="n",
+            display_name="Number of Completions",
+            info="How many completions to generate per prompt.",
+            value=1,
+            advanced=True,
+        ),
+        BoolInput(
+            name="stream",
+            display_name="Stream",
+            info="Stream the response token by token.",
+            value=False,
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="base_url",
+            display_name="Base URL",
+            info="ModelsLab API base URL. Override only if using a custom endpoint.",
+            value=MODELSLAB_CHAT_BASE_URL,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(
+            display_name="Text",
+            name="text_output",
+            method="text_response",
+        ),
+        Output(
+            display_name="Language Model",
+            name="model_output",
+            method="build_model",
+        ),
+    ]
+
+    def build_model(self) -> LanguageModel:
+        """
+        Instantiate and return a ChatOpenAI model configured for ModelsLab.
+        """
+        if not self.api_key:
+            msg = (
+                "ModelsLab API key is required. "
+                "Get yours at https://modelslab.com"
+            )
+            raise ValueError(msg)
+
+        params: dict = {
+            "model": self.model_name,
+            "openai_api_key": self.api_key,
+            "openai_api_base": self.base_url or MODELSLAB_CHAT_BASE_URL,
+            "temperature": self.temperature,
+            "streaming": self.stream,
+            "n": self.n,
+            "top_p": self.top_p,
+        }
+
+        if self.max_tokens and self.max_tokens > 0:
+            params["max_tokens"] = self.max_tokens
+
+        return ChatOpenAI(**params)

--- a/src/backend/base/langflow/components/utilities/modelslab_image.py
+++ b/src/backend/base/langflow/components/utilities/modelslab_image.py
@@ -1,5 +1,4 @@
-"""
-ModelsLab Image Generation component for Langflow.
+"""ModelsLab Image Generation component for Langflow.
 
 Generates images using ModelsLab's text-to-image API (Flux, SDXL,
 Playground v2.5, and 1000+ community models). Handles both synchronous
@@ -42,8 +41,7 @@ MODELSLAB_IMAGE_MODELS = [
 
 
 class ModelsLabImageComponent(Component):
-    """
-    ModelsLab Image Generation component for Langflow.
+    """ModelsLab Image Generation component for Langflow.
 
     Generates images via ModelsLab's API and returns the image URL(s)
     as Langflow Data objects compatible with downstream components.
@@ -146,9 +144,7 @@ class ModelsLabImageComponent(Component):
     ]
 
     def generate_image(self) -> Data:
-        """
-        Call ModelsLab image API and return image URL(s) as a Data object.
-        """
+        """Call ModelsLab image API and return image URL(s) as a Data object."""
         if not self.api_key:
             msg = "ModelsLab API key is required."
             raise ValueError(msg)

--- a/src/backend/base/langflow/components/utilities/modelslab_image.py
+++ b/src/backend/base/langflow/components/utilities/modelslab_image.py
@@ -1,0 +1,256 @@
+"""
+ModelsLab Image Generation component for Langflow.
+
+Generates images using ModelsLab's text-to-image API (Flux, SDXL,
+Playground v2.5, and 1000+ community models). Handles both synchronous
+and asynchronous (polling) responses automatically.
+
+Get your API key at: https://modelslab.com
+API docs: https://docs.modelslab.com/image-generation/text-to-image
+"""
+
+import time
+from typing import Any
+
+import requests
+from langflow.custom import Component
+from langflow.io import (
+    DropdownInput,
+    IntInput,
+    MessageTextInput,
+    Output,
+    SecretStrInput,
+    SliderInput,
+)
+from langflow.schema import Data
+
+MODELSLAB_IMAGE_API = "https://modelslab.com/api/v6/images/text2img"
+MODELSLAB_FETCH_API = "https://modelslab.com/api/v6/fetch/{task_id}"
+
+MODELSLAB_IMAGE_MODELS = [
+    "flux",
+    "flux-schnell",
+    "stable-diffusion-xl-base-1.0",
+    "playground-v2.5-1024px-aesthetic",
+    "dreamshaper-8",
+    "realistic-vision-v5",
+    "juggernautXL-v9",
+    "deliberate-v3",
+    "revAnimated-v2",
+    "dreamlike-photoreal-2.0",
+]
+
+
+class ModelsLabImageComponent(Component):
+    """
+    ModelsLab Image Generation component for Langflow.
+
+    Generates images via ModelsLab's API and returns the image URL(s)
+    as Langflow Data objects compatible with downstream components.
+    """
+
+    display_name: str = "ModelsLab Image Generation"
+    description: str = (
+        "Generate images using ModelsLab's API. Supports Flux, SDXL, "
+        "Playground v2.5, and 1000+ community models. Returns image URL(s)."
+    )
+    documentation: str = "https://docs.modelslab.com/image-generation/text-to-image"
+    icon: str = "Image"
+    name: str = "ModelsLabImage"
+
+    inputs = [
+        SecretStrInput(
+            name="api_key",
+            display_name="ModelsLab API Key",
+            info="Your ModelsLab API key. Get one at https://modelslab.com",
+            required=True,
+        ),
+        MessageTextInput(
+            name="prompt",
+            display_name="Prompt",
+            info="Text description of the image to generate.",
+            required=True,
+        ),
+        MessageTextInput(
+            name="negative_prompt",
+            display_name="Negative Prompt",
+            info="What to exclude from the image.",
+            value="low quality, blurry, deformed, ugly, watermark",
+            advanced=True,
+        ),
+        DropdownInput(
+            name="model_id",
+            display_name="Model",
+            info="Image generation model to use.",
+            options=MODELSLAB_IMAGE_MODELS,
+            value="flux",
+        ),
+        IntInput(
+            name="width",
+            display_name="Width",
+            info="Image width in pixels.",
+            value=1024,
+            advanced=True,
+        ),
+        IntInput(
+            name="height",
+            display_name="Height",
+            info="Image height in pixels.",
+            value=1024,
+            advanced=True,
+        ),
+        IntInput(
+            name="num_inference_steps",
+            display_name="Steps",
+            info="Number of denoising steps. More steps = better quality but slower.",
+            value=20,
+            advanced=True,
+        ),
+        SliderInput(
+            name="guidance_scale",
+            display_name="Guidance Scale (CFG)",
+            info="How closely to follow the prompt. Higher = more literal.",
+            value=7.5,
+            range_spec={"min": 1.0, "max": 20.0, "step": 0.5},
+            advanced=True,
+        ),
+        IntInput(
+            name="seed",
+            display_name="Seed",
+            info="Random seed for reproducibility. Use -1 for random.",
+            value=-1,
+            advanced=True,
+        ),
+        IntInput(
+            name="samples",
+            display_name="Number of Images",
+            info="How many images to generate.",
+            value=1,
+            advanced=True,
+        ),
+        IntInput(
+            name="poll_timeout",
+            display_name="Timeout (seconds)",
+            info="Maximum seconds to wait for async generation jobs.",
+            value=180,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(
+            display_name="Image URL(s)",
+            name="image_urls",
+            method="generate_image",
+        ),
+    ]
+
+    def generate_image(self) -> Data:
+        """
+        Call ModelsLab image API and return image URL(s) as a Data object.
+        """
+        if not self.api_key:
+            msg = "ModelsLab API key is required."
+            raise ValueError(msg)
+
+        if not self.prompt:
+            msg = "Prompt is required."
+            raise ValueError(msg)
+
+        payload: dict[str, Any] = {
+            "key": self.api_key,
+            "model_id": self.model_id,
+            "prompt": self.prompt,
+            "negative_prompt": self.negative_prompt or "",
+            "width": str(self.width),
+            "height": str(self.height),
+            "samples": str(self.samples),
+            "num_inference_steps": self.num_inference_steps,
+            "guidance_scale": self.guidance_scale,
+            "safety_checker": "no",
+            "enhance_prompt": "yes",
+        }
+
+        if self.seed and self.seed != -1:
+            payload["seed"] = self.seed
+
+        try:
+            response = requests.post(
+                MODELSLAB_IMAGE_API,
+                json=payload,
+                timeout=30,
+            )
+            response.raise_for_status()
+            result = response.json()
+        except requests.RequestException as e:
+            msg = f"ModelsLab API request failed: {e}"
+            raise RuntimeError(msg) from e
+
+        # Handle failure immediately
+        if result.get("status") == "failed":
+            msg = f"ModelsLab generation failed: {result.get('message', 'unknown error')}"
+            raise RuntimeError(msg)
+
+        # Async path — poll until done
+        if result.get("status") == "processing":
+            task_id = result.get("id")
+            if not task_id:
+                msg = "ModelsLab returned processing status but no task ID"
+                raise RuntimeError(msg)
+            result = self._poll_until_done(task_id)
+
+        # Extract image URLs
+        image_urls: list[str] = []
+        if isinstance(result.get("output"), list):
+            image_urls = result["output"]
+        elif result.get("output"):
+            image_urls = [result["output"]]
+        elif result.get("url"):
+            image_urls = [result["url"]]
+
+        if not image_urls:
+            msg = "ModelsLab returned no image URLs"
+            raise RuntimeError(msg)
+
+        self.status = f"Generated {len(image_urls)} image(s)"
+
+        return Data(
+            data={
+                "image_urls": image_urls,
+                "model": self.model_id,
+                "prompt": self.prompt,
+            },
+            text=image_urls[0],
+        )
+
+    def _poll_until_done(self, task_id: str) -> dict:
+        """Poll ModelsLab fetch endpoint until the task completes."""
+        deadline = time.time() + self.poll_timeout
+        poll_interval = 3.0
+
+        while time.time() < deadline:
+            time.sleep(poll_interval)
+
+            try:
+                resp = requests.post(
+                    MODELSLAB_FETCH_API.format(task_id=task_id),
+                    json={"key": self.api_key},
+                    timeout=15,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+            except requests.RequestException:
+                # Transient network error — keep polling
+                continue
+
+            if data.get("status") == "success":
+                return data
+            if data.get("status") == "failed":
+                msg = f"ModelsLab task failed: {data.get('message', 'unknown')}"
+                raise RuntimeError(msg)
+
+            # Still processing — back off slightly
+            poll_interval = min(poll_interval * 1.2, 10.0)
+
+        msg = f"ModelsLab image generation timed out after {self.poll_timeout}s (task: {task_id})"
+        raise TimeoutError(msg)

--- a/tests/test_modelslab_components.py
+++ b/tests/test_modelslab_components.py
@@ -1,0 +1,263 @@
+"""
+Tests for ModelsLab Langflow components.
+
+Run with: pytest tests/test_modelslab_components.py -v
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def make_llm_component(**kwargs):
+    """Create a ModelsLabModelComponent with mocked Langflow internals."""
+    from langflow.components.models.modelslab import ModelsLabModelComponent
+
+    comp = ModelsLabModelComponent.__new__(ModelsLabModelComponent)
+    # Set defaults
+    comp.api_key = kwargs.get("api_key", "test-key-12345")
+    comp.model_name = kwargs.get("model_name", "llama-3.1-8b-uncensored")
+    comp.temperature = kwargs.get("temperature", 0.7)
+    comp.max_tokens = kwargs.get("max_tokens", 0)
+    comp.top_p = kwargs.get("top_p", 1.0)
+    comp.n = kwargs.get("n", 1)
+    comp.stream = kwargs.get("stream", False)
+    comp.base_url = kwargs.get(
+        "base_url", "https://modelslab.com/uncensored-chat/v1"
+    )
+    return comp
+
+
+def make_image_component(**kwargs):
+    from langflow.components.utilities.modelslab_image import ModelsLabImageComponent
+
+    comp = ModelsLabImageComponent.__new__(ModelsLabImageComponent)
+    comp.api_key = kwargs.get("api_key", "test-key-12345")
+    comp.prompt = kwargs.get("prompt", "a sunset over mountains")
+    comp.negative_prompt = kwargs.get("negative_prompt", "")
+    comp.model_id = kwargs.get("model_id", "flux")
+    comp.width = kwargs.get("width", 1024)
+    comp.height = kwargs.get("height", 1024)
+    comp.num_inference_steps = kwargs.get("num_inference_steps", 20)
+    comp.guidance_scale = kwargs.get("guidance_scale", 7.5)
+    comp.seed = kwargs.get("seed", -1)
+    comp.samples = kwargs.get("samples", 1)
+    comp.poll_timeout = kwargs.get("poll_timeout", 30)
+    comp.status = ""
+    return comp
+
+
+# ── LLM Component Tests ───────────────────────────────────────────────────────
+
+
+class TestModelsLabModelComponent:
+    """Tests for the chat LLM component."""
+
+    @patch("langflow.components.models.modelslab.ChatOpenAI")
+    def test_build_model_returns_chat_openai(self, MockChatOpenAI):
+        mock_llm = MagicMock()
+        MockChatOpenAI.return_value = mock_llm
+
+        comp = make_llm_component()
+        result = comp.build_model()
+
+        assert result is mock_llm
+        MockChatOpenAI.assert_called_once()
+
+    @patch("langflow.components.models.modelslab.ChatOpenAI")
+    def test_build_model_passes_correct_base_url(self, MockChatOpenAI):
+        MockChatOpenAI.return_value = MagicMock()
+        comp = make_llm_component()
+        comp.build_model()
+
+        call_kwargs = MockChatOpenAI.call_args.kwargs
+        assert call_kwargs["openai_api_base"] == "https://modelslab.com/uncensored-chat/v1"
+
+    @patch("langflow.components.models.modelslab.ChatOpenAI")
+    def test_build_model_passes_api_key(self, MockChatOpenAI):
+        MockChatOpenAI.return_value = MagicMock()
+        comp = make_llm_component(api_key="my-secret-key")
+        comp.build_model()
+
+        call_kwargs = MockChatOpenAI.call_args.kwargs
+        assert call_kwargs["openai_api_key"] == "my-secret-key"
+
+    @patch("langflow.components.models.modelslab.ChatOpenAI")
+    def test_build_model_passes_model_name(self, MockChatOpenAI):
+        MockChatOpenAI.return_value = MagicMock()
+        comp = make_llm_component(model_name="llama-3.1-70b-uncensored")
+        comp.build_model()
+
+        call_kwargs = MockChatOpenAI.call_args.kwargs
+        assert call_kwargs["model"] == "llama-3.1-70b-uncensored"
+
+    @patch("langflow.components.models.modelslab.ChatOpenAI")
+    def test_build_model_excludes_max_tokens_when_zero(self, MockChatOpenAI):
+        MockChatOpenAI.return_value = MagicMock()
+        comp = make_llm_component(max_tokens=0)
+        comp.build_model()
+
+        call_kwargs = MockChatOpenAI.call_args.kwargs
+        assert "max_tokens" not in call_kwargs
+
+    @patch("langflow.components.models.modelslab.ChatOpenAI")
+    def test_build_model_includes_max_tokens_when_set(self, MockChatOpenAI):
+        MockChatOpenAI.return_value = MagicMock()
+        comp = make_llm_component(max_tokens=2048)
+        comp.build_model()
+
+        call_kwargs = MockChatOpenAI.call_args.kwargs
+        assert call_kwargs["max_tokens"] == 2048
+
+    def test_build_model_raises_without_api_key(self):
+        comp = make_llm_component(api_key="")
+        with pytest.raises(ValueError, match="API key"):
+            comp.build_model()
+
+    def test_display_name(self):
+        from langflow.components.models.modelslab import ModelsLabModelComponent
+        assert ModelsLabModelComponent.display_name == "ModelsLab"
+
+    def test_has_both_outputs(self):
+        from langflow.components.models.modelslab import ModelsLabModelComponent
+        output_names = [o.name for o in ModelsLabModelComponent.outputs]
+        assert "text_output" in output_names
+        assert "model_output" in output_names
+
+
+# ── Image Component Tests ─────────────────────────────────────────────────────
+
+
+class TestModelsLabImageComponent:
+    """Tests for the image generation component."""
+
+    @patch("langflow.components.utilities.modelslab_image.requests.post")
+    def test_generate_image_sync_success(self, mock_post):
+        mock_post.return_value = MagicMock(
+            ok=True,
+            json=lambda: {
+                "status": "success",
+                "output": ["https://cdn.modelslab.com/test-image.png"],
+            },
+        )
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        comp = make_image_component()
+        result = comp.generate_image()
+
+        assert result.data["image_urls"] == ["https://cdn.modelslab.com/test-image.png"]
+        assert result.text == "https://cdn.modelslab.com/test-image.png"
+
+    @patch("langflow.components.utilities.modelslab_image.time.sleep")
+    @patch("langflow.components.utilities.modelslab_image.requests.post")
+    def test_generate_image_async_polling(self, mock_post, mock_sleep):
+        mock_post.side_effect = [
+            # Initial request — processing
+            MagicMock(
+                ok=True,
+                json=lambda: {"status": "processing", "id": "task-xyz"},
+                raise_for_status=MagicMock(),
+            ),
+            # Poll #1 — done
+            MagicMock(
+                ok=True,
+                json=lambda: {
+                    "status": "success",
+                    "output": ["https://cdn.modelslab.com/polled.png"],
+                },
+                raise_for_status=MagicMock(),
+            ),
+        ]
+
+        comp = make_image_component(poll_timeout=60)
+        result = comp.generate_image()
+
+        assert result.data["image_urls"] == ["https://cdn.modelslab.com/polled.png"]
+        assert mock_sleep.called
+
+    @patch("langflow.components.utilities.modelslab_image.requests.post")
+    def test_generate_image_raises_on_failed_status(self, mock_post):
+        mock_post.return_value = MagicMock(
+            ok=True,
+            json=lambda: {"status": "failed", "message": "Invalid model_id"},
+            raise_for_status=MagicMock(),
+        )
+
+        comp = make_image_component()
+        with pytest.raises(RuntimeError, match="Invalid model_id"):
+            comp.generate_image()
+
+    @patch("langflow.components.utilities.modelslab_image.requests.post")
+    def test_generate_image_raises_on_http_error(self, mock_post):
+        import requests as req
+        mock_post.return_value = MagicMock(
+            ok=False,
+            raise_for_status=MagicMock(side_effect=req.HTTPError("500 Server Error")),
+        )
+
+        comp = make_image_component()
+        with pytest.raises(RuntimeError, match="API request failed"):
+            comp.generate_image()
+
+    def test_generate_image_raises_without_api_key(self):
+        comp = make_image_component(api_key="")
+        with pytest.raises(ValueError, match="API key"):
+            comp.generate_image()
+
+    def test_generate_image_raises_without_prompt(self):
+        comp = make_image_component(prompt="")
+        with pytest.raises(ValueError, match="Prompt"):
+            comp.generate_image()
+
+    @patch("langflow.components.utilities.modelslab_image.requests.post")
+    def test_correct_payload_sent(self, mock_post):
+        mock_post.return_value = MagicMock(
+            ok=True,
+            json=lambda: {
+                "status": "success",
+                "output": ["https://cdn.modelslab.com/img.png"],
+            },
+            raise_for_status=MagicMock(),
+        )
+
+        comp = make_image_component(
+            model_id="stable-diffusion-xl-base-1.0",
+            prompt="a red dragon",
+            width=768,
+            height=768,
+            num_inference_steps=30,
+            guidance_scale=8.0,
+            seed=42,
+        )
+        comp.generate_image()
+
+        _, kwargs = mock_post.call_args
+        payload = kwargs["json"]
+        assert payload["model_id"] == "stable-diffusion-xl-base-1.0"
+        assert payload["prompt"] == "a red dragon"
+        assert payload["width"] == "768"
+        assert payload["height"] == "768"
+        assert payload["num_inference_steps"] == 30
+        assert payload["guidance_scale"] == 8.0
+        assert payload["seed"] == 42
+
+    @patch("langflow.components.utilities.modelslab_image.requests.post")
+    def test_seed_minus_one_excluded_from_payload(self, mock_post):
+        mock_post.return_value = MagicMock(
+            ok=True,
+            json=lambda: {"status": "success", "output": ["https://x.com/img.png"]},
+            raise_for_status=MagicMock(),
+        )
+
+        comp = make_image_component(seed=-1)
+        comp.generate_image()
+
+        _, kwargs = mock_post.call_args
+        assert "seed" not in kwargs["json"]
+
+    def test_display_name(self):
+        from langflow.components.utilities.modelslab_image import ModelsLabImageComponent
+        assert ModelsLabImageComponent.display_name == "ModelsLab Image Generation"

--- a/tests/test_modelslab_components.py
+++ b/tests/test_modelslab_components.py
@@ -1,5 +1,4 @@
-"""
-Tests for ModelsLab Langflow components.
+"""Tests for ModelsLab Langflow components.
 
 Run with: pytest tests/test_modelslab_components.py -v
 """
@@ -7,7 +6,6 @@ Run with: pytest tests/test_modelslab_components.py -v
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -25,9 +23,7 @@ def make_llm_component(**kwargs):
     comp.top_p = kwargs.get("top_p", 1.0)
     comp.n = kwargs.get("n", 1)
     comp.stream = kwargs.get("stream", False)
-    comp.base_url = kwargs.get(
-        "base_url", "https://modelslab.com/uncensored-chat/v1"
-    )
+    comp.base_url = kwargs.get("base_url", "https://modelslab.com/uncensored-chat/v1")
     return comp
 
 
@@ -119,10 +115,12 @@ class TestModelsLabModelComponent:
 
     def test_display_name(self):
         from langflow.components.models.modelslab import ModelsLabModelComponent
+
         assert ModelsLabModelComponent.display_name == "ModelsLab"
 
     def test_has_both_outputs(self):
         from langflow.components.models.modelslab import ModelsLabModelComponent
+
         output_names = [o.name for o in ModelsLabModelComponent.outputs]
         assert "text_output" in output_names
         assert "model_output" in output_names
@@ -193,6 +191,7 @@ class TestModelsLabImageComponent:
     @patch("langflow.components.utilities.modelslab_image.requests.post")
     def test_generate_image_raises_on_http_error(self, mock_post):
         import requests as req
+
         mock_post.return_value = MagicMock(
             ok=False,
             raise_for_status=MagicMock(side_effect=req.HTTPError("500 Server Error")),
@@ -260,4 +259,5 @@ class TestModelsLabImageComponent:
 
     def test_display_name(self):
         from langflow.components.utilities.modelslab_image import ModelsLabImageComponent
+
         assert ModelsLabImageComponent.display_name == "ModelsLab Image Generation"


### PR DESCRIPTION
# feat: Add ModelsLab LLM and image generation components

## Summary

Adds two ModelsLab components to Langflow:
1. **ModelsLab** (models category) — uncensored Llama 3.1 8B & 70B chat with 128K context
2. **ModelsLab Image Generation** (utilities category) — Flux, SDXL, Playground v2.5 + 1000+ community models

## What is ModelsLab?

[ModelsLab](https://modelslab.com) is an AI API platform providing uncensored language models, Flux/SDXL image generation, video, TTS, and more. Their chat endpoint is OpenAI-compatible; the image API uses an async polling pattern for heavy models.

- Docs: https://docs.modelslab.com
- API key: https://modelslab.com/dashboard

## Files Added

| File | Description |
|---|---|
| `langflow/components/models/modelslab.py` | `ModelsLabModelComponent` — chat LLM via `ChatOpenAI` + custom base URL |
| `langflow/components/utilities/modelslab_image.py` | `ModelsLabImageComponent` — image gen with async polling |
| `tests/test_modelslab_components.py` | 16 test cases covering both components |

### Register in `__init__.py` (patch)
```diff
# langflow/components/models/__init__.py
+from .modelslab import ModelsLabModelComponent

# langflow/components/utilities/__init__.py
+from .modelslab_image import ModelsLabImageComponent
```

## Chat Component — `ModelsLabModelComponent`

**Inputs:**
- `api_key` — ModelsLab API key (SecretStrInput)
- `model_name` — dropdown: `llama-3.1-8b-uncensored` / `llama-3.1-70b-uncensored`
- `temperature`, `max_tokens`, `top_p`, `n`, `stream` — standard LLM params
- `base_url` — override for custom endpoints (advanced)

**Output:** LangChain `LanguageModel` (plug into any Langflow chain/agent)

**Implementation:** Uses `ChatOpenAI` with `openai_api_base` pointing to ModelsLab's OpenAI-compatible endpoint — no new dependencies required.

## Image Generation Component — `ModelsLabImageComponent`

**Inputs:**
- `api_key`, `prompt`, `negative_prompt`
- `model_id` — Flux, FLUX Schnell, SDXL, Playground v2.5, + 7 others
- `width`, `height`, `num_inference_steps`, `guidance_scale`, `seed`, `samples`
- `poll_timeout` — seconds to wait for async jobs (default 180s)

**Output:** `Data` object with `image_urls` list + first URL as `.text`

**Implementation:** Calls `POST /api/v6/images/text2img`, handles both synchronous and asynchronous (polling via `/api/v6/fetch/{id}`) responses.

## Testing

```bash
pytest tests/test_modelslab_components.py -v
```

16 test cases:
- ✅ LLM: build_model success, correct base URL, API key, model name, max_tokens logic, missing key error
- ✅ Image: sync success, async polling, failed status, HTTP error, missing key/prompt, payload correctness, seed=-1 handling

## Checklist

- [x] Extends `LCModelComponent` (chat) / `Component` (image) — no new base classes
- [x] Uses `langchain_openai.ChatOpenAI` (already a dependency) — no new packages
- [x] Image component uses only `requests` (already a dependency)
- [x] Async polling handled internally — users don't need to think about it
- [x] All inputs follow existing Langflow input patterns
- [x] Both outputs properly defined
- [x] Test coverage for success + error paths
- [x] `display_name`, `description`, `icon`, `documentation` set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ModelsLab LLM component for accessing Llama 3.1 models with configurable temperature, token limits, and streaming support.
  * Added ModelsLab text-to-image component supporting both synchronous and asynchronous image generation with polling capability.

* **Tests**
  * Comprehensive test coverage for both new ModelsLab components including error handling and parameter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->