### PR TITLE
fix: address PR review recommendations for feat-unify-models++

### DIFF
--- a/src/backend/tests/unit/components/files_and_knowledge/test_ingestion.py
+++ b/src/backend/tests/unit/components/files_and_knowledge/test_ingestion.py
@@ -291,3 +291,103 @@ class TestKnowledgeIngestionComponent(ComponentTestBaseWithClient):
 
         with pytest.raises(ValueError, match="Invalid knowledge base name"):
             await component.update_build_config(build_config, field_value, "knowledge_base")
+
+    @patch("lfx.components.files_and_knowledge.ingestion.get_embeddings")
+    async def test_build_kb_info_with_new_format_metadata(
+        self, mock_get_embeddings, component_class, default_kwargs, tmp_path, active_user
+    ):
+        """Test that build_kb_info uses model_selection directly from new-format metadata."""
+        # Overwrite the default metadata file to use the new format (includes model_selection key).
+        # The old format only had embedding_model/embedding_provider strings; the new format
+        # stores the full model_selection dict so get_embeddings() can reconstruct the client.
+        kb_path = tmp_path / active_user.username / "test_kb"
+        new_format_metadata = {
+            "embedding_provider": "HuggingFace",
+            "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+            "model_selection": {
+                "name": "sentence-transformers/all-MiniLM-L6-v2",
+                "provider": "HuggingFace",
+                "metadata": {},
+            },
+            "api_key": None,
+            "api_key_used": False,
+            "chunk_size": 1000,
+            "created_at": "2024-01-01T00:00:00Z",
+        }
+        (kb_path / "embedding_metadata.json").write_text(json.dumps(new_format_metadata))
+
+        component = component_class(**default_kwargs)
+        mock_get_embeddings.return_value = MagicMock()
+
+        with patch.object(component, "_create_vector_store"), patch.object(component, "_save_kb_files"):
+            result = await component.build_kb_info()
+
+        assert isinstance(result, Data)
+        assert result.data["rows"] == 2
+
+        # Verify get_embeddings was called with the full model_selection from the new-format metadata,
+        # not a minimal reconstructed dict from the backward-compat path.
+        call_kwargs = mock_get_embeddings.call_args
+        passed_model = call_kwargs.kwargs.get("model") or call_kwargs.args[0]
+        assert isinstance(passed_model, list)
+        assert passed_model[0]["name"] == "sentence-transformers/all-MiniLM-L6-v2"
+        assert passed_model[0]["provider"] == "HuggingFace"
+
+    async def test_convert_df_to_data_objects_allow_duplicates(self, component_class, default_kwargs):
+        """Test that allow_duplicates=True returns all rows even when their hashes already exist."""
+        default_kwargs["allow_duplicates"] = True
+        component = component_class(**default_kwargs)
+        data_df = default_kwargs["input_df"]
+        config_list = default_kwargs["column_config"]
+
+        with patch("lfx.components.files_and_knowledge.ingestion.Chroma") as mock_chroma:
+            mock_chroma_instance = MagicMock()
+            # Simulate all rows as already-existing duplicates in the store
+            mock_chroma_instance.get.return_value = {
+                "metadatas": [{"_id": "hash_1"}, {"_id": "hash_2"}]
+            }
+            mock_chroma.return_value = mock_chroma_instance
+
+            with patch("lfx.components.files_and_knowledge.ingestion.hashlib.sha256") as mock_hash:
+                mock_hash_obj = MagicMock()
+                # Return hashes that match the existing IDs above
+                mock_hash_obj.hexdigest.side_effect = ["hash_1", "hash_2"]
+                mock_hash.return_value = mock_hash_obj
+
+                data_objects = await component._convert_df_to_data_objects(data_df, config_list)
+
+        # All rows should be included — duplicates are allowed
+        assert len(data_objects) == 2
+
+    @patch("lfx.components.files_and_knowledge.ingestion.get_embeddings")
+    async def test_build_kb_info_no_metadata_file_raises_error(
+        self, mock_get_embeddings, component_class, default_kwargs, tmp_path, active_user
+    ):
+        """Test that build_kb_info raises RuntimeError when no embedding metadata file exists."""
+        # Remove the metadata file so model_selection cannot be determined
+        kb_path = tmp_path / active_user.username / "test_kb"
+        (kb_path / "embedding_metadata.json").unlink()
+
+        component = component_class(**default_kwargs)
+
+        with pytest.raises(RuntimeError, match="No embedding model configuration found"):
+            await component.build_kb_info()
+
+    def test_build_embedding_metadata_without_api_key(self, component_class, default_kwargs):
+        """Test _build_embedding_metadata with no API key stores model_selection for later use."""
+        component = component_class(**default_kwargs)
+        model_selection = [
+            {"name": "sentence-transformers/all-MiniLM-L6-v2", "provider": "HuggingFace", "metadata": {}}
+        ]
+
+        metadata = component._build_embedding_metadata(model_selection, api_key=None)
+
+        assert metadata["embedding_provider"] == "HuggingFace"
+        assert metadata["embedding_model"] == "sentence-transformers/all-MiniLM-L6-v2"
+        assert metadata["api_key"] is None
+        assert metadata["api_key_used"] is False
+        # New in this PR: full model_selection is stored alongside the string fields so
+        # build_kb_info() can reconstruct the embedding client without hitting the model registry.
+        assert "model_selection" in metadata
+        assert metadata["model_selection"]["name"] == "sentence-transformers/all-MiniLM-L6-v2"
+        assert metadata["model_selection"]["provider"] == "HuggingFace"

