### PR TITLE
ci: wire pre_release input to cross-platform tests

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -22,6 +22,11 @@ on:
         description: "Name of the LFX package artifact"
         required: false
         type: string
+      pre_release:
+        description: "Whether this is a pre-release build"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-if-needed:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -594,6 +594,7 @@ jobs:
       base-artifact-name: "dist-base"
       main-artifact-name: "dist-main"
       lfx-artifact-name: "dist-lfx"
+      pre_release: ${{ inputs.pre_release }}
 
   publish-base:
     name: Publish Langflow Base to PyPI


### PR DESCRIPTION
## Problem

The cross-platform installation tests fail for all platforms during pre-release 
runs. The `cross-platform-test.yml` references 
`inputs.pre_release` in its force-reinstall steps, but:

1. `pre_release` is never declared as a `workflow_call` input in `cross-platform-test.yml`
2. `release.yml` never passes it when calling the workflow

This means `inputs.pre_release` is always empty → force-reinstall always uses 
`--no-deps` → dependency resolution fails for RC versions.

## Fix

- Add `pre_release` as a `workflow_call` boolean input in `cross-platform-test.yml`
- Pass `pre_release: ${{ inputs.pre_release }}` from `release.yml`

## Changes

- `.github/workflows/cross-platform-test.yml` — declare `pre_release` input
- `.github/workflows/release.yml` — forward `pre_release` to cross-platform tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to support configurable pre-release build handling, enabling improved management of pre-release distributions across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->