### PR TITLE
feat: improve AzureOpenAI component (#11620)

### DIFF
--- a/docs/docs/Components/bundles-azure.mdx
+++ b/docs/docs/Components/bundles-azure.mdx
@@ -32,7 +32,7 @@ For more information, see [Language model components](/components-models).
 | Deployment Name | String | Input parameter. The Azure deployment name. Auto-populated from model selection; can be overridden for custom deployments. |
 | API Key | SecretString | Input parameter. Your Azure OpenAI API key. |
 | Use Legacy API | Boolean | Advanced parameter. Use the legacy versioned API instead of the V1 Foundry API. Defaults to `false`. |
-| API Version | Dropdown | Advanced parameter. Specifies the version of the Azure OpenAI API to use (only visible when using legacy API). |
+| API Version | Dropdown | Input parameter. Specifies the version of the Azure OpenAI API to use (only visible when using legacy API). |
 | Reasoning Effort | Dropdown | Input parameter. Controls reasoning depth for reasoning models. Options: none, minimal, low, medium, high. Defaults to `medium`. |
 | Temperature | Float | Advanced parameter. Specifies the sampling temperature (hidden for reasoning models). Defaults to `0.7`. |
 | Seed | Integer | Advanced parameter. Controls reproducibility of the job (hidden for reasoning models). |

--- a/docs/docs/Components/bundles-azure.mdx
+++ b/docs/docs/Components/bundles-azure.mdx
@@ -27,15 +27,23 @@ For more information, see [Language model components](/components-models).
 
 | Name | Type | Description |
 |------|------|-------------|
-| Model Name | String | Input parameter. Specifies the name of the Azure OpenAI model to be used for text generation. |
 | Azure Endpoint | String | Input parameter. Your Azure endpoint, including the resource. |
-| Deployment Name | String | Input parameter. Specifies the name of the deployment. |
-| API Version | String | Input parameter. Specifies the version of the Azure OpenAI API to be used. |
+| Model | Dropdown | Input parameter. Specifies the Azure OpenAI model to use for text generation. |
+| Deployment Name | String | Input parameter. The Azure deployment name. Auto-populated from model selection; can be overridden for custom deployments. |
 | API Key | SecretString | Input parameter. Your Azure OpenAI API key. |
-| Temperature | Float | Input parameter. Specifies the sampling temperature. Defaults to `1.0`. |
-| Max Tokens | Integer | Input parameter. Specifies the maximum number of tokens to generate. Defaults to `1000`. |
+| Use Legacy API | Boolean | Advanced parameter. Use the legacy versioned API instead of the V1 Foundry API. Defaults to `false`. |
+| API Version | Dropdown | Advanced parameter. Specifies the version of the Azure OpenAI API to use (only visible when using legacy API). |
+| Reasoning Effort | Dropdown | Input parameter. Controls reasoning depth for reasoning models. Options: none, minimal, low, medium, high. Defaults to `medium`. |
+| Temperature | Float | Advanced parameter. Specifies the sampling temperature (hidden for reasoning models). Defaults to `0.7`. |
+| Seed | Integer | Advanced parameter. Controls reproducibility of the job (hidden for reasoning models). |
+| Max Tokens | Integer | Advanced parameter. Specifies the maximum number of tokens to generate. Set to 0 for unlimited tokens. |
+| Model Kwargs | Dict | Advanced parameter. Additional keyword arguments to pass to the model. |
 | Input Value | String | Input parameter. Specifies the input text for text generation. |
-| Stream | Boolean | Input parameter. Specifies whether to stream the response from the model. Default to `false`. |
+| Stream | Boolean | Input parameter. Specifies whether to stream the response from the model. Defaults to `false`. |
+
+:::info
+By default, this component uses the **V1 Foundry API** (`/openai/v1` endpoint). To use the legacy versioned API, enable the **Use Legacy API** toggle.
+:::
 
 ## Azure OpenAI Embeddings
 

--- a/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
+++ b/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
@@ -1,0 +1,139 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_openai import AzureChatOpenAI, ChatOpenAI
+from lfx.components.azure.azure_openai import AzureChatOpenAIComponent
+
+from tests.base import ComponentTestBaseWithoutClient
+
+
+class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
+    @pytest.fixture
+    def component_class(self):
+        return AzureChatOpenAIComponent
+
+    @pytest.fixture
+    def default_kwargs(self):
+        return {
+            "azure_endpoint": "https://example.azure.openai.com/",
+            "model_name": "gpt-5.1",
+            "azure_deployment": "YOUR-DEPLOYMENT-gpt-5.1",
+            "api_key": "test-api-key",
+            "use_legacy_api": False,
+            "temperature": 0.7,
+            "max_tokens": 1000,
+            "model_kwargs": {},
+        }
+
+    @pytest.fixture
+    def file_names_mapping(self):
+        return []
+
+    @patch("lfx.components.azure.azure_openai.ChatOpenAI")
+    async def test_build_model_v1(
+        self, mock_chat_openai, component_class, default_kwargs
+    ):
+        """Test V1 Foundry API model building (default)."""
+        mock_instance = MagicMock()
+        mock_chat_openai.return_value = mock_instance
+        component = component_class(**default_kwargs)
+        model = component.build_model()
+
+        mock_chat_openai.assert_called_once_with(
+            model="YOUR-DEPLOYMENT-gpt-5.1",
+            api_key="test-api-key",
+            base_url="https://example.azure.openai.com/openai/v1",
+            streaming=False,
+            model_kwargs={},
+            temperature=0.7,
+            max_tokens=1000,
+        )
+        assert model == mock_instance
+
+    @patch("lfx.components.azure.azure_openai.AzureChatOpenAI")
+    async def test_build_model_legacy(
+        self, mock_azure_chat_openai, component_class, default_kwargs
+    ):
+        """Test legacy API model building."""
+        mock_instance = MagicMock()
+        mock_azure_chat_openai.return_value = mock_instance
+        default_kwargs["use_legacy_api"] = True
+        default_kwargs["api_version"] = "2025-04-01-preview"
+        component = component_class(**default_kwargs)
+        model = component.build_model()
+
+        mock_azure_chat_openai.assert_called_once_with(
+            azure_endpoint="https://example.azure.openai.com/",
+            azure_deployment="YOUR-DEPLOYMENT-gpt-5.1",
+            api_version="2025-04-01-preview",
+            api_key="test-api-key",
+            streaming=False,
+            model_kwargs={},
+            temperature=0.7,
+            max_tokens=1000,
+        )
+        assert model == mock_instance
+
+    @patch("lfx.components.azure.azure_openai.ChatOpenAI")
+    async def test_build_model_reasoning(
+        self, mock_chat_openai, component_class, default_kwargs
+    ):
+        """Test reasoning model handling with V1 API."""
+        mock_instance = MagicMock()
+        mock_chat_openai.return_value = mock_instance
+        default_kwargs["model_name"] = "gpt-5.1"
+        default_kwargs["reasoning_effort"] = "high"
+        default_kwargs["seed"] = 42
+        component = component_class(**default_kwargs)
+        model = component.build_model()
+
+        # For reasoning models, temperature and seed should be excluded
+        # reasoning_effort should be in model_kwargs
+        _args, kwargs = mock_chat_openai.call_args
+        assert "temperature" not in kwargs
+        assert "seed" not in kwargs
+        assert kwargs["model_kwargs"]["reasoning_effort"] == "high"
+        assert model == mock_instance
+
+    async def test_update_build_config_reasoning(self, component_class, default_kwargs):
+        """Test build config updates for reasoning vs non-reasoning models."""
+        component = component_class(**default_kwargs)
+        build_config = {
+            "temperature": {"show": True},
+            "seed": {"show": True},
+            "reasoning_effort": {"show": True},
+        }
+
+        # Test with reasoning model (gpt-5.1)
+        updated_config = component.update_build_config(
+            build_config, "gpt-5.1", "model_name"
+        )
+        assert updated_config["temperature"]["show"] is False
+        assert updated_config["seed"]["show"] is False
+        assert updated_config["reasoning_effort"]["show"] is True
+
+        # Reset
+        build_config["temperature"]["show"] = True
+        build_config["seed"]["show"] = True
+
+        # Test with non-reasoning model
+        updated_config = component.update_build_config(
+            build_config, "gpt-4", "model_name"
+        )
+        assert updated_config["temperature"]["show"] is True
+        assert updated_config["seed"]["show"] is True
+        assert updated_config["reasoning_effort"]["show"] is False
+
+    async def test_deployment_name_override(self, component_class, default_kwargs):
+        """Test that custom azure_deployment value overrides the model-to-deployment mapping."""
+        default_kwargs["azure_deployment"] = "my-custom-deployment"
+        component = component_class(**default_kwargs)
+
+        deployment = component._resolve_deployment_name()
+        assert deployment == "my-custom-deployment"
+
+        # Test that empty deployment falls back to mapping
+        component.azure_deployment = ""
+        component.model_name = "gpt-5.1"
+        deployment = component._resolve_deployment_name()
+        assert deployment == "YOUR-DEPLOYMENT-gpt-5.1"

--- a/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
+++ b/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from langchain_openai import AzureChatOpenAI, ChatOpenAI
 from lfx.components.azure.azure_openai import AzureChatOpenAIComponent
 
 from tests.base import ComponentTestBaseWithoutClient
@@ -30,9 +29,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         return []
 
     @patch("lfx.components.azure.azure_openai.ChatOpenAI")
-    async def test_build_model_v1(
-        self, mock_chat_openai, component_class, default_kwargs
-    ):
+    async def test_build_model_v1(self, mock_chat_openai, component_class, default_kwargs):
         """Test V1 Foundry API model building (default)."""
         mock_instance = MagicMock()
         mock_chat_openai.return_value = mock_instance
@@ -51,9 +48,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         assert model == mock_instance
 
     @patch("lfx.components.azure.azure_openai.AzureChatOpenAI")
-    async def test_build_model_legacy(
-        self, mock_azure_chat_openai, component_class, default_kwargs
-    ):
+    async def test_build_model_legacy(self, mock_azure_chat_openai, component_class, default_kwargs):
         """Test legacy API model building."""
         mock_instance = MagicMock()
         mock_azure_chat_openai.return_value = mock_instance
@@ -75,9 +70,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         assert model == mock_instance
 
     @patch("lfx.components.azure.azure_openai.ChatOpenAI")
-    async def test_build_model_reasoning(
-        self, mock_chat_openai, component_class, default_kwargs
-    ):
+    async def test_build_model_reasoning(self, mock_chat_openai, component_class, default_kwargs):
         """Test reasoning model handling with V1 API."""
         mock_instance = MagicMock()
         mock_chat_openai.return_value = mock_instance
@@ -105,9 +98,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         }
 
         # Test with reasoning model (gpt-5.1)
