### PR TITLE
fix: replace deprecated asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -165,50 +165,50 @@ def get_lifespan(*, fix_migration=False, version=None):
         mcp_init_task = None
 
         try:
-            start_time = asyncio.get_event_loop().time()
+            start_time = asyncio.get_running_loop().time()
 
             await logger.adebug("Initializing services")
             await initialize_services(fix_migration=fix_migration)
-            await logger.adebug(f"Services initialized in {asyncio.get_event_loop().time() - start_time:.2f}s")
+            await logger.adebug(f"Services initialized in {asyncio.get_running_loop().time() - start_time:.2f}s")
 
-            current_time = asyncio.get_event_loop().time()
+            current_time = asyncio.get_running_loop().time()
             await logger.adebug("Setting up LLM caching")
             setup_llm_caching()
-            await logger.adebug(f"LLM caching setup in {asyncio.get_event_loop().time() - current_time:.2f}s")
+            await logger.adebug(f"LLM caching setup in {asyncio.get_running_loop().time() - current_time:.2f}s")
 
-            current_time = asyncio.get_event_loop().time()
+            current_time = asyncio.get_running_loop().time()
             await logger.adebug("Copying profile pictures")
             await copy_profile_pictures()
-            await logger.adebug(f"Profile pictures copied in {asyncio.get_event_loop().time() - current_time:.2f}s")
+            await logger.adebug(f"Profile pictures copied in {asyncio.get_running_loop().time() - current_time:.2f}s")
 
             if get_settings_service().auth_settings.AUTO_LOGIN:
-                current_time = asyncio.get_event_loop().time()
+                current_time = asyncio.get_running_loop().time()
                 await logger.adebug("Initializing default super user")
                 await initialize_auto_login_default_superuser()
                 await logger.adebug(
-                    f"Default super user initialized in {asyncio.get_event_loop().time() - current_time:.2f}s"
+                    f"Default super user initialized in {asyncio.get_running_loop().time() - current_time:.2f}s"
                 )
 
             await logger.adebug("Initializing super user")
             await initialize_auto_login_default_superuser()
-            await logger.adebug(f"Super user initialized in {asyncio.get_event_loop().time() - current_time:.2f}s")
+            await logger.adebug(f"Super user initialized in {asyncio.get_running_loop().time() - current_time:.2f}s")
 
-            current_time = asyncio.get_event_loop().time()
+            current_time = asyncio.get_running_loop().time()
             await logger.adebug("Loading bundles")
             temp_dirs, bundles_components_paths = await load_bundles_with_error_handling()
             get_settings_service().settings.components_path.extend(bundles_components_paths)
-            await logger.adebug(f"Bundles loaded in {asyncio.get_event_loop().time() - current_time:.2f}s")
+            await logger.adebug(f"Bundles loaded in {asyncio.get_running_loop().time() - current_time:.2f}s")
 
-            current_time = asyncio.get_event_loop().time()
+            current_time = asyncio.get_running_loop().time()
             await logger.adebug("Caching types")
             all_types_dict = await get_and_cache_all_types_dict(get_settings_service(), telemetry_service)
-            await logger.adebug(f"Types cached in {asyncio.get_event_loop().time() - current_time:.2f}s")
+            await logger.adebug(f"Types cached in {asyncio.get_running_loop().time() - current_time:.2f}s")
 
             # Use file-based lock to prevent multiple workers from creating duplicate starter projects concurrently.
             # Note that it's still possible that one worker may complete this task, release the lock,
             # then another worker pick it up, but the operation is idempotent so worst case it duplicates
             # the initialization work.
-            current_time = asyncio.get_event_loop().time()
+            current_time = asyncio.get_running_loop().time()
             await logger.adebug("Creating/updating starter projects")
 
             lock_file = Path(tempfile.gettempdir()) / "langflow_starter_projects.lock"
@@ -217,7 +217,7 @@ def get_lifespan(*, fix_migration=False, version=None):
                 with lock:
                     await create_or_update_starter_projects(all_types_dict)
                     await logger.adebug(
-                        f"Starter projects created/updated in {asyncio.get_event_loop().time() - current_time:.2f}s"
+                        f"Starter projects created/updated in {asyncio.get_running_loop().time() - current_time:.2f}s"
                     )
             except TimeoutError:
                 # Another process has the lock
