### PR TITLE
fix: add clean_output to field_order in SplitText starter project templates

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -163,7 +163,7 @@
         "filename": ".github/workflows/release.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 269,
+        "line_number": 273,
         "is_secret": false
       }
     ],
@@ -173,8 +173,24 @@
         "filename": ".github/workflows/release_nightly.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 226,
+        "line_number": 413,
         "is_secret": false
+      }
+    ],
+    "SECURITY.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "SECURITY.md",
+        "hashed_secret": "d67b0bfe20b56dac12b19258dcfe74b0998d8eeb",
+        "is_verified": false,
+        "line_number": 140
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "SECURITY.md",
+        "hashed_secret": "e57eb248dee276a7a8931d338105a49725dd6ec7",
+        "is_verified": false,
+        "line_number": 141
       }
     ],
     "deploy/.env.example": [
@@ -217,160 +233,220 @@
         "is_secret": false
       }
     ],
-    "docs/docs/API-Reference/api-reference-api-examples.md": [
+    "docs/docs/API-Reference/api-openai-responses.mdx": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/API-Reference/api-reference-api-examples.md",
+        "filename": "docs/docs/API-Reference/api-openai-responses.mdx",
+        "hashed_secret": "f8f0b44da6dd51f3e5db5129c12a1b95ec71c2d9",
+        "is_verified": false,
+        "line_number": 45
+      }
+    ],
+    "docs/docs/API-Reference/api-reference-api-examples.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/api-reference-api-examples.mdx",
+        "hashed_secret": "7d268ec0fc8a845ff8e1b1af5317ee5dc164808b",
+        "is_verified": false,
+        "line_number": 94
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/api-reference-api-examples.mdx",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 86,
-        "is_secret": false
-      },
+        "line_number": 98
+      }
+    ],
+    "docs/docs/API-Reference/api-users.mdx": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/API-Reference/api-reference-api-examples.md",
+        "filename": "docs/docs/API-Reference/api-users.mdx",
         "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
         "is_verified": false,
-        "line_number": 2428,
-        "is_secret": false
+        "line_number": 21
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/API-Reference/api-reference-api-examples.md",
+        "filename": "docs/docs/API-Reference/api-users.mdx",
         "hashed_secret": "8f7d56d9f06f8f052a331fedbe14548f0a3305a3",
         "is_verified": false,
-        "line_number": 2629,
-        "is_secret": false
+        "line_number": 213
       }
     ],
-    "docs/docs/Concepts/embedded-chat-widget.md": [
+    "docs/docs/API-Reference/typescript-client.mdx": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/Concepts/embedded-chat-widget.md",
-        "hashed_secret": "1e3667aaaaa887721550cf5cc8a0c5c5760810ed",
+        "filename": "docs/docs/API-Reference/typescript-client.mdx",
+        "hashed_secret": "159500287c06851df741128ec4b073ea394414b6",
         "is_verified": false,
-        "line_number": 72,
-        "is_secret": false
+        "line_number": 55
       }
     ],
-    "docs/docs/Configuration/configuration-custom-database.md": [
+    "docs/docs/Deployment/deployment-docker.mdx": [
       {
         "type": "Basic Auth Credentials",
-        "filename": "docs/docs/Configuration/configuration-custom-database.md",
+        "filename": "docs/docs/Deployment/deployment-docker.mdx",
+        "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
+        "is_verified": false,
+        "line_number": 82
+      }
+    ],
+    "docs/docs/Deployment/deployment-kubernetes-dev.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/Deployment/deployment-kubernetes-dev.mdx",
+        "hashed_secret": "0324bd7e241b5b7c50b91d8a6036f8134bafb078",
+        "is_verified": false,
+        "line_number": 115
+      }
+    ],
+    "docs/docs/Deployment/deployment-public-server.mdx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/docs/Deployment/deployment-public-server.mdx",
+        "hashed_secret": "991dcae394b42727eca3fc81bf221cecb92370e5",
+        "is_verified": false,
+        "line_number": 71
+      }
+    ],
+    "docs/docs/Develop/configuration-custom-database.mdx": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/docs/Develop/configuration-custom-database.mdx",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 18,
-        "is_secret": false
+        "line_number": 22
+      }
+    ],
+    "docs/docs/Develop/enterprise-database-guide.mdx": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/docs/Develop/enterprise-database-guide.mdx",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 30
       },
       {
         "type": "Basic Auth Credentials",
-        "filename": "docs/docs/Configuration/configuration-custom-database.md",
-        "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
+        "filename": "docs/docs/Develop/enterprise-database-guide.mdx",
+        "hashed_secret": "ea0c04513c32717f3a09ff7b1fa882c4d8424b2a",
         "is_verified": false,
-        "line_number": 68,
-        "is_secret": false
-      }
-    ],
-    "docs/docs/Configuration/environment-variables.md": [
+        "line_number": 30
+      },
       {
         "type": "Basic Auth Credentials",
-        "filename": "docs/docs/Configuration/environment-variables.md",
+        "filename": "docs/docs/Develop/enterprise-database-guide.mdx",
+        "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
+        "is_verified": false,
+        "line_number": 68
+      }
+    ],
+    "docs/docs/Develop/environment-variables.mdx": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/docs/Develop/environment-variables.mdx",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 71,
-        "is_secret": false
+        "line_number": 96
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "docs/docs/Configuration/environment-variables.md",
+        "filename": "docs/docs/Develop/environment-variables.mdx",
         "hashed_secret": "dacd53eb505b8486197552a888eef99192ffd390",
         "is_verified": false,
-        "line_number": 298,
-        "is_secret": false
+        "line_number": 217
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/Configuration/environment-variables.md",
+        "filename": "docs/docs/Develop/environment-variables.mdx",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 362,
-        "is_secret": false
+        "line_number": 285
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/Configuration/environment-variables.md",
+        "filename": "docs/docs/Develop/environment-variables.mdx",
         "hashed_secret": "2d301f84472a0bacb783628ee7badae5566c0b4b",
         "is_verified": false,
-        "line_number": 364,
-        "is_secret": false
+        "line_number": 287
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/Configuration/environment-variables.md",
+        "filename": "docs/docs/Develop/environment-variables.mdx",
         "hashed_secret": "74913f5cd5f61ec0bcfdb775414c2fb3d161b620",
         "is_verified": false,
-        "line_number": 368,
-        "is_secret": false
+        "line_number": 290
       }
     ],
-    "docs/docs/Deployment/deployment-kubernetes-dev.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/docs/Deployment/deployment-kubernetes-dev.md",
-        "hashed_secret": "0324bd7e241b5b7c50b91d8a6036f8134bafb078",
-        "is_verified": false,
-        "line_number": 98,
-        "is_secret": false
-      }
-    ],
-    "docs/docs/Develop/Clients/typescript-client.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/docs/Develop/Clients/typescript-client.md",
-        "hashed_secret": "159500287c06851df741128ec4b073ea394414b6",
-        "is_verified": false,
-        "line_number": 60,
-        "is_secret": false
-      }
-    ],
-    "docs/docs/Develop/memory.md": [
+    "docs/docs/Develop/integrations-langfuse.mdx": [
       {
         "type": "Basic Auth Credentials",
-        "filename": "docs/docs/Develop/memory.md",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 63,
-        "is_secret": false
-      }
-    ],
-    "docs/docs/Integrations/integrations-langfuse.md": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "docs/docs/Integrations/integrations-langfuse.md",
+        "filename": "docs/docs/Develop/integrations-langfuse.mdx",
         "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
         "is_verified": false,
-        "line_number": 102,
-        "is_secret": false
+        "line_number": 109
       }
     ],
-    "docs/docs/Integrations/integrations-langsmith.md": [
+    "docs/docs/Develop/integrations-langsmith.mdx": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/Integrations/integrations-langsmith.md",
+        "filename": "docs/docs/Develop/integrations-langsmith.mdx",
         "hashed_secret": "6a0ece37dcf14c4acd0710a1a54bfbdcc7bc55fb",
         "is_verified": false,
-        "line_number": 23,
-        "is_secret": false
+        "line_number": 21
       }
     ],
-    "docs/docs/Integrations/integrations-langwatch.md": [
+    "docs/docs/Develop/integrations-langwatch.mdx": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/Integrations/integrations-langwatch.md",
-        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
+        "filename": "docs/docs/Develop/integrations-langwatch.mdx",
+        "hashed_secret": "28676f3e163fda95ab69f9f29c3948009a04e0e0",
         "is_verified": false,
-        "line_number": 23,
-        "is_secret": false
+        "line_number": 17
+      }
+    ],
+    "docs/docs/Develop/memory.mdx": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/docs/Develop/memory.mdx",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 74
+      }
+    ],
+    "docs/docs/Flows/concepts-publish.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/Flows/concepts-publish.mdx",
+        "hashed_secret": "7d268ec0fc8a845ff8e1b1af5317ee5dc164808b",
+        "is_verified": false,
+        "line_number": 60
+      }
+    ],
+    "docs/docs/Get-Started/get-started-quickstart.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/Get-Started/get-started-quickstart.mdx",
+        "hashed_secret": "7d268ec0fc8a845ff8e1b1af5317ee5dc164808b",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/Get-Started/get-started-quickstart.mdx",
+        "hashed_secret": "1a37d41260f96724ee881be5e261b4d043f0626b",
+        "is_verified": false,
+        "line_number": 550
+      }
+    ],
+    "docs/docs/Tutorials/agent.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/Tutorials/agent.mdx",
+        "hashed_secret": "e42fd8b9ad15d8fa5f4718cad7cf19b522807996",
+        "is_verified": false,
+        "line_number": 82
       }
     ],
     "docs/docusaurus.config.js": [
@@ -379,7 +455,7 @@
         "filename": "docs/docusaurus.config.js",
         "hashed_secret": "2dc79dceb6a4e48f38ef47d8dcabbbfaa441218f",
         "is_verified": false,
-        "line_number": 384,
+        "line_number": 509,
         "is_secret": false
       },
       {
@@ -387,8 +463,17 @@
         "filename": "docs/docusaurus.config.js",
         "hashed_secret": "2dc79dceb6a4e48f38ef47d8dcabbbfaa441218f",
         "is_verified": false,
-        "line_number": 384,
+        "line_number": 509,
         "is_secret": false
+      }
+    ],
+    "docs/features/windows-postgresql-eventloop-fix.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/features/windows-postgresql-eventloop-fix.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 418
       }
     ],
     "scripts/aws/lib/construct/db.ts": [
@@ -401,13 +486,123 @@
         "is_secret": false
       }
     ],
+    "src/backend/base/langflow/agentic/flows/LangflowAssistant.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/agentic/flows/LangflowAssistant.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 583
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/LangflowAssistant.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 1673
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/LangflowAssistant.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 3484
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/LangflowAssistant.json",
+        "hashed_secret": "1b9dea00d77ef5f671532b6167d8c6b6482c2dde",
+        "is_verified": false,
+        "line_number": 4065
+      }
+    ],
+    "src/backend/base/langflow/agentic/flows/SystemMessageGen.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/SystemMessageGen.json",
+        "hashed_secret": "05c44419f0be64056556f8c81c87e5d3bc7cd1f5",
+        "is_verified": false,
+        "line_number": 331
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/SystemMessageGen.json",
+        "hashed_secret": "4468fc558061951f8910ed8a4f41798661005062",
+        "is_verified": false,
+        "line_number": 438
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/SystemMessageGen.json",
+        "hashed_secret": "abb09440424b40c661e344d4a61e560975620221",
+        "is_verified": false,
+        "line_number": 645
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/SystemMessageGen.json",
+        "hashed_secret": "59416d210387d77a76c3c93f0fdcb89c08e42e6f",
+        "is_verified": false,
+        "line_number": 2324
+      }
+    ],
+    "src/backend/base/langflow/agentic/flows/TemplateAssistant.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/TemplateAssistant.json",
+        "hashed_secret": "d8b16a7764b2b6b2da9a15df8e4cca6b3bb16593",
+        "is_verified": false,
+        "line_number": 1134
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/TemplateAssistant.json",
+        "hashed_secret": "05c44419f0be64056556f8c81c87e5d3bc7cd1f5",
+        "is_verified": false,
+        "line_number": 1927
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/TemplateAssistant.json",
+        "hashed_secret": "a7db96ddbe558c8ec7514abb20420e4fbdc50da5",
+        "is_verified": false,
+        "line_number": 2082
+      }
+    ],
+    "src/backend/base/langflow/agentic/flows/langflow_assistant.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/agentic/flows/langflow_assistant.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 123
+      }
+    ],
+    "src/backend/base/langflow/agentic/flows/translation_flow.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/agentic/flows/translation_flow.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 63
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/006b3990db50_add_unique_constraints.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/006b3990db50_add_unique_constraints.py",
+        "hashed_secret": "8cff1de371e27e5606142515cca15a2683174700",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
     "src/backend/base/langflow/alembic/versions/012fb73ac359_add_folder_table.py": [
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/alembic/versions/012fb73ac359_add_folder_table.py",
         "hashed_secret": "e56198337433b2a24520b89a1b89d55650bc4b79",
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 16,
         "is_secret": false
       }
     ],
@@ -417,8 +612,15 @@
         "filename": "src/backend/base/langflow/alembic/versions/0ae3a2674f32_update_the_columns_that_need_to_change_.py",
         "hashed_secret": "7bc83b3d42770da22a102a8c960d12ac8e6c6fe6",
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 17,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/0ae3a2674f32_update_the_columns_that_need_to_change_.py",
+        "hashed_secret": "277fad192ca5323bb92c06fe32a270286463cf29",
+        "is_verified": false,
+        "line_number": 18
       }
     ],
     "src/backend/base/langflow/alembic/versions/0d60fcbd4e8e_create_vertex_builds_table.py": [
@@ -431,14 +633,30 @@
         "is_secret": false
       }
     ],
