### PR TITLE
fix: langflow breaks when we click on the last level of the chain

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/TraceComponent/SpanDetail.tsx
+++ b/src/frontend/src/pages/FlowPage/components/TraceComponent/SpanDetail.tsx
@@ -31,10 +31,10 @@ export function SpanDetail({ span }: SpanDetailProps) {
     );
   }
 
-  const hasInputs = Object.keys(span.inputs).length > 0;
-  const hasOutputs = Object.keys(span.outputs).length > 0;
-  const hasTokenUsage = span.tokenUsage && span.tokenUsage.totalTokens > 0;
-  const isLlmSpan = span.type === "llm";
+  const hasInputs = Object.keys(span?.inputs || {}).length > 0;
+  const hasOutputs = Object.keys(span?.outputs || {}).length > 0;
+  const hasTokenUsage = span?.tokenUsage && span.tokenUsage.totalTokens > 0;
+  const isLlmSpan = span?.type === "llm";
 
   const { colorClass, iconName, shouldSpin } = getStatusIconProps(span.status);
 


### PR DESCRIPTION
Description
We are not protecting against the span having an input or output property that is null. So I just added a nullish operator to protect.

Before
https://github.com/user-attachments/assets/014561c3-a6fa-4788-8399-dcc47fe22d12
After
https://github.com/user-attachments/assets/49f619c3-d708-4d32-9499-b82dbc0e54d0