@@ -231,73 +231,73 @@ def get_lifespan(*, fix_migration=False, version=None):
             if get_settings_service().settings.agentic_experience:
                 from langflow.api.utils.mcp.agentic_mcp import initialize_agentic_global_variables
 
-                current_time = asyncio.get_event_loop().time()
+                current_time = asyncio.get_running_loop().time()
                 await logger.ainfo("Initializing agentic global variables...")
                 try:
                     async with session_scope() as session:
                         await initialize_agentic_global_variables(session)
                     await logger.adebug(
-                        f"Agentic global variables initialized in {asyncio.get_event_loop().time() - current_time:.2f}s"
+                        f"Agentic global variables initialized in {asyncio.get_running_loop().time() - current_time:.2f}s"
                     )
                 except Exception as e:  # noqa: BLE001
                     await logger.awarning(f"Failed to initialize agentic global variables: {e}")
 
-            current_time = asyncio.get_event_loop().time()
+            current_time = asyncio.get_running_loop().time()
             await logger.adebug("Starting telemetry service")
             telemetry_service.start()
-            await logger.adebug(f"started telemetry service in {asyncio.get_event_loop().time() - current_time:.2f}s")
+            await logger.adebug(f"started telemetry service in {asyncio.get_running_loop().time() - current_time:.2f}s")
 
-            current_time = asyncio.get_event_loop().time()
+            current_time = asyncio.get_running_loop().time()
             await logger.adebug("Starting MCP Composer service")
             mcp_composer_service = cast("MCPComposerService", get_service(ServiceType.MCP_COMPOSER_SERVICE))
             await mcp_composer_service.start()
             await logger.adebug(
-                f"started MCP Composer service in {asyncio.get_event_loop().time() - current_time:.2f}s"
+                f"started MCP Composer service in {asyncio.get_running_loop().time() - current_time:.2f}s"
             )
 
             # Auto-configure Agentic MCP server if enabled (after variables are initialized)
             if get_settings_service().settings.agentic_experience:
                 from langflow.api.utils.mcp.agentic_mcp import auto_configure_agentic_mcp_server
 
-                current_time = asyncio.get_event_loop().time()
+                current_time = asyncio.get_running_loop().time()
                 await logger.ainfo("Configuring Agentic MCP server...")
                 try:
                     async with session_scope() as session:
                         await auto_configure_agentic_mcp_server(session)
                     await logger.adebug(
-                        f"Agentic MCP server configured in {asyncio.get_event_loop().time() - current_time:.2f}s"
+                        f"Agentic MCP server configured in {asyncio.get_running_loop().time() - current_time:.2f}s"
                     )
                 except Exception as e:  # noqa: BLE001
                     await logger.awarning(f"Failed to configure agentic MCP server: {e}")
 
-            current_time = asyncio.get_event_loop().time()
+            current_time = asyncio.get_running_loop().time()
             await logger.adebug("Loading flows")
             await load_flows_from_directory()
             sync_flows_from_fs_task = asyncio.create_task(sync_flows_from_fs())
             queue_service = get_queue_service()
             if not queue_service.is_started():  # Start if not already started
                 queue_service.start()
-            await logger.adebug(f"Flows loaded in {asyncio.get_event_loop().time() - current_time:.2f}s")
+            await logger.adebug(f"Flows loaded in {asyncio.get_running_loop().time() - current_time:.2f}s")
 
-            total_time = asyncio.get_event_loop().time() - start_time
+            total_time = asyncio.get_running_loop().time() - start_time
             await logger.adebug(f"Total initialization time: {total_time:.2f}s")
 
             async def delayed_init_mcp_servers():
                 await asyncio.sleep(10.0)  # Increased delay to allow starter projects to be created
-                current_time = asyncio.get_event_loop().time()
+                current_time = asyncio.get_running_loop().time()
                 await logger.adebug("Loading MCP servers for projects")
                 try:
                     await init_mcp_servers()
-                    await logger.adebug(f"MCP servers loaded in {asyncio.get_event_loop().time() - current_time:.2f}s")
+                    await logger.adebug(f"MCP servers loaded in {asyncio.get_running_loop().time() - current_time:.2f}s")
                 except Exception as e:  # noqa: BLE001
                     await logger.awarning(f"First MCP server initialization attempt failed: {e}")
                     await asyncio.sleep(5.0)  # Increased retry delay
