### PR TITLE
fix: Resolve ruff lint violations in deployment service                                                               

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,6 +276,9 @@ external = ["RUF027"]
     "EM101",  # NotImplementedError messages as literals
     "TC003",  # Type-only imports used in signatures
 ]
+"src/lfx/src/lfx/services/deployment/service.py" = [
+    "ARG002",  # No-op stub: unused args required by interface
+]
 "src/lfx/src/lfx/base/mcp/util.py" = [
     "SLF001",  # MCP library private member access
 ]

--- a/src/lfx/src/lfx/services/deployment/exceptions.py
+++ b/src/lfx/src/lfx/services/deployment/exceptions.py
@@ -129,7 +129,8 @@ class DeploymentNotConfiguredError(DeploymentError):
 
     def __init__(
         self,
-        message: str = "No deployment adapter is registered. Register a concrete adapter to enable deployment operations.",
+        message: str = "No deployment adapter is registered. "
+        "Register a concrete adapter to enable deployment operations.",
         *,
         method: str | None = None,
         cause: Exception | None = None,

--- a/src/lfx/src/lfx/services/deployment/schema.py
+++ b/src/lfx/src/lfx/services/deployment/schema.py
@@ -57,10 +57,10 @@ class BaseFlowArtifact(BaseModel):
             raise ValueError(msg)
         if not isinstance(value["nodes"], list):
             msg = "Flow 'nodes' must be a list"
-            raise ValueError(msg)
+            raise TypeError(msg)
         if not isinstance(value["edges"], list):
             msg = "Flow 'edges' must be a list"
-            raise ValueError(msg)
+            raise TypeError(msg)
         return value
 
 

--- a/src/lfx/tests/unit/services/deployment/test_deployment_exceptions.py
+++ b/src/lfx/tests/unit/services/deployment/test_deployment_exceptions.py
@@ -143,19 +143,17 @@ def test_deployment_not_configured_default_message() -> None:
 
 def test_auth_errors_not_caught_by_deployment_error() -> None:
     """Ensure except DeploymentError does NOT catch auth failures."""
+    assert not issubclass(CredentialResolutionError, DeploymentError)
     with pytest.raises(AuthenticationError):
-        try:
-            raise CredentialResolutionError()
-        except DeploymentError:
-            pytest.fail("DeploymentError should not catch AuthenticationError")
+        raise CredentialResolutionError
 
 
 def test_deployment_service_error_catches_both_hierarchies() -> None:
     """DeploymentServiceError catches both deployment and auth errors."""
     with pytest.raises(DeploymentServiceError):
-        raise CredentialResolutionError()
+        raise CredentialResolutionError
     with pytest.raises(DeploymentServiceError):
-        raise DeploymentNotFoundError()
+        raise DeploymentNotFoundError
 
 
 def test_package_exports_base_and_error() -> None:


### PR DESCRIPTION
Objective                                                                                                                                
  Fix 40 ruff lint errors introduced in #11979 across the deployment service module.

Changes
  - Break long string literal in DeploymentNotConfiguredError to comply with 120-char line limit (E501)
  - Use TypeError instead of ValueError for type-check validations in BaseFlowArtifact (TRY004)
  - Add per-file-ignore for ARG002 on deployment stub service, matching existing auth/service.py pattern
  - Simplify pytest.raises blocks and remove unnecessary parentheses on raised exceptions (PT012, RSE102)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated exception type handling in deployment schema validation for improved error consistency.

* **Chores**
  * Added new linting rule configuration for deployment services.
  * Updated error message formatting in deployment configuration exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->