### PR TITLE
fix: pass event_manager as keyword arg in Graph.start() to fix arg mismatch

### DIFF
--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -459,7 +459,7 @@ class Graph:
 
             try:
                 # Run the async generator
-                async_gen = self.async_start(inputs, max_iterations, event_manager)
+                async_gen = self.async_start(inputs, max_iterations, event_manager=event_manager)
 
                 while True:
                     try:


### PR DESCRIPTION
## Summary

- **Bug**: In `Graph.start()`, the call `self.async_start(inputs, max_iterations, event_manager)` passes `event_manager` as the third positional argument, which binds to the `config` parameter instead of `event_manager` in `async_start(self, inputs, max_iterations, config, event_manager, *, reset_output_values)`.
- **Impact**: The `event_manager` object is incorrectly treated as a `config` dict (causing silent failures or errors in `__apply_config`), while the real `event_manager` in `async_start` is left as `None` — so vertex lifecycle events (`on_end_vertex`, `on_build_start`) are never emitted during synchronous graph execution via `start()`.
- **Fix**: Pass `event_manager` as a keyword argument (`event_manager=event_manager`) so it binds to the correct parameter. The `config` parameter correctly defaults to `None` since `start()` already applies the config before calling `async_start()`.

## Test plan

- [ ] Verify synchronous `Graph.start(event_manager=em)` now correctly emits `on_build_start` and `on_end_vertex` events
- [ ] Verify `Graph.start(config=cfg)` still applies config correctly (applied once in `start()`, not double-applied)
- [ ] Existing tests for `Graph.start()` and `Graph.async_start()` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an internal function call to ensure proper initialization of async operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->