### PR TITLE
fix: prevent NaN values in JSON serialization for PostgreSQL

### DIFF
--- a/src/backend/base/langflow/services/database/models/base.py
+++ b/src/backend/base/langflow/services/database/models/base.py
@@ -12,14 +12,14 @@ def orjson_dumps(v, *, default=None, sort_keys=False, indent_2=True):
             option = orjson.OPT_INDENT_2
         else:
             option |= orjson.OPT_INDENT_2
-    
+
     # Add NON_STRICT to prevent NaN/Infinity values (fixes PostgreSQL JSON error)
     # PostgreSQL does not support NaN/Infinity in JSON columns
     if option is None:
         option = orjson.OPT_NON_STRICT
     else:
         option |= orjson.OPT_NON_STRICT
-    
+
     if default is None:
         return orjson.dumps(v, option=option).decode()
     return orjson.dumps(v, default=default, option=option).decode()

--- a/src/backend/base/langflow/services/database/models/base.py
+++ b/src/backend/base/langflow/services/database/models/base.py
@@ -12,6 +12,14 @@ def orjson_dumps(v, *, default=None, sort_keys=False, indent_2=True):
             option = orjson.OPT_INDENT_2
         else:
             option |= orjson.OPT_INDENT_2
+    
+    # Add NON_STRICT to prevent NaN/Infinity values (fixes PostgreSQL JSON error)
+    # PostgreSQL does not support NaN/Infinity in JSON columns
+    if option is None:
+        option = orjson.OPT_NON_STRICT
+    else:
+        option |= orjson.OPT_NON_STRICT
+    
     if default is None:
         return orjson.dumps(v, option=option).decode()
     return orjson.dumps(v, default=default, option=option).decode()


### PR DESCRIPTION
Fixes issue #11905 - Postgres JSON column fails with Token NaN is invalid

Added orjson.OPT_NON_STRICT flag to prevent NaN/Inf values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed critical database data integrity issues by preventing invalid JSON encoding values from corrupting stored database records. This change ensures reliable and consistent data persistence when handling complex data structures, completely eliminating potential database errors that could occur during save and retrieval operations across production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->