### PR TITLE
test: Fix unawaited coroutine warnings in Ollama mock tests                                                               

### DIFF
--- a/src/backend/tests/unit/components/embeddings/test_ollama_embeddings_component.py
+++ b/src/backend/tests/unit/components/embeddings/test_ollama_embeddings_component.py
@@ -356,7 +356,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component = component_class()
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "nomic-embed-text"},
@@ -367,7 +367,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         # First model has embedding capability, second doesn't, third does
         mock_post_response.json.side_effect = [
             {component.JSON_CAPABILITIES_KEY: [component.EMBEDDING_CAPABILITY]},
@@ -405,7 +405,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component = component_class()
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "nomic-embed-text"},
@@ -414,7 +414,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.return_value = {component.JSON_CAPABILITIES_KEY: [component.EMBEDDING_CAPABILITY]}
         mock_post.return_value = mock_post_response
 
@@ -436,7 +436,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component.api_key = "test-api-key"
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "nomic-embed-text"},
@@ -445,7 +445,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.return_value = {component.JSON_CAPABILITIES_KEY: [component.EMBEDDING_CAPABILITY]}
         mock_post.return_value = mock_post_response
 
@@ -468,7 +468,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component = component_class()
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {component.JSON_MODELS_KEY: []}
         mock_get.return_value = mock_get_response
 
@@ -486,7 +486,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component = component_class()
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "model-without-caps"},
@@ -496,7 +496,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         # First model has no capabilities key, second has embedding capability
         mock_post_response.json.side_effect = [
             {},  # No capabilities key at all
@@ -520,7 +520,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component.api_key = None
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "nomic-embed-text"},
@@ -529,7 +529,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.return_value = {component.JSON_CAPABILITIES_KEY: [component.EMBEDDING_CAPABILITY]}
         mock_post.return_value = mock_post_response
 
@@ -553,7 +553,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component = component_class()
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "nomic-embed-text"},
@@ -562,7 +562,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.return_value = {component.JSON_CAPABILITIES_KEY: [component.EMBEDDING_CAPABILITY]}
         mock_post.return_value = mock_post_response
 
@@ -584,7 +584,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component = component_class()
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "nomic-embed-text"},
@@ -593,7 +593,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.return_value = {component.JSON_CAPABILITIES_KEY: [component.EMBEDDING_CAPABILITY]}
         mock_post.return_value = mock_post_response
 
@@ -615,7 +615,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component = component_class()
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "llama3.1"},
@@ -625,7 +625,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         # All models have completion capability only, no embedding
         mock_post_response.json.side_effect = [
             {component.JSON_CAPABILITIES_KEY: ["completion"]},
@@ -650,7 +650,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component = component_class()
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "nomic-embed-text"},
@@ -779,7 +779,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component = component_class()
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "nomic-embed-text"},
@@ -789,7 +789,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.side_effect = [
             {component.JSON_CAPABILITIES_KEY: [component.EMBEDDING_CAPABILITY]},
             {component.JSON_CAPABILITIES_KEY: [component.EMBEDDING_CAPABILITY]},
@@ -817,7 +817,7 @@ class TestOllamaEmbeddingsComponent(ComponentTestBaseWithoutClient):
         component = component_class()
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "nomic-embed-text"},

--- a/src/backend/tests/unit/components/languagemodels/test_chatollama_component.py
+++ b/src/backend/tests/unit/components/languagemodels/test_chatollama_component.py
@@ -137,7 +137,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
     async def test_get_models_success(self, mock_get, mock_post):
         component = ChatOllamaComponent()
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "model1"},
@@ -147,7 +147,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.side_effect = [
             {component.JSON_CAPABILITIES_KEY: [component.DESIRED_CAPABILITY]},
             {component.JSON_CAPABILITIES_KEY: []},
@@ -170,7 +170,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
         """
         component = ChatOllamaComponent()
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "old-model-1"},
@@ -181,7 +181,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
 
         # Simulate older Ollama API that doesn't return capabilities field
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.side_effect = [
             {},  # No capabilities field
             {},  # No capabilities field
@@ -203,7 +203,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
         """Test that models without capabilities field are excluded when tool_model_enabled=True."""
         component = ChatOllamaComponent()
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "old-model-1"},
@@ -214,7 +214,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
 
         # Simulate older Ollama API that doesn't return capabilities field
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.side_effect = [
             {},  # No capabilities field
             {},  # No capabilities field
@@ -236,7 +236,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
         """Test mixed scenario: some models have capabilities, some don't."""
         component = ChatOllamaComponent()
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "new-model"},
@@ -247,7 +247,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.side_effect = [
             {component.JSON_CAPABILITIES_KEY: [component.DESIRED_CAPABILITY]},  # new-model has completion
             {},  # old-model has no capabilities field
@@ -567,7 +567,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
         """Test that get_models strips /v1 suffix when fetching models."""
         component = ChatOllamaComponent()
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "model1"},
@@ -576,7 +576,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.return_value = {component.JSON_CAPABILITIES_KEY: [component.DESIRED_CAPABILITY]}
         mock_post.return_value = mock_post_response
 
@@ -1048,7 +1048,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
         component.api_key = "test-cloud-api-key"
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "deepseek-v3.1:671b-cloud"},
@@ -1058,7 +1058,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.side_effect = [
             {component.JSON_CAPABILITIES_KEY: [component.DESIRED_CAPABILITY]},
             {component.JSON_CAPABILITIES_KEY: [component.DESIRED_CAPABILITY]},
@@ -1090,7 +1090,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
         component.api_key = None
 
         mock_get_response = AsyncMock()
-        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.raise_for_status = MagicMock(return_value=None)
         mock_get_response.json.return_value = {
             component.JSON_MODELS_KEY: [
                 {component.JSON_NAME_KEY: "llama3.1"},
@@ -1099,7 +1099,7 @@ class TestChatOllamaComponent(ComponentTestBaseWithoutClient):
         mock_get.return_value = mock_get_response
 
         mock_post_response = AsyncMock()
-        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.raise_for_status = MagicMock(return_value=None)
         mock_post_response.json.return_value = {component.JSON_CAPABILITIES_KEY: [component.DESIRED_CAPABILITY]}
         mock_post.return_value = mock_post_response
 


### PR DESCRIPTION
Eliminate RuntimeWarning "coroutine was never awaited" in Ollama component tests caused by incorrect mock setup.

Changes
- Replace AsyncMock().raise_for_status.return_value = None with MagicMock(return_value=None) assignment across ChatOllama and OllamaEmbeddings test files
- Fix 15 occurrences in test_chatollama_component.py and 21 in test_ollama_embeddings_component.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test infrastructure for mock configuration in embeddings and language model components. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->