-        updated_config = component.update_build_config(
-            build_config, "gpt-5.1", "model_name"
-        )
+        updated_config = component.update_build_config(build_config, "gpt-5.1", "model_name")
         assert updated_config["temperature"]["show"] is False
         assert updated_config["seed"]["show"] is False
         assert updated_config["reasoning_effort"]["show"] is True
@@ -117,9 +108,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         build_config["seed"]["show"] = True
 
         # Test with non-reasoning model
-        updated_config = component.update_build_config(
-            build_config, "gpt-4", "model_name"
-        )
+        updated_config = component.update_build_config(build_config, "gpt-4", "model_name")
         assert updated_config["temperature"]["show"] is True
         assert updated_config["seed"]["show"] is True
         assert updated_config["reasoning_effort"]["show"] is False

--- a/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
+++ b/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
@@ -1,9 +1,9 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from lfx.components.azure.azure_openai import AzureChatOpenAIComponent
 from pydantic.v1 import SecretStr
 
-from lfx.components.azure.azure_openai import AzureChatOpenAIComponent
 from tests.base import ComponentTestBaseWithoutClient
 
 
@@ -34,9 +34,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
     # ------------------------------------------------------------------
 
     @patch("lfx.components.azure.azure_openai.ChatOpenAI")
-    async def test_build_model_v1(
-        self, mock_chat_openai, component_class, default_kwargs
-    ):
+    async def test_build_model_v1(self, mock_chat_openai, component_class, default_kwargs):
         """Test V1 Foundry API model building (default)."""
         mock_instance = MagicMock()
         mock_chat_openai.return_value = mock_instance
@@ -58,9 +56,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
     # ------------------------------------------------------------------
 
     @patch("lfx.components.azure.azure_openai.ChatOpenAI")
-    async def test_build_model_v1_non_reasoning(
-        self, mock_chat_openai, component_class, default_kwargs
-    ):
+    async def test_build_model_v1_non_reasoning(self, mock_chat_openai, component_class, default_kwargs):
         """V1 non-reasoning model includes temperature and seed."""
         mock_instance = MagicMock()
         mock_chat_openai.return_value = mock_instance
@@ -88,9 +84,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
     # ------------------------------------------------------------------
 
     @patch("lfx.components.azure.azure_openai.AzureChatOpenAI")
-    async def test_build_model_legacy(
-        self, mock_azure_chat_openai, component_class, default_kwargs
-    ):
+    async def test_build_model_legacy(self, mock_azure_chat_openai, component_class, default_kwargs):
         """Test legacy API model building."""
         mock_instance = MagicMock()
         mock_azure_chat_openai.return_value = mock_instance
@@ -115,9 +109,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
     # ------------------------------------------------------------------
 
     @patch("lfx.components.azure.azure_openai.AzureChatOpenAI")
-    async def test_build_model_legacy_non_reasoning(
-        self, mock_azure_chat_openai, component_class, default_kwargs
-    ):
+    async def test_build_model_legacy_non_reasoning(self, mock_azure_chat_openai, component_class, default_kwargs):
         """Legacy non-reasoning model includes temperature and seed."""
         mock_instance = MagicMock()
         mock_azure_chat_openai.return_value = mock_instance
@@ -142,9 +134,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
     # ------------------------------------------------------------------
 
     @patch("lfx.components.azure.azure_openai.ChatOpenAI")
-    async def test_build_model_reasoning(
-        self, mock_chat_openai, component_class, default_kwargs
-    ):
+    async def test_build_model_reasoning(self, mock_chat_openai, component_class, default_kwargs):
         """Test reasoning model handling with V1 API."""
         mock_instance = MagicMock()
         mock_chat_openai.return_value = mock_instance
@@ -168,52 +158,38 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         "lfx.components.azure.azure_openai.ChatOpenAI",
         side_effect=RuntimeError("connection refused"),
     )
-    async def test_build_model_v1_connection_error(
-        self, _mock, component_class, default_kwargs
-    ):
+    async def test_build_model_v1_connection_error(self, _mock, component_class, default_kwargs):
         """V1 build wraps SDK errors in a descriptive ValueError."""
         component = component_class(**default_kwargs)
 
-        with pytest.raises(
-            ValueError, match="Could not connect to Azure OpenAI V1 API"
-        ):
+        with pytest.raises(ValueError, match="Could not connect to Azure OpenAI V1 API"):
             component.build_model()
 
     @patch(
         "lfx.components.azure.azure_openai.AzureChatOpenAI",
         side_effect=RuntimeError("timeout"),
     )
-    async def test_build_model_legacy_connection_error(
-        self, _mock, component_class, default_kwargs
-    ):
+    async def test_build_model_legacy_connection_error(self, _mock, component_class, default_kwargs):
         """Legacy build wraps SDK errors in a descriptive ValueError."""
         default_kwargs["use_legacy_api"] = True
         default_kwargs["api_version"] = "2025-04-01-preview"
         component = component_class(**default_kwargs)
 
-        with pytest.raises(
-            ValueError, match="Could not connect to Azure OpenAI API"
-        ):
+        with pytest.raises(ValueError, match="Could not connect to Azure OpenAI API"):
             component.build_model()
 
     # ------------------------------------------------------------------
     # update_build_config: reasoning vs non-reasoning
     # ------------------------------------------------------------------
 
-    async def test_update_build_config_reasoning(
-        self, component_class, default_kwargs
-    ):
+    async def test_update_build_config_reasoning(self, component_class, default_kwargs):
         """Test build config for reasoning vs non-reasoning models."""
-        component = await self.component_setup(
-            component_class, default_kwargs
-        )
+        component = await self.component_setup(component_class, default_kwargs)
 
         frontend_node = component.to_frontend_node()
         build_config = frontend_node["data"]["node"]["template"]
 
-        updated_config = component.update_build_config(
-            build_config, "gpt-5.1", "model_name"
-        )
+        updated_config = component.update_build_config(build_config, "gpt-5.1", "model_name")
         assert updated_config["temperature"]["show"] is False
         assert updated_config["seed"]["show"] is False
         assert updated_config["reasoning_effort"]["show"] is True
@@ -222,9 +198,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         build_config["temperature"]["show"] = True
         build_config["seed"]["show"] = True
 
-        updated_config = component.update_build_config(
-            build_config, "gpt-4", "model_name"
-        )
+        updated_config = component.update_build_config(build_config, "gpt-4", "model_name")
         assert updated_config["temperature"]["show"] is True
         assert updated_config["seed"]["show"] is True
         assert updated_config["reasoning_effort"]["show"] is False
@@ -234,69 +208,49 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
     # update_build_config: use_legacy_api toggling api_version visibility
     # ------------------------------------------------------------------
 
-    async def test_update_build_config_use_legacy_api_true(
-        self, component_class, default_kwargs
-    ):
+    async def test_update_build_config_use_legacy_api_true(self, component_class, default_kwargs):
         """Enabling legacy API makes api_version visible."""
-        component = await self.component_setup(
-            component_class, default_kwargs
-        )
+        component = await self.component_setup(component_class, default_kwargs)
 
         frontend_node = component.to_frontend_node()
         build_config = frontend_node["data"]["node"]["template"]
 
         assert build_config["api_version"]["show"] is False
 
-        updated = component.update_build_config(
-            build_config, True, "use_legacy_api"
-        )
+        updated = component.update_build_config(build_config, True, "use_legacy_api")
         assert updated["api_version"]["show"] is True
 
-    async def test_update_build_config_use_legacy_api_false(
-        self, component_class, default_kwargs
-    ):
+    async def test_update_build_config_use_legacy_api_false(self, component_class, default_kwargs):
         """Disabling legacy API hides api_version."""
-        component = await self.component_setup(
-            component_class, default_kwargs
-        )
+        component = await self.component_setup(component_class, default_kwargs)
 
         frontend_node = component.to_frontend_node()
         build_config = frontend_node["data"]["node"]["template"]
         build_config["api_version"]["show"] = True
 
-        updated = component.update_build_config(
-            build_config, False, "use_legacy_api"
-        )
+        updated = component.update_build_config(build_config, False, "use_legacy_api")
         assert updated["api_version"]["show"] is False
 
     # ------------------------------------------------------------------
     # update_build_config: partial config (KeyError guard)
     # ------------------------------------------------------------------
 
-    async def test_update_build_config_partial_config_no_keyerror(
-        self, component_class, default_kwargs
-    ):
+    async def test_update_build_config_partial_config_no_keyerror(self, component_class, default_kwargs):
         """Partial build_config missing keys must not raise KeyError."""
         component = component_class(**default_kwargs)
         sparse_config: dict = {}
 
-        result = component.update_build_config(
-            sparse_config, True, "use_legacy_api"
-        )
+        result = component.update_build_config(sparse_config, True, "use_legacy_api")
         assert result == {}
 
-        result = component.update_build_config(
-            sparse_config, "gpt-5.1", "model_name"
-        )
+        result = component.update_build_config(sparse_config, "gpt-5.1", "model_name")
         assert result == {}
 
     # ------------------------------------------------------------------
     # _is_reasoning_model
     # ------------------------------------------------------------------
 
