### PR TITLE
Fix #11792: make docker_build failing- ModuleNotFoundError: No module na

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,9 @@ override-dependencies = [
     "python-pptx>=1.0.2",
 ]
 
+[tool.uv.extra-build-dependencies]
+langflow-base = ["hatchling"]
+
 [project.scripts]
 langflow = "langflow.langflow_launcher:main"
 


### PR DESCRIPTION
Fixes #11792

## Summary
This PR addresses: make docker_build failing- ModuleNotFoundError: No module named 'hatchling.build'

## Changes
```
pyproject.toml | 3 +++
 1 file changed, 3 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration to include additional build-time dependencies for improved project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->