### PR TITLE
fix: Fixes Kubernetes deployment crash on runtime_port parsing

### DIFF
--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -374,7 +374,10 @@ class Settings(BaseSettings):
             if "://" in value:
                 from urllib.parse import urlparse
 
-                parsed_port = urlparse(value).port
+                try:
+                    parsed_port = urlparse(value).port
+                except ValueError:
+                    return None
                 if parsed_port is not None:
                     return parsed_port
         return None

--- a/src/lfx/tests/unit/services/settings/test_runtime_port.py
+++ b/src/lfx/tests/unit/services/settings/test_runtime_port.py
@@ -30,8 +30,9 @@ def test_runtime_port_from_integer_string(monkeypatch):
     assert settings.runtime_port == 7865
 
 
-def test_runtime_port_default_is_none():
+def test_runtime_port_default_is_none(monkeypatch):
     """Without env var, runtime_port defaults to None."""
+    monkeypatch.delenv("LANGFLOW_RUNTIME_PORT", raising=False)
     settings = Settings()
     assert settings.runtime_port is None
 
@@ -44,7 +45,7 @@ def test_runtime_port_garbage_value_returns_none(monkeypatch):
 
 
 def test_runtime_port_from_http_url(monkeypatch):
-    """http:// URLs are also parsed (some K8s setups use these)."""
+    """http:// URLs are also parsed correctly (validator is scheme-agnostic)."""
     monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "http://10.96.0.1:7865")
     settings = Settings()
     assert settings.runtime_port == 7865
@@ -53,5 +54,26 @@ def test_runtime_port_from_http_url(monkeypatch):
 def test_runtime_port_url_without_port_returns_none(monkeypatch):
     """A URL without a port component falls back to None."""
     monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "tcp://10.96.0.1")
+    settings = Settings()
+    assert settings.runtime_port is None
+
+
+def test_runtime_port_url_with_out_of_range_port_returns_none(monkeypatch):
+    """A URL with port > 65535 should not crash, falls back to None."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "tcp://10.0.0.1:99999")
+    settings = Settings()
+    assert settings.runtime_port is None
+
+
+def test_runtime_port_url_with_non_numeric_port_returns_none(monkeypatch):
+    """A URL with non-numeric port should not crash, falls back to None."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "tcp://10.0.0.1:abc")
+    settings = Settings()
+    assert settings.runtime_port is None
+
+
+def test_runtime_port_url_with_negative_port_returns_none(monkeypatch):
+    """A URL with negative port should not crash, falls back to None."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "tcp://10.0.0.1:-1")
     settings = Settings()
     assert settings.runtime_port is None


### PR DESCRIPTION
## Summary

- Fixes #11445
- Kubernetes auto-injects service discovery env vars like `LANGFLOW_RUNTIME_PORT=tcp://<ip>:<port>` into pods, which collides with pydantic-settings' `LANGFLOW_` env prefix. Since `runtime_port` was added in v1.7.0, this causes a `ValidationError` on startup.
- Adds a `field_validator` on `runtime_port` that extracts the port number from URL-like values instead of failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced runtime_port configuration to accept Kubernetes service-discovery style environment variables (e.g., tcp://<ip>:<port>), numeric strings, and traditional integer formats. The system now intelligently extracts port numbers from URL-like values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->