### PR TITLE
fix(ui): Add array validation for provider variables mapping

### DIFF
--- a/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
+++ b/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
@@ -201,7 +201,7 @@ export const useProviderConfiguration = ({
 
     const providerName = syncedSelectedProvider.provider;
     const apiVariables = providerVariablesMapping[providerName];
-    if (apiVariables && apiVariables.length > 0) {
+    if (Array.isArray(apiVariables) && apiVariables.length > 0) {
       return apiVariables;
     }
 


### PR DESCRIPTION
Objective
Prevent runtime errors when providerVariablesMapping returns a non-array value for a provider name.

Changes
Replace truthy check with Array.isArray() guard before accessing .length on apiVariables in useProviderConfiguration hook