-    async def test_is_reasoning_model_positive(
-        self, component_class, default_kwargs
-    ):
+    async def test_is_reasoning_model_positive(self, component_class, default_kwargs):
         """Known reasoning model names should be detected."""
         component = component_class(**default_kwargs)
         assert component._is_reasoning_model("gpt-5.1") is True
@@ -304,9 +258,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         assert component._is_reasoning_model("o1") is True
         assert component._is_reasoning_model("GPT-5.1") is True
 
-    async def test_is_reasoning_model_negative(
-        self, component_class, default_kwargs
-    ):
+    async def test_is_reasoning_model_negative(self, component_class, default_kwargs):
         """Non-reasoning model names should not be detected."""
         component = component_class(**default_kwargs)
         assert component._is_reasoning_model("gpt-4") is False
@@ -317,9 +269,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
     # _resolve_deployment_name
     # ------------------------------------------------------------------
 
-    async def test_deployment_name_override(
-        self, component_class, default_kwargs
-    ):
+    async def test_deployment_name_override(self, component_class, default_kwargs):
         """Custom azure_deployment overrides the model-to-deployment mapping."""
         default_kwargs["azure_deployment"] = "my-custom-deployment"
         component = component_class(**default_kwargs)
@@ -331,9 +281,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         component.model_name = "gpt-5.1"
         assert component._resolve_deployment_name() == "gpt-5.1"
 
-    async def test_deployment_name_falls_back_to_model_name(
-        self, component_class, default_kwargs
-    ):
+    async def test_deployment_name_falls_back_to_model_name(self, component_class, default_kwargs):
         """Empty MODEL_TO_DEPLOYMENT falls back to model_name."""
         default_kwargs["azure_deployment"] = ""
         default_kwargs["model_name"] = "gpt-4.1"
@@ -344,24 +292,18 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
     # _resolve_api_key
     # ------------------------------------------------------------------
 
-    async def test_resolve_api_key_plain_string(
-        self, component_class, default_kwargs
-    ):
+    async def test_resolve_api_key_plain_string(self, component_class, default_kwargs):
         """Plain string API key is returned as-is."""
         component = component_class(**default_kwargs)
         assert component._resolve_api_key() == "test-api-key"
 
-    async def test_resolve_api_key_secret_str(
-        self, component_class, default_kwargs
-    ):
+    async def test_resolve_api_key_secret_str(self, component_class, default_kwargs):
         """SecretStr API key is unwrapped."""
         default_kwargs["api_key"] = SecretStr("secret-value")
         component = component_class(**default_kwargs)
         assert component._resolve_api_key() == "secret-value"
 
-    async def test_resolve_api_key_none(
-        self, component_class, default_kwargs
-    ):
+    async def test_resolve_api_key_none(self, component_class, default_kwargs):
         """None API key returns None."""
         default_kwargs["api_key"] = None
         component = component_class(**default_kwargs)
@@ -371,9 +313,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
     # _prepare_model_kwargs
     # ------------------------------------------------------------------
 
