### PR TITLE
fix: pin protobuf version

### DIFF
--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -95,7 +95,8 @@ dependencies = [
     "langchain-chroma>=0.1.4,<1.0.0",
     "jaraco-context>=6.1.0",
     "wheel>=0.46.2,<1.0.0",
-    "onnxruntime>=1.20,<=1.23" # >=1.24 does not support Python 3.10
+    "onnxruntime>=1.20,<=1.23", # >=1.24 does not support Python 3.10
+    "protobuf>=3.20.0,<3.21.0"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
protobuf>=3.20.0,<3.21.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend dependencies and configuration formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->