### PR TITLE
fix: ReDoS vulnerability in mustache template validation (LE-505)

### DIFF
--- a/src/lfx/src/lfx/utils/mustache_security.py
+++ b/src/lfx/src/lfx/utils/mustache_security.py
@@ -19,6 +19,22 @@ DANGEROUS_PATTERNS = [
 ]
 
 
+def _find_mustache_patterns(template: str) -> list[str]:
+    """Find all {{...}} patterns in a template using string search (no regex)."""
+    patterns = []
+    start = 0
+    while True:
+        idx = template.find("{{", start)
+        if idx == -1:
+            break
+        end = template.find("}}", idx + 2)
+        if end == -1:
+            break
+        patterns.append(template[idx : end + 2])
+        start = end + 2
+    return patterns
+
+
 def validate_mustache_template(template: str) -> None:
     """Validate that a mustache template only contains simple variable substitutions.
 
@@ -37,7 +53,7 @@ def validate_mustache_template(template: str) -> None:
             raise ValueError(msg)
 
     # Check that all {{ }} patterns are simple variables
-    all_mustache_patterns = re.findall(r"\{\{[^}]*\}\}", template)
+    all_mustache_patterns = _find_mustache_patterns(template)
     for pattern in all_mustache_patterns:
         if not SIMPLE_VARIABLE_PATTERN.match(pattern):
             msg = f"Invalid mustache variable: {pattern}. Only simple variable names like {{{{variable}}}} are allowed."


### PR DESCRIPTION
## Summary
- Fixes CodeQL alert [#177](https://github.com/langflow-ai/langflow/security/code-scanning/177) — polynomial ReDoS in `mustache_security.py`
- Replaced vulnerable regex `\{\{[^}]*\}\}` with a linear-time string-based search using `str.find`
- The regex was susceptible to polynomial backtracking on crafted inputs with many `{{` repetitions (CWE-1333)

## Test plan
- [x] Verified all existing mustache patterns are detected correctly
- [x] Verified dangerous patterns still rejected (triple braces, sections, etc.)
- [x] Verified ReDoS input (`"{{" * 5000`) completes in under 1 second
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal template validation logic for improved performance and code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->