-    async def test_prepare_model_kwargs_strips_api_key(
-        self, component_class, default_kwargs
-    ):
+    async def test_prepare_model_kwargs_strips_api_key(self, component_class, default_kwargs):
         """api_key inside model_kwargs must be stripped."""
         default_kwargs["model_kwargs"] = {
             "api_key": "leaked",
@@ -385,9 +325,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         assert "api_key" not in result
         assert result["custom_param"] == 42
 
-    async def test_prepare_model_kwargs_empty(
-        self, component_class, default_kwargs
-    ):
+    async def test_prepare_model_kwargs_empty(self, component_class, default_kwargs):
         """Empty or None model_kwargs returns an empty dict."""
         default_kwargs["model_kwargs"] = None
         component = component_class(**default_kwargs)
@@ -397,33 +335,21 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
     # api_version visibility alignment
     # ------------------------------------------------------------------
 
-    async def test_api_version_hidden_by_default(
-        self, component_class, default_kwargs
-    ):
+    async def test_api_version_hidden_by_default(self, component_class, default_kwargs):
         """api_version starts hidden when use_legacy_api is False."""
-        component = await self.component_setup(
-            component_class, default_kwargs
-        )
+        component = await self.component_setup(component_class, default_kwargs)
         frontend_node = component.to_frontend_node()
         build_config = frontend_node["data"]["node"]["template"]
         assert build_config["api_version"]["show"] is False
 
-    async def test_api_version_visible_when_legacy(
-        self, component_class, default_kwargs
-    ):
+    async def test_api_version_visible_when_legacy(self, component_class, default_kwargs):
         """api_version becomes visible when use_legacy_api is True."""
-        component = await self.component_setup(
-            component_class, default_kwargs
-        )
+        component = await self.component_setup(component_class, default_kwargs)
         frontend_node = component.to_frontend_node()
         build_config = frontend_node["data"]["node"]["template"]
 
-        component.update_build_config(
-            build_config, True, "use_legacy_api"
-        )
+        component.update_build_config(build_config, True, "use_legacy_api")
         assert build_config["api_version"]["show"] is True
 
-        component.update_build_config(
-            build_config, False, "use_legacy_api"
-        )
+        component.update_build_config(build_config, False, "use_legacy_api")
         assert build_config["api_version"]["show"] is False

--- a/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
+++ b/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
@@ -1,8 +1,9 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from lfx.components.azure.azure_openai import AzureChatOpenAIComponent
+from pydantic.v1 import SecretStr
 
+from lfx.components.azure.azure_openai import AzureChatOpenAIComponent
 from tests.base import ComponentTestBaseWithoutClient
 
 
@@ -28,15 +29,20 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
     def file_names_mapping(self):
         return []
 
+    # ------------------------------------------------------------------
+    # build_model: V1 reasoning (default path)
+    # ------------------------------------------------------------------
+
     @patch("lfx.components.azure.azure_openai.ChatOpenAI")
-    async def test_build_model_v1(self, mock_chat_openai, component_class, default_kwargs):
+    async def test_build_model_v1(
+        self, mock_chat_openai, component_class, default_kwargs
+    ):
         """Test V1 Foundry API model building (default)."""
         mock_instance = MagicMock()
         mock_chat_openai.return_value = mock_instance
         component = component_class(**default_kwargs)
         model = component.build_model()
 
-        # gpt-5.1 is a reasoning model, so it uses max_completion_tokens and reasoning_effort
         mock_chat_openai.assert_called_once_with(
             model="gpt-5.1",
             api_key="test-api-key",
@@ -47,8 +53,44 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         )
         assert model == mock_instance
 
+    # ------------------------------------------------------------------
+    # build_model: V1 non-reasoning (temperature + seed included)
+    # ------------------------------------------------------------------
+
+    @patch("lfx.components.azure.azure_openai.ChatOpenAI")
+    async def test_build_model_v1_non_reasoning(
+        self, mock_chat_openai, component_class, default_kwargs
+    ):
+        """V1 non-reasoning model includes temperature and seed."""
+        mock_instance = MagicMock()
+        mock_chat_openai.return_value = mock_instance
+
+        default_kwargs["model_name"] = "gpt-4.1"
+        default_kwargs["azure_deployment"] = "my-gpt4-deploy"
+        default_kwargs["seed"] = 42
+        component = component_class(**default_kwargs)
+        model = component.build_model()
+
+        mock_chat_openai.assert_called_once_with(
+            model="my-gpt4-deploy",
+            api_key="test-api-key",
+            base_url="https://example.azure.openai.com/openai/v1",
+            streaming=False,
+            model_kwargs={},
+            temperature=0.7,
+            seed=42,
+            max_tokens=1000,
+        )
+        assert model == mock_instance
+
+    # ------------------------------------------------------------------
+    # build_model: legacy reasoning
+    # ------------------------------------------------------------------
+
     @patch("lfx.components.azure.azure_openai.AzureChatOpenAI")
-    async def test_build_model_legacy(self, mock_azure_chat_openai, component_class, default_kwargs):
+    async def test_build_model_legacy(
+        self, mock_azure_chat_openai, component_class, default_kwargs
+    ):
         """Test legacy API model building."""
         mock_instance = MagicMock()
         mock_azure_chat_openai.return_value = mock_instance
@@ -57,7 +99,6 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         component = component_class(**default_kwargs)
         model = component.build_model()
 
-        # gpt-5.1 is a reasoning model, so it uses max_completion_tokens and reasoning_effort
         mock_azure_chat_openai.assert_called_once_with(
             azure_endpoint="https://example.azure.openai.com/",
             azure_deployment="gpt-5.1",
@@ -69,8 +110,41 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         )
         assert model == mock_instance
 
+    # ------------------------------------------------------------------
+    # build_model: legacy non-reasoning
+    # ------------------------------------------------------------------
+
+    @patch("lfx.components.azure.azure_openai.AzureChatOpenAI")
+    async def test_build_model_legacy_non_reasoning(
+        self, mock_azure_chat_openai, component_class, default_kwargs
+    ):
+        """Legacy non-reasoning model includes temperature and seed."""
+        mock_instance = MagicMock()
+        mock_azure_chat_openai.return_value = mock_instance
+
+        default_kwargs["use_legacy_api"] = True
+        default_kwargs["api_version"] = "2025-04-01-preview"
+        default_kwargs["model_name"] = "gpt-4.1-mini"
+        default_kwargs["azure_deployment"] = "gpt-4.1-mini"
+        default_kwargs["seed"] = 7
+        component = component_class(**default_kwargs)
+        model = component.build_model()
+
+        _args, kwargs = mock_azure_chat_openai.call_args
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["seed"] == 7
+        assert kwargs["max_tokens"] == 1000
+        assert "reasoning_effort" not in kwargs.get("model_kwargs", {})
+        assert model == mock_instance
+
+    # ------------------------------------------------------------------
+    # build_model: reasoning model excludes temperature/seed
+    # ------------------------------------------------------------------
+
     @patch("lfx.components.azure.azure_openai.ChatOpenAI")
-    async def test_build_model_reasoning(self, mock_chat_openai, component_class, default_kwargs):
+    async def test_build_model_reasoning(
+        self, mock_chat_openai, component_class, default_kwargs
+    ):
         """Test reasoning model handling with V1 API."""
         mock_instance = MagicMock()
         mock_chat_openai.return_value = mock_instance
@@ -80,52 +154,276 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         component = component_class(**default_kwargs)
         model = component.build_model()
 
-        # For reasoning models, temperature and seed should be excluded
-        # reasoning_effort should be in model_kwargs
         _args, kwargs = mock_chat_openai.call_args
         assert "temperature" not in kwargs
         assert "seed" not in kwargs
         assert kwargs["model_kwargs"]["reasoning_effort"] == "high"
         assert model == mock_instance
 
-    async def test_update_build_config_reasoning(self, component_class, default_kwargs):
-        """Test build config updates for reasoning vs non-reasoning models."""
-        component = await self.component_setup(component_class, default_kwargs)
+    # ------------------------------------------------------------------
+    # build_model: error scenarios
+    # ------------------------------------------------------------------
 
-        # Get the full frontend node to get a complete build_config
+    @patch(
+        "lfx.components.azure.azure_openai.ChatOpenAI",
+        side_effect=RuntimeError("connection refused"),
+    )
+    async def test_build_model_v1_connection_error(
+        self, _mock, component_class, default_kwargs
+    ):
+        """V1 build wraps SDK errors in a descriptive ValueError."""
+        component = component_class(**default_kwargs)
+
+        with pytest.raises(
+            ValueError, match="Could not connect to Azure OpenAI V1 API"
+        ):
+            component.build_model()
+
+    @patch(
+        "lfx.components.azure.azure_openai.AzureChatOpenAI",
+        side_effect=RuntimeError("timeout"),
+    )
+    async def test_build_model_legacy_connection_error(
+        self, _mock, component_class, default_kwargs
+    ):
+        """Legacy build wraps SDK errors in a descriptive ValueError."""
+        default_kwargs["use_legacy_api"] = True
+        default_kwargs["api_version"] = "2025-04-01-preview"
+        component = component_class(**default_kwargs)
+
+        with pytest.raises(
+            ValueError, match="Could not connect to Azure OpenAI API"
+        ):
+            component.build_model()
+
+    # ------------------------------------------------------------------
+    # update_build_config: reasoning vs non-reasoning
+    # ------------------------------------------------------------------
+
+    async def test_update_build_config_reasoning(
+        self, component_class, default_kwargs
+    ):
+        """Test build config for reasoning vs non-reasoning models."""
+        component = await self.component_setup(
+            component_class, default_kwargs
+        )
+
         frontend_node = component.to_frontend_node()
         build_config = frontend_node["data"]["node"]["template"]
 
-        # Test with reasoning model (gpt-5.1)
-        updated_config = component.update_build_config(build_config, "gpt-5.1", "model_name")
+        updated_config = component.update_build_config(
+            build_config, "gpt-5.1", "model_name"
+        )
         assert updated_config["temperature"]["show"] is False
         assert updated_config["seed"]["show"] is False
         assert updated_config["reasoning_effort"]["show"] is True
-        # Verify azure_deployment is auto-populated to the model name (since MODEL_TO_DEPLOYMENT is empty)
         assert updated_config["azure_deployment"]["value"] == "gpt-5.1"
 
-        # Reset visibility flags for next test
         build_config["temperature"]["show"] = True
         build_config["seed"]["show"] = True
 
-        # Test with non-reasoning model (gpt-4)
-        updated_config = component.update_build_config(build_config, "gpt-4", "model_name")
+        updated_config = component.update_build_config(
+            build_config, "gpt-4", "model_name"
+        )
         assert updated_config["temperature"]["show"] is True
         assert updated_config["seed"]["show"] is True
         assert updated_config["reasoning_effort"]["show"] is False
-        # Verify azure_deployment is auto-populated to the model name
         assert updated_config["azure_deployment"]["value"] == "gpt-4"
 
-    async def test_deployment_name_override(self, component_class, default_kwargs):
-        """Test that custom azure_deployment value overrides the model-to-deployment mapping."""
+    # ------------------------------------------------------------------
+    # update_build_config: use_legacy_api toggling api_version visibility
+    # ------------------------------------------------------------------
+
+    async def test_update_build_config_use_legacy_api_true(
+        self, component_class, default_kwargs
+    ):
+        """Enabling legacy API makes api_version visible."""
+        component = await self.component_setup(
+            component_class, default_kwargs
+        )
+
+        frontend_node = component.to_frontend_node()
+        build_config = frontend_node["data"]["node"]["template"]
+
+        assert build_config["api_version"]["show"] is False
+
+        updated = component.update_build_config(
+            build_config, True, "use_legacy_api"
+        )
+        assert updated["api_version"]["show"] is True
+
+    async def test_update_build_config_use_legacy_api_false(
+        self, component_class, default_kwargs
+    ):
+        """Disabling legacy API hides api_version."""
+        component = await self.component_setup(
+            component_class, default_kwargs
+        )
+
+        frontend_node = component.to_frontend_node()
+        build_config = frontend_node["data"]["node"]["template"]
+        build_config["api_version"]["show"] = True
+
+        updated = component.update_build_config(
+            build_config, False, "use_legacy_api"
+        )
+        assert updated["api_version"]["show"] is False
+
+    # ------------------------------------------------------------------
+    # update_build_config: partial config (KeyError guard)
+    # ------------------------------------------------------------------
+
+    async def test_update_build_config_partial_config_no_keyerror(
+        self, component_class, default_kwargs
+    ):
+        """Partial build_config missing keys must not raise KeyError."""
+        component = component_class(**default_kwargs)
+        sparse_config: dict = {}
+
+        result = component.update_build_config(
+            sparse_config, True, "use_legacy_api"
+        )
+        assert result == {}
+
+        result = component.update_build_config(
+            sparse_config, "gpt-5.1", "model_name"
+        )
+        assert result == {}
+
+    # ------------------------------------------------------------------
+    # _is_reasoning_model
+    # ------------------------------------------------------------------
+
+    async def test_is_reasoning_model_positive(
+        self, component_class, default_kwargs
+    ):
+        """Known reasoning model names should be detected."""
+        component = component_class(**default_kwargs)
+        assert component._is_reasoning_model("gpt-5.1") is True
+        assert component._is_reasoning_model("gpt-5-mini") is True
+        assert component._is_reasoning_model("o1") is True
+        assert component._is_reasoning_model("GPT-5.1") is True
+
+    async def test_is_reasoning_model_negative(
+        self, component_class, default_kwargs
+    ):
+        """Non-reasoning model names should not be detected."""
+        component = component_class(**default_kwargs)
+        assert component._is_reasoning_model("gpt-4") is False
+        assert component._is_reasoning_model("gpt-4.1-mini") is False
+        assert component._is_reasoning_model("some-custom-model") is False
+
+    # ------------------------------------------------------------------
+    # _resolve_deployment_name
+    # ------------------------------------------------------------------
+
+    async def test_deployment_name_override(
+        self, component_class, default_kwargs
+    ):
+        """Custom azure_deployment overrides the model-to-deployment mapping."""
         default_kwargs["azure_deployment"] = "my-custom-deployment"
         component = component_class(**default_kwargs)
 
-        deployment = component._resolve_deployment_name()
-        assert deployment == "my-custom-deployment"
+        result = component._resolve_deployment_name()
+        assert result == "my-custom-deployment"
 
-        # Test that empty deployment falls back to model name
         component.azure_deployment = ""
         component.model_name = "gpt-5.1"
-        deployment = component._resolve_deployment_name()
-        assert deployment == "gpt-5.1"
+        assert component._resolve_deployment_name() == "gpt-5.1"
+
+    async def test_deployment_name_falls_back_to_model_name(
+        self, component_class, default_kwargs
+    ):
+        """Empty MODEL_TO_DEPLOYMENT falls back to model_name."""
+        default_kwargs["azure_deployment"] = ""
+        default_kwargs["model_name"] = "gpt-4.1"
+        component = component_class(**default_kwargs)
+        assert component._resolve_deployment_name() == "gpt-4.1"
+
+    # ------------------------------------------------------------------
+    # _resolve_api_key
+    # ------------------------------------------------------------------
+
+    async def test_resolve_api_key_plain_string(
+        self, component_class, default_kwargs
+    ):
+        """Plain string API key is returned as-is."""
+        component = component_class(**default_kwargs)
+        assert component._resolve_api_key() == "test-api-key"
+
+    async def test_resolve_api_key_secret_str(
+        self, component_class, default_kwargs
+    ):
+        """SecretStr API key is unwrapped."""
+        default_kwargs["api_key"] = SecretStr("secret-value")
+        component = component_class(**default_kwargs)
+        assert component._resolve_api_key() == "secret-value"
+
+    async def test_resolve_api_key_none(
+        self, component_class, default_kwargs
+    ):
+        """None API key returns None."""
+        default_kwargs["api_key"] = None
+        component = component_class(**default_kwargs)
+        assert component._resolve_api_key() is None
+
+    # ------------------------------------------------------------------
+    # _prepare_model_kwargs
+    # ------------------------------------------------------------------
+
+    async def test_prepare_model_kwargs_strips_api_key(
+        self, component_class, default_kwargs
+    ):
+        """api_key inside model_kwargs must be stripped."""
+        default_kwargs["model_kwargs"] = {
+            "api_key": "leaked",
+            "custom_param": 42,
+        }
+        component = component_class(**default_kwargs)
+
+        result = component._prepare_model_kwargs()
+        assert "api_key" not in result
+        assert result["custom_param"] == 42
+
+    async def test_prepare_model_kwargs_empty(
+        self, component_class, default_kwargs
+    ):
+        """Empty or None model_kwargs returns an empty dict."""
+        default_kwargs["model_kwargs"] = None
+        component = component_class(**default_kwargs)
+        assert component._prepare_model_kwargs() == {}
+
+    # ------------------------------------------------------------------
+    # api_version visibility alignment
+    # ------------------------------------------------------------------
+
+    async def test_api_version_hidden_by_default(
+        self, component_class, default_kwargs
+    ):
+        """api_version starts hidden when use_legacy_api is False."""
+        component = await self.component_setup(
+            component_class, default_kwargs
+        )
+        frontend_node = component.to_frontend_node()
+        build_config = frontend_node["data"]["node"]["template"]
+        assert build_config["api_version"]["show"] is False
+
+    async def test_api_version_visible_when_legacy(
+        self, component_class, default_kwargs
+    ):
+        """api_version becomes visible when use_legacy_api is True."""
+        component = await self.component_setup(
+            component_class, default_kwargs
+        )
+        frontend_node = component.to_frontend_node()
+        build_config = frontend_node["data"]["node"]["template"]
+
+        component.update_build_config(
+            build_config, True, "use_legacy_api"
+        )
+        assert build_config["api_version"]["show"] is True
+
+        component.update_build_config(
+            build_config, False, "use_legacy_api"
+        )
+        assert build_config["api_version"]["show"] is False

--- a/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
+++ b/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
@@ -16,7 +16,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         return {
             "azure_endpoint": "https://example.azure.openai.com/",
             "model_name": "gpt-5.1",
-            "azure_deployment": "YOUR-DEPLOYMENT-gpt-5.1",
+            "azure_deployment": "gpt-5.1",
             "api_key": "test-api-key",
             "use_legacy_api": False,
             "temperature": 0.7,
@@ -36,14 +36,14 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         component = component_class(**default_kwargs)
         model = component.build_model()
 
+        # gpt-5.1 is a reasoning model, so it uses max_completion_tokens and reasoning_effort
         mock_chat_openai.assert_called_once_with(
-            model="YOUR-DEPLOYMENT-gpt-5.1",
+            model="gpt-5.1",
             api_key="test-api-key",
             base_url="https://example.azure.openai.com/openai/v1",
             streaming=False,
-            model_kwargs={},
-            temperature=0.7,
-            max_tokens=1000,
+            model_kwargs={"reasoning_effort": "medium"},
+            max_completion_tokens=1000,
         )
         assert model == mock_instance
 
@@ -57,15 +57,15 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         component = component_class(**default_kwargs)
         model = component.build_model()
 
+        # gpt-5.1 is a reasoning model, so it uses max_completion_tokens and reasoning_effort
         mock_azure_chat_openai.assert_called_once_with(
             azure_endpoint="https://example.azure.openai.com/",
-            azure_deployment="YOUR-DEPLOYMENT-gpt-5.1",
+            azure_deployment="gpt-5.1",
             api_version="2025-04-01-preview",
             api_key="test-api-key",
             streaming=False,
-            model_kwargs={},
-            temperature=0.7,
-            max_tokens=1000,
+            model_kwargs={"reasoning_effort": "medium"},
+            max_completion_tokens=1000,
         )
         assert model == mock_instance
 
@@ -90,28 +90,31 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
 
     async def test_update_build_config_reasoning(self, component_class, default_kwargs):
         """Test build config updates for reasoning vs non-reasoning models."""
-        component = component_class(**default_kwargs)
-        build_config = {
-            "temperature": {"show": True},
-            "seed": {"show": True},
-            "reasoning_effort": {"show": True},
-        }
+        component = await self.component_setup(component_class, default_kwargs)
+
+        # Get the full frontend node to get a complete build_config
+        frontend_node = component.to_frontend_node()
+        build_config = frontend_node["data"]["node"]["template"]
 
         # Test with reasoning model (gpt-5.1)
         updated_config = component.update_build_config(build_config, "gpt-5.1", "model_name")
         assert updated_config["temperature"]["show"] is False
         assert updated_config["seed"]["show"] is False
         assert updated_config["reasoning_effort"]["show"] is True
+        # Verify azure_deployment is auto-populated to the model name (since MODEL_TO_DEPLOYMENT is empty)
+        assert updated_config["azure_deployment"]["value"] == "gpt-5.1"
 
-        # Reset
+        # Reset visibility flags for next test
         build_config["temperature"]["show"] = True
         build_config["seed"]["show"] = True
 
-        # Test with non-reasoning model
+        # Test with non-reasoning model (gpt-4)
         updated_config = component.update_build_config(build_config, "gpt-4", "model_name")
         assert updated_config["temperature"]["show"] is True
         assert updated_config["seed"]["show"] is True
         assert updated_config["reasoning_effort"]["show"] is False
+        # Verify azure_deployment is auto-populated to the model name
+        assert updated_config["azure_deployment"]["value"] == "gpt-4"
 
     async def test_deployment_name_override(self, component_class, default_kwargs):
         """Test that custom azure_deployment value overrides the model-to-deployment mapping."""
@@ -121,8 +124,8 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         deployment = component._resolve_deployment_name()
         assert deployment == "my-custom-deployment"
 
-        # Test that empty deployment falls back to mapping
+        # Test that empty deployment falls back to model name
         component.azure_deployment = ""
         component.model_name = "gpt-5.1"
         deployment = component._resolve_deployment_name()
-        assert deployment == "YOUR-DEPLOYMENT-gpt-5.1"
+        assert deployment == "gpt-5.1"

--- a/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
+++ b/src/backend/tests/unit/components/languagemodels/test_azure_openai.py
@@ -158,7 +158,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         "lfx.components.azure.azure_openai.ChatOpenAI",
         side_effect=RuntimeError("connection refused"),
     )
-    async def test_build_model_v1_connection_error(self, _mock, component_class, default_kwargs):
+    async def test_build_model_v1_connection_error(self, _mock, component_class, default_kwargs):  # noqa: PT019
         """V1 build wraps SDK errors in a descriptive ValueError."""
         component = component_class(**default_kwargs)
 
@@ -169,7 +169,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         "lfx.components.azure.azure_openai.AzureChatOpenAI",
         side_effect=RuntimeError("timeout"),
     )
