### PR TITLE
Fix ModuleNotFoundError: No module named 'hatchling.build'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -387,5 +387,5 @@ mypy_path = "langflow"
 ignore_missing_imports = true
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatchling.build"]
 build-backend = "hatchling.build"

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -169,7 +169,7 @@ formatter-cmds = ["ruff check --exit-zero --fix $file", "ruff format $file"]
 pytest-cmd = "pytest -p no:profiling -p no:sugar -p no:xdist -p no:cov -p no:split"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatchling.build"]
 build-backend = "hatchling.build"
 
 


### PR DESCRIPTION
## Closing this PR

This fix was incorrect. As CodeRabbit correctly identified, `hatchling.build` is a module path, not a PyPI package. Adding it to `build-system.requires` would cause a different error.

## Root Cause

The `ModuleNotFoundError: No module named 'hatchling.build'` error is a known uv issue (#16228) caused by a corrupted build cache - not a missing dependency.

## Correct Fix

Clear the uv cache before building:

```bash
# If using Docker/Podman cache mount
podman builder prune -a --external

# Or clear uv cache
uv cache clean
```

For Podman specifically, resetting the machine may be needed:
```bash
podman machine reset
```

The `build-system.requires = ["hatchling"]` configuration is correct and should not be changed.