### PR TITLE
fix: Fixes Kubernetes deployment crash on runtime_port parsing (#11968)

### DIFF
--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -355,6 +355,33 @@ class Settings(BaseSettings):
     Note: This setting only takes effect when ssrf_protection_enabled is True.
     When protection is disabled, all hosts are allowed regardless of this setting."""
 
+    @field_validator("runtime_port", mode="before")
+    @classmethod
+    def validate_runtime_port(cls, value):
+        """Parse port from Kubernetes service discovery env vars.
+
+        Kubernetes auto-creates env vars like LANGFLOW_RUNTIME_PORT=tcp://<ip>:<port>
+        for services, which collides with the LANGFLOW_ env prefix. Extract the port
+        number from URL-like values instead of failing.
+        """
+        if value is None:
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            if value.isdigit():
+                return int(value)
+            if "://" in value:
+                from urllib.parse import urlparse
+
+                try:
+                    parsed_port = urlparse(value).port
+                except ValueError:
+                    return None
+                if parsed_port is not None:
+                    return parsed_port
+        return None
+
     @field_validator("cors_origins", mode="before")
     @classmethod
     def validate_cors_origins(cls, value):

--- a/src/lfx/tests/unit/services/settings/test_runtime_port.py
+++ b/src/lfx/tests/unit/services/settings/test_runtime_port.py
@@ -1,0 +1,79 @@
+"""Tests for runtime_port validator in Settings.
+
+Kubernetes auto-creates service discovery env vars like
+LANGFLOW_RUNTIME_PORT=tcp://<ip>:<port> which collide with
+pydantic-settings LANGFLOW_ prefix. The validator should
+extract the port from URL-like values.
+"""
+
+from lfx.services.settings.base import Settings
+
+
+def test_runtime_port_from_k8s_tcp_url(monkeypatch):
+    """Kubernetes tcp:// service discovery value is parsed to the port number."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "tcp://10.96.0.1:7865")
+    settings = Settings()
+    assert settings.runtime_port == 7865
+
+
+def test_runtime_port_from_k8s_tcp_url_different_port(monkeypatch):
+    """Different port numbers are parsed correctly."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "tcp://10.0.0.5:8080")
+    settings = Settings()
+    assert settings.runtime_port == 8080
+
+
+def test_runtime_port_from_integer_string(monkeypatch):
+    """A plain integer string is parsed normally."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "7865")
+    settings = Settings()
+    assert settings.runtime_port == 7865
+
+
+def test_runtime_port_default_is_none(monkeypatch):
+    """Without env var, runtime_port defaults to None."""
+    monkeypatch.delenv("LANGFLOW_RUNTIME_PORT", raising=False)
+    settings = Settings()
+    assert settings.runtime_port is None
+
+
+def test_runtime_port_garbage_value_returns_none(monkeypatch):
+    """Unparseable values fall back to None."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "not-a-port")
+    settings = Settings()
+    assert settings.runtime_port is None
+
+
+def test_runtime_port_from_http_url(monkeypatch):
+    """http:// URLs are also parsed correctly (validator is scheme-agnostic)."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "http://10.96.0.1:7865")
+    settings = Settings()
+    assert settings.runtime_port == 7865
+
+
+def test_runtime_port_url_without_port_returns_none(monkeypatch):
+    """A URL without a port component falls back to None."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "tcp://10.96.0.1")
+    settings = Settings()
+    assert settings.runtime_port is None
+
+
+def test_runtime_port_url_with_out_of_range_port_returns_none(monkeypatch):
+    """A URL with port > 65535 should not crash, falls back to None."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "tcp://10.0.0.1:99999")
+    settings = Settings()
+    assert settings.runtime_port is None
+
+
+def test_runtime_port_url_with_non_numeric_port_returns_none(monkeypatch):
+    """A URL with non-numeric port should not crash, falls back to None."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "tcp://10.0.0.1:abc")
+    settings = Settings()
+    assert settings.runtime_port is None
+
+
+def test_runtime_port_url_with_negative_port_returns_none(monkeypatch):
+    """A URL with negative port should not crash, falls back to None."""
+    monkeypatch.setenv("LANGFLOW_RUNTIME_PORT", "tcp://10.0.0.1:-1")
+    settings = Settings()
+    assert settings.runtime_port is None


### PR DESCRIPTION
* feat: add runtime port validation for Kubernetes service discovery

* test: add unit tests for runtime port validation in Settings

* fix: improve runtime port validation to handle exceptions and edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced runtime port configuration to accept multiple input formats, including Kubernetes service discovery URLs, numeric strings, and standard port URLs with automatic parsing and validation.

* **Tests**
  * Added comprehensive unit tests validating port configuration across various input scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->