-    async def test_build_model_legacy_connection_error(self, _mock, component_class, default_kwargs):
+    async def test_build_model_legacy_connection_error(self, _mock, component_class, default_kwargs):  # noqa: PT019
         """Legacy build wraps SDK errors in a descriptive ValueError."""
         default_kwargs["use_legacy_api"] = True
         default_kwargs["api_version"] = "2025-04-01-preview"
@@ -217,7 +217,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
 
         assert build_config["api_version"]["show"] is False
 
-        updated = component.update_build_config(build_config, True, "use_legacy_api")
+        updated = component.update_build_config(build_config, field_value=True, field_name="use_legacy_api")
         assert updated["api_version"]["show"] is True
 
     async def test_update_build_config_use_legacy_api_false(self, component_class, default_kwargs):
@@ -228,7 +228,7 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         build_config = frontend_node["data"]["node"]["template"]
         build_config["api_version"]["show"] = True
 
-        updated = component.update_build_config(build_config, False, "use_legacy_api")
+        updated = component.update_build_config(build_config, field_value=False, field_name="use_legacy_api")
         assert updated["api_version"]["show"] is False
 
     # ------------------------------------------------------------------
@@ -240,10 +240,10 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         component = component_class(**default_kwargs)
         sparse_config: dict = {}
 
-        result = component.update_build_config(sparse_config, True, "use_legacy_api")
+        result = component.update_build_config(sparse_config, field_value=True, field_name="use_legacy_api")
         assert result == {}
 
-        result = component.update_build_config(sparse_config, "gpt-5.1", "model_name")
+        result = component.update_build_config(sparse_config, field_value="gpt-5.1", field_name="model_name")
         assert result == {}
 
     # ------------------------------------------------------------------
@@ -348,8 +348,8 @@ class TestAzureChatOpenAIComponent(ComponentTestBaseWithoutClient):
         frontend_node = component.to_frontend_node()
         build_config = frontend_node["data"]["node"]["template"]
 
-        component.update_build_config(build_config, True, "use_legacy_api")
+        component.update_build_config(build_config, field_value=True, field_name="use_legacy_api")
         assert build_config["api_version"]["show"] is True
 
-        component.update_build_config(build_config, False, "use_legacy_api")
+        component.update_build_config(build_config, field_value=False, field_name="use_legacy_api")
         assert build_config["api_version"]["show"] is False

--- a/src/lfx/src/lfx/_assets/stable_hash_history.json
+++ b/src/lfx/src/lfx/_assets/stable_hash_history.json
@@ -126,7 +126,7 @@
   },
   "AzureOpenAIModel": {
     "versions": {
-      "0.3.0": "be5baf7de5dc"
+      "0.3.0": "d7dc1027daf4"
     }
   },
   "AzureOpenAIEmbeddings": {

--- a/src/lfx/src/lfx/_assets/stable_hash_history.json
+++ b/src/lfx/src/lfx/_assets/stable_hash_history.json
@@ -126,7 +126,7 @@
   },
   "AzureOpenAIModel": {
     "versions": {
-      "0.3.0": "2ba26202203e"
+      "0.3.0": "be5baf7de5dc"
     }
   },
   "AzureOpenAIEmbeddings": {

--- a/src/lfx/src/lfx/_assets/stable_hash_history.json
+++ b/src/lfx/src/lfx/_assets/stable_hash_history.json
@@ -126,7 +126,7 @@
   },
   "AzureOpenAIModel": {
     "versions": {
-      "0.3.0": "d7dc1027daf4"
+      "0.3.0": "f672f15a2ce2"
     }
   },
   "AzureOpenAIEmbeddings": {

--- a/src/lfx/src/lfx/components/azure/azure_openai.py
+++ b/src/lfx/src/lfx/components/azure/azure_openai.py
@@ -32,12 +32,10 @@ REASONING_MODEL_NAMES = {
 }
 
 MODEL_TO_DEPLOYMENT = {
-    "gpt-5.1": "dsailangflow-gpt-5.1",
-    "gpt-5-mini": "dsailangflow-gpt-5-mini",
-    "gpt-5-nano": "dsailangflow-gpt-5-nano",
-    "gpt-4.1": "dsailangflow-gpt4.1",
-    "gpt-4.1-mini": "dsailangflow-gpt4.1-mini",
-    "gpt-4.1-nano": "dsailangflow-gpt4.1-nano",
+    "gpt-5.1": "YOUR-DEPLOYMENT-gpt-5.1",
+    "gpt-5-mini": "YOUR-DEPLOYMENT-gpt-5-mini",
+    "gpt-4.1": "YOUR-DEPLOYMENT-gpt4.1",
+    "gpt-4.1-mini": "YOUR-DEPLOYMENT-gpt4.1-mini",
 }
 AZURE_MODEL_NAMES = list(MODEL_TO_DEPLOYMENT)
 
@@ -66,6 +64,13 @@ class AzureChatOpenAIComponent(LCModelComponent):
             options=AZURE_MODEL_NAMES,
             value=AZURE_MODEL_NAMES[0],
             combobox=True,
+            required=True,
+            real_time_refresh=True,
+        ),
+        MessageTextInput(
+            name="azure_deployment",
+            display_name="Deployment Name",
+            info="The Azure deployment name to use. Auto-populated from model selection; override for custom deployments.",
             required=True,
             real_time_refresh=True,
         ),
