### PR TITLE
fix: update openai api key prefix in fe

### DIFF
--- a/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
@@ -13,7 +13,7 @@ const PROVIDER_KEY_PREVIEW: Record<
   string,
   { prefix: string; totalLength: number }
 > = {
-  OpenAI: { prefix: "sk-proj-", totalLength: 164 },
+  OpenAI: { prefix: "sk-", totalLength: 164 },
   Anthropic: { prefix: "sk-ant-", totalLength: 108 },
   "Google Generative AI": { prefix: "AIza", totalLength: 39 },
   "IBM watsonx": { prefix: "", totalLength: 44 },


### PR DESCRIPTION
OpenAI API Keys can start with sk-proj (project keys) sk- (legacy user account keys) sk-svcacct (service account keys) or sk-None (not associated with a user) 

https://community.openai.com/t/incorrect-api-is-generated-in-the-openai-account/879912