+    "src/backend/base/langflow/alembic/versions/182e5471b900_add_context_message.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/182e5471b900_add_context_message.py",
+        "hashed_secret": "8487c3a6010fc552932418b5d1bc132b5ea3aab1",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
     "src/backend/base/langflow/alembic/versions/1a110b568907_replace_credential_table_with_variable.py": [
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/alembic/versions/1a110b568907_replace_credential_table_with_variable.py",
         "hashed_secret": "0e7383d6894e28a521e4f12f47fda9268f1cd2e4",
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 16,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/1a110b568907_replace_credential_table_with_variable.py",
+        "hashed_secret": "8772fa35328d4e8db45ffcb6a43daef8461a78bb",
+        "is_verified": false,
+        "line_number": 17
       }
     ],
     "src/backend/base/langflow/alembic/versions/1b8b740a6fa3_remove_fk_constraint_in_message_.py": [
@@ -457,8 +675,17 @@
         "filename": "src/backend/base/langflow/alembic/versions/1c79524817ed_add_unique_constraints_per_user_in_.py",
         "hashed_secret": "2cd99a879ec2567e4b741e7b6f58a2e1e89edb17",
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 15,
         "is_secret": false
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/1cb603706752_modify_uniqueness_constraint_on_file_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/1cb603706752_modify_uniqueness_constraint_on_file_.py",
+        "hashed_secret": "355862036d9f8a9500cb479852431aee6b3b8ca8",
+        "is_verified": false,
+        "line_number": 20
       }
     ],
     "src/backend/base/langflow/alembic/versions/1d90f8a0efe1_update_description_columns_type.py": [
@@ -467,8 +694,15 @@
         "filename": "src/backend/base/langflow/alembic/versions/1d90f8a0efe1_update_description_columns_type.py",
         "hashed_secret": "38fd2a52ef411b96ff362844e9704a18a8ae3e30",
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 17,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/1d90f8a0efe1_update_description_columns_type.py",
+        "hashed_secret": "28a7b333a264c4f91c72ea7b6000e137b06e0abb",
+        "is_verified": false,
+        "line_number": 18
       }
     ],
     "src/backend/base/langflow/alembic/versions/1eab2c3eb45e_event_error.py": [
@@ -477,8 +711,15 @@
         "filename": "src/backend/base/langflow/alembic/versions/1eab2c3eb45e_event_error.py",
         "hashed_secret": "0e10bacb2371860c03a1dc6b4c00a9c28abfcdec",
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 15,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/1eab2c3eb45e_event_error.py",
+        "hashed_secret": "1a8ccd1199b5c911783d07d3bfe2057cdbaefdde",
+        "is_verified": false,
+        "line_number": 16
       }
     ],
     "src/backend/base/langflow/alembic/versions/1ef9c4f3765d_.py": [
@@ -487,7 +728,7 @@
         "filename": "src/backend/base/langflow/alembic/versions/1ef9c4f3765d_.py",
         "hashed_secret": "8cff1de371e27e5606142515cca15a2683174700",
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 15,
         "is_secret": false
       }
     ],
@@ -497,7 +738,7 @@
         "filename": "src/backend/base/langflow/alembic/versions/1f4d6df60295_add_default_fields_column.py",
         "hashed_secret": "da267f392eaf38538ba97e1b271b7eba82d13857",
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 15,
         "is_secret": false
       }
     ],
@@ -507,8 +748,15 @@
         "filename": "src/backend/base/langflow/alembic/versions/29fe8f1f806b_add_missing_index.py",
         "hashed_secret": "28b763f9898b285436ce150ad5a365988d740045",
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 14,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/29fe8f1f806b_add_missing_index.py",
+        "hashed_secret": "e56198337433b2a24520b89a1b89d55650bc4b79",
+        "is_verified": false,
+        "line_number": 15
       }
     ],
     "src/backend/base/langflow/alembic/versions/2ac71eb9c3ae_adds_credential_table.py": [
@@ -517,8 +765,31 @@
         "filename": "src/backend/base/langflow/alembic/versions/2ac71eb9c3ae_adds_credential_table.py",
         "hashed_secret": "87a982e7fbfe20e388f9ad1e6d73a86f469e982d",
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 16,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/2ac71eb9c3ae_adds_credential_table.py",
+        "hashed_secret": "6ca0ea9d38b83b662977a0341596297495d44ba6",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/3162e83e485f_add_auth_settings_to_folder_and_merge.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/3162e83e485f_add_auth_settings_to_folder_and_merge.py",
+        "hashed_secret": "7e801006ecc7ecb1bcc6bcf973a57e859613991c",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/3162e83e485f_add_auth_settings_to_folder_and_merge.py",
+        "hashed_secret": "7bc83b3d42770da22a102a8c960d12ac8e6c6fe6",
+        "is_verified": false,
+        "line_number": 16
       }
     ],
     "src/backend/base/langflow/alembic/versions/58b28437a398_modify_nullable.py": [
@@ -527,8 +798,17 @@
         "filename": "src/backend/base/langflow/alembic/versions/58b28437a398_modify_nullable.py",
         "hashed_secret": "156a9d188eaddf456117b22218326324222c6716",
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 20,
         "is_secret": false
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/5ace73a7f223_new_remove_table_upgrade_op.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/5ace73a7f223_new_remove_table_upgrade_op.py",
+        "hashed_secret": "7bc83b3d42770da22a102a8c960d12ac8e6c6fe6",
+        "is_verified": false,
+        "line_number": 16
       }
     ],
     "src/backend/base/langflow/alembic/versions/631faacf5da2_add_webhook_columns.py": [
@@ -537,8 +817,15 @@
         "filename": "src/backend/base/langflow/alembic/versions/631faacf5da2_add_webhook_columns.py",
         "hashed_secret": "5c33b4de5b1db4fd7fd286c572465bd959d77232",
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 15,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/631faacf5da2_add_webhook_columns.py",
+        "hashed_secret": "2cd99a879ec2567e4b741e7b6f58a2e1e89edb17",
+        "is_verified": false,
+        "line_number": 16
       }
     ],
     "src/backend/base/langflow/alembic/versions/63b9c451fd30_add_icon_and_icon_bg_color_to_flow.py": [
@@ -547,8 +834,15 @@
         "filename": "src/backend/base/langflow/alembic/versions/63b9c451fd30_add_icon_and_icon_bg_color_to_flow.py",
         "hashed_secret": "8772fa35328d4e8db45ffcb6a43daef8461a78bb",
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 16,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/63b9c451fd30_add_icon_and_icon_bg_color_to_flow.py",
+        "hashed_secret": "ab81185e2fa7d735e9008a929f5624d07ee35590",
+        "is_verified": false,
+        "line_number": 17
       }
     ],
     "src/backend/base/langflow/alembic/versions/66f72f04a1de_add_mcp_support_with_project_settings_.py": [
@@ -557,8 +851,42 @@
         "filename": "src/backend/base/langflow/alembic/versions/66f72f04a1de_add_mcp_support_with_project_settings_.py",
         "hashed_secret": "a89bf934c28e94e1010980f9f1c3553f6588169f",
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/66f72f04a1de_add_mcp_support_with_project_settings_.py",
+        "hashed_secret": "78544fcecf88ff40d2e14662421e9e5fddee3e04",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/6e7b581b5648_fix_nullable.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/6e7b581b5648_fix_nullable.py",
+        "hashed_secret": "156a9d188eaddf456117b22218326324222c6716",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/7843803a87b5_store_updates.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/7843803a87b5_store_updates.py",
+        "hashed_secret": "e9c8b06ec30332b1bde551fb8416eb0b32d2d22e",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/79e675cb6752_change_datetime_type.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/79e675cb6752_change_datetime_type.py",
+        "hashed_secret": "fd40bad2b7b22570b0dfce60649d8ce8c181c21a",
+        "is_verified": false,
+        "line_number": 18
       }
     ],
     "src/backend/base/langflow/alembic/versions/7d2162acc8b2_adds_updated_at_and_folder_cols.py": [
@@ -567,8 +895,24 @@
         "filename": "src/backend/base/langflow/alembic/versions/7d2162acc8b2_adds_updated_at_and_folder_cols.py",
         "hashed_secret": "6ca0ea9d38b83b662977a0341596297495d44ba6",
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 16,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/7d2162acc8b2_adds_updated_at_and_folder_cols.py",
+        "hashed_secret": "3f44353e662497d21aecf8790ef88831c9c806bd",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/90be8e2ed91e_create_transactions_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/90be8e2ed91e_create_transactions_table.py",
+        "hashed_secret": "bd8d1aff576828548137b5284933c00094bbd608",
+        "is_verified": false,
+        "line_number": 19
       }
     ],
     "src/backend/base/langflow/alembic/versions/93e2705fa8d6_add_column_save_path_to_flow.py": [
@@ -577,8 +921,17 @@
         "filename": "src/backend/base/langflow/alembic/versions/93e2705fa8d6_add_column_save_path_to_flow.py",
         "hashed_secret": "90f0f8d291336efffe200380b1d3b6485e97c4ed",
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 16,
         "is_secret": false
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/a72f5cf9c2f9_add_endpoint_name_col.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/a72f5cf9c2f9_add_endpoint_name_col.py",
+        "hashed_secret": "28b763f9898b285436ce150ad5a365988d740045",
+        "is_verified": false,
+        "line_number": 17
       }
     ],
     "src/backend/base/langflow/alembic/versions/b2fa308044b5_add_unique_constraints.py": [
@@ -587,7 +940,7 @@
         "filename": "src/backend/base/langflow/alembic/versions/b2fa308044b5_add_unique_constraints.py",
         "hashed_secret": "304de84429cb38a3e39d54672e818f1bfa0cea72",
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 17,
         "is_secret": false
       }
     ],
@@ -597,8 +950,24 @@
         "filename": "src/backend/base/langflow/alembic/versions/bc2f01c40e4a_new_fixes.py",
         "hashed_secret": "ab81185e2fa7d735e9008a929f5624d07ee35590",
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 17,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/bc2f01c40e4a_new_fixes.py",
+        "hashed_secret": "304de84429cb38a3e39d54672e818f1bfa0cea72",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/c153816fd85f_set_name_and_value_to_not_nullable.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/c153816fd85f_set_name_and_value_to_not_nullable.py",
+        "hashed_secret": "da267f392eaf38538ba97e1b271b7eba82d13857",
+        "is_verified": false,
+        "line_number": 16
       }
     ],
     "src/backend/base/langflow/alembic/versions/d066bfd22890_add_message_table.py": [
@@ -609,6 +978,13 @@
         "is_verified": false,
         "line_number": 18,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/d066bfd22890_add_message_table.py",
+        "hashed_secret": "5c33b4de5b1db4fd7fd286c572465bd959d77232",
+        "is_verified": false,
+        "line_number": 19
       }
     ],
     "src/backend/base/langflow/alembic/versions/d2d475a1f7c0_add_tags_column_to_flow.py": [
@@ -617,8 +993,24 @@
         "filename": "src/backend/base/langflow/alembic/versions/d2d475a1f7c0_add_tags_column_to_flow.py",
         "hashed_secret": "277fad192ca5323bb92c06fe32a270286463cf29",
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 17,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/d2d475a1f7c0_add_tags_column_to_flow.py",
+        "hashed_secret": "31b17a81cbd0842650e47a3c65b68eddb5526205",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/d37bc4322900_drop_single_constraint_on_files_name_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/d37bc4322900_drop_single_constraint_on_files_name_.py",
+        "hashed_secret": "72e882bd130f8fdc42bef7d615c74e3f07644a80",
+        "is_verified": false,
+        "line_number": 18
       }
     ],
     "src/backend/base/langflow/alembic/versions/d3dbf656a499_add_gradient_column_in_flow.py": [
@@ -631,6 +1023,24 @@
         "is_secret": false
       }
     ],
+    "src/backend/base/langflow/alembic/versions/d9a6ea21edcd_rename_default_folder.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/d9a6ea21edcd_rename_default_folder.py",
+        "hashed_secret": "a89bf934c28e94e1010980f9f1c3553f6588169f",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/dd9e0804ebd1_add_v2_file_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/dd9e0804ebd1_add_v2_file_table.py",
+        "hashed_secret": "eceb2ed92b0253127427e9f750970811f876ec06",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
     "src/backend/base/langflow/alembic/versions/e3162c1804e6_add_persistent_locked_state.py": [
       {
         "type": "Hex High Entropy String",
@@ -639,6 +1049,13 @@
         "is_verified": false,
         "line_number": 16,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/e3162c1804e6_add_persistent_locked_state.py",
+        "hashed_secret": "0e10bacb2371860c03a1dc6b4c00a9c28abfcdec",
+        "is_verified": false,
+        "line_number": 17
       }
     ],
     "src/backend/base/langflow/alembic/versions/e3bc869fa272_fix_nullable.py": [
@@ -647,8 +1064,15 @@
         "filename": "src/backend/base/langflow/alembic/versions/e3bc869fa272_fix_nullable.py",
         "hashed_secret": "fd40bad2b7b22570b0dfce60649d8ce8c181c21a",
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 15,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/e3bc869fa272_fix_nullable.py",
+        "hashed_secret": "0e7383d6894e28a521e4f12f47fda9268f1cd2e4",
+        "is_verified": false,
+        "line_number": 16
       }
     ],
     "src/backend/base/langflow/alembic/versions/e56d87f8994a_add_optins_column_to_user.py": [
@@ -657,8 +1081,24 @@
         "filename": "src/backend/base/langflow/alembic/versions/e56d87f8994a_add_optins_column_to_user.py",
         "hashed_secret": "78544fcecf88ff40d2e14662421e9e5fddee3e04",
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 17,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/e56d87f8994a_add_optins_column_to_user.py",
+        "hashed_secret": "7dc2d5ca49ddbde37e4b62670697b3bf968ce6a2",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/e5a65ecff2cd_nullable_in_vertex_build.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/e5a65ecff2cd_nullable_in_vertex_build.py",
+        "hashed_secret": "38fd2a52ef411b96ff362844e9704a18a8ae3e30",
+        "is_verified": false,
+        "line_number": 18
       }
     ],
     "src/backend/base/langflow/alembic/versions/eb5866d51fd2_change_columns_to_be_nullable.py": [
@@ -677,8 +1117,17 @@
         "filename": "src/backend/base/langflow/alembic/versions/eb5e72293a8e_add_error_and_edit_flags_to_message.py",
         "hashed_secret": "1a8ccd1199b5c911783d07d3bfe2057cdbaefdde",
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 15,
         "is_secret": false
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/f3b2d1f1002d_add_column_access_type_to_flow.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/f3b2d1f1002d_add_column_access_type_to_flow.py",
+        "hashed_secret": "90f0f8d291336efffe200380b1d3b6485e97c4ed",
+        "is_verified": false,
+        "line_number": 18
       }
     ],
     "src/backend/base/langflow/alembic/versions/f5ee9749d1a6_user_id_can_be_null_in_flow.py": [
@@ -691,68 +1140,22 @@
         "is_secret": false
       }
     ],
