### PR TITLE
fix(tracing): nest LangChain spans under Langflow component spans in Phoenix

### DIFF
--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -111,6 +111,7 @@ class ArizePhoenixTracer(BaseTracer):
                 self.propagator.inject(carrier=self.carrier)
 
             self.child_spans: dict[str, Span] = {}
+            self._context_tokens: dict[str, object] = {}
 
         except Exception as e:  # noqa: BLE001
             logger.error("[Arize/Phoenix] Error Setting Up Tracer: %s", str(e), exc_info=True)
@@ -263,6 +264,13 @@ class ArizePhoenixTracer(BaseTracer):
         elif component_name == "ChatOutput":
             self.chat_output_value = processed_inputs["input_value"]
 
+        # Attach child span to OTel context so LangChain auto-instrumented
+        # spans (via LangChainInstrumentor) become children of this span
+        from opentelemetry import context as otel_context
+        from opentelemetry.trace import set_span_in_context
+
+        self._context_tokens[trace_id] = otel_context.attach(set_span_in_context(child_span))
+
         self.child_spans[trace_id] = child_span
 
     @override
@@ -293,6 +301,14 @@ class ArizePhoenixTracer(BaseTracer):
             child_span.set_attribute("logs", self._safe_json_dumps(processed_logs))
 
         self._set_span_status(child_span, error)
+
+        # Detach from OTel context before ending the span
+        token = self._context_tokens.pop(trace_id, None)
+        if token is not None:
+            from opentelemetry import context as otel_context
+
+            otel_context.detach(token)
+
         child_span.end(end_time=self._get_current_timestamp())
         self.child_spans.pop(trace_id)
 


### PR DESCRIPTION
## Summary

LangChain auto-instrumented spans (created by `LangChainInstrumentor`) appear as **separate top-level traces** in Phoenix/Arize instead of being nested under the Langflow component span that triggered them.

This happens because `add_trace` creates a child span via the propagator context but doesn't attach it to the active OpenTelemetry context. When LangChain runs (e.g. an OpenAI call inside a component), the instrumentor sees no active parent span and creates a new root trace.

### Before
The Traces tab in Phoenix shows **N+1 entries** per flow execution: one root "Langflow" span plus separate disconnected LangChain spans (OpenAI, RunnableSequence, etc.).

### After
The Traces tab shows **1 entry** per flow execution. All LangChain-instrumented spans are properly nested under the Langflow component span that triggered them.

## Changes

In `arize_phoenix.py`:

1. **`__init__`**: Added `_context_tokens` dict to track OTel context tokens per trace
2. **`add_trace`**: After creating the child span, attach it to the OTel context so LangChain instrumentor picks it up as the parent
3. **`end_trace`**: Detach from OTel context before ending the span to restore the previous context

## Test plan

- Deploy Langflow with Phoenix tracing enabled and `LangChainInstrumentor` active
- Execute a flow that includes LLM calls (e.g. OpenAI via LangChain)
- Open Phoenix Traces tab and verify:
  - Only one root trace per flow execution (not multiple disconnected traces)
  - LangChain spans (OpenAI, RunnableSequence, etc.) appear nested under the component span
  - Spans tab still shows all individual spans with correct timing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal tracing infrastructure to improve observability and reliability of trace management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->