### PR TITLE
fix(ui): Prevent auto-focus and tooltip on dialog close button

### DIFF
--- a/src/frontend/src/components/ui/__tests__/dialog.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/dialog.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "../dialog";
+
+// Mock genericIconComponent (already globally mocked, but be explicit)
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+};
+
+describe("DialogContent", () => {
+  it("should_not_auto_focus_close_button_when_dialog_opens", () => {
+    // Arrange — open dialog with default behavior (no custom onOpenAutoFocus)
+    renderWithProviders(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Test Dialog</DialogTitle>
+          <DialogDescription>Test description</DialogDescription>
+          <p>Content</p>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    // Act — dialog is already open, focus should have been handled
+
+    // Assert — close button must NOT have focus
+    const closeButton = screen.getByRole("button", { name: /close/i });
+    expect(closeButton).not.toHaveFocus();
+
+    // Assert — "Close" tooltip must NOT be visible on open
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("should_call_custom_onOpenAutoFocus_when_provided", () => {
+    // Arrange — provide a custom onOpenAutoFocus handler
+    const customHandler = jest.fn((e: Event) => {
+      e.preventDefault();
+    });
+
+    renderWithProviders(
+      <Dialog open>
+        <DialogContent onOpenAutoFocus={customHandler}>
+          <DialogTitle>Test Dialog</DialogTitle>
+          <DialogDescription>Test description</DialogDescription>
+          <p>Content</p>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    // Assert — custom handler was called
+    expect(customHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/frontend/src/components/ui/badge.tsx
+++ b/src/frontend/src/components/ui/badge.tsx
@@ -3,7 +3,7 @@ import type * as React from "react";
 import { cn } from "../../utils/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center border rounded-full px-2.5 font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center border rounded-full px-2.5 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
   {
     variants: {
       variant: {

--- a/src/frontend/src/components/ui/dialog.tsx
+++ b/src/frontend/src/components/ui/dialog.tsx
@@ -58,7 +58,14 @@ const DialogContent = React.forwardRef<
   }
 >(
   (
-    { className, children, hideTitle = false, closeButtonClassName, ...props },
+    {
+      className,
+      children,
+      hideTitle = false,
+      closeButtonClassName,
+      onOpenAutoFocus,
+      ...props
+    },
     ref,
   ) => {
     // Check if DialogTitle is included in children
@@ -79,6 +86,13 @@ const DialogContent = React.forwardRef<
             "fixed z-50 flex w-full max-w-lg flex-col gap-4 rounded-xl border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]",
             className,
           )}
+          onOpenAutoFocus={(e) => {
+            if (onOpenAutoFocus) {
+              onOpenAutoFocus(e);
+            } else {
+              e.preventDefault();
+            }
+          }}
           {...props}
         >
           {!hasDialogTitle && (
@@ -100,7 +114,7 @@ const DialogContent = React.forwardRef<
           >
             <DialogPrimitive.Close
               className={cn(
-                "absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-sm ring-offset-background transition-opacity hover:bg-secondary-hover hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
+                "absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-sm ring-offset-background transition-opacity hover:bg-secondary-hover hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
                 closeButtonClassName,
               )}
             >

--- a/src/frontend/src/components/ui/select.tsx
+++ b/src/frontend/src/components/ui/select.tsx
@@ -20,7 +20,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-8 items-center justify-between gap-2 rounded-md border border-input px-4 py-2 text-sm text-primary ring-offset-background placeholder:text-muted-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      "flex h-8 items-center justify-between gap-2 rounded-md border border-input px-4 py-2 text-sm text-primary ring-offset-background placeholder:text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
       className,
     )}
     {...props}

--- a/src/frontend/src/modals/IOModal/components/chat-view-wrapper.tsx
+++ b/src/frontend/src/modals/IOModal/components/chat-view-wrapper.tsx
@@ -66,7 +66,7 @@ export const ChatViewWrapper = ({
         <div
           className={cn(
             sidebarOpen ? "pointer-events-none opacity-0" : "",
-            "flex items-center justify-center rounded-sm ring-offset-background transition-opacity focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+            "flex items-center justify-center rounded-sm ring-offset-background transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
             playgroundPage ? "right-2 top-4" : "absolute right-12 top-2 h-8",
           )}
         >

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/SourceChunksPage.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/SourceChunksPage.tsx
@@ -227,7 +227,7 @@ export const SourceChunksPage = () => {
                                     );
                                   }
                                 }}
-                                className="h-7 w-16 rounded border border-input bg-background px-2 text-center text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                                className="h-7 w-16 rounded border border-input bg-background px-2 text-center text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                               />
                               <span>of {totalPages}</span>
                             </div>


### PR DESCRIPTION
Objective                                                                                                                             
Prevent the close button from receiving programmatic focus when dialogs open, which caused an unwanted "Close" tooltip and focus ring to appear.

Changes
  - Add default onOpenAutoFocus handler to DialogContent that calls preventDefault, preventing Radix from auto-focusing the close button
  - Replace focus: with focus-visible: on dialog close button, select trigger, badge, chat-view-wrapper, and SourceChunksPage input so
  focus ring only shows on keyboard navigation
  - Add Jest tests verifying close button does not receive focus and tooltip does not appear on dialog open