-    "src/backend/base/langflow/components/composio/googlecalendar_composio.py": [
+    "src/backend/base/langflow/alembic/versions/fd531f8868b1_fix_credential_table.py": [
       {
-        "type": "Base64 High Entropy String",
-        "filename": "src/backend/base/langflow/components/composio/googlecalendar_composio.py",
-        "hashed_secret": "224819290aee395cbbf6b943d692e38a2115d479",
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/fd531f8868b1_fix_credential_table.py",
+        "hashed_secret": "87a982e7fbfe20e388f9ad1e6d73a86f469e982d",
         "is_verified": false,
-        "line_number": 31,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/backend/base/langflow/components/composio/googlecalendar_composio.py",
-        "hashed_secret": "b1132e2965d0465974a2aa2554fb23c31e31c61f",
-        "is_verified": false,
-        "line_number": 38,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/backend/base/langflow/components/composio/googlecalendar_composio.py",
-        "hashed_secret": "ed6a260c611f8dfa5292fe03911f265c671f7ba8",
-        "is_verified": false,
-        "line_number": 124,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/backend/base/langflow/components/composio/googlecalendar_composio.py",
-        "hashed_secret": "cb770d8681e319de0c900d84ff81e4ae7326ce9e",
-        "is_verified": false,
-        "line_number": 125,
-        "is_secret": false
+        "line_number": 16
       }
     ],
-    "src/backend/base/langflow/components/languagemodels/openrouter.py": [
+    "src/backend/base/langflow/api/utils/core.py": [
       {
         "type": "Secret Keyword",
-        "filename": "src/backend/base/langflow/components/languagemodels/openrouter.py",
-        "hashed_secret": "f36e208b871e6891e1d755cd789c089747a28f71",
+        "filename": "src/backend/base/langflow/api/utils/core.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 114,
-        "is_secret": false
-      }
-    ],
-    "src/backend/base/langflow/components/memories/mem0_chat_memory.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/base/langflow/components/memories/mem0_chat_memory.py",
-        "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
-        "is_verified": false,
-        "line_number": 35,
-        "is_secret": false
-      }
-    ],
-    "src/backend/base/langflow/components/vectorstores/mongodb_atlas.py": [
-      {
-        "type": "Private Key",
-        "filename": "src/backend/base/langflow/components/vectorstores/mongodb_atlas.py",
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_verified": false,
-        "line_number": 31,
-        "is_secret": false
+        "line_number": 417
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json": [
@@ -761,7 +1164,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json",
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 357,
+        "line_number": 390,
         "is_secret": false
       },
       {
@@ -769,7 +1172,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json",
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
-        "line_number": 625,
+        "line_number": 657,
         "is_secret": false
       },
       {
@@ -777,7 +1180,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 1400,
+        "line_number": 1502,
         "is_secret": false
       },
       {
@@ -785,7 +1188,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json",
         "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
         "is_verified": false,
-        "line_number": 1535,
+        "line_number": 1637,
         "is_secret": false
       },
       {
@@ -793,7 +1196,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json",
         "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
         "is_verified": false,
-        "line_number": 1595,
+        "line_number": 1697,
         "is_secret": false
       },
       {
@@ -801,26 +1204,435 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json",
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
-        "line_number": 1660,
+        "line_number": 1762,
         "is_secret": false
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 122
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 618
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 900
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 1093
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json",
+        "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
+        "is_verified": false,
+        "line_number": 1228
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json",
+        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
+        "is_verified": false,
+        "line_number": 1288
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json",
+        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "is_verified": false,
+        "line_number": 1353
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 532
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json",
+        "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
+        "is_verified": false,
+        "line_number": 830
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 1422
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 1984
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 2262
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 2547
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json": [
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json",
-        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 731,
-        "is_secret": false
+        "line_number": 151
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json",
-        "hashed_secret": "a99d6de03c251f8eb8922fab5a383523e4acbadd",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
-        "line_number": 1210,
-        "is_secret": false
+        "line_number": 412
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 918
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json",
+        "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
+        "is_verified": false,
+        "line_number": 1308
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 124
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 408
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json",
+        "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
+        "is_verified": false,
+        "line_number": 741
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 888
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json",
+        "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
+        "is_verified": false,
+        "line_number": 1023
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json",
+        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
+        "is_verified": false,
+        "line_number": 1083
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json",
+        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "is_verified": false,
+        "line_number": 1148
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json",
+        "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
+        "is_verified": false,
+        "line_number": 1391
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 206
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json",
+        "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
+        "is_verified": false,
+        "line_number": 479
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 668
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json",
+        "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
+        "is_verified": false,
+        "line_number": 1985
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 179
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 450
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json",
+        "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
+        "is_verified": false,
+        "line_number": 1097
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 1244
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json",
+        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
+        "is_verified": false,
+        "line_number": 1322
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 1574
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 318
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 1120
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json",
+        "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
+        "is_verified": false,
+        "line_number": 1650
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 2644
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 338
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json",
+        "hashed_secret": "f16b56e2e46c4df6bf412a7a9b90c86957016575",
+        "is_verified": false,
+        "line_number": 673
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 892
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Knowledge Ingestion.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Knowledge Ingestion.json",
+        "hashed_secret": "c2dc8a1d72a39ee9da360d47dcadfd7a5560ee7f",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Knowledge Ingestion.json",
+        "hashed_secret": "2db95e850ecd2695362e438d827e9a58ee36e4b0",
+        "is_verified": false,
+        "line_number": 766
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 255
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json",
+        "hashed_secret": "199d0299098f4097fd8926648d9977fe2d08fb15",
+        "is_verified": false,
+        "line_number": 534
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Market Research.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Market Research.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 179
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Market Research.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 446
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Market Research.json",
+        "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
+        "is_verified": false,
+        "line_number": 768
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Market Research.json",
+        "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
+        "is_verified": false,
+        "line_number": 1753
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Market Research.json",
+        "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
+        "is_verified": false,
+        "line_number": 1941
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 672
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 2079
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 3035
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 149
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 421
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 1296
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json": [
@@ -835,110 +1647,559 @@
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json",
-        "hashed_secret": "7881caec48fc330c8cde89fb096ae27690c8d8a9",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 883,
-        "is_secret": false
+        "line_number": 576
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 879
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json",
+        "hashed_secret": "53d87de97f77c9ea8b7795228a6ce24ed3dc0781",
+        "is_verified": false,
+        "line_number": 1745
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 233
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 510
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json",
+        "hashed_secret": "cf0d9ce83080dd2d9110b1c6e260b2fc1f6180f2",
+        "is_verified": false,
+        "line_number": 1740
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json": [
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
-        "hashed_secret": "b223275895a74015ca0555983d6e9685efdb03fe",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
-        "line_number": 201,
-        "is_secret": false
+        "line_number": 322
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
-        "hashed_secret": "a99d6de03c251f8eb8922fab5a383523e4acbadd",
+        "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
         "is_verified": false,
-        "line_number": 934,
-        "is_secret": false
+        "line_number": 914
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 1590
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 1781
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
+        "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
+        "is_verified": false,
+        "line_number": 1916
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
+        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
+        "is_verified": false,
+        "line_number": 1976
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
+        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "is_verified": false,
+        "line_number": 2041
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
+        "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
+        "is_verified": false,
+        "line_number": 2309
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 138
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 416
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json",
+        "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
+        "is_verified": false,
+        "line_number": 706
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json",
+        "hashed_secret": "1be2449adf6092e0729be455a98c93034cc90bc8",
+        "is_verified": false,
+        "line_number": 1120
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 508
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json",
+        "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
+        "is_verified": false,
+        "line_number": 1351
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 1763
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 2047
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json": [
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json",
-        "hashed_secret": "abb09440424b40c661e344d4a61e560975620221",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
-        "line_number": 987,
-        "is_secret": false
+        "line_number": 364
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json",
-        "hashed_secret": "e66321745fc15e1b80035de7c59f8c700d7e9976",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 1624,
-        "is_secret": false
+        "line_number": 644
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 952
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 1143
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json",
+        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
+        "is_verified": false,
+        "line_number": 1221
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json",
+        "hashed_secret": "d985ccfa99e2931b452a8fc1106b44ab1fa129a3",
+        "is_verified": false,
+        "line_number": 1460
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json",
+        "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
+        "is_verified": false,
+        "line_number": 1594
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 624
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 930
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 401
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json",
+        "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
+        "is_verified": false,
+        "line_number": 715
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Search agent.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Search agent.json",
+        "hashed_secret": "f59912210d43c78fe803463f6bfb35688508a2bf",
+        "is_verified": false,
+        "line_number": 106
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Search agent.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 291
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Search agent.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 566
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 2069
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json",
+        "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
+        "is_verified": false,
+        "line_number": 3192
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json",
+        "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
+        "is_verified": false,
+        "line_number": 3363
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 3774
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json",
+        "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
+        "is_verified": false,
+        "line_number": 200
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 368
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 647
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 1273
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json",
+        "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
+        "is_verified": false,
+        "line_number": 1405
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json",
+        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
+        "is_verified": false,
+        "line_number": 1465
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json",
+        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "is_verified": false,
+        "line_number": 1530
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json",
+        "hashed_secret": "59d43c509612f89c187f862266890ae0dd5fbb9a",
+        "is_verified": false,
+        "line_number": 147
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 694
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 970
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json": [
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json",
-        "hashed_secret": "a99d6de03c251f8eb8922fab5a383523e4acbadd",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
-        "line_number": 2342,
-        "is_secret": false
+        "line_number": 820
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 1472
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 1663
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json",
+        "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
+        "is_verified": false,
+        "line_number": 1798
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json",
+        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
+        "is_verified": false,
+        "line_number": 1858
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json",
+        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "is_verified": false,
+        "line_number": 1923
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json",
+        "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
+        "is_verified": false,
+        "line_number": 3567
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 232
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 499
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json",
+        "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
+        "is_verified": false,
+        "line_number": 1217
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json",
+        "hashed_secret": "5bf984f56eac13589ac2369cb0bae2f61869810a",
+        "is_verified": false,
+        "line_number": 1384
+      }
+    ],
+    "src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 284
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 702
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 2015
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json": [
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
-        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 586,
-        "is_secret": false
+        "line_number": 324
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
-        "hashed_secret": "ab06ef2a8cc8a90a8526e3511be8f376c7cb0387",
+        "hashed_secret": "c2dc8a1d72a39ee9da360d47dcadfd7a5560ee7f",
         "is_verified": false,
-        "line_number": 764,
-        "is_secret": false
+        "line_number": 798
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
-        "hashed_secret": "3de7722ca43ab9676c384eb479950083fb2385bb",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
-        "line_number": 1357,
-        "is_secret": false
+        "line_number": 1117
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
-        "hashed_secret": "a99d6de03c251f8eb8922fab5a383523e4acbadd",
+        "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
         "is_verified": false,
-        "line_number": 2678,
-        "is_secret": false
-      }
-    ],
-    "src/backend/base/langflow/inputs/input_mixin.py": [
+        "line_number": 1720
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 2395
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/backend/base/langflow/inputs/input_mixin.py",
-        "hashed_secret": "3442496b96dd01591a8cd44b1eec1368ab728aba",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 22,
-        "is_secret": false
+        "line_number": 2588
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
+        "hashed_secret": "cf0d9ce83080dd2d9110b1c6e260b2fc1f6180f2",
+        "is_verified": false,
+        "line_number": 4535
       }
     ],
-    "src/backend/base/langflow/schema/table.py": [
+    "src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json",
+        "hashed_secret": "ef3435e29e3a2c5dcbbb633856c85561848cd995",
+        "is_verified": false,
+        "line_number": 262
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/backend/base/langflow/schema/table.py",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 112,
-        "is_secret": false
+        "line_number": 832
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 1443
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 2195
       }
     ],
     "src/backend/base/langflow/services/auth/utils.py": [
@@ -951,14 +2212,13 @@
         "is_secret": false
       }
     ],
-    "src/backend/base/langflow/services/settings/constants.py": [
+    "src/backend/base/langflow/services/database/models/api_key/crud.py": [
       {
         "type": "Secret Keyword",
-        "filename": "src/backend/base/langflow/services/settings/constants.py",
-        "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
+        "filename": "src/backend/base/langflow/services/database/models/api_key/crud.py",
+        "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 2,
-        "is_secret": false
+        "line_number": 93
       }
     ],
     "src/backend/tests/conftest.py": [
@@ -967,7 +2227,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 481,
+        "line_number": 480,
         "is_secret": false
       },
       {
@@ -975,7 +2235,7 @@
         "filename": "src/backend/tests/conftest.py",
         "hashed_secret": "61fbb5a12cd7b1f1fe1624120089efc0cd299e43",
         "is_verified": false,
-        "line_number": 691,
+        "line_number": 690,
         "is_secret": false
       }
     ],
@@ -1005,6 +2265,145 @@
         "is_secret": false
       }
     ],
