### PR TITLE
feat(files): add Flow Files tab to show and manage flow-specific files

### DIFF
--- a/src/backend/base/langflow/api/v1/files.py
+++ b/src/backend/base/langflow/api/v1/files.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 from datetime import datetime, timezone
 from http import HTTPStatus
 from io import BytesIO
@@ -11,12 +12,24 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
 from lfx.services.settings.service import SettingsService
 from lfx.utils.helpers import build_content_type_from_extension
+from pydantic import BaseModel
+from sqlmodel import select
 
 from langflow.api.utils import CurrentActiveUser, DbSession, ValidatedFileName
 from langflow.api.v1.schemas import UploadFileResponse
 from langflow.services.database.models.flow.model import Flow
 from langflow.services.deps import get_settings_service, get_storage_service
 from langflow.services.storage.service import StorageService
+
+
+class FlowFileInfo(BaseModel):
+    flow_id: str
+    flow_name: str
+    file_name: str
+    file_size: int
+
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Files"], prefix="/files")
 
@@ -272,6 +285,41 @@ async def list_profile_pictures(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
     return {"files": results}
+
+
+@router.get("/list")
+async def list_all_flow_files(
+    current_user: CurrentActiveUser,
+    session: DbSession,
+    storage_service: Annotated[StorageService, Depends(get_storage_service)],
+) -> list[FlowFileInfo]:
+    """List all files across all flows owned by the current user."""
+    stmt = select(Flow).where(Flow.user_id == current_user.id)
+    flows = (await session.exec(stmt)).all()
+
+    result: list[FlowFileInfo] = []
+    for flow in flows:
+        try:
+            files = await storage_service.list_files(flow_id=str(flow.id))
+        except FileNotFoundError:
+            continue
+        except OSError:
+            logger.warning("Failed to list files for flow %s", flow.id)
+            continue
+        for file_name in files:
+            try:
+                file_size = await storage_service.get_file_size(flow_id=str(flow.id), file_name=file_name)
+            except (FileNotFoundError, OSError):
+                file_size = 0
+            result.append(
+                FlowFileInfo(
+                    flow_id=str(flow.id),
+                    flow_name=flow.name,
+                    file_name=file_name,
+                    file_size=file_size,
+                )
+            )
+    return result
 
 
 @router.get("/list/{flow_id}")

--- a/src/backend/tests/unit/api/v1/test_files.py
+++ b/src/backend/tests/unit/api/v1/test_files.py
@@ -1079,9 +1079,7 @@ async def test_list_all_flow_files_with_files(files_client, files_created_api_ke
     assert data[0]["file_size"] > 0
 
 
-async def test_list_all_flow_files_only_own_flows(
-    files_client, files_created_api_key, files_flow, files_active_user
-):
+async def test_list_all_flow_files_only_own_flows(files_client, files_created_api_key, files_flow, files_active_user):
     """Test that listing all flow files does not return files from other users' flows."""
     headers = {"x-api-key": files_created_api_key.api_key}
 
@@ -1095,7 +1093,6 @@ async def test_list_all_flow_files_only_own_flows(
 
     # Create a second user and a flow for them
     from langflow.services.auth.utils import get_password_hash
-    from langflow.services.database.models.flow.model import FlowCreate
     from langflow.services.database.models.user.model import User
     from lfx.services.deps import session_scope
     from sqlmodel import select

--- a/src/backend/tests/unit/api/v1/test_files.py
+++ b/src/backend/tests/unit/api/v1/test_files.py
@@ -1126,9 +1126,7 @@ async def test_list_all_flow_files_only_own_flows(files_client, files_created_ap
     data = response.json()
     assert len(data) >= 1, "Should return at least the authenticated user's file"
     for file_info in data:
-        assert file_info["flow_id"] != other_flow_id, (
-            "Should not return files from other users' flows"
-        )
+        assert file_info["flow_id"] != other_flow_id, "Should not return files from other users' flows"
         assert file_info["flow_id"] == str(files_flow.id), (
             "Should only return files from the authenticated user's flows"
         )

--- a/src/backend/tests/unit/api/v1/test_files.py
+++ b/src/backend/tests/unit/api/v1/test_files.py
@@ -1079,7 +1079,7 @@ async def test_list_all_flow_files_with_files(files_client, files_created_api_ke
     assert data[0]["file_size"] > 0
 
 
-async def test_list_all_flow_files_only_own_flows(files_client, files_created_api_key, files_flow, files_active_user):  # noqa: ARG001
+async def test_list_all_flow_files_only_own_flows(files_client, files_created_api_key, files_flow, json_flow: str):
     """Test that listing all flow files does not return files from other users' flows."""
     headers = {"x-api-key": files_created_api_key.api_key}
 
@@ -1091,11 +1091,10 @@ async def test_list_all_flow_files_only_own_flows(files_client, files_created_ap
     )
     assert upload_response.status_code == 201
 
-    # Create a second user and a flow for them
-    from langflow.services.auth.utils import get_password_hash
-    from langflow.services.database.models.user.model import User
-    from lfx.services.deps import session_scope
-    from sqlmodel import select
+    # Create a second user with a flow and a file
+    from langflow.services.deps import get_storage_service
+
+    loaded_json = json.loads(json_flow)
 
     async with session_scope() as session:
         other_user = User(
@@ -1104,27 +1103,43 @@ async def test_list_all_flow_files_only_own_flows(files_client, files_created_ap
             is_active=True,
             is_superuser=False,
         )
-        stmt = select(User).where(User.username == other_user.username)
-        if existing := (await session.exec(stmt)).first():
-            other_user = existing
-        else:
-            session.add(other_user)
-            await session.flush()
-            await session.refresh(other_user)
+        session.add(other_user)
+        await session.flush()
+        await session.refresh(other_user)
+
+        other_flow_data = FlowCreate(name="other_user_flow", data=loaded_json.get("data"), user_id=other_user.id)
+        other_flow = Flow.model_validate(other_flow_data)
+        session.add(other_flow)
+        await session.flush()
+        await session.refresh(other_flow)
+        other_flow_id = str(other_flow.id)
         other_user_id = other_user.id
 
-    # The list endpoint should only return files from flows owned by the authenticated user
+    # Store a file directly in the other user's flow storage
+    storage_service = get_storage_service()
+    await storage_service.save_file(flow_id=other_flow_id, file_name="other_file.txt", data=b"other content")
+
+    # The list endpoint should only return files from the authenticated user's flows
     response = await files_client.get("api/v1/files/list", headers=headers)
     assert response.status_code == 200
 
     data = response.json()
+    assert len(data) >= 1, "Should return at least the authenticated user's file"
     for file_info in data:
+        assert file_info["flow_id"] != other_flow_id, (
+            "Should not return files from other users' flows"
+        )
         assert file_info["flow_id"] == str(files_flow.id), (
             "Should only return files from the authenticated user's flows"
         )
 
-    # Clean up other user
+    # Clean up
+    with suppress(FileNotFoundError):
+        await storage_service.delete_file(flow_id=other_flow_id, file_name="other_file.txt")
     async with session_scope() as session:
+        flow_to_delete = await session.get(Flow, other_flow.id)
+        if flow_to_delete:
+            await session.delete(flow_to_delete)
         user_to_delete = await session.get(User, other_user_id)
         if user_to_delete:
             await session.delete(user_to_delete)

--- a/src/backend/tests/unit/api/v1/test_files.py
+++ b/src/backend/tests/unit/api/v1/test_files.py
@@ -1079,7 +1079,7 @@ async def test_list_all_flow_files_with_files(files_client, files_created_api_ke
     assert data[0]["file_size"] > 0
 
 
-async def test_list_all_flow_files_only_own_flows(files_client, files_created_api_key, files_flow, files_active_user):
+async def test_list_all_flow_files_only_own_flows(files_client, files_created_api_key, files_flow, files_active_user):  # noqa: ARG001
     """Test that listing all flow files does not return files from other users' flows."""
     headers = {"x-api-key": files_created_api_key.api_key}
 

--- a/src/backend/tests/unit/api/v1/test_files.py
+++ b/src/backend/tests/unit/api/v1/test_files.py
@@ -1045,3 +1045,89 @@ async def test_delete_file_forward_slash_traversal_blocked(
     assert response.status_code == 404, (
         f"Forward slash traversal should be blocked by routing: {malicious_filename}, got {response.status_code}"
     )
+
+
+async def test_list_all_flow_files_empty(files_client, files_created_api_key, files_active_user):  # noqa: ARG001
+    """Test that listing all flow files returns empty list when user has no flows with files."""
+    headers = {"x-api-key": files_created_api_key.api_key}
+    response = await files_client.get("api/v1/files/list", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_list_all_flow_files_with_files(files_client, files_created_api_key, files_flow):
+    """Test that listing all flow files returns files from all user flows."""
+    headers = {"x-api-key": files_created_api_key.api_key}
+
+    # Upload a file to the flow
+    upload_response = await files_client.post(
+        f"api/v1/files/upload/{files_flow.id}",
+        files={"file": ("report.pdf", b"pdf content")},
+        headers=headers,
+    )
+    assert upload_response.status_code == 201
+
+    # List all flow files
+    response = await files_client.get("api/v1/files/list", headers=headers)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["flow_id"] == str(files_flow.id)
+    assert data[0]["flow_name"] == files_flow.name
+    assert "report.pdf" in data[0]["file_name"]
+    assert data[0]["file_size"] > 0
+
+
+async def test_list_all_flow_files_only_own_flows(
+    files_client, files_created_api_key, files_flow, files_active_user
+):
+    """Test that listing all flow files does not return files from other users' flows."""
+    headers = {"x-api-key": files_created_api_key.api_key}
+
+    # Upload a file to own flow
+    upload_response = await files_client.post(
+        f"api/v1/files/upload/{files_flow.id}",
+        files={"file": ("own_file.txt", b"own content")},
+        headers=headers,
+    )
+    assert upload_response.status_code == 201
+
+    # Create a second user and a flow for them
+    from langflow.services.auth.utils import get_password_hash
+    from langflow.services.database.models.flow.model import FlowCreate
+    from langflow.services.database.models.user.model import User
+    from lfx.services.deps import session_scope
+    from sqlmodel import select
+
+    async with session_scope() as session:
+        other_user = User(
+            username="other_files_user",
+            password=get_password_hash("testpassword"),
+            is_active=True,
+            is_superuser=False,
+        )
+        stmt = select(User).where(User.username == other_user.username)
+        if existing := (await session.exec(stmt)).first():
+            other_user = existing
+        else:
+            session.add(other_user)
+            await session.flush()
+            await session.refresh(other_user)
+        other_user_id = other_user.id
+
+    # The list endpoint should only return files from flows owned by the authenticated user
+    response = await files_client.get("api/v1/files/list", headers=headers)
+    assert response.status_code == 200
+
+    data = response.json()
+    for file_info in data:
+        assert file_info["flow_id"] == str(files_flow.id), (
+            "Should only return files from the authenticated user's flows"
+        )
+
+    # Clean up other user
+    async with session_scope() as session:
+        user_to_delete = await session.get(User, other_user_id)
+        if user_to_delete:
+            await session.delete(user_to_delete)

--- a/src/frontend/src/controllers/API/queries/file-management/use-delete-flow-file.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-delete-flow-file.ts
@@ -1,0 +1,40 @@
+import type { UseMutationResult } from "@tanstack/react-query";
+import { BASE_URL_API } from "@/constants/constants";
+import type { useMutationFunctionType } from "@/types/api";
+import { api } from "@/controllers/API/api";
+import { UseRequestProcessor } from "../../services/request-processor";
+
+interface IDeleteFlowFile {
+  flowId: string;
+  fileName: string;
+}
+
+export const useDeleteFlowFile: useMutationFunctionType<
+  undefined,
+  IDeleteFlowFile
+> = (options?) => {
+  const { mutate, queryClient } = UseRequestProcessor();
+
+  const deleteFlowFileFn = async (params: IDeleteFlowFile): Promise<any> => {
+    const response = await api.delete<any>(
+      `${BASE_URL_API}files/delete/${params.flowId}/${params.fileName}`,
+    );
+    return response.data;
+  };
+
+  const mutation: UseMutationResult<any, any, IDeleteFlowFile> = mutate(
+    ["useDeleteFlowFile"],
+    deleteFlowFileFn,
+    {
+      ...options,
+      onSettled: (...args) => {
+        queryClient.invalidateQueries({
+          queryKey: ["useGetFlowFiles"],
+        });
+        options?.onSettled?.(...args);
+      },
+    },
+  );
+
+  return mutation;
+};

--- a/src/frontend/src/controllers/API/queries/file-management/use-delete-flow-file.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-delete-flow-file.ts
@@ -1,7 +1,7 @@
 import type { UseMutationResult } from "@tanstack/react-query";
 import { BASE_URL_API } from "@/constants/constants";
-import type { useMutationFunctionType } from "@/types/api";
 import { api } from "@/controllers/API/api";
+import type { useMutationFunctionType } from "@/types/api";
 import { UseRequestProcessor } from "../../services/request-processor";
 
 interface IDeleteFlowFile {
@@ -17,7 +17,7 @@ export const useDeleteFlowFile: useMutationFunctionType<
 
   const deleteFlowFileFn = async (params: IDeleteFlowFile): Promise<any> => {
     const response = await api.delete<any>(
-      `${BASE_URL_API}files/delete/${params.flowId}/${params.fileName}`,
+      `${BASE_URL_API}files/delete/${params.flowId}/${encodeURIComponent(params.fileName)}`,
     );
     return response.data;
   };

--- a/src/frontend/src/controllers/API/queries/file-management/use-get-flow-files.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-get-flow-files.ts
@@ -1,0 +1,35 @@
+import { keepPreviousData } from "@tanstack/react-query";
+import { BASE_URL_API } from "@/constants/constants";
+import type { useQueryFunctionType } from "@/types/api";
+import { api } from '@/controllers/API/api'
+import { UseRequestProcessor } from "../../services/request-processor";
+
+export interface FlowFileInfo {
+  flow_id: string;
+  flow_name: string;
+  file_name: string;
+  file_size: number;
+}
+
+export type FlowFilesResponse = FlowFileInfo[];
+
+export const useGetFlowFiles: useQueryFunctionType<
+  undefined,
+  FlowFilesResponse
+> = (config) => {
+  const { query } = UseRequestProcessor();
+
+  const getFlowFilesFn = async () => {
+    const response = await api.get<FlowFilesResponse>(
+      `${BASE_URL_API}files/list`,
+    );
+    return response["data"] ?? [];
+  };
+
+  const queryResult = query(["useGetFlowFiles"], getFlowFilesFn, {
+    placeholderData: keepPreviousData,
+    ...config,
+  });
+
+  return queryResult;
+};

--- a/src/frontend/src/controllers/API/queries/file-management/use-get-flow-files.ts
+++ b/src/frontend/src/controllers/API/queries/file-management/use-get-flow-files.ts
@@ -1,7 +1,7 @@
 import { keepPreviousData } from "@tanstack/react-query";
 import { BASE_URL_API } from "@/constants/constants";
+import { api } from "@/controllers/API/api";
 import type { useQueryFunctionType } from "@/types/api";
-import { api } from '@/controllers/API/api'
 import { UseRequestProcessor } from "../../services/request-processor";
 
 export interface FlowFileInfo {

--- a/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/flow-files-col-defs.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/flow-files-col-defs.tsx
@@ -1,0 +1,127 @@
+import type { ColDef } from "ag-grid-community";
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { FlowFileInfo } from "@/controllers/API/queries/file-management/use-get-flow-files";
+import { formatFileSize } from "@/utils/stringManipulation";
+import { FILE_ICONS } from "@/utils/styleUtils";
+import { cn } from "@/utils/utils";
+
+interface FlowFilesColDefsOptions {
+  onDownload: (flowId: string, fileName: string) => void;
+  onDelete: (file: FlowFileInfo) => void;
+}
+
+export const getFlowFilesColDefs = ({
+  onDownload,
+  onDelete,
+}: FlowFilesColDefsOptions): ColDef[] => [
+  {
+    headerName: "File Name",
+    field: "file_name",
+    flex: 2,
+    headerCheckboxSelection: true,
+    checkboxSelection: true,
+    filter: "agTextColumnFilter",
+    cellRenderer: (params) => {
+      const extension = params.value.split(".").pop()?.toLowerCase() ?? "";
+      return (
+        <div className="flex items-center gap-4 font-medium">
+          <div className="file-icon pointer-events-none relative">
+            <ForwardedIconComponent
+              name={FILE_ICONS[extension]?.icon ?? "File"}
+              className={cn(
+                "-mx-[3px] h-6 w-6 shrink-0",
+                FILE_ICONS[extension]?.color ?? undefined,
+              )}
+            />
+          </div>
+          <span className="text-sm font-medium">{params.value}</span>
+        </div>
+      );
+    },
+  },
+  {
+    headerName: "Type",
+    field: "file_name",
+    flex: 1,
+    filter: "agTextColumnFilter",
+    editable: false,
+    valueFormatter: (params) => {
+      return params.value.split(".").pop()?.toUpperCase() ?? "";
+    },
+    cellClass: "text-muted-foreground cursor-text select-text",
+  },
+  {
+    headerName: "Flow",
+    field: "flow_name",
+    flex: 1,
+    filter: "agTextColumnFilter",
+    cellClass: "text-muted-foreground cursor-text select-text",
+  },
+  {
+    headerName: "Size",
+    field: "file_size",
+    flex: 1,
+    valueFormatter: (params) => formatFileSize(params.value),
+    cellClass: "text-muted-foreground",
+  },
+  {
+    maxWidth: 60,
+    editable: false,
+    resizable: false,
+    cellClass: "cursor-default",
+    cellRenderer: (params) => {
+      return (
+        <div className="flex h-full cursor-default items-center justify-center">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="iconMd">
+                <ForwardedIconComponent name="EllipsisVertical" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              sideOffset={0}
+              side="bottom"
+              className="-ml-24"
+            >
+              <DropdownMenuItem
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDownload(params.data.flow_id, params.data.file_name);
+                }}
+                className="cursor-pointer"
+              >
+                <ForwardedIconComponent
+                  name="Download"
+                  aria-hidden="true"
+                  className="mr-2 h-4 w-4"
+                />
+                Download
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDelete(params.data);
+                }}
+                className="cursor-pointer text-destructive"
+              >
+                <ForwardedIconComponent
+                  name="Trash2"
+                  aria-hidden="true"
+                  className="mr-2 h-4 w-4"
+                />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      );
+    },
+  },
+];

--- a/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/flow-files-col-defs.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/flow-files-col-defs.tsx
@@ -81,7 +81,11 @@ export const getFlowFilesColDefs = ({
         <div className="flex h-full cursor-default items-center justify-center">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="iconMd">
+              <Button
+                variant="ghost"
+                size="iconMd"
+                aria-label={`Open actions for ${params.data.file_name}`}
+              >
                 <ForwardedIconComponent name="EllipsisVertical" />
               </Button>
             </DropdownMenuTrigger>

--- a/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/hooks/use-flow-file-actions.ts
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/hooks/use-flow-file-actions.ts
@@ -16,7 +16,7 @@ export const useFlowFileActions = () => {
   const handleDownload = async (flowId: string, fileName: string) => {
     try {
       const response = await fetch(
-        `${BASE_URL_API}files/download/${flowId}/${fileName}`,
+        `${BASE_URL_API}files/download/${flowId}/${encodeURIComponent(fileName)}`,
         {
           headers: { Accept: "*/*" },
           credentials: getFetchCredentials(),
@@ -77,27 +77,36 @@ export const useFlowFileActions = () => {
     let errors = 0;
     const total = files.length;
 
+    const finalize = () => {
+      if (completed + errors !== total) return;
+
+      if (errors === 0) {
+        setSuccessData({
+          title: `${completed} file${completed > 1 ? "s" : ""} deleted successfully`,
+        });
+      } else {
+        setErrorData({
+          title:
+            completed === 0
+              ? `Failed to delete ${errors} file${errors > 1 ? "s" : ""}`
+              : `Deleted ${completed} file${completed > 1 ? "s" : ""}, failed to delete ${errors}`,
+        });
+      }
+
+      onComplete();
+    };
+
     for (const file of files) {
       deleteFile(
         { flowId: file.flow_id, fileName: file.file_name },
         {
           onSuccess: () => {
             completed++;
-            if (completed + errors === total) {
-              setSuccessData({
-                title: `${completed} file${completed > 1 ? "s" : ""} deleted successfully`,
-              });
-              onComplete();
-            }
+            finalize();
           },
           onError: () => {
             errors++;
-            if (completed + errors === total) {
-              setErrorData({
-                title: `Failed to delete ${errors} file${errors > 1 ? "s" : ""}`,
-              });
-              onComplete();
-            }
+            finalize();
           },
         },
       );

--- a/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/hooks/use-flow-file-actions.ts
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/hooks/use-flow-file-actions.ts
@@ -1,0 +1,108 @@
+import { BASE_URL_API } from "@/constants/constants";
+import { useDeleteFlowFile } from "@/controllers/API/queries/file-management/use-delete-flow-file";
+import type { FlowFileInfo } from "@/controllers/API/queries/file-management/use-get-flow-files";
+import { getFetchCredentials } from "@/customization/utils/get-fetch-credentials";
+import useAlertStore from "@/stores/alertStore";
+
+interface BulkDeleteCallbacks {
+  onComplete: () => void;
+}
+
+export const useFlowFileActions = () => {
+  const setErrorData = useAlertStore((state) => state.setErrorData);
+  const setSuccessData = useAlertStore((state) => state.setSuccessData);
+  const { mutate: deleteFile } = useDeleteFlowFile();
+
+  const handleDownload = async (flowId: string, fileName: string) => {
+    try {
+      const response = await fetch(
+        `${BASE_URL_API}files/download/${flowId}/${fileName}`,
+        {
+          headers: { Accept: "*/*" },
+          credentials: getFetchCredentials(),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(`Download failed with status ${response.status}`);
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", fileName);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "An error occurred while downloading the file";
+      setErrorData({
+        title: "Error downloading file",
+        list: [message],
+      });
+    }
+  };
+
+  const handleDeleteSingle = (file: FlowFileInfo, onComplete?: () => void) => {
+    deleteFile(
+      { flowId: file.flow_id, fileName: file.file_name },
+      {
+        onSuccess: () => {
+          setSuccessData({ title: "File deleted successfully" });
+          onComplete?.();
+        },
+        onError: (error: unknown) => {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "An error occurred while deleting the file";
+          setErrorData({
+            title: "Error deleting file",
+            list: [message],
+          });
+          onComplete?.();
+        },
+      },
+    );
+  };
+
+  const handleBulkDelete = (
+    files: FlowFileInfo[],
+    { onComplete }: BulkDeleteCallbacks,
+  ) => {
+    let completed = 0;
+    let errors = 0;
+    const total = files.length;
+
+    for (const file of files) {
+      deleteFile(
+        { flowId: file.flow_id, fileName: file.file_name },
+        {
+          onSuccess: () => {
+            completed++;
+            if (completed + errors === total) {
+              setSuccessData({
+                title: `${completed} file${completed > 1 ? "s" : ""} deleted successfully`,
+              });
+              onComplete();
+            }
+          },
+          onError: () => {
+            errors++;
+            if (completed + errors === total) {
+              setErrorData({
+                title: `Failed to delete ${errors} file${errors > 1 ? "s" : ""}`,
+              });
+              onComplete();
+            }
+          },
+        },
+      );
+    }
+  };
+
+  return { handleDownload, handleDeleteSingle, handleBulkDelete };
+};

--- a/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/index.tsx
@@ -1,0 +1,170 @@
+import type { SelectionChangedEvent } from "ag-grid-community";
+import { useState } from "react";
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import CardsWrapComponent from "@/components/core/cardsWrapComponent";
+import TableComponent from "@/components/core/parameterRenderComponent/components/tableComponent";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import Loading from "@/components/ui/loading";
+import {
+  type FlowFileInfo,
+  useGetFlowFiles,
+} from "@/controllers/API/queries/file-management/use-get-flow-files";
+import ConfirmationModal from "@/modals/confirmationModal";
+import DeleteConfirmationModal from "@/modals/deleteConfirmationModal";
+import { getFlowFilesColDefs } from "./flow-files-col-defs";
+import { useFlowFileActions } from "./hooks/use-flow-file-actions";
+
+const FlowFilesTab = () => {
+  const { data: flowFiles } = useGetFlowFiles();
+  const { handleDownload, handleDeleteSingle, handleBulkDelete } =
+    useFlowFileActions();
+
+  const [quickFilterText, setQuickFilterText] = useState("");
+  const [selectedFiles, setSelectedFiles] = useState<FlowFileInfo[]>([]);
+  const [quantitySelected, setQuantitySelected] = useState(0);
+  const [fileToDelete, setFileToDelete] = useState<FlowFileInfo | null>(null);
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
+
+  const resetSelection = () => {
+    setSelectedFiles([]);
+    setQuantitySelected(0);
+  };
+
+  const closeDeleteModal = () => {
+    setShowDeleteConfirmation(false);
+    setFileToDelete(null);
+  };
+
+  const confirmDeleteSingle = () => {
+    if (!fileToDelete) return;
+    handleDeleteSingle(fileToDelete, closeDeleteModal);
+  };
+
+  const confirmBulkDelete = () => {
+    handleBulkDelete(selectedFiles, { onComplete: resetSelection });
+  };
+
+  const handleSelectionChanged = (event: SelectionChangedEvent) => {
+    const selectedRows = event.api.getSelectedRows();
+    setSelectedFiles(selectedRows);
+
+    if (selectedRows.length === 0) {
+      setTimeout(() => {
+        setQuantitySelected(0);
+      }, 300);
+      return;
+    }
+
+    setQuantitySelected(selectedRows.length);
+  };
+
+  const colDefs = getFlowFilesColDefs({
+    onDownload: handleDownload,
+    onDelete: (file) => {
+      setFileToDelete(file);
+      setShowDeleteConfirmation(true);
+    },
+  });
+
+  return (
+    <div className="flex h-full flex-col">
+      {flowFiles && flowFiles.length > 0 && (
+        <div className="flex justify-between">
+          <div className="flex w-full xl:w-5/12">
+            <Input
+              icon="Search"
+              data-testid="search-flow-files-input"
+              type="text"
+              placeholder="Search flow files..."
+              className="mr-2 w-full"
+              value={quickFilterText}
+              onChange={(event) => setQuickFilterText(event.target.value)}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            {quantitySelected > 0 && (
+              <DeleteConfirmationModal
+                onConfirm={confirmBulkDelete}
+                description={"file" + (quantitySelected > 1 ? "s" : "")}
+              >
+                <Button
+                  variant="destructive"
+                  className="flex items-center gap-2 !px-3 font-semibold md:!px-4 md:!pl-3.5"
+                  data-testid="bulk-delete-flow-files-btn"
+                >
+                  <ForwardedIconComponent name="Trash2" className="h-4 w-4" />
+                  <span className="hidden whitespace-nowrap md:inline">
+                    Delete ({quantitySelected})
+                  </span>
+                </Button>
+              </DeleteConfirmationModal>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="flex h-full flex-col py-4">
+        {!flowFiles || !Array.isArray(flowFiles) ? (
+          <div className="flex h-full w-full items-center justify-center">
+            <Loading />
+          </div>
+        ) : flowFiles.length > 0 ? (
+          <div className="relative h-full">
+            <TableComponent
+              rowHeight={45}
+              headerHeight={45}
+              cellSelection={false}
+              tableOptions={{ hide_options: true }}
+              rowSelection="multiple"
+              onSelectionChanged={handleSelectionChanged}
+              columnDefs={colDefs}
+              rowData={flowFiles}
+              className="ag-no-border w-full"
+              domLayout="autoHeight"
+              pagination
+              quickFilterText={quickFilterText}
+              gridOptions={{
+                ensureDomOrder: true,
+                colResizeDefault: "shift",
+              }}
+            />
+          </div>
+        ) : (
+          <CardsWrapComponent dragMessage="">
+            <div className="flex h-full w-full flex-col items-center justify-center gap-8 pb-8">
+              <div className="flex flex-col items-center gap-2">
+                <h3 className="text-2xl font-semibold">No flow files</h3>
+                <p className="text-lg text-secondary-foreground">
+                  Files uploaded to your flows will appear here.
+                </p>
+              </div>
+            </div>
+          </CardsWrapComponent>
+        )}
+      </div>
+
+      <ConfirmationModal
+        open={showDeleteConfirmation}
+        onClose={closeDeleteModal}
+        onCancel={closeDeleteModal}
+        title="Delete File"
+        titleHeader={`Are you sure you want to delete "${fileToDelete?.file_name}"?`}
+        cancelText="Cancel"
+        size="x-small"
+        confirmationText="Delete"
+        icon="Trash2"
+        destructive
+        onConfirm={confirmDeleteSingle}
+      >
+        <ConfirmationModal.Content>
+          <div className="text-sm text-muted-foreground">
+            This action cannot be undone. The file will be permanently deleted.
+          </div>
+        </ConfirmationModal.Content>
+      </ConfirmationModal>
+    </div>
+  );
+};
+
+export default FlowFilesTab;

--- a/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/index.tsx
@@ -16,7 +16,7 @@ import { getFlowFilesColDefs } from "./flow-files-col-defs";
 import { useFlowFileActions } from "./hooks/use-flow-file-actions";
 
 const FlowFilesTab = () => {
-  const { data: flowFiles } = useGetFlowFiles();
+  const { data: flowFiles, isLoading, isError } = useGetFlowFiles();
   const { handleDownload, handleDeleteSingle, handleBulkDelete } =
     useFlowFileActions();
 
@@ -48,14 +48,6 @@ const FlowFilesTab = () => {
   const handleSelectionChanged = (event: SelectionChangedEvent) => {
     const selectedRows = event.api.getSelectedRows();
     setSelectedFiles(selectedRows);
-
-    if (selectedRows.length === 0) {
-      setTimeout(() => {
-        setQuantitySelected(0);
-      }, 300);
-      return;
-    }
-
     setQuantitySelected(selectedRows.length);
   };
 
@@ -105,11 +97,25 @@ const FlowFilesTab = () => {
       )}
 
       <div className="flex h-full flex-col py-4">
-        {!flowFiles || !Array.isArray(flowFiles) ? (
+        {isLoading ? (
           <div className="flex h-full w-full items-center justify-center">
             <Loading />
           </div>
-        ) : flowFiles.length > 0 ? (
+        ) : isError ? (
+          <CardsWrapComponent dragMessage="">
+            <div className="flex h-full w-full flex-col items-center justify-center gap-8 pb-8">
+              <div className="flex flex-col items-center gap-2">
+                <h3 className="text-2xl font-semibold">
+                  Error loading flow files
+                </h3>
+                <p className="text-lg text-secondary-foreground">
+                  An error occurred while fetching your flow files. Please try
+                  again later.
+                </p>
+              </div>
+            </div>
+          </CardsWrapComponent>
+        ) : flowFiles && flowFiles.length > 0 ? (
           <div className="relative h-full">
             <TableComponent
               rowHeight={45}

--- a/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/index.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import FilesTab from "./components/FilesTab";
+import FlowFilesTab from "./components/flowFilesTab";
 
 export const FilesPage = () => {
   const [selectedFiles, setSelectedFiles] = useState<any[]>([]);
   const [quantitySelected, setQuantitySelected] = useState(0);
   const [isShiftPressed, setIsShiftPressed] = useState(false);
   const [quickFilterText, setQuickFilterText] = useState("");
+  const [activeTab, setActiveTab] = useState("my-files");
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -67,7 +70,27 @@ export const FilesPage = () => {
               Files
             </div>
             <div className="flex h-full flex-col">
-              <FilesTab {...tabProps} />
+              <Tabs
+                value={activeTab}
+                onValueChange={(value) => {
+                  setActiveTab(value);
+                  setSelectedFiles([]);
+                  setQuantitySelected(0);
+                  setQuickFilterText("");
+                }}
+                className="flex h-full flex-col"
+              >
+                <TabsList className="mb-4">
+                  <TabsTrigger value="my-files">My Files</TabsTrigger>
+                  <TabsTrigger value="flow-files">Flow Files</TabsTrigger>
+                </TabsList>
+                <TabsContent value="my-files" className="flex-1">
+                  <FilesTab {...tabProps} />
+                </TabsContent>
+                <TabsContent value="flow-files" className="flex-1">
+                  <FlowFilesTab />
+                </TabsContent>
+              </Tabs>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Adds a new **Flow Files** tab to the `/assets/files` page, providing a centralized view of all files uploaded to flows via the v1 API.

Currently, users can only see flow-specific files by navigating to each flow individually. This feature surfaces all flow files in one place with download, delete, and bulk delete capabilities.

### Backend
- New `GET /api/v1/files/list` endpoint that lists all files across all flows owned by the current user
- Returns `flow_id`, `flow_name`, `file_name`, and `file_size` for each file
- Proper error handling with specific exceptions (`FileNotFoundError`, `OSError`)

### Frontend
- New `FlowFilesTab` component with AG Grid table (File Name, Type, Flow, Size columns)
- Context menu with Download and Delete actions per file
- Bulk delete with checkbox selection
- Search/filter across all columns
- Empty state when no flow files exist
- Radix UI Tabs to switch between "My Files" and "Flow Files"

### New files
- `src/backend/base/langflow/api/v1/files.py` (modified — new endpoint + model)
- `src/frontend/src/controllers/API/queries/file-management/use-get-flow-files.ts`
- `src/frontend/src/controllers/API/queries/file-management/use-delete-flow-file.ts`
- `src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/index.tsx`
- `src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/flow-files-col-defs.tsx`
- `src/frontend/src/pages/MainPage/pages/filesPage/components/flowFilesTab/hooks/use-flow-file-actions.ts`
- `src/frontend/src/pages/MainPage/pages/filesPage/index.tsx` (modified — added Tabs)

# Demo
https://github.com/user-attachments/assets/3b5e9b1a-01c2-4e78-976e-eb082440743f



## Test plan
- [x] Unit tests for `GET /api/v1/files/list` (empty, with files, only own flows)
- [x] Upload a file to a flow via `POST /api/v1/files/upload/{flow_id}`
- [x] Navigate to `/assets/files` → "Flow Files" tab shows the uploaded file
- [x] Download the file from the context menu
- [x] Delete a single file from the context menu (with confirmation modal)
- [x] Select multiple files and bulk delete
- [x] Search/filter works across file name and flow name
- [x] "My Files" tab continues to work normally
- [x] Empty state shows when user has no flow files

Related to #12085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added "Flow Files" tab to the Files page for unified file management across all user flows
- Search and filter capabilities to quickly locate files
- File details display including name, type, size, and associated flow name
- Download and delete individual files with bulk deletion support
- Organized table view for efficient file browsing

## Tests
- Added unit tests for flow file listing and access scope validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->