### PR TITLE
fix: migrate remaining class Config to model_config for Pydantic v2 compatibility

### DIFF
--- a/src/backend/base/langflow/api/v2/schemas.py
+++ b/src/backend/base/langflow/api/v2/schemas.py
@@ -1,16 +1,15 @@
 """Pydantic schemas for v2 API endpoints."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class MCPServerConfig(BaseModel):
     """Pydantic model for MCP server configuration."""
+
+    model_config = ConfigDict(extra="allow")
 
     command: str | None = None
     args: list[str] | None = None
     env: dict[str, str] | None = None
     headers: dict[str, str] | None = None
     url: str | None = None
-
-    class Config:
-        extra = "allow"  # Allow additional fields for flexibility

--- a/src/backend/base/langflow/services/database/models/transactions/model.py
+++ b/src/backend/base/langflow/services/database/models/transactions/model.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID, uuid4
 
-from pydantic import field_serializer, field_validator
+from pydantic import ConfigDict, field_serializer, field_validator
 from sqlmodel import JSON, Column, Field, SQLModel
 
 from langflow.serialization.serialization import get_max_items_length, get_max_text_length, serialize
@@ -121,8 +121,7 @@ class TransactionBase(SQLModel):
     flow_id: UUID = Field()
 
     # Needed for Column(JSON)
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(self, **data):
         # Sanitize inputs and outputs to remove sensitive data before storing

--- a/src/backend/base/langflow/services/database/models/vertex_builds/model.py
+++ b/src/backend/base/langflow/services/database/models/vertex_builds/model.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, field_serializer, field_validator
+from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
 from sqlalchemy import Text
 from sqlmodel import JSON, Column, Field, SQLModel
 
@@ -19,8 +19,7 @@ class VertexBuildBase(SQLModel):
     job_id: UUID | None = Field(default=None, index=True)
 
     # Needed for Column(JSON)
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @field_validator("flow_id", mode="before")
     @classmethod

--- a/src/lfx/src/lfx/components/google/google_drive.py
+++ b/src/lfx/src/lfx/components/google/google_drive.py
@@ -2,6 +2,7 @@ import json
 from json.decoder import JSONDecodeError
 
 from google.auth.exceptions import RefreshError
+from pydantic import ConfigDict
 from google.oauth2.credentials import Credentials
 from langchain_google_community import GoogleDriveLoader
 
@@ -47,8 +48,7 @@ class GoogleDriveComponent(Component):
                 msg = "No credentials provided."
                 raise ValueError(msg)
 
-            class Config:
-                arbitrary_types_allowed = True
+            model_config = ConfigDict(arbitrary_types_allowed=True)
 
         json_string = self.json_string
 

--- a/src/lfx/src/lfx/services/settings/feature_flags.py
+++ b/src/lfx/src/lfx/services/settings/feature_flags.py
@@ -1,11 +1,10 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class FeatureFlags(BaseSettings):
-    mvp_components: bool = False
+    model_config = SettingsConfigDict(env_prefix="LANGFLOW_FEATURE_")
 
-    class Config:
-        env_prefix = "LANGFLOW_FEATURE_"
+    mvp_components: bool = False
 
 
 FEATURE_FLAGS = FeatureFlags()


### PR DESCRIPTION
## Summary

Migrate the remaining deprecated Pydantic v1 `class Config:` inner classes to the Pydantic v2 `model_config = ConfigDict(...)` pattern.

The rest of the codebase already uses `model_config`; these 5 files were leftover v1-style declarations:

- `src/lfx/src/lfx/services/settings/feature_flags.py` — `SettingsConfigDict(env_prefix=...)`
- `src/backend/base/langflow/api/v2/schemas.py` — `ConfigDict(extra="allow")`
- `src/backend/base/langflow/services/database/models/vertex_builds/model.py` — `ConfigDict(arbitrary_types_allowed=True)`
- `src/backend/base/langflow/services/database/models/transactions/model.py` — `ConfigDict(arbitrary_types_allowed=True)`
- `src/lfx/src/lfx/components/google/google_drive.py` — `ConfigDict(arbitrary_types_allowed=True)`

No behavioral changes — only syntactic migration to the recommended Pydantic v2 API.

## Test plan

- [ ] Existing tests pass (no behavioral changes)
- [ ] Verify models with `arbitrary_types_allowed` still accept non-standard types
- [ ] Verify `MCPServerConfig` still allows extra fields
- [ ] Verify `FeatureFlags` still reads `LANGFLOW_FEATURE_` env vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration mechanisms across the codebase to maintain compatibility with current framework standards and improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->