+    "src/backend/tests/integration/components/bundles/cometapi/test_cometapi_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/integration/components/bundles/cometapi/test_cometapi_integration.py",
+        "hashed_secret": "7d7048eaa43ebb90728877db61b4c016f9353229",
+        "is_verified": false,
+        "line_number": 98
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/integration/components/bundles/cometapi/test_cometapi_integration.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 184
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/integration/components/bundles/cometapi/test_cometapi_integration.py",
+        "hashed_secret": "18de8e8747c829741cc7fd44c0f801a10a1d2b5b",
+        "is_verified": false,
+        "line_number": 195
+      }
+    ],
+    "src/backend/tests/integration/test_openai_streaming_comparison.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/integration/test_openai_streaming_comparison.py",
+        "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
+        "is_verified": false,
+        "line_number": 56
+      }
+    ],
+    "src/backend/tests/locust/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/locust/README.md",
+        "hashed_secret": "adfa4d3a74f7f661b4c6105469ebe5ee76cf02e1",
+        "is_verified": false,
+        "line_number": 145
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/locust/README.md",
+        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
+        "is_verified": false,
+        "line_number": 269
+      }
+    ],
+    "src/backend/tests/locust/langflow_setup_test.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/locust/langflow_setup_test.py",
+        "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
+        "is_verified": false,
+        "line_number": 205
+      }
+    ],
+    "src/backend/tests/unit/agentic/flows/test_langflow_assistant.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/flows/test_langflow_assistant.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/flows/test_langflow_assistant.py",
+        "hashed_secret": "e5ad10f370283c6276789de684bca60e30306ad5",
+        "is_verified": false,
+        "line_number": 139
+      }
+    ],
+    "src/backend/tests/unit/agentic/flows/test_translation_flow.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/flows/test_translation_flow.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/flows/test_translation_flow.py",
+        "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
+        "is_verified": false,
+        "line_number": 126
+      }
+    ],
+    "src/backend/tests/unit/agentic/services/helpers/test_flow_loader.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/services/helpers/test_flow_loader.py",
+        "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
+        "is_verified": false,
+        "line_number": 219
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/services/helpers/test_flow_loader.py",
+        "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
+        "is_verified": false,
+        "line_number": 413
+      }
+    ],
+    "src/backend/tests/unit/agentic/services/helpers/test_intent_classification.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/services/helpers/test_intent_classification.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/services/helpers/test_intent_classification.py",
+        "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
+        "is_verified": false,
+        "line_number": 169
+      }
+    ],
+    "src/backend/tests/unit/agentic/services/test_flow_executor.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/services/test_flow_executor.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 85
+      }
+    ],
+    "src/backend/tests/unit/agentic/services/test_provider_service.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/services/test_provider_service.py",
+        "hashed_secret": "c92b9809dacd9240dc85e86da6388e9b1bfc8a7d",
+        "is_verified": false,
+        "line_number": 147
+      }
+    ],
     "src/backend/tests/unit/api/v1/test_api_key.py": [
       {
         "type": "Secret Keyword",
@@ -1013,6 +2412,13 @@
         "is_verified": false,
         "line_number": 21,
         "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_api_key.py",
+        "hashed_secret": "0d1f7c04669ca1989ea046d30a13c8a03252aa8e",
+        "is_verified": false,
+        "line_number": 105
       }
     ],
     "src/backend/tests/unit/api/v1/test_files.py": [
@@ -1025,13 +2431,192 @@
         "is_secret": false
       }
     ],
+    "src/backend/tests/unit/api/v1/test_mcp_projects.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_mcp_projects.py",
+        "hashed_secret": "4258d43e3b1f9658067ceea9c682a96cbdbb5ca0",
+        "is_verified": false,
+        "line_number": 575
+      }
+    ],
+    "src/backend/tests/unit/api/v1/test_transactions.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "ec29e1e75ca11a2e23acccfb95548e0f91776ef9",
+        "is_verified": false,
+        "line_number": 80
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "ec29e1e75ca11a2e23acccfb95548e0f91776ef9",
+        "is_verified": false,
+        "line_number": 80
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "542b1e6680a5cbc3f39d5f4be262d3943937faf3",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
+        "is_verified": false,
+        "line_number": 100
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "505ec48792179142f72e24a216dce70aae572c92",
+        "is_verified": false,
+        "line_number": 117
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "605e6913994b131694c06427356ca2e0cd80fbc5",
+        "is_verified": false,
+        "line_number": 128
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "46a9cde9bf7b714ac6939f8a7223616529f22beb",
+        "is_verified": false,
+        "line_number": 136
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "93a08826b0f86bbd589bc809c429224a28c5debd",
+        "is_verified": false,
+        "line_number": 149
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "f584b92a3b013f0455ba3bbf7281c1b92dc83293",
+        "is_verified": false,
+        "line_number": 202
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "f584b92a3b013f0455ba3bbf7281c1b92dc83293",
+        "is_verified": false,
+        "line_number": 202
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "335bab1896809036873e94809e2a077f1592c2cf",
+        "is_verified": false,
+        "line_number": 204
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "09dfcb80ee109eafad45dd04dc950da5be463e8a",
+        "is_verified": false,
+        "line_number": 215
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "2eec374681b67acd87af8e38a0052d66a28273eb",
+        "is_verified": false,
+        "line_number": 218
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "88901d9186e9179e7b569b4c5c7d9918a1a9a305",
+        "is_verified": false,
+        "line_number": 219
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "b5f65b338843840535d6907922528975fc14bb22",
+        "is_verified": false,
+        "line_number": 224
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "c2ba906c7226e464ecf45018257b169e96c71845",
+        "is_verified": false,
+        "line_number": 248
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "656271dfefb8c6633d869d57586413e453204e9b",
+        "is_verified": false,
+        "line_number": 260
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "5cd1f3f6347b1ea434808cb89618224808108ead",
+        "is_verified": false,
+        "line_number": 261
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "d2b83d3591223bb40917c4e07ba712f075148a80",
+        "is_verified": false,
+        "line_number": 280
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "7fe6e4fbc01009cec1576fae7f3c80fc89eb857c",
+        "is_verified": false,
+        "line_number": 281
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "d7266cdeff65f3f2f75a3a8f9d2f512a2e056043",
+        "is_verified": false,
+        "line_number": 282
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_transactions.py",
+        "hashed_secret": "b1356aef8b72efd781630d266ea921ee74fdb2c8",
+        "is_verified": false,
+        "line_number": 414
+      }
+    ],
     "src/backend/tests/unit/api/v1/test_users.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_users.py",
+        "hashed_secret": "a240a1757ef2e0abf3f252dccec6895fc90d6385",
+        "is_verified": false,
+        "line_number": 7
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_users.py",
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_verified": false,
+        "line_number": 27
+      },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/api/v1/test_users.py",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 6,
+        "line_number": 39,
         "is_secret": false
       },
       {
@@ -1039,7 +2624,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_users.py",
         "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
         "is_verified": false,
-        "line_number": 73,
+        "line_number": 106,
         "is_secret": false
       }
     ],
@@ -1063,64 +2648,13 @@
         "is_secret": false
       }
     ],
-    "src/backend/tests/unit/components/bundles/composio/test_base.py": [
+    "src/backend/tests/unit/components/bundles/cometapi/test_cometapi_component.py": [
       {
         "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/components/bundles/composio/test_base.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "filename": "src/backend/tests/unit/components/bundles/cometapi/test_cometapi_component.py",
+        "hashed_secret": "7d7048eaa43ebb90728877db61b4c016f9353229",
         "is_verified": false,
-        "line_number": 61,
-        "is_secret": false
-      }
-    ],
-    "src/backend/tests/unit/components/bundles/composio/test_github.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/components/bundles/composio/test_github.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 65,
-        "is_secret": false
-      }
-    ],
-    "src/backend/tests/unit/components/bundles/composio/test_gmail.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/components/bundles/composio/test_gmail.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 68,
-        "is_secret": false
-      }
-    ],
-    "src/backend/tests/unit/components/bundles/composio/test_googlecalendar.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/components/bundles/composio/test_googlecalendar.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 57,
-        "is_secret": false
-      }
-    ],
-    "src/backend/tests/unit/components/bundles/composio/test_outlook.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/components/bundles/composio/test_outlook.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 57,
-        "is_secret": false
-      }
-    ],
-    "src/backend/tests/unit/components/bundles/composio/test_slack.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/components/bundles/composio/test_slack.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_verified": false,
-        "line_number": 59,
-        "is_secret": false
+        "line_number": 20
       }
     ],
     "src/backend/tests/unit/components/bundles/google/test_google_bq_sql_executor_component.py": [
@@ -1129,8 +2663,65 @@
         "filename": "src/backend/tests/unit/components/bundles/google/test_google_bq_sql_executor_component.py",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 32,
         "is_secret": false
+      }
+    ],
+    "src/backend/tests/unit/components/bundles/langwatch/test_langwatch_component.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/bundles/langwatch/test_langwatch_component.py",
+        "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "src/backend/tests/unit/components/embeddings/test_ollama_embeddings_component.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/embeddings/test_ollama_embeddings_component.py",
+        "hashed_secret": "74ba31d41223751c75cc0a453dd7df04889bdc72",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/embeddings/test_ollama_embeddings_component.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 109
+      }
+    ],
+    "src/backend/tests/unit/components/files_and_knowledge/test_file_component.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/files_and_knowledge/test_file_component.py",
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_verified": false,
+        "line_number": 585
+      }
+    ],
+    "src/backend/tests/unit/components/languagemodels/test_chatollama_component.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/languagemodels/test_chatollama_component.py",
+        "hashed_secret": "74ba31d41223751c75cc0a453dd7df04889bdc72",
+        "is_verified": false,
+        "line_number": 924
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/languagemodels/test_chatollama_component.py",
+        "hashed_secret": "472100b49debe0ea8a5d0d994475240c69af00d9",
+        "is_verified": false,
+        "line_number": 947
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/languagemodels/test_chatollama_component.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 1134
       }
     ],
     "src/backend/tests/unit/components/languagemodels/test_deepseek.py": [
@@ -1149,6 +2740,15 @@
         "is_verified": false,
         "line_number": 106,
         "is_secret": false
+      }
+    ],
+    "src/backend/tests/unit/components/languagemodels/test_openai_model.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/languagemodels/test_openai_model.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 24
       }
     ],
     "src/backend/tests/unit/components/languagemodels/test_xai.py": [
@@ -1177,40 +2777,163 @@
         "is_secret": false
       }
     ],
-    "src/backend/tests/unit/components/models/test_embedding_model_component.py": [
+    "src/backend/tests/unit/components/llm_operations/test_batch_run_component.py": [
       {
         "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/components/models/test_embedding_model_component.py",
-        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "filename": "src/backend/tests/unit/components/llm_operations/test_batch_run_component.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 21,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/components/models/test_embedding_model_component.py",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 54,
-        "is_secret": false
+        "line_number": 28
       }
     ],
-    "src/backend/tests/unit/components/models/test_language_model_component.py": [
+    "src/backend/tests/unit/components/llm_operations/test_lambda_filter.py": [
       {
         "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/components/models/test_language_model_component.py",
-        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "filename": "src/backend/tests/unit/components/llm_operations/test_lambda_filter.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 22,
-        "is_secret": false
+        "line_number": 34
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/components/models/test_language_model_component.py",
+        "filename": "src/backend/tests/unit/components/llm_operations/test_lambda_filter.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 45
+      }
+    ],
+    "src/backend/tests/unit/components/llm_operations/test_structured_output_component.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/llm_operations/test_structured_output_component.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/llm_operations/test_structured_output_component.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/llm_operations/test_structured_output_component.py",
+        "hashed_secret": "5c0de9cfda6a9b3fa1ab03901221c68ce6359f9f",
+        "is_verified": false,
+        "line_number": 730
+      }
+    ],
+    "src/backend/tests/unit/components/models_and_agents/test_agent_component.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_agent_component.py",
+        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "is_verified": false,
+        "line_number": 459
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_agent_component.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 494
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_agent_component.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 528
+      }
+    ],
+    "src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 26
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 65,
-        "is_secret": false
+        "line_number": 70
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py",
+        "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py",
+        "hashed_secret": "61590b1c314aea752829602c7e0d653e51d52738",
+        "is_verified": false,
+        "line_number": 182
+      }
+    ],
+    "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 32
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 37
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
+        "hashed_secret": "69dba6dfc0be932d10cdbfaae770c300cd7e0e3c",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
+        "hashed_secret": "60dae6886103a20b3fd75814ece38eb861246083",
+        "is_verified": false,
+        "line_number": 141
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
+        "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
+        "hashed_secret": "def8ea5f5fccca7b36fe20a520a8bcc431d87d88",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 277
       }
     ],
     "src/backend/tests/unit/components/search/test_google_search_api.py": [
@@ -1243,16 +2966,6 @@
         "is_secret": false
       }
     ],
-    "src/backend/tests/unit/graph/graph/test_graph_state_model.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/graph/graph/test_graph_state_model.py",
-        "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
-        "is_verified": false,
-        "line_number": 36,
-        "is_secret": false
-      }
-    ],
     "src/backend/tests/unit/initial_setup/starter_projects/test_memory_chatbot.py": [
       {
         "type": "Secret Keyword",
@@ -1271,6 +2984,50 @@
         "is_verified": false,
         "line_number": 31,
         "is_secret": false
+      }
+    ],
+    "src/backend/tests/unit/interface/initialize/test_loading.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
+        "hashed_secret": "65882b5e8dbab0e649474b2a626c1d24e1b317f5",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
+        "hashed_secret": "6af5a378fdb0e7d397c9f47c744e5e14195c0228",
+        "is_verified": false,
+        "line_number": 28
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
+        "hashed_secret": "425697fa9692ea5035739863d2481dbfcddfa31f",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
+        "hashed_secret": "720e215bd26587c3f3c482b63f7fd9d6a384b076",
+        "is_verified": false,
+        "line_number": 96
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
+        "hashed_secret": "b671351c066092d76821f7f13ed7356e16db335e",
+        "is_verified": false,
+        "line_number": 118
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
+        "hashed_secret": "8aca50283f32858dc0592c0855803fc70abda920",
+        "is_verified": false,
+        "line_number": 141
       }
     ],
     "src/backend/tests/unit/services/tracing/test_tracing_service.py": [
@@ -1319,13 +3076,86 @@
         "is_secret": false
       }
     ],
+    "src/backend/tests/unit/test_api_key_source.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/test_api_key_source.py",
+        "hashed_secret": "0352a8acc949c7df21fec16e566ba9a74e797a97",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/test_api_key_source.py",
+        "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "src/backend/tests/unit/test_auth_jwt_algorithms.py": [
+      {
+        "type": "Private Key",
+        "filename": "src/backend/tests/unit/test_auth_jwt_algorithms.py",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 57
+      }
+    ],
+    "src/backend/tests/unit/test_auth_settings.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/test_auth_settings.py",
+        "hashed_secret": "0352a8acc949c7df21fec16e566ba9a74e797a97",
+        "is_verified": false,
+        "line_number": 65
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/test_auth_settings.py",
+        "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/test_auth_settings.py",
+        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
+        "is_verified": false,
+        "line_number": 83
+      }
+    ],
+    "src/backend/tests/unit/test_database_windows_postgres_integration.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/backend/tests/unit/test_database_windows_postgres_integration.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 32
+      }
+    ],
+    "src/backend/tests/unit/test_get_api_key.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/test_get_api_key.py",
+        "hashed_secret": "d378f22450ce32736345a7a4647561bca9f4095a",
+        "is_verified": false,
+        "line_number": 74
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/test_get_api_key.py",
+        "hashed_secret": "d3d442c7b46954cf767fbb60a2643917c55ac964",
+        "is_verified": false,
+        "line_number": 76
+      }
+    ],
     "src/backend/tests/unit/test_initial_setup.py": [
       {
         "type": "Base64 High Entropy String",
         "filename": "src/backend/tests/unit/test_initial_setup.py",
         "hashed_secret": "97665ff5eecf8fe96f0462b2d08ed2a2270b4277",
         "is_verified": false,
-        "line_number": 245,
+        "line_number": 261,
         "is_secret": false
       }
     ],