@@ -102,7 +107,7 @@ class AzureChatOpenAIComponent(LCModelComponent):
         SliderInput(
             name="temperature",
             display_name="Temperature",
-            value=1.0,
+            value=0.7,
             range_spec=RangeSpec(min=0, max=2, step=0.01),
             info="Controls randomness. Lower values are more deterministic, higher values are more creative.",
             advanced=True,
@@ -139,6 +144,9 @@ class AzureChatOpenAIComponent(LCModelComponent):
             model = str(field_value) if field_value else ""
             is_reasoning = self._is_reasoning_model(model)
             self._apply_reasoning_visibility(build_config, is_reasoning=is_reasoning)
+            build_config["azure_deployment"]["value"] = MODEL_TO_DEPLOYMENT.get(
+                model, model
+            )
 
         return build_config
 
@@ -147,10 +155,13 @@ class AzureChatOpenAIComponent(LCModelComponent):
         return any(model in name for model in REASONING_MODEL_NAMES)
 
     def _resolve_deployment_name(self) -> str:
-        """Map the selected model name to its Azure deployment name.
+        """Return the Azure deployment name.
 
-        Falls back to the raw value for custom entries typed into the combobox.
+        Uses azure_deployment as the primary source. Falls back to mapping
+        the model name if deployment is not set.
         """
+        if self.azure_deployment:
+            return self.azure_deployment
         return MODEL_TO_DEPLOYMENT.get(self.model_name, self.model_name)
 
     def _apply_legacy_api_visibility(

--- a/src/lfx/src/lfx/components/azure/azure_openai.py
+++ b/src/lfx/src/lfx/components/azure/azure_openai.py
@@ -29,13 +29,8 @@ AZURE_OPENAI_API_VERSIONS = [
 
 REASONING_MODEL_NAMES = {m["name"] for m in OPENAI_MODELS_DETAILED if m.get("reasoning")}
 
-MODEL_TO_DEPLOYMENT = {
-    "gpt-5.1": "YOUR-DEPLOYMENT-gpt-5.1",
-    "gpt-5-mini": "YOUR-DEPLOYMENT-gpt-5-mini",
-    "gpt-4.1": "YOUR-DEPLOYMENT-gpt4.1",
-    "gpt-4.1-mini": "YOUR-DEPLOYMENT-gpt4.1-mini",
-}
-AZURE_MODEL_NAMES = list(MODEL_TO_DEPLOYMENT)
+MODEL_TO_DEPLOYMENT: dict[str, str] = {}
+AZURE_MODEL_NAMES = ["gpt-5.1", "gpt-5-mini", "gpt-4.1", "gpt-4.1-mini"]
 
 
 class AzureChatOpenAIComponent(LCModelComponent):
@@ -66,7 +61,10 @@ class AzureChatOpenAIComponent(LCModelComponent):
         MessageTextInput(
             name="azure_deployment",
             display_name="Deployment Name",
-            info="The Azure deployment name to use. Auto-populated from model selection; override for custom deployments.",
+            info=(
+                "The Azure deployment name to use. Auto-populated from model selection; "
+                "override for custom deployments."
+            ),
             required=True,
             real_time_refresh=True,
         ),
@@ -138,7 +136,8 @@ class AzureChatOpenAIComponent(LCModelComponent):
             model = str(field_value) if field_value else ""
             is_reasoning = self._is_reasoning_model(model)
             self._apply_reasoning_visibility(build_config, is_reasoning=is_reasoning)
-            build_config["azure_deployment"]["value"] = MODEL_TO_DEPLOYMENT.get(model, model)
+            if "azure_deployment" in build_config and isinstance(build_config["azure_deployment"], dict):
+                build_config["azure_deployment"]["value"] = MODEL_TO_DEPLOYMENT.get(model, model)
 
         return build_config
 
@@ -152,9 +151,7 @@ class AzureChatOpenAIComponent(LCModelComponent):
         Uses azure_deployment as the primary source. Falls back to mapping
         the model name if deployment is not set.
         """
-        if self.azure_deployment:
-            return self.azure_deployment
-        return MODEL_TO_DEPLOYMENT.get(self.model_name, self.model_name)
+        return self.azure_deployment or MODEL_TO_DEPLOYMENT.get(self.model_name, self.model_name)
 
     def _apply_legacy_api_visibility(self, build_config: dict, *, is_legacy: bool) -> None:
         build_config["api_version"]["show"] = is_legacy

--- a/src/lfx/src/lfx/components/azure/azure_openai.py
+++ b/src/lfx/src/lfx/components/azure/azure_openai.py
@@ -129,6 +129,13 @@ class AzureChatOpenAIComponent(LCModelComponent):
     ]
 
     def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:
+        """Toggle UI field visibility based on the changed field.
+
+        Handles two field triggers:
+        - ``use_legacy_api``: shows/hides the ``api_version`` dropdown.
+        - ``model_name``: toggles reasoning-specific vs standard parameters
+          and auto-populates the deployment name.
+        """
         if field_name == "use_legacy_api":
             self._apply_legacy_api_visibility(build_config, is_legacy=bool(field_value))
 
@@ -142,6 +149,11 @@ class AzureChatOpenAIComponent(LCModelComponent):
         return build_config
 
     def _is_reasoning_model(self, model_name: str) -> bool:
+        """Check whether *model_name* is a reasoning model.
+
+        Performs a case-insensitive substring match against the known
+        reasoning model names from ``OPENAI_MODELS_DETAILED``.
+        """
         name = model_name.lower()
         return any(model in name for model in REASONING_MODEL_NAMES)
 
@@ -154,14 +166,29 @@ class AzureChatOpenAIComponent(LCModelComponent):
         return self.azure_deployment or MODEL_TO_DEPLOYMENT.get(self.model_name, self.model_name)
 
     def _apply_legacy_api_visibility(self, build_config: dict, *, is_legacy: bool) -> None:
-        build_config["api_version"]["show"] = is_legacy
+        """Show the ``api_version`` field only when the legacy API is selected."""
+        if "api_version" in build_config and isinstance(build_config["api_version"], dict):
+            build_config["api_version"]["show"] = is_legacy
 
     def _apply_reasoning_visibility(self, build_config: dict, *, is_reasoning: bool) -> None:
-        build_config["temperature"]["show"] = not is_reasoning
-        build_config["seed"]["show"] = not is_reasoning
-        build_config["reasoning_effort"]["show"] = is_reasoning
+        """Toggle parameter visibility based on whether the model supports reasoning.
+
+        Reasoning models expose ``reasoning_effort`` and hide ``temperature``
+        and ``seed``; standard models do the inverse.
+        """
+        if "temperature" in build_config and isinstance(build_config["temperature"], dict):
+            build_config["temperature"]["show"] = not is_reasoning
+        if "seed" in build_config and isinstance(build_config["seed"], dict):
+            build_config["seed"]["show"] = not is_reasoning
+        if "reasoning_effort" in build_config and isinstance(build_config["reasoning_effort"], dict):
+            build_config["reasoning_effort"]["show"] = is_reasoning
 
     def build_model(self) -> LanguageModel:  # type: ignore[type-var]
+        """Build and return a configured language model instance.
+
+        Routes to the V1 Foundry API (``ChatOpenAI``) or the legacy versioned
+        API (``AzureChatOpenAI``) depending on ``use_legacy_api``.
+        """
         api_key_value = self._resolve_api_key()
         model_kwargs = self._prepare_model_kwargs()
         is_reasoning = self._is_reasoning_model(self.model_name or "")
@@ -171,6 +198,7 @@ class AzureChatOpenAIComponent(LCModelComponent):
         return self._build_v1_model(api_key_value, model_kwargs, is_reasoning=is_reasoning)
 
     def _resolve_api_key(self) -> str | None:
+        """Unwrap the API key from a ``SecretStr`` or return it as a plain string."""
         if not self.api_key:
             return None
         if isinstance(self.api_key, SecretStr):
@@ -178,11 +206,21 @@ class AzureChatOpenAIComponent(LCModelComponent):
         return str(self.api_key)
 
     def _prepare_model_kwargs(self) -> dict:
+        """Return a sanitised copy of ``model_kwargs``.
+
+        Strips ``api_key`` to prevent it from being passed twice to the
+        underlying LangChain constructor.
+        """
         model_kwargs = dict(self.model_kwargs) if self.model_kwargs else {}
         model_kwargs.pop("api_key", None)
         return model_kwargs
 
     def _build_v1_model(self, api_key: str | None, model_kwargs: dict, *, is_reasoning: bool) -> LanguageModel:
