### PR TITLE
feat: Add Noveum.ai tracing integration

### DIFF
--- a/docs/docs/Develop/integrations-noveum.mdx
+++ b/docs/docs/Develop/integrations-noveum.mdx
@@ -1,0 +1,87 @@
+---
+title: Noveum
+slug: /integrations-noveum
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+[Noveum.ai](https://noveum.ai) is a platform for LLM observability and tracing. It provides tracing and monitoring capabilities for AI applications, helping developers debug, analyze, and optimize their AI systems. Noveum integrates with various tools and frameworks, including workflow builders and runtimes like Langflow.
+
+This guide explains how to configure Langflow to collect tracing data about your flow executions and automatically send the data to Noveum.ai.
+
+## Prerequisites
+
+- An account on [Noveum.ai](https://noveum.ai)
+- A [running Langflow server](/get-started-installation) with a [flow](/concepts-flows) that you want to trace
+
+:::tip
+If you need a flow to test the Noveum integration, see the [Langflow quickstart](/get-started-quickstart).
+:::
+
+## Set Noveum credentials as environment variables {#noveum-credentials}
+
+1. Create an account on [Noveum.ai](https://noveum.ai) if you haven't already.
+
+2. Get your API key from your Noveum.ai account dashboard.
+
+3. Set your Noveum project credentials as environment variables in the same environment where you run Langflow.
+
+    In the following examples, replace `API_KEY`, `ENVIRONMENT`, and `PROJECT` with your values from Noveum.ai.
+
+    <Tabs>
+    <TabItem value="linux-macos" label="Linux or macOS" default>
+
+    These commands set the environment variables in a Linux or macOS terminal session:
+
+    ```
+    export NOVEUM_API_KEY=API_KEY
+    export NOVEUM_ENVIRONMENT=ENVIRONMENT
+    export NOVEUM_PROJECT=PROJECT
+    ```
+
+    :::note
+    `NOVEUM_PROJECT` is optional but recommended. If not set, Langflow will use the project name from the flow configuration.
+    :::
+
+    </TabItem>
+    <TabItem value="windows" label="Windows">
+
+    These commands set the environment variables in a Windows command prompt session:
+
+    ```
+    set NOVEUM_API_KEY=API_KEY
+    set NOVEUM_ENVIRONMENT=ENVIRONMENT
+    set NOVEUM_PROJECT=PROJECT
+    ```
+
+    :::note
+    `NOVEUM_PROJECT` is optional but recommended. If not set, Langflow will use the project name from the flow configuration.
+    :::
+
+    </TabItem>
+    </Tabs>
+
+## Start Langflow and view traces in Noveum
+
+1. Start Langflow in the same environment where you set the Noveum environment variables:
+
+    ```bash
+    uv run langflow run
+    ```
+
+2. Run a flow.
+
+    Langflow automatically collects and sends tracing data about the flow execution to Noveum.ai.
+
+3. View the collected data in your [Noveum.ai dashboard](https://noveum.ai).
+
+    You can find your traces at [noveum.ai](https://noveum.ai) in your project dashboard.
+
+## Disable Noveum tracing
+
+To disable the Noveum integration, remove the [Noveum environment variables](#noveum-credentials), and then restart Langflow.
+
+## See also
+
+* [Noveum.ai website](https://noveum.ai)

--- a/docs/docs/Develop/integrations-noveum.mdx
+++ b/docs/docs/Develop/integrations-noveum.mdx
@@ -1,6 +1,8 @@
 ---
 title: Noveum
 slug: /integrations-noveum
+description: Configure Langflow to send tracing data to Noveum.ai for LLM observability and monitoring.
+sidebar_position: 5
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -138,6 +138,7 @@ module.exports = {
                 "Develop/integrations-langfuse",
                 "Develop/integrations-langsmith",
                 "Develop/integrations-langwatch",
+                "Develop/integrations-noveum",
                 "Develop/integrations-opik",
                 "Develop/integrations-instana-traceloop",
               ],

--- a/src/backend/base/langflow/services/tracing/noveum_trace.py
+++ b/src/backend/base/langflow/services/tracing/noveum_trace.py
@@ -16,8 +16,8 @@ try:
     import noveum_trace
     from noveum_trace import NoveumClient
     from noveum_trace.core import _register_client
-    from noveum_trace.integrations.langchain import NoveumTraceCallbackHandler
     from noveum_trace.core.context import set_current_trace
+    from noveum_trace.integrations.langchain import NoveumTraceCallbackHandler
 except ImportError:
     noveum_trace = None  # type: ignore[assignment]
     NoveumClient = None  # type: ignore[assignment, misc]
@@ -47,7 +47,7 @@ class NoveumTracer(BaseTracer):
         project_name: str,
         trace_id: UUID,
         user_id: str | None = None,
-        session_id: str | None = None,      
+        session_id: str | None = None,
     ) -> None:
         """Initialize the Noveum.ai tracer.
 
@@ -87,8 +87,9 @@ class NoveumTracer(BaseTracer):
         """
         try:
             if noveum_trace is None:
-                raise ImportError("noveum_trace not available")
-            
+                msg = "noveum_trace not available"
+                raise ImportError(msg)
+
             # Always create a new client for this tracer
             logger.debug("Creating new NoveumClient instance")
             self._client = NoveumClient(
@@ -97,16 +98,16 @@ class NoveumTracer(BaseTracer):
                 environment=config["environment"],
                 endpoint=config.get("endpoint"),
             )
-            
+
             _register_client(self._client)
-            
+
             if hasattr(noveum_trace, "_client_lock"):
                 with noveum_trace._client_lock:
                     noveum_trace._client = self._client
             else:
                 # Fallback: set directly if lock doesn't exist
                 noveum_trace._client = self._client
-            
+
             logger.debug("setup_noveum was called, a new trace will be created.")
 
             # Create the main trace for this graph run
@@ -115,7 +116,7 @@ class NoveumTracer(BaseTracer):
                 "trace_type": self.trace_type,
                 "flow_id": self.flow_id,
             }
-            
+
             # Add user_id and session_id to metadata if provided
             if self.user_id:
                 trace_attributes["user_id"] = self.user_id
@@ -136,17 +137,16 @@ class NoveumTracer(BaseTracer):
 
             logger.debug("Noveum.ai Trace initialized successfully")
             logger.debug(f"Trace {self.trace.trace_id} set in context for callback handler")
-            return True
 
         except ImportError:
-            logger.exception(
-                "Could not import noveum_trace. Please install it with `pip install noveum-trace`."
-            )
+            logger.exception("Could not import noveum_trace. Please install it with `pip install noveum-trace`.")
             return False
 
         except Exception as e:  # noqa: BLE001
             logger.debug(f"Error setting up Noveum.ai Trace: {e}")
             return False
+        else:
+            return True
 
     @override
     def add_trace(
@@ -199,9 +199,11 @@ class NoveumTracer(BaseTracer):
                     parent_span_id = parent_span.span_id
                     logger.debug(f"Found parent span {parent_span_id} for component {name} (from {edge.source_id})")
                     break  # Use first found parent
-            
+
             if parent_span_id is None and vertex.incoming_edges:
-                logger.debug(f"No parent span found for component {name} despite {len(vertex.incoming_edges)} incoming edges")
+                logger.debug(
+                    f"No parent span found for component {name} despite {len(vertex.incoming_edges)} incoming edges"
+                )
 
         try:
             # Create component span with proper parent relationship
@@ -291,7 +293,7 @@ class NoveumTracer(BaseTracer):
         try:
             # Update trace attributes with final inputs/outputs (JSON-serializable)
             trace_attributes = {}
-            
+
             if inputs:
                 trace_attributes["final_inputs"] = self._ensure_json_serializable(serialize(inputs))
             if outputs:
@@ -391,9 +393,10 @@ class NoveumTracer(BaseTracer):
         # Try to serialize the entire object first
         try:
             json.dumps(obj)
-            return obj
         except (TypeError, ValueError, OverflowError):
             pass  # Continue to recursive cleaning
+        else:
+            return obj
 
         # Handle dictionaries recursively
         if isinstance(obj, dict):
@@ -410,14 +413,14 @@ class NoveumTracer(BaseTracer):
 
         # Handle lists and tuples recursively
         if isinstance(obj, (list, tuple)):
-            result = []
+            result_list = []
             for i, item in enumerate(obj):
                 try:
-                    result.append(self._ensure_json_serializable(item, depth + 1, max_depth))
+                    result_list.append(self._ensure_json_serializable(item, depth + 1, max_depth))
                 except Exception as e:  # noqa: BLE001
                     logger.warning(f"Failed to serialize list item at index {i}: {e}")
-                    result.append(f"<Non-serializable: {type(item).__name__}>")
-            return result
+                    result_list.append(f"<Non-serializable: {type(item).__name__}>")
+            return result_list
 
         # For other types, return a type descriptor
         type_name = type(obj).__name__

--- a/src/backend/base/langflow/services/tracing/noveum_trace.py
+++ b/src/backend/base/langflow/services/tracing/noveum_trace.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from collections import OrderedDict
 from datetime import datetime, timezone
@@ -179,8 +180,8 @@ class NoveumTracer(BaseTracer):
         # Clean up component name (remove ID suffix)
         name = trace_name.removesuffix(f" ({trace_id})")
 
-        # Serialize inputs for tracing
-        serialized_inputs = serialize(inputs)
+        # Serialize inputs for tracing and ensure JSON-serializable
+        serialized_inputs = self._ensure_json_serializable(serialize(inputs))
 
         # Create span attributes combining inputs and metadata
         span_attributes = {
@@ -188,17 +189,32 @@ class NoveumTracer(BaseTracer):
             "inputs": serialized_inputs,
         }
 
+        # Determine parent span based on incoming edges (execution flow)
+        parent_span_id = None
+        if vertex and vertex.incoming_edges:
+            # Find spans of components that triggered this one
+            for edge in vertex.incoming_edges:
+                parent_span = self.spans.get(edge.source_id)
+                if parent_span:
+                    parent_span_id = parent_span.span_id
+                    logger.debug(f"Found parent span {parent_span_id} for component {name} (from {edge.source_id})")
+                    break  # Use first found parent
+            
+            if parent_span_id is None and vertex.incoming_edges:
+                logger.debug(f"No parent span found for component {name} despite {len(vertex.incoming_edges)} incoming edges")
+
         try:
-            # Create component span under the main trace
+            # Create component span with proper parent relationship
             span = self.trace.create_span(
                 name=name,
                 attributes=span_attributes,
                 start_time=start_time,
+                parent_span_id=parent_span_id,
             )
 
             # Store the span for later retrieval
             self.spans[trace_id] = span
-            logger.debug(f"Created span {span.span_id} for component {name} in trace {self.trace.trace_id}")
+            logger.debug(f"Created span {span.span_id} for component {name} with parent {parent_span_id}")
 
         except Exception as e:  # noqa: BLE001
             logger.debug(f"Error creating span for component {trace_name}: {e}")
@@ -232,11 +248,11 @@ class NoveumTracer(BaseTracer):
             return
 
         try:
-            # Build output data
+            # Build output data with JSON-serializable validation
             output_data: dict = {}
-            output_data |= serialize(outputs) if outputs else {}
+            output_data |= self._ensure_json_serializable(serialize(outputs)) if outputs else {}
             output_data |= {"error": str(error)} if error else {}
-            output_data |= {"logs": [serialize(log) for log in logs]} if logs else {}
+            output_data |= {"logs": [self._ensure_json_serializable(serialize(log)) for log in logs]} if logs else {}
 
             # Set span attributes for outputs
             if output_data:
@@ -273,15 +289,15 @@ class NoveumTracer(BaseTracer):
             return
 
         try:
-            # Update trace attributes with final inputs/outputs
+            # Update trace attributes with final inputs/outputs (JSON-serializable)
             trace_attributes = {}
             
             if inputs:
-                trace_attributes["final_inputs"] = serialize(inputs)
+                trace_attributes["final_inputs"] = self._ensure_json_serializable(serialize(inputs))
             if outputs:
-                trace_attributes["final_outputs"] = serialize(outputs)
+                trace_attributes["final_outputs"] = self._ensure_json_serializable(serialize(outputs))
             if metadata:
-                trace_attributes["final_metadata"] = serialize(metadata)
+                trace_attributes["final_metadata"] = self._ensure_json_serializable(serialize(metadata))
             if error:
                 trace_attributes["error"] = str(error)
 
@@ -348,3 +364,62 @@ class NoveumTracer(BaseTracer):
             return config
 
         return {}
+
+    def _ensure_json_serializable(self, obj: Any, depth: int = 0, max_depth: int = 20) -> Any:
+        """Ensure object is JSON-serializable, replacing non-serializable parts.
+
+        This provides a first line of defense against non-serializable objects
+        before they reach the noveum-trace SDK.
+
+        Args:
+            obj: Object to validate and clean
+            depth: Current recursion depth
+            max_depth: Maximum recursion depth to prevent infinite loops
+
+        Returns:
+            JSON-serializable version of the object
+        """
+        # Prevent infinite recursion
+        if depth > max_depth:
+            logger.warning(f"Max recursion depth ({max_depth}) reached during JSON serialization")
+            return f"<Max depth exceeded: {type(obj).__name__}>"
+
+        # Quick test for primitives
+        if obj is None or isinstance(obj, (str, int, float, bool)):
+            return obj
+
+        # Try to serialize the entire object first
+        try:
+            json.dumps(obj)
+            return obj
+        except (TypeError, ValueError, OverflowError):
+            pass  # Continue to recursive cleaning
+
+        # Handle dictionaries recursively
+        if isinstance(obj, dict):
+            result = {}
+            for key, value in obj.items():
+                try:
+                    # Ensure key is string
+                    str_key = str(key) if not isinstance(key, str) else key
+                    result[str_key] = self._ensure_json_serializable(value, depth + 1, max_depth)
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(f"Failed to serialize dict key '{key}': {e}")
+                    result[str(key)] = f"<Non-serializable: {type(value).__name__}>"
+            return result
+
+        # Handle lists and tuples recursively
+        if isinstance(obj, (list, tuple)):
+            result = []
+            for i, item in enumerate(obj):
+                try:
+                    result.append(self._ensure_json_serializable(item, depth + 1, max_depth))
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(f"Failed to serialize list item at index {i}: {e}")
+                    result.append(f"<Non-serializable: {type(item).__name__}>")
+            return result
+
+        # For other types, return a type descriptor
+        type_name = type(obj).__name__
+        logger.debug(f"Replacing non-serializable object of type {type_name}")
+        return f"<Non-serializable: {type_name}>"

--- a/src/backend/base/langflow/services/tracing/noveum_trace.py
+++ b/src/backend/base/langflow/services/tracing/noveum_trace.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import os
+from collections import OrderedDict
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from lfx.log.logger import logger
+from typing_extensions import override
+
+from langflow.serialization.serialization import serialize
+from langflow.services.tracing.base import BaseTracer
+
+try:
+    import noveum_trace
+    from noveum_trace import NoveumClient
+    from noveum_trace.core import _register_client
+    from noveum_trace.integrations.langchain import NoveumTraceCallbackHandler
+    from noveum_trace.core.context import set_current_trace
+except ImportError:
+    noveum_trace = None  # type: ignore[assignment]
+    NoveumClient = None  # type: ignore[assignment, misc]
+    _register_client = None  # type: ignore[assignment, misc]
+    NoveumTraceCallbackHandler = None  # type: ignore[assignment, misc]
+    set_current_trace = None  # type: ignore[assignment, misc]
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from uuid import UUID
+
+    from langchain.callbacks.base import BaseCallbackHandler
+    from lfx.graph.vertex.base import Vertex
+
+    from langflow.services.tracing.schema import Log
+
+
+class NoveumTracer(BaseTracer):
+    """Tracer implementation for Noveum.ai Trace SDK integration."""
+
+    flow_id: str
+
+    def __init__(
+        self,
+        trace_name: str,
+        trace_type: str,
+        project_name: str,
+        trace_id: UUID,
+        user_id: str | None = None,
+        session_id: str | None = None,      
+    ) -> None:
+        """Initialize the Noveum.ai tracer.
+
+        Args:
+            trace_name: Name of the trace (flow name + flow id)
+            trace_type: Type of trace (e.g., "chain")
+            project_name: Project name for organizing traces
+            trace_id: Unique identifier for this trace
+            user_id: Optional user identifier
+            session_id: Optional session identifier
+        """
+        self.project_name = project_name
+        self.trace_name = trace_name
+        self.trace_type = trace_type
+        self.trace_id = trace_id
+        self.user_id = user_id
+        self.session_id = session_id
+        self.flow_id = trace_name.split(" - ")[-1]
+        self.spans: dict = OrderedDict()  # spans that are not ended
+
+        config = self._get_config()
+        self._ready: bool = self.setup_noveum(config) if config else False
+
+    @property
+    def ready(self):
+        """Check if the tracer is ready to trace."""
+        return self._ready
+
+    def setup_noveum(self, config: dict) -> bool:
+        """Setup the Noveum.ai Trace client and initialize the main trace.
+
+        Args:
+            config: Configuration dictionary with api_key, project, environment, endpoint
+
+        Returns:
+            True if setup was successful, False otherwise
+        """
+        try:
+            if noveum_trace is None:
+                raise ImportError("noveum_trace not available")
+            
+            # Always create a new client for this tracer
+            logger.debug("Creating new NoveumClient instance")
+            self._client = NoveumClient(
+                api_key=config["api_key"],
+                project=config["project"],
+                environment=config["environment"],
+                endpoint=config.get("endpoint"),
+            )
+            
+            _register_client(self._client)
+            
+            if hasattr(noveum_trace, "_client_lock"):
+                with noveum_trace._client_lock:
+                    noveum_trace._client = self._client
+            else:
+                # Fallback: set directly if lock doesn't exist
+                noveum_trace._client = self._client
+            
+            logger.debug("setup_noveum was called, a new trace will be created.")
+
+            # Create the main trace for this graph run
+            # Prepare trace attributes including metadata
+            trace_attributes = {
+                "trace_type": self.trace_type,
+                "flow_id": self.flow_id,
+            }
+            
+            # Add user_id and session_id to metadata if provided
+            if self.user_id:
+                trace_attributes["user_id"] = self.user_id
+            if self.session_id:
+                trace_attributes["session_id"] = self.session_id
+
+            self.trace = self._client.start_trace(
+                name=self.flow_id,
+                attributes=trace_attributes,
+            )
+
+            # Set the trace in the context so the callback handler can use it
+            # This ensures LangChain operations are traced under our main trace
+            set_current_trace(self.trace)
+
+            # Create the callback handler and associate it with the trace
+            self._callback_handler = NoveumTraceCallbackHandler()
+
+            logger.debug("Noveum.ai Trace initialized successfully")
+            logger.debug(f"Trace {self.trace.trace_id} set in context for callback handler")
+            return True
+
+        except ImportError:
+            logger.exception(
+                "Could not import noveum_trace. Please install it with `pip install noveum-trace`."
+            )
+            return False
+
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Error setting up Noveum.ai Trace: {e}")
+            return False
+
+    @override
+    def add_trace(
+        self,
+        trace_id: str,  # actually component id
+        trace_name: str,
+        trace_type: str,
+        inputs: dict[str, Any],
+        metadata: dict[str, Any] | None = None,
+        vertex: Vertex | None = None,
+    ) -> None:
+        """Start tracing a component execution by creating a span.
+
+        Args:
+            trace_id: Component ID
+            trace_name: Component name (with ID suffix)
+            trace_type: Type of component
+            inputs: Component inputs
+            metadata: Additional metadata
+            vertex: Graph vertex (optional)
+        """
+        start_time = datetime.now(tz=timezone.utc)
+        if not self._ready:
+            return
+
+        # Build metadata attributes
+        metadata_: dict = {"from_langflow_component": True, "component_id": trace_id}
+        metadata_ |= {"trace_type": trace_type} if trace_type else {}
+        metadata_ |= metadata or {}
+
+        # Clean up component name (remove ID suffix)
+        name = trace_name.removesuffix(f" ({trace_id})")
+
+        # Serialize inputs for tracing
+        serialized_inputs = serialize(inputs)
+
+        # Create span attributes combining inputs and metadata
+        span_attributes = {
+            **metadata_,
+            "inputs": serialized_inputs,
+        }
+
+        try:
+            # Create component span under the main trace
+            span = self.trace.create_span(
+                name=name,
+                attributes=span_attributes,
+                start_time=start_time,
+            )
+
+            # Store the span for later retrieval
+            self.spans[trace_id] = span
+            logger.debug(f"Created span {span.span_id} for component {name} in trace {self.trace.trace_id}")
+
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Error creating span for component {trace_name}: {e}")
+
+    @override
+    def end_trace(
+        self,
+        trace_id: str,
+        trace_name: str,
+        outputs: dict[str, Any] | None = None,
+        error: Exception | None = None,
+        logs: Sequence[Log | dict] = (),
+    ) -> None:
+        """End tracing a component execution by finishing its span.
+
+        Args:
+            trace_id: Component ID
+            trace_name: Component name
+            outputs: Component outputs
+            error: Exception if component failed
+            logs: Execution logs
+        """
+        end_time = datetime.now(tz=timezone.utc)
+        if not self._ready:
+            return
+
+        # Retrieve and remove the span
+        span = self.spans.pop(trace_id, None)
+        if not span:
+            logger.debug(f"No span found for component {trace_name}")
+            return
+
+        try:
+            # Build output data
+            output_data: dict = {}
+            output_data |= serialize(outputs) if outputs else {}
+            output_data |= {"error": str(error)} if error else {}
+            output_data |= {"logs": [serialize(log) for log in logs]} if logs else {}
+
+            # Set span attributes for outputs
+            if output_data:
+                span.set_attributes({"outputs": output_data})
+
+            # Set error status if there was an error
+            if error:
+                span.set_status("error", str(error))
+
+            # Finish the span
+            span.finish(end_time=end_time)
+            logger.debug(f"Finished span {span.span_id} for component {trace_name}")
+
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Error ending span for component {trace_name}: {e}")
+
+    @override
+    def end(
+        self,
+        inputs: dict[str, Any],
+        outputs: dict[str, Any],
+        error: Exception | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Finalize the main trace for the graph run.
+
+        Args:
+            inputs: Graph inputs
+            outputs: Graph outputs
+            error: Exception if graph failed
+            metadata: Additional metadata
+        """
+        if not self._ready:
+            return
+
+        try:
+            # Update trace attributes with final inputs/outputs
+            trace_attributes = {}
+            
+            if inputs:
+                trace_attributes["final_inputs"] = serialize(inputs)
+            if outputs:
+                trace_attributes["final_outputs"] = serialize(outputs)
+            if metadata:
+                trace_attributes["final_metadata"] = serialize(metadata)
+            if error:
+                trace_attributes["error"] = str(error)
+
+            if trace_attributes:
+                self.trace.set_attributes(trace_attributes)
+
+            # Set error status if there was an error
+            if error:
+                self.trace.set_status("error", str(error))
+
+            # Finish and export the trace using client.finish_trace()
+            self._client.finish_trace(self.trace)
+            logger.debug(f"Finished and exported trace {self.trace.trace_id} via client.finish_trace()")
+
+            # Flush the client to ensure all data is sent
+            if hasattr(self._client, "flush"):
+                self._client.flush()
+                logger.debug("Flushed client after trace completion")
+
+            # Shutdown the client
+            # NoveumClient has a shutdown() method that flushes all pending data and cleans up resources
+            try:
+                self._client.shutdown()
+                logger.debug("Shutdown NoveumClient after trace completion")
+            except Exception as e:  # noqa: BLE001
+                logger.debug(f"Error shutting down NoveumClient: {e}")
+
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Error finalizing trace: {e}")
+
+    def get_langchain_callback(self) -> BaseCallbackHandler | None:
+        """Get the LangChain callback handler for tracing LangChain operations.
+
+        Returns:
+            NoveumTraceCallbackHandler instance or None if not ready
+        """
+        if not self._ready:
+            return None
+
+        return self._callback_handler
+
+    def _get_config(self) -> dict:
+        """Read configuration from environment variables, falling back to instance parameters.
+
+        Returns:
+            Configuration dictionary with api_key, project, environment, endpoint
+            Empty dict if required variables are missing
+        """
+        api_key = os.getenv("NOVEUM_API_KEY", None)
+        project = os.getenv("NOVEUM_PROJECT", None) or self.project_name
+        environment = os.getenv("NOVEUM_ENVIRONMENT", None)
+        endpoint = os.getenv("NOVEUM_ENDPOINT", None)
+
+        # All three required variables must be present (project can come from env var or parameter)
+        if api_key and project and environment:
+            config = {
+                "api_key": api_key,
+                "project": project,
+                "environment": environment,
+            }
+            # Add endpoint if provided (otherwise NoveumClient will use default)
+            if endpoint:
+                config["endpoint"] = endpoint
+            return config
+
+        return {}

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -59,6 +59,12 @@ def _get_traceloop_tracer():
     return TraceloopTracer
 
 
+def _get_noveum_tracer():
+    from langflow.services.tracing.noveum_trace import NoveumTracer
+
+    return NoveumTracer
+
+
 trace_context_var: ContextVar[TraceContext | None] = ContextVar("trace_context", default=None)
 component_context_var: ContextVar[ComponentTraceContext | None] = ContextVar("component_trace_context", default=None)
 
@@ -220,6 +226,19 @@ class TracingService(Service):
             session_id=trace_context.session_id,
         )
 
+    def _initialize_noveum_trace_tracer(self, trace_context: TraceContext) -> None:
+        if self.deactivated:
+            return
+        noveum_tracer = _get_noveum_tracer()
+        trace_context.tracers["noveum_trace"] = noveum_tracer(
+            trace_name=trace_context.run_name,
+            trace_type="chain",
+            project_name=trace_context.project_name,
+            trace_id=trace_context.run_id,
+            user_id=trace_context.user_id,
+            session_id=trace_context.session_id,
+        )
+
     async def start_tracers(
         self,
         run_id: UUID,
@@ -247,6 +266,7 @@ class TracingService(Service):
             self._initialize_arize_phoenix_tracer(trace_context)
             self._initialize_opik_tracer(trace_context)
             self._initialize_traceloop_tracer(trace_context)
+            self._initialize_noveum_trace_tracer(trace_context)
         except Exception as e:  # noqa: BLE001
             await logger.adebug(f"Error initializing tracers: {e}")
 

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -324,6 +324,7 @@ langchain-mcp-adapters = ["langchain-mcp-adapters>=0.1.14,<0.2.0"]
 # Additional monitoring
 opik = ["opik>=1.6.3,<2.0.0"]
 traceloop = ["traceloop-sdk>=0.43.1,<1.0.0"]
+noveum = ["noveum-trace>=0.1.0"]
 
 # Document processing / OCR
 docling = [
@@ -451,6 +452,7 @@ complete = [
     # Additional monitoring
     "langflow-base[opik]",
     "langflow-base[traceloop]",
+    "langflow-base[noveum]",
     # Document processing / OCR
     "langflow-base[docling]",
     "langflow-base[easyocr]",

--- a/src/backend/tests/unit/services/tracing/test_noveum_trace.py
+++ b/src/backend/tests/unit/services/tracing/test_noveum_trace.py
@@ -1,0 +1,943 @@
+"""Unit tests for NoveumTracer."""
+
+import os
+import uuid
+from collections import OrderedDict
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langflow.services.tracing.noveum_trace import NoveumTracer
+
+
+@pytest.fixture
+def sample_trace_id():
+    """Generate a sample trace ID for testing."""
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def sample_trace_name():
+    """Sample trace name for testing."""
+    return "Test Flow - flow_123"
+
+
+@pytest.fixture
+def sample_config():
+    """Sample configuration dict for testing."""
+    return {
+        "api_key": "test_api_key",
+        "project": "test_project",
+        "environment": "test_environment",
+        "endpoint": "https://test.endpoint.com",
+    }
+
+
+@pytest.fixture
+def mock_noveum_modules():
+    """Mock all noveum_trace imports."""
+    mock_client_class = MagicMock()
+    mock_client_instance = MagicMock()
+    mock_client_class.return_value = mock_client_instance
+
+    mock_trace = MagicMock()
+    mock_trace.trace_id = "test_trace_id"
+    mock_client_instance.start_trace.return_value = mock_trace
+
+    mock_callback_handler = MagicMock()
+    mock_register_client = MagicMock()
+    mock_set_current_trace = MagicMock()
+
+    mock_noveum_module = MagicMock()
+    mock_noveum_module._client = None
+    mock_noveum_module._client_lock = MagicMock()
+
+    with (
+        patch("langflow.services.tracing.noveum_trace.noveum_trace", mock_noveum_module),
+        patch("langflow.services.tracing.noveum_trace.NoveumClient", mock_client_class),
+        patch("langflow.services.tracing.noveum_trace._register_client", mock_register_client),
+        patch("langflow.services.tracing.noveum_trace.set_current_trace", mock_set_current_trace),
+        patch("langflow.services.tracing.noveum_trace.NoveumTraceCallbackHandler", return_value=mock_callback_handler),
+    ):
+        yield {
+            "client_class": mock_client_class,
+            "client_instance": mock_client_instance,
+            "trace": mock_trace,
+            "callback_handler": mock_callback_handler,
+            "register_client": mock_register_client,
+            "set_current_trace": mock_set_current_trace,
+            "noveum_module": mock_noveum_module,
+        }
+
+
+@pytest.fixture
+def mock_span():
+    """Mock span object with required methods."""
+    span = MagicMock()
+    span.span_id = "test_span_id"
+    span.set_attributes = MagicMock()
+    span.set_status = MagicMock()
+    span.finish = MagicMock()
+    return span
+
+
+class TestNoveumTracerInit:
+    """Test NoveumTracer initialization."""
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_init_successful_with_config(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test successful initialization with valid config."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        assert tracer.trace_name == sample_trace_name
+        assert tracer.trace_type == "chain"
+        assert tracer.project_name == "test_project"
+        assert tracer.trace_id == sample_trace_id
+        assert tracer.flow_id == "flow_123"
+        assert isinstance(tracer.spans, OrderedDict)
+        assert tracer._ready is True
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_init_without_config(self, sample_trace_id, sample_trace_name):
+        """Test initialization without config."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        assert tracer._ready is False
+        assert tracer.flow_id == "flow_123"
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_init_with_user_id_and_session_id(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test initialization with user_id and session_id."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+            user_id="user_123",
+            session_id="session_456",
+        )
+
+        assert tracer.user_id == "user_123"
+        assert tracer.session_id == "session_456"
+        assert tracer._ready is True
+
+
+class TestNoveumTracerGetConfig:
+    """Test _get_config method."""
+
+    def test_get_config_all_env_vars_present(self, sample_trace_id, sample_trace_name):
+        """Test _get_config with all environment variables present."""
+        with patch.dict(
+            os.environ,
+            {
+                "NOVEUM_API_KEY": "test_key",
+                "NOVEUM_PROJECT": "test_project",
+                "NOVEUM_ENVIRONMENT": "test_env",
+                "NOVEUM_ENDPOINT": "https://test.endpoint.com",
+            },
+        ):
+            tracer = NoveumTracer(
+                trace_name=sample_trace_name,
+                trace_type="chain",
+                project_name="test_project",
+                trace_id=sample_trace_id,
+            )
+            config = tracer._get_config()
+
+            assert config["api_key"] == "test_key"
+            assert config["project"] == "test_project"
+            assert config["environment"] == "test_env"
+            assert config["endpoint"] == "https://test.endpoint.com"
+
+    def test_get_config_missing_api_key(self, sample_trace_id, sample_trace_name):
+        """Test _get_config with missing NOVEUM_API_KEY."""
+        with patch.dict(os.environ, {"NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}, clear=True):
+            tracer = NoveumTracer(
+                trace_name=sample_trace_name,
+                trace_type="chain",
+                project_name="test_project",
+                trace_id=sample_trace_id,
+            )
+            config = tracer._get_config()
+
+            assert config == {}
+
+    def test_get_config_missing_environment(self, sample_trace_id, sample_trace_name):
+        """Test _get_config with missing NOVEUM_ENVIRONMENT."""
+        with patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project"}, clear=True):
+            tracer = NoveumTracer(
+                trace_name=sample_trace_name,
+                trace_type="chain",
+                project_name="test_project",
+                trace_id=sample_trace_id,
+            )
+            config = tracer._get_config()
+
+            assert config == {}
+
+    def test_get_config_project_fallback(self, sample_trace_id, sample_trace_name):
+        """Test _get_config project fallback to instance parameter."""
+        with patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_ENVIRONMENT": "test_env"}, clear=True):
+            tracer = NoveumTracer(
+                trace_name=sample_trace_name,
+                trace_type="chain",
+                project_name="fallback_project",
+                trace_id=sample_trace_id,
+            )
+            config = tracer._get_config()
+
+            assert config["project"] == "fallback_project"
+
+    def test_get_config_endpoint_optional(self, sample_trace_id, sample_trace_name):
+        """Test _get_config with optional endpoint."""
+        with patch.dict(
+            os.environ,
+            {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"},
+            clear=True,
+        ):
+            tracer = NoveumTracer(
+                trace_name=sample_trace_name,
+                trace_type="chain",
+                project_name="test_project",
+                trace_id=sample_trace_id,
+            )
+            config = tracer._get_config()
+
+            assert "endpoint" not in config
+            assert config["api_key"] == "test_key"
+            assert config["project"] == "test_project"
+            assert config["environment"] == "test_env"
+
+
+class TestNoveumTracerSetupNoveum:
+    """Test setup_noveum method."""
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_setup_noveum_successful(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test successful setup_noveum."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_client_class = mock_noveum_modules["client_class"]
+        mock_client_instance = mock_noveum_modules["client_instance"]
+        mock_register_client = mock_noveum_modules["register_client"]
+        mock_set_current_trace = mock_noveum_modules["set_current_trace"]
+        mock_noveum_module = mock_noveum_modules["noveum_module"]
+
+        assert tracer._ready is True
+        mock_client_class.assert_called_once_with(
+            api_key="test_key",
+            project="test_project",
+            environment="test_env",
+            endpoint=None,
+        )
+        mock_register_client.assert_called_once_with(mock_client_instance)
+        mock_set_current_trace.assert_called_once()
+        mock_client_instance.start_trace.assert_called_once()
+        assert mock_noveum_module._client == mock_client_instance
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_setup_noveum_with_user_id_and_session_id(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test setup_noveum with user_id and session_id."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+            user_id="user_123",
+            session_id="session_456",
+        )
+
+        mock_client_instance = mock_noveum_modules["client_instance"]
+        call_args = mock_client_instance.start_trace.call_args
+
+        assert call_args is not None
+        attributes = call_args[1]["attributes"]
+        assert attributes["user_id"] == "user_123"
+        assert attributes["session_id"] == "session_456"
+        assert attributes["trace_type"] == "chain"
+        assert attributes["flow_id"] == "flow_123"
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_setup_noveum_without_user_id_and_session_id(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test setup_noveum without user_id and session_id."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_client_instance = mock_noveum_modules["client_instance"]
+        call_args = mock_client_instance.start_trace.call_args
+
+        assert call_args is not None
+        attributes = call_args[1]["attributes"]
+        assert "user_id" not in attributes
+        assert "session_id" not in attributes
+        assert attributes["trace_type"] == "chain"
+        assert attributes["flow_id"] == "flow_123"
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_setup_noveum_import_error(self, sample_trace_id, sample_trace_name):
+        """Test setup_noveum with ImportError."""
+        with patch("langflow.services.tracing.noveum_trace.noveum_trace", None):
+            with patch("langflow.services.tracing.noveum_trace.logger") as mock_logger:
+                tracer = NoveumTracer(
+                    trace_name=sample_trace_name,
+                    trace_type="chain",
+                    project_name="test_project",
+                    trace_id=sample_trace_id,
+                )
+
+                assert tracer._ready is False
+                mock_logger.exception.assert_called()
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_setup_noveum_general_exception(self, sample_trace_id, sample_trace_name):
+        """Test setup_noveum with general exception."""
+        with patch("langflow.services.tracing.noveum_trace.NoveumClient", side_effect=Exception("Test error")):
+            with patch("langflow.services.tracing.noveum_trace.logger") as mock_logger:
+                tracer = NoveumTracer(
+                    trace_name=sample_trace_name,
+                    trace_type="chain",
+                    project_name="test_project",
+                    trace_id=sample_trace_id,
+                )
+
+                assert tracer._ready is False
+                mock_logger.debug.assert_called()
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_setup_noveum_with_client_lock(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test setup_noveum with _client_lock attribute."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_noveum_module = mock_noveum_modules["noveum_module"]
+        assert hasattr(mock_noveum_module, "_client_lock")
+        assert mock_noveum_module._client is not None
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_setup_noveum_without_client_lock(self, sample_trace_id, sample_trace_name):
+        """Test setup_noveum without _client_lock attribute (fallback path)."""
+        mock_noveum_module = MagicMock()
+        mock_noveum_module._client = None
+        # Don't set _client_lock
+
+        mock_client_class = MagicMock()
+        mock_client_instance = MagicMock()
+        mock_trace = MagicMock()
+        mock_client_instance.start_trace.return_value = mock_trace
+        mock_client_class.return_value = mock_client_instance
+
+        with (
+            patch("langflow.services.tracing.noveum_trace.noveum_trace", mock_noveum_module),
+            patch("langflow.services.tracing.noveum_trace.NoveumClient", mock_client_class),
+            patch("langflow.services.tracing.noveum_trace._register_client", MagicMock()),
+            patch("langflow.services.tracing.noveum_trace.set_current_trace", MagicMock()),
+            patch("langflow.services.tracing.noveum_trace.NoveumTraceCallbackHandler", return_value=MagicMock()),
+        ):
+            tracer = NoveumTracer(
+                trace_name=sample_trace_name,
+                trace_type="chain",
+                project_name="test_project",
+                trace_id=sample_trace_id,
+            )
+
+            assert tracer._ready is True
+            assert mock_noveum_module._client == mock_client_instance
+
+
+class TestNoveumTracerAddTrace:
+    """Test add_trace method."""
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_add_trace_successful(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test successful span creation."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_trace = mock_noveum_modules["trace"]
+        mock_span = MagicMock()
+        mock_span.span_id = "test_span_id"
+        mock_trace.create_span.return_value = mock_span
+
+        inputs = {"input_key": "input_value"}
+        metadata = {"custom_meta": "value"}
+
+        tracer.add_trace(
+            trace_id="component_123",
+            trace_name="Test Component (component_123)",
+            trace_type="component",
+            inputs=inputs,
+            metadata=metadata,
+        )
+
+        assert "component_123" in tracer.spans
+        assert tracer.spans["component_123"] == mock_span
+        mock_trace.create_span.assert_called_once()
+        call_kwargs = mock_trace.create_span.call_args[1]
+        assert call_kwargs["name"] == "Test Component"
+        assert call_kwargs["attributes"]["from_langflow_component"] is True
+        assert call_kwargs["attributes"]["component_id"] == "component_123"
+        assert call_kwargs["attributes"]["trace_type"] == "component"
+        assert call_kwargs["attributes"]["custom_meta"] == "value"
+        assert "inputs" in call_kwargs["attributes"]
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_add_trace_not_ready(self, sample_trace_id, sample_trace_name):
+        """Test add_trace when tracer is not ready."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+        tracer._ready = False
+
+        tracer.add_trace(
+            trace_id="component_123",
+            trace_name="Test Component (component_123)",
+            trace_type="component",
+            inputs={},
+        )
+
+        assert len(tracer.spans) == 0
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_add_trace_name_cleanup(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test name cleanup in add_trace."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_trace = mock_noveum_modules["trace"]
+        mock_span = MagicMock()
+        mock_trace.create_span.return_value = mock_span
+
+        # Test with ID suffix
+        tracer.add_trace(
+            trace_id="comp_123",
+            trace_name="My Component (comp_123)",
+            trace_type="component",
+            inputs={},
+        )
+
+        call_kwargs = mock_trace.create_span.call_args[1]
+        assert call_kwargs["name"] == "My Component"
+
+        # Test without ID suffix
+        tracer.add_trace(
+            trace_id="comp_456",
+            trace_name="My Component",
+            trace_type="component",
+            inputs={},
+        )
+
+        call_kwargs = mock_trace.create_span.call_args[1]
+        assert call_kwargs["name"] == "My Component"
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_add_trace_metadata_merging(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test metadata merging in add_trace."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_trace = mock_noveum_modules["trace"]
+        mock_span = MagicMock()
+        mock_trace.create_span.return_value = mock_span
+
+        tracer.add_trace(
+            trace_id="component_123",
+            trace_name="Test Component (component_123)",
+            trace_type="custom_type",
+            inputs={},
+            metadata={"custom_key": "custom_value"},
+        )
+
+        call_kwargs = mock_trace.create_span.call_args[1]
+        attributes = call_kwargs["attributes"]
+        assert attributes["from_langflow_component"] is True
+        assert attributes["component_id"] == "component_123"
+        assert attributes["trace_type"] == "custom_type"
+        assert attributes["custom_key"] == "custom_value"
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_add_trace_input_serialization(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test input serialization in add_trace."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_trace = mock_noveum_modules["trace"]
+        mock_span = MagicMock()
+        mock_trace.create_span.return_value = mock_span
+
+        with patch("langflow.services.tracing.noveum_trace.serialize") as mock_serialize:
+            mock_serialize.return_value = {"serialized": "inputs"}
+            inputs = {"input_key": "input_value"}
+
+            tracer.add_trace(
+                trace_id="component_123",
+                trace_name="Test Component (component_123)",
+                trace_type="component",
+                inputs=inputs,
+            )
+
+            mock_serialize.assert_called_once_with(inputs)
+            call_kwargs = mock_trace.create_span.call_args[1]
+            assert call_kwargs["attributes"]["inputs"] == {"serialized": "inputs"}
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_add_trace_exception_handling(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test exception handling in add_trace."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_trace = mock_noveum_modules["trace"]
+        mock_trace.create_span.side_effect = Exception("Test error")
+
+        with patch("langflow.services.tracing.noveum_trace.logger") as mock_logger:
+            tracer.add_trace(
+                trace_id="component_123",
+                trace_name="Test Component (component_123)",
+                trace_type="component",
+                inputs={},
+            )
+
+            mock_logger.debug.assert_called()
+            assert "component_123" not in tracer.spans
+
+
+class TestNoveumTracerEndTrace:
+    """Test end_trace method."""
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_trace_successful(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):
+        """Test successful span finishing."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        tracer.spans["component_123"] = mock_span
+
+        outputs = {"output_key": "output_value"}
+        end_time = datetime.now(tz=timezone.utc)
+
+        with patch("langflow.services.tracing.noveum_trace.datetime") as mock_datetime:
+            mock_datetime.now.return_value = end_time
+            tracer.end_trace(
+                trace_id="component_123",
+                trace_name="Test Component",
+                outputs=outputs,
+            )
+
+        assert "component_123" not in tracer.spans
+        mock_span.set_attributes.assert_called_once()
+        mock_span.finish.assert_called_once_with(end_time=end_time)
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_trace_not_ready(self, sample_trace_id, sample_trace_name):
+        """Test end_trace when tracer is not ready."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+        tracer._ready = False
+        tracer.spans["component_123"] = MagicMock()
+
+        tracer.end_trace(
+            trace_id="component_123",
+            trace_name="Test Component",
+            outputs={},
+        )
+
+        assert "component_123" in tracer.spans
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_trace_missing_span(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test end_trace with missing span."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        with patch("langflow.services.tracing.noveum_trace.logger") as mock_logger:
+            tracer.end_trace(
+                trace_id="nonexistent_component",
+                trace_name="Test Component",
+                outputs={},
+            )
+
+            mock_logger.debug.assert_called()
+            assert "nonexistent_component" not in tracer.spans
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_trace_with_outputs(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):
+        """Test end_trace with outputs."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        tracer.spans["component_123"] = mock_span
+
+        with patch("langflow.services.tracing.noveum_trace.serialize") as mock_serialize:
+            mock_serialize.return_value = {"serialized": "outputs"}
+            outputs = {"output_key": "output_value"}
+
+            tracer.end_trace(
+                trace_id="component_123",
+                trace_name="Test Component",
+                outputs=outputs,
+            )
+
+            mock_serialize.assert_called_once_with(outputs)
+            call_kwargs = mock_span.set_attributes.call_args[0][0]
+            assert call_kwargs["outputs"]["serialized"] == "outputs"
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_trace_with_error(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):
+        """Test end_trace with error."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        tracer.spans["component_123"] = mock_span
+        error = ValueError("Test error")
+
+        tracer.end_trace(
+            trace_id="component_123",
+            trace_name="Test Component",
+            outputs={},
+            error=error,
+        )
+
+        call_kwargs = mock_span.set_attributes.call_args[0][0]
+        assert call_kwargs["outputs"]["error"] == "Test error"
+        mock_span.set_status.assert_called_once_with("error", "Test error")
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_trace_with_logs(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):
+        """Test end_trace with logs."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        tracer.spans["component_123"] = mock_span
+
+        logs = [{"log_key": "log_value"}, {"another_log": "value"}]
+
+        with patch("langflow.services.tracing.noveum_trace.serialize") as mock_serialize:
+            mock_serialize.side_effect = lambda x: {"serialized": str(x)}
+
+            tracer.end_trace(
+                trace_id="component_123",
+                trace_name="Test Component",
+                outputs={},
+                logs=logs,
+            )
+
+            call_kwargs = mock_span.set_attributes.call_args[0][0]
+            assert "logs" in call_kwargs["outputs"]
+            assert len(call_kwargs["outputs"]["logs"]) == 2
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_trace_exception_handling(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):
+        """Test exception handling in end_trace."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        tracer.spans["component_123"] = mock_span
+        mock_span.finish.side_effect = Exception("Test error")
+
+        with patch("langflow.services.tracing.noveum_trace.logger") as mock_logger:
+            tracer.end_trace(
+                trace_id="component_123",
+                trace_name="Test Component",
+                outputs={},
+            )
+
+            mock_logger.debug.assert_called()
+            assert "component_123" not in tracer.spans  # Should still be removed
+
+
+class TestNoveumTracerEnd:
+    """Test end method."""
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_successful(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test successful trace finalization."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_client_instance = mock_noveum_modules["client_instance"]
+        mock_trace = mock_noveum_modules["trace"]
+        mock_client_instance.flush = MagicMock()
+
+        inputs = {"input_key": "input_value"}
+        outputs = {"output_key": "output_value"}
+        metadata = {"meta_key": "meta_value"}
+
+        tracer.end(inputs=inputs, outputs=outputs, metadata=metadata)
+
+        mock_trace.set_attributes.assert_called_once()
+        call_kwargs = mock_trace.set_attributes.call_args[0][0]
+        assert "final_inputs" in call_kwargs
+        assert "final_outputs" in call_kwargs
+        assert "final_metadata" in call_kwargs
+        mock_client_instance.finish_trace.assert_called_once_with(mock_trace)
+        mock_client_instance.flush.assert_called_once()
+        mock_client_instance.shutdown.assert_called_once()
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_not_ready(self, sample_trace_id, sample_trace_name):
+        """Test end when tracer is not ready."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+        tracer._ready = False
+
+        tracer.end(inputs={}, outputs={})
+
+        # Should return early without doing anything
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_with_error(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test end with error."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_trace = mock_noveum_modules["trace"]
+        error = ValueError("Test error")
+
+        tracer.end(inputs={}, outputs={}, error=error)
+
+        call_kwargs = mock_trace.set_attributes.call_args[0][0]
+        assert call_kwargs["error"] == "Test error"
+        mock_trace.set_status.assert_called_once_with("error", "Test error")
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_without_inputs_outputs_metadata(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test end without inputs/outputs/metadata."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_client_instance = mock_noveum_modules["client_instance"]
+        mock_trace = mock_noveum_modules["trace"]
+        mock_client_instance.flush = MagicMock()
+
+        tracer.end(inputs=None, outputs=None, metadata=None)
+
+        # When all inputs/outputs/metadata are None, trace_attributes is empty
+        # so set_attributes should NOT be called
+        mock_trace.set_attributes.assert_not_called()
+        # But finish_trace should still be called
+        mock_client_instance.finish_trace.assert_called_once()
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_flush_handling(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test end flush handling."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_client_instance = mock_noveum_modules["client_instance"]
+        mock_client_instance.flush = MagicMock()
+
+        tracer.end(inputs={}, outputs={})
+
+        mock_client_instance.flush.assert_called_once()
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_without_flush(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test end when flush method doesn't exist."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_client_instance = mock_noveum_modules["client_instance"]
+        del mock_client_instance.flush  # Remove flush method
+
+        # Should not crash
+        tracer.end(inputs={}, outputs={})
+
+        mock_client_instance.finish_trace.assert_called_once()
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_shutdown_exception_handling(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test end shutdown exception handling."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_client_instance = mock_noveum_modules["client_instance"]
+        mock_client_instance.flush = MagicMock()
+        mock_client_instance.shutdown.side_effect = Exception("Shutdown error")
+
+        with patch("langflow.services.tracing.noveum_trace.logger") as mock_logger:
+            tracer.end(inputs={}, outputs={})
+
+            mock_logger.debug.assert_called()
+            mock_client_instance.finish_trace.assert_called_once()  # Should still be called
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_end_general_exception_handling(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test end general exception handling."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        mock_trace = mock_noveum_modules["trace"]
+        mock_trace.set_attributes.side_effect = Exception("Test error")
+
+        with patch("langflow.services.tracing.noveum_trace.logger") as mock_logger:
+            tracer.end(inputs={}, outputs={})
+
+            mock_logger.debug.assert_called()
+
+
+class TestNoveumTracerGetLangchainCallback:
+    """Test get_langchain_callback method."""
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_get_langchain_callback_when_ready(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test get_langchain_callback when ready."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        callback = tracer.get_langchain_callback()
+
+        assert callback is not None
+        assert callback == mock_noveum_modules["callback_handler"]
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_get_langchain_callback_when_not_ready(self, sample_trace_id, sample_trace_name):
+        """Test get_langchain_callback when not ready."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+        tracer._ready = False
+
+        callback = tracer.get_langchain_callback()
+
+        assert callback is None
+
+
+class TestNoveumTracerReadyProperty:
+    """Test ready property."""
+
+    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    def test_ready_property_true(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+        """Test ready property returns True when _ready is True."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        assert tracer.ready is True
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_ready_property_false(self, sample_trace_id, sample_trace_name):
+        """Test ready property returns False when _ready is False."""
+        tracer = NoveumTracer(
+            trace_name=sample_trace_name,
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=sample_trace_id,
+        )
+
+        assert tracer.ready is False

--- a/src/backend/tests/unit/services/tracing/test_noveum_trace.py
+++ b/src/backend/tests/unit/services/tracing/test_noveum_trace.py
@@ -7,7 +7,6 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from langflow.services.tracing.noveum_trace import NoveumTracer
 
 
@@ -85,8 +84,10 @@ def mock_span():
 class TestNoveumTracerInit:
     """Test NoveumTracer initialization."""
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
-    def test_init_successful_with_config(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
+    def test_init_successful_with_config(self, mock_noveum_modules, sample_trace_id, sample_trace_name):  # noqa: ARG002
         """Test successful initialization with valid config."""
         tracer = NoveumTracer(
             trace_name=sample_trace_name,
@@ -116,8 +117,10 @@ class TestNoveumTracerInit:
         assert tracer._ready is False
         assert tracer.flow_id == "flow_123"
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
-    def test_init_with_user_id_and_session_id(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
+    def test_init_with_user_id_and_session_id(self, mock_noveum_modules, sample_trace_id, sample_trace_name):  # noqa: ARG002
         """Test initialization with user_id and session_id."""
         tracer = NoveumTracer(
             trace_name=sample_trace_name,
@@ -223,7 +226,9 @@ class TestNoveumTracerGetConfig:
 class TestNoveumTracerSetupNoveum:
     """Test setup_noveum method."""
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_setup_noveum_successful(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test successful setup_noveum."""
         tracer = NoveumTracer(
@@ -251,10 +256,12 @@ class TestNoveumTracerSetupNoveum:
         mock_client_instance.start_trace.assert_called_once()
         assert mock_noveum_module._client == mock_client_instance
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_setup_noveum_with_user_id_and_session_id(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test setup_noveum with user_id and session_id."""
-        tracer = NoveumTracer(
+        _tracer = NoveumTracer(
             trace_name=sample_trace_name,
             trace_type="chain",
             project_name="test_project",
@@ -273,10 +280,12 @@ class TestNoveumTracerSetupNoveum:
         assert attributes["trace_type"] == "chain"
         assert attributes["flow_id"] == "flow_123"
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_setup_noveum_without_user_id_and_session_id(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test setup_noveum without user_id and session_id."""
-        tracer = NoveumTracer(
+        _tracer = NoveumTracer(
             trace_name=sample_trace_name,
             trace_type="chain",
             project_name="test_project",
@@ -293,40 +302,50 @@ class TestNoveumTracerSetupNoveum:
         assert attributes["trace_type"] == "chain"
         assert attributes["flow_id"] == "flow_123"
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_setup_noveum_import_error(self, sample_trace_id, sample_trace_name):
         """Test setup_noveum with ImportError."""
-        with patch("langflow.services.tracing.noveum_trace.noveum_trace", None):
-            with patch("langflow.services.tracing.noveum_trace.logger") as mock_logger:
-                tracer = NoveumTracer(
-                    trace_name=sample_trace_name,
-                    trace_type="chain",
-                    project_name="test_project",
-                    trace_id=sample_trace_id,
-                )
+        with (
+            patch("langflow.services.tracing.noveum_trace.noveum_trace", None),
+            patch("langflow.services.tracing.noveum_trace.logger") as mock_logger,
+        ):
+            tracer = NoveumTracer(
+                trace_name=sample_trace_name,
+                trace_type="chain",
+                project_name="test_project",
+                trace_id=sample_trace_id,
+            )
 
-                assert tracer._ready is False
-                mock_logger.exception.assert_called()
+            assert tracer._ready is False
+            mock_logger.exception.assert_called()
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_setup_noveum_general_exception(self, sample_trace_id, sample_trace_name):
         """Test setup_noveum with general exception."""
-        with patch("langflow.services.tracing.noveum_trace.NoveumClient", side_effect=Exception("Test error")):
-            with patch("langflow.services.tracing.noveum_trace.logger") as mock_logger:
-                tracer = NoveumTracer(
-                    trace_name=sample_trace_name,
-                    trace_type="chain",
-                    project_name="test_project",
-                    trace_id=sample_trace_id,
-                )
+        with (
+            patch("langflow.services.tracing.noveum_trace.NoveumClient", side_effect=Exception("Test error")),
+            patch("langflow.services.tracing.noveum_trace.logger") as mock_logger,
+        ):
+            tracer = NoveumTracer(
+                trace_name=sample_trace_name,
+                trace_type="chain",
+                project_name="test_project",
+                trace_id=sample_trace_id,
+            )
 
-                assert tracer._ready is False
-                mock_logger.debug.assert_called()
+            assert tracer._ready is False
+            mock_logger.debug.assert_called()
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_setup_noveum_with_client_lock(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test setup_noveum with _client_lock attribute."""
-        tracer = NoveumTracer(
+        _tracer = NoveumTracer(
             trace_name=sample_trace_name,
             trace_type="chain",
             project_name="test_project",
@@ -337,7 +356,9 @@ class TestNoveumTracerSetupNoveum:
         assert hasattr(mock_noveum_module, "_client_lock")
         assert mock_noveum_module._client is not None
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_setup_noveum_without_client_lock(self, sample_trace_id, sample_trace_name):
         """Test setup_noveum without _client_lock attribute (fallback path)."""
         mock_noveum_module = MagicMock()
@@ -371,7 +392,9 @@ class TestNoveumTracerSetupNoveum:
 class TestNoveumTracerAddTrace:
     """Test add_trace method."""
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_add_trace_successful(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test successful span creation."""
         tracer = NoveumTracer(
@@ -408,7 +431,9 @@ class TestNoveumTracerAddTrace:
         assert call_kwargs["attributes"]["custom_meta"] == "value"
         assert "inputs" in call_kwargs["attributes"]
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_add_trace_not_ready(self, sample_trace_id, sample_trace_name):
         """Test add_trace when tracer is not ready."""
         tracer = NoveumTracer(
@@ -428,7 +453,9 @@ class TestNoveumTracerAddTrace:
 
         assert len(tracer.spans) == 0
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_add_trace_name_cleanup(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test name cleanup in add_trace."""
         tracer = NoveumTracer(
@@ -464,7 +491,9 @@ class TestNoveumTracerAddTrace:
         call_kwargs = mock_trace.create_span.call_args[1]
         assert call_kwargs["name"] == "My Component"
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_add_trace_metadata_merging(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test metadata merging in add_trace."""
         tracer = NoveumTracer(
@@ -493,7 +522,9 @@ class TestNoveumTracerAddTrace:
         assert attributes["trace_type"] == "custom_type"
         assert attributes["custom_key"] == "custom_value"
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_add_trace_input_serialization(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test input serialization in add_trace."""
         tracer = NoveumTracer(
@@ -522,7 +553,9 @@ class TestNoveumTracerAddTrace:
             call_kwargs = mock_trace.create_span.call_args[1]
             assert call_kwargs["attributes"]["inputs"] == {"serialized": "inputs"}
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_add_trace_exception_handling(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test exception handling in add_trace."""
         tracer = NoveumTracer(
@@ -550,8 +583,10 @@ class TestNoveumTracerAddTrace:
 class TestNoveumTracerEndTrace:
     """Test end_trace method."""
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
-    def test_end_trace_successful(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
+    def test_end_trace_successful(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):  # noqa: ARG002
         """Test successful span finishing."""
         tracer = NoveumTracer(
             trace_name=sample_trace_name,
@@ -577,7 +612,9 @@ class TestNoveumTracerEndTrace:
         mock_span.set_attributes.assert_called_once()
         mock_span.finish.assert_called_once_with(end_time=end_time)
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_end_trace_not_ready(self, sample_trace_id, sample_trace_name):
         """Test end_trace when tracer is not ready."""
         tracer = NoveumTracer(
@@ -597,8 +634,10 @@ class TestNoveumTracerEndTrace:
 
         assert "component_123" in tracer.spans
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
-    def test_end_trace_missing_span(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
+    def test_end_trace_missing_span(self, mock_noveum_modules, sample_trace_id, sample_trace_name):  # noqa: ARG002
         """Test end_trace with missing span."""
         tracer = NoveumTracer(
             trace_name=sample_trace_name,
@@ -617,8 +656,10 @@ class TestNoveumTracerEndTrace:
             mock_logger.debug.assert_called()
             assert "nonexistent_component" not in tracer.spans
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
-    def test_end_trace_with_outputs(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
+    def test_end_trace_with_outputs(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):  # noqa: ARG002
         """Test end_trace with outputs."""
         tracer = NoveumTracer(
             trace_name=sample_trace_name,
@@ -643,8 +684,10 @@ class TestNoveumTracerEndTrace:
             call_kwargs = mock_span.set_attributes.call_args[0][0]
             assert call_kwargs["outputs"]["serialized"] == "outputs"
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
-    def test_end_trace_with_error(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
+    def test_end_trace_with_error(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):  # noqa: ARG002
         """Test end_trace with error."""
         tracer = NoveumTracer(
             trace_name=sample_trace_name,
@@ -667,8 +710,10 @@ class TestNoveumTracerEndTrace:
         assert call_kwargs["outputs"]["error"] == "Test error"
         mock_span.set_status.assert_called_once_with("error", "Test error")
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
-    def test_end_trace_with_logs(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
+    def test_end_trace_with_logs(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):  # noqa: ARG002
         """Test end_trace with logs."""
         tracer = NoveumTracer(
             trace_name=sample_trace_name,
@@ -695,8 +740,10 @@ class TestNoveumTracerEndTrace:
             assert "logs" in call_kwargs["outputs"]
             assert len(call_kwargs["outputs"]["logs"]) == 2
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
-    def test_end_trace_exception_handling(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
+    def test_end_trace_exception_handling(self, mock_noveum_modules, sample_trace_id, sample_trace_name, mock_span):  # noqa: ARG002
         """Test exception handling in end_trace."""
         tracer = NoveumTracer(
             trace_name=sample_trace_name,
@@ -722,7 +769,9 @@ class TestNoveumTracerEndTrace:
 class TestNoveumTracerEnd:
     """Test end method."""
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_end_successful(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test successful trace finalization."""
         tracer = NoveumTracer(
@@ -751,7 +800,9 @@ class TestNoveumTracerEnd:
         mock_client_instance.flush.assert_called_once()
         mock_client_instance.shutdown.assert_called_once()
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_end_not_ready(self, sample_trace_id, sample_trace_name):
         """Test end when tracer is not ready."""
         tracer = NoveumTracer(
@@ -766,7 +817,9 @@ class TestNoveumTracerEnd:
 
         # Should return early without doing anything
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_end_with_error(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test end with error."""
         tracer = NoveumTracer(
@@ -785,7 +838,9 @@ class TestNoveumTracerEnd:
         assert call_kwargs["error"] == "Test error"
         mock_trace.set_status.assert_called_once_with("error", "Test error")
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_end_without_inputs_outputs_metadata(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test end without inputs/outputs/metadata."""
         tracer = NoveumTracer(
@@ -807,7 +862,9 @@ class TestNoveumTracerEnd:
         # But finish_trace should still be called
         mock_client_instance.finish_trace.assert_called_once()
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_end_flush_handling(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test end flush handling."""
         tracer = NoveumTracer(
@@ -824,7 +881,9 @@ class TestNoveumTracerEnd:
 
         mock_client_instance.flush.assert_called_once()
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_end_without_flush(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test end when flush method doesn't exist."""
         tracer = NoveumTracer(
@@ -842,7 +901,9 @@ class TestNoveumTracerEnd:
 
         mock_client_instance.finish_trace.assert_called_once()
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_end_shutdown_exception_handling(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test end shutdown exception handling."""
         tracer = NoveumTracer(
@@ -862,7 +923,9 @@ class TestNoveumTracerEnd:
             mock_logger.debug.assert_called()
             mock_client_instance.finish_trace.assert_called_once()  # Should still be called
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_end_general_exception_handling(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test end general exception handling."""
         tracer = NoveumTracer(
@@ -884,7 +947,9 @@ class TestNoveumTracerEnd:
 class TestNoveumTracerGetLangchainCallback:
     """Test get_langchain_callback method."""
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_get_langchain_callback_when_ready(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
         """Test get_langchain_callback when ready."""
         tracer = NoveumTracer(
@@ -899,7 +964,9 @@ class TestNoveumTracerGetLangchainCallback:
         assert callback is not None
         assert callback == mock_noveum_modules["callback_handler"]
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
     def test_get_langchain_callback_when_not_ready(self, sample_trace_id, sample_trace_name):
         """Test get_langchain_callback when not ready."""
         tracer = NoveumTracer(
@@ -918,8 +985,10 @@ class TestNoveumTracerGetLangchainCallback:
 class TestNoveumTracerReadyProperty:
     """Test ready property."""
 
-    @patch.dict(os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"})
-    def test_ready_property_true(self, mock_noveum_modules, sample_trace_id, sample_trace_name):
+    @patch.dict(
+        os.environ, {"NOVEUM_API_KEY": "test_key", "NOVEUM_PROJECT": "test_project", "NOVEUM_ENVIRONMENT": "test_env"}
+    )
+    def test_ready_property_true(self, mock_noveum_modules, sample_trace_id, sample_trace_name):  # noqa: ARG002
         """Test ready property returns True when _ready is True."""
         tracer = NoveumTracer(
             trace_name=sample_trace_name,

--- a/src/backend/tests/unit/services/tracing/test_tracing_service.py
+++ b/src/backend/tests/unit/services/tracing/test_tracing_service.py
@@ -145,6 +145,10 @@ def mock_tracers():
             "langflow.services.tracing.service._get_traceloop_tracer",
             return_value=MockTracer,
         ),
+        patch(
+            "langflow.services.tracing.service._get_noveum_tracer",
+            return_value=MockTracer,
+        ),
     ):
         yield
 
@@ -176,6 +180,7 @@ async def test_start_end_tracers(tracing_service):
     assert "langfuse" in trace_context.tracers
     assert "arize_phoenix" in trace_context.tracers
     assert "traceloop" in trace_context.tracers
+    assert "noveum_trace" in trace_context.tracers
 
     await tracing_service.end_tracers(outputs)
 

--- a/uv.lock
+++ b/uv.lock
@@ -6085,6 +6085,7 @@ all = [
     { name = "mlx-vlm", marker = "python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "needle-python" },
     { name = "nltk" },
+    { name = "noveum-trace" },
     { name = "numexpr" },
     { name = "openai" },
     { name = "openinference-instrumentation-langchain" },
@@ -6250,6 +6251,7 @@ complete = [
     { name = "mlx-vlm", marker = "python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "needle-python" },
     { name = "nltk" },
+    { name = "noveum-trace" },
     { name = "numexpr" },
     { name = "openai" },
     { name = "openinference-instrumentation-langchain" },
@@ -6439,6 +6441,9 @@ needle = [
 ]
 nltk = [
     { name = "nltk" },
+]
+noveum = [
+    { name = "noveum-trace" },
 ]
 numexpr = [
     { name = "numexpr" },
@@ -6760,6 +6765,7 @@ requires-dist = [
     { name = "langflow-base", extras = ["mongodb-vectors"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["needle"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["nltk"], marker = "extra == 'complete'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["noveum"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["numexpr"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["nvidia"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["ollama"], marker = "extra == 'complete'", editable = "src/backend/base" },
@@ -6818,6 +6824,7 @@ requires-dist = [
     { name = "nest-asyncio", specifier = ">=1.6.0,<2.0.0" },
     { name = "networkx", specifier = ">=3.4.2,<4.0.0" },
     { name = "nltk", marker = "extra == 'nltk'", specifier = "==3.9.1" },
+    { name = "noveum-trace", marker = "extra == 'noveum'", specifier = ">=0.1.0" },
     { name = "numexpr", marker = "extra == 'numexpr'", specifier = "==2.10.2" },
     { name = "onnxruntime", specifier = ">=1.20,<=1.23" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.68.2,<2.0.0" },
@@ -6888,7 +6895,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = ">=1.0.0,<2.0.0" },
     { name = "zep-python", marker = "extra == 'zep'", specifier = "==2.0.2" },
 ]
-provides-extras = ["audio", "postgresql", "local", "couchbase", "cassandra", "clickhouse", "mongodb", "supabase", "redis", "elasticsearch", "faiss", "qdrant", "weaviate", "chroma", "upstash", "pinecone", "milvus", "mongodb-vectors", "astradb", "openai", "anthropic", "cohere", "google", "ollama", "nvidia", "mistral", "sambanova", "groq", "llama-cpp", "sentence-transformers", "ctransformers", "langfuse", "langwatch", "langsmith", "arize", "pypdf", "docx", "pytube", "dspy", "smolagents", "beautifulsoup", "serpapi", "google-api", "wikipedia", "fake-useragent", "duckduckgo", "yfinance", "wolframalpha", "pyarrow", "fastavro", "gitpython", "nltk", "lark", "huggingface", "metaphor", "metal", "markup", "aws", "numexpr", "qianfan", "pgvector", "litellm", "zep", "youtube", "markdown", "kubernetes", "json-repair", "astra", "composio", "ragstack", "opensearch", "atlassian", "mem0", "needle", "sseclient", "openinference", "mcp", "ag2", "scrapegraph", "pydantic-ai", "apify", "spider", "altk", "langchain-huggingface", "langchain-unstructured", "graph-retriever", "langchain-mcp-adapters", "opik", "traceloop", "docling", "easyocr", "cleanlab", "twelvelabs", "jigsawstack", "assemblyai", "datasets", "fastparquet", "vlmrun", "cuga", "mlx", "fastmcp", "aioboto3", "astrapy", "gassist", "complete", "all"]
+provides-extras = ["audio", "postgresql", "local", "couchbase", "cassandra", "clickhouse", "mongodb", "supabase", "redis", "elasticsearch", "faiss", "qdrant", "weaviate", "chroma", "upstash", "pinecone", "milvus", "mongodb-vectors", "astradb", "openai", "anthropic", "cohere", "google", "ollama", "nvidia", "mistral", "sambanova", "groq", "llama-cpp", "sentence-transformers", "ctransformers", "langfuse", "langwatch", "langsmith", "arize", "pypdf", "docx", "pytube", "dspy", "smolagents", "beautifulsoup", "serpapi", "google-api", "wikipedia", "fake-useragent", "duckduckgo", "yfinance", "wolframalpha", "pyarrow", "fastavro", "gitpython", "nltk", "lark", "huggingface", "metaphor", "metal", "markup", "aws", "numexpr", "qianfan", "pgvector", "litellm", "zep", "youtube", "markdown", "kubernetes", "json-repair", "astra", "composio", "ragstack", "opensearch", "atlassian", "mem0", "needle", "sseclient", "openinference", "mcp", "ag2", "scrapegraph", "pydantic-ai", "apify", "spider", "altk", "langchain-huggingface", "langchain-unstructured", "graph-retriever", "langchain-mcp-adapters", "opik", "traceloop", "noveum", "docling", "easyocr", "cleanlab", "twelvelabs", "jigsawstack", "assemblyai", "datasets", "fastparquet", "vlmrun", "cuga", "mlx", "fastmcp", "aioboto3", "astrapy", "gassist", "complete", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -8521,6 +8528,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "noveum-trace"
+version = "1.5.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/63/85563b9c68902bf3a084bfe288c606a0bda8f1537bf42f994c731e59913e/noveum_trace-1.5.7.tar.gz", hash = "sha256:0ea29e775d5e566634fe7f3e1b1e6a25980b0b58f1fccd1a6e74e59bd62aa873", size = 309126, upload-time = "2026-02-11T04:19:54.48Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/db/220354a62cb5ccaed0f62b3a0813019664bcc90b4001ee6ef682b13d37e0/noveum_trace-1.5.7-py3-none-any.whl", hash = "sha256:46aa5cf457a128ed9763614e36ac87978f80c2241355ce8acf3d2b075291616b", size = 174283, upload-time = "2026-02-11T04:19:52.942Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds support for Noveum.ai as an optional tracing provider in Langflow.

Noveum is an LLM observability platform (similar in scope to Langfuse) that enables structured tracing and monitoring of AI applications. With this integration, Langflow flows can emit execution traces directly to Noveum.

## Summary of changes

New NoveumTracer implementing BaseTracer
Creates one root trace per flow run
Creates spans per component execution
Preserves parent-child relationships via graph edges
Captures inputs, outputs, logs, errors, and final metadata
Integrates with LangChain via NoveumTraceCallbackHandler
Includes defensive JSON-serialization to avoid SDK failures

## Tracing service integration

Added _get_noveum_tracer()
Initialized in start_tracers
Registered under trace_context.tracers["noveum_trace"]

## Optional dependency
Added noveum-trace as an extra

Safe import handling; tracer remains inactive if not configured

## Docs

New integration page (Develop/integrations-noveum)

## Tests

Unit tests for NoveumTracer
Updated tracing service tests to assert registration

## Activation

Enabled via environment variables:

export NOVEUM_API_KEY=...
export NOVEUM_ENVIRONMENT=...
export NOVEUM_PROJECT=...  # optional

If not configured, there is no behavioral impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Noveum.ai integration for distributed tracing and observability is now available
  * Configure via environment variables for API credentials and project settings
  * Traces automatically emit to the Noveum.ai dashboard

* **Documentation**
  * Added integration guide with setup instructions and platform-specific configuration examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->