@@ -1335,7 +3165,7 @@
         "filename": "src/backend/tests/unit/test_login.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 26,
         "is_secret": false
       },
       {
@@ -1343,7 +3173,7 @@
         "filename": "src/backend/tests/unit/test_login.py",
         "hashed_secret": "d8ecf7db8fc9ec9c31bc5c9ae2929cc599c75f8d",
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 42,
         "is_secret": false
       }
     ],
@@ -1357,13 +3187,22 @@
         "is_secret": false
       }
     ],
+    "src/backend/tests/unit/test_setup_superuser_flow.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/test_setup_superuser_flow.py",
+        "hashed_secret": "6b7065a54fddbb64d6fbe6c4ce55cc668e8a3511",
+        "is_verified": false,
+        "line_number": 168
+      }
+    ],
     "src/backend/tests/unit/test_user.py": [
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/test_user.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 61,
+        "line_number": 71,
         "is_secret": false
       },
       {
@@ -1371,8 +3210,17 @@
         "filename": "src/backend/tests/unit/test_user.py",
         "hashed_secret": "f2c57870308dc87f432e5912d4de6f8e322721ba",
         "is_verified": false,
-        "line_number": 199,
+        "line_number": 209,
         "is_secret": false
+      }
+    ],
+    "src/backend/tests/unit/test_windows_postgres_helper.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/backend/tests/unit/test_windows_postgres_helper.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 47
       }
     ],
     "src/backend/tests/unit/utils/test_util_strings.py": [
@@ -1401,6 +3249,15 @@
         "is_secret": false
       }
     ],
+    "src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx",
+        "hashed_secret": "1fc7e28f6929181fa221e6ead6d9a07b4dd4ddfe",
+        "is_verified": false,
+        "line_number": 352
+      }
+    ],
     "src/frontend/src/components/core/parameterRenderComponent/components/queryComponent/index.tsx": [
       {
         "type": "Secret Keyword",
@@ -1417,7 +3274,7 @@
         "filename": "src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 21,
         "is_secret": false
       }
     ],
@@ -1469,7 +3326,7 @@
         "filename": "src/frontend/src/constants/constants.ts",
         "hashed_secret": "c04f8fbf55c9096907a982750b1c6b0e4c1dd658",
         "is_verified": false,
-        "line_number": 939,
+        "line_number": 940,
         "is_secret": false
       }
     ],
@@ -1507,7 +3364,7 @@
         "filename": "src/frontend/src/icons/Postgres/Postgres.jsx",
         "hashed_secret": "7d4828001532cf24b2f4a5a09ff614478a8f4df3",
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 16,
         "is_secret": false
       },
       {
@@ -1515,7 +3372,7 @@
         "filename": "src/frontend/src/icons/Postgres/Postgres.jsx",
         "hashed_secret": "2b2285b2c97ee645977dc1757299e0df2ec266ec",
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 33,
         "is_secret": false
       }
     ],
@@ -1525,7 +3382,7 @@
         "filename": "src/frontend/src/icons/VectaraIcon/Vectara.jsx",
         "hashed_secret": "ad12133e37f762cfdb830ad4a69d3aa2439a8d49",
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 23,
         "is_secret": false
       }
     ],
@@ -1547,13 +3404,194 @@
         "is_secret": false
       }
     ],
+    "src/frontend/src/modals/apiModal/utils/__tests__/api-snippet-generation.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/modals/apiModal/utils/__tests__/api-snippet-generation.test.ts",
+        "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
+        "is_verified": false,
+        "line_number": 111
+      }
+    ],
+    "src/frontend/src/modals/apiModal/utils/__tests__/get-js-api-code.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/modals/apiModal/utils/__tests__/get-js-api-code.test.ts",
+        "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "src/frontend/src/modals/apiModal/utils/__tests__/get-python-api-code.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/modals/apiModal/utils/__tests__/get-python-api-code.test.ts",
+        "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
+        "is_verified": false,
+        "line_number": 33
+      }
+    ],
+    "src/frontend/src/modals/apiModal/utils/get-js-api-code.tsx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/modals/apiModal/utils/get-js-api-code.tsx",
+        "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
+        "is_verified": false,
+        "line_number": 45
+      }
+    ],
+    "src/frontend/src/modals/apiModal/utils/get-python-api-code.tsx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/modals/apiModal/utils/get-python-api-code.tsx",
+        "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
+        "is_verified": false,
+        "line_number": 39
+      }
+    ],
+    "src/frontend/src/modals/authModal/__tests__/AuthModal.test.tsx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/modals/authModal/__tests__/AuthModal.test.tsx",
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_verified": false,
+        "line_number": 195
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/modals/authModal/__tests__/AuthModal.test.tsx",
+        "hashed_secret": "c8d8f8140951794fa875ea2c2d010c4382f36566",
+        "is_verified": false,
+        "line_number": 240
+      }
+    ],
+    "src/frontend/src/modals/modelProviderModal/__tests__/ModelProviderEdit.test.tsx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/modals/modelProviderModal/__tests__/ModelProviderEdit.test.tsx",
+        "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
+        "is_verified": false,
+        "line_number": 124
+      }
+    ],
+    "src/frontend/src/pages/FlowPage/components/InspectionPanel/__tests__/InspectionPanelHeader.test.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/frontend/src/pages/FlowPage/components/InspectionPanel/__tests__/InspectionPanelHeader.test.tsx",
+        "hashed_secret": "d11f0577fd56df40c7ad6f53b27ba7df86ccdaeb",
+        "is_verified": false,
+        "line_number": 372
+      }
+    ],
+    "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "00a0ee020d58d4855fae550f6ecf2d02d48ef746",
+        "is_verified": false,
+        "line_number": 20
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "1581e8ad89bd25d3bb297bbe6c64b75aa0de116e",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "cff396dc53137e98c1aed9431de7597e7d2d5a37",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "058d72eb25d2e4acfa1598b5f3898391cd58a1a8",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "8382bf9a010d3920123e7dd6fabb45e0b99e9954",
+        "is_verified": false,
+        "line_number": 69
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "25dff0180bdce5c818314a1167a78c626bd5d0d6",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "db99845855b2ecbfecca9a095062b96c3e27703f",
+        "is_verified": false,
+        "line_number": 97
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "eddad44cee264b9d493d75583777c145fc12c4fd",
+        "is_verified": false,
+        "line_number": 194
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "2f8536ceebe81bfa5be647c8e728f9eceefbaca8",
+        "is_verified": false,
+        "line_number": 314
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 315
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
+        "is_verified": false,
+        "line_number": 418
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "c636e8e238fd7af97e2e500f8c6f0f4c0bedafb0",
+        "is_verified": false,
+        "line_number": 419
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts",
+        "hashed_secret": "d9814f9ac9df86bfb47aaa601ba604ffaab04726",
+        "is_verified": false,
+        "line_number": 453
+      }
+    ],
+    "src/frontend/src/utils/mcpUtils.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/utils/mcpUtils.ts",
+        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
     "src/frontend/tests/assets/group_test_iadevs.json": [
       {
         "type": "Base64 High Entropy String",
         "filename": "src/frontend/tests/assets/group_test_iadevs.json",
         "hashed_secret": "eb45f77314f672a9905ecd7f6ed1735861223a22",
         "is_verified": false,
-        "line_number": 94,
+        "line_number": 103,
         "is_secret": false
       }
     ],
@@ -1567,6 +3605,2573 @@
         "is_secret": false
       }
     ],
