### PR TITLE
fix: Add file upload extension filter for multi-select and folders

### DIFF
--- a/src/frontend/src/modals/knowledgeBaseUploadModal/__tests__/KnowledgeBaseUploadModal.test.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/__tests__/KnowledgeBaseUploadModal.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { BrowserRouter } from "react-router-dom";
@@ -91,23 +91,35 @@ jest.mock("@/stores/alertStore", () => {
   return { __esModule: true, default: store };
 });
 
+interface MockModelInputProps {
+  value: { id: string; name: string }[];
+  handleOnNewValue: (val: { value: { id: string; name: string }[] }) => void;
+  options: { id: string; name: string }[];
+  placeholder?: string;
+}
+
 // Renders as a plain <select> so tests can inspect options and fire selections
 jest.mock(
   "@/components/core/parameterRenderComponent/components/modelInputComponent",
   () => ({
     __esModule: true,
-    default: ({ value, handleOnNewValue, options, placeholder }: any) => (
+    default: ({
+      value,
+      handleOnNewValue,
+      options,
+      placeholder,
+    }: MockModelInputProps) => (
       <div data-testid="mock-model-input">
         <select
           data-testid="embedding-model-select"
           value={value?.[0]?.id || ""}
           onChange={(e) => {
-            const selected = options?.find((o: any) => o.id === e.target.value);
+            const selected = options?.find((o) => o.id === e.target.value);
             if (selected) handleOnNewValue({ value: [selected] });
           }}
         >
           <option value="">{placeholder || "Select..."}</option>
-          {options?.map((opt: any) => (
+          {options?.map((opt) => (
             <option key={opt.id} value={opt.id}>
               {opt.name}
             </option>
@@ -497,6 +509,109 @@ describe("KnowledgeBaseUploadModal", () => {
       ]);
       expect(screen.getByText("file-a.txt")).toBeInTheDocument();
       expect(screen.getByText("file-b.txt")).toBeInTheDocument();
+    });
+
+    it("filters out unsupported file types and shows an error message with excluded files", async () => {
+      render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
+        wrapper: createWrapper(),
+      });
+      const fileInput = document.getElementById(
+        "file-input",
+      ) as HTMLInputElement;
+
+      const validFile = new File(["content"], "valid.txt", {
+        type: "text/plain",
+      });
+      const invalidFile = new File(["content"], "invalid.exe", {
+        type: "application/x-msdownload",
+      });
+
+      // Manually trigger the change event to bypass userEvent.upload's attribute-based filtering
+      const event = {
+        target: {
+          files: [validFile, invalidFile],
+        },
+      } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+      fireEvent.change(fileInput, event);
+
+      // Only the valid file should be rendered in the FilesPanel
+      expect(screen.getByText("valid.txt")).toBeInTheDocument();
+      expect(screen.queryByText("invalid.exe")).not.toBeInTheDocument();
+
+      // Verify that the alert store was called with the correct error information
+      expect(mockSetErrorData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining("Some files were skipped"),
+          list: expect.arrayContaining(["invalid.exe"]),
+        }),
+      );
+    });
+
+    it("filters out unsupported file types during folder upload", async () => {
+      render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
+        wrapper: createWrapper(),
+      });
+      const folderInput = document.getElementById(
+        "folder-input",
+      ) as HTMLInputElement;
+
+      const validFile = new File(["content"], "valid.md", {
+        type: "text/markdown",
+      });
+      const invalidFile = new File(["content"], "invalid.pdf", {
+        type: "application/pdf",
+      });
+
+      // Manually trigger the change event
+      const event = {
+        target: {
+          files: [validFile, invalidFile],
+        },
+      } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+      fireEvent.change(folderInput, event);
+
+      expect(screen.getByText("valid.md")).toBeInTheDocument();
+      expect(screen.queryByText("invalid.pdf")).not.toBeInTheDocument();
+
+      expect(mockSetErrorData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          list: expect.arrayContaining(["invalid.pdf"]),
+        }),
+      );
+    });
+
+    it("verifies file panel doesn't open and error is shown when ALL files are unsupported", async () => {
+      render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
+        wrapper: createWrapper(),
+      });
+      const fileInput = document.getElementById(
+        "file-input",
+      ) as HTMLInputElement;
+
+      const invalidFile = new File(["content"], "invalid.exe", {
+        type: "application/x-msdownload",
+      });
+
+      const event = {
+        target: {
+          files: [invalidFile],
+        },
+      } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+      fireEvent.change(fileInput, event);
+
+      // The FilesPanel (implied by file names being visible) should not be open
+      expect(screen.queryByText("invalid.exe")).not.toBeInTheDocument();
+
+      // Verify that the error notification was shown
+      expect(mockSetErrorData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining("Some files were skipped"),
+          list: expect.arrayContaining(["invalid.exe"]),
+        }),
+      );
     });
   });
 

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
@@ -156,8 +156,10 @@ export function StepConfiguration({
         <input
           id="folder-input"
           type="file"
+          multiple
           className="hidden"
           onChange={onFolderSelect}
+          accept={ACCEPTED_FILE_TYPES}
           {...({
             webkitdirectory: "",
             directory: "",

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_CHUNK_OVERLAP,
   DEFAULT_CHUNK_SIZE,
   DEFAULT_SEPARATOR,
+  KB_INGEST_EXTENSIONS,
   KB_NAME_REGEX,
   MAX_TOTAL_FILE_SIZE,
 } from "../constants";
@@ -412,21 +413,43 @@ export function useKnowledgeBaseForm({
     }
   };
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedFiles = e.target.files;
+  const processSelectedFiles = (selectedFiles: FileList | null) => {
     if (selectedFiles && selectedFiles.length > 0) {
-      setFiles((prev) => [...prev, ...Array.from(selectedFiles)]);
-      setIsFilePanelOpen(true);
+      const allFiles = Array.from(selectedFiles);
+      const filteredFiles: File[] = [];
+      const excludedFiles: string[] = [];
+
+      for (const file of allFiles) {
+        const extension = file.name.split(".").pop()?.toLowerCase();
+        if (extension && KB_INGEST_EXTENSIONS.includes(extension)) {
+          filteredFiles.push(file);
+        } else {
+          excludedFiles.push(file.name);
+        }
+      }
+
+      if (filteredFiles.length > 0) {
+        setFiles((prev) => [...prev, ...filteredFiles]);
+        setIsFilePanelOpen(true);
+      }
+
+      if (excludedFiles.length > 0) {
+        setErrorData({
+          title:
+            "Some files were skipped. Only supported file types were uploaded. Excluded files:",
+          list: excludedFiles,
+        });
+      }
     }
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    processSelectedFiles(e.target.files);
     e.target.value = "";
   };
 
   const handleFolderSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedFiles = e.target.files;
-    if (selectedFiles && selectedFiles.length > 0) {
-      setFiles((prev) => [...prev, ...Array.from(selectedFiles)]);
-      setIsFilePanelOpen(true);
-    }
+    processSelectedFiles(e.target.files);
     e.target.value = "";
   };
 


### PR DESCRIPTION
LE-476 

KB ingestion file uploads were  allowing disallowed file types when selecting `Upload Folder` as the option. Added sanitizing mechanism that drops illegal file types and uploads only allowed file types.

- Added the file upload extension  sanitization filter to file uploads, multi-select, and folder uploads.
- Added relevant error message to notify user about dropped files.



<img width="2483" height="1351" alt="Screenshot 2026-03-04 at 1 12 39 PM" src="https://github.com/user-attachments/assets/4736bd9d-efb0-4182-ac84-b5dbfff117cf" />