-                    current_time = asyncio.get_event_loop().time()
+                    current_time = asyncio.get_running_loop().time()
                     await logger.adebug("Retrying MCP servers initialization")
                     try:
                         await init_mcp_servers()
                         await logger.adebug(
-                            f"MCP servers loaded on retry in {asyncio.get_event_loop().time() - current_time:.2f}s"
+                            f"MCP servers loaded on retry in {asyncio.get_running_loop().time() - current_time:.2f}s"
                         )
                     except Exception as e2:  # noqa: BLE001
                         await logger.aexception(f"Failed to initialize MCP servers after retry: {e2}")

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -189,6 +189,7 @@ def get_lifespan(*, fix_migration=False, version=None):
                     f"Default super user initialized in {asyncio.get_running_loop().time() - current_time:.2f}s"
                 )
 
+            current_time = asyncio.get_running_loop().time()
             await logger.adebug("Initializing super user")
             await initialize_auto_login_default_superuser()
             await logger.adebug(f"Super user initialized in {asyncio.get_running_loop().time() - current_time:.2f}s")

--- a/src/backend/tests/integration/components/mcp/test_mcp_memory_leak.py
+++ b/src/backend/tests/integration/components/mcp/test_mcp_memory_leak.py
@@ -376,7 +376,7 @@ async def test_session_manager_cleanup_all(process_tracker):
                     "session": "mock_session",
                     "task": asyncio.create_task(asyncio.sleep(10)),
                     "type": "stdio",
-                    "last_used": asyncio.get_event_loop().time(),
+                    "last_used": asyncio.get_running_loop().time(),
                 }
             }
         },
@@ -386,7 +386,7 @@ async def test_session_manager_cleanup_all(process_tracker):
                     "session": "mock_session",
                     "task": asyncio.create_task(asyncio.sleep(10)),
                     "type": "sse",
-                    "last_used": asyncio.get_event_loop().time(),
+                    "last_used": asyncio.get_running_loop().time(),
                 }
             }
         },

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -530,7 +530,7 @@ class MCPSessionManager:
 
     async def _cleanup_idle_sessions(self):
         """Clean up sessions that have been idle for too long."""
-        current_time = asyncio.get_event_loop().time()
+        current_time = asyncio.get_running_loop().time()
         servers_to_remove = []
 
         for server_key, server_data in self.sessions_by_server.items():
@@ -629,7 +629,7 @@ class MCPSessionManager:
 
         # Ensure server entry exists
         if server_key not in self.sessions_by_server:
-            self.sessions_by_server[server_key] = {"sessions": {}, "last_cleanup": asyncio.get_event_loop().time()}
+            self.sessions_by_server[server_key] = {"sessions": {}, "last_cleanup": asyncio.get_running_loop().time()}
 
         server_data = self.sessions_by_server[server_key]
         sessions = server_data["sessions"]
@@ -642,7 +642,7 @@ class MCPSessionManager:
             # Check if session is still alive
             if not task.done():
                 # Update last used time
-                session_info["last_used"] = asyncio.get_event_loop().time()
+                session_info["last_used"] = asyncio.get_running_loop().time()
 
                 # Quick health check
                 if await self._validate_session_connectivity(session):
@@ -693,7 +693,7 @@ class MCPSessionManager:
             "session": session,
             "task": task,
             "type": actual_transport,
-            "last_used": asyncio.get_event_loop().time(),
+            "last_used": asyncio.get_running_loop().time(),
         }
 
         # register mapping & initial ref-count for the new session


### PR DESCRIPTION
## Summary

- Replace all `asyncio.get_event_loop()` calls with `asyncio.get_running_loop()` in two files:
  - `src/backend/base/langflow/main.py` (30 occurrences in the async `lifespan` context manager)
  - `src/lfx/src/lfx/base/mcp/util.py` (4 occurrences in async methods of `MCPSessionManager`)

## Motivation

`asyncio.get_event_loop()` has been deprecated since Python 3.10 and emits a `DeprecationWarning` when called without a running event loop. Since Langflow requires Python >= 3.10, and all call sites in this PR are inside `async` functions (where a running loop is guaranteed), `asyncio.get_running_loop()` is the correct replacement.

`get_running_loop()` is also safer: it raises a `RuntimeError` if no loop is running, rather than silently creating a new one—making bugs easier to catch.

## Test plan

- All replaced call sites are inside `async def` functions, so `get_running_loop()` will always find the running loop
- No behavioral change: both APIs return the same loop object when called from within an async context
- Existing tests should pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal timing accuracy in asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->