+    "src/lfx/src/lfx/_assets/component_index.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "5717a1ee406aa657a2dacc80e2816c8f7dcae7e2",
+        "is_verified": false,
+        "line_number": 863
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "d43f7dd3e51ce7cb8b9f3c26531a9e4c3a685785",
+        "is_verified": false,
+        "line_number": 1360
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "1be2449adf6092e0729be455a98c93034cc90bc8",
+        "is_verified": false,
+        "line_number": 1485
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "42a810efde880424b1aec6d80360d8befa6c6521",
+        "is_verified": false,
+        "line_number": 1786
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "7014798bb60656a38da4a856545a06c773976112",
+        "is_verified": false,
+        "line_number": 3661
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a45df4ec5e76a1eb1199091a12fa8ee5e7af12a8",
+        "is_verified": false,
+        "line_number": 4072
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "b664327352fbd206a6ab38a8903fcabf1b1036a9",
+        "is_verified": false,
+        "line_number": 4301
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "59d43c509612f89c187f862266890ae0dd5fbb9a",
+        "is_verified": false,
+        "line_number": 4630
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "c2258af5c2c23419d7469b26f77c954af427b4b8",
+        "is_verified": false,
+        "line_number": 7002
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "597868714ac401a26b57be0f857457eeb984be18",
+        "is_verified": false,
+        "line_number": 7701
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a178830480afc434270a7a53512d97758ec6d139",
+        "is_verified": false,
+        "line_number": 7946
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "6c7724fbb114bfc616ee7bbbb3214e58907abaf1",
+        "is_verified": false,
+        "line_number": 8401
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "794ae8fea8a51838b63423486552f5398a47e6fc",
+        "is_verified": false,
+        "line_number": 8818
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "97e68220b094141268772b8b601fa6cd7432de92",
+        "is_verified": false,
+        "line_number": 9081
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a5af47522dc8a08746c380da81917bdd6eda057a",
+        "is_verified": false,
+        "line_number": 9686
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "9f66cbc518bb79dc6f0a78af0aa52bbadefe2399",
+        "is_verified": false,
+        "line_number": 10146
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "b3c2f9fda15f2d3816c7edc667bb24267be41a58",
+        "is_verified": false,
+        "line_number": 10382
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "72be8a21dd766c795332576419e6864eddc5db4e",
+        "is_verified": false,
+        "line_number": 10604
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "1659f95bebec345a9e20e32fa71e8eac4f32f6a2",
+        "is_verified": false,
+        "line_number": 12869
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "15e5f792860e53987a756bed19fba1204a671e19",
+        "is_verified": false,
+        "line_number": 13516
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "91700b2378ff5d682d1d57cff40818586609015d",
+        "is_verified": false,
+        "line_number": 14810
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "4b9838e8ff9ae89c3d23d3c853e0d07935618f00",
+        "is_verified": false,
+        "line_number": 16751
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "1aa0d90add98cf00965a327eed79bf65d589e3ce",
+        "is_verified": false,
+        "line_number": 17398
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "3698dc86868353e8ff5ed4564f78d45f1e6c08b7",
+        "is_verified": false,
+        "line_number": 18045
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "def35d315dd1ab5b0b4a05fc66847f6b73d0d853",
+        "is_verified": false,
+        "line_number": 21280
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "932fd84fba062a90506c3086945b53d4a6a3f169",
+        "is_verified": false,
+        "line_number": 22574
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "d1a66c6f4de1b56cc6e24cb0a9c78f5ba0230f56",
+        "is_verified": false,
+        "line_number": 23221
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "ddd35c43ce79e9b7ffc5f2894a1a92ad4da3297d",
+        "is_verified": false,
+        "line_number": 23868
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "bfa2c52c96d82a086f93287e90c3c889e292989e",
+        "is_verified": false,
+        "line_number": 24515
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "ac40271e91c0d84c26bf3613a94545872a801998",
+        "is_verified": false,
+        "line_number": 27750
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "691ee8aa156c92e8ae67859d9463020d1d5bec11",
+        "is_verified": false,
+        "line_number": 30338
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "5c33c0e3b39aa99ab095bf885b5f0688a9332b95",
+        "is_verified": false,
+        "line_number": 30985
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "7bfbc3a0161bb7553a4e14c1eb459d30cf104fdf",
+        "is_verified": false,
+        "line_number": 31632
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "da7592fd328658e5e783f4d16c62d1d6f9d3acd4",
+        "is_verified": false,
+        "line_number": 32279
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "f0e0ec0ff365d37b4fe860d63a9625ae529d3079",
+        "is_verified": false,
+        "line_number": 32926
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "23ce66526235ae0035cd8da3920a63c12c1c137a",
+        "is_verified": false,
+        "line_number": 34867
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a75703e0eb9d3a13d977bf04fa3cc42e9d3c94a2",
+        "is_verified": false,
+        "line_number": 38102
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "2efc38920659af83e871e71004839171d3eaeba4",
+        "is_verified": false,
+        "line_number": 40043
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "4f514a159d49488561a2efe8585871ce25141548",
+        "is_verified": false,
+        "line_number": 40690
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "adb1d675969fb13f1d752232026b9872475aca4b",
+        "is_verified": false,
+        "line_number": 43925
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "99b6e13d3c63e4f323776aec40dda0551bc0aa56",
+        "is_verified": false,
+        "line_number": 44572
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "914bd29a063d63f5cda65b9193612041bf1b04e9",
+        "is_verified": false,
+        "line_number": 47160
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "dca20b45dc15f99f985e0f87aacf5569b014ede8",
+        "is_verified": false,
+        "line_number": 47807
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "9d48b00c8700d1dcab9108609465af7112840243",
+        "is_verified": false,
+        "line_number": 48454
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "e72cb4e0e589831cbbd71514f5b6db7f0d09fd37",
+        "is_verified": false,
+        "line_number": 51042
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "03546202d2aee0b0998d1518625a6b271c345de1",
+        "is_verified": false,
+        "line_number": 51676
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "753c0fdfc1e518b8c44cd464fb28080f3f94a9f4",
+        "is_verified": false,
+        "line_number": 51916
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "ab9b46808af9e1164b7a21d946a2cefcbfa9b769",
+        "is_verified": false,
+        "line_number": 52567
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "f4a6791157ee757125b9f46c2cf72ea19cdfb50e",
+        "is_verified": false,
+        "line_number": 52987
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "23a1f3524f7b992e6a225072ec63fc780f21da34",
+        "is_verified": false,
+        "line_number": 53213
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "6e81bc86a17e501523832acc9a7ee79033f03bd9",
+        "is_verified": false,
+        "line_number": 54599
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "3179ea06ef24aee254dce7a4a3d7a02bcc6cb77f",
+        "is_verified": false,
+        "line_number": 54957
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "6ea8490b9c5872990ccc69e5d54fe850c28796b0",
+        "is_verified": false,
+        "line_number": 55120
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "9a96eb0a8598688b358bdb4b37cdd0019f9934c7",
+        "is_verified": false,
+        "line_number": 55264
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "f846d79058594083280ddae8a1dbce083aaf6427",
+        "is_verified": false,
+        "line_number": 55603
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "fb0e32db4013340e8e096da4d7cba00c099d9542",
+        "is_verified": false,
+        "line_number": 55730
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "d33546b1bd9d0542435f0f0946a6231edc175701",
+        "is_verified": false,
+        "line_number": 56687
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "f9ca36cde6942f27b76eac83290189854ff3acd5",
+        "is_verified": false,
+        "line_number": 56894
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "cf2179b851fcddc8328e4f40e46bec14a56747f8",
+        "is_verified": false,
+        "line_number": 56965
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "cc008700c5e02d5c9a7ca24219677922a3f82f17",
+        "is_verified": false,
+        "line_number": 57152
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "7863a3a0eb2ed4e19329374549df3cef1ab7ed16",
+        "is_verified": false,
+        "line_number": 58367
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "41da17b522aa582bfb292d52e8dd307bada14400",
+        "is_verified": false,
+        "line_number": 59534
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "3632913dea26578a835e7c77ab7f4293d6ec1fe6",
+        "is_verified": false,
+        "line_number": 60177
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "0321ad34ab13e2dee03faa30b7645b932f24c4d6",
+        "is_verified": false,
+        "line_number": 61316
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "cb2623c527dbce4b4e4ac56407979cad7149ea9a",
+        "is_verified": false,
+        "line_number": 61560
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "0839ff6d12baf1682b362b287997db739ee07350",
+        "is_verified": false,
+        "line_number": 62541
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a0e9cb28c049bc9f6680cd51dbef7f227f556e50",
+        "is_verified": false,
+        "line_number": 63522
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "9d96bf4bfa3991d6ddafe69d58248b75905775cc",
+        "is_verified": false,
+        "line_number": 64296
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "110175c16ed3cc17e9b0bceed842a0b83f89ba75",
+        "is_verified": false,
+        "line_number": 64900
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "5bc62a0f48f3bd1f4c9aa548fba2a0b0234fbbd8",
+        "is_verified": false,
+        "line_number": 65637
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "af246ca4758a5700d172533c40ff71522ae42d99",
+        "is_verified": false,
+        "line_number": 65757
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
+        "is_verified": false,
+        "line_number": 66201
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "2db95e850ecd2695362e438d827e9a58ee36e4b0",
+        "is_verified": false,
+        "line_number": 66873
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "199d0299098f4097fd8926648d9977fe2d08fb15",
+        "is_verified": false,
+        "line_number": 67245
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "53d87de97f77c9ea8b7795228a6ce24ed3dc0781",
+        "is_verified": false,
+        "line_number": 67482
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "70fb06614f8b86a3daac0c88f0409b40d689689c",
+        "is_verified": false,
+        "line_number": 68316
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "21c64dba6f59dad4f7f4934d4416f2805cefbd5a",
+        "is_verified": false,
+        "line_number": 68497
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "1d3051aec8271f45991f72a68fc9be099d3e92c1",
+        "is_verified": false,
+        "line_number": 68691
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "d985ccfa99e2931b452a8fc1106b44ab1fa129a3",
+        "is_verified": false,
+        "line_number": 69395
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "9f99b00169e0298e86716cdca88d9e546f9de36c",
+        "is_verified": false,
+        "line_number": 69494
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "d377ef5b36367a118f28c20eb126e6ec376e02ea",
+        "is_verified": false,
+        "line_number": 69739
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "b521ee08d1454bfeda09d831eaae591d8c12404c",
+        "is_verified": false,
+        "line_number": 70130
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "face7337620d002b928dc0088e5617aafb67b966",
+        "is_verified": false,
+        "line_number": 70355
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "f0b2022fc412b5599ddcb48c6f8f87c5a53c26af",
+        "is_verified": false,
+        "line_number": 70546
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "19b7d99d9b41aa84e4779f676bd2b22ce574906f",
+        "is_verified": false,
+        "line_number": 70682
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "446fa65c4cc6c235fabac8cb7d9241fb018514b8",
+        "is_verified": false,
+        "line_number": 71977
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "9cc81943eb951dbf87e0fbb52da90903304b8db9",
+        "is_verified": false,
+        "line_number": 72461
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "c69107ff29daaa4b30788f9cecd01d67bfc29b71",
+        "is_verified": false,
+        "line_number": 72633
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "54be28b91891ca9ef7b85502a59b32a2a03a5cb9",
+        "is_verified": false,
+        "line_number": 72789
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "60f948a394e2811370ba0bb6849777f217ab5274",
+        "is_verified": false,
+        "line_number": 72953
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a3921015132fde6780bc41c2bc32e18ec744fff2",
+        "is_verified": false,
+        "line_number": 73956
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 74391
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 74653
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "303d5144ff32301287cc201ecc9243e2d73850bf",
+        "is_verified": false,
+        "line_number": 75109
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "8b7be7f7fae86960989b939578d36ce617b498c6",
+        "is_verified": false,
+        "line_number": 75267
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a6c79dfeb177d34d195c2be48cc62800e629f115",
+        "is_verified": false,
+        "line_number": 75758
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "ef417aa1e71aee527bd6fa12f4490f7d960ec54f",
+        "is_verified": false,
+        "line_number": 75954
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a356ce34c2d87126e0170adbec7077e4421af5a5",
+        "is_verified": false,
+        "line_number": 76750
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "e2bef388cd098d7468b82db3fbb8eb2f90683de2",
+        "is_verified": false,
+        "line_number": 77257
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "d3acb69a725a514fb55033e2920abcc24e0162cc",
+        "is_verified": false,
+        "line_number": 77859
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "871ca8e6c9f88aba0a0e921f9d2f47120b55bdfc",
+        "is_verified": false,
+        "line_number": 78246
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "fd9c33bb8d9004eaf453d9be4de583758d69a025",
+        "is_verified": false,
+        "line_number": 79069
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "9783a191c8c2f45497db9684e7fafe06b95f83e9",
+        "is_verified": false,
+        "line_number": 79390
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "1f7c6ecf67ba34903861aad770957fdbfa774269",
+        "is_verified": false,
+        "line_number": 79658
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "cd37616882a8287de17e49c9f91ecad00e0b0eae",
+        "is_verified": false,
+        "line_number": 79820
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "6a49a2f5d4cb2f215b8c8a61024903ea314f9916",
+        "is_verified": false,
+        "line_number": 80215
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "9373f1ccd9980640fbcec9c685d34eac3c4b9867",
+        "is_verified": false,
+        "line_number": 80474
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "227af0d6a86c8c8619233794dcb4ea5ed1195be3",
+        "is_verified": false,
+        "line_number": 80569
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "797b61cd33f73538a622541ccdb8eee79c4b51c2",
+        "is_verified": false,
+        "line_number": 80944
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "1f46a509c4dbc5802c9541bef7ae6ae30807f3c3",
+        "is_verified": false,
+        "line_number": 81482
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "e404b5cd5a9b9314fa22ecbd85a89defdaeafacb",
+        "is_verified": false,
+        "line_number": 82974
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "7bdcea8d073c580f79a0a1982007a226a2439dbb",
+        "is_verified": false,
+        "line_number": 83249
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "34e009441a3d84fe6d22ef3faceb9229532f0c69",
+        "is_verified": false,
+        "line_number": 83501
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "15978126ab20054ba1215d2250564590cb6ba403",
+        "is_verified": false,
+        "line_number": 83743
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
+        "is_verified": false,
+        "line_number": 84012
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "3b991cdd2510d7fd1de8b025f0c7cbb9ac84b931",
+        "is_verified": false,
+        "line_number": 84300
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "573b6322edd45ab8e47491791f0909764e4a2f37",
+        "is_verified": false,
+        "line_number": 84803
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "cf0d9ce83080dd2d9110b1c6e260b2fc1f6180f2",
+        "is_verified": false,
+        "line_number": 86969
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "cef0406c8a7b2f61138425016c06ffa5b7a30112",
+        "is_verified": false,
+        "line_number": 87343
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "47ce443fa2c6d2894c896af5bf215e058b9211a7",
+        "is_verified": false,
+        "line_number": 88264
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "4676cd86733e19676c0704d55f548833f5273643",
+        "is_verified": false,
+        "line_number": 88417
+      },
+      {
+        "type": "Private Key",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 88492
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "f16b56e2e46c4df6bf412a7a9b90c86957016575",
+        "is_verified": false,
+        "line_number": 88873
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a60fc256aaca59a332b08d58bd88404348a8bcb9",
+        "is_verified": false,
+        "line_number": 89041
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "04d0a3a2f4c5f2e29f293507958a27b53728c4e8",
+        "is_verified": false,
+        "line_number": 89857
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "dede8930d7418d092a12d114de08e444bf0dd82e",
+        "is_verified": false,
+        "line_number": 90904
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "2a6863fb102cdb7c5f83b6afd00a794efb701566",
+        "is_verified": false,
+        "line_number": 91213
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "3de7722ca43ab9676c384eb479950083fb2385bb",
+        "is_verified": false,
+        "line_number": 92401
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "5ab5903f6c15a46a71c8db55e70119352304cc15",
+        "is_verified": false,
+        "line_number": 93669
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "4311a7e1eaf728d4f31467084f690eff7493a9e4",
+        "is_verified": false,
+        "line_number": 94226
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "c6654393d0b0f14057873630031d040e3dea115d",
+        "is_verified": false,
+        "line_number": 94535
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a229317aa176166d90f06d566b71932cff018638",
+        "is_verified": false,
+        "line_number": 94700
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "244a01453acc60cca4380edd62539519c250d395",
+        "is_verified": false,
+        "line_number": 95085
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "3d442b2ea6e64698db1e44f7bd5ecb36daebc8a9",
+        "is_verified": false,
+        "line_number": 95900
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "ef4b28ff7563e530637c74c37555b1fb5a6966f0",
+        "is_verified": false,
+        "line_number": 96240
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "6516fc2579d674314a52e49462a84159df8479d9",
+        "is_verified": false,
+        "line_number": 96527
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "8ab07507a1c24711ad94bb37308e838447d4a5ca",
+        "is_verified": false,
+        "line_number": 96681
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "c89fdd11b805574e2ba8910cf63c4273044b887c",
+        "is_verified": false,
+        "line_number": 96884
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "f2dd454db702c939d54193f0be69d772368ac676",
+        "is_verified": false,
+        "line_number": 97147
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
+        "is_verified": false,
+        "line_number": 97405
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "30ddcbfccd38de28196e92b6fcf77e65d122294d",
+        "is_verified": false,
+        "line_number": 97686
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "c2dc8a1d72a39ee9da360d47dcadfd7a5560ee7f",
+        "is_verified": false,
+        "line_number": 97809
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "efa90513d8e6348d4005c33485f2981bb2cc3411",
+        "is_verified": false,
+        "line_number": 98035
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "eb2f1f46999a581c6a1b8a2279963002e4effd2d",
+        "is_verified": false,
+        "line_number": 98237
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "25118f28f0772791b1febea557df6f8eb10d0dd8",
+        "is_verified": false,
+        "line_number": 98802
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "240cd2b6629abde66f97f1955dd87fab8e045258",
+        "is_verified": false,
+        "line_number": 98937
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "cd50293b35634a61add9cbfeb9e48fbd44e78bc3",
+        "is_verified": false,
+        "line_number": 99950
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "b016c72dac43dd6eec034d8b49aa1ded1cc0c6fa",
+        "is_verified": false,
+        "line_number": 100183
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "f59912210d43c78fe803463f6bfb35688508a2bf",
+        "is_verified": false,
+        "line_number": 100620
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "b0e82a9a7bedac4135f97637be0c11faa2122599",
+        "is_verified": false,
+        "line_number": 100731
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "5bf984f56eac13589ac2369cb0bae2f61869810a",
+        "is_verified": false,
+        "line_number": 100878
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "9f29336453dfa317f190f570b08116937a529f0b",
+        "is_verified": false,
+        "line_number": 101576
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
+        "is_verified": false,
+        "line_number": 101746
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "2acd680fbb8b14e98aea68cfef28ce81eba86c71",
+        "is_verified": false,
+        "line_number": 102100
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "2dd96ae1cb8802018fb2f6a27926bb5f78957fb0",
+        "is_verified": false,
+        "line_number": 102223
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "3b61d62768cfb3c63d994d7988306f1ebd2acd6b",
+        "is_verified": false,
+        "line_number": 102400
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "d17b2d823c9310229ad18c83ffe543f49406ff9b",
+        "is_verified": false,
+        "line_number": 102882
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "e7d0065af9edfc8b2de193bbe26faf5a636e0e9f",
+        "is_verified": false,
+        "line_number": 103039
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "1bfed9fbd700374425b35a35ddf0f49a1e2469c2",
+        "is_verified": false,
+        "line_number": 103445
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "28ab1b1b9c8f05c055b6741bcaeab7337f5b5dc7",
+        "is_verified": false,
+        "line_number": 103660
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "76377d63ef7d864c0cefc5b38c762e16d3ab39b5",
+        "is_verified": false,
+        "line_number": 104034
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "562c0bc758bca6446fabf1aacf71f63d47bc62ed",
+        "is_verified": false,
+        "line_number": 104158
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "0113110e3d49f7b3a48e00192d478584449800e7",
+        "is_verified": false,
+        "line_number": 104351
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "8e201f749e20ab2d51d0de3da73effa5f616448d",
+        "is_verified": false,
+        "line_number": 105089
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "4ffc5d8cd514be957c9b87ac84c66205ab6d08d3",
+        "is_verified": false,
+        "line_number": 106041
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
+        "is_verified": false,
+        "line_number": 106340
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "c0576697d180e97695dd29883a4e1ccb01b2f653",
+        "is_verified": false,
+        "line_number": 106429
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "497af5dcf573db44fc30ac071ebb008e7ac37669",
+        "is_verified": false,
+        "line_number": 106746
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "6a5f46048b547457e72572c2d38fb1046591ca71",
+        "is_verified": false,
+        "line_number": 107745
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "7d770d0728208206c486b536b06077c9953d21f2",
+        "is_verified": false,
+        "line_number": 108114
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "6fb5a96582d72c338a3f3a7d8144190630d64133",
+        "is_verified": false,
+        "line_number": 108502
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "270c9abba84329e1be2fa7130b44134c23891f1f",
+        "is_verified": false,
+        "line_number": 108831
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a781a6064ef5e2cb085282bb1912e65232fb55d1",
+        "is_verified": false,
+        "line_number": 109226
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "ef3435e29e3a2c5dcbbb633856c85561848cd995",
+        "is_verified": false,
+        "line_number": 110913
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "be1df677c309419f4efa0ac48afb2a573beeb95d",
+        "is_verified": false,
+        "line_number": 111583
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "5d65cf087adec89fb18354508030304fc3809586",
+        "is_verified": false,
+        "line_number": 111846
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "76913f65d6da6c5660de587c8a3e807aafa039dd",
+        "is_verified": false,
+        "line_number": 112047
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "4f24919ffd7775f2df3ec3fa57eae8c5a62053ce",
+        "is_verified": false,
+        "line_number": 112200
+      }
+    ],
+    "src/lfx/src/lfx/_assets/stable_hash_history.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "5717a1ee406aa657a2dacc80e2816c8f7dcae7e2",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "d43f7dd3e51ce7cb8b9f3c26531a9e4c3a685785",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "1be2449adf6092e0729be455a98c93034cc90bc8",
+        "is_verified": false,
+        "line_number": 49
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "42a810efde880424b1aec6d80360d8befa6c6521",
+        "is_verified": false,
+        "line_number": 59
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "7014798bb60656a38da4a856545a06c773976112",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a45df4ec5e76a1eb1199091a12fa8ee5e7af12a8",
+        "is_verified": false,
+        "line_number": 84
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "b664327352fbd206a6ab38a8903fcabf1b1036a9",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "59d43c509612f89c187f862266890ae0dd5fbb9a",
+        "is_verified": false,
+        "line_number": 94
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "c2258af5c2c23419d7469b26f77c954af427b4b8",
+        "is_verified": false,
+        "line_number": 144
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "597868714ac401a26b57be0f857457eeb984be18",
+        "is_verified": false,
+        "line_number": 154
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a178830480afc434270a7a53512d97758ec6d139",
+        "is_verified": false,
+        "line_number": 159
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "6c7724fbb114bfc616ee7bbbb3214e58907abaf1",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "794ae8fea8a51838b63423486552f5398a47e6fc",
+        "is_verified": false,
+        "line_number": 169
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "97e68220b094141268772b8b601fa6cd7432de92",
+        "is_verified": false,
+        "line_number": 174
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a5af47522dc8a08746c380da81917bdd6eda057a",
+        "is_verified": false,
+        "line_number": 184
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "9f66cbc518bb79dc6f0a78af0aa52bbadefe2399",
+        "is_verified": false,
+        "line_number": 189
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "b3c2f9fda15f2d3816c7edc667bb24267be41a58",
+        "is_verified": false,
+        "line_number": 194
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "72be8a21dd766c795332576419e6864eddc5db4e",
+        "is_verified": false,
+        "line_number": 199
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "1659f95bebec345a9e20e32fa71e8eac4f32f6a2",
+        "is_verified": false,
+        "line_number": 224
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "15e5f792860e53987a756bed19fba1204a671e19",
+        "is_verified": false,
+        "line_number": 229
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "91700b2378ff5d682d1d57cff40818586609015d",
+        "is_verified": false,
+        "line_number": 239
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "4b9838e8ff9ae89c3d23d3c853e0d07935618f00",
+        "is_verified": false,
+        "line_number": 254
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "1aa0d90add98cf00965a327eed79bf65d589e3ce",
+        "is_verified": false,
+        "line_number": 259
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "3698dc86868353e8ff5ed4564f78d45f1e6c08b7",
+        "is_verified": false,
+        "line_number": 264
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "def35d315dd1ab5b0b4a05fc66847f6b73d0d853",
+        "is_verified": false,
+        "line_number": 294
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "932fd84fba062a90506c3086945b53d4a6a3f169",
+        "is_verified": false,
+        "line_number": 304
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "d1a66c6f4de1b56cc6e24cb0a9c78f5ba0230f56",
+        "is_verified": false,
+        "line_number": 309
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "ddd35c43ce79e9b7ffc5f2894a1a92ad4da3297d",
+        "is_verified": false,
+        "line_number": 314
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "bfa2c52c96d82a086f93287e90c3c889e292989e",
+        "is_verified": false,
+        "line_number": 319
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "ac40271e91c0d84c26bf3613a94545872a801998",
+        "is_verified": false,
+        "line_number": 344
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "691ee8aa156c92e8ae67859d9463020d1d5bec11",
+        "is_verified": false,
+        "line_number": 364
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "f0e0ec0ff365d37b4fe860d63a9625ae529d3079",
+        "is_verified": false,
+        "line_number": 369
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "5c33c0e3b39aa99ab095bf885b5f0688a9332b95",
+        "is_verified": false,
+        "line_number": 374
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "7bfbc3a0161bb7553a4e14c1eb459d30cf104fdf",
+        "is_verified": false,
+        "line_number": 384
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "da7592fd328658e5e783f4d16c62d1d6f9d3acd4",
+        "is_verified": false,
+        "line_number": 389
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "23ce66526235ae0035cd8da3920a63c12c1c137a",
+        "is_verified": false,
+        "line_number": 399
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a75703e0eb9d3a13d977bf04fa3cc42e9d3c94a2",
+        "is_verified": false,
+        "line_number": 424
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "2efc38920659af83e871e71004839171d3eaeba4",
+        "is_verified": false,
+        "line_number": 439
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "4f514a159d49488561a2efe8585871ce25141548",
+        "is_verified": false,
+        "line_number": 444
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "adb1d675969fb13f1d752232026b9872475aca4b",
+        "is_verified": false,
+        "line_number": 469
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "99b6e13d3c63e4f323776aec40dda0551bc0aa56",
+        "is_verified": false,
+        "line_number": 474
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "914bd29a063d63f5cda65b9193612041bf1b04e9",
+        "is_verified": false,
+        "line_number": 494
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "dca20b45dc15f99f985e0f87aacf5569b014ede8",
+        "is_verified": false,
+        "line_number": 499
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "9d48b00c8700d1dcab9108609465af7112840243",
+        "is_verified": false,
+        "line_number": 504
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "e72cb4e0e589831cbbd71514f5b6db7f0d09fd37",
+        "is_verified": false,
+        "line_number": 524
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "03546202d2aee0b0998d1518625a6b271c345de1",
+        "is_verified": false,
+        "line_number": 529
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "753c0fdfc1e518b8c44cd464fb28080f3f94a9f4",
+        "is_verified": false,
+        "line_number": 534
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "ab9b46808af9e1164b7a21d946a2cefcbfa9b769",
+        "is_verified": false,
+        "line_number": 544
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "f4a6791157ee757125b9f46c2cf72ea19cdfb50e",
+        "is_verified": false,
+        "line_number": 554
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "23a1f3524f7b992e6a225072ec63fc780f21da34",
+        "is_verified": false,
+        "line_number": 564
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "6e81bc86a17e501523832acc9a7ee79033f03bd9",
+        "is_verified": false,
+        "line_number": 579
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "3179ea06ef24aee254dce7a4a3d7a02bcc6cb77f",
+        "is_verified": false,
+        "line_number": 584
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "6ea8490b9c5872990ccc69e5d54fe850c28796b0",
+        "is_verified": false,
+        "line_number": 589
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "9a96eb0a8598688b358bdb4b37cdd0019f9934c7",
+        "is_verified": false,
+        "line_number": 594
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "f846d79058594083280ddae8a1dbce083aaf6427",
+        "is_verified": false,
+        "line_number": 604
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "fb0e32db4013340e8e096da4d7cba00c099d9542",
+        "is_verified": false,
+        "line_number": 609
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "cc008700c5e02d5c9a7ca24219677922a3f82f17",
+        "is_verified": false,
+        "line_number": 624
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "7863a3a0eb2ed4e19329374549df3cef1ab7ed16",
+        "is_verified": false,
+        "line_number": 634
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "41da17b522aa582bfb292d52e8dd307bada14400",
+        "is_verified": false,
+        "line_number": 639
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "3632913dea26578a835e7c77ab7f4293d6ec1fe6",
+        "is_verified": false,
+        "line_number": 644
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "d33546b1bd9d0542435f0f0946a6231edc175701",
+        "is_verified": false,
+        "line_number": 664
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "0321ad34ab13e2dee03faa30b7645b932f24c4d6",
+        "is_verified": false,
+        "line_number": 684
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "cb2623c527dbce4b4e4ac56407979cad7149ea9a",
+        "is_verified": false,
+        "line_number": 689
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "f9ca36cde6942f27b76eac83290189854ff3acd5",
+        "is_verified": false,
+        "line_number": 694
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "cf2179b851fcddc8328e4f40e46bec14a56747f8",
+        "is_verified": false,
+        "line_number": 699
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "0839ff6d12baf1682b362b287997db739ee07350",
+        "is_verified": false,
+        "line_number": 709
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a0e9cb28c049bc9f6680cd51dbef7f227f556e50",
+        "is_verified": false,
+        "line_number": 724
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "9d96bf4bfa3991d6ddafe69d58248b75905775cc",
+        "is_verified": false,
+        "line_number": 739
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "110175c16ed3cc17e9b0bceed842a0b83f89ba75",
+        "is_verified": false,
+        "line_number": 744
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "5bc62a0f48f3bd1f4c9aa548fba2a0b0234fbbd8",
+        "is_verified": false,
+        "line_number": 754
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "af246ca4758a5700d172533c40ff71522ae42d99",
+        "is_verified": false,
+        "line_number": 759
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
+        "is_verified": false,
+        "line_number": 769
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "2db95e850ecd2695362e438d827e9a58ee36e4b0",
+        "is_verified": false,
+        "line_number": 774
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "199d0299098f4097fd8926648d9977fe2d08fb15",
+        "is_verified": false,
+        "line_number": 779
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "53d87de97f77c9ea8b7795228a6ce24ed3dc0781",
+        "is_verified": false,
+        "line_number": 784
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "70fb06614f8b86a3daac0c88f0409b40d689689c",
+        "is_verified": false,
+        "line_number": 799
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "21c64dba6f59dad4f7f4934d4416f2805cefbd5a",
+        "is_verified": false,
+        "line_number": 804
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "1d3051aec8271f45991f72a68fc9be099d3e92c1",
+        "is_verified": false,
+        "line_number": 809
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "d985ccfa99e2931b452a8fc1106b44ab1fa129a3",
+        "is_verified": false,
+        "line_number": 829
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "9f99b00169e0298e86716cdca88d9e546f9de36c",
+        "is_verified": false,
+        "line_number": 834
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "d377ef5b36367a118f28c20eb126e6ec376e02ea",
+        "is_verified": false,
+        "line_number": 844
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "b521ee08d1454bfeda09d831eaae591d8c12404c",
+        "is_verified": false,
+        "line_number": 854
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "face7337620d002b928dc0088e5617aafb67b966",
+        "is_verified": false,
+        "line_number": 864
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "19b7d99d9b41aa84e4779f676bd2b22ce574906f",
+        "is_verified": false,
+        "line_number": 869
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "f0b2022fc412b5599ddcb48c6f8f87c5a53c26af",
+        "is_verified": false,
+        "line_number": 874
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "446fa65c4cc6c235fabac8cb7d9241fb018514b8",
+        "is_verified": false,
+        "line_number": 909
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "9cc81943eb951dbf87e0fbb52da90903304b8db9",
+        "is_verified": false,
+        "line_number": 919
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "c69107ff29daaa4b30788f9cecd01d67bfc29b71",
+        "is_verified": false,
+        "line_number": 924
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "60f948a394e2811370ba0bb6849777f217ab5274",
+        "is_verified": false,
+        "line_number": 929
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "54be28b91891ca9ef7b85502a59b32a2a03a5cb9",
+        "is_verified": false,
+        "line_number": 934
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a3921015132fde6780bc41c2bc32e18ec744fff2",
+        "is_verified": false,
+        "line_number": 944
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 954
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 959
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "303d5144ff32301287cc201ecc9243e2d73850bf",
+        "is_verified": false,
+        "line_number": 974
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "8b7be7f7fae86960989b939578d36ce617b498c6",
+        "is_verified": false,
+        "line_number": 979
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a6c79dfeb177d34d195c2be48cc62800e629f115",
+        "is_verified": false,
+        "line_number": 994
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "ef417aa1e71aee527bd6fa12f4490f7d960ec54f",
+        "is_verified": false,
+        "line_number": 999
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a356ce34c2d87126e0170adbec7077e4421af5a5",
+        "is_verified": false,
+        "line_number": 1019
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "e2bef388cd098d7468b82db3fbb8eb2f90683de2",
+        "is_verified": false,
+        "line_number": 1044
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "d3acb69a725a514fb55033e2920abcc24e0162cc",
+        "is_verified": false,
+        "line_number": 1054
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "797b61cd33f73538a622541ccdb8eee79c4b51c2",
+        "is_verified": false,
+        "line_number": 1074
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "871ca8e6c9f88aba0a0e921f9d2f47120b55bdfc",
+        "is_verified": false,
+        "line_number": 1079
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "fd9c33bb8d9004eaf453d9be4de583758d69a025",
+        "is_verified": false,
+        "line_number": 1094
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "9783a191c8c2f45497db9684e7fafe06b95f83e9",
+        "is_verified": false,
+        "line_number": 1099
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "1f7c6ecf67ba34903861aad770957fdbfa774269",
+        "is_verified": false,
+        "line_number": 1104
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "cd37616882a8287de17e49c9f91ecad00e0b0eae",
+        "is_verified": false,
+        "line_number": 1109
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "6a49a2f5d4cb2f215b8c8a61024903ea314f9916",
+        "is_verified": false,
+        "line_number": 1129
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "9373f1ccd9980640fbcec9c685d34eac3c4b9867",
+        "is_verified": false,
+        "line_number": 1134
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "227af0d6a86c8c8619233794dcb4ea5ed1195be3",
+        "is_verified": false,
+        "line_number": 1139
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "1f46a509c4dbc5802c9541bef7ae6ae30807f3c3",
+        "is_verified": false,
+        "line_number": 1144
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "34e009441a3d84fe6d22ef3faceb9229532f0c69",
+        "is_verified": false,
+        "line_number": 1174
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "15978126ab20054ba1215d2250564590cb6ba403",
+        "is_verified": false,
+        "line_number": 1179
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "7bdcea8d073c580f79a0a1982007a226a2439dbb",
+        "is_verified": false,
+        "line_number": 1184
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
+        "is_verified": false,
+        "line_number": 1189
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "3b991cdd2510d7fd1de8b025f0c7cbb9ac84b931",
+        "is_verified": false,
+        "line_number": 1194
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "573b6322edd45ab8e47491791f0909764e4a2f37",
+        "is_verified": false,
+        "line_number": 1204
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "cf0d9ce83080dd2d9110b1c6e260b2fc1f6180f2",
+        "is_verified": false,
+        "line_number": 1234
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "cef0406c8a7b2f61138425016c06ffa5b7a30112",
+        "is_verified": false,
+        "line_number": 1239
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "47ce443fa2c6d2894c896af5bf215e058b9211a7",
+        "is_verified": false,
+        "line_number": 1254
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "4676cd86733e19676c0704d55f548833f5273643",
+        "is_verified": false,
+        "line_number": 1259
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "f16b56e2e46c4df6bf412a7a9b90c86957016575",
+        "is_verified": false,
+        "line_number": 1264
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a60fc256aaca59a332b08d58bd88404348a8bcb9",
+        "is_verified": false,
+        "line_number": 1269
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "04d0a3a2f4c5f2e29f293507958a27b53728c4e8",
+        "is_verified": false,
+        "line_number": 1279
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "dede8930d7418d092a12d114de08e444bf0dd82e",
+        "is_verified": false,
+        "line_number": 1294
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "2a6863fb102cdb7c5f83b6afd00a794efb701566",
+        "is_verified": false,
+        "line_number": 1304
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "3de7722ca43ab9676c384eb479950083fb2385bb",
+        "is_verified": false,
+        "line_number": 1319
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "5ab5903f6c15a46a71c8db55e70119352304cc15",
+        "is_verified": false,
+        "line_number": 1334
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "4311a7e1eaf728d4f31467084f690eff7493a9e4",
+        "is_verified": false,
+        "line_number": 1344
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "c6654393d0b0f14057873630031d040e3dea115d",
+        "is_verified": false,
+        "line_number": 1349
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a229317aa176166d90f06d566b71932cff018638",
+        "is_verified": false,
+        "line_number": 1354
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "25118f28f0772791b1febea557df6f8eb10d0dd8",
+        "is_verified": false,
+        "line_number": 1359
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "3d442b2ea6e64698db1e44f7bd5ecb36daebc8a9",
+        "is_verified": false,
+        "line_number": 1379
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "244a01453acc60cca4380edd62539519c250d395",
+        "is_verified": false,
+        "line_number": 1384
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "ef4b28ff7563e530637c74c37555b1fb5a6966f0",
+        "is_verified": false,
+        "line_number": 1399
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "6516fc2579d674314a52e49462a84159df8479d9",
+        "is_verified": false,
+        "line_number": 1409
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "8ab07507a1c24711ad94bb37308e838447d4a5ca",
+        "is_verified": false,
+        "line_number": 1414
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "c89fdd11b805574e2ba8910cf63c4273044b887c",
+        "is_verified": false,
+        "line_number": 1424
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "f2dd454db702c939d54193f0be69d772368ac676",
+        "is_verified": false,
+        "line_number": 1434
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
+        "is_verified": false,
+        "line_number": 1444
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "30ddcbfccd38de28196e92b6fcf77e65d122294d",
+        "is_verified": false,
+        "line_number": 1454
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "c2dc8a1d72a39ee9da360d47dcadfd7a5560ee7f",
+        "is_verified": false,
+        "line_number": 1459
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "efa90513d8e6348d4005c33485f2981bb2cc3411",
+        "is_verified": false,
+        "line_number": 1464
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "eb2f1f46999a581c6a1b8a2279963002e4effd2d",
+        "is_verified": false,
+        "line_number": 1469
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "240cd2b6629abde66f97f1955dd87fab8e045258",
+        "is_verified": false,
+        "line_number": 1474
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "cd50293b35634a61add9cbfeb9e48fbd44e78bc3",
+        "is_verified": false,
+        "line_number": 1494
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "b016c72dac43dd6eec034d8b49aa1ded1cc0c6fa",
+        "is_verified": false,
+        "line_number": 1499
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "f59912210d43c78fe803463f6bfb35688508a2bf",
+        "is_verified": false,
+        "line_number": 1509
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "b0e82a9a7bedac4135f97637be0c11faa2122599",
+        "is_verified": false,
+        "line_number": 1514
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "5bf984f56eac13589ac2369cb0bae2f61869810a",
+        "is_verified": false,
+        "line_number": 1519
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "9f29336453dfa317f190f570b08116937a529f0b",
+        "is_verified": false,
+        "line_number": 1534
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
+        "is_verified": false,
+        "line_number": 1539
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "2acd680fbb8b14e98aea68cfef28ce81eba86c71",
+        "is_verified": false,
+        "line_number": 1544
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "2dd96ae1cb8802018fb2f6a27926bb5f78957fb0",
+        "is_verified": false,
+        "line_number": 1549
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "3b61d62768cfb3c63d994d7988306f1ebd2acd6b",
+        "is_verified": false,
+        "line_number": 1554
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "d17b2d823c9310229ad18c83ffe543f49406ff9b",
+        "is_verified": false,
+        "line_number": 1564
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "e7d0065af9edfc8b2de193bbe26faf5a636e0e9f",
+        "is_verified": false,
+        "line_number": 1574
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "1bfed9fbd700374425b35a35ddf0f49a1e2469c2",
+        "is_verified": false,
+        "line_number": 1579
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "28ab1b1b9c8f05c055b6741bcaeab7337f5b5dc7",
+        "is_verified": false,
+        "line_number": 1584
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "76377d63ef7d864c0cefc5b38c762e16d3ab39b5",
+        "is_verified": false,
+        "line_number": 1589
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "562c0bc758bca6446fabf1aacf71f63d47bc62ed",
+        "is_verified": false,
+        "line_number": 1594
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "0113110e3d49f7b3a48e00192d478584449800e7",
+        "is_verified": false,
+        "line_number": 1599
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "8e201f749e20ab2d51d0de3da73effa5f616448d",
+        "is_verified": false,
+        "line_number": 1609
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "4ffc5d8cd514be957c9b87ac84c66205ab6d08d3",
+        "is_verified": false,
+        "line_number": 1644
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
+        "is_verified": false,
+        "line_number": 1649
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "c0576697d180e97695dd29883a4e1ccb01b2f653",
+        "is_verified": false,
+        "line_number": 1654
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "497af5dcf573db44fc30ac071ebb008e7ac37669",
+        "is_verified": false,
+        "line_number": 1669
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "7d770d0728208206c486b536b06077c9953d21f2",
+        "is_verified": false,
+        "line_number": 1684
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "6a5f46048b547457e72572c2d38fb1046591ca71",
+        "is_verified": false,
+        "line_number": 1689
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "270c9abba84329e1be2fa7130b44134c23891f1f",
+        "is_verified": false,
+        "line_number": 1694
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "6fb5a96582d72c338a3f3a7d8144190630d64133",
+        "is_verified": false,
+        "line_number": 1699
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a781a6064ef5e2cb085282bb1912e65232fb55d1",
+        "is_verified": false,
+        "line_number": 1704
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "ef3435e29e3a2c5dcbbb633856c85561848cd995",
+        "is_verified": false,
+        "line_number": 1744
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "be1df677c309419f4efa0ac48afb2a573beeb95d",
+        "is_verified": false,
+        "line_number": 1759
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "5d65cf087adec89fb18354508030304fc3809586",
+        "is_verified": false,
+        "line_number": 1764
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "76913f65d6da6c5660de587c8a3e807aafa039dd",
+        "is_verified": false,
+        "line_number": 1774
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "e404b5cd5a9b9314fa22ecbd85a89defdaeafacb",
+        "is_verified": false,
+        "line_number": 1779
+      }
+    ],
+    "src/lfx/src/lfx/base/models/unified_models.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 69
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
+        "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
+        "is_verified": false,
+        "line_number": 87
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
+        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
+        "is_verified": false,
+        "line_number": 96
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
+        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "is_verified": false,
+        "line_number": 106
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
+        "hashed_secret": "a19ee5a9fdc191092796cd9bfa97c55fe5631695",
+        "is_verified": false,
+        "line_number": 380
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
+        "hashed_secret": "b780a23b530ef6bb5c3b722a0c9c5e3abf222e8b",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
+        "hashed_secret": "ed96761b106155514463a9f82d02b14042e75b61",
+        "is_verified": false,
+        "line_number": 382
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
+        "hashed_secret": "ac579e82cacca3f9c1a8b18bdfdad78e8b6140f8",
+        "is_verified": false,
+        "line_number": 383
+      }
+    ],
+    "src/lfx/src/lfx/cli/serve_app.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/cli/serve_app.py",
+        "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
+        "is_verified": false,
+        "line_number": 40
+      }
+    ],
+    "src/lfx/src/lfx/components/mem0/mem0_chat_memory.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/components/mem0/mem0_chat_memory.py",
+        "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
+        "is_verified": false,
+        "line_number": 34
+      }
+    ],
+    "src/lfx/src/lfx/components/mongodb/mongodb_atlas.py": [
+      {
+        "type": "Private Key",
+        "filename": "src/lfx/src/lfx/components/mongodb/mongodb_atlas.py",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
     "src/lfx/src/lfx/inputs/input_mixin.py": [
       {
         "type": "Secret Keyword",
@@ -1576,7 +6181,249 @@
         "line_number": 21,
         "is_secret": false
       }
+    ],
+    "src/lfx/src/lfx/schema/table.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/schema/table.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 114
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Basic Prompting.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Basic Prompting.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 343
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Blog Writer.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Blog Writer.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 180
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Custom Component Generator.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Custom Component Generator.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 563
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Document Q&A.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Document Q&A.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 635
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Hybrid Search RAG.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Hybrid Search RAG.json",
+        "hashed_secret": "da3146ee22694a3b79bedbeae8842f85384f3431",
+        "is_verified": false,
+        "line_number": 1039
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Image Sentiment Analysis.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Image Sentiment Analysis.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 725
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Instagram Copywriter.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Instagram Copywriter.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 552
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Invoice Summarizer.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Invoice Summarizer.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 174
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Meeting Summary.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Meeting Summary.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 470
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Memory Chatbot.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Memory Chatbot.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 645
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Research Agent.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Research Agent.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 319
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/SEO Keyword Generator.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/SEO Keyword Generator.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 122
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/SaaS Pricing.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/SaaS Pricing.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 119
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Sequential Tasks Agents.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Sequential Tasks Agents.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 1649
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Twitter Thread Generator.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Twitter Thread Generator.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 1433
+      }
+    ],
+    "src/lfx/tests/data/starter_projects_1_6_0/Vector Store RAG.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/tests/data/starter_projects_1_6_0/Vector Store RAG.json",
+        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
+        "is_verified": false,
+        "line_number": 551
+      }
+    ],
+    "src/lfx/tests/data/vector_store_grouped.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/lfx/tests/data/vector_store_grouped.json",
+        "hashed_secret": "235edeaf33250eafce9270c364af8a7fcbb9b110",
+        "is_verified": false,
+        "line_number": 1
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/lfx/tests/data/vector_store_grouped.json",
+        "hashed_secret": "99dd7eb59ef1cd6c5a11e6c737bda80db54612a2",
+        "is_verified": false,
+        "line_number": 1
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/lfx/tests/data/vector_store_grouped.json",
+        "hashed_secret": "a6865946da108064ab17a0cf4518c151a006b810",
+        "is_verified": false,
+        "line_number": 1
+      }
+    ],
+    "src/lfx/tests/unit/cli/test_serve_simple.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/tests/unit/cli/test_serve_simple.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 67
+      }
+    ],
+    "src/lfx/tests/unit/run/test_base.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/tests/unit/run/test_base.py",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 326
+      }
+    ],
+    "src/lfx/tests/unit/run/test_base_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/tests/unit/run/test_base_integration.py",
+        "hashed_secret": "1e7772b7ee7a12f8dbb12351cabcb9dcd43221e8",
+        "is_verified": false,
+        "line_number": 83
+      }
+    ],
+    "src/lfx/tests/unit/services/settings/test_mcp_composer.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/tests/unit/services/settings/test_mcp_composer.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 162
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/tests/unit/services/settings/test_mcp_composer.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 202
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/tests/unit/services/settings/test_mcp_composer.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 335
+      }
+    ],
+    "src/lfx/tests/unit/services/settings/test_mcp_composer_windows.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/tests/unit/services/settings/test_mcp_composer_windows.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 217
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/tests/unit/services/settings/test_mcp_composer_windows.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 536
+      }
     ]
   },