--- a/src/backend/tests/unit/components/llm_operations/test_batch_run_component.py
+++ b/src/backend/tests/unit/components/llm_operations/test_batch_run_component.py
@@ -2,10 +2,21 @@ import re
 from unittest.mock import patch
 
 import pytest
+from langchain_core.messages import AIMessage
 from lfx.components.llm_operations.batch_run import BatchRunComponent
 from lfx.schema import DataFrame
 
 from tests.base import ComponentTestBaseWithoutClient
+
+
+class _MockLLM:
+    """Minimal mock LLM for unit-testing batch processing without live API keys."""
+
+    def with_config(self, *_, **__):
+        return self
+
+    async def abatch(self, conversations):
+        return [AIMessage(content=f"Response to: {conv[-1]['content']}") for conv in conversations]
 
 
 class TestBatchRunComponent(ComponentTestBaseWithoutClient):
@@ -40,24 +51,12 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
         """Return an empty list since this component doesn't have version-specific files."""
         return []
 
-    @pytest.mark.skip(reason="Requires API key after ModelInput migration - needs mocking refactor")
     async def test_successful_batch_run_with_system_message(self):
         # Create test data
         test_df = DataFrame({"text": ["Hello", "World", "Test"]})
 
         component = BatchRunComponent(
-            model=[
-                {
-                    "name": "gpt-4o",
-                    "provider": "OpenAI",
-                    "icon": "OpenAI",
-                    "metadata": {
-                        "model_class": "ChatOpenAI",
-                        "model_name_param": "model",
-                        "api_key_param": "api_key",
-                    },
-                }
-            ],
+            model=_MockLLM(),
             system_message="You are a helpful assistant",
             df=test_df,
             column_name="text",
@@ -80,23 +79,11 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
         assert all(row["metadata"]["has_system_message"] for row in result_dicts)
         assert all(row["metadata"]["processing_status"] == "success" for row in result_dicts)
 
-    @pytest.mark.skip(reason="Requires API key after ModelInput migration - needs mocking refactor")
     async def test_batch_run_without_metadata(self):
         test_df = DataFrame({"text": ["Hello", "World"]})
 
         component = BatchRunComponent(
-            model=[
-                {
-                    "name": "gpt-4o",
-                    "provider": "OpenAI",
-                    "icon": "OpenAI",
-                    "metadata": {
-                        "model_class": "ChatOpenAI",
-                        "model_name_param": "model",
-                        "api_key_param": "api_key",
-                    },
-                }
-            ],
+            model=_MockLLM(),
             df=test_df,
             column_name="text",
             enable_metadata=False,
@@ -109,21 +96,9 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
         assert "metadata" not in result.columns
         assert all(isinstance(resp, str) for resp in result["model_response"])
 
-    @pytest.mark.skip(reason="Requires API key after ModelInput migration - needs mocking refactor")
     async def test_batch_run_error_with_metadata(self):
         component = BatchRunComponent(
-            model=[
-                {
-                    "name": "gpt-4o",
-                    "provider": "OpenAI",
-                    "icon": "OpenAI",
-                    "metadata": {
-                        "model_class": "ChatOpenAI",
-                        "model_name_param": "model",
-                        "api_key_param": "api_key",
-                    },
-                }
-            ],
+            model=_MockLLM(),
             df="not_a_dataframe",  # This will cause a TypeError
             column_name="text",
             enable_metadata=True,
@@ -132,21 +107,9 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
         with pytest.raises(TypeError, match=re.escape("Expected DataFrame input, got <class 'str'>")):
             await component.run_batch()
 
-    @pytest.mark.skip(reason="Requires API key after ModelInput migration - needs mocking refactor")
     async def test_batch_run_error_without_metadata(self):
         component = BatchRunComponent(
-            model=[
-                {
-                    "name": "gpt-4o",
-                    "provider": "OpenAI",
-                    "icon": "OpenAI",
-                    "metadata": {
-                        "model_class": "ChatOpenAI",
-                        "model_name_param": "model",
-                        "api_key_param": "api_key",
-                    },
-                }
-            ],
+            model=_MockLLM(),
             df="not_a_dataframe",  # This will cause a TypeError
             column_name="text",
             enable_metadata=False,
@@ -155,7 +118,6 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
         with pytest.raises(TypeError, match=re.escape("Expected DataFrame input, got <class 'str'>")):
             await component.run_batch()
 
-    @pytest.mark.skip(reason="Requires API key after ModelInput migration - needs mocking refactor")
     async def test_operational_error_with_metadata(self):
         # Create a mock model that raises an AttributeError during processing
         class ErrorModel:
@@ -167,18 +129,7 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
                 raise AttributeError(msg)
 
         component = BatchRunComponent(
-            model=[
-                {
-                    "name": "gpt-4o",
-                    "provider": "OpenAI",
-                    "icon": "OpenAI",
-                    "metadata": {
-                        "model_class": "ErrorModel",
-                        "model_name_param": "model",
-                        "api_key_param": "api_key",
-                    },
-                }
-            ],
+            model=ErrorModel(),
             df=DataFrame({"text": ["test1", "test2"]}),
             column_name="text",
             enable_metadata=True,
@@ -196,7 +147,6 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
         assert error_row["model_response"] == ""
         assert error_row["batch_index"] == -1
 
-    @pytest.mark.skip(reason="Requires API key after ModelInput migration - needs mocking refactor")
     async def test_operational_error_without_metadata(self):
         # Create a mock model that raises an AttributeError during processing
         class ErrorModel:
@@ -208,18 +158,7 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
                 raise AttributeError(msg)
 
         component = BatchRunComponent(
-            model=[
-                {
-                    "name": "gpt-4o",
-                    "provider": "OpenAI",
-                    "icon": "OpenAI",
-                    "metadata": {
-                        "model_class": "ErrorModel",
-                        "model_name_param": "model",
-                        "api_key_param": "api_key",
-                    },
-                }
-            ],
+            model=ErrorModel(),
             df=DataFrame({"text": ["test1", "test2"]}),
             column_name="text",
             enable_metadata=False,
@@ -294,21 +233,9 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
         # Como o metadata está desabilitado, ele não deve existir
         assert "metadata" not in row
 
-    @pytest.mark.skip(reason="Requires API key after ModelInput migration - needs mocking refactor")
     async def test_invalid_column_name(self):
         component = BatchRunComponent(
-            model=[
-                {
-                    "name": "gpt-4o",
-                    "provider": "OpenAI",
-                    "icon": "OpenAI",
-                    "metadata": {
-                        "model_class": "ChatOpenAI",
-                        "model_name_param": "model",
-                        "api_key_param": "api_key",
-                    },
-                }
-            ],
+            model=_MockLLM(),
             df=DataFrame({"text": ["Hello"]}),
             column_name="nonexistent_column",
             enable_metadata=True,
@@ -320,21 +247,9 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
         ):
             await component.run_batch()
 
-    @pytest.mark.skip(reason="Requires API key after ModelInput migration - needs mocking refactor")
     async def test_empty_dataframe(self):
         component = BatchRunComponent(
-            model=[
-                {
-                    "name": "gpt-4o",
-                    "provider": "OpenAI",
-                    "icon": "OpenAI",
-                    "metadata": {
-                        "model_class": "ChatOpenAI",
-                        "model_name_param": "model",
-                        "api_key_param": "api_key",
-                    },
-                }
-            ],
+            model=_MockLLM(),
             df=DataFrame({"text": []}),
             column_name="text",
             enable_metadata=True,
@@ -344,23 +259,11 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
         assert isinstance(result, DataFrame)
         assert len(result) == 0
 
-    @pytest.mark.skip(reason="Requires API key after ModelInput migration - needs mocking refactor")
     async def test_non_string_column_conversion(self):
         test_df = DataFrame({"text": [123, 456, 789]})  # Numeric values
 
         component = BatchRunComponent(
-            model=[
-                {
-                    "name": "gpt-4o",
-                    "provider": "OpenAI",
-                    "icon": "OpenAI",
-                    "metadata": {
-                        "model_class": "ChatOpenAI",
-                        "model_name_param": "model",
-                        "api_key_param": "api_key",
-                    },
-                }
-            ],
+            model=_MockLLM(),
             df=test_df,
             column_name="text",
             enable_metadata=True,
@@ -387,8 +290,6 @@ class TestBatchRunComponent(ComponentTestBaseWithoutClient):
 
             async def abatch(self, conversations):
                 # Model should still work without config
-                from langchain_core.messages import AIMessage
-
                 return [AIMessage(content=f"Response to: {conv[0]['content']}") for conv in conversations]
 
         test_df = DataFrame({"text": ["test1", "test2"]})

--- a/src/backend/tests/unit/components/models_and_agents/test_agent_component.py
+++ b/src/backend/tests/unit/components/models_and_agents/test_agent_component.py
@@ -309,6 +309,9 @@ class TestAgentComponent(ComponentTestBaseWithoutClient):
 
         component = await self.component_setup(component_class, default_kwargs)
 
+        # validate_model_selection requires a list — set a valid model selection
+        component.model = [{"name": "gpt-4o", "provider": "OpenAI", "metadata": {}}]
+
         # Call get_agent_requirements which internally calls get_llm
         await component.get_agent_requirements()
 
@@ -338,6 +341,9 @@ class TestAgentComponent(ComponentTestBaseWithoutClient):
             del default_kwargs["max_tokens"]
 
         component = await self.component_setup(component_class, default_kwargs)
+
+        # validate_model_selection requires a list — set a valid model selection
+        component.model = [{"name": "gpt-4o", "provider": "OpenAI", "metadata": {}}]
 
         # Call get_agent_requirements which internally calls get_llm
         await component.get_agent_requirements()
@@ -370,6 +376,9 @@ class TestAgentComponent(ComponentTestBaseWithoutClient):
         default_kwargs["max_tokens"] = 1000
 
         component = await self.component_setup(component_class, default_kwargs)
+
+        # validate_model_selection requires a list — set a valid model selection
+        component.model = [{"name": "gpt-4o", "provider": "OpenAI", "metadata": {}}]
 
         # Call get_agent_requirements which internally calls get_llm
         await component.get_agent_requirements()

--- a/src/lfx/src/lfx/base/models/unified_models.py
+++ b/src/lfx/src/lfx/base/models/unified_models.py
@@ -207,6 +207,7 @@ def get_provider_required_variable_keys(provider: str) -> list[str]:
 def apply_provider_variable_config_to_build_config(
     build_config: dict,
     provider: str,
+    user_id: UUID | str | None = None,
 ) -> dict:
     """Apply provider variable metadata to component build config fields.
 
@@ -220,12 +221,13 @@ def apply_provider_variable_config_to_build_config(
     Args:
         build_config: The component's build configuration dict
         provider: The selected provider name (e.g., "OpenAI", "IBM WatsonX")
+        user_id: The user ID used to retrieve stored credential values from the
+            variable service. Falls back to environment variables when None or
+            when a variable is not found in the database.
 
     Returns:
         Updated build_config dict
     """
-    import os
-
     provider_vars = get_provider_all_variables(provider)
 
     # Build a lookup by component_metadata.mapping_field
@@ -235,6 +237,11 @@ def apply_provider_variable_config_to_build_config(
         mapping_field = component_meta.get("mapping_field")
         if mapping_field:
             vars_by_field[mapping_field] = v
+
+    # Fetch all stored credential values for this provider in one call so we
+    # use the variable service (DB-first, env fallback) rather than reading
+    # os.environ directly.
+    stored_values = get_all_variables_for_provider(user_id, provider)
 
     for field_name, var_info in vars_by_field.items():
         if field_name not in build_config:
@@ -259,19 +266,19 @@ def apply_provider_variable_config_to_build_config(
         # Show the field since it's relevant to this provider
         field_config["show"] = True
 
-        # If no value is set, try to get from environment variable
-        env_var_key = var_info.get("variable_key")
-        if env_var_key:
+        # If no value is set, pre-populate from the stored credential value
+        var_key = var_info.get("variable_key")
+        if var_key:
             current_value = field_config.get("value")
-            # Only set from env if field is empty/None
+            # Only set if field is empty/None
             if not current_value or (isinstance(current_value, str) and not current_value.strip()):
-                env_value = os.environ.get(env_var_key)
-                if env_value and env_value.strip():
-                    field_config["value"] = env_value
+                stored_value = stored_values.get(var_key)
+                if stored_value and stored_value.strip():
+                    field_config["value"] = stored_value
                     logger.debug(
-                        "Set field %s from environment variable %s",
+                        "Set field %s from stored variable %s",
                         field_name,
-                        env_var_key,
+                        var_key,
                     )
 
     return build_config
@@ -1910,7 +1917,9 @@ def handle_model_input_update(
     if isinstance(current_model_value, list) and len(current_model_value) > 0:
         provider = current_model_value[0].get("provider", "")
         if provider:
-            build_config = apply_provider_variable_config_to_build_config(build_config, provider)
+            build_config = apply_provider_variable_config_to_build_config(
+                build_config, provider, user_id=getattr(component, "user_id", None)
+            )
 
         # Also handle WatsonX-specific embedding fields that are not in provider metadata
         if cache_key_prefix == "embedding_model_options":

--- a/src/lfx/src/lfx/components/agentics/helpers/model_config.py
+++ b/src/lfx/src/lfx/components/agentics/helpers/model_config.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
-from lfx.components.agentics.constants import ERROR_MODEL_NOT_SELECTED
+from lfx.components.agentics.constants import (
+    ERROR_MODEL_NOT_SELECTED,
+    PROVIDER_IBM_WATSONX,
+    PROVIDER_OLLAMA,
+)
 
 
 def validate_model_selection(model: Any) -> tuple[str, str]:
@@ -33,3 +38,68 @@ def validate_model_selection(model: Any) -> tuple[str, str]:
         raise ValueError(ERROR_MODEL_NOT_SELECTED)
 
     return model_name, provider
+
+
+# ---------------------------------------------------------------------------
+# Deprecated – kept for backward compatibility only
+# These functions were superseded by handle_model_input_update() in
+# lfx.base.models.unified_models, which centralises provider-field show/hide
+# logic across all components.  They will be removed in a future release.
+# ---------------------------------------------------------------------------
+
+
+def update_provider_fields_visibility(
+    build_config: dict,
+    field_value: Any,
+    field_name: str | None,
+) -> dict:
+    """Deprecated. Use handle_model_input_update() from lfx.base.models.unified_models instead.
+
+    Update visibility of provider-specific fields based on the selected model.
+
+    .. deprecated::
+        This function was replaced by the unified ``handle_model_input_update()``
+        helper, which additionally refreshes model options and pre-populates
+        credential fields from the variable service.  Custom components should
+        call ``handle_model_input_update(self, build_config, field_value, field_name)``
+        from their ``update_build_config`` method instead.
+    """
+    warnings.warn(
+        "update_provider_fields_visibility is deprecated and will be removed in a future release. "
+        "Use handle_model_input_update() from lfx.base.models.unified_models instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    current_model_value = field_value if field_name == "model" else build_config.get("model", {}).get("value")
+
+    if not isinstance(current_model_value, list) or len(current_model_value) == 0:
+        return build_config
+
+    selected_model = current_model_value[0]
+    provider = selected_model.get("provider", "")
+
+    _update_watsonx_fields(build_config, provider)
+    _update_ollama_fields(build_config, provider)
+
+    return build_config
+
+
+def _update_watsonx_fields(build_config: dict, provider: str) -> None:
+    """Deprecated internal helper – absorbed into handle_model_input_update()."""
+    is_watsonx = provider == PROVIDER_IBM_WATSONX
+
+    if "base_url_ibm_watsonx" in build_config:
+        build_config["base_url_ibm_watsonx"]["show"] = is_watsonx
+        build_config["base_url_ibm_watsonx"]["required"] = is_watsonx
+
+    if "project_id" in build_config:
+        build_config["project_id"]["show"] = is_watsonx
+        build_config["project_id"]["required"] = is_watsonx
+
+
+def _update_ollama_fields(build_config: dict, provider: str) -> None:
+    """Deprecated internal helper – absorbed into handle_model_input_update()."""
+    is_ollama = provider == PROVIDER_OLLAMA
+
+    if "ollama_base_url" in build_config:
+        build_config["ollama_base_url"]["show"] = is_ollama

--- a/src/lfx/src/lfx/components/llm_operations/structured_output.py
+++ b/src/lfx/src/lfx/components/llm_operations/structured_output.py
@@ -78,7 +78,7 @@ class StructuredOutputComponent(Component):
             display_name="Output Schema",
             info="Define the structure and data types for the model's output.",
             required=True,
-            # TODO: remove deault value
+            # TODO: remove default value
             table_schema=[
                 {
                     "name": "name",


### PR DESCRIPTION
## Summary

Follow-up to the initial PR review, addressing the remaining recommendations:

- **Fix 9 skipped tests** in `test_batch_run_component.py` — replaced model list with `_MockLLM` instances so tests run without live API keys, following the existing `test_with_config_failure_handling` pattern
- **Fix 3 max_tokens tests** in `test_agent_component.py` — set `component.model` to a valid list before calling `get_agent_requirements()` since `validate_model_selection` (added in the previous PR) now requires list format
- **Replace `os.environ` direct reads** in `apply_provider_variable_config_to_build_config` with `get_all_variables_for_provider()`, which uses DB-first lookup with env fallback; threads `user_id` through from `handle_model_input_update`
- **Add deprecated stubs** for `update_provider_fields_visibility`, `_update_watsonx_fields`, and `_update_ollama_fields` in `model_config.py` with `DeprecationWarning` pointing to `handle_model_input_update`
- **Fix typo** `"deault"` → `"default"` in `structured_output.py`
- **Add 4 new `KnowledgeIngestionComponent` tests**: new-format `model_selection` metadata path, `allow_duplicates=True` behaviour, missing metadata file error, and `_build_embedding_metadata` without API key

## Test plan

- [ ] `pytest src/backend/tests/unit/components/llm_operations/test_batch_run_component.py` — all 9 previously skipped tests now pass
- [ ] `pytest src/backend/tests/unit/components/models_and_agents/test_agent_component.py::TestAgentComponent` — all 13 tests pass (verified locally)
- [ ] `pytest src/backend/tests/unit/components/files_and_knowledge/test_ingestion.py` — 4 new tests pass
- [ ] `pytest src/backend/tests/unit/test_unified_models.py` — no regressions from variable service change

🤖 Generated with [Claude Code](https://claude.com/claude-code)