### PR TITLE
fix: reset button

### DIFF
--- a/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/EditShortcutButton/helpers.ts
+++ b/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/EditShortcutButton/helpers.ts
@@ -1,0 +1,59 @@
+import { toCamelCase, toTitleCase } from "@/utils/utils";
+
+type ShortcutItem = {
+  name: string;
+  shortcut: string;
+  display_name: string;
+};
+
+export function findShortcutByName(
+  shortcuts: ShortcutItem[],
+  shortcutName: string,
+): ShortcutItem | undefined {
+  return shortcuts.find(
+    (shortcut) =>
+      toCamelCase(shortcut.name) === toCamelCase(shortcutName ?? ""),
+  );
+}
+
+export function isDuplicateCombination(
+  shortcuts: ShortcutItem[],
+  currentName: string,
+  newCombination: string,
+): boolean {
+  return shortcuts.some(
+    (existing) =>
+      existing.name !== currentName &&
+      existing.shortcut.toLowerCase() === newCombination.toLowerCase(),
+  );
+}
+
+export function getFixedCombination(
+  oldKey: string | null,
+  key: string,
+): string {
+  if (oldKey === null) {
+    return `${key.length > 0 ? toTitleCase(key) : toTitleCase(key)}`;
+  }
+  return `${
+    oldKey.length > 0 ? toTitleCase(oldKey) : oldKey.toUpperCase()
+  } + ${key.length > 0 ? toTitleCase(key) : key.toUpperCase()}`;
+}
+
+export function checkForKeys(keys: string, keyToCompare: string): boolean {
+  const keysArr = keys.split(" ");
+  return keysArr.some(
+    (k) => k.toLowerCase().trim() === keyToCompare.toLowerCase().trim(),
+  );
+}
+
+export function normalizeRecordedCombination(recorded: string): string {
+  const parts = recorded.split(" ");
+  if (
+    parts[0]?.toLowerCase().includes("ctrl") ||
+    parts[0]?.toLowerCase().includes("cmd")
+  ) {
+    parts[0] = "mod";
+  }
+  return parts.join("").toLowerCase();
+}

--- a/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/EditShortcutButton/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/EditShortcutButton/index.tsx
@@ -5,11 +5,19 @@ import { Button } from "../../../../../components/ui/button";
 import BaseModal from "../../../../../modals/baseModal";
 import useAlertStore from "../../../../../stores/alertStore";
 import { useShortcutsStore } from "../../../../../stores/shortcuts";