-  "generated_at": "2026-02-19T20:02:44Z"
+  "generated_at": "2026-02-20T16:21:40Z"
 }

--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Ingestion.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Ingestion.json
@@ -82,7 +82,8 @@
               "chunk_size",
               "separator",
               "text_key",
-              "keep_separator"
+              "keep_separator",
+              "clean_output"
             ],
             "frozen": false,
             "icon": "scissors-line-dashed",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -787,7 +787,8 @@
               "chunk_size",
               "separator",
               "text_key",
-              "keep_separator"
+              "keep_separator",
+              "clean_output"
             ],
             "frozen": false,
             "icon": "scissors-line-dashed",


### PR DESCRIPTION
This pull request adds a new parameter, `clean_output`, to the configuration options in two starter project JSON files. This change allows for additional control over the output cleaning process in chunking operations.

Configuration updates:

* Added the `clean_output` parameter to the list of configurable options in `Knowledge Ingestion.json` and `Vector Store RAG.json` starter project files. [[1]](diffhunk://#diff-d09e4e9f1d0ff3e090540f959176b853b31e02494b655358f379476813b76944L85-R86) [[2]](diffhunk://#diff-10837b87e2da91a231aa3ec84c3b6317cd239066c0c8979d2ce127f6408cf67dL790-R791)