### PR TITLE
Fix Tweaks model to allow bool, int, and float values

### DIFF
--- a/src/lfx/src/lfx/schema/graph.py
+++ b/src/lfx/src/lfx/schema/graph.py
@@ -16,7 +16,7 @@ class InputValue(BaseModel):
 
 
 class Tweaks(RootModel):
-    root: dict[str, str | dict[str, Any]] = Field(
+    root: dict[str, bool | int | float | str | dict[str, Any]] = Field(
         description="A dictionary of tweaks to adjust the flow's execution. "
         "Allows customizing flow behavior dynamically. "
         "All tweaks are overridden by the input values.",


### PR DESCRIPTION
Fixes #11830. The Tweaks model only allowed str or dict[str, Any] as values, preventing booleans, numbers, and other types from being used as root-level tweak values. This fix updates the type annotation to allow bool, int, float, str, and dict[str, Any] values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended configuration values to support boolean and numeric types (integers and floats) in addition to strings, providing greater flexibility for system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->