-import { toCamelCase, toTitleCase } from "../../../../../utils/utils";
+import { toCamelCase } from "../../../../../utils/utils";
+import {
+  checkForKeys,
+  findShortcutByName,
+  getFixedCombination,
+  isDuplicateCombination,
+  normalizeRecordedCombination,
+} from "./helpers";
 
 export default function EditShortcutButton({
   children,
   shortcut,
+  shortcuts,
   defaultShortcuts,
   open,
   setOpen,
@@ -18,6 +26,11 @@ export default function EditShortcutButton({
 }: {
   children: JSX.Element;
   shortcut: string[];
+  shortcuts: Array<{
+    name: string;
+    shortcut: string;
+    display_name: string;
+  }>;
   defaultShortcuts: Array<{
     name: string;
     shortcut: string;
@@ -28,74 +41,65 @@ export default function EditShortcutButton({
   disable?: boolean;
   setSelected: (selected: string[]) => void;
 }): JSX.Element {
-  const shortcutInitialValue =
-    defaultShortcuts.length > 0
-      ? defaultShortcuts.find(
-          (s) => toCamelCase(s.name) === toCamelCase(shortcut[0]),
-        )?.shortcut
-      : "";
+  const shortcutInitialValue = findShortcutByName(
+    shortcuts,
+    shortcut[0],
+  )?.shortcut;
   const [key, setKey] = useState<string | null>(null);
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
   const setShortcuts = useShortcutsStore((state) => state.setShortcuts);
   const setErrorData = useAlertStore((state) => state.setErrorData);
 
-  function canEditCombination(newCombination: string): boolean {
-    let canSave = true;
-    defaultShortcuts.forEach(({ shortcut }) => {
-      if (shortcut.toLowerCase() === newCombination.toLowerCase()) {
-        canSave = false;
-      }
-    });
-    return canSave;
-  }
-
   const setUniqueShortcut = useShortcutsStore(
     (state) => state.updateUniqueShortcut,
   );
 
-  function editCombination(): void {
-    if (key) {
-      if (canEditCombination(key)) {
-        const fixCombination = key.split(" ");
-        if (
-          fixCombination[0].toLowerCase().includes("ctrl") ||
-          fixCombination[0].toLowerCase().includes("cmd")
-        ) {
-          fixCombination[0] = "mod";
-        }
-        const newCombination = defaultShortcuts.map((s) => {
-          if (s.name === shortcut[0]) {
-            return {
-              name: s.name,
-              display_name: s.display_name,
-              shortcut: fixCombination.join("").toLowerCase(),
-            };
-          }
-          return {
-            name: s.name,
-            display_name: s.display_name,
-            shortcut: s.shortcut,
-          };
-        });
-        const shortcutName = toCamelCase(shortcut[0]);
-        setUniqueShortcut(shortcutName, fixCombination.join("").toLowerCase());
-        setShortcuts(newCombination);
-        localStorage.setItem(
-          "langflow-shortcuts",
-          JSON.stringify(newCombination),
-        );
-        setKey(null);
-        setOpen(false);
-        setSuccessData({
-          title: `${shortcut[0]} shortcut successfully changed`,
-        });
-        return;
+  function applyShortcutUpdate(newCombination: string, successTitle: string) {
+    const nextShortcuts = shortcuts.map((s) => {
+      if (s.name === shortcut[0]) {
+        return {
+          name: s.name,
+          display_name: s.display_name,
+          shortcut: newCombination,
+        };
       }
-    }
-    setErrorData({
-      title: "Error saving key combination",
-      list: ["This combination already exists!"],
+      return {
+        name: s.name,
+        display_name: s.display_name,
+        shortcut: s.shortcut,
+      };
     });
+    const shortcutName = toCamelCase(shortcut[0]);
+    setUniqueShortcut(shortcutName, newCombination);
+    setShortcuts(nextShortcuts);
+    localStorage.setItem("langflow-shortcuts", JSON.stringify(nextShortcuts));
+    setKey(null);
+    setOpen(false);
+    setSuccessData({
+      title: successTitle,
+    });
+  }
+
+  function editCombination(): void {
+    if (!key) {
+      setErrorData({
+        title: "Error saving key combination",
+        list: ["No key combination recorded."],
+      });
+      return;
+    }
+    const normalizedCombination = normalizeRecordedCombination(key);
+    if (isDuplicateCombination(shortcuts, shortcut[0], normalizedCombination)) {
+      setErrorData({
+        title: "Error saving key combination",
+        list: ["This combination already exists!"],
+      });
+      return;
+    }
+    applyShortcutUpdate(
+      normalizedCombination,
+      `${shortcut[0]} shortcut successfully changed`,
+    );
   }
 
   useEffect(() => {
@@ -105,26 +109,28 @@ export default function EditShortcutButton({
     }
   }, [open, setOpen, key]);
 
-  function getFixedCombination({
-    oldKey,
-    key,
-  }: {
-    oldKey: string;
-    key: string;
-  }): string {
-    if (oldKey === null) {
-      return `${key.length > 0 ? toTitleCase(key) : toTitleCase(key)}`;
+  function handleResetToDefault(): void {
+    const defaultShortcut = findShortcutByName(
+      defaultShortcuts,
+      shortcut[0],
+    )?.shortcut;
+    if (!defaultShortcut) {
+      setErrorData({
+        title: "Error resetting shortcut",
+        list: ["Default shortcut not found."],
+      });
+      return;
     }
-    return `${
-      oldKey.length > 0 ? toTitleCase(oldKey) : oldKey.toUpperCase()
-    } + ${key.length > 0 ? toTitleCase(key) : key.toUpperCase()}`;
-  }
-
-  function checkForKeys(keys: string, keyToCompare: string): boolean {
-    const keysArr = keys.split(" ");
-    const _hasNewKey = false;
-    return keysArr.some(
-      (k) => k.toLowerCase().trim() === keyToCompare.toLowerCase().trim(),
+    if (isDuplicateCombination(shortcuts, shortcut[0], defaultShortcut)) {
+      setErrorData({
+        title: "Error resetting shortcut",
+        list: ["This combination already exists!"],
+      });
+      return;
+    }
+    applyShortcutUpdate(
+      defaultShortcut,
+      `${shortcut[0]} shortcut reset to default`,
     );
   }
 
@@ -144,9 +150,7 @@ export default function EditShortcutButton({
       if (key) {
         if (checkForKeys(key, fixedKey)) return;
       }
-      setKey((oldKey) =>
-        getFixedCombination({ oldKey: oldKey!, key: fixedKey }),
-      );
+      setKey((oldKey) => getFixedCombination(oldKey, fixedKey));
     }
 
     document.addEventListener("keydown", onKeyDown);
@@ -183,7 +187,7 @@ export default function EditShortcutButton({
         <Button
           className="mr-5"
           variant={"destructive"}
-          onClick={() => setKey(null)}
+          onClick={handleResetToDefault}
         >
           Reset
         </Button>

--- a/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/__tests__/EditShortcutButton.helpers.test.ts
+++ b/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/__tests__/EditShortcutButton.helpers.test.ts
@@ -1,0 +1,49 @@
+import {
+  checkForKeys,
+  findShortcutByName,
+  getFixedCombination,
+  isDuplicateCombination,
+  normalizeRecordedCombination,
+} from "../EditShortcutButton/helpers";
+
+describe("EditShortcutButton helpers", () => {
+  const shortcuts = [
+    { name: "Docs", display_name: "Docs", shortcut: "mod+shift+d" },
+    { name: "Code", display_name: "Code", shortcut: "mod+." },
+    { name: "Open Playground", display_name: "Playground", shortcut: "mod+k" },
+  ];
+
+  it("finds a shortcut by name", () => {
+    const result = findShortcutByName(shortcuts, "open playground");
+    expect(result?.shortcut).toBe("mod+k");
+  });
+
+  it("detects duplicate combinations across shortcuts", () => {
+    const hasDuplicate = isDuplicateCombination(shortcuts, "Code", "mod+k");
+    expect(hasDuplicate).toBe(true);
+  });
+
+  it("returns false for duplicates on the same shortcut", () => {
+    const hasDuplicate = isDuplicateCombination(
+      shortcuts,
+      "Open Playground",
+      "mod+k",
+    );
+    expect(hasDuplicate).toBe(false);
+  });
+
+  it("normalizes recorded combinations", () => {
+    expect(normalizeRecordedCombination("Ctrl + K")).toBe("mod+k");
+    expect(normalizeRecordedCombination("Cmd + Shift + P")).toBe("mod+shift+p");
+  });
+
+  it("builds fixed combinations", () => {
+    expect(getFixedCombination(null, "space")).toBe("Space");
+    expect(getFixedCombination("Ctrl", "k")).toBe("Ctrl + K");
+  });
+
+  it("checks for existing keys", () => {
+    expect(checkForKeys("Ctrl + K", "Ctrl")).toBe(true);
+    expect(checkForKeys("Ctrl + K", "Shift")).toBe(false);
+  });
+});

--- a/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/__tests__/EditShortcutButton.test.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/__tests__/EditShortcutButton.test.tsx
@@ -1,0 +1,187 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import EditShortcutButton from "../EditShortcutButton";
+
+const mockSetSuccessData = jest.fn();
+const mockSetErrorData = jest.fn();
+const mockSetShortcuts = jest.fn();
+const mockUpdateUniqueShortcut = jest.fn();
+
+type AlertStoreState = {
+  setSuccessData: typeof mockSetSuccessData;
+  setErrorData: typeof mockSetErrorData;
+};
+
+type ShortcutsStoreState = {
+  setShortcuts: typeof mockSetShortcuts;
+  updateUniqueShortcut: typeof mockUpdateUniqueShortcut;
+};
+
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: (selector: (state: AlertStoreState) => unknown) =>
+    selector({
+      setSuccessData: mockSetSuccessData,
+      setErrorData: mockSetErrorData,
+    }),
+}));
+
+jest.mock("@/stores/shortcuts", () => ({
+  __esModule: true,
+  useShortcutsStore: (selector: (state: ShortcutsStoreState) => unknown) =>
+    selector({
+      setShortcuts: mockSetShortcuts,
+      updateUniqueShortcut: mockUpdateUniqueShortcut,
+    }),
+}));
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: ReactNode;
+};
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, ...props }: ButtonProps) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock(
+  "@/components/common/renderIconComponent/components/renderKey",
+  () => ({
+    __esModule: true,
+    default: ({ value }: { value: string }) => <span>{value}</span>,
+  }),
+);
+
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name }: { name: string }) => (
+    <span data-testid={`icon-${name}`}>{name}</span>
+  ),
+}));
+
+jest.mock("@/modals/baseModal", () => {
+  interface ChildrenProps {
+    children: ReactNode;
+  }
+
+  interface HeaderProps extends ChildrenProps {
+    description?: string;
+  }
+
+  interface TriggerProps extends ChildrenProps {
+    disable?: boolean;
+    asChild?: boolean;
+  }
+
+  interface BaseModalProps extends ChildrenProps {
+    open?: boolean;
+    setOpen?: (open: boolean) => void;
+    size?: string;
+  }
+
+  const MockContent = ({ children }: ChildrenProps) => (
+    <div data-testid="modal-content">{children}</div>
+  );
+  const MockHeader = ({ children, description }: HeaderProps) => (
+    <div data-testid="modal-header" data-description={description}>
+      {children}
+    </div>
+  );
+  const MockTrigger = ({ children, disable }: TriggerProps) => (
+    <div data-testid="modal-trigger" data-disabled={disable}>
+      {children}
+    </div>
+  );
+  const MockFooter = ({ children }: ChildrenProps) => (
+    <div data-testid="modal-footer">{children}</div>
+  );
+
+  function MockBaseModal({ children, open, size }: BaseModalProps) {
+    if (!open) {
+      return <div data-testid="base-modal-closed" data-size={size} />;
+    }
+
+    return (
+      <div data-testid="base-modal" data-size={size}>
+        {children}
+      </div>
+    );
+  }
+
+  MockContent.displayName = "Content";
+  MockHeader.displayName = "Header";
+  MockTrigger.displayName = "Trigger";
+  MockFooter.displayName = "Footer";
+
+  MockBaseModal.Content = MockContent;
+  MockBaseModal.Header = MockHeader;
+  MockBaseModal.Trigger = MockTrigger;
+  MockBaseModal.Footer = MockFooter;
+
+  return { __esModule: true, default: MockBaseModal };
+});
+
+describe("EditShortcutButton", () => {
+  let setItemSpy: jest.SpyInstance<void, [string, string]>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setItemSpy = jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    setItemSpy.mockRestore();
+  });
+
+  it("resets shortcut to default value", async () => {
+    const user = userEvent.setup();
+    const shortcuts = [
+      { name: "Docs", display_name: "Docs", shortcut: "mod+shift+d" },
+      { name: "Code", display_name: "Code", shortcut: "mod+." },
+    ];
+    const defaultShortcuts = [
+      { name: "Docs", display_name: "Docs", shortcut: "mod+shift+d" },
+      { name: "Code", display_name: "Code", shortcut: "space" },
+    ];
+
+    const setOpen = jest.fn();
+    const setSelected = jest.fn();
+
+    render(
+      <EditShortcutButton
+        open={true}
+        setOpen={setOpen}
+        shortcut={["Code"]}
+        shortcuts={shortcuts}
+        defaultShortcuts={defaultShortcuts}
+        setSelected={setSelected}
+      >
+        <div />
+      </EditShortcutButton>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(mockSetShortcuts).toHaveBeenCalledWith([
+      { name: "Docs", display_name: "Docs", shortcut: "mod+shift+d" },
+      { name: "Code", display_name: "Code", shortcut: "space" },
+    ]);
+    expect(mockUpdateUniqueShortcut).toHaveBeenCalledWith("code", "space");
+    expect(mockSetSuccessData).toHaveBeenCalledWith({
+      title: "Code shortcut reset to default",
+    });
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "langflow-shortcuts",
+      JSON.stringify([
+        { name: "Docs", display_name: "Docs", shortcut: "mod+shift+d" },
+        { name: "Code", display_name: "Code", shortcut: "space" },
+      ]),
+    );
+  });
+});

--- a/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/index.tsx
@@ -80,7 +80,8 @@ export default function ShortcutsPage() {
                 <EditShortcutButton
                   disable={selectedRows.length === 0}
                   shortcut={selectedRows}
-                  defaultShortcuts={shortcuts}
+                  shortcuts={shortcuts}
+                  defaultShortcuts={defaultShortcuts}
                   open={open}
                   setOpen={setOpen}
                   setSelected={setSelectedRows}


### PR DESCRIPTION
Description

The initial issue was that clicking Reset on a single shortcut did not return it to the system default. Instead, it reverted to the last saved/custom value, because the reset logic was based on the current shortcut list (which already included the user’s edits) rather than the original default list. The only way to truly restore defaults was the Restore button, which reset all shortcuts at once.

Refactored the shortcut editing logic into helpers and reduced inline logic in the component to improve readability and testability. The main component now calls these helpers and uses a dedicated reset handler instead of inline onClick logic, so the UI behavior is clearer and easier to maintain.

Added a helper module that centralizes shortcut lookup, duplication checks, normalization, and key-combination formatting. This makes those behaviors reusable and straightforward to unit test.

Added unit tests covering the helper behaviors (lookup, duplication detection, normalization, key formatting).

Before
https://github.com/user-attachments/assets/e4322f02-5cc0-41d3-a0d7-f1227c3aad02


After
https://github.com/user-attachments/assets/8c7b0619-8bda-4e91-b2a3-10229d6e6b4e

