### PR TITLE
fix: correct typo 'recieved' to 'received' in CugaAgent

### DIFF
--- a/src/lfx/src/lfx/_assets/stable_hash_history.json
+++ b/src/lfx/src/lfx/_assets/stable_hash_history.json
@@ -566,7 +566,7 @@
   },
   "Cuga": {
     "versions": {
-      "0.3.0": "35e838f89d13"
+      "0.3.0": "39929ae344f1"
     }
   },
   "CustomComponent": {

--- a/src/lfx/src/lfx/components/cuga/cuga_agent.py
+++ b/src/lfx/src/lfx/components/cuga/cuga_agent.py
@@ -282,7 +282,7 @@ class CugaComponent(ToolCallingAgentComponent):
                 async for event in cuga_agent.run_task_generic_yield(
                     eval_mode=False, goal=current_input, chat_messages=lc_messages
                 ):
-                    logger.debug(f"[CUGA] recieved event {event}")
+                    logger.debug(f"[CUGA] received event {event}")
                     if last_event is not None and tool_run_id is not None:
                         logger.debug(f"[CUGA] last event {last_event}")
                         try:


### PR DESCRIPTION
## Summary

Fixed typo in CugaAgent component.

## Changes

- `recieved` → `received` in cuga_agent.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed a spelling error in internal logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->