### PR TITLE
feat: Deployment Tab Mockups for Design and BE (POC)

### DIFF
--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx
@@ -98,7 +98,7 @@ export default function PublishDropdown({
           <Button
             variant="ghost"
             size="md"
-            className="!px-2.5 font-normal bg-foreground text-background"
+            className="!px-2.5 font-normal"
             data-testid="publish-button"
           >
             Share

--- a/src/frontend/src/components/core/flowToolbarComponent/components/flow-toolbar-options.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/flow-toolbar-options.tsx
@@ -1,3 +1,6 @@
+import IconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import useFlowStore from "@/stores/flowStore";
 import PublishDropdown from "./deploy-dropdown";
 import PlaygroundButton from "./playground-button";
@@ -11,6 +14,7 @@ const FlowToolbarOptions = ({
   setOpenApiModal,
 }: FlowToolbarOptionsProps) => {
   const hasIO = useFlowStore((state) => state.hasIO);
+  const navigate = useCustomNavigate();
 
   return (
     <div className="flex items-center gap-1">
@@ -19,6 +23,16 @@ const FlowToolbarOptions = ({
         openApiModal={openApiModal}
         setOpenApiModal={setOpenApiModal}
       />
+      <Button
+        variant="secondary"
+        size="md"
+        className="!px-2.5 font-normal"
+        onClick={() => navigate("/all")}
+        data-testid="deploy-button"
+      >
+        Deploy
+        <IconComponent name="EllipsisVertical" className="!h-4 !w-4" />
+      </Button>
     </div>
   );
 };

--- a/src/frontend/src/customization/feature-flags.ts
+++ b/src/frontend/src/customization/feature-flags.ts
@@ -17,7 +17,7 @@ export const ENABLE_IMAGE_ON_PLAYGROUND = false;
 export const ENABLE_MCP = true;
 export const ENABLE_DEPLOYMENTS = true;
 export const ENABLE_MCP_NOTICE = false;
-export const ENABLE_KNOWLEDGE_BASES = false;
+export const ENABLE_KNOWLEDGE_BASES = true;
 export const ENABLE_INSPECTION_PANEL = true;
 
 export const ENABLE_MCP_COMPOSER =

--- a/src/frontend/src/customization/feature-flags.ts
+++ b/src/frontend/src/customization/feature-flags.ts
@@ -17,7 +17,7 @@ export const ENABLE_IMAGE_ON_PLAYGROUND = false;
 export const ENABLE_MCP = true;
 export const ENABLE_DEPLOYMENTS = true;
 export const ENABLE_MCP_NOTICE = false;
-export const ENABLE_KNOWLEDGE_BASES = true;
+export const ENABLE_KNOWLEDGE_BASES = false;
 export const ENABLE_INSPECTION_PANEL = true;
 
 export const ENABLE_MCP_COMPOSER =

--- a/src/frontend/src/customization/feature-flags.ts
+++ b/src/frontend/src/customization/feature-flags.ts
@@ -15,8 +15,9 @@ export const LANGFLOW_AGENTIC_EXPERIENCE = false;
 export const ENABLE_VOICE_ASSISTANT = true;
 export const ENABLE_IMAGE_ON_PLAYGROUND = false;
 export const ENABLE_MCP = true;
+export const ENABLE_DEPLOYMENTS = true;
 export const ENABLE_MCP_NOTICE = false;
-export const ENABLE_KNOWLEDGE_BASES = false;
+export const ENABLE_KNOWLEDGE_BASES = true;
 export const ENABLE_INSPECTION_PANEL = true;
 
 export const ENABLE_MCP_COMPOSER =

--- a/src/frontend/src/modals/stepperModal/components/ProgressIndicator.tsx
+++ b/src/frontend/src/modals/stepperModal/components/ProgressIndicator.tsx
@@ -1,0 +1,29 @@
+import { MIN_PROGRESS_PERCENTAGE } from "../constants";
+
+interface ProgressIndicatorProps {
+  currentStep: number;
+  totalSteps: number;
+}
+
+export function ProgressIndicator({
+  currentStep,
+  totalSteps,
+}: ProgressIndicatorProps) {
+  const progressPercentage = ((currentStep - 1) / (totalSteps - 1)) * 100;
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="h-1.5 w-16 overflow-hidden rounded-full bg-border">
+        <div
+          className="h-full rounded-full bg-primary transition-all duration-300"
+          style={{
+            width: `${Math.max(progressPercentage, MIN_PROGRESS_PERCENTAGE)}%`,
+          }}
+        />
+      </div>
+      <span className="text-sm text-muted-foreground whitespace-nowrap">
+        {currentStep}/{totalSteps} completed
+      </span>
+    </div>
+  );
+}

--- a/src/frontend/src/modals/stepperModal/components/SidePanel.tsx
+++ b/src/frontend/src/modals/stepperModal/components/SidePanel.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/utils";
+import { SIDE_PANEL_WIDTH } from "../constants";
+
+interface SidePanelProps {
+  children: ReactNode;
+  open: boolean;
+}
+
+export function SidePanel({ children, open }: SidePanelProps) {
+  return (
+    <div
+      className={cn(
+        "absolute left-full top-[-1px] bottom-[-1px] flex transition-opacity duration-150",
+        open ? "opacity-100" : "opacity-0 pointer-events-none",
+      )}
+    >
+      {/* Vertical separator line */}
+      <div className="w-[1px] shrink-0 bg-border" />
+      {/* Sliding panel content */}
+      <div className="overflow-hidden">
+        <div
+          className={cn(
+            "h-full transition-transform duration-300 ease-out",
+            open ? "translate-x-0" : "-translate-x-full",
+          )}
+        >
+          <div
+            className={cn(
+              "flex h-full flex-col rounded-r-xl border-y border-r bg-background shadow-lg",
+              SIDE_PANEL_WIDTH,
+            )}
+          >
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/modals/stepperModal/components/StepperModalFooter.tsx
+++ b/src/frontend/src/modals/stepperModal/components/StepperModalFooter.tsx
@@ -1,0 +1,82 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import {
+  DEFAULT_BACK_LABEL,
+  DEFAULT_HELP_LABEL,
+  DEFAULT_NEXT_LABEL,
+  DEFAULT_SUBMIT_LABEL,
+} from "../constants";
+import type { StepperModalFooterProps } from "../types";
+
+export function StepperModalFooter({
+  currentStep,
+  totalSteps,
+  onBack,
+  onNext,
+  onSubmit,
+  nextDisabled = false,
+  submitDisabled = false,
+  isSubmitting = false,
+  submitLabel = DEFAULT_SUBMIT_LABEL,
+  nextLabel = DEFAULT_NEXT_LABEL,
+  backLabel = DEFAULT_BACK_LABEL,
+  helpHref,
+  onHelp,
+  helpLabel = DEFAULT_HELP_LABEL,
+}: StepperModalFooterProps) {
+  const showHelp = helpHref || onHelp;
+
+  return (
+    <div className="flex w-full items-center justify-between">
+      <div>
+        {showHelp &&
+          (helpHref ? (
+            <Button
+              variant="link"
+              asChild
+              className="px-2 text-muted-foreground"
+            >
+              <a
+                href={helpHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                {helpLabel}
+                <ForwardedIconComponent
+                  name="ExternalLink"
+                  className="ml-1 h-4 w-4"
+                />
+              </a>
+            </Button>
+          ) : (
+            <Button variant="secondary" onClick={onHelp}>
+              {helpLabel}
+            </Button>
+          ))}
+      </div>
+      <div className="flex items-center gap-3">
+        {currentStep > 1 && onBack && (
+          <Button variant="outline" onClick={onBack}>
+            {backLabel}
+          </Button>
+        )}
+        {currentStep < totalSteps ? (
+          <Button onClick={onNext} disabled={nextDisabled}>
+            {nextLabel}
+          </Button>
+        ) : (
+          <Button onClick={onSubmit} disabled={submitDisabled || isSubmitting}>
+            {isSubmitting && (
+              <ForwardedIconComponent
+                name="Loader2"
+                className="mr-2 h-4 w-4 animate-spin"
+              />
+            )}
+            {submitLabel}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/modals/stepperModal/constants.ts
+++ b/src/frontend/src/modals/stepperModal/constants.ts
@@ -1,0 +1,14 @@
+import type { StepperModalSize } from "./types";
+
+export const DEFAULT_ICON = "Database";
+export const DEFAULT_SIZE: StepperModalSize = "small-h-full";
+export const DEFAULT_SHOW_PROGRESS = true;
+export const DEFAULT_SIDE_PANEL_OPEN = false;
+
+export const DEFAULT_SUBMIT_LABEL = "Create";
+export const DEFAULT_NEXT_LABEL = "Next Step";
+export const DEFAULT_BACK_LABEL = "Back";
+export const DEFAULT_HELP_LABEL = "Need Help?";
+
+export const MIN_PROGRESS_PERCENTAGE = 10;
+export const SIDE_PANEL_WIDTH = "w-[300px]";

--- a/src/frontend/src/modals/stepperModal/hooks/useStepperContext.ts
+++ b/src/frontend/src/modals/stepperModal/hooks/useStepperContext.ts
@@ -1,0 +1,12 @@
+import { createContext, useContext } from "react";
+import type { StepperContextValue } from "../types";
+
+export const StepperContext = createContext<StepperContextValue | null>(null);
+
+export function useStepperContext() {
+  const context = useContext(StepperContext);
+  if (!context) {
+    throw new Error("useStepperContext must be used within a StepperModal");
+  }
+  return context;
+}

--- a/src/frontend/src/modals/stepperModal/index.tsx
+++ b/src/frontend/src/modals/stepperModal/index.tsx
@@ -1,0 +1,128 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/utils/utils";
+import { switchCaseModalSize } from "../baseModal/helpers/switch-case-size";
+import { ProgressIndicator } from "./components/ProgressIndicator";
+import { SidePanel } from "./components/SidePanel";
+import {
+  DEFAULT_ICON,
+  DEFAULT_SHOW_PROGRESS,
+  DEFAULT_SIDE_PANEL_OPEN,
+  DEFAULT_SIZE,
+} from "./constants";
+import { StepperContext } from "./hooks/useStepperContext";
+import type { StepperModalProps } from "./types";
+
+export function StepperModal({
+  open,
+  onOpenChange,
+  currentStep,
+  totalSteps,
+  title,
+  description,
+  icon = DEFAULT_ICON,
+  children,
+  footer,
+  className,
+  contentClassName,
+  size = DEFAULT_SIZE,
+  showProgress = DEFAULT_SHOW_PROGRESS,
+  height: customHeight,
+  width: customWidth,
+  sidePanel,
+  sidePanelOpen = DEFAULT_SIDE_PANEL_OPEN,
+}: StepperModalProps) {
+  const { minWidth, height: sizeHeight } = switchCaseModalSize(size);
+  const isNumericHeight = customHeight && /^\d+$/.test(customHeight);
+  const heightClass = isNumericHeight ? undefined : customHeight || sizeHeight;
+  const heightStyle = isNumericHeight
+    ? { height: `${customHeight}px` }
+    : undefined;
+
+  return (
+    <StepperContext.Provider
+      value={{ currentStep, totalSteps, title, description }}
+    >
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          style={heightStyle}
+          className={cn(
+            "flex max-h-[85vh] flex-col gap-0 overflow-visible border bg-background p-0 shadow-lg transition-[height,width,border-radius,opacity] duration-300 ease-in-out",
+            customWidth ? `${customWidth} !max-w-none` : minWidth,
+            heightClass,
+            sidePanel && sidePanelOpen
+              ? "rounded-l-xl rounded-r-none border-r-0"
+              : "rounded-xl",
+            className,
+          )}
+          closeButtonClassName="top-4 right-4"
+        >
+          {/* Header */}
+          <div className="flex flex-col gap-1 px-4 pt-4 pr-14">
+            <div className="flex items-center justify-between">
+              <DialogTitle className="flex items-center gap-2 text-base font-semibold">
+                <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted">
+                  <ForwardedIconComponent name={icon} className="h-4 w-4" />
+                </div>
+                {title}
+              </DialogTitle>
+              <div
+                className={cn(
+                  "transition-all duration-300 ease-in-out",
+                  showProgress
+                    ? "opacity-100 translate-x-0"
+                    : "opacity-0 translate-x-4 pointer-events-none",
+                )}
+              >
+                <ProgressIndicator
+                  currentStep={currentStep}
+                  totalSteps={totalSteps}
+                />
+              </div>
+            </div>
+            {description && (
+              <DialogDescription className="text-sm text-muted-foreground">
+                {description}
+              </DialogDescription>
+            )}
+          </div>
+
+          {/* Content */}
+          <div
+            className={cn(
+              "flex-1 min-h-0 overflow-hidden px-4 py-4 border border-border m-4 rounded-lg",
+              contentClassName,
+            )}
+          >
+            {children}
+          </div>
+
+          {/* Footer */}
+          {footer && (
+            <div className="flex items-center px-4 pb-4">{footer}</div>
+          )}
+
+          {/* Side Panel */}
+          {sidePanel && <SidePanel open={sidePanelOpen}>{sidePanel}</SidePanel>}
+        </DialogContent>
+      </Dialog>
+    </StepperContext.Provider>
+  );
+}
+
+// Re-exports for public API
+export { StepperModalFooter } from "./components/StepperModalFooter";
+export { useStepperContext } from "./hooks/useStepperContext";
+export type {
+  StepperContextValue,
+  StepperModalFooterProps,
+  StepperModalProps,
+  StepperModalSize,
+} from "./types";
+
+export default StepperModal;

--- a/src/frontend/src/modals/stepperModal/types.ts
+++ b/src/frontend/src/modals/stepperModal/types.ts
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+export type StepperModalSize =
+  | "x-small"
+  | "smaller"
+  | "smaller-h-full"
+  | "small"
+  | "small-h-full"
+  | "medium"
+  | "medium-tall"
+  | "medium-h-full"
+  | "large"
+  | "large-h-full"
+  | "x-large";
+
+export interface StepperContextValue {
+  currentStep: number;
+  totalSteps: number;
+  title: string;
+  description?: string;
+}
+
+export interface StepperModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentStep: number;
+  totalSteps: number;
+  title: string;
+  description?: string;
+  icon?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  size?: StepperModalSize;
+  showProgress?: boolean;
+  height?: string;
+  width?: string;
+  sidePanel?: ReactNode;
+  sidePanelOpen?: boolean;
+}
+
+export interface StepperModalFooterProps {
+  currentStep: number;
+  totalSteps: number;
+  onBack?: () => void;
+  onNext?: () => void;
+  onSubmit?: () => void;
+  nextDisabled?: boolean;
+  submitDisabled?: boolean;
+  isSubmitting?: boolean;
+  submitLabel?: string;
+  nextLabel?: string;
+  backLabel?: string;
+  helpHref?: string;
+  onHelp?: () => void;
+  helpLabel?: string;
+}

--- a/src/frontend/src/pages/MainPage/components/header/components/BulkActions.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/components/BulkActions.tsx
@@ -1,0 +1,64 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import DeleteConfirmationModal from "@/modals/deleteConfirmationModal";
+import { cn } from "@/utils/utils";
+
+interface BulkActionsProps {
+  selectedFlows: string[];
+  onDownload: () => void;
+  onDelete: () => void;
+  isDownloading: boolean;
+  isDeleting: boolean;
+}
+
+const BulkActions = ({
+  selectedFlows,
+  onDownload,
+  onDelete,
+  isDownloading,
+  isDeleting,
+}: BulkActionsProps) => {
+  const hasSelection = selectedFlows.length > 0;
+  const isMultiple = selectedFlows.length > 1;
+
+  return (
+    <div
+      className={cn(
+        "flex w-0 items-center gap-2 overflow-hidden opacity-0 transition-all duration-300",
+        hasSelection && "w-36 opacity-100",
+      )}
+    >
+      <Button
+        variant="outline"
+        size="iconMd"
+        className="h-8 w-8"
+        data-testid="download-bulk-btn"
+        onClick={onDownload}
+        loading={isDownloading}
+        tabIndex={hasSelection ? 0 : -1}
+      >
+        <ForwardedIconComponent name="Download" />
+      </Button>
+      <DeleteConfirmationModal
+        asChild
+        onConfirm={onDelete}
+        description={"flow" + (isMultiple ? "s" : "")}
+        note={"and " + (isMultiple ? "their" : "its") + " message history"}
+      >
+        <Button
+          variant="destructive"
+          size="iconMd"
+          className="px-2.5 !text-mmd"
+          data-testid="delete-bulk-btn"
+          loading={isDeleting}
+          tabIndex={hasSelection ? 0 : -1}
+        >
+          <ForwardedIconComponent name="Trash2" />
+          Delete
+        </Button>
+      </DeleteConfirmationModal>
+    </div>
+  );
+};
+
+export default BulkActions;

--- a/src/frontend/src/pages/MainPage/components/header/components/HeaderTabs.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/components/HeaderTabs.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/components/ui/button";
+import { FlowType } from "../types";
+
+const getTabLabel = (type: string): string => {
+  if (type === "mcp") return "MCP Server";
+  return type.charAt(0).toUpperCase() + type.slice(1);
+};
+
+interface HeaderTabsProps {
+  flowType: FlowType;
+  setFlowType: (flowType: FlowType) => void;
+  tabTypes: string[];
+}
+
+const HeaderTabs = ({ flowType, setFlowType, tabTypes }: HeaderTabsProps) => (
+  <div className="flex flex-row-reverse">
+    <div className="w-full border-b dark:border-border" />
+    {tabTypes.map((type) => (
+      <Button
+        key={type}
+        unstyled
+        id={`${type}-btn`}
+        data-testid={`${type}-btn`}
+        onClick={() => setFlowType(type as FlowType)}
+        className={`border-b ${
+          flowType === type
+            ? "border-b-2 border-foreground text-foreground"
+            : "border-border text-muted-foreground hover:text-foreground"
+        } text-nowrap px-2 pb-2 pt-1 text-mmd`}
+      >
+        <span className="flex flex-col items-center overflow-hidden">
+          <span
+            aria-hidden
+            className="invisible h-0 overflow-hidden font-semibold"
+          >
+            {getTabLabel(type)}
+          </span>
+          <span className={flowType === type ? "font-semibold" : ""}>
+            {getTabLabel(type)}
+          </span>
+        </span>
+      </Button>
+    ))}
+  </div>
+);
+
+export default HeaderTabs;

--- a/src/frontend/src/pages/MainPage/components/header/components/HeaderTitle.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/components/HeaderTitle.tsx
@@ -1,0 +1,28 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+
+interface HeaderTitleProps {
+  folderName: string;
+}
+
+const HeaderTitle = ({ folderName }: HeaderTitleProps) => (
+  <div
+    className="flex items-center pb-4 text-xl font-semibold"
+    data-testid="mainpage_title"
+  >
+    <div className="h-7 w-10 transition-all group-data-[open=true]/sidebar-wrapper:md:w-0 lg:hidden">
+      <div className="relative left-0 opacity-100 transition-all group-data-[open=true]/sidebar-wrapper:md:opacity-0">
+        <SidebarTrigger>
+          <ForwardedIconComponent
+            name="PanelLeftOpen"
+            aria-hidden="true"
+            className=""
+          />
+        </SidebarTrigger>
+      </div>
+    </div>
+    {folderName}
+  </div>
+);
+
+export default HeaderTitle;

--- a/src/frontend/src/pages/MainPage/components/header/components/HeaderToolbar.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/components/HeaderToolbar.tsx
@@ -1,11 +1,11 @@
-import ForwardedIconComponent from '@/components/common/genericIconComponent';
-import ShadTooltip from '@/components/common/shadTooltipComponent';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { useHeaderSearch } from '../hooks/useHeaderSearch';
-import { FlowType, ViewType } from '../types';
-import BulkActions from './BulkActions';
-import ViewToggle from './ViewToggle';
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import ShadTooltip from "@/components/common/shadTooltipComponent";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useHeaderSearch } from "../hooks/useHeaderSearch";
+import { FlowType, ViewType } from "../types";
+import BulkActions from "./BulkActions";
+import ViewToggle from "./ViewToggle";
 
 interface HeaderToolbarProps {
   flowType: FlowType;

--- a/src/frontend/src/pages/MainPage/components/header/components/HeaderToolbar.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/components/HeaderToolbar.tsx
@@ -1,0 +1,76 @@
+import ForwardedIconComponent from '@/components/common/genericIconComponent';
+import ShadTooltip from '@/components/common/shadTooltipComponent';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useHeaderSearch } from '../hooks/useHeaderSearch';
+import { FlowType, ViewType } from '../types';
+import BulkActions from './BulkActions';
+import ViewToggle from './ViewToggle';
+
+interface HeaderToolbarProps {
+  flowType: FlowType;
+  view: ViewType;
+  setView: (view: ViewType) => void;
+  setSearch: (search: string) => void;
+  setNewProjectModal: (open: boolean) => void;
+  selectedFlows: string[];
+  onDownload: () => void;
+  onDelete: () => void;
+  isDownloading: boolean;
+  isDeleting: boolean;
+}
+
+const HeaderToolbar = ({
+  flowType,
+  view,
+  setView,
+  setSearch,
+  setNewProjectModal,
+  selectedFlows,
+  onDownload,
+  onDelete,
+  isDownloading,
+  isDeleting,
+}: HeaderToolbarProps) => {
+  const { inputValue, handleSearch } = useHeaderSearch(setSearch);
+
+  return (
+    <div className="flex justify-between pt-5 px-5">
+      <div className="flex w-full xl:w-5/12">
+        <Input
+          icon="Search"
+          data-testid="search-store-input"
+          type="text"
+          placeholder={`Search ${flowType}...`}
+          className="mr-2 !text-mmd"
+          inputClassName="!text-mmd"
+          value={inputValue}
+          onChange={handleSearch}
+        />
+        <ViewToggle view={view} setView={setView} />
+      </div>
+      <div className="flex items-center">
+        <BulkActions
+          selectedFlows={selectedFlows}
+          onDownload={onDownload}
+          onDelete={onDelete}
+          isDownloading={isDownloading}
+          isDeleting={isDeleting}
+        />
+        <ShadTooltip content="New Flow" side="bottom">
+          <Button
+            className="flex items-center gap-2 font-semibold"
+            onClick={() => setNewProjectModal(true)}
+            id="new-project-btn"
+            data-testid="new-project-btn"
+          >
+            <ForwardedIconComponent name="Plus" />
+            New Flow
+          </Button>
+        </ShadTooltip>
+      </div>
+    </div>
+  );
+};
+
+export default HeaderToolbar;

--- a/src/frontend/src/pages/MainPage/components/header/components/ViewToggle.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/components/ViewToggle.tsx
@@ -1,0 +1,46 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import { ViewType } from "../types";
+
+interface ViewToggleProps {
+  view: ViewType;
+  setView: (view: ViewType) => void;
+}
+
+const VIEW_OPTIONS: { type: ViewType; icon: string }[] = [
+  { type: "list", icon: "Menu" },
+  { type: "grid", icon: "LayoutGrid" },
+];
+
+const ViewToggle = ({ view, setView }: ViewToggleProps) => (
+  <div className="relative mr-2 flex h-fit rounded-lg border border-border bg-background">
+    <div
+      className={`absolute top-[2px] h-[32px] w-8 transform rounded-md bg-muted shadow-sm transition-transform duration-300 ${
+        view === "list"
+          ? "left-[2px] translate-x-0"
+          : "left-[6px] translate-x-full"
+      }`}
+    />
+    {VIEW_OPTIONS.map(({ type, icon }) => (
+      <Button
+        key={type}
+        unstyled
+        size="icon"
+        className={`group relative z-10 m-[2px] flex-1 rounded-lg p-2 ${
+          view === type
+            ? "text-foreground"
+            : "text-muted-foreground hover:bg-muted"
+        }`}
+        onClick={() => setView(type)}
+      >
+        <ForwardedIconComponent
+          name={icon}
+          aria-hidden="true"
+          className="h-4 w-4 group-hover:text-foreground"
+        />
+      </Button>
+    ))}
+  </div>
+);
+
+export default ViewToggle;

--- a/src/frontend/src/pages/MainPage/components/header/hooks/useHeaderSearch.ts
+++ b/src/frontend/src/pages/MainPage/components/header/hooks/useHeaderSearch.ts
@@ -1,0 +1,26 @@
+import { debounce } from "lodash";
+import { useCallback, useEffect, useState } from "react";
+
+export const useHeaderSearch = (setSearch: (search: string) => void) => {
+  const [inputValue, setInputValue] = useState("");
+
+  const debouncedSetSearch = useCallback(
+    debounce((value: string) => {
+      setSearch(value);
+    }, 1000),
+    [setSearch],
+  );
+
+  useEffect(() => {
+    debouncedSetSearch(inputValue);
+    return () => {
+      debouncedSetSearch.cancel();
+    };
+  }, [inputValue, debouncedSetSearch]);
+
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+
+  return { inputValue, handleSearch };
+};

--- a/src/frontend/src/pages/MainPage/components/header/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/index.tsx
@@ -1,256 +1,52 @@
-import { debounce } from "lodash";
-import { useCallback, useEffect, useState } from "react";
-import ForwardedIconComponent from "@/components/common/genericIconComponent";
-import ShadTooltip from "@/components/common/shadTooltipComponent";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { SidebarTrigger } from "@/components/ui/sidebar";
-import { useDeleteDeleteFlows } from "@/controllers/API/queries/flows/use-delete-delete-flows";
-import { useGetDownloadFlows } from "@/controllers/API/queries/flows/use-get-download-flows";
-import { ENABLE_MCP } from "@/customization/feature-flags";
-import DeleteConfirmationModal from "@/modals/deleteConfirmationModal";
-import useAlertStore from "@/stores/alertStore";
-import { cn } from "@/utils/utils";
+import { useEffect } from "react";
+import { ENABLE_DEPLOYMENTS, ENABLE_MCP } from "@/customization/feature-flags";
+import HeaderTabs from "./components/HeaderTabs";
+import HeaderTitle from "./components/HeaderTitle";
+import { FlowType } from "./types";
+
+const TAB_TYPES_MCP: FlowType[] = ["deployments", "mcp", "flows"];
+const TAB_TYPES_DEFAULT: FlowType[] = ["deployments", "components", "flows"];
 
 interface HeaderComponentProps {
-  flowType: "flows" | "components" | "mcp";
-  setFlowType: (flowType: "flows" | "components" | "mcp") => void;
-  view: "list" | "grid";
-  setView: (view: "list" | "grid") => void;
-  setNewProjectModal: (newProjectModal: boolean) => void;
+  flowType: FlowType;
+  setFlowType: (flowType: FlowType) => void;
   folderName?: string;
-  setSearch: (search: string) => void;
   isEmptyFolder: boolean;
-  selectedFlows: string[];
 }
 
 const HeaderComponent = ({
   folderName = "",
   flowType,
   setFlowType,
-  view,
-  setView,
-  setNewProjectModal,
-  setSearch,
   isEmptyFolder,
-  selectedFlows,
 }: HeaderComponentProps) => {
-  const [debouncedSearch, setDebouncedSearch] = useState("");
   const isMCPEnabled = ENABLE_MCP;
-  const setSuccessData = useAlertStore((state) => state.setSuccessData);
-  // Debounce the setSearch function from the parent
-  const debouncedSetSearch = useCallback(
-    debounce((value: string) => {
-      setSearch(value);
-    }, 1000),
-    [setSearch],
-  );
+  const rawTabTypes = isMCPEnabled ? TAB_TYPES_MCP : TAB_TYPES_DEFAULT;
+  const tabTypes = ENABLE_DEPLOYMENTS
+    ? rawTabTypes
+    : rawTabTypes.filter((t) => t !== "deployments");
 
-  const { mutate: downloadFlows, isPending: isDownloading } =
-    useGetDownloadFlows();
-  const { mutate: deleteFlows, isPending: isDeleting } = useDeleteDeleteFlows();
-
-  useEffect(() => {
-    debouncedSetSearch(debouncedSearch);
-
-    return () => {
-      debouncedSetSearch.cancel(); // Cleanup on unmount
-    };
-  }, [debouncedSearch, debouncedSetSearch]);
-
-  // If current flowType is not available based on feature flag, switch to flows
   useEffect(() => {
     if (
       (flowType === "mcp" && !isMCPEnabled) ||
-      (flowType === "components" && isMCPEnabled)
+      (flowType === "components" && isMCPEnabled) ||
+      (flowType === "deployments" && !ENABLE_DEPLOYMENTS)
     ) {
       setFlowType("flows");
     }
   }, [flowType, isMCPEnabled, setFlowType]);
 
-  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDebouncedSearch(e.target.value);
-  };
-
-  // Determine which tabs to show based on feature flag
-  const tabTypes = isMCPEnabled ? ["mcp", "flows"] : ["components", "flows"];
-
-  const handleDownload = () => {
-    downloadFlows({ ids: selectedFlows });
-    setSuccessData({ title: "Flows downloaded successfully" });
-  };
-
-  const handleDelete = () => {
-    deleteFlows(
-      { flow_ids: selectedFlows },
-      {
-        onSuccess: () => {
-          setSuccessData({ title: "Flows deleted successfully" });
-        },
-      },
-    );
-  };
-
-  const hasSelection = selectedFlows.length > 0;
-
   return (
-    <>
-      <div
-        className="flex items-center pb-4 text-sm font-medium"
-        data-testid="mainpage_title"
-      >
-        <div className="h-7 w-10 transition-all group-data-[open=true]/sidebar-wrapper:md:w-0 lg:hidden">
-          <div className="relative left-0 opacity-100 transition-all group-data-[open=true]/sidebar-wrapper:md:opacity-0">
-            <SidebarTrigger>
-              <ForwardedIconComponent
-                name="PanelLeftOpen"
-                aria-hidden="true"
-                className=""
-              />
-            </SidebarTrigger>
-          </div>
-        </div>
-        {folderName}
-      </div>
+    <div className="px-5 pt-5">
+      <HeaderTitle folderName={folderName} />
       {!isEmptyFolder && (
-        <>
-          <div className={cn("flex flex-row-reverse pb-4")}>
-            <div className="w-full border-b dark:border-border" />
-            {tabTypes.map((type) => (
-              <Button
-                key={type}
-                unstyled
-                id={`${type}-btn`}
-                data-testid={`${type}-btn`}
-                onClick={() => {
-                  setFlowType(type as "flows" | "components" | "mcp");
-                }}
-                className={`border-b ${
-                  flowType === type
-                    ? "border-b-2 border-foreground text-foreground"
-                    : "border-border text-muted-foreground hover:text-foreground"
-                } text-nowrap px-2 pb-2 pt-1 text-mmd`}
-              >
-                <div className={flowType === type ? "-mb-px" : ""}>
-                  {type === "mcp"
-                    ? "MCP Server"
-                    : type.charAt(0).toUpperCase() + type.slice(1)}
-                </div>
-              </Button>
-            ))}
-          </div>
-          {/* Search and filters */}
-          {flowType !== "mcp" && (
-            <div className="flex justify-between">
-              <div className="flex w-full xl:w-5/12">
-                <Input
-                  icon="Search"
-                  data-testid="search-store-input"
-                  type="text"
-                  placeholder={`Search ${flowType}...`}
-                  className="mr-2 !text-mmd"
-                  inputClassName="!text-mmd"
-                  value={debouncedSearch}
-                  onChange={handleSearch}
-                />
-                <div className="relative mr-2 flex h-fit rounded-lg border border-muted bg-muted">
-                  {/* Sliding Indicator */}
-                  <div
-                    className={`absolute top-[2px] h-[32px] w-8 transform rounded-md bg-background shadow-md transition-transform duration-300 ${
-                      view === "list"
-                        ? "left-[2px] translate-x-0"
-                        : "left-[6px] translate-x-full"
-                    }`}
-                  ></div>
-
-                  {/* Buttons */}
-                  {["list", "grid"].map((viewType) => (
-                    <Button
-                      key={viewType}
-                      unstyled
-                      size="icon"
-                      className={`group relative z-10 m-[2px] flex-1 rounded-lg p-2 ${
-                        view === viewType
-                          ? "text-foreground"
-                          : "text-muted-foreground hover:bg-muted"
-                      }`}
-                      onClick={() => setView(viewType as "list" | "grid")}
-                    >
-                      <ForwardedIconComponent
-                        name={viewType === "list" ? "Menu" : "LayoutGrid"}
-                        aria-hidden="true"
-                        className="h-4 w-4 group-hover:text-foreground"
-                      />
-                    </Button>
-                  ))}
-                </div>
-              </div>
-              <div className="flex items-center">
-                <div
-                  className={cn(
-                    "flex w-0 items-center gap-2 overflow-hidden opacity-0 transition-all duration-300",
-                    selectedFlows.length > 0 && "w-36 opacity-100",
-                  )}
-                >
-                  <Button
-                    variant="outline"
-                    size="iconMd"
-                    className="h-8 w-8"
-                    data-testid="download-bulk-btn"
-                    onClick={handleDownload}
-                    loading={isDownloading}
-                    tabIndex={hasSelection ? 0 : -1}
-                  >
-                    <ForwardedIconComponent name="Download" />
-                  </Button>
-                  <DeleteConfirmationModal
-                    asChild
-                    onConfirm={handleDelete}
-                    description={"flow" + (selectedFlows.length > 1 ? "s" : "")}
-                    note={
-                      "and " +
-                      (selectedFlows.length > 1 ? "their" : "its") +
-                      " message history"
-                    }
-                  >
-                    <Button
-                      variant="destructive"
-                      size="iconMd"
-                      className="px-2.5 !text-mmd"
-                      data-testid="delete-bulk-btn"
-                      loading={isDeleting}
-                      tabIndex={hasSelection ? 0 : -1}
-                    >
-                      <ForwardedIconComponent name="Trash2" />
-                      Delete
-                    </Button>
-                  </DeleteConfirmationModal>
-                </div>
-                <ShadTooltip content="New Flow" side="bottom">
-                  <Button
-                    variant="default"
-                    size="iconMd"
-                    className="z-50 px-2.5 !text-mmd"
-                    onClick={() => setNewProjectModal(true)}
-                    id="new-project-btn"
-                    data-testid="new-project-btn"
-                  >
-                    <ForwardedIconComponent
-                      name="Plus"
-                      aria-hidden="true"
-                      className="h-4 w-4"
-                    />
-                    <span className="hidden whitespace-nowrap font-semibold md:inline">
-                      New Flow
-                    </span>
-                  </Button>
-                </ShadTooltip>
-              </div>
-            </div>
-          )}
-        </>
+        <HeaderTabs
+          flowType={flowType}
+          setFlowType={setFlowType}
+          tabTypes={tabTypes}
+        />
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/frontend/src/pages/MainPage/components/header/types.ts
+++ b/src/frontend/src/pages/MainPage/components/header/types.ts
@@ -1,0 +1,2 @@
+export type FlowType = "flows" | "components" | "mcp" | "deployments";
+export type ViewType = "list" | "grid";

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/DeploymentProvidersView.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/DeploymentProvidersView.tsx
@@ -1,0 +1,219 @@
+import LangflowLogo from "@/assets/LangflowLogo.svg?react";
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { MOCK_CONFIGURATIONS, MOCK_PROVIDERS } from "./mockData";
+
+const STATUS_COLOR: Record<string, string> = {
+  Connected: "text-green-500",
+  Error: "text-red-500",
+  Pending: "text-yellow-400",
+};
+
+const STATUS_DOT_COLOR: Record<string, string> = {
+  Connected: "bg-green-500",
+  Error: "bg-red-500",
+  Pending: "bg-yellow-400",
+};
+
+export const DeploymentProvidersView = () => {
+  return (
+    <div className="flex flex-col gap-6 pb-4">
+      {/* Provider Cards Grid */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {MOCK_PROVIDERS.map((provider) => (
+          <div
+            key={provider.id}
+            className="flex flex-col gap-4 rounded-xl border border-border bg-card p-5"
+          >
+            {/* Card Header */}
+            <div className="flex items-start gap-3">
+              <div
+                className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${provider.iconBg}`}
+              >
+                {provider.icon === "LangflowLogo" ? (
+                  <LangflowLogo className={`h-5 w-5 ${provider.iconColor}`} />
+                ) : (
+                  <ForwardedIconComponent
+                    name={provider.icon}
+                    className={`h-5 w-5 ${provider.iconColor}`}
+                  />
+                )}
+              </div>
+              <div className="min-w-0 w-full">
+                <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-0.5">
+                  <span className="text-sm font-semibold leading-tight">
+                    {provider.name}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span
+                      className={`h-1.5 w-1.5 rounded-full ${STATUS_DOT_COLOR[provider.status] ?? "bg-muted-foreground"}`}
+                    />
+                    <span
+                      className={`text-xs ${STATUS_COLOR[provider.status] ?? "text-muted-foreground"}`}
+                    >
+                      {provider.status}
+                    </span>
+                  </span>
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  {provider.subLabel}
+                </span>
+              </div>
+            </div>
+
+            {/* Endpoint */}
+            <div className="flex flex-col gap-0.5">
+              <span className="text-xs text-muted-foreground">Endpoint</span>
+              <span className="truncate text-sm">{provider.endpoint}</span>
+            </div>
+
+            {/* Stats Row */}
+            <div className="grid grid-cols-2 gap-2">
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs text-muted-foreground">
+                  Last Verified
+                </span>
+                <span className="text-sm">{provider.lastVerified}</span>
+              </div>
+              <div className="flex flex-col gap-0.5 text-right">
+                <span className="text-xs text-muted-foreground">
+                  Deployments
+                </span>
+                <span className="text-sm">{provider.deployments}</span>
+              </div>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="flex gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                className="h-8 flex-1 gap-1.5 text-xs"
+              >
+                <ForwardedIconComponent
+                  name="Settings"
+                  className="h-3.5 w-3.5"
+                />
+                Configure
+              </Button>
+              {provider.status === "Error" ? (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="h-8 flex-1 gap-1.5 text-xs"
+                >
+                  <ForwardedIconComponent
+                    name="RefreshCcw"
+                    className="h-3.5 w-3.5"
+                  />
+                  Reconnect
+                </Button>
+              ) : (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="h-8 flex-1 gap-1.5 text-xs"
+                >
+                  <ForwardedIconComponent
+                    name="CircleCheck"
+                    className="h-3.5 w-3.5"
+                  />
+                  Test Connection
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Deployment Configurations */}
+      <div className="flex flex-col gap-3">
+        <h2 className="text-base font-semibold">Deployment Configurations</h2>
+        <div className="rounded-lg ">
+          {/* Table Header */}
+          <div className="grid grid-cols-[2fr_3fr_1.5fr_1.5fr_40px] border-b border-border px-4 py-2.5">
+            <span className="text-xs font-medium text-muted-foreground">
+              Name
+            </span>
+            <span className="text-xs font-medium text-muted-foreground">
+              Description
+            </span>
+            <span className="text-xs font-medium text-muted-foreground">
+              Used By
+            </span>
+            <span className="text-xs font-medium text-muted-foreground">
+              Created
+            </span>
+            <span />
+          </div>
+
+          {/* Table Rows */}
+          {MOCK_CONFIGURATIONS.map((config, i) => (
+            <div
+              key={config.id}
+              className={`grid grid-cols-[2fr_3fr_1.5fr_1.5fr_40px] items-center px-4 py-3 ${
+                i < MOCK_CONFIGURATIONS.length - 1
+                  ? "border-b border-border"
+                  : ""
+              }`}
+            >
+              <span className="text-sm font-semibold">{config.name}</span>
+              <span className="truncate pr-4 text-sm text-muted-foreground">
+                {config.description}
+              </span>
+              <span className="text-sm text-muted-foreground">
+                {config.usedBy} deployments
+              </span>
+              <span className="text-sm text-muted-foreground">
+                {config.created}
+              </span>
+              <div className="flex justify-end">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      unstyled
+                      className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+                    >
+                      <ForwardedIconComponent
+                        name="EllipsisVertical"
+                        className="h-4 w-4"
+                      />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-44">
+                    <DropdownMenuItem className="gap-2">
+                      <ForwardedIconComponent
+                        name="Pencil"
+                        className="h-4 w-4"
+                      />
+                      Edit
+                    </DropdownMenuItem>
+                    <DropdownMenuItem className="gap-2">
+                      <ForwardedIconComponent name="Copy" className="h-4 w-4" />
+                      Duplicate
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem className="gap-2 text-destructive focus:text-destructive">
+                      <ForwardedIconComponent
+                        name="Trash2"
+                        className="h-4 w-4"
+                      />
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/columnDefs.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/columnDefs.tsx
@@ -1,0 +1,147 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { STATUS_DOT } from "./constants";
+
+export const columnDefs = [
+  {
+    headerName: "Name",
+    field: "name",
+    flex: 3,
+    cellRenderer: (params: { value: string; data: { url: string } }) => (
+      <div className="flex flex-col justify-center gap-0.5 py-2">
+        <span className="text-sm font-medium leading-tight">
+          {params.value}
+        </span>
+        <span className="truncate text-xs text-muted-foreground">
+          {params.data.url}
+        </span>
+      </div>
+    ),
+  },
+  {
+    headerName: "Type",
+    field: "type",
+    flex: 1,
+    cellRenderer: (params: { value: string }) => (
+      <div className="flex items-center">
+        <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+          {params.value === "MCP" ? (
+            <ForwardedIconComponent name="Mcp" className="h-3 w-3" />
+          ) : (
+            <ForwardedIconComponent name="Bot" className="h-3 w-3" />
+          )}
+          {params.value}
+        </span>
+      </div>
+    ),
+  },
+  {
+    headerName: "Status",
+    field: "status",
+    flex: 1,
+    cellRenderer: (params: { value: string }) => (
+      <div className="flex items-center gap-1.5">
+        <span
+          className={`h-2 w-2 rounded-full ${STATUS_DOT[params.value] ?? "bg-muted-foreground"}`}
+        />
+        <span className="text-sm">{params.value}</span>
+      </div>
+    ),
+  },
+  {
+    headerName: "Attached",
+    field: "attached",
+    flex: 1,
+    cellRenderer: (params: { value: number }) => (
+      <span className="text-sm text-muted-foreground">
+        {params.value} {params.value === 1 ? "item" : "items"}
+      </span>
+    ),
+  },
+  {
+    headerName: "Config (AppID)",
+    field: "configs",
+    flex: 2,
+    cellRenderer: (params: {
+      value: { id: string; count: number | null }[];
+    }) => (
+      <div className="flex h-full flex-col items-start justify-center gap-1">
+        {params.value.map(
+          (cfg: { id: string; count: number | null }, i: number) => (
+            <div key={i} className="flex items-center gap-1">
+              <span className="inline-flex w-fit items-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+                {cfg.id}
+              </span>
+              {cfg.count !== null && (
+                <span className="text-xs text-muted-foreground">
+                  ({cfg.count})
+                </span>
+              )}
+            </div>
+          ),
+        )}
+      </div>
+    ),
+  },
+  {
+    headerName: "Last Modified",
+    field: "modifiedDate",
+    flex: 1.5,
+    headerClass: "[&_.ag-header-cell-resize]:hidden",
+    cellRenderer: (params: { value: string; data: { modifiedBy: string } }) => (
+      <div className="flex flex-col justify-center gap-0.5 py-2">
+        <span className="text-sm leading-tight">{params.value}</span>
+        <span className="text-xs text-muted-foreground">
+          by {params.data.modifiedBy}
+        </span>
+      </div>
+    ),
+  },
+  {
+    headerName: "",
+    field: "actions",
+    width: 48,
+    sortable: false,
+    filter: false,
+    resizable: false,
+    cellRenderer: () => (
+      <div className="flex h-full items-center justify-end">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              unstyled
+              className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <ForwardedIconComponent
+                name="EllipsisVertical"
+                className="h-4 w-4"
+              />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
+            <DropdownMenuItem className="gap-2">
+              <ForwardedIconComponent name="Copy" className="h-4 w-4" />
+              Duplicate
+            </DropdownMenuItem>
+            <DropdownMenuItem className="gap-2">
+              <ForwardedIconComponent name="Pencil" className="h-4 w-4" />
+              Update
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="gap-2 text-destructive focus:text-destructive">
+              <ForwardedIconComponent name="Trash2" className="h-4 w-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    ),
+  },
+];

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/constants.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/constants.ts
@@ -1,0 +1,23 @@
+export const STATUS_DOT: Record<string, string> = {
+  Healthy: "bg-green-500",
+  Pending: "bg-yellow-400",
+  Unhealthy: "bg-red-500",
+};
+
+export const TOGGLE_OPTIONS = [
+  "All Deployments",
+  "Deployment Provider",
+] as const;
+export type DeploymentView = (typeof TOGGLE_OPTIONS)[number];
+
+export const ATTACH_TABS = ["Flows", "Snapshots"] as const;
+export type AttachTab = (typeof ATTACH_TABS)[number];
+
+export const DEPLOYMENT_TYPES = ["Agent", "MCP"] as const;
+export type DeploymentType = (typeof DEPLOYMENT_TYPES)[number];
+
+export type ConfigMode = "reuse" | "create" | "modify";
+export type KeyFormat = "assisted" | "auto" | "manual";
+export type VariableScope = "coarse" | "granular";
+
+export const TOTAL_STEPS = 5;

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/constants.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/constants.ts
@@ -5,8 +5,8 @@ export const STATUS_DOT: Record<string, string> = {
 };
 
 export const TOGGLE_OPTIONS = [
-  "All Deployments",
-  "Deployment Provider",
+  "Live Deployments",
+  "Deployment Providers",
 ] as const;
 export type DeploymentView = (typeof TOGGLE_OPTIONS)[number];
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/index.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { StepperModal, StepperModalFooter } from "@/modals/stepperModal";
 import { columnDefs } from "./columnDefs";
 import { TOGGLE_OPTIONS, TOTAL_STEPS } from "./constants";
+import { DeploymentProvidersView } from "./DeploymentProvidersView";
 import { MOCK_DEPLOYMENTS } from "./mockData";
 import { StepAttach } from "./steps/StepAttach";
 import { StepBasics } from "./steps/StepBasics";
@@ -51,8 +52,8 @@ const DeploymentsTab = () => {
           <div
             className="absolute h-7 rounded-md bg-muted shadow-sm transition-all duration-200"
             style={{
-              width: activeView === "All Deployments" ? 133 : 165,
-              left: activeView === "All Deployments" ? "4px" : 137,
+              width: activeView === "Live Deployments" ? 133 : 175,
+              left: activeView === "Live Deployments" ? "4px" : 141,
             }}
           />
           {TOGGLE_OPTIONS.map((option) => (
@@ -71,30 +72,48 @@ const DeploymentsTab = () => {
         </div>
         <Button
           className="flex items-center gap-2 font-semibold"
-          onClick={() => handleOpenChange(true)}
+          onClick={() => {
+            if (activeView === "Deployment Providers") {
+              // TODO: Open provider modal
+              alert("Open provider modal");
+            } else {
+              handleOpenChange(true);
+            }
+          }}
         >
-          <ForwardedIconComponent name="Plus" /> New Deployment
+          <ForwardedIconComponent name="Plus" />{" "}
+          {activeView === "Deployment Providers"
+            ? "Add Provider"
+            : "New Deployment"}
         </Button>
       </div>
 
-      <div className="flex h-full flex-col pt-4">
-        <div className="relative h-full">
-          <TableComponent
-            rowHeight={65}
-            cellSelection={false}
-            tableOptions={{ hide_options: true }}
-            columnDefs={columnDefs}
-            rowData={MOCK_DEPLOYMENTS}
-            className="w-full ag-no-border"
-            pagination
-            quickFilterText=""
-            gridOptions={{
-              ensureDomOrder: true,
-              colResizeDefault: "shift",
-            }}
-          />
+      {activeView === "Deployment Providers" && (
+        <div className="pt-4">
+          <DeploymentProvidersView />
         </div>
-      </div>
+      )}
+
+      {activeView === "Live Deployments" && (
+        <div className="flex h-full flex-col pt-4">
+          <div className="relative h-full">
+            <TableComponent
+              rowHeight={65}
+              cellSelection={false}
+              tableOptions={{ hide_options: true }}
+              columnDefs={columnDefs}
+              rowData={MOCK_DEPLOYMENTS}
+              className="w-full ag-no-border"
+              pagination
+              quickFilterText=""
+              gridOptions={{
+                ensureDomOrder: true,
+                colResizeDefault: "shift",
+              }}
+            />
+          </div>
+        </div>
+      )}
       <StepperModal
         open={newDeploymentOpen}
         onOpenChange={handleOpenChange}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/index.tsx
@@ -1,0 +1,259 @@
+import { useState } from "react";
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import TableComponent from "@/components/core/parameterRenderComponent/components/tableComponent";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+const MOCK_DEPLOYMENTS = [
+  {
+    name: "Production Sales Agent",
+    url: "https://api.production.example.com/sales-agent",
+    type: "Agent",
+    status: "Healthy",
+    attached: 2,
+    configs: [{ id: "SALES_BOT_PROD", count: 3 }],
+    modifiedDate: "2026-02-15",
+    modifiedBy: "Sarah Han",
+  },
+  {
+    name: "Test Environment Sales Agent",
+    url: "https://api.staging.example.com/sales-agent",
+    type: "Agent",
+    status: "Healthy",
+    attached: 1,
+    configs: [{ id: "SALES_BOT_STAGING", count: 2 }],
+    modifiedDate: "2026-02-18",
+    modifiedBy: "Sarah Han",
+  },
+  {
+    name: "Customer Support MCP",
+    url: "https://api.dev.example.com/customer-support",
+    type: "MCP",
+    status: "Pending",
+    attached: 1,
+    configs: [{ id: "CUSTOMER_SUPPORT_PROD", count: null }],
+    modifiedDate: "2026-02-19",
+    modifiedBy: "Sarah Han",
+  },
+  {
+    name: "Multi-Config Sales Pipeline",
+    url: "https://api.dev.example.com/multi-config",
+    type: "Agent",
+    status: "Unhealthy",
+    attached: 3,
+    configs: [
+      { id: "SALES_BOT_PROD", count: 3 },
+      { id: "SALES_BOT_STAGING", count: 2 },
+    ],
+    modifiedDate: "2026-02-08",
+    modifiedBy: "Sarah Han",
+  },
+];
+
+const STATUS_DOT: Record<string, string> = {
+  Healthy: "bg-green-500",
+  Pending: "bg-yellow-400",
+  Unhealthy: "bg-red-500",
+};
+
+const columnDefs = [
+  {
+    headerName: "Name",
+    field: "name",
+    flex: 3,
+    cellRenderer: (params: any) => (
+      <div className="flex flex-col justify-center gap-0.5 py-2">
+        <span className="text-sm font-medium leading-tight">
+          {params.value}
+        </span>
+        <span className="truncate text-xs text-muted-foreground">
+          {params.data.url}
+        </span>
+      </div>
+    ),
+  },
+  {
+    headerName: "Type",
+    field: "type",
+    flex: 1,
+    cellRenderer: (params: any) => (
+      <div className="flex items-center">
+        <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+          {params.value === "MCP" ? (
+            <ForwardedIconComponent name="Mcp" className="h-3 w-3" />
+          ) : (
+            <ForwardedIconComponent name="Bot" className="h-3 w-3" />
+          )}
+          {params.value}
+        </span>
+      </div>
+    ),
+  },
+  {
+    headerName: "Status",
+    field: "status",
+    flex: 1,
+    cellRenderer: (params: any) => (
+      <div className="flex items-center gap-1.5">
+        <span
+          className={`h-2 w-2 rounded-full ${STATUS_DOT[params.value] ?? "bg-muted-foreground"}`}
+        />
+        <span className="text-sm">{params.value}</span>
+      </div>
+    ),
+  },
+  {
+    headerName: "Attached",
+    field: "attached",
+    flex: 1,
+    cellRenderer: (params: any) => (
+      <span className="text-sm text-muted-foreground">
+        {params.value} {params.value === 1 ? "item" : "items"}
+      </span>
+    ),
+  },
+  {
+    headerName: "Config (AppID)",
+    field: "configs",
+    flex: 2,
+    cellRenderer: (params: any) => (
+      <div className="flex h-full flex-col items-start justify-center gap-1">
+        {params.value.map(
+          (cfg: { id: string; count: number | null }, i: number) => (
+            <div key={i} className="flex items-center gap-1">
+              <span className="inline-flex w-fit items-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+                {cfg.id}
+              </span>
+              {cfg.count !== null && (
+                <span className="text-xs text-muted-foreground">
+                  ({cfg.count})
+                </span>
+              )}
+            </div>
+          ),
+        )}
+      </div>
+    ),
+  },
+  {
+    headerName: "Last Modified",
+    field: "modifiedDate",
+    flex: 1.5,
+    headerClass: "[&_.ag-header-cell-resize]:hidden",
+    cellRenderer: (params: any) => (
+      <div className="flex flex-col justify-center gap-0.5 py-2">
+        <span className="text-sm leading-tight">{params.value}</span>
+        <span className="text-xs text-muted-foreground">
+          by {params.data.modifiedBy}
+        </span>
+      </div>
+    ),
+  },
+  {
+    headerName: "",
+    field: "actions",
+    width: 48,
+    sortable: false,
+    filter: false,
+    resizable: false,
+    cellRenderer: () => (
+      <div className="flex h-full items-center justify-end">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              unstyled
+              className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <ForwardedIconComponent
+                name="EllipsisVertical"
+                className="h-4 w-4"
+              />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
+            <DropdownMenuItem className="gap-2">
+              <ForwardedIconComponent name="Copy" className="h-4 w-4" />
+              Duplicate
+            </DropdownMenuItem>
+            <DropdownMenuItem className="gap-2">
+              <ForwardedIconComponent name="Pencil" className="h-4 w-4" />
+              Update
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="gap-2 text-destructive focus:text-destructive">
+              <ForwardedIconComponent name="Trash2" className="h-4 w-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    ),
+  },
+];
+
+const TOGGLE_OPTIONS = ["All Deployments", "Deployment Provider"] as const;
+type DeploymentView = (typeof TOGGLE_OPTIONS)[number];
+
+const DeploymentsTab = () => {
+  const [activeView, setActiveView] =
+    useState<DeploymentView>("All Deployments");
+
+  return (
+    <div className="flex h-full flex-col p-5">
+      <div className="flex justify-between items-center">
+        <div className="relative flex h-9 items-center rounded-lg border border-border bg-background p-1">
+          <div
+            className="absolute h-7 rounded-md bg-muted shadow-sm transition-all duration-200"
+            style={{
+              width: activeView === "All Deployments" ? 133 : 165,
+              left: activeView === "All Deployments" ? "4px" : 137,
+            }}
+          />
+          {TOGGLE_OPTIONS.map((option) => (
+            <button
+              key={option}
+              onClick={() => setActiveView(option)}
+              className={`relative z-10 flex-1 whitespace-nowrap rounded-md px-3 py-1 text-center text-sm font-medium transition-colors ${
+                activeView === option
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+        <Button className="flex items-center gap-2 font-semibold">
+          <ForwardedIconComponent name="Plus" /> New Deployment
+        </Button>
+      </div>
+
+      <div className="flex h-full flex-col pt-4">
+        <div className="relative h-full">
+          <TableComponent
+            rowHeight={65}
+            cellSelection={false}
+            tableOptions={{ hide_options: true }}
+            columnDefs={columnDefs}
+            rowData={MOCK_DEPLOYMENTS}
+            className="w-full ag-no-border"
+            pagination
+            quickFilterText=""
+            gridOptions={{
+              ensureDomOrder: true,
+              colResizeDefault: "shift",
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeploymentsTab;

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/index.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import TableComponent from "@/components/core/parameterRenderComponent/components/tableComponent";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -9,6 +10,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { StepperModal, StepperModalFooter } from "@/modals/stepperModal";
 
 const MOCK_DEPLOYMENTS = [
   {
@@ -200,9 +204,89 @@ const columnDefs = [
 const TOGGLE_OPTIONS = ["All Deployments", "Deployment Provider"] as const;
 type DeploymentView = (typeof TOGGLE_OPTIONS)[number];
 
+const MOCK_FLOWS = [
+  {
+    id: "flow-1",
+    name: "Qualify Lead",
+    updatedDate: "2026-02-18",
+    snapshotDate: "2026-02-17",
+  },
+  {
+    id: "flow-2",
+    name: "Summarize Call Notes",
+    updatedDate: "2026-02-19",
+    snapshotDate: "2026-02-18",
+  },
+  {
+    id: "flow-3",
+    name: "Create Ticket",
+    updatedDate: "2026-02-16",
+    snapshotDate: null,
+  },
+];
+
+const MOCK_SNAPSHOTS = [
+  { id: "snap-1", name: "Qualify Lead v1.2", updatedDate: "2026-02-17" },
+  {
+    id: "snap-2",
+    name: "Summarize Call Notes v2.0",
+    updatedDate: "2026-02-18",
+  },
+];
+
+const ATTACH_TABS = ["Flows", "Snapshots"] as const;
+type AttachTab = (typeof ATTACH_TABS)[number];
+
+const DEPLOYMENT_TYPES = ["Agent", "MCP"] as const;
+type DeploymentType = (typeof DEPLOYMENT_TYPES)[number];
+
+const TOTAL_STEPS = 5;
+
 const DeploymentsTab = () => {
   const [activeView, setActiveView] =
     useState<DeploymentView>("All Deployments");
+
+  const [newDeploymentOpen, setNewDeploymentOpen] = useState(false);
+  const [currentStep, setCurrentStep] = useState(1);
+  const [deploymentType, setDeploymentType] = useState<DeploymentType>("Agent");
+  const [deploymentName, setDeploymentName] = useState("");
+  const [deploymentDescription, setDeploymentDescription] = useState("");
+  const [deploymentUrl, setDeploymentUrl] = useState("");
+  const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
+  const [attachTab, setAttachTab] = useState<AttachTab>("Flows");
+
+  const handleBack = () => setCurrentStep((s) => Math.max(1, s - 1));
+  const handleNext = () => setCurrentStep((s) => Math.min(TOTAL_STEPS, s + 1));
+  const handleSubmit = () => {
+    setNewDeploymentOpen(false);
+    setCurrentStep(1);
+    setDeploymentName("");
+    setDeploymentDescription("");
+    setDeploymentUrl("");
+    setDeploymentType("Agent");
+    setSelectedItems(new Set());
+    setAttachTab("Flows");
+  };
+  const handleOpenChange = (open: boolean) => {
+    setNewDeploymentOpen(open);
+    if (!open) {
+      setCurrentStep(1);
+      setDeploymentName("");
+      setDeploymentDescription("");
+      setDeploymentUrl("");
+      setDeploymentType("Agent");
+      setSelectedItems(new Set());
+      setAttachTab("Flows");
+    }
+  };
+
+  const toggleItem = (id: string) => {
+    setSelectedItems((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
 
   return (
     <div className="flex h-full flex-col p-5">
@@ -229,7 +313,10 @@ const DeploymentsTab = () => {
             </button>
           ))}
         </div>
-        <Button className="flex items-center gap-2 font-semibold">
+        <Button
+          className="flex items-center gap-2 font-semibold"
+          onClick={() => setNewDeploymentOpen(true)}
+        >
           <ForwardedIconComponent name="Plus" /> New Deployment
         </Button>
       </div>
@@ -252,6 +339,196 @@ const DeploymentsTab = () => {
           />
         </div>
       </div>
+      <StepperModal
+        open={newDeploymentOpen}
+        onOpenChange={handleOpenChange}
+        currentStep={currentStep}
+        totalSteps={TOTAL_STEPS}
+        title="Create Deployment"
+        contentClassName="bg-secondary"
+        icon="Rocket"
+        description="Deploy your Langflow workflows to watsonx Orchestrate"
+        showProgress
+        width="w-[800px]"
+        height="h-[618px]"
+        size="medium-h-full"
+        footer={
+          <StepperModalFooter
+            currentStep={currentStep}
+            totalSteps={TOTAL_STEPS}
+            onBack={handleBack}
+            onNext={handleNext}
+            onSubmit={handleSubmit}
+            nextDisabled={
+              (currentStep === 1 && !deploymentName.trim()) ||
+              (currentStep === 2 && selectedItems.size === 0)
+            }
+            submitLabel="Create Deployment"
+          />
+        }
+      >
+        {currentStep === 1 && (
+          <div className="flex h-full flex-col gap-5 overflow-y-auto">
+            <div>
+              <h3 className="text-base font-semibold">Deployment Basics</h3>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">
+                Deployment Name <span className="text-destructive">*</span>
+              </label>
+              <Input
+                placeholder="e.g., Production Sales Agent"
+                value={deploymentName}
+                onChange={(e) => setDeploymentName(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">Description</label>
+              <Textarea
+                placeholder="Describe what this deployment does..."
+                value={deploymentDescription}
+                onChange={(e) => setDeploymentDescription(e.target.value)}
+                rows={4}
+                className="resize-none placeholder:text-placeholder-foreground"
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium">
+                Deployment Type <span className="text-destructive">*</span>
+              </label>
+              <div className="grid grid-cols-2 gap-3">
+                {(
+                  [
+                    {
+                      type: "Agent" as DeploymentType,
+                      label: "Agent",
+                      icon: "Bot",
+                      description:
+                        "Conversational agent with chat interface and tool calling",
+                    },
+                    {
+                      type: "MCP" as DeploymentType,
+                      label: "MCP Server",
+                      icon: "Mcp",
+                      description:
+                        "Model Context Protocol server for tool integration",
+                    },
+                  ] as const
+                ).map(({ type, label, icon, description }) => (
+                  <button
+                    key={type}
+                    onClick={() => setDeploymentType(type)}
+                    className={`flex flex-col gap-2 rounded-xl border p-4 text-left transition-colors ${
+                      deploymentType === type
+                        ? "border-primary bg-background"
+                        : "border-border hover:border-muted-foreground"
+                    }`}
+                  >
+                    <div
+                      className={`flex h-9 w-9 items-center justify-center rounded-md ${
+                        deploymentType === type ? "bg-primary/10" : "bg-muted"
+                      }`}
+                    >
+                      <ForwardedIconComponent
+                        name={icon}
+                        className={`h-5 w-5 ${
+                          deploymentType === type
+                            ? "text-primary"
+                            : "text-muted-foreground"
+                        }`}
+                      />
+                    </div>
+                    <p className="text-sm font-semibold">{label}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {description}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {currentStep === 2 && (
+          <div className="flex h-full flex-col gap-4">
+            <div>
+              <h3 className="text-base font-semibold">
+                Attach Flows or Snapshots
+              </h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Select one or more flows or snapshots to include in this
+                deployment
+              </p>
+            </div>
+            <div className="flex border-b border-border">
+              {ATTACH_TABS.map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setAttachTab(tab)}
+                  className={`px-4 pb-2 text-sm font-medium transition-colors ${
+                    attachTab === tab
+                      ? "border-b-2 border-foreground text-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  {tab}
+                </button>
+              ))}
+            </div>
+            <div className="flex flex-col gap-2 overflow-y-auto">
+              {(attachTab === "Flows" ? MOCK_FLOWS : MOCK_SNAPSHOTS).map(
+                (item) => (
+                  <button
+                    key={item.id}
+                    onClick={() => toggleItem(item.id)}
+                    className={`flex items-start gap-3 rounded-lg border bg-background p-3 text-left transition-colors ${
+                      selectedItems.has(item.id)
+                        ? "border-primary"
+                        : "border-border hover:border-muted-foreground"
+                    }`}
+                  >
+                    <Checkbox
+                      checked={selectedItems.has(item.id)}
+                      className="mt-0.5 pointer-events-none"
+                    />
+                    <div className="flex flex-col gap-0.5">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-semibold">
+                          {item.name}
+                        </span>
+                        <span className="inline-flex items-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+                          {attachTab === "Flows" ? "Flow" : "Snapshot"}
+                        </span>
+                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        Last updated: {item.updatedDate}
+                        {"snapshotDate" in item && item.snapshotDate
+                          ? ` • Snapshot available (${item.snapshotDate})`
+                          : ""}
+                      </span>
+                    </div>
+                  </button>
+                ),
+              )}
+            </div>
+            {selectedItems.size === 0 && (
+              <p className="mt-auto text-center text-sm text-muted-foreground">
+                Select at least one flow or snapshot to continue
+              </p>
+            )}
+          </div>
+        )}
+
+        {currentStep === 3 && (
+          <div className="flex h-full flex-col gap-3">WIP 3</div>
+        )}
+        {currentStep === 4 && (
+          <div className="flex h-full flex-col gap-3">WIP 4</div>
+        )}
+        {currentStep === 5 && (
+          <div className="flex h-full flex-col gap-3">WIP 5</div>
+        )}
+      </StepperModal>
     </div>
   );
 };

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/index.tsx
@@ -1,292 +1,48 @@
-import { useState } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import TableComponent from "@/components/core/parameterRenderComponent/components/tableComponent";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { StepperModal, StepperModalFooter } from "@/modals/stepperModal";
-
-const MOCK_DEPLOYMENTS = [
-  {
-    name: "Production Sales Agent",
-    url: "https://api.production.example.com/sales-agent",
-    type: "Agent",
-    status: "Healthy",
-    attached: 2,
-    configs: [{ id: "SALES_BOT_PROD", count: 3 }],
-    modifiedDate: "2026-02-15",
-    modifiedBy: "Sarah Han",
-  },
-  {
-    name: "Test Environment Sales Agent",
-    url: "https://api.staging.example.com/sales-agent",
-    type: "Agent",
-    status: "Healthy",
-    attached: 1,
-    configs: [{ id: "SALES_BOT_STAGING", count: 2 }],
-    modifiedDate: "2026-02-18",
-    modifiedBy: "Sarah Han",
-  },
-  {
-    name: "Customer Support MCP",
-    url: "https://api.dev.example.com/customer-support",
-    type: "MCP",
-    status: "Pending",
-    attached: 1,
-    configs: [{ id: "CUSTOMER_SUPPORT_PROD", count: null }],
-    modifiedDate: "2026-02-19",
-    modifiedBy: "Sarah Han",
-  },
-  {
-    name: "Multi-Config Sales Pipeline",
-    url: "https://api.dev.example.com/multi-config",
-    type: "Agent",
-    status: "Unhealthy",
-    attached: 3,
-    configs: [
-      { id: "SALES_BOT_PROD", count: 3 },
-      { id: "SALES_BOT_STAGING", count: 2 },
-    ],
-    modifiedDate: "2026-02-08",
-    modifiedBy: "Sarah Han",
-  },
-];
-
-const STATUS_DOT: Record<string, string> = {
-  Healthy: "bg-green-500",
-  Pending: "bg-yellow-400",
-  Unhealthy: "bg-red-500",
-};
-
-const columnDefs = [
-  {
-    headerName: "Name",
-    field: "name",
-    flex: 3,
-    cellRenderer: (params: any) => (
-      <div className="flex flex-col justify-center gap-0.5 py-2">
-        <span className="text-sm font-medium leading-tight">
-          {params.value}
-        </span>
-        <span className="truncate text-xs text-muted-foreground">
-          {params.data.url}
-        </span>
-      </div>
-    ),
-  },
-  {
-    headerName: "Type",
-    field: "type",
-    flex: 1,
-    cellRenderer: (params: any) => (
-      <div className="flex items-center">
-        <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-          {params.value === "MCP" ? (
-            <ForwardedIconComponent name="Mcp" className="h-3 w-3" />
-          ) : (
-            <ForwardedIconComponent name="Bot" className="h-3 w-3" />
-          )}
-          {params.value}
-        </span>
-      </div>
-    ),
-  },
-  {
-    headerName: "Status",
-    field: "status",
-    flex: 1,
-    cellRenderer: (params: any) => (
-      <div className="flex items-center gap-1.5">
-        <span
-          className={`h-2 w-2 rounded-full ${STATUS_DOT[params.value] ?? "bg-muted-foreground"}`}
-        />
-        <span className="text-sm">{params.value}</span>
-      </div>
-    ),
-  },
-  {
-    headerName: "Attached",
-    field: "attached",
-    flex: 1,
-    cellRenderer: (params: any) => (
-      <span className="text-sm text-muted-foreground">
-        {params.value} {params.value === 1 ? "item" : "items"}
-      </span>
-    ),
-  },
-  {
-    headerName: "Config (AppID)",
-    field: "configs",
-    flex: 2,
-    cellRenderer: (params: any) => (
-      <div className="flex h-full flex-col items-start justify-center gap-1">
-        {params.value.map(
-          (cfg: { id: string; count: number | null }, i: number) => (
-            <div key={i} className="flex items-center gap-1">
-              <span className="inline-flex w-fit items-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
-                {cfg.id}
-              </span>
-              {cfg.count !== null && (
-                <span className="text-xs text-muted-foreground">
-                  ({cfg.count})
-                </span>
-              )}
-            </div>
-          ),
-        )}
-      </div>
-    ),
-  },
-  {
-    headerName: "Last Modified",
-    field: "modifiedDate",
-    flex: 1.5,
-    headerClass: "[&_.ag-header-cell-resize]:hidden",
-    cellRenderer: (params: any) => (
-      <div className="flex flex-col justify-center gap-0.5 py-2">
-        <span className="text-sm leading-tight">{params.value}</span>
-        <span className="text-xs text-muted-foreground">
-          by {params.data.modifiedBy}
-        </span>
-      </div>
-    ),
-  },
-  {
-    headerName: "",
-    field: "actions",
-    width: 48,
-    sortable: false,
-    filter: false,
-    resizable: false,
-    cellRenderer: () => (
-      <div className="flex h-full items-center justify-end">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              unstyled
-              className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-            >
-              <ForwardedIconComponent
-                name="EllipsisVertical"
-                className="h-4 w-4"
-              />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-44">
-            <DropdownMenuItem className="gap-2">
-              <ForwardedIconComponent name="Copy" className="h-4 w-4" />
-              Duplicate
-            </DropdownMenuItem>
-            <DropdownMenuItem className="gap-2">
-              <ForwardedIconComponent name="Pencil" className="h-4 w-4" />
-              Update
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem className="gap-2 text-destructive focus:text-destructive">
-              <ForwardedIconComponent name="Trash2" className="h-4 w-4" />
-              Delete
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-    ),
-  },
-];
-
-const TOGGLE_OPTIONS = ["All Deployments", "Deployment Provider"] as const;
-type DeploymentView = (typeof TOGGLE_OPTIONS)[number];
-
-const MOCK_FLOWS = [
-  {
-    id: "flow-1",
-    name: "Qualify Lead",
-    updatedDate: "2026-02-18",
-    snapshotDate: "2026-02-17",
-  },
-  {
-    id: "flow-2",
-    name: "Summarize Call Notes",
-    updatedDate: "2026-02-19",
-    snapshotDate: "2026-02-18",
-  },
-  {
-    id: "flow-3",
-    name: "Create Ticket",
-    updatedDate: "2026-02-16",
-    snapshotDate: null,
-  },
-];
-
-const MOCK_SNAPSHOTS = [
-  { id: "snap-1", name: "Qualify Lead v1.2", updatedDate: "2026-02-17" },
-  {
-    id: "snap-2",
-    name: "Summarize Call Notes v2.0",
-    updatedDate: "2026-02-18",
-  },
-];
-
-const ATTACH_TABS = ["Flows", "Snapshots"] as const;
-type AttachTab = (typeof ATTACH_TABS)[number];
-
-const DEPLOYMENT_TYPES = ["Agent", "MCP"] as const;
-type DeploymentType = (typeof DEPLOYMENT_TYPES)[number];
-
-const TOTAL_STEPS = 5;
+import { columnDefs } from "./columnDefs";
+import { TOGGLE_OPTIONS, TOTAL_STEPS } from "./constants";
+import { MOCK_DEPLOYMENTS } from "./mockData";
+import { StepAttach } from "./steps/StepAttach";
+import { StepBasics } from "./steps/StepBasics";
+import { StepConfiguration } from "./steps/StepConfiguration";
+import { StepReview } from "./steps/StepReview";
+import { StepScope } from "./steps/StepScope";
+import { useDeploymentForm } from "./useDeploymentForm";
 
 const DeploymentsTab = () => {
-  const [activeView, setActiveView] =
-    useState<DeploymentView>("All Deployments");
-
-  const [newDeploymentOpen, setNewDeploymentOpen] = useState(false);
-  const [currentStep, setCurrentStep] = useState(1);
-  const [deploymentType, setDeploymentType] = useState<DeploymentType>("Agent");
-  const [deploymentName, setDeploymentName] = useState("");
-  const [deploymentDescription, setDeploymentDescription] = useState("");
-  const [deploymentUrl, setDeploymentUrl] = useState("");
-  const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
-  const [attachTab, setAttachTab] = useState<AttachTab>("Flows");
-
-  const handleBack = () => setCurrentStep((s) => Math.max(1, s - 1));
-  const handleNext = () => setCurrentStep((s) => Math.min(TOTAL_STEPS, s + 1));
-  const handleSubmit = () => {
-    setNewDeploymentOpen(false);
-    setCurrentStep(1);
-    setDeploymentName("");
-    setDeploymentDescription("");
-    setDeploymentUrl("");
-    setDeploymentType("Agent");
-    setSelectedItems(new Set());
-    setAttachTab("Flows");
-  };
-  const handleOpenChange = (open: boolean) => {
-    setNewDeploymentOpen(open);
-    if (!open) {
-      setCurrentStep(1);
-      setDeploymentName("");
-      setDeploymentDescription("");
-      setDeploymentUrl("");
-      setDeploymentType("Agent");
-      setSelectedItems(new Set());
-      setAttachTab("Flows");
-    }
-  };
-
-  const toggleItem = (id: string) => {
-    setSelectedItems((prev) => {
-      const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
-      return next;
-    });
-  };
+  const {
+    activeView,
+    setActiveView,
+    newDeploymentOpen,
+    currentStep,
+    deploymentType,
+    setDeploymentType,
+    deploymentName,
+    setDeploymentName,
+    deploymentDescription,
+    setDeploymentDescription,
+    selectedItems,
+    attachTab,
+    setAttachTab,
+    configMode,
+    setConfigMode,
+    configName,
+    setConfigName,
+    keyFormat,
+    setKeyFormat,
+    envVars,
+    setEnvVars,
+    variableScope,
+    setVariableScope,
+    handleBack,
+    handleNext,
+    handleSubmit,
+    handleOpenChange,
+    toggleItem,
+  } = useDeploymentForm();
 
   return (
     <div className="flex h-full flex-col p-5">
@@ -315,7 +71,7 @@ const DeploymentsTab = () => {
         </div>
         <Button
           className="flex items-center gap-2 font-semibold"
-          onClick={() => setNewDeploymentOpen(true)}
+          onClick={() => handleOpenChange(true)}
         >
           <ForwardedIconComponent name="Plus" /> New Deployment
         </Button>
@@ -350,7 +106,7 @@ const DeploymentsTab = () => {
         description="Deploy your Langflow workflows to watsonx Orchestrate"
         showProgress
         width="w-[800px]"
-        height="h-[618px]"
+        height="h-[700px]"
         size="medium-h-full"
         footer={
           <StepperModalFooter
@@ -361,172 +117,63 @@ const DeploymentsTab = () => {
             onSubmit={handleSubmit}
             nextDisabled={
               (currentStep === 1 && !deploymentName.trim()) ||
-              (currentStep === 2 && selectedItems.size === 0)
+              (currentStep === 2 && selectedItems.size === 0) ||
+              (currentStep === 3 && !configName.trim())
             }
-            submitLabel="Create Deployment"
+            submitLabel="Deployment"
           />
         }
       >
         {currentStep === 1 && (
-          <div className="flex h-full flex-col gap-5 overflow-y-auto">
-            <div>
-              <h3 className="text-base font-semibold">Deployment Basics</h3>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium">
-                Deployment Name <span className="text-destructive">*</span>
-              </label>
-              <Input
-                placeholder="e.g., Production Sales Agent"
-                value={deploymentName}
-                onChange={(e) => setDeploymentName(e.target.value)}
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium">Description</label>
-              <Textarea
-                placeholder="Describe what this deployment does..."
-                value={deploymentDescription}
-                onChange={(e) => setDeploymentDescription(e.target.value)}
-                rows={4}
-                className="resize-none placeholder:text-placeholder-foreground"
-              />
-            </div>
-            <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium">
-                Deployment Type <span className="text-destructive">*</span>
-              </label>
-              <div className="grid grid-cols-2 gap-3">
-                {(
-                  [
-                    {
-                      type: "Agent" as DeploymentType,
-                      label: "Agent",
-                      icon: "Bot",
-                      description:
-                        "Conversational agent with chat interface and tool calling",
-                    },
-                    {
-                      type: "MCP" as DeploymentType,
-                      label: "MCP Server",
-                      icon: "Mcp",
-                      description:
-                        "Model Context Protocol server for tool integration",
-                    },
-                  ] as const
-                ).map(({ type, label, icon, description }) => (
-                  <button
-                    key={type}
-                    onClick={() => setDeploymentType(type)}
-                    className={`flex flex-col gap-2 rounded-xl border p-4 text-left transition-colors ${
-                      deploymentType === type
-                        ? "border-primary bg-background"
-                        : "border-border hover:border-muted-foreground"
-                    }`}
-                  >
-                    <div
-                      className={`flex h-9 w-9 items-center justify-center rounded-md ${
-                        deploymentType === type ? "bg-primary/10" : "bg-muted"
-                      }`}
-                    >
-                      <ForwardedIconComponent
-                        name={icon}
-                        className={`h-5 w-5 ${
-                          deploymentType === type
-                            ? "text-primary"
-                            : "text-muted-foreground"
-                        }`}
-                      />
-                    </div>
-                    <p className="text-sm font-semibold">{label}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {description}
-                    </p>
-                  </button>
-                ))}
-              </div>
-            </div>
-          </div>
+          <StepBasics
+            deploymentName={deploymentName}
+            setDeploymentName={setDeploymentName}
+            deploymentDescription={deploymentDescription}
+            setDeploymentDescription={setDeploymentDescription}
+            deploymentType={deploymentType}
+            setDeploymentType={setDeploymentType}
+          />
         )}
 
         {currentStep === 2 && (
-          <div className="flex h-full flex-col gap-4">
-            <div>
-              <h3 className="text-base font-semibold">
-                Attach Flows or Snapshots
-              </h3>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Select one or more flows or snapshots to include in this
-                deployment
-              </p>
-            </div>
-            <div className="flex border-b border-border">
-              {ATTACH_TABS.map((tab) => (
-                <button
-                  key={tab}
-                  onClick={() => setAttachTab(tab)}
-                  className={`px-4 pb-2 text-sm font-medium transition-colors ${
-                    attachTab === tab
-                      ? "border-b-2 border-foreground text-foreground"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  {tab}
-                </button>
-              ))}
-            </div>
-            <div className="flex flex-col gap-2 overflow-y-auto">
-              {(attachTab === "Flows" ? MOCK_FLOWS : MOCK_SNAPSHOTS).map(
-                (item) => (
-                  <button
-                    key={item.id}
-                    onClick={() => toggleItem(item.id)}
-                    className={`flex items-start gap-3 rounded-lg border bg-background p-3 text-left transition-colors ${
-                      selectedItems.has(item.id)
-                        ? "border-primary"
-                        : "border-border hover:border-muted-foreground"
-                    }`}
-                  >
-                    <Checkbox
-                      checked={selectedItems.has(item.id)}
-                      className="mt-0.5 pointer-events-none"
-                    />
-                    <div className="flex flex-col gap-0.5">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-semibold">
-                          {item.name}
-                        </span>
-                        <span className="inline-flex items-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
-                          {attachTab === "Flows" ? "Flow" : "Snapshot"}
-                        </span>
-                      </div>
-                      <span className="text-xs text-muted-foreground">
-                        Last updated: {item.updatedDate}
-                        {"snapshotDate" in item && item.snapshotDate
-                          ? ` • Snapshot available (${item.snapshotDate})`
-                          : ""}
-                      </span>
-                    </div>
-                  </button>
-                ),
-              )}
-            </div>
-            {selectedItems.size === 0 && (
-              <p className="mt-auto text-center text-sm text-muted-foreground">
-                Select at least one flow or snapshot to continue
-              </p>
-            )}
-          </div>
+          <StepAttach
+            attachTab={attachTab}
+            setAttachTab={setAttachTab}
+            selectedItems={selectedItems}
+            toggleItem={toggleItem}
+          />
         )}
 
         {currentStep === 3 && (
-          <div className="flex h-full flex-col gap-3">WIP 3</div>
+          <StepConfiguration
+            configMode={configMode}
+            setConfigMode={setConfigMode}
+            configName={configName}
+            setConfigName={setConfigName}
+            keyFormat={keyFormat}
+            setKeyFormat={setKeyFormat}
+            envVars={envVars}
+            setEnvVars={setEnvVars}
+          />
         )}
         {currentStep === 4 && (
-          <div className="flex h-full flex-col gap-3">WIP 4</div>
+          <StepScope
+            variableScope={variableScope}
+            setVariableScope={setVariableScope}
+          />
         )}
         {currentStep === 5 && (
-          <div className="flex h-full flex-col gap-3">WIP 5</div>
+          <StepReview
+            deploymentType={deploymentType}
+            deploymentName={deploymentName}
+            deploymentDescription={deploymentDescription}
+            selectedItems={selectedItems}
+            configMode={configMode}
+            configName={configName}
+            keyFormat={keyFormat}
+            envVars={envVars}
+            variableScope={variableScope}
+          />
         )}
       </StepperModal>
     </div>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/mockData.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/mockData.ts
@@ -73,3 +73,78 @@ export const MOCK_SNAPSHOTS = [
     updatedDate: "2026-02-18",
   },
 ];
+
+export const MOCK_PROVIDERS = [
+  {
+    id: "langflow-cloud",
+    name: "Langflow Cloud",
+    subLabel: "Langflow",
+    icon: "LangflowLogo",
+    iconBg: "bg-zinc-700",
+    iconColor: "text-white",
+    status: "Connected",
+    endpoint: "https://cloud.langflow.io",
+    lastVerified: "6 days ago",
+    deployments: 12,
+  },
+  {
+    id: "watsonx",
+    name: "watsonx Orchestrate",
+    subLabel: "watsonx",
+    icon: "WatsonxAI",
+    iconBg: "bg-blue-600",
+    iconColor: "text-white",
+    status: "Connected",
+    endpoint: "https://api.watsonx-orchestrate.ibm.com/inst",
+    lastVerified: "6 days ago",
+    deployments: 8,
+  },
+  {
+    id: "aws",
+    name: "AWS Cloud Deploy",
+    subLabel: "cloud",
+    icon: "AWS",
+    iconBg: "bg-[#232F3E]",
+    iconColor: "text-[#FF9900]",
+    status: "Error",
+    endpoint: "https://aws.example.com",
+    lastVerified: "6 days ago",
+    deployments: 3,
+  },
+  {
+    id: "azure",
+    name: "Azure Functions",
+    subLabel: "cloud",
+    icon: "Azure",
+    iconBg: "bg-[#0078D4]",
+    iconColor: "text-white",
+    status: "Connected",
+    endpoint: "https://azure-functions.microsoft.com",
+    lastVerified: "6 days ago",
+    deployments: 5,
+  },
+];
+
+export const MOCK_CONFIGURATIONS = [
+  {
+    id: "config-1",
+    name: "Standard Production Config",
+    description: "Default configuration for production environments",
+    usedBy: 15,
+    created: "Jan 14, 2026",
+  },
+  {
+    id: "config-2",
+    name: "Test Environment Config",
+    description: "Lightweight configuration for testing environments",
+    usedBy: 8,
+    created: "Jan 19, 2026",
+  },
+  {
+    id: "config-3",
+    name: "High Performance Config",
+    description: "Enhanced configuration for high-load scenarios",
+    usedBy: 3,
+    created: "Jan 31, 2026",
+  },
+];

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/mockData.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/mockData.ts
@@ -1,0 +1,75 @@
+export const MOCK_DEPLOYMENTS = [
+  {
+    name: "Production Sales Agent",
+    url: "https://api.production.example.com/sales-agent",
+    type: "Agent",
+    status: "Healthy",
+    attached: 2,
+    configs: [{ id: "SALES_BOT_PROD", count: 3 }],
+    modifiedDate: "2026-02-15",
+    modifiedBy: "Sarah Han",
+  },
+  {
+    name: "Test Environment Sales Agent",
+    url: "https://api.staging.example.com/sales-agent",
+    type: "Agent",
+    status: "Healthy",
+    attached: 1,
+    configs: [{ id: "SALES_BOT_STAGING", count: 2 }],
+    modifiedDate: "2026-02-18",
+    modifiedBy: "Sarah Han",
+  },
+  {
+    name: "Customer Support MCP",
+    url: "https://api.dev.example.com/customer-support",
+    type: "MCP",
+    status: "Pending",
+    attached: 1,
+    configs: [{ id: "CUSTOMER_SUPPORT_PROD", count: null }],
+    modifiedDate: "2026-02-19",
+    modifiedBy: "Sarah Han",
+  },
+  {
+    name: "Multi-Config Sales Pipeline",
+    url: "https://api.dev.example.com/multi-config",
+    type: "Agent",
+    status: "Unhealthy",
+    attached: 3,
+    configs: [
+      { id: "SALES_BOT_PROD", count: 3 },
+      { id: "SALES_BOT_STAGING", count: 2 },
+    ],
+    modifiedDate: "2026-02-08",
+    modifiedBy: "Sarah Han",
+  },
+];
+
+export const MOCK_FLOWS = [
+  {
+    id: "flow-1",
+    name: "Qualify Lead",
+    updatedDate: "2026-02-18",
+    snapshotDate: "2026-02-17",
+  },
+  {
+    id: "flow-2",
+    name: "Summarize Call Notes",
+    updatedDate: "2026-02-19",
+    snapshotDate: "2026-02-18",
+  },
+  {
+    id: "flow-3",
+    name: "Create Ticket",
+    updatedDate: "2026-02-16",
+    snapshotDate: null,
+  },
+];
+
+export const MOCK_SNAPSHOTS = [
+  { id: "snap-1", name: "Qualify Lead v1.2", updatedDate: "2026-02-17" },
+  {
+    id: "snap-2",
+    name: "Summarize Call Notes v2.0",
+    updatedDate: "2026-02-18",
+  },
+];

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/steps/StepAttach.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/steps/StepAttach.tsx
@@ -1,0 +1,78 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { ATTACH_TABS, type AttachTab } from "../constants";
+import { MOCK_FLOWS, MOCK_SNAPSHOTS } from "../mockData";
+
+type StepAttachProps = {
+  attachTab: AttachTab;
+  setAttachTab: (v: AttachTab) => void;
+  selectedItems: Set<string>;
+  toggleItem: (id: string) => void;
+};
+
+export const StepAttach = ({
+  attachTab,
+  setAttachTab,
+  selectedItems,
+  toggleItem,
+}: StepAttachProps) => (
+  <div className="flex h-full flex-col gap-4">
+    <div>
+      <h3 className="text-base font-semibold">Attach Flows or Snapshots</h3>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Select one or more flows or snapshots to include in this deployment
+      </p>
+    </div>
+    <div className="flex border-b border-border">
+      {ATTACH_TABS.map((tab) => (
+        <button
+          key={tab}
+          onClick={() => setAttachTab(tab)}
+          className={`px-4 pb-2 text-sm font-medium transition-colors ${
+            attachTab === tab
+              ? "border-b-2 border-foreground text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+    <div className="flex flex-col gap-2 overflow-y-auto">
+      {(attachTab === "Flows" ? MOCK_FLOWS : MOCK_SNAPSHOTS).map((item) => (
+        <button
+          key={item.id}
+          onClick={() => toggleItem(item.id)}
+          className={`flex items-start gap-3 rounded-lg border bg-background p-3 text-left transition-colors ${
+            selectedItems.has(item.id)
+              ? "border-primary"
+              : "border-border hover:border-muted-foreground"
+          }`}
+        >
+          <Checkbox
+            checked={selectedItems.has(item.id)}
+            className="mt-0.5 pointer-events-none"
+          />
+          <div className="flex flex-col gap-0.5">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-semibold">{item.name}</span>
+              <span className="inline-flex items-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+                {attachTab === "Flows" ? "Flow" : "Snapshot"}
+              </span>
+            </div>
+            <span className="text-xs text-muted-foreground">
+              Last updated: {item.updatedDate}
+              {"snapshotDate" in item && item.snapshotDate
+                ? ` • Snapshot available (${item.snapshotDate})`
+                : ""}
+            </span>
+          </div>
+        </button>
+      ))}
+    </div>
+    {selectedItems.size === 0 && (
+      <p className="mt-auto text-center text-sm text-muted-foreground">
+        Select at least one flow or snapshot to continue
+      </p>
+    )}
+  </div>
+);

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/steps/StepBasics.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/steps/StepBasics.tsx
@@ -1,0 +1,102 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { DeploymentType } from "../constants";
+
+type StepBasicsProps = {
+  deploymentName: string;
+  setDeploymentName: (v: string) => void;
+  deploymentDescription: string;
+  setDeploymentDescription: (v: string) => void;
+  deploymentType: DeploymentType;
+  setDeploymentType: (v: DeploymentType) => void;
+};
+
+export const StepBasics = ({
+  deploymentName,
+  setDeploymentName,
+  deploymentDescription,
+  setDeploymentDescription,
+  deploymentType,
+  setDeploymentType,
+}: StepBasicsProps) => (
+  <div className="flex h-full flex-col gap-5 overflow-y-auto">
+    <div>
+      <h3 className="text-base font-semibold">Deployment Basics</h3>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Give your deployment a name, description, and choose a deployment type.
+      </p>
+    </div>
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium">
+        Deployment Name <span className="text-destructive">*</span>
+      </label>
+      <Input
+        placeholder="e.g., Production Sales Agent"
+        value={deploymentName}
+        onChange={(e) => setDeploymentName(e.target.value)}
+      />
+    </div>
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium">Description</label>
+      <Textarea
+        placeholder="Describe what this deployment does..."
+        value={deploymentDescription}
+        onChange={(e) => setDeploymentDescription(e.target.value)}
+        rows={6}
+        className="resize-none placeholder:text-placeholder-foreground"
+      />
+    </div>
+    <div className="flex min-h-0 flex-1 flex-col gap-2">
+      <label className="text-sm font-medium">
+        Deployment Type <span className="text-destructive">*</span>
+      </label>
+      <div className="grid h-full grid-cols-2 gap-3">
+        {(
+          [
+            {
+              type: "Agent" as DeploymentType,
+              label: "Agent",
+              icon: "Bot",
+              description:
+                "Conversational agent with chat interface and tool calling",
+            },
+            {
+              type: "MCP" as DeploymentType,
+              label: "MCP Server",
+              icon: "Mcp",
+              description: "Model Context Protocol server for tool integration",
+            },
+          ] as const
+        ).map(({ type, label, icon, description }) => (
+          <button
+            key={type}
+            onClick={() => setDeploymentType(type)}
+            className={`flex h-full flex-col gap-3 rounded-xl border p-4 text-left transition-colors ${
+              deploymentType === type
+                ? "border-primary bg-background"
+                : "border-border hover:border-muted-foreground"
+            }`}
+          >
+            <div
+              className={`flex h-9 w-9 items-center justify-center rounded-md ${
+                deploymentType === type ? "bg-primary/10" : "bg-muted"
+              }`}
+            >
+              <ForwardedIconComponent
+                name={icon}
+                className={`h-5 w-5 ${
+                  deploymentType === type
+                    ? "text-primary"
+                    : "text-muted-foreground"
+                }`}
+              />
+            </div>
+            <p className="text-sm font-semibold">{label}</p>
+            <p className="text-xs text-muted-foreground">{description}</p>
+          </button>
+        ))}
+      </div>
+    </div>
+  </div>
+);

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/steps/StepConfiguration.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/steps/StepConfiguration.tsx
@@ -1,0 +1,184 @@
+import { type Dispatch, type SetStateAction } from "react";
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Input } from "@/components/ui/input";
+import type { ConfigMode, KeyFormat } from "../constants";
+
+type EnvVar = { key: string; value: string };
+
+type StepConfigurationProps = {
+  configMode: ConfigMode;
+  setConfigMode: (v: ConfigMode) => void;
+  configName: string;
+  setConfigName: (v: string) => void;
+  keyFormat: KeyFormat;
+  setKeyFormat: (v: KeyFormat) => void;
+  envVars: EnvVar[];
+  setEnvVars: Dispatch<SetStateAction<EnvVar[]>>;
+};
+
+export const StepConfiguration = ({
+  configMode,
+  setConfigMode,
+  configName,
+  setConfigName,
+  keyFormat,
+  setKeyFormat,
+  envVars,
+  setEnvVars,
+}: StepConfigurationProps) => (
+  <div className="flex h-full flex-col gap-4 overflow-y-auto">
+    <div>
+      <h3 className="text-base font-semibold">Deployment Configuration</h3>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Choose how to configure environment variables. The Config name becomes
+        the Connection AppID in watsonx Orchestrate.
+      </p>
+    </div>
+    <div className="grid grid-cols-3 gap-2">
+      {(
+        [
+          {
+            mode: "reuse" as ConfigMode,
+            label: "Reuse existing Config",
+            description: "Use a Config that's already been created",
+            warn: false,
+          },
+          {
+            mode: "create" as ConfigMode,
+            label: "Create new Config",
+            description: "Define a new Config with environment variables",
+            warn: false,
+          },
+          {
+            mode: "modify" as ConfigMode,
+            label: "Modify selected Config",
+            description:
+              "Edit an existing Config (may affect other deployments)",
+            warn: true,
+          },
+        ] as const
+      ).map(({ mode, label, description, warn }) => (
+        <button
+          key={mode}
+          onClick={() => setConfigMode(mode)}
+          className={`flex flex-col gap-0.5 rounded-lg border bg-background p-4 text-left transition-colors ${
+            configMode === mode
+              ? "border-primary"
+              : "border-border hover:border-muted-foreground"
+          }`}
+        >
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold">{label}</span>
+            {warn && (
+              <ForwardedIconComponent
+                name="TriangleAlert"
+                className="h-4 w-4 text-yellow-400"
+              />
+            )}
+          </div>
+          <span className="text-sm text-muted-foreground">{description}</span>
+        </button>
+      ))}
+    </div>
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium">
+        Config Name (AppID) <span className="text-destructive">*</span>
+      </label>
+      <Input
+        placeholder="e.g., SALES_BOT_PROD"
+        value={configName}
+        onChange={(e) => setConfigName(e.target.value)}
+      />
+      <p className="text-xs text-muted-foreground">
+        This name becomes the Connection AppID in watsonx Orchestrate. Use
+        uppercase letters, numbers, and underscores only.
+      </p>
+    </div>
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium">Variable Key Format</label>
+      <div className="flex gap-2">
+        {(
+          [
+            { id: "assisted" as KeyFormat, label: "Assisted Prefix" },
+            { id: "auto" as KeyFormat, label: "Auto-Prefix" },
+            { id: "manual" as KeyFormat, label: "Manual" },
+          ] as const
+        ).map(({ id, label }) => (
+          <button
+            key={id}
+            onClick={() => setKeyFormat(id)}
+            className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
+              keyFormat === id
+                ? "border-foreground bg-background font-semibold text-foreground"
+                : "border-border bg-background text-muted-foreground hover:border-muted-foreground"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+    <div className="flex min-h-0 flex-1 flex-col gap-1.5">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium">
+          Environment Variables <span className="text-destructive">*</span>
+        </label>
+        <button
+          onClick={() =>
+            setEnvVars((prev) => [...prev, { key: "", value: "" }])
+          }
+          className="flex items-center gap-1 text-sm text-foreground hover:text-muted-foreground"
+        >
+          <ForwardedIconComponent name="Plus" className="h-4 w-4" />
+          Add Variable
+        </button>
+      </div>
+      <div className="flex h-full flex-col rounded-lg border border-border bg-background">
+        {envVars.length === 0 ? (
+          <p className="flex h-full min-h-[80px] items-center justify-center text-sm text-muted-foreground">
+            No variables yet. Click "Add Variable" to get started.
+          </p>
+        ) : (
+          <div className="flex flex-col divide-y divide-border">
+            {envVars.map((v, i) => (
+              <div key={i} className="flex items-center gap-2 p-2">
+                <Input
+                  placeholder="KEY"
+                  value={v.key}
+                  onChange={(e) =>
+                    setEnvVars((prev) =>
+                      prev.map((x, j) =>
+                        j === i ? { ...x, key: e.target.value } : x,
+                      ),
+                    )
+                  }
+                  className="flex-1"
+                />
+                <Input
+                  placeholder="VALUE"
+                  value={v.value}
+                  onChange={(e) =>
+                    setEnvVars((prev) =>
+                      prev.map((x, j) =>
+                        j === i ? { ...x, value: e.target.value } : x,
+                      ),
+                    )
+                  }
+                  className="flex-1"
+                />
+                <button
+                  onClick={() =>
+                    setEnvVars((prev) => prev.filter((_, j) => j !== i))
+                  }
+                  className="text-muted-foreground hover:text-destructive"
+                >
+                  <ForwardedIconComponent name="X" className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+);

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/steps/StepReview.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/steps/StepReview.tsx
@@ -1,0 +1,141 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import type {
+  ConfigMode,
+  DeploymentType,
+  KeyFormat,
+  VariableScope,
+} from "../constants";
+import { MOCK_FLOWS, MOCK_SNAPSHOTS } from "../mockData";
+
+type EnvVar = { key: string; value: string };
+
+type StepReviewProps = {
+  deploymentType: DeploymentType;
+  deploymentName: string;
+  deploymentDescription: string;
+  selectedItems: Set<string>;
+  configMode: ConfigMode;
+  configName: string;
+  keyFormat: KeyFormat;
+  envVars: EnvVar[];
+  variableScope: VariableScope;
+};
+
+export const StepReview = ({
+  deploymentType,
+  deploymentName,
+  deploymentDescription,
+  selectedItems,
+  configMode,
+  configName,
+  keyFormat,
+  envVars,
+  variableScope,
+}: StepReviewProps) => {
+  const allItems = [
+    ...MOCK_FLOWS.map((i) => ({ ...i, kind: "Flow" as const })),
+    ...MOCK_SNAPSHOTS.map((i) => ({ ...i, kind: "Snapshot" as const })),
+  ];
+  const selectedNames = allItems
+    .filter((i) => selectedItems.has(i.id))
+    .map((i) => ({ name: i.name, kind: i.kind }));
+
+  const configModeLabel = {
+    reuse: "Reuse existing Config",
+    create: "Create new Config",
+    modify: "Modify selected Config",
+  }[configMode];
+
+  const keyFormatLabel = {
+    assisted: "Assisted Prefix",
+    auto: "Auto-Prefix",
+    manual: "Manual",
+  }[keyFormat];
+
+  const scopeLabel =
+    variableScope === "coarse"
+      ? "Coarse (Shared Config)"
+      : "Granular (Per-Flow Config)";
+
+  return (
+    <div className="flex h-full flex-col gap-4 overflow-y-auto">
+      <div>
+        <h3 className="text-base font-semibold">Review & Confirm</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Review your deployment details before creating.
+        </p>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex h-full flex-col rounded-lg border border-border bg-background p-4">
+          <p className="mb-3 text-md font-semibold text-primary">Deployment</p>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
+            <dt className="text-muted-foreground">Type</dt>
+            <dd className="flex items-center gap-1.5 font-medium">
+              <ForwardedIconComponent
+                name={deploymentType === "MCP" ? "Mcp" : "Bot"}
+                className="h-3.5 w-3.5 text-muted-foreground"
+              />
+              {deploymentType === "MCP" ? "MCP Server" : deploymentType}
+            </dd>
+            <dt className="text-muted-foreground">Name</dt>
+            <dd className="truncate font-medium">{deploymentName}</dd>
+          </dl>
+          {deploymentDescription && (
+            <div className="mt-2 flex flex-col gap-1 text-sm">
+              <span className="text-muted-foreground">Description</span>
+              <p
+                className="line-clamp-2 font-medium"
+                title={deploymentDescription}
+              >
+                {deploymentDescription}
+              </p>
+            </div>
+          )}
+        </div>
+        <div className="rounded-lg border border-border bg-background p-4">
+          <p className="mb-3 text-md font-semibold text-primary">
+            Attached Items
+          </p>
+          {selectedNames.length > 0 ? (
+            <ul className="flex flex-col gap-1">
+              {selectedNames.map(({ name, kind }) => (
+                <li key={name} className="flex items-center gap-2 text-sm">
+                  <ForwardedIconComponent
+                    name={kind === "Flow" ? "Workflow" : "Camera"}
+                    className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+                  />
+                  <span className="font-medium">{name}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <span className="text-sm text-muted-foreground italic">
+              None selected
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="flex-1 rounded-lg border border-border bg-background p-4">
+        <p className="mb-3 text-md font-semibold text-primary">Configuration</p>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
+          <dt className="text-muted-foreground">Mode</dt>
+          <dd className="font-medium">{configModeLabel}</dd>
+          <dt className="text-muted-foreground">Config Name</dt>
+          <dd className="font-mono font-medium">{configName}</dd>
+          <dt className="text-muted-foreground">Key Format</dt>
+          <dd className="font-medium">{keyFormatLabel}</dd>
+          <dt className="text-muted-foreground">Env Variables</dt>
+          <dd className="font-medium">
+            {envVars.length > 0 ? (
+              `${envVars.length} variable${envVars.length > 1 ? "s" : ""}`
+            ) : (
+              <span className="italic text-muted-foreground">None</span>
+            )}
+          </dd>
+          <dt className="text-muted-foreground">Variable Scope</dt>
+          <dd className="font-medium">{scopeLabel}</dd>
+        </dl>
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/steps/StepScope.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/steps/StepScope.tsx
@@ -1,0 +1,72 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import type { VariableScope } from "../constants";
+
+type StepScopeProps = {
+  variableScope: VariableScope;
+  setVariableScope: (v: VariableScope) => void;
+};
+
+export const StepScope = ({
+  variableScope,
+  setVariableScope,
+}: StepScopeProps) => (
+  <div className="flex h-full flex-col gap-4">
+    <div>
+      <h3 className="text-base font-semibold">Variable Scope</h3>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Choose how configs are applied to your attached flows
+      </p>
+    </div>
+    <div className="grid grid-cols-2 gap-3">
+      {(
+        [
+          {
+            id: "coarse" as VariableScope,
+            label: "Coarse (Shared Config)",
+            description:
+              "One Config applies to all attached Flows/Snapshots. Simpler mental model, fewer errors.",
+          },
+          {
+            id: "granular" as VariableScope,
+            label: "Granular (Per-Flow Config)",
+            description:
+              "Each Flow can use its own Config. Maximum flexibility where flows need different connections.",
+          },
+        ] as const
+      ).map(({ id, label, description }) => (
+        <button
+          key={id}
+          onClick={() => setVariableScope(id)}
+          className={`flex items-start gap-3 rounded-lg border bg-background p-4 text-left transition-colors ${
+            variableScope === id
+              ? "border-primary"
+              : "border-border hover:border-muted-foreground"
+          }`}
+        >
+          <div className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2 border-muted-foreground">
+            {variableScope === id && (
+              <div className="h-2 w-2 rounded-full bg-foreground" />
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-semibold">{label}</span>
+            <span className="text-xs text-muted-foreground">{description}</span>
+          </div>
+        </button>
+      ))}
+    </div>
+    <div className="flex-1 rounded-lg border border-border bg-background p-4">
+      <div className="flex items-center gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
+          <ForwardedIconComponent
+            name="ClipboardList"
+            className="h-4 w-4 text-muted-foreground"
+          />
+        </div>
+        <span className="text-sm font-semibold">
+          Single Shared Configuration
+        </span>
+      </div>
+    </div>
+  </div>
+);

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/useDeploymentForm.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/useDeploymentForm.ts
@@ -11,7 +11,7 @@ import {
 
 export const useDeploymentForm = () => {
   const [activeView, setActiveView] =
-    useState<DeploymentView>("All Deployments");
+    useState<DeploymentView>("Live Deployments");
   const [newDeploymentOpen, setNewDeploymentOpen] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
   const [deploymentType, setDeploymentType] = useState<DeploymentType>("Agent");

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/useDeploymentForm.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/useDeploymentForm.ts
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import {
+  type AttachTab,
+  type ConfigMode,
+  type DeploymentType,
+  type DeploymentView,
+  type KeyFormat,
+  TOTAL_STEPS,
+  type VariableScope,
+} from "./constants";
+
+export const useDeploymentForm = () => {
+  const [activeView, setActiveView] =
+    useState<DeploymentView>("All Deployments");
+  const [newDeploymentOpen, setNewDeploymentOpen] = useState(false);
+  const [currentStep, setCurrentStep] = useState(1);
+  const [deploymentType, setDeploymentType] = useState<DeploymentType>("Agent");
+  const [deploymentName, setDeploymentName] = useState("");
+  const [deploymentDescription, setDeploymentDescription] = useState("");
+  const [deploymentUrl, setDeploymentUrl] = useState("");
+  const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
+  const [attachTab, setAttachTab] = useState<AttachTab>("Flows");
+  const [configMode, setConfigMode] = useState<ConfigMode>("reuse");
+  const [configName, setConfigName] = useState("");
+  const [keyFormat, setKeyFormat] = useState<KeyFormat>("assisted");
+  const [envVars, setEnvVars] = useState<{ key: string; value: string }[]>([]);
+  const [variableScope, setVariableScope] = useState<VariableScope>("coarse");
+
+  const resetForm = () => {
+    setCurrentStep(1);
+    setDeploymentName("");
+    setDeploymentDescription("");
+    setDeploymentUrl("");
+    setDeploymentType("Agent");
+    setSelectedItems(new Set());
+    setAttachTab("Flows");
+    setConfigMode("reuse");
+    setConfigName("");
+    setKeyFormat("assisted");
+    setEnvVars([]);
+    setVariableScope("coarse");
+  };
+
+  const handleBack = () => setCurrentStep((s) => Math.max(1, s - 1));
+  const handleNext = () => setCurrentStep((s) => Math.min(TOTAL_STEPS, s + 1));
+
+  const handleSubmit = () => {
+    setNewDeploymentOpen(false);
+    resetForm();
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    setNewDeploymentOpen(open);
+    if (!open) resetForm();
+  };
+
+  const toggleItem = (id: string) => {
+    setSelectedItems((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  return {
+    activeView,
+    setActiveView,
+    newDeploymentOpen,
+    setNewDeploymentOpen,
+    currentStep,
+    deploymentType,
+    setDeploymentType,
+    deploymentName,
+    setDeploymentName,
+    deploymentDescription,
+    setDeploymentDescription,
+    deploymentUrl,
+    setDeploymentUrl,
+    selectedItems,
+    attachTab,
+    setAttachTab,
+    configMode,
+    setConfigMode,
+    configName,
+    setConfigName,
+    keyFormat,
+    setKeyFormat,
+    envVars,
+    setEnvVars,
+    variableScope,
+    setVariableScope,
+    handleBack,
+    handleNext,
+    handleSubmit,
+    handleOpenChange,
+    toggleItem,
+  };
+};

--- a/src/frontend/src/pages/MainPage/pages/emptyFolder/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/emptyFolder/index.tsx
@@ -10,7 +10,7 @@ export const EmptyFolder = ({ setOpenModal }: EmptyFolderProps) => {
   const folders = useFolderStore((state) => state.folders);
 
   return (
-    <div className="m-0 flex w-full justify-center">
+    <div className="m-0 flex w-full justify-center pt-4">
       <div className="absolute top-1/2 flex w-full -translate-y-1/2 flex-col items-center justify-center gap-2">
         <h3
           className="pt-5 font-chivo text-2xl font-semibold"

--- a/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
@@ -47,10 +47,10 @@ export const FilesPage = () => {
       data-testid="cards-wrapper"
     >
       <div className="flex h-full w-full flex-col xl:container">
-        <div className="flex flex-1 flex-col justify-start px-5 pt-10">
+        <div className="flex flex-1 flex-col justify-start px-5 pt-5">
           <div className="flex h-full flex-col justify-start">
             <div
-              className="flex items-center pb-8 text-xl font-semibold"
+              className="flex items-center pb-4 text-xl font-semibold"
               data-testid="mainpage_title"
             >
               <div className="h-7 w-10 transition-all group-data-[open=true]/sidebar-wrapper:md:w-0 lg:hidden">

--- a/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
@@ -3,12 +3,11 @@ import { useParams } from "react-router-dom";
 
 import { ForwardedIconComponent } from "@/components/common/genericIconComponent";
 import { Button } from "@/components/ui/button";
+import type { MCPTransport } from "@/controllers/API/queries/mcp/use-patch-install-mcp";
 import { ENABLE_MCP_COMPOSER } from "@/customization/feature-flags";
 import { useCustomIsLocalConnection } from "@/customization/hooks/use-custom-is-local-connection";
 import useTheme from "@/customization/hooks/use-custom-theme";
 import AuthModal from "@/modals/authModal";
-
-import type { MCPTransport } from "@/controllers/API/queries/mcp/use-patch-install-mcp";
 import { useFolderStore } from "@/stores/foldersStore";
 import { cn, getOS } from "@/utils/utils";
 import { useMcpServer } from "../hooks/useMcpServer";
@@ -65,7 +64,7 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
   });
 
   return (
-    <div>
+    <div className="p-5">
       <div className="flex justify-between gap-4 items-start">
         <div>
           <div className="pb-2 font-medium" data-testid="mcp-server-title">

--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -3,6 +3,8 @@ import { useParams } from "react-router-dom";
 import PaginatorComponent from "@/components/common/paginatorComponent";
 import CardsWrapComponent from "@/components/core/cardsWrapComponent";
 import { IS_MAC } from "@/constants/constants";
+import { useDeleteDeleteFlows } from "@/controllers/API/queries/flows/use-delete-delete-flows";
+import { useGetDownloadFlows } from "@/controllers/API/queries/flows/use-get-download-flows";
 import { useGetFolderQuery } from "@/controllers/API/queries/folders/use-get-folder";
 import { CustomBanner } from "@/customization/components/custom-banner";
 import { CustomMcpServerTab } from "@/customization/components/custom-McpServerTab";
@@ -11,17 +13,24 @@ import {
   ENABLE_MCP,
 } from "@/customization/feature-flags";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
+import useAlertStore from "@/stores/alertStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { useFolderStore } from "@/stores/foldersStore";
 import { FlowType } from "@/types/flow";
 import HeaderComponent from "../../components/header";
+import HeaderToolbar from "../../components/header/components/HeaderToolbar";
 import ListComponent from "../../components/list";
 import ListSkeleton from "../../components/listSkeleton";
 import ModalsComponent from "../../components/modalsComponent";
 import useFileDrop from "../../hooks/use-on-file-drop";
+import DeploymentsTab from "../deploymentsPage";
 import EmptyFolder from "../emptyFolder";
 
-const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
+const HomePage = ({
+  type,
+}: {
+  type: "flows" | "components" | "mcp" | "deployments";
+}) => {
   const [view, setView] = useState<"grid" | "list">(() => {
     const savedView = localStorage.getItem("view");
     return savedView === "grid" || savedView === "list" ? savedView : "list";
@@ -33,9 +42,9 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
   const [search, setSearch] = useState("");
   const navigate = useCustomNavigate();
 
-  const [flowType, setFlowType] = useState<"flows" | "components" | "mcp">(
-    type,
-  );
+  const [flowType, setFlowType] = useState<
+    "flows" | "components" | "mcp" | "deployments"
+  >(type);
   const myCollectionId = useFolderStore((state) => state.myCollectionId);
   const folders = useFolderStore((state) => state.folders);
   const folderName =
@@ -130,6 +139,29 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
   );
   const [isShiftPressed, setIsShiftPressed] = useState(false);
   const [isCtrlPressed, setIsCtrlPressed] = useState(false);
+
+  const setSuccessData = useAlertStore((state) => state.setSuccessData);
+  const { mutate: downloadFlows, isPending: isDownloading } =
+    useGetDownloadFlows();
+  const { mutate: deleteFlows, isPending: isDeleting } = useDeleteDeleteFlows();
+
+  const handleDownload = () => {
+    downloadFlows({ ids: selectedFlows });
+    setSuccessData({ title: "Flows downloaded successfully" });
+  };
+
+  const handleDelete = () => {
+    deleteFlows(
+      { flow_ids: selectedFlows },
+      {
+        onSuccess: () =>
+          setSuccessData({ title: "Flows deleted successfully" }),
+      },
+    );
+  };
+
+  const showToolbar =
+    !isEmptyFolder && flowType !== "mcp" && flowType !== "deployments";
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -252,19 +284,28 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
       >
         <div className="flex h-full w-full flex-col 3xl:container">
           {ENABLE_DATASTAX_LANGFLOW && <CustomBanner />}
-          <div className="flex flex-1 flex-col justify-start p-4">
+          <div className="flex flex-1 flex-col justify-start">
             <div className="flex h-full flex-col justify-start">
               <HeaderComponent
                 folderName={folderName}
                 flowType={flowType}
                 setFlowType={setFlowType}
-                view={view}
-                setView={setView}
-                setNewProjectModal={setNewProjectModal}
-                setSearch={onSearch}
                 isEmptyFolder={isEmptyFolder}
-                selectedFlows={selectedFlows}
               />
+              {showToolbar && (
+                <HeaderToolbar
+                  flowType={flowType}
+                  view={view}
+                  setView={setView}
+                  setSearch={onSearch}
+                  setNewProjectModal={setNewProjectModal}
+                  selectedFlows={selectedFlows}
+                  onDownload={handleDownload}
+                  onDelete={handleDelete}
+                  isDownloading={isDownloading}
+                  isDeleting={isDeleting}
+                />
+              )}
               {isEmptyFolder ? (
                 <EmptyFolder setOpenModal={setNewProjectModal} />
               ) : (
@@ -281,13 +322,15 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
                         <ListSkeleton />
                       </div>
                     )
+                  ) : flowType === "deployments" ? (
+                    <DeploymentsTab />
                   ) : flowType === "mcp" ? (
                     <CustomMcpServerTab folderName={folderName} />
                   ) : (flowType === "flows" || flowType === "components") &&
                     data &&
                     data.pagination.total > 0 ? (
                     view === "grid" ? (
-                      <div className="mt-4 grid grid-cols-1 gap-1 md:grid-cols-2 lg:grid-cols-3">
+                      <div className="p-5 grid grid-cols-1 gap-1 md:grid-cols-2 lg:grid-cols-3">
                         {data.flows.map((flow, index) => (
                           <ListComponent
                             key={flow.id}
@@ -301,7 +344,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
                         ))}
                       </div>
                     ) : (
-                      <div className="mt-4 flex flex-col gap-1">
+                      <div className="flex flex-col gap-1 p-5">
                         {data.flows.map((flow, index) => (
                           <ListComponent
                             key={flow.id}

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/index.tsx
@@ -98,10 +98,10 @@ export const KnowledgePage = () => {
         }`}
       >
         <div className="flex h-full w-full flex-col xl:container">
-          <div className="flex flex-1 flex-col justify-start px-5 pt-10">
+          <div className="flex flex-1 flex-col justify-start px-5 pt-5">
             <div className="flex h-full flex-col justify-start">
               <div
-                className="flex items-center pb-8 text-xl font-semibold"
+                className="flex items-center pb-4 text-xl font-semibold"
                 data-testid="mainpage_title"
               >
                 <div className="h-7 w-10 transition-all group-data-[open=true]/sidebar-wrapper:md:w-0 lg:hidden">

--- a/src/frontend/tests/extended/features/filterEdge-shard-1.spec.ts
+++ b/src/frontend/tests/extended/features/filterEdge-shard-1.spec.ts
@@ -69,7 +69,6 @@ test(
       "disclosure-data sources",
       "disclosure-models & agents",
       "disclosure-llm operations",
-      "disclosure-files",
       "disclosure-processing",
       "disclosure-flow control",
       "disclosure-utilities",

--- a/src/frontend/tests/extended/features/filterEdge-shard-1.spec.ts
+++ b/src/frontend/tests/extended/features/filterEdge-shard-1.spec.ts
@@ -69,6 +69,7 @@ test(
       "disclosure-data sources",
       "disclosure-models & agents",
       "disclosure-llm operations",
+      "disclosure-files",
       "disclosure-processing",
       "disclosure-flow control",
       "disclosure-utilities",


### PR DESCRIPTION
Prototyping deployment tab from [figma](https://www.figma.com/design/DCC7F0i2w13UAsuk6beMDH/Langflow-Publish-and-Deploy?node-id=980-14815&t=8glrkPwRP3pCWxL5-0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deployments page launched with full management capabilities (create, update, delete, duplicate)
  * Bulk actions for flows (download and delete multiple items)
  * View toggle between list and grid layouts
  * Search functionality with real-time filtering
  * Knowledge bases feature now enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->