### PR TITLE
ci: set explicit read-only GITHUB_TOKEN permissions in core workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ on:
   pull_request:
     types: [opened, synchronize, labeled]
   merge_group:
+
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -45,6 +45,10 @@ on:
           - self-hosted
           - '["self-hosted", "linux", "ARM64", "langflow-ai-arm64-40gb-ephemeral"]'
         default: ubuntu-latest
+
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "1.8.2"
   NODE_VERSION: "22"

--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -63,6 +63,9 @@ on:
           - '["self-hosted", "linux", "ARM64", "langflow-ai-arm64-40gb-ephemeral"]'
         default: ubuntu-latest
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: "22"
   PYTHON_VERSION: "3.13"


### PR DESCRIPTION
## Summary\n- add explicit top-level `permissions` to three primary CI workflows\n- set default token scope to `contents: read` for least privilege\n\n## Why\nGitHub recommends explicitly declaring workflow permissions to avoid broad default token scopes. These workflows only require repository read access at the workflow level.\n\n## Changed workflows\n- `.github/workflows/ci.yml`\n- `.github/workflows/python_test.yml`\n- `.github/workflows/typescript_test.yml`\n\n## Testing\n- workflow YAML updates only (no runtime logic changes)\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow permissions and testing configurations for improved build and test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->