### PR TITLE
fix(tracing): pass session_id to ArizePhoenixTracer

### DIFF
--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -206,6 +206,7 @@ class TracingService(Service):
             trace_type="chain",
             project_name=trace_context.project_name,
             trace_id=trace_context.run_id,
+            session_id=trace_context.session_id,
         )
 
     def _initialize_opik_tracer(self, trace_context: TraceContext) -> None:


### PR DESCRIPTION
## Summary

`_initialize_arize_phoenix_tracer` does not forward `trace_context.session_id` when constructing the `ArizePhoenixTracer`, even though `ArizePhoenixTracer.__init__` already accepts and uses a `session_id` parameter to set `SpanAttributes.SESSION_ID` on the root span.

Without this, all Phoenix traces fall back to `flow_id` as the session identifier (line 100 of `arize_phoenix.py`: `self.session_id or self.flow_id`), making it impossible to group traces by actual user/chat session.

Every other tracer initializer (`_initialize_langsmith_tracer`, `_initialize_langwatch_tracer`, `_initialize_langfuse_tracer`, `_initialize_opik_tracer`) already passes `session_id` — this one-line fix aligns the Phoenix tracer with them.

## Changes

- Added `session_id=trace_context.session_id` to the `arize_phoenix_tracer()` call in `_initialize_arize_phoenix_tracer`

## Test plan

- Deploy Langflow with Phoenix tracing enabled
- Send messages through a flow with a specific session_id
- Verify in Phoenix that traces are grouped under the correct session_id instead of falling back to flow_id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced session tracking in internal monitoring infrastructure for improved diagnostic capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->