+        """Construct a ``ChatOpenAI`` instance targeting the V1 Foundry API.
+
+        Reasoning models receive ``reasoning_effort`` in *model_kwargs* and
+        ``max_completion_tokens`` instead of ``max_tokens``.
+        """
         base_url = self.azure_endpoint.rstrip("/") + "/openai/v1"
         if is_reasoning:
             model_kwargs = {**model_kwargs, "reasoning_effort": self.reasoning_effort}
@@ -212,6 +250,11 @@ class AzureChatOpenAIComponent(LCModelComponent):
             raise ValueError(msg) from e
 
     def _build_legacy_model(self, api_key: str | None, model_kwargs: dict, *, is_reasoning: bool) -> LanguageModel:
+        """Construct an ``AzureChatOpenAI`` instance using the legacy versioned API.
+
+        Reasoning models receive ``reasoning_effort`` in *model_kwargs* and
+        ``max_completion_tokens`` instead of ``max_tokens``.
+        """
         if is_reasoning:
             model_kwargs = {**model_kwargs, "reasoning_effort": self.reasoning_effort}
 

--- a/src/lfx/src/lfx/components/azure/azure_openai.py
+++ b/src/lfx/src/lfx/components/azure/azure_openai.py
@@ -1,34 +1,56 @@
-from langchain_openai import AzureChatOpenAI
+from typing import Any
+
+from langchain_openai import AzureChatOpenAI, ChatOpenAI
+from pydantic.v1 import SecretStr
 
 from lfx.base.models.model import LCModelComponent
+from lfx.base.models.openai_constants import OPENAI_MODELS_DETAILED
 from lfx.field_typing import LanguageModel
 from lfx.field_typing.range_spec import RangeSpec
-from lfx.inputs.inputs import MessageTextInput
+from lfx.inputs.inputs import BoolInput, DictInput, MessageTextInput
 from lfx.io import DropdownInput, IntInput, SecretStrInput, SliderInput
+
+AZURE_OPENAI_API_VERSIONS = [
+    "2025-04-01-preview",
+    "2025-03-01-preview",
+    "2025-02-01-preview",
+    "2025-01-01-preview",
+    "2024-12-01-preview",
+    "2024-10-01-preview",
+    "2024-09-01-preview",
+    "2024-08-01-preview",
+    "2024-07-01-preview",
+    "2024-06-01",
+    "2024-03-01-preview",
+    "2024-02-15-preview",
+    "2023-12-01-preview",
+    "2023-05-15",
+]
+
+REASONING_MODEL_NAMES = {
+    m["name"] for m in OPENAI_MODELS_DETAILED if m.get("reasoning")
+}
+
+MODEL_TO_DEPLOYMENT = {
+    "gpt-5.1": "dsailangflow-gpt-5.1",
+    "gpt-5-mini": "dsailangflow-gpt-5-mini",
+    "gpt-5-nano": "dsailangflow-gpt-5-nano",
+    "gpt-4.1": "dsailangflow-gpt4.1",
+    "gpt-4.1-mini": "dsailangflow-gpt4.1-mini",
+    "gpt-4.1-nano": "dsailangflow-gpt4.1-nano",
+}
+AZURE_MODEL_NAMES = list(MODEL_TO_DEPLOYMENT)
 
 
 class AzureChatOpenAIComponent(LCModelComponent):
     display_name: str = "Azure OpenAI"
     description: str = "Generate text using Azure OpenAI LLMs."
-    documentation: str = "https://python.langchain.com/docs/integrations/llms/azure_openai"
+    documentation: str = (
+        "https://python.langchain.com/docs/integrations/llms/azure_openai"
+    )
     beta = False
     icon = "Azure"
     name = "AzureOpenAIModel"
-
-    AZURE_OPENAI_API_VERSIONS = [
-        "2024-06-01",
-        "2024-07-01-preview",
-        "2024-08-01-preview",
-        "2024-09-01-preview",
-        "2024-10-01-preview",
-        "2023-05-15",
-        "2023-12-01-preview",
-        "2024-02-15-preview",
-        "2024-03-01-preview",
-        "2024-12-01-preview",
-        "2025-01-01-preview",
-        "2025-02-01-preview",
-    ]
 
     inputs = [
         *LCModelComponent.get_base_inputs(),
@@ -38,20 +60,44 @@ class AzureChatOpenAIComponent(LCModelComponent):
             info="Your Azure endpoint, including the resource. Example: `https://example-resource.azure.openai.com/`",
             required=True,
         ),
-        MessageTextInput(name="azure_deployment", display_name="Deployment Name", required=True),
-        SecretStrInput(name="api_key", display_name="Azure Chat OpenAI API Key", required=True),
+        DropdownInput(
+            name="model_name",
+            display_name="Model",
+            options=AZURE_MODEL_NAMES,
+            value=AZURE_MODEL_NAMES[0],
+            combobox=True,
+            required=True,
+            real_time_refresh=True,
+        ),
+        SecretStrInput(
+            name="api_key",
+            display_name="API Key",
+            required=True,
+        ),
+        BoolInput(
+            name="use_legacy_api",
+            display_name="Use Legacy API",
+            info="Use the legacy versioned API instead of the V1 Foundry API.",
+            value=False,
+            advanced=True,
+            real_time_refresh=True,
+        ),
         DropdownInput(
             name="api_version",
             display_name="API Version",
-            options=sorted(AZURE_OPENAI_API_VERSIONS, reverse=True),
-            value=next(
-                (
-                    version
-                    for version in sorted(AZURE_OPENAI_API_VERSIONS, reverse=True)
-                    if not version.endswith("-preview")
-                ),
-                AZURE_OPENAI_API_VERSIONS[0],
-            ),
+            options=AZURE_OPENAI_API_VERSIONS,
+            value=AZURE_OPENAI_API_VERSIONS[0],
+            advanced=False,
+            show=False,
+        ),
+        DropdownInput(
+            name="reasoning_effort",
+            display_name="Reasoning Effort",
+            info="Controls reasoning depth. Higher values use more tokens but may produce better results.",
+            options=["none", "minimal", "low", "medium", "high"],
+            value="medium",
+            advanced=False,
+            show=True,
         ),
         SliderInput(
             name="temperature",
@@ -60,6 +106,14 @@ class AzureChatOpenAIComponent(LCModelComponent):
             range_spec=RangeSpec(min=0, max=2, step=0.01),
             info="Controls randomness. Lower values are more deterministic, higher values are more creative.",
             advanced=True,
+            show=False,
+        ),
+        IntInput(
+            name="seed",
+            display_name="Seed",
+            info="The seed controls the reproducibility of the job.",
+            advanced=True,
+            show=False,
         ),
         IntInput(
             name="max_tokens",
@@ -67,29 +121,137 @@ class AzureChatOpenAIComponent(LCModelComponent):
             advanced=True,
             info="The maximum number of tokens to generate. Set to 0 for unlimited tokens.",
         ),
+        DictInput(
+            name="model_kwargs",
+            display_name="Model Kwargs",
+            advanced=True,
+            info="Additional keyword arguments to pass to the model.",
+        ),
     ]
 
+    def update_build_config(
+        self, build_config: dict, field_value: Any, field_name: str | None = None
+    ) -> dict:
+        if field_name == "use_legacy_api":
+            self._apply_legacy_api_visibility(build_config, is_legacy=bool(field_value))
+
+        if field_name == "model_name":
+            model = str(field_value) if field_value else ""
+            is_reasoning = self._is_reasoning_model(model)
+            self._apply_reasoning_visibility(build_config, is_reasoning=is_reasoning)
+
+        return build_config
+
+    def _is_reasoning_model(self, model_name: str) -> bool:
+        name = model_name.lower()
+        return any(model in name for model in REASONING_MODEL_NAMES)
+
+    def _resolve_deployment_name(self) -> str:
+        """Map the selected model name to its Azure deployment name.
+
+        Falls back to the raw value for custom entries typed into the combobox.
+        """
+        return MODEL_TO_DEPLOYMENT.get(self.model_name, self.model_name)
+
+    def _apply_legacy_api_visibility(
+        self, build_config: dict, *, is_legacy: bool
+    ) -> None:
+        build_config["api_version"]["show"] = is_legacy
+
+    def _apply_reasoning_visibility(
+        self, build_config: dict, *, is_reasoning: bool
+    ) -> None:
+        build_config["temperature"]["show"] = not is_reasoning
+        build_config["seed"]["show"] = not is_reasoning
+        build_config["reasoning_effort"]["show"] = is_reasoning
+
     def build_model(self) -> LanguageModel:  # type: ignore[type-var]
-        azure_endpoint = self.azure_endpoint
-        azure_deployment = self.azure_deployment
-        api_version = self.api_version
-        api_key = self.api_key
-        temperature = self.temperature
-        max_tokens = self.max_tokens
-        stream = self.stream
+        api_key_value = self._resolve_api_key()
+        model_kwargs = self._prepare_model_kwargs()
+        is_reasoning = self._is_reasoning_model(self.model_name or "")
+
+        if self.use_legacy_api:
+            return self._build_legacy_model(
+                api_key_value, model_kwargs, is_reasoning=is_reasoning
+            )
+        return self._build_v1_model(
+            api_key_value, model_kwargs, is_reasoning=is_reasoning
+        )
+
+    def _resolve_api_key(self) -> str | None:
+        if not self.api_key:
+            return None
+        if isinstance(self.api_key, SecretStr):
+            return self.api_key.get_secret_value()
+        return str(self.api_key)
+
+    def _prepare_model_kwargs(self) -> dict:
+        model_kwargs = dict(self.model_kwargs) if self.model_kwargs else {}
+        model_kwargs.pop("api_key", None)
+        return model_kwargs
+
+    def _build_v1_model(
+        self, api_key: str | None, model_kwargs: dict, *, is_reasoning: bool
+    ) -> LanguageModel:
+        base_url = self.azure_endpoint.rstrip("/") + "/openai/v1"
+        if is_reasoning:
+            model_kwargs = {**model_kwargs, "reasoning_effort": self.reasoning_effort}
+
+        parameters: dict[str, Any] = {
+            "model": self._resolve_deployment_name(),
+            "api_key": api_key,
+            "base_url": base_url,
+            "streaming": self.stream,
+            "model_kwargs": model_kwargs,
+        }
+
+        if is_reasoning:
+            if self.max_tokens:
+                parameters["max_completion_tokens"] = self.max_tokens
+        else:
+            parameters["temperature"] = (
+                self.temperature if self.temperature is not None else 0.7
+            )
+            if self.seed:
+                parameters["seed"] = self.seed
+            if self.max_tokens:
+                parameters["max_tokens"] = self.max_tokens
 
         try:
-            output = AzureChatOpenAI(
-                azure_endpoint=azure_endpoint,
-                azure_deployment=azure_deployment,
-                api_version=api_version,
-                api_key=api_key,
-                temperature=temperature,
-                max_tokens=max_tokens or None,
-                streaming=stream,
-            )
+            return ChatOpenAI(**parameters)
         except Exception as e:
-            msg = f"Could not connect to AzureOpenAI API: {e}"
+            msg = f"Could not connect to Azure OpenAI V1 API: {e}"
             raise ValueError(msg) from e
 
-        return output
+    def _build_legacy_model(
+        self, api_key: str | None, model_kwargs: dict, *, is_reasoning: bool
+    ) -> LanguageModel:
+        if is_reasoning:
+            model_kwargs = {**model_kwargs, "reasoning_effort": self.reasoning_effort}
+
+        parameters: dict[str, Any] = {
+            "azure_endpoint": self.azure_endpoint,
+            "azure_deployment": self._resolve_deployment_name(),
+            "api_version": self.api_version,
+            "api_key": api_key,
+            "streaming": self.stream,
+            "model_kwargs": model_kwargs,
+        }
+
+        if is_reasoning:
+            if self.max_tokens:
+                parameters["max_completion_tokens"] = self.max_tokens
+        else:
+            parameters["temperature"] = (
+                self.temperature if self.temperature is not None else 0.7
+            )
+            if self.seed:
+                parameters["seed"] = self.seed
+            if self.max_tokens:
+                parameters["max_tokens"] = self.max_tokens
+
+        try:
+            return AzureChatOpenAI(**parameters)
+        except Exception as e:
+            msg = f"Could not connect to Azure OpenAI API: {e}"
+            raise ValueError(msg) from e

--- a/src/lfx/src/lfx/components/azure/azure_openai.py
+++ b/src/lfx/src/lfx/components/azure/azure_openai.py
@@ -27,9 +27,7 @@ AZURE_OPENAI_API_VERSIONS = [
     "2023-05-15",
 ]
 
-REASONING_MODEL_NAMES = {
-    m["name"] for m in OPENAI_MODELS_DETAILED if m.get("reasoning")
-}
+REASONING_MODEL_NAMES = {m["name"] for m in OPENAI_MODELS_DETAILED if m.get("reasoning")}
 
 MODEL_TO_DEPLOYMENT = {
     "gpt-5.1": "YOUR-DEPLOYMENT-gpt-5.1",
@@ -43,9 +41,7 @@ AZURE_MODEL_NAMES = list(MODEL_TO_DEPLOYMENT)
 class AzureChatOpenAIComponent(LCModelComponent):
     display_name: str = "Azure OpenAI"
     description: str = "Generate text using Azure OpenAI LLMs."
-    documentation: str = (
-        "https://python.langchain.com/docs/integrations/llms/azure_openai"
-    )
+    documentation: str = "https://python.langchain.com/docs/integrations/llms/azure_openai"
     beta = False
     icon = "Azure"
     name = "AzureOpenAIModel"
@@ -134,9 +130,7 @@ class AzureChatOpenAIComponent(LCModelComponent):
         ),
     ]
 
-    def update_build_config(
-        self, build_config: dict, field_value: Any, field_name: str | None = None
-    ) -> dict:
+    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:
         if field_name == "use_legacy_api":
             self._apply_legacy_api_visibility(build_config, is_legacy=bool(field_value))
 
@@ -144,9 +138,7 @@ class AzureChatOpenAIComponent(LCModelComponent):
             model = str(field_value) if field_value else ""
             is_reasoning = self._is_reasoning_model(model)
             self._apply_reasoning_visibility(build_config, is_reasoning=is_reasoning)
-            build_config["azure_deployment"]["value"] = MODEL_TO_DEPLOYMENT.get(
-                model, model
-            )
+            build_config["azure_deployment"]["value"] = MODEL_TO_DEPLOYMENT.get(model, model)
 
         return build_config
 
@@ -164,14 +156,10 @@ class AzureChatOpenAIComponent(LCModelComponent):
             return self.azure_deployment
         return MODEL_TO_DEPLOYMENT.get(self.model_name, self.model_name)
 
-    def _apply_legacy_api_visibility(
-        self, build_config: dict, *, is_legacy: bool
-    ) -> None:
+    def _apply_legacy_api_visibility(self, build_config: dict, *, is_legacy: bool) -> None:
         build_config["api_version"]["show"] = is_legacy
 
-    def _apply_reasoning_visibility(
-        self, build_config: dict, *, is_reasoning: bool
-    ) -> None:
+    def _apply_reasoning_visibility(self, build_config: dict, *, is_reasoning: bool) -> None:
         build_config["temperature"]["show"] = not is_reasoning
         build_config["seed"]["show"] = not is_reasoning
         build_config["reasoning_effort"]["show"] = is_reasoning
@@ -182,12 +170,8 @@ class AzureChatOpenAIComponent(LCModelComponent):
         is_reasoning = self._is_reasoning_model(self.model_name or "")
 
         if self.use_legacy_api:
-            return self._build_legacy_model(
-                api_key_value, model_kwargs, is_reasoning=is_reasoning
-            )
-        return self._build_v1_model(
-            api_key_value, model_kwargs, is_reasoning=is_reasoning
-        )
+            return self._build_legacy_model(api_key_value, model_kwargs, is_reasoning=is_reasoning)
+        return self._build_v1_model(api_key_value, model_kwargs, is_reasoning=is_reasoning)
 
     def _resolve_api_key(self) -> str | None:
         if not self.api_key:
@@ -201,9 +185,7 @@ class AzureChatOpenAIComponent(LCModelComponent):
         model_kwargs.pop("api_key", None)
         return model_kwargs
 
-    def _build_v1_model(
-        self, api_key: str | None, model_kwargs: dict, *, is_reasoning: bool
-    ) -> LanguageModel:
+    def _build_v1_model(self, api_key: str | None, model_kwargs: dict, *, is_reasoning: bool) -> LanguageModel:
         base_url = self.azure_endpoint.rstrip("/") + "/openai/v1"
         if is_reasoning:
             model_kwargs = {**model_kwargs, "reasoning_effort": self.reasoning_effort}
@@ -220,9 +202,7 @@ class AzureChatOpenAIComponent(LCModelComponent):
             if self.max_tokens:
                 parameters["max_completion_tokens"] = self.max_tokens
         else:
-            parameters["temperature"] = (
-                self.temperature if self.temperature is not None else 0.7
-            )
+            parameters["temperature"] = self.temperature if self.temperature is not None else 0.7
             if self.seed:
                 parameters["seed"] = self.seed
             if self.max_tokens:
@@ -234,9 +214,7 @@ class AzureChatOpenAIComponent(LCModelComponent):
             msg = f"Could not connect to Azure OpenAI V1 API: {e}"
             raise ValueError(msg) from e
 
-    def _build_legacy_model(
-        self, api_key: str | None, model_kwargs: dict, *, is_reasoning: bool
-    ) -> LanguageModel:
+    def _build_legacy_model(self, api_key: str | None, model_kwargs: dict, *, is_reasoning: bool) -> LanguageModel:
         if is_reasoning:
             model_kwargs = {**model_kwargs, "reasoning_effort": self.reasoning_effort}
 
@@ -253,9 +231,7 @@ class AzureChatOpenAIComponent(LCModelComponent):
             if self.max_tokens:
                 parameters["max_completion_tokens"] = self.max_tokens
         else:
-            parameters["temperature"] = (
-                self.temperature if self.temperature is not None else 0.7
-            )
+            parameters["temperature"] = self.temperature if self.temperature is not None else 0.7
             if self.seed:
                 parameters["seed"] = self.seed
             if self.max_tokens:


### PR DESCRIPTION
**NB I used Cursor with Claude Opus 4.6 to draft this PR.** 

Closes #11620 

---

## Model vs. Deployment in Azure OpenAI

Azure OpenAI distinguishes between **models** and **deployments**:

- **Model**: The underlying AI model (e.g., `gpt-5.1`, `gpt-5-mini`)
- **Deployment**: The user-created instance of that model in Azure, with a custom name

For example:
- Model: `gpt-5.1`
- Deployment name: `my-gpt-5.1` (custom name chosen during deployment creation)

The V1 Foundry API endpoint structure is:
```
https://{resource}.azure.openai.com/openai/v1
```

And the model parameter sent to the API must be the **deployment name**, not the model name.

## Current Implementation

The component has two separate fields:
1. **Model** (`model_name`): Dropdown to select the model (drives reasoning detection)
2. **Deployment Name** (`azure_deployment`): Text input for the actual deployment name

When a user selects a model from the dropdown, the deployment name **auto-populates to the model name** (e.g., selecting `gpt-5.1` sets the deployment name to `gpt-5.1`). This is the most common Azure convention. The user can **always override** the deployment name with their own custom value.

An empty `MODEL_TO_DEPLOYMENT` dict is available for bundle authors who want to provide organization-specific default mappings from model names to deployment names.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dual API path support (Legacy and V1) for Azure OpenAI configuration.
  * Introduced reasoning models with dedicated parameters and control options.
  * Added auto-population of deployment names based on model selection, with override capability.
  * Introduced advanced parameters: API versioning, reasoning effort, temperature, seed, and max tokens controls.

* **Documentation**
  * Updated Azure OpenAI component documentation with new configuration options and parameters.

* **Tests**
  * Added comprehensive unit tests for Azure OpenAI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
