### PR TITLE
chore: clean up secrets.baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -183,14 +183,16 @@
         "filename": "SECURITY.md",
         "hashed_secret": "d67b0bfe20b56dac12b19258dcfe74b0998d8eeb",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 153,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "SECURITY.md",
         "hashed_secret": "e57eb248dee276a7a8931d338105a49725dd6ec7",
         "is_verified": false,
-        "line_number": 141
+        "line_number": 154,
+        "is_secret": false
       }
     ],
     "deploy/.env.example": [
@@ -233,6 +235,26 @@
         "is_secret": false
       }
     ],
+    "docs/docs/API-Reference/api-flows-run.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/api-flows-run.mdx",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 433,
+        "is_secret": false
+      }
+    ],
+    "docs/docs/API-Reference/api-monitor.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/api-monitor.mdx",
+        "hashed_secret": "d622736b5a599d5f9798164134b84e1bd96c48fe",
+        "is_verified": false,
+        "line_number": 704,
+        "is_secret": false
+      }
+    ],
     "docs/docs/API-Reference/api-openai-responses.mdx": [
       {
         "type": "Secret Keyword",
@@ -240,7 +262,7 @@
         "hashed_secret": "f8f0b44da6dd51f3e5db5129c12a1b95ec71c2d9",
         "is_verified": false,
         "line_number": 45,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docs/API-Reference/api-reference-api-examples.mdx": [
@@ -250,7 +272,7 @@
         "hashed_secret": "7d268ec0fc8a845ff8e1b1af5317ee5dc164808b",
         "is_verified": false,
         "line_number": 94,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -258,7 +280,7 @@
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
         "line_number": 98,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docs/API-Reference/api-users.mdx": [
@@ -268,7 +290,7 @@
         "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
         "is_verified": false,
         "line_number": 21,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -276,7 +298,7 @@
         "hashed_secret": "8f7d56d9f06f8f052a331fedbe14548f0a3305a3",
         "is_verified": false,
         "line_number": 213,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docs/API-Reference/typescript-client.mdx": [
@@ -286,7 +308,17 @@
         "hashed_secret": "159500287c06851df741128ec4b073ea394414b6",
         "is_verified": false,
         "line_number": 55,
-        "is_secret": true
+        "is_secret": false
+      }
+    ],
+    "docs/docs/Agents/mcp-client.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/Agents/mcp-client.mdx",
+        "hashed_secret": "9111962ab5f488016ff73a5139d30dd69b2db6de",
+        "is_verified": false,
+        "line_number": 155,
+        "is_secret": false
       }
     ],
     "docs/docs/Deployment/deployment-docker.mdx": [
@@ -295,8 +327,8 @@
         "filename": "docs/docs/Deployment/deployment-docker.mdx",
         "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
         "is_verified": false,
-        "line_number": 82,
-        "is_secret": true
+        "line_number": 83,
+        "is_secret": false
       }
     ],
     "docs/docs/Deployment/deployment-kubernetes-dev.mdx": [
@@ -306,7 +338,7 @@
         "hashed_secret": "0324bd7e241b5b7c50b91d8a6036f8134bafb078",
         "is_verified": false,
         "line_number": 115,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docs/Deployment/deployment-public-server.mdx": [
@@ -316,7 +348,7 @@
         "hashed_secret": "991dcae394b42727eca3fc81bf221cecb92370e5",
         "is_verified": false,
         "line_number": 71,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docs/Develop/configuration-custom-database.mdx": [
@@ -326,7 +358,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
         "line_number": 22,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docs/Develop/enterprise-database-guide.mdx": [
@@ -336,7 +368,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
         "line_number": 30,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Basic Auth Credentials",
@@ -344,7 +376,7 @@
         "hashed_secret": "ea0c04513c32717f3a09ff7b1fa882c4d8424b2a",
         "is_verified": false,
         "line_number": 30,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Basic Auth Credentials",
@@ -352,7 +384,7 @@
         "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
         "is_verified": false,
         "line_number": 68,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docs/Develop/environment-variables.mdx": [
@@ -362,7 +394,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
         "line_number": 96,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -370,7 +402,7 @@
         "hashed_secret": "dacd53eb505b8486197552a888eef99192ffd390",
         "is_verified": false,
         "line_number": 217,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -378,7 +410,7 @@
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
         "line_number": 285,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -386,7 +418,7 @@
         "hashed_secret": "2d301f84472a0bacb783628ee7badae5566c0b4b",
         "is_verified": false,
         "line_number": 287,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -394,7 +426,7 @@
         "hashed_secret": "74913f5cd5f61ec0bcfdb775414c2fb3d161b620",
         "is_verified": false,
         "line_number": 290,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docs/Develop/integrations-langfuse.mdx": [
@@ -404,7 +436,7 @@
         "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
         "is_verified": false,
         "line_number": 109,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docs/Develop/integrations-langsmith.mdx": [
@@ -414,7 +446,7 @@
         "hashed_secret": "6a0ece37dcf14c4acd0710a1a54bfbdcc7bc55fb",
         "is_verified": false,
         "line_number": 21,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docs/Develop/integrations-langwatch.mdx": [
@@ -424,7 +456,43 @@
         "hashed_secret": "28676f3e163fda95ab69f9f29c3948009a04e0e0",
         "is_verified": false,
         "line_number": 17,
-        "is_secret": true
+        "is_secret": false
+      }
+    ],
+    "docs/docs/Develop/integrations-openlayer.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/Develop/integrations-openlayer.mdx",
+        "hashed_secret": "1e3667aaaaa887721550cf5cc8a0c5c5760810ed",
+        "is_verified": false,
+        "line_number": 39,
+        "is_secret": false
+      }
+    ],
+    "docs/docs/Develop/jwt-authentication.mdx": [
+      {
+        "type": "JSON Web Token",
+        "filename": "docs/docs/Develop/jwt-authentication.mdx",
+        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
+        "is_verified": false,
+        "line_number": 24,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/Develop/jwt-authentication.mdx",
+        "hashed_secret": "c64762e07c71726176ac412099a50ae51e103275",
+        "is_verified": false,
+        "line_number": 81,
+        "is_secret": false
+      },
+      {
+        "type": "Private Key",
+        "filename": "docs/docs/Develop/jwt-authentication.mdx",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 102,
+        "is_secret": false
       }
     ],
     "docs/docs/Develop/memory.mdx": [
@@ -433,7 +501,8 @@
         "filename": "docs/docs/Develop/memory.mdx",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 74
+        "line_number": 76,
+        "is_secret": false
       }
     ],
     "docs/docs/Flows/concepts-publish.mdx": [
@@ -443,7 +512,7 @@
         "hashed_secret": "7d268ec0fc8a845ff8e1b1af5317ee5dc164808b",
         "is_verified": false,
         "line_number": 60,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docs/Get-Started/get-started-quickstart.mdx": [
@@ -452,14 +521,16 @@
         "filename": "docs/docs/Get-Started/get-started-quickstart.mdx",
         "hashed_secret": "7d268ec0fc8a845ff8e1b1af5317ee5dc164808b",
         "is_verified": false,
-        "line_number": 34
+        "line_number": 35,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/docs/Get-Started/get-started-quickstart.mdx",
-        "hashed_secret": "1a37d41260f96724ee881be5e261b4d043f0626b",
+        "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
         "is_verified": false,
-        "line_number": 550
+        "line_number": 560,
+        "is_secret": false
       }
     ],
     "docs/docs/Tutorials/agent.mdx": [
@@ -469,7 +540,7 @@
         "hashed_secret": "e42fd8b9ad15d8fa5f4718cad7cf19b522807996",
         "is_verified": false,
         "line_number": 82,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "docs/docusaurus.config.js": [
@@ -478,7 +549,7 @@
         "filename": "docs/docusaurus.config.js",
         "hashed_secret": "2dc79dceb6a4e48f38ef47d8dcabbbfaa441218f",
         "is_verified": false,
-        "line_number": 509,
+        "line_number": 514,
         "is_secret": false
       },
       {
@@ -486,7 +557,7 @@
         "filename": "docs/docusaurus.config.js",
         "hashed_secret": "2dc79dceb6a4e48f38ef47d8dcabbbfaa441218f",
         "is_verified": false,
-        "line_number": 509,
+        "line_number": 514,
         "is_secret": false
       }
     ],
@@ -497,7 +568,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
         "line_number": 418,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "scripts/aws/lib/construct/db.ts": [
@@ -517,7 +588,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 583,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -525,7 +596,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 1673,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -533,7 +604,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 3484,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -541,7 +612,7 @@
         "hashed_secret": "1b9dea00d77ef5f671532b6167d8c6b6482c2dde",
         "is_verified": false,
         "line_number": 4065,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/agentic/flows/SystemMessageGen.json": [
@@ -551,7 +622,7 @@
         "hashed_secret": "05c44419f0be64056556f8c81c87e5d3bc7cd1f5",
         "is_verified": false,
         "line_number": 331,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -559,7 +630,7 @@
         "hashed_secret": "4468fc558061951f8910ed8a4f41798661005062",
         "is_verified": false,
         "line_number": 438,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -567,7 +638,7 @@
         "hashed_secret": "abb09440424b40c661e344d4a61e560975620221",
         "is_verified": false,
         "line_number": 645,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -575,7 +646,7 @@
         "hashed_secret": "59416d210387d77a76c3c93f0fdcb89c08e42e6f",
         "is_verified": false,
         "line_number": 2324,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/agentic/flows/TemplateAssistant.json": [
@@ -585,7 +656,7 @@
         "hashed_secret": "d8b16a7764b2b6b2da9a15df8e4cca6b3bb16593",
         "is_verified": false,
         "line_number": 1134,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -593,7 +664,7 @@
         "hashed_secret": "05c44419f0be64056556f8c81c87e5d3bc7cd1f5",
         "is_verified": false,
         "line_number": 1927,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -601,7 +672,7 @@
         "hashed_secret": "a7db96ddbe558c8ec7514abb20420e4fbdc50da5",
         "is_verified": false,
         "line_number": 2082,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/agentic/flows/langflow_assistant.py": [
@@ -611,7 +682,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 123,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/agentic/flows/translation_flow.py": [
@@ -621,7 +692,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 63,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/006b3990db50_add_unique_constraints.py": [
@@ -631,7 +702,7 @@
         "hashed_secret": "8cff1de371e27e5606142515cca15a2683174700",
         "is_verified": false,
         "line_number": 16,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/012fb73ac359_add_folder_table.py": [
@@ -659,7 +730,7 @@
         "hashed_secret": "277fad192ca5323bb92c06fe32a270286463cf29",
         "is_verified": false,
         "line_number": 18,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/0d60fcbd4e8e_create_vertex_builds_table.py": [
@@ -679,7 +750,7 @@
         "hashed_secret": "8487c3a6010fc552932418b5d1bc132b5ea3aab1",
         "is_verified": false,
         "line_number": 15,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/1a110b568907_replace_credential_table_with_variable.py": [
@@ -697,7 +768,7 @@
         "hashed_secret": "8772fa35328d4e8db45ffcb6a43daef8461a78bb",
         "is_verified": false,
         "line_number": 17,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/1b8b740a6fa3_remove_fk_constraint_in_message_.py": [
@@ -727,7 +798,7 @@
         "hashed_secret": "355862036d9f8a9500cb479852431aee6b3b8ca8",
         "is_verified": false,
         "line_number": 20,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/1d90f8a0efe1_update_description_columns_type.py": [
@@ -745,7 +816,7 @@
         "hashed_secret": "28a7b333a264c4f91c72ea7b6000e137b06e0abb",
         "is_verified": false,
         "line_number": 18,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/1eab2c3eb45e_event_error.py": [
@@ -763,7 +834,7 @@
         "hashed_secret": "1a8ccd1199b5c911783d07d3bfe2057cdbaefdde",
         "is_verified": false,
         "line_number": 16,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/1ef9c4f3765d_.py": [
@@ -801,7 +872,7 @@
         "hashed_secret": "e56198337433b2a24520b89a1b89d55650bc4b79",
         "is_verified": false,
         "line_number": 15,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/2ac71eb9c3ae_adds_credential_table.py": [
@@ -819,7 +890,7 @@
         "hashed_secret": "6ca0ea9d38b83b662977a0341596297495d44ba6",
         "is_verified": false,
         "line_number": 17,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/3162e83e485f_add_auth_settings_to_folder_and_merge.py": [
@@ -829,7 +900,7 @@
         "hashed_secret": "7e801006ecc7ecb1bcc6bcf973a57e859613991c",
         "is_verified": false,
         "line_number": 15,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -837,7 +908,7 @@
         "hashed_secret": "7bc83b3d42770da22a102a8c960d12ac8e6c6fe6",
         "is_verified": false,
         "line_number": 16,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/58b28437a398_modify_nullable.py": [
@@ -857,7 +928,7 @@
         "hashed_secret": "7bc83b3d42770da22a102a8c960d12ac8e6c6fe6",
         "is_verified": false,
         "line_number": 16,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/631faacf5da2_add_webhook_columns.py": [
@@ -875,7 +946,7 @@
         "hashed_secret": "2cd99a879ec2567e4b741e7b6f58a2e1e89edb17",
         "is_verified": false,
         "line_number": 16,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/63b9c451fd30_add_icon_and_icon_bg_color_to_flow.py": [
@@ -893,7 +964,7 @@
         "hashed_secret": "ab81185e2fa7d735e9008a929f5624d07ee35590",
         "is_verified": false,
         "line_number": 17,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/66f72f04a1de_add_mcp_support_with_project_settings_.py": [
@@ -911,7 +982,7 @@
         "hashed_secret": "78544fcecf88ff40d2e14662421e9e5fddee3e04",
         "is_verified": false,
         "line_number": 17,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/6e7b581b5648_fix_nullable.py": [
@@ -921,7 +992,7 @@
         "hashed_secret": "156a9d188eaddf456117b22218326324222c6716",
         "is_verified": false,
         "line_number": 16,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/7843803a87b5_store_updates.py": [
@@ -931,7 +1002,7 @@
         "hashed_secret": "e9c8b06ec30332b1bde551fb8416eb0b32d2d22e",
         "is_verified": false,
         "line_number": 17,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/79e675cb6752_change_datetime_type.py": [
@@ -941,7 +1012,7 @@
         "hashed_secret": "fd40bad2b7b22570b0dfce60649d8ce8c181c21a",
         "is_verified": false,
         "line_number": 18,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/7d2162acc8b2_adds_updated_at_and_folder_cols.py": [
@@ -959,7 +1030,25 @@
         "hashed_secret": "3f44353e662497d21aecf8790ef88831c9c806bd",
         "is_verified": false,
         "line_number": 17,
-        "is_secret": true
+        "is_secret": false
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/7d327cfafab6_add_flow_history_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/7d327cfafab6_add_flow_history_table.py",
+        "hashed_secret": "31ce1faee4361304f9034d0600f0b0ecf0f424f3",
+        "is_verified": false,
+        "line_number": 17,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/7d327cfafab6_add_flow_history_table.py",
+        "hashed_secret": "46238deb026d87309521d47dda8ef48b267038b8",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/90be8e2ed91e_create_transactions_table.py": [
@@ -969,7 +1058,7 @@
         "hashed_secret": "bd8d1aff576828548137b5284933c00094bbd608",
         "is_verified": false,
         "line_number": 19,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/93e2705fa8d6_add_column_save_path_to_flow.py": [
@@ -989,7 +1078,17 @@
         "hashed_secret": "28b763f9898b285436ce150ad5a365988d740045",
         "is_verified": false,
         "line_number": 17,
-        "is_secret": true
+        "is_secret": false
+      }
+    ],
+    "src/backend/base/langflow/alembic/versions/b1c2d3e4f5a6_add_sso_plugin_tables_sso_user_profile_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/alembic/versions/b1c2d3e4f5a6_add_sso_plugin_tables_sso_user_profile_.py",
+        "hashed_secret": "67e71f59c479818d8d271427edeaee49eae77ffe",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/b2fa308044b5_add_unique_constraints.py": [
@@ -1017,7 +1116,7 @@
         "hashed_secret": "304de84429cb38a3e39d54672e818f1bfa0cea72",
         "is_verified": false,
         "line_number": 18,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/c153816fd85f_set_name_and_value_to_not_nullable.py": [
@@ -1027,7 +1126,7 @@
         "hashed_secret": "da267f392eaf38538ba97e1b271b7eba82d13857",
         "is_verified": false,
         "line_number": 16,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/d066bfd22890_add_message_table.py": [
@@ -1045,7 +1144,7 @@
         "hashed_secret": "5c33b4de5b1db4fd7fd286c572465bd959d77232",
         "is_verified": false,
         "line_number": 19,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/d2d475a1f7c0_add_tags_column_to_flow.py": [
@@ -1063,7 +1162,7 @@
         "hashed_secret": "31b17a81cbd0842650e47a3c65b68eddb5526205",
         "is_verified": false,
         "line_number": 18,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/d37bc4322900_drop_single_constraint_on_files_name_.py": [
@@ -1073,7 +1172,7 @@
         "hashed_secret": "72e882bd130f8fdc42bef7d615c74e3f07644a80",
         "is_verified": false,
         "line_number": 18,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/d3dbf656a499_add_gradient_column_in_flow.py": [
@@ -1093,7 +1192,7 @@
         "hashed_secret": "a89bf934c28e94e1010980f9f1c3553f6588169f",
         "is_verified": false,
         "line_number": 16,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/dd9e0804ebd1_add_v2_file_table.py": [
@@ -1103,7 +1202,7 @@
         "hashed_secret": "eceb2ed92b0253127427e9f750970811f876ec06",
         "is_verified": false,
         "line_number": 19,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/e3162c1804e6_add_persistent_locked_state.py": [
@@ -1121,7 +1220,7 @@
         "hashed_secret": "0e10bacb2371860c03a1dc6b4c00a9c28abfcdec",
         "is_verified": false,
         "line_number": 17,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/e3bc869fa272_fix_nullable.py": [
@@ -1139,7 +1238,7 @@
         "hashed_secret": "0e7383d6894e28a521e4f12f47fda9268f1cd2e4",
         "is_verified": false,
         "line_number": 16,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/e56d87f8994a_add_optins_column_to_user.py": [
@@ -1157,7 +1256,7 @@
         "hashed_secret": "7dc2d5ca49ddbde37e4b62670697b3bf968ce6a2",
         "is_verified": false,
         "line_number": 18,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/e5a65ecff2cd_nullable_in_vertex_build.py": [
@@ -1167,7 +1266,7 @@
         "hashed_secret": "38fd2a52ef411b96ff362844e9704a18a8ae3e30",
         "is_verified": false,
         "line_number": 18,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/eb5866d51fd2_change_columns_to_be_nullable.py": [
@@ -1197,7 +1296,7 @@
         "hashed_secret": "90f0f8d291336efffe200380b1d3b6485e97c4ed",
         "is_verified": false,
         "line_number": 18,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/alembic/versions/f5ee9749d1a6_user_id_can_be_null_in_flow.py": [
@@ -1217,7 +1316,7 @@
         "hashed_secret": "87a982e7fbfe20e388f9ad1e6d73a86f469e982d",
         "is_verified": false,
         "line_number": 16,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/api/utils/core.py": [
@@ -1226,7 +1325,8 @@
         "filename": "src/backend/base/langflow/api/utils/core.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 417
+        "line_number": 429,
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json": [
@@ -1286,7 +1386,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 122,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1294,7 +1394,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 618,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1302,7 +1402,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 900,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1310,7 +1410,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 1093,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1318,7 +1418,7 @@
         "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
         "is_verified": false,
         "line_number": 1228,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1326,7 +1426,7 @@
         "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
         "is_verified": false,
         "line_number": 1288,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1334,7 +1434,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
         "line_number": 1353,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json": [
@@ -1344,7 +1444,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 532,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1352,7 +1452,7 @@
         "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
         "is_verified": false,
         "line_number": 830,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1360,7 +1460,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 1422,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json": [
@@ -1370,7 +1470,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 1984,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1378,7 +1478,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 2262,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1386,7 +1486,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 2547,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json": [
@@ -1396,7 +1496,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 151,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1404,7 +1504,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 412,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1412,7 +1512,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 918,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1420,7 +1520,7 @@
         "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
         "is_verified": false,
         "line_number": 1308,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json": [
@@ -1430,7 +1530,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 124,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1438,7 +1538,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 408,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1446,7 +1546,7 @@
         "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
         "is_verified": false,
         "line_number": 741,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1454,7 +1554,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 888,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1462,7 +1562,7 @@
         "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
         "is_verified": false,
         "line_number": 1023,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1470,7 +1570,7 @@
         "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
         "is_verified": false,
         "line_number": 1083,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1478,7 +1578,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
         "line_number": 1148,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1486,7 +1586,7 @@
         "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
         "is_verified": false,
         "line_number": 1391,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json": [
@@ -1495,28 +1595,56 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json",
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 206
+        "line_number": 202,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json",
         "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
         "is_verified": false,
-        "line_number": 479
+        "line_number": 475,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json",
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
-        "line_number": 668
+        "line_number": 664,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json",
         "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
         "is_verified": false,
-        "line_number": 1985
+        "line_number": 1156,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 1303,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json",
+        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
+        "is_verified": false,
+        "line_number": 1438,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json",
+        "hashed_secret": "e054a834b866b974a3c4802bab3a96e64226dc2e",
+        "is_verified": false,
+        "line_number": 1732,
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json": [
@@ -1526,7 +1654,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 179,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1534,7 +1662,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 450,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1542,7 +1670,7 @@
         "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
         "is_verified": false,
         "line_number": 1097,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1550,7 +1678,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 1244,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1558,7 +1686,7 @@
         "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
         "is_verified": false,
         "line_number": 1322,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1566,7 +1694,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 1574,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json": [
@@ -1576,7 +1704,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 318,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1584,7 +1712,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 1120,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1592,7 +1720,7 @@
         "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
         "is_verified": false,
         "line_number": 1650,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1600,7 +1728,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 2644,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json": [
@@ -1610,7 +1738,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 338,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1618,7 +1746,7 @@
         "hashed_secret": "f16b56e2e46c4df6bf412a7a9b90c86957016575",
         "is_verified": false,
         "line_number": 673,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1626,7 +1754,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 892,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json": [
@@ -1636,7 +1764,15 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 255,
-        "is_secret": true
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json",
+        "hashed_secret": "1f01a7c11bde62eaf153d74394c282aa11574f2a",
+        "is_verified": false,
+        "line_number": 534,
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Market Research.json": [
@@ -1646,7 +1782,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 179,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1654,7 +1790,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 446,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1662,7 +1798,7 @@
         "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
         "is_verified": false,
         "line_number": 768,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1670,7 +1806,7 @@
         "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
         "is_verified": false,
         "line_number": 1753,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1678,7 +1814,7 @@
         "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
         "is_verified": false,
         "line_number": 1941,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json": [
@@ -1688,7 +1824,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 672,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1696,7 +1832,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 2079,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1704,7 +1840,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 3035,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json": [
@@ -1714,7 +1850,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 149,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1722,7 +1858,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 421,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1730,7 +1866,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 1296,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json": [
@@ -1748,7 +1884,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 576,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1756,7 +1892,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 879,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1764,7 +1900,7 @@
         "hashed_secret": "53d87de97f77c9ea8b7795228a6ce24ed3dc0781",
         "is_verified": false,
         "line_number": 1745,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json": [
@@ -1774,7 +1910,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 233,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1782,14 +1918,15 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 510,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json",
-        "hashed_secret": "cf0d9ce83080dd2d9110b1c6e260b2fc1f6180f2",
+        "hashed_secret": "591e20afc4fe981a10fed4cff9ea150e520d8585",
         "is_verified": false,
-        "line_number": 1740
+        "line_number": 1740,
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json": [
@@ -1799,7 +1936,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 322,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1807,7 +1944,7 @@
         "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
         "is_verified": false,
         "line_number": 914,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1815,7 +1952,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 1590,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1823,7 +1960,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 1781,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1831,7 +1968,7 @@
         "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
         "is_verified": false,
         "line_number": 1916,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1839,7 +1976,7 @@
         "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
         "is_verified": false,
         "line_number": 1976,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1847,7 +1984,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
         "line_number": 2041,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1855,7 +1992,7 @@
         "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
         "is_verified": false,
         "line_number": 2309,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json": [
@@ -1865,7 +2002,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 138,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1873,7 +2010,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 416,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1881,7 +2018,7 @@
         "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
         "is_verified": false,
         "line_number": 706,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1889,7 +2026,7 @@
         "hashed_secret": "1be2449adf6092e0729be455a98c93034cc90bc8",
         "is_verified": false,
         "line_number": 1120,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json": [
@@ -1899,7 +2036,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 508,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1907,7 +2044,7 @@
         "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
         "is_verified": false,
         "line_number": 1351,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1915,7 +2052,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 1763,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1923,7 +2060,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 2047,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json": [
@@ -1933,7 +2070,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 364,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1941,7 +2078,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 644,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1949,7 +2086,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 952,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1957,7 +2094,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 1143,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -1965,7 +2102,7 @@
         "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
         "is_verified": false,
         "line_number": 1221,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1973,7 +2110,7 @@
         "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
         "is_verified": false,
         "line_number": 1594,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json": [
@@ -1983,7 +2120,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 624,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -1991,7 +2128,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 930,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json": [
@@ -2001,7 +2138,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 401,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2009,7 +2146,7 @@
         "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
         "is_verified": false,
         "line_number": 715,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Search agent.json": [
@@ -2019,7 +2156,7 @@
         "hashed_secret": "f59912210d43c78fe803463f6bfb35688508a2bf",
         "is_verified": false,
         "line_number": 106,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2027,7 +2164,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 291,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2035,7 +2172,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 566,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json": [
@@ -2045,7 +2182,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 2069,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2053,7 +2190,7 @@
         "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
         "is_verified": false,
         "line_number": 3192,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2061,7 +2198,7 @@
         "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
         "is_verified": false,
         "line_number": 3363,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2069,7 +2206,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 3774,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json": [
@@ -2079,7 +2216,7 @@
         "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
         "is_verified": false,
         "line_number": 200,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2087,7 +2224,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 368,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2095,7 +2232,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 647,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2103,7 +2240,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 1273,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2111,7 +2248,7 @@
         "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
         "is_verified": false,
         "line_number": 1405,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2119,7 +2256,7 @@
         "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
         "is_verified": false,
         "line_number": 1465,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2127,7 +2264,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
         "line_number": 1530,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json": [
@@ -2137,7 +2274,7 @@
         "hashed_secret": "59d43c509612f89c187f862266890ae0dd5fbb9a",
         "is_verified": false,
         "line_number": 147,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2145,7 +2282,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 694,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2153,7 +2290,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 970,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json": [
@@ -2163,7 +2300,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 820,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2171,7 +2308,7 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 1472,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2179,7 +2316,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 1663,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2187,7 +2324,7 @@
         "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
         "is_verified": false,
         "line_number": 1798,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2195,7 +2332,7 @@
         "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
         "is_verified": false,
         "line_number": 1858,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2203,7 +2340,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
         "line_number": 1923,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2211,7 +2348,7 @@
         "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
         "is_verified": false,
         "line_number": 3567,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json": [
@@ -2221,7 +2358,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 232,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2229,7 +2366,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 499,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2237,7 +2374,7 @@
         "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
         "is_verified": false,
         "line_number": 1217,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2245,7 +2382,7 @@
         "hashed_secret": "5bf984f56eac13589ac2369cb0bae2f61869810a",
         "is_verified": false,
         "line_number": 1384,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json": [
@@ -2255,7 +2392,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 284,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2263,7 +2400,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 702,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2271,51 +2408,99 @@
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 2015,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json": [
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 237,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
-        "line_number": 586,
+        "line_number": 502,
         "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
-        "hashed_secret": "ab06ef2a8cc8a90a8526e3511be8f376c7cb0387",
+        "hashed_secret": "c2dc8a1d72a39ee9da360d47dcadfd7a5560ee7f",
         "is_verified": false,
-        "line_number": 764,
+        "line_number": 681,
         "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
-        "hashed_secret": "3de7722ca43ab9676c384eb479950083fb2385bb",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
-        "line_number": 1357,
+        "line_number": 1000,
         "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
-        "hashed_secret": "a99d6de03c251f8eb8922fab5a383523e4acbadd",
+        "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
         "is_verified": false,
-        "line_number": 2678,
+        "line_number": 1538,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 2213,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 2402,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
+        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
+        "is_verified": false,
+        "line_number": 2537,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
+        "hashed_secret": "e054a834b866b974a3c4802bab3a96e64226dc2e",
+        "is_verified": false,
+        "line_number": 2835,
         "is_secret": false
       }
     ],
-    "src/backend/base/langflow/inputs/input_mixin.py": [
+    "src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json",
+        "hashed_secret": "ef3435e29e3a2c5dcbbb633856c85561848cd995",
+        "is_verified": false,
+        "line_number": 262,
+        "is_secret": false
+      },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 832,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2323,7 +2508,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 1443,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -2331,7 +2516,15 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 2195,
-        "is_secret": true
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json",
+        "hashed_secret": "bd773713e294c76ec00f052b4aa03f8501b74ee7",
+        "is_verified": false,
+        "line_number": 2472,
+        "is_secret": false
       }
     ],
     "src/backend/base/langflow/services/auth/utils.py": [
@@ -2351,7 +2544,7 @@
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
         "line_number": 93,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/conftest.py": [
@@ -2405,7 +2598,7 @@
         "hashed_secret": "7d7048eaa43ebb90728877db61b4c016f9353229",
         "is_verified": false,
         "line_number": 98,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2413,7 +2606,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
         "line_number": 184,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2421,7 +2614,17 @@
         "hashed_secret": "18de8e8747c829741cc7fd44c0f801a10a1d2b5b",
         "is_verified": false,
         "line_number": 195,
-        "is_secret": true
+        "is_secret": false
+      }
+    ],
+    "src/backend/tests/integration/test_openai_responses_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/integration/test_openai_responses_integration.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 65,
+        "is_secret": false
       }
     ],
     "src/backend/tests/integration/test_openai_streaming_comparison.py": [
@@ -2431,7 +2634,7 @@
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_verified": false,
         "line_number": 56,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/locust/README.md": [
@@ -2441,7 +2644,7 @@
         "hashed_secret": "adfa4d3a74f7f661b4c6105469ebe5ee76cf02e1",
         "is_verified": false,
         "line_number": 145,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2449,7 +2652,7 @@
         "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
         "is_verified": false,
         "line_number": 269,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/locust/langflow_setup_test.py": [
@@ -2459,7 +2662,7 @@
         "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
         "is_verified": false,
         "line_number": 205,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/agentic/flows/test_langflow_assistant.py": [
@@ -2469,7 +2672,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 29,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2477,7 +2680,7 @@
         "hashed_secret": "e5ad10f370283c6276789de684bca60e30306ad5",
         "is_verified": false,
         "line_number": 139,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/agentic/flows/test_translation_flow.py": [
@@ -2487,7 +2690,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 29,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2495,7 +2698,7 @@
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
         "line_number": 126,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/agentic/services/helpers/test_flow_loader.py": [
@@ -2505,7 +2708,7 @@
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
         "line_number": 219,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2513,7 +2716,7 @@
         "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
         "is_verified": false,
         "line_number": 413,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/agentic/services/helpers/test_intent_classification.py": [
@@ -2523,7 +2726,7 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 164,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2531,7 +2734,7 @@
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
         "line_number": 169,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/agentic/services/test_flow_executor.py": [
@@ -2541,7 +2744,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 85,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/agentic/services/test_provider_service.py": [
@@ -2551,7 +2754,7 @@
         "hashed_secret": "c92b9809dacd9240dc85e86da6388e9b1bfc8a7d",
         "is_verified": false,
         "line_number": 147,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/api/v1/test_api_key.py": [
@@ -2569,7 +2772,25 @@
         "hashed_secret": "0d1f7c04669ca1989ea046d30a13c8a03252aa8e",
         "is_verified": false,
         "line_number": 105,
-        "is_secret": true
+        "is_secret": false
+      }
+    ],
+    "src/backend/tests/unit/api/v1/test_deployment_schemas.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_deployment_schemas.py",
+        "hashed_secret": "99091d046a81493ef2545d8c3cd8e881e8702893",
+        "is_verified": false,
+        "line_number": 45,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_deployment_schemas.py",
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_verified": false,
+        "line_number": 67,
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/api/v1/test_files.py": [
@@ -2589,7 +2810,7 @@
         "hashed_secret": "4258d43e3b1f9658067ceea9c682a96cbdbb5ca0",
         "is_verified": false,
         "line_number": 575,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/api/v1/test_transactions.py": [
@@ -2599,7 +2820,7 @@
         "hashed_secret": "ec29e1e75ca11a2e23acccfb95548e0f91776ef9",
         "is_verified": false,
         "line_number": 80,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2607,7 +2828,7 @@
         "hashed_secret": "ec29e1e75ca11a2e23acccfb95548e0f91776ef9",
         "is_verified": false,
         "line_number": 80,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2615,7 +2836,7 @@
         "hashed_secret": "542b1e6680a5cbc3f39d5f4be262d3943937faf3",
         "is_verified": false,
         "line_number": 91,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2623,7 +2844,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_verified": false,
         "line_number": 100,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2631,7 +2852,7 @@
         "hashed_secret": "505ec48792179142f72e24a216dce70aae572c92",
         "is_verified": false,
         "line_number": 117,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2639,7 +2860,7 @@
         "hashed_secret": "605e6913994b131694c06427356ca2e0cd80fbc5",
         "is_verified": false,
         "line_number": 128,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2647,7 +2868,7 @@
         "hashed_secret": "46a9cde9bf7b714ac6939f8a7223616529f22beb",
         "is_verified": false,
         "line_number": 136,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2655,7 +2876,7 @@
         "hashed_secret": "93a08826b0f86bbd589bc809c429224a28c5debd",
         "is_verified": false,
         "line_number": 149,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -2663,7 +2884,7 @@
         "hashed_secret": "f584b92a3b013f0455ba3bbf7281c1b92dc83293",
         "is_verified": false,
         "line_number": 202,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2671,7 +2892,7 @@
         "hashed_secret": "f584b92a3b013f0455ba3bbf7281c1b92dc83293",
         "is_verified": false,
         "line_number": 202,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2679,7 +2900,7 @@
         "hashed_secret": "335bab1896809036873e94809e2a077f1592c2cf",
         "is_verified": false,
         "line_number": 204,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2687,7 +2908,7 @@
         "hashed_secret": "09dfcb80ee109eafad45dd04dc950da5be463e8a",
         "is_verified": false,
         "line_number": 215,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2695,7 +2916,7 @@
         "hashed_secret": "2eec374681b67acd87af8e38a0052d66a28273eb",
         "is_verified": false,
         "line_number": 218,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2703,7 +2924,7 @@
         "hashed_secret": "88901d9186e9179e7b569b4c5c7d9918a1a9a305",
         "is_verified": false,
         "line_number": 219,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2711,7 +2932,7 @@
         "hashed_secret": "b5f65b338843840535d6907922528975fc14bb22",
         "is_verified": false,
         "line_number": 224,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2719,7 +2940,7 @@
         "hashed_secret": "c2ba906c7226e464ecf45018257b169e96c71845",
         "is_verified": false,
         "line_number": 248,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2727,7 +2948,7 @@
         "hashed_secret": "656271dfefb8c6633d869d57586413e453204e9b",
         "is_verified": false,
         "line_number": 260,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2735,7 +2956,7 @@
         "hashed_secret": "5cd1f3f6347b1ea434808cb89618224808108ead",
         "is_verified": false,
         "line_number": 261,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2743,7 +2964,7 @@
         "hashed_secret": "d2b83d3591223bb40917c4e07ba712f075148a80",
         "is_verified": false,
         "line_number": 280,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2751,7 +2972,7 @@
         "hashed_secret": "7fe6e4fbc01009cec1576fae7f3c80fc89eb857c",
         "is_verified": false,
         "line_number": 281,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2759,7 +2980,7 @@
         "hashed_secret": "d7266cdeff65f3f2f75a3a8f9d2f512a2e056043",
         "is_verified": false,
         "line_number": 282,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2767,7 +2988,7 @@
         "hashed_secret": "b1356aef8b72efd781630d266ea921ee74fdb2c8",
         "is_verified": false,
         "line_number": 414,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/api/v1/test_users.py": [
@@ -2777,7 +2998,7 @@
         "hashed_secret": "a240a1757ef2e0abf3f252dccec6895fc90d6385",
         "is_verified": false,
         "line_number": 7,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2785,7 +3006,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_verified": false,
         "line_number": 27,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2824,6 +3045,50 @@
         "is_secret": false
       }
     ],
+    "src/backend/tests/unit/components/bundles/agentics/test_llm_factory.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/bundles/agentics/test_llm_factory.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 54,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/bundles/agentics/test_llm_factory.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 197,
+        "is_secret": false
+      }
+    ],
+    "src/backend/tests/unit/components/bundles/agentics/test_llm_setup.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/bundles/agentics/test_llm_setup.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 27,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/bundles/agentics/test_llm_setup.py",
+        "hashed_secret": "2db1f0509b717c05d1465ac287454e9fe4419d0f",
+        "is_verified": false,
+        "line_number": 96,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/bundles/agentics/test_llm_setup.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 145,
+        "is_secret": false
+      }
+    ],
     "src/backend/tests/unit/components/bundles/cometapi/test_cometapi_component.py": [
       {
         "type": "Secret Keyword",
@@ -2831,7 +3096,7 @@
         "hashed_secret": "7d7048eaa43ebb90728877db61b4c016f9353229",
         "is_verified": false,
         "line_number": 20,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/bundles/google/test_google_bq_sql_executor_component.py": [
@@ -2851,7 +3116,7 @@
         "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
         "is_verified": false,
         "line_number": 28,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/embeddings/test_ollama_embeddings_component.py": [
@@ -2861,7 +3126,7 @@
         "hashed_secret": "74ba31d41223751c75cc0a453dd7df04889bdc72",
         "is_verified": false,
         "line_number": 51,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2869,7 +3134,7 @@
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
         "line_number": 109,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/files_and_knowledge/test_file_component.py": [
@@ -2879,7 +3144,33 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_verified": false,
         "line_number": 585,
-        "is_secret": true
+        "is_secret": false
+      }
+    ],
+    "src/backend/tests/unit/components/files_and_knowledge/test_retrieval.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/files_and_knowledge/test_retrieval.py",
+        "hashed_secret": "3658a95db0b214e73694335448df084f979c526f",
+        "is_verified": false,
+        "line_number": 350,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/files_and_knowledge/test_retrieval.py",
+        "hashed_secret": "3d3c09dc9101fcd18909dd4071d6429141ec1bef",
+        "is_verified": false,
+        "line_number": 418,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/files_and_knowledge/test_retrieval.py",
+        "hashed_secret": "b871b1863882c37735c7754f2cb49d38356e7f1e",
+        "is_verified": false,
+        "line_number": 799,
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/languagemodels/test_chatollama_component.py": [
@@ -2889,7 +3180,7 @@
         "hashed_secret": "74ba31d41223751c75cc0a453dd7df04889bdc72",
         "is_verified": false,
         "line_number": 924,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2897,7 +3188,7 @@
         "hashed_secret": "472100b49debe0ea8a5d0d994475240c69af00d9",
         "is_verified": false,
         "line_number": 947,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2905,7 +3196,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
         "line_number": 1134,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/languagemodels/test_deepseek.py": [
@@ -2926,6 +3217,24 @@
         "is_secret": false
       }
     ],
+    "src/backend/tests/unit/components/languagemodels/test_litellm_proxy.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/languagemodels/test_litellm_proxy.py",
+        "hashed_secret": "69dba6dfc0be932d10cdbfaae770c300cd7e0e3c",
+        "is_verified": false,
+        "line_number": 32,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/components/languagemodels/test_litellm_proxy.py",
+        "hashed_secret": "c0bbca26d5c14d2c768e552a484bfd701d861bc6",
+        "is_verified": false,
+        "line_number": 111,
+        "is_secret": false
+      }
+    ],
     "src/backend/tests/unit/components/languagemodels/test_openai_model.py": [
       {
         "type": "Secret Keyword",
@@ -2933,7 +3242,7 @@
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
         "line_number": 24,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/languagemodels/test_xai.py": [
@@ -2969,7 +3278,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 28,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/llm_operations/test_lambda_filter.py": [
@@ -2979,7 +3288,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 34,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -2987,7 +3296,7 @@
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
         "line_number": 45,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/llm_operations/test_structured_output_component.py": [
@@ -2997,7 +3306,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 38,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3005,14 +3314,15 @@
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
         "line_number": 42,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/components/llm_operations/test_structured_output_component.py",
         "hashed_secret": "5c0de9cfda6a9b3fa1ab03901221c68ce6359f9f",
         "is_verified": false,
-        "line_number": 730
+        "line_number": 724,
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/models_and_agents/test_agent_component.py": [
@@ -3022,7 +3332,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
         "line_number": 459,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3030,7 +3340,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 494,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3038,7 +3348,7 @@
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
         "line_number": 528,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py": [
@@ -3048,7 +3358,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 26,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3056,28 +3366,31 @@
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
         "line_number": 38,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 68,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py",
         "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
         "is_verified": false,
-        "line_number": 175
+        "line_number": 169,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py",
         "hashed_secret": "61590b1c314aea752829602c7e0d653e51d52738",
         "is_verified": false,
-        "line_number": 182
+        "line_number": 176,
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py": [
@@ -3087,7 +3400,7 @@
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
         "line_number": 32,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3095,42 +3408,47 @@
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
         "line_number": 37,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
         "hashed_secret": "69dba6dfc0be932d10cdbfaae770c300cd7e0e3c",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 91,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
         "hashed_secret": "60dae6886103a20b3fd75814ece38eb861246083",
         "is_verified": false,
-        "line_number": 141
+        "line_number": 137,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
         "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
         "is_verified": false,
-        "line_number": 181
+        "line_number": 175,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
         "hashed_secret": "def8ea5f5fccca7b36fe20a520a8bcc431d87d88",
         "is_verified": false,
-        "line_number": 186
+        "line_number": 180,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/components/models_and_agents/test_language_model_component.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 277
+        "line_number": 271,
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/components/search/test_google_search_api.py": [
@@ -3190,7 +3508,7 @@
         "hashed_secret": "65882b5e8dbab0e649474b2a626c1d24e1b317f5",
         "is_verified": false,
         "line_number": 19,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3198,7 +3516,7 @@
         "hashed_secret": "6af5a378fdb0e7d397c9f47c744e5e14195c0228",
         "is_verified": false,
         "line_number": 28,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3206,7 +3524,7 @@
         "hashed_secret": "425697fa9692ea5035739863d2481dbfcddfa31f",
         "is_verified": false,
         "line_number": 77,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3214,7 +3532,7 @@
         "hashed_secret": "720e215bd26587c3f3c482b63f7fd9d6a384b076",
         "is_verified": false,
         "line_number": 96,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3222,7 +3540,7 @@
         "hashed_secret": "b671351c066092d76821f7f13ed7356e16db335e",
         "is_verified": false,
         "line_number": 118,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3230,7 +3548,7 @@
         "hashed_secret": "8aca50283f32858dc0592c0855803fc70abda920",
         "is_verified": false,
         "line_number": 141,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/services/tracing/test_tracing_service.py": [
@@ -3286,7 +3604,7 @@
         "hashed_secret": "0352a8acc949c7df21fec16e566ba9a74e797a97",
         "is_verified": false,
         "line_number": 4,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3294,7 +3612,7 @@
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
         "line_number": 5,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/test_auth_jwt_algorithms.py": [
@@ -3304,7 +3622,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
         "line_number": 57,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/test_auth_settings.py": [
@@ -3314,7 +3632,7 @@
         "hashed_secret": "0352a8acc949c7df21fec16e566ba9a74e797a97",
         "is_verified": false,
         "line_number": 65,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3322,7 +3640,7 @@
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
         "line_number": 77,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3330,7 +3648,7 @@
         "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
         "is_verified": false,
         "line_number": 83,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/test_database_windows_postgres_integration.py": [
@@ -3340,7 +3658,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
         "line_number": 32,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/test_get_api_key.py": [
@@ -3350,7 +3668,7 @@
         "hashed_secret": "d378f22450ce32736345a7a4647561bca9f4095a",
         "is_verified": false,
         "line_number": 74,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3358,7 +3676,7 @@
         "hashed_secret": "d3d442c7b46954cf767fbb60a2643917c55ac964",
         "is_verified": false,
         "line_number": 76,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/test_initial_setup.py": [
@@ -3367,7 +3685,7 @@
         "filename": "src/backend/tests/unit/test_initial_setup.py",
         "hashed_secret": "97665ff5eecf8fe96f0462b2d08ed2a2270b4277",
         "is_verified": false,
-        "line_number": 261,
+        "line_number": 290,
         "is_secret": false
       }
     ],
@@ -3405,7 +3723,18 @@
         "filename": "src/backend/tests/unit/test_setup_superuser_flow.py",
         "hashed_secret": "6b7065a54fddbb64d6fbe6c4ce55cc668e8a3511",
         "is_verified": false,
-        "line_number": 168
+        "line_number": 186,
+        "is_secret": false
+      }
+    ],
+    "src/backend/tests/unit/test_sso_models.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/test_sso_models.py",
+        "hashed_secret": "6318553899daae2941718c02508aeee938af1a1c",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/test_user.py": [
@@ -3433,7 +3762,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
         "line_number": 47,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/backend/tests/unit/utils/test_util_strings.py": [
@@ -3469,7 +3798,7 @@
         "hashed_secret": "1fc7e28f6929181fa221e6ead6d9a07b4dd4ddfe",
         "is_verified": false,
         "line_number": 352,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/frontend/src/components/core/parameterRenderComponent/components/queryComponent/index.tsx": [
@@ -3625,7 +3954,7 @@
         "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
         "is_verified": false,
         "line_number": 111,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/frontend/src/modals/apiModal/utils/__tests__/get-js-api-code.test.ts": [
@@ -3635,7 +3964,7 @@
         "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
         "is_verified": false,
         "line_number": 28,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/frontend/src/modals/apiModal/utils/__tests__/get-python-api-code.test.ts": [
@@ -3645,7 +3974,7 @@
         "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
         "is_verified": false,
         "line_number": 33,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/frontend/src/modals/apiModal/utils/get-js-api-code.tsx": [
@@ -3655,7 +3984,7 @@
         "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
         "is_verified": false,
         "line_number": 45,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/frontend/src/modals/apiModal/utils/get-python-api-code.tsx": [
@@ -3665,7 +3994,7 @@
         "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
         "is_verified": false,
         "line_number": 39,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/frontend/src/modals/authModal/__tests__/AuthModal.test.tsx": [
@@ -3675,7 +4004,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_verified": false,
         "line_number": 195,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3683,7 +4012,7 @@
         "hashed_secret": "c8d8f8140951794fa875ea2c2d010c4382f36566",
         "is_verified": false,
         "line_number": 240,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/frontend/src/pages/FlowPage/components/InspectionPanel/__tests__/InspectionPanelHeader.test.tsx": [
@@ -3693,7 +4022,7 @@
         "hashed_secret": "d11f0577fd56df40c7ad6f53b27ba7df86ccdaeb",
         "is_verified": false,
         "line_number": 372,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/frontend/src/utils/__tests__/clean-mcp-config.test.ts": [
@@ -3703,7 +4032,7 @@
         "hashed_secret": "00a0ee020d58d4855fae550f6ecf2d02d48ef746",
         "is_verified": false,
         "line_number": 20,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3711,7 +4040,7 @@
         "hashed_secret": "1581e8ad89bd25d3bb297bbe6c64b75aa0de116e",
         "is_verified": false,
         "line_number": 21,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3719,7 +4048,7 @@
         "hashed_secret": "cff396dc53137e98c1aed9431de7597e7d2d5a37",
         "is_verified": false,
         "line_number": 24,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3727,7 +4056,7 @@
         "hashed_secret": "058d72eb25d2e4acfa1598b5f3898391cd58a1a8",
         "is_verified": false,
         "line_number": 54,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3735,7 +4064,7 @@
         "hashed_secret": "8382bf9a010d3920123e7dd6fabb45e0b99e9954",
         "is_verified": false,
         "line_number": 69,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3743,7 +4072,7 @@
         "hashed_secret": "25dff0180bdce5c818314a1167a78c626bd5d0d6",
         "is_verified": false,
         "line_number": 82,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3751,7 +4080,7 @@
         "hashed_secret": "db99845855b2ecbfecca9a095062b96c3e27703f",
         "is_verified": false,
         "line_number": 97,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3759,7 +4088,7 @@
         "hashed_secret": "eddad44cee264b9d493d75583777c145fc12c4fd",
         "is_verified": false,
         "line_number": 194,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3767,7 +4096,7 @@
         "hashed_secret": "2f8536ceebe81bfa5be647c8e728f9eceefbaca8",
         "is_verified": false,
         "line_number": 314,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3775,7 +4104,7 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 315,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3783,7 +4112,7 @@
         "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
         "is_verified": false,
         "line_number": 418,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3791,7 +4120,7 @@
         "hashed_secret": "c636e8e238fd7af97e2e500f8c6f0f4c0bedafb0",
         "is_verified": false,
         "line_number": 419,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -3799,7 +4128,7 @@
         "hashed_secret": "d9814f9ac9df86bfb47aaa601ba604ffaab04726",
         "is_verified": false,
         "line_number": 453,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/frontend/src/utils/mcpUtils.ts": [
@@ -3809,7 +4138,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
         "line_number": 5,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/frontend/tests/assets/group_test_iadevs.json": [
@@ -3838,1246 +4167,1408 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "5717a1ee406aa657a2dacc80e2816c8f7dcae7e2",
         "is_verified": false,
-        "line_number": 863
+        "line_number": 930,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d43f7dd3e51ce7cb8b9f3c26531a9e4c3a685785",
         "is_verified": false,
-        "line_number": 1360
+        "line_number": 1464,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "f261488408e7c6c4f5e9721426e652052ff36092",
+        "is_verified": false,
+        "line_number": 1594,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "e47929f0dc35b0d4eea6b4c80fa8fcdedd506d23",
+        "is_verified": false,
+        "line_number": 1980,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a1d4fff4042a2dcb8c40293e53611f28a8721d8d",
+        "is_verified": false,
+        "line_number": 2385,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1be2449adf6092e0729be455a98c93034cc90bc8",
         "is_verified": false,
-        "line_number": 1485
+        "line_number": 2771,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "42a810efde880424b1aec6d80360d8befa6c6521",
         "is_verified": false,
-        "line_number": 1786
+        "line_number": 3088,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7014798bb60656a38da4a856545a06c773976112",
         "is_verified": false,
-        "line_number": 3661
+        "line_number": 5025,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a45df4ec5e76a1eb1199091a12fa8ee5e7af12a8",
         "is_verified": false,
-        "line_number": 4072
+        "line_number": 5448,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "b664327352fbd206a6ab38a8903fcabf1b1036a9",
         "is_verified": false,
-        "line_number": 4301
+        "line_number": 5687,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "59d43c509612f89c187f862266890ae0dd5fbb9a",
         "is_verified": false,
-        "line_number": 4630
+        "line_number": 6029,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "c2258af5c2c23419d7469b26f77c954af427b4b8",
         "is_verified": false,
-        "line_number": 7002
+        "line_number": 8524,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "597868714ac401a26b57be0f857457eeb984be18",
         "is_verified": false,
-        "line_number": 7701
+        "line_number": 9261,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a178830480afc434270a7a53512d97758ec6d139",
         "is_verified": false,
-        "line_number": 7946
+        "line_number": 9521,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "6c7724fbb114bfc616ee7bbbb3214e58907abaf1",
         "is_verified": false,
-        "line_number": 8401
+        "line_number": 10001,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "794ae8fea8a51838b63423486552f5398a47e6fc",
         "is_verified": false,
-        "line_number": 8818
+        "line_number": 10436,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "97e68220b094141268772b8b601fa6cd7432de92",
         "is_verified": false,
-        "line_number": 9081
+        "line_number": 10724,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a5af47522dc8a08746c380da81917bdd6eda057a",
         "is_verified": false,
-        "line_number": 9686
+        "line_number": 11364,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9f66cbc518bb79dc6f0a78af0aa52bbadefe2399",
         "is_verified": false,
-        "line_number": 10146
+        "line_number": 11840,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "b3c2f9fda15f2d3816c7edc667bb24267be41a58",
         "is_verified": false,
-        "line_number": 10382
+        "line_number": 12086,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "72be8a21dd766c795332576419e6864eddc5db4e",
         "is_verified": false,
-        "line_number": 10604
+        "line_number": 12317,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1659f95bebec345a9e20e32fa71e8eac4f32f6a2",
         "is_verified": false,
-        "line_number": 12869
+        "line_number": 14636,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "15e5f792860e53987a756bed19fba1204a671e19",
         "is_verified": false,
-        "line_number": 13516
+        "line_number": 15289,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "91700b2378ff5d682d1d57cff40818586609015d",
         "is_verified": false,
-        "line_number": 14810
+        "line_number": 16595,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4b9838e8ff9ae89c3d23d3c853e0d07935618f00",
         "is_verified": false,
-        "line_number": 16751
+        "line_number": 18554,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1aa0d90add98cf00965a327eed79bf65d589e3ce",
         "is_verified": false,
-        "line_number": 17398
+        "line_number": 19207,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3698dc86868353e8ff5ed4564f78d45f1e6c08b7",
         "is_verified": false,
-        "line_number": 18045
+        "line_number": 19860,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "def35d315dd1ab5b0b4a05fc66847f6b73d0d853",
         "is_verified": false,
-        "line_number": 21280
+        "line_number": 23125,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "932fd84fba062a90506c3086945b53d4a6a3f169",
         "is_verified": false,
-        "line_number": 22574
+        "line_number": 24431,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d1a66c6f4de1b56cc6e24cb0a9c78f5ba0230f56",
         "is_verified": false,
-        "line_number": 23221
+        "line_number": 25084,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ddd35c43ce79e9b7ffc5f2894a1a92ad4da3297d",
         "is_verified": false,
-        "line_number": 23868
+        "line_number": 25737,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "bfa2c52c96d82a086f93287e90c3c889e292989e",
         "is_verified": false,
-        "line_number": 24515
+        "line_number": 26390,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ac40271e91c0d84c26bf3613a94545872a801998",
         "is_verified": false,
-        "line_number": 27750
+        "line_number": 29655,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "691ee8aa156c92e8ae67859d9463020d1d5bec11",
         "is_verified": false,
-        "line_number": 30338
+        "line_number": 32267,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "5c33c0e3b39aa99ab095bf885b5f0688a9332b95",
         "is_verified": false,
-        "line_number": 30985
+        "line_number": 32920,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7bfbc3a0161bb7553a4e14c1eb459d30cf104fdf",
         "is_verified": false,
-        "line_number": 31632
+        "line_number": 33573,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "da7592fd328658e5e783f4d16c62d1d6f9d3acd4",
         "is_verified": false,
-        "line_number": 32279
+        "line_number": 34226,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f0e0ec0ff365d37b4fe860d63a9625ae529d3079",
         "is_verified": false,
-        "line_number": 32926
+        "line_number": 34879,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "23ce66526235ae0035cd8da3920a63c12c1c137a",
         "is_verified": false,
-        "line_number": 34867
+        "line_number": 36838,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a75703e0eb9d3a13d977bf04fa3cc42e9d3c94a2",
         "is_verified": false,
-        "line_number": 38102
+        "line_number": 40103,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "2efc38920659af83e871e71004839171d3eaeba4",
         "is_verified": false,
-        "line_number": 40043
+        "line_number": 42062,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4f514a159d49488561a2efe8585871ce25141548",
         "is_verified": false,
-        "line_number": 40690
+        "line_number": 42715,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "adb1d675969fb13f1d752232026b9872475aca4b",
         "is_verified": false,
-        "line_number": 43925
+        "line_number": 45980,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "99b6e13d3c63e4f323776aec40dda0551bc0aa56",
         "is_verified": false,
-        "line_number": 44572
+        "line_number": 46633,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "914bd29a063d63f5cda65b9193612041bf1b04e9",
         "is_verified": false,
-        "line_number": 47160
+        "line_number": 49245,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "dca20b45dc15f99f985e0f87aacf5569b014ede8",
         "is_verified": false,
-        "line_number": 47807
+        "line_number": 49898,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9d48b00c8700d1dcab9108609465af7112840243",
         "is_verified": false,
-        "line_number": 48454
+        "line_number": 50551,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "e72cb4e0e589831cbbd71514f5b6db7f0d09fd37",
         "is_verified": false,
-        "line_number": 51042
+        "line_number": 53163,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "03546202d2aee0b0998d1518625a6b271c345de1",
         "is_verified": false,
-        "line_number": 51676
+        "line_number": 53803,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "753c0fdfc1e518b8c44cd464fb28080f3f94a9f4",
         "is_verified": false,
-        "line_number": 51916
+        "line_number": 54048,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ab9b46808af9e1164b7a21d946a2cefcbfa9b769",
         "is_verified": false,
-        "line_number": 52567
+        "line_number": 54726,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f4a6791157ee757125b9f46c2cf72ea19cdfb50e",
         "is_verified": false,
-        "line_number": 52987
+        "line_number": 55174,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "23a1f3524f7b992e6a225072ec63fc780f21da34",
         "is_verified": false,
-        "line_number": 53213
+        "line_number": 55408,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "6e81bc86a17e501523832acc9a7ee79033f03bd9",
+        "hashed_secret": "85080cbcb6a89304476c8a35d0c1e522afc56c47",
         "is_verified": false,
-        "line_number": 54599
+        "line_number": 56861,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3179ea06ef24aee254dce7a4a3d7a02bcc6cb77f",
         "is_verified": false,
-        "line_number": 54957
+        "line_number": 57247,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "6ea8490b9c5872990ccc69e5d54fe850c28796b0",
         "is_verified": false,
-        "line_number": 55120
+        "line_number": 57428,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9a96eb0a8598688b358bdb4b37cdd0019f9934c7",
         "is_verified": false,
-        "line_number": 55264
+        "line_number": 57586,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f846d79058594083280ddae8a1dbce083aaf6427",
         "is_verified": false,
-        "line_number": 55603
+        "line_number": 57942,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "fb0e32db4013340e8e096da4d7cba00c099d9542",
         "is_verified": false,
-        "line_number": 55730
+        "line_number": 58075,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d33546b1bd9d0542435f0f0946a6231edc175701",
         "is_verified": false,
-        "line_number": 56687
+        "line_number": 59082,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f9ca36cde6942f27b76eac83290189854ff3acd5",
         "is_verified": false,
-        "line_number": 56894
+        "line_number": 59304,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "cf2179b851fcddc8328e4f40e46bec14a56747f8",
         "is_verified": false,
-        "line_number": 56965
+        "line_number": 59379,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "cc008700c5e02d5c9a7ca24219677922a3f82f17",
         "is_verified": false,
-        "line_number": 57152
+        "line_number": 59578,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "e054a834b866b974a3c4802bab3a96e64226dc2e",
+        "is_verified": false,
+        "line_number": 60001,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7863a3a0eb2ed4e19329374549df3cef1ab7ed16",
         "is_verified": false,
-        "line_number": 58367
+        "line_number": 60860,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "41da17b522aa582bfb292d52e8dd307bada14400",
         "is_verified": false,
-        "line_number": 59534
+        "line_number": 62056,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3632913dea26578a835e7c77ab7f4293d6ec1fe6",
         "is_verified": false,
-        "line_number": 60177
+        "line_number": 62718,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "0321ad34ab13e2dee03faa30b7645b932f24c4d6",
         "is_verified": false,
-        "line_number": 61316
+        "line_number": 63904,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "cb2623c527dbce4b4e4ac56407979cad7149ea9a",
         "is_verified": false,
-        "line_number": 61560
+        "line_number": 64166,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "0839ff6d12baf1682b362b287997db739ee07350",
+        "hashed_secret": "427a8b3d029b9d8020cf1648330b5b0a01eb7e65",
         "is_verified": false,
-        "line_number": 62541
+        "line_number": 65878,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a0e9cb28c049bc9f6680cd51dbef7f227f556e50",
         "is_verified": false,
-        "line_number": 63522
+        "line_number": 66266,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "9d96bf4bfa3991d6ddafe69d58248b75905775cc",
+        "hashed_secret": "b5c86792f89b5c8eb61c92e9940a014475247b23",
         "is_verified": false,
-        "line_number": 64296
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "110175c16ed3cc17e9b0bceed842a0b83f89ba75",
-        "is_verified": false,
-        "line_number": 64900
+        "line_number": 67089,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "5bc62a0f48f3bd1f4c9aa548fba2a0b0234fbbd8",
         "is_verified": false,
-        "line_number": 65637
+        "line_number": 68588,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "af246ca4758a5700d172533c40ff71522ae42d99",
         "is_verified": false,
-        "line_number": 65757
+        "line_number": 68718,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
         "is_verified": false,
-        "line_number": 66201
+        "line_number": 69175,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "2db95e850ecd2695362e438d827e9a58ee36e4b0",
+        "hashed_secret": "1f01a7c11bde62eaf153d74394c282aa11574f2a",
         "is_verified": false,
-        "line_number": 66873
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "199d0299098f4097fd8926648d9977fe2d08fb15",
-        "is_verified": false,
-        "line_number": 67245
+        "line_number": 69862,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "53d87de97f77c9ea8b7795228a6ce24ed3dc0781",
         "is_verified": false,
-        "line_number": 67482
+        "line_number": 70121,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "70fb06614f8b86a3daac0c88f0409b40d689689c",
         "is_verified": false,
-        "line_number": 68316
+        "line_number": 70989,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "21c64dba6f59dad4f7f4934d4416f2805cefbd5a",
         "is_verified": false,
-        "line_number": 68497
+        "line_number": 71176,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1d3051aec8271f45991f72a68fc9be099d3e92c1",
         "is_verified": false,
-        "line_number": 68691
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "d985ccfa99e2931b452a8fc1106b44ab1fa129a3",
-        "is_verified": false,
-        "line_number": 69395
+        "line_number": 71380,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9f99b00169e0298e86716cdca88d9e546f9de36c",
         "is_verified": false,
-        "line_number": 69494
+        "line_number": 72245,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d377ef5b36367a118f28c20eb126e6ec376e02ea",
         "is_verified": false,
-        "line_number": 69739
+        "line_number": 72509,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "b521ee08d1454bfeda09d831eaae591d8c12404c",
         "is_verified": false,
-        "line_number": 70130
+        "line_number": 72929,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "face7337620d002b928dc0088e5617aafb67b966",
         "is_verified": false,
-        "line_number": 70355
+        "line_number": 73171,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f0b2022fc412b5599ddcb48c6f8f87c5a53c26af",
         "is_verified": false,
-        "line_number": 70546
+        "line_number": 73372,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "19b7d99d9b41aa84e4779f676bd2b22ce574906f",
         "is_verified": false,
-        "line_number": 70682
+        "line_number": 73520,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "446fa65c4cc6c235fabac8cb7d9241fb018514b8",
         "is_verified": false,
-        "line_number": 71977
+        "line_number": 74891,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9cc81943eb951dbf87e0fbb52da90903304b8db9",
         "is_verified": false,
-        "line_number": 72461
+        "line_number": 75398,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "c69107ff29daaa4b30788f9cecd01d67bfc29b71",
         "is_verified": false,
-        "line_number": 72633
+        "line_number": 75581,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "54be28b91891ca9ef7b85502a59b32a2a03a5cb9",
         "is_verified": false,
-        "line_number": 72789
+        "line_number": 75747,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "60f948a394e2811370ba0bb6849777f217ab5274",
         "is_verified": false,
-        "line_number": 72953
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "a3921015132fde6780bc41c2bc32e18ec744fff2",
-        "is_verified": false,
-        "line_number": 73956
+        "line_number": 75920,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 74391
+        "line_number": 77434,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
-        "line_number": 74653
+        "line_number": 77709,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "303d5144ff32301287cc201ecc9243e2d73850bf",
         "is_verified": false,
-        "line_number": 75109
+        "line_number": 78205,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "8b7be7f7fae86960989b939578d36ce617b498c6",
         "is_verified": false,
-        "line_number": 75267
+        "line_number": 78369,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a6c79dfeb177d34d195c2be48cc62800e629f115",
         "is_verified": false,
-        "line_number": 75758
+        "line_number": 78892,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ef417aa1e71aee527bd6fa12f4490f7d960ec54f",
         "is_verified": false,
-        "line_number": 75954
+        "line_number": 79092,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a356ce34c2d87126e0170adbec7077e4421af5a5",
         "is_verified": false,
-        "line_number": 76750
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "e2bef388cd098d7468b82db3fbb8eb2f90683de2",
-        "is_verified": false,
-        "line_number": 77257
+        "line_number": 79948,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d3acb69a725a514fb55033e2920abcc24e0162cc",
         "is_verified": false,
-        "line_number": 77859
+        "line_number": 81217,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "871ca8e6c9f88aba0a0e921f9d2f47120b55bdfc",
         "is_verified": false,
-        "line_number": 78246
+        "line_number": 81631,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "fd9c33bb8d9004eaf453d9be4de583758d69a025",
+        "hashed_secret": "f746c3a4610d3b777453c50c95dc93598c8ad694",
         "is_verified": false,
-        "line_number": 79069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "9783a191c8c2f45497db9684e7fafe06b95f83e9",
-        "is_verified": false,
-        "line_number": 79390
+        "line_number": 82508,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1f7c6ecf67ba34903861aad770957fdbfa774269",
         "is_verified": false,
-        "line_number": 79658
+        "line_number": 83313,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "cd37616882a8287de17e49c9f91ecad00e0b0eae",
         "is_verified": false,
-        "line_number": 79820
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "6a49a2f5d4cb2f215b8c8a61024903ea314f9916",
-        "is_verified": false,
-        "line_number": 80215
+        "line_number": 83484,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9373f1ccd9980640fbcec9c685d34eac3c4b9867",
         "is_verified": false,
-        "line_number": 80474
+        "line_number": 84280,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "227af0d6a86c8c8619233794dcb4ea5ed1195be3",
         "is_verified": false,
-        "line_number": 80569
+        "line_number": 84385,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "797b61cd33f73538a622541ccdb8eee79c4b51c2",
         "is_verified": false,
-        "line_number": 80944
+        "line_number": 84786,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "1f46a509c4dbc5802c9541bef7ae6ae30807f3c3",
+        "hashed_secret": "e907fb1ce9090d3555f18d6b2f2ea364d94c6217",
         "is_verified": false,
-        "line_number": 81482
+        "line_number": 85349,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "e404b5cd5a9b9314fa22ecbd85a89defdaeafacb",
+        "hashed_secret": "bd773713e294c76ec00f052b4aa03f8501b74ee7",
         "is_verified": false,
-        "line_number": 82974
+        "line_number": 87198,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "a71266907512ba33211f8ee38accedd3b84bf81a",
+        "is_verified": false,
+        "line_number": 87464,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7bdcea8d073c580f79a0a1982007a226a2439dbb",
         "is_verified": false,
-        "line_number": 83249
+        "line_number": 87756,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "34e009441a3d84fe6d22ef3faceb9229532f0c69",
         "is_verified": false,
-        "line_number": 83501
+        "line_number": 88029,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "15978126ab20054ba1215d2250564590cb6ba403",
         "is_verified": false,
-        "line_number": 83743
+        "line_number": 88285,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
         "is_verified": false,
-        "line_number": 84012
+        "line_number": 88565,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3b991cdd2510d7fd1de8b025f0c7cbb9ac84b931",
         "is_verified": false,
-        "line_number": 84300
+        "line_number": 88878,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "573b6322edd45ab8e47491791f0909764e4a2f37",
         "is_verified": false,
-        "line_number": 84803
+        "line_number": 89399,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "cf0d9ce83080dd2d9110b1c6e260b2fc1f6180f2",
+        "hashed_secret": "591e20afc4fe981a10fed4cff9ea150e520d8585",
         "is_verified": false,
-        "line_number": 86969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "cef0406c8a7b2f61138425016c06ffa5b7a30112",
-        "is_verified": false,
-        "line_number": 87343
+        "line_number": 91659,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "47ce443fa2c6d2894c896af5bf215e058b9211a7",
         "is_verified": false,
-        "line_number": 88264
+        "line_number": 92984,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4676cd86733e19676c0704d55f548833f5273643",
         "is_verified": false,
-        "line_number": 88417
+        "line_number": 93144,
+        "is_secret": false
       },
       {
         "type": "Private Key",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 88492
+        "line_number": 93223,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f16b56e2e46c4df6bf412a7a9b90c86957016575",
         "is_verified": false,
-        "line_number": 88873
+        "line_number": 93628,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a60fc256aaca59a332b08d58bd88404348a8bcb9",
         "is_verified": false,
-        "line_number": 89041
+        "line_number": 93805,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "04d0a3a2f4c5f2e29f293507958a27b53728c4e8",
         "is_verified": false,
-        "line_number": 89857
+        "line_number": 94667,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "dede8930d7418d092a12d114de08e444bf0dd82e",
         "is_verified": false,
-        "line_number": 90904
+        "line_number": 95741,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "2a6863fb102cdb7c5f83b6afd00a794efb701566",
         "is_verified": false,
-        "line_number": 91213
+        "line_number": 96068,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "4048123bacfc4d262ce85016a54ae55c8063edeb",
+        "is_verified": false,
+        "line_number": 96301,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3de7722ca43ab9676c384eb479950083fb2385bb",
         "is_verified": false,
-        "line_number": 92401
+        "line_number": 97314,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "5ab5903f6c15a46a71c8db55e70119352304cc15",
         "is_verified": false,
-        "line_number": 93669
+        "line_number": 98630,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4311a7e1eaf728d4f31467084f690eff7493a9e4",
         "is_verified": false,
-        "line_number": 94226
+        "line_number": 99212,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "c6654393d0b0f14057873630031d040e3dea115d",
         "is_verified": false,
-        "line_number": 94535
+        "line_number": 99539,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a229317aa176166d90f06d566b71932cff018638",
         "is_verified": false,
-        "line_number": 94700
+        "line_number": 99723,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "244a01453acc60cca4380edd62539519c250d395",
+        "hashed_secret": "08e984ad7dce0d92490e6fc8fe01910c8951109e",
         "is_verified": false,
-        "line_number": 95085
+        "line_number": 100611,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3d442b2ea6e64698db1e44f7bd5ecb36daebc8a9",
         "is_verified": false,
-        "line_number": 95900
+        "line_number": 101047,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ef4b28ff7563e530637c74c37555b1fb5a6966f0",
         "is_verified": false,
-        "line_number": 96240
+        "line_number": 101423,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "6516fc2579d674314a52e49462a84159df8479d9",
         "is_verified": false,
-        "line_number": 96527
+        "line_number": 101732,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "8ab07507a1c24711ad94bb37308e838447d4a5ca",
         "is_verified": false,
-        "line_number": 96681
+        "line_number": 101897,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "c89fdd11b805574e2ba8910cf63c4273044b887c",
         "is_verified": false,
-        "line_number": 96884
+        "line_number": 102126,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f2dd454db702c939d54193f0be69d772368ac676",
         "is_verified": false,
-        "line_number": 97147
+        "line_number": 102416,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
         "is_verified": false,
-        "line_number": 97405
+        "line_number": 102701,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "30ddcbfccd38de28196e92b6fcf77e65d122294d",
         "is_verified": false,
-        "line_number": 97686
+        "line_number": 103015,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "c2dc8a1d72a39ee9da360d47dcadfd7a5560ee7f",
         "is_verified": false,
-        "line_number": 97809
+        "line_number": 103146,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "efa90513d8e6348d4005c33485f2981bb2cc3411",
         "is_verified": false,
-        "line_number": 98035
+        "line_number": 103389,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "eb2f1f46999a581c6a1b8a2279963002e4effd2d",
         "is_verified": false,
-        "line_number": 98237
+        "line_number": 103605,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "25118f28f0772791b1febea557df6f8eb10d0dd8",
         "is_verified": false,
-        "line_number": 98802
+        "line_number": 104184,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "240cd2b6629abde66f97f1955dd87fab8e045258",
         "is_verified": false,
-        "line_number": 98937
+        "line_number": 104331,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "cd50293b35634a61add9cbfeb9e48fbd44e78bc3",
         "is_verified": false,
-        "line_number": 99950
+        "line_number": 105398,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "b016c72dac43dd6eec034d8b49aa1ded1cc0c6fa",
         "is_verified": false,
-        "line_number": 100183
+        "line_number": 105640,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f59912210d43c78fe803463f6bfb35688508a2bf",
         "is_verified": false,
-        "line_number": 100620
+        "line_number": 106099,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "b0e82a9a7bedac4135f97637be0c11faa2122599",
         "is_verified": false,
-        "line_number": 100731
+        "line_number": 106220,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "5bf984f56eac13589ac2369cb0bae2f61869810a",
         "is_verified": false,
-        "line_number": 100878
+        "line_number": 106375,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9f29336453dfa317f190f570b08116937a529f0b",
         "is_verified": false,
-        "line_number": 101576
+        "line_number": 107111,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
         "is_verified": false,
-        "line_number": 101746
+        "line_number": 107290,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "2acd680fbb8b14e98aea68cfef28ce81eba86c71",
         "is_verified": false,
-        "line_number": 102100
+        "line_number": 107668,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "2dd96ae1cb8802018fb2f6a27926bb5f78957fb0",
         "is_verified": false,
-        "line_number": 102223
+        "line_number": 107802,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3b61d62768cfb3c63d994d7988306f1ebd2acd6b",
         "is_verified": false,
-        "line_number": 102400
+        "line_number": 107988,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d17b2d823c9310229ad18c83ffe543f49406ff9b",
         "is_verified": false,
-        "line_number": 102882
+        "line_number": 108505,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "e7d0065af9edfc8b2de193bbe26faf5a636e0e9f",
         "is_verified": false,
-        "line_number": 103039
+        "line_number": 108675,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1bfed9fbd700374425b35a35ddf0f49a1e2469c2",
         "is_verified": false,
-        "line_number": 103445
+        "line_number": 109101,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "28ab1b1b9c8f05c055b6741bcaeab7337f5b5dc7",
         "is_verified": false,
-        "line_number": 103660
+        "line_number": 109327,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "76377d63ef7d864c0cefc5b38c762e16d3ab39b5",
         "is_verified": false,
-        "line_number": 104034
+        "line_number": 109729,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "562c0bc758bca6446fabf1aacf71f63d47bc62ed",
         "is_verified": false,
-        "line_number": 104158
+        "line_number": 109864,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "0113110e3d49f7b3a48e00192d478584449800e7",
         "is_verified": false,
-        "line_number": 104351
+        "line_number": 110074,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "8e201f749e20ab2d51d0de3da73effa5f616448d",
         "is_verified": false,
-        "line_number": 105089
+        "line_number": 110860,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4ffc5d8cd514be957c9b87ac84c66205ab6d08d3",
         "is_verified": false,
-        "line_number": 106041
+        "line_number": 111863,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
         "is_verified": false,
-        "line_number": 106340
+        "line_number": 112179,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "c0576697d180e97695dd29883a4e1ccb01b2f653",
         "is_verified": false,
-        "line_number": 106429
+        "line_number": 112276,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "497af5dcf573db44fc30ac071ebb008e7ac37669",
         "is_verified": false,
-        "line_number": 106746
+        "line_number": 112615,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "6a5f46048b547457e72572c2d38fb1046591ca71",
         "is_verified": false,
-        "line_number": 107745
+        "line_number": 113660,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7d770d0728208206c486b536b06077c9953d21f2",
         "is_verified": false,
-        "line_number": 108114
+        "line_number": 114044,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "6fb5a96582d72c338a3f3a7d8144190630d64133",
         "is_verified": false,
-        "line_number": 108502
+        "line_number": 114446,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "270c9abba84329e1be2fa7130b44134c23891f1f",
         "is_verified": false,
-        "line_number": 108831
+        "line_number": 114784,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a781a6064ef5e2cb085282bb1912e65232fb55d1",
         "is_verified": false,
-        "line_number": 109226
+        "line_number": 115189,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ef3435e29e3a2c5dcbbb633856c85561848cd995",
         "is_verified": false,
-        "line_number": 110913
+        "line_number": 116957,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "be1df677c309419f4efa0ac48afb2a573beeb95d",
         "is_verified": false,
-        "line_number": 111583
+        "line_number": 117672,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "5d65cf087adec89fb18354508030304fc3809586",
         "is_verified": false,
-        "line_number": 111846
+        "line_number": 117939,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "76913f65d6da6c5660de587c8a3e807aafa039dd",
         "is_verified": false,
-        "line_number": 112047
+        "line_number": 118151,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "4f24919ffd7775f2df3ec3fa57eae8c5a62053ce",
+        "hashed_secret": "ee52396d431bc5b88b6f5e9480b6586862988b17",
         "is_verified": false,
-        "line_number": 112200
+        "line_number": 118315,
+        "is_secret": false
       }
     ],
     "src/lfx/src/lfx/_assets/stable_hash_history.json": [
@@ -5087,7 +5578,7 @@
         "hashed_secret": "5717a1ee406aa657a2dacc80e2816c8f7dcae7e2",
         "is_verified": false,
         "line_number": 14,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5095,7 +5586,7 @@
         "hashed_secret": "d43f7dd3e51ce7cb8b9f3c26531a9e4c3a685785",
         "is_verified": false,
         "line_number": 29,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5103,7 +5594,7 @@
         "hashed_secret": "1be2449adf6092e0729be455a98c93034cc90bc8",
         "is_verified": false,
         "line_number": 49,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5111,7 +5602,7 @@
         "hashed_secret": "42a810efde880424b1aec6d80360d8befa6c6521",
         "is_verified": false,
         "line_number": 59,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5119,7 +5610,7 @@
         "hashed_secret": "7014798bb60656a38da4a856545a06c773976112",
         "is_verified": false,
         "line_number": 79,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5127,7 +5618,7 @@
         "hashed_secret": "a45df4ec5e76a1eb1199091a12fa8ee5e7af12a8",
         "is_verified": false,
         "line_number": 84,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5135,7 +5626,7 @@
         "hashed_secret": "b664327352fbd206a6ab38a8903fcabf1b1036a9",
         "is_verified": false,
         "line_number": 89,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5143,7 +5634,7 @@
         "hashed_secret": "59d43c509612f89c187f862266890ae0dd5fbb9a",
         "is_verified": false,
         "line_number": 94,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5151,7 +5642,7 @@
         "hashed_secret": "c2258af5c2c23419d7469b26f77c954af427b4b8",
         "is_verified": false,
         "line_number": 144,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5159,7 +5650,7 @@
         "hashed_secret": "597868714ac401a26b57be0f857457eeb984be18",
         "is_verified": false,
         "line_number": 154,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5167,7 +5658,7 @@
         "hashed_secret": "a178830480afc434270a7a53512d97758ec6d139",
         "is_verified": false,
         "line_number": 159,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5175,7 +5666,7 @@
         "hashed_secret": "6c7724fbb114bfc616ee7bbbb3214e58907abaf1",
         "is_verified": false,
         "line_number": 164,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5183,7 +5674,7 @@
         "hashed_secret": "794ae8fea8a51838b63423486552f5398a47e6fc",
         "is_verified": false,
         "line_number": 169,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5191,7 +5682,7 @@
         "hashed_secret": "97e68220b094141268772b8b601fa6cd7432de92",
         "is_verified": false,
         "line_number": 174,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5199,7 +5690,7 @@
         "hashed_secret": "a5af47522dc8a08746c380da81917bdd6eda057a",
         "is_verified": false,
         "line_number": 184,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5207,7 +5698,7 @@
         "hashed_secret": "9f66cbc518bb79dc6f0a78af0aa52bbadefe2399",
         "is_verified": false,
         "line_number": 189,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5215,7 +5706,7 @@
         "hashed_secret": "b3c2f9fda15f2d3816c7edc667bb24267be41a58",
         "is_verified": false,
         "line_number": 194,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5223,7 +5714,7 @@
         "hashed_secret": "72be8a21dd766c795332576419e6864eddc5db4e",
         "is_verified": false,
         "line_number": 199,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5231,7 +5722,7 @@
         "hashed_secret": "1659f95bebec345a9e20e32fa71e8eac4f32f6a2",
         "is_verified": false,
         "line_number": 224,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5239,7 +5730,7 @@
         "hashed_secret": "15e5f792860e53987a756bed19fba1204a671e19",
         "is_verified": false,
         "line_number": 229,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5247,7 +5738,7 @@
         "hashed_secret": "91700b2378ff5d682d1d57cff40818586609015d",
         "is_verified": false,
         "line_number": 239,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5255,7 +5746,7 @@
         "hashed_secret": "4b9838e8ff9ae89c3d23d3c853e0d07935618f00",
         "is_verified": false,
         "line_number": 254,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5263,7 +5754,7 @@
         "hashed_secret": "1aa0d90add98cf00965a327eed79bf65d589e3ce",
         "is_verified": false,
         "line_number": 259,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5271,7 +5762,7 @@
         "hashed_secret": "3698dc86868353e8ff5ed4564f78d45f1e6c08b7",
         "is_verified": false,
         "line_number": 264,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5279,7 +5770,7 @@
         "hashed_secret": "def35d315dd1ab5b0b4a05fc66847f6b73d0d853",
         "is_verified": false,
         "line_number": 294,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5287,7 +5778,7 @@
         "hashed_secret": "932fd84fba062a90506c3086945b53d4a6a3f169",
         "is_verified": false,
         "line_number": 304,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5295,7 +5786,7 @@
         "hashed_secret": "d1a66c6f4de1b56cc6e24cb0a9c78f5ba0230f56",
         "is_verified": false,
         "line_number": 309,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5303,7 +5794,7 @@
         "hashed_secret": "ddd35c43ce79e9b7ffc5f2894a1a92ad4da3297d",
         "is_verified": false,
         "line_number": 314,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5311,7 +5802,7 @@
         "hashed_secret": "bfa2c52c96d82a086f93287e90c3c889e292989e",
         "is_verified": false,
         "line_number": 319,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5319,7 +5810,7 @@
         "hashed_secret": "ac40271e91c0d84c26bf3613a94545872a801998",
         "is_verified": false,
         "line_number": 344,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5327,7 +5818,7 @@
         "hashed_secret": "691ee8aa156c92e8ae67859d9463020d1d5bec11",
         "is_verified": false,
         "line_number": 364,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5335,7 +5826,7 @@
         "hashed_secret": "f0e0ec0ff365d37b4fe860d63a9625ae529d3079",
         "is_verified": false,
         "line_number": 369,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5343,7 +5834,7 @@
         "hashed_secret": "5c33c0e3b39aa99ab095bf885b5f0688a9332b95",
         "is_verified": false,
         "line_number": 374,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5351,7 +5842,7 @@
         "hashed_secret": "7bfbc3a0161bb7553a4e14c1eb459d30cf104fdf",
         "is_verified": false,
         "line_number": 384,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5359,7 +5850,7 @@
         "hashed_secret": "da7592fd328658e5e783f4d16c62d1d6f9d3acd4",
         "is_verified": false,
         "line_number": 389,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5367,7 +5858,7 @@
         "hashed_secret": "23ce66526235ae0035cd8da3920a63c12c1c137a",
         "is_verified": false,
         "line_number": 399,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5375,7 +5866,7 @@
         "hashed_secret": "a75703e0eb9d3a13d977bf04fa3cc42e9d3c94a2",
         "is_verified": false,
         "line_number": 424,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5383,7 +5874,7 @@
         "hashed_secret": "2efc38920659af83e871e71004839171d3eaeba4",
         "is_verified": false,
         "line_number": 439,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5391,7 +5882,7 @@
         "hashed_secret": "4f514a159d49488561a2efe8585871ce25141548",
         "is_verified": false,
         "line_number": 444,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5399,7 +5890,7 @@
         "hashed_secret": "adb1d675969fb13f1d752232026b9872475aca4b",
         "is_verified": false,
         "line_number": 469,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5407,7 +5898,7 @@
         "hashed_secret": "99b6e13d3c63e4f323776aec40dda0551bc0aa56",
         "is_verified": false,
         "line_number": 474,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5415,7 +5906,7 @@
         "hashed_secret": "914bd29a063d63f5cda65b9193612041bf1b04e9",
         "is_verified": false,
         "line_number": 494,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5423,7 +5914,7 @@
         "hashed_secret": "dca20b45dc15f99f985e0f87aacf5569b014ede8",
         "is_verified": false,
         "line_number": 499,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5431,7 +5922,7 @@
         "hashed_secret": "9d48b00c8700d1dcab9108609465af7112840243",
         "is_verified": false,
         "line_number": 504,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5439,7 +5930,7 @@
         "hashed_secret": "e72cb4e0e589831cbbd71514f5b6db7f0d09fd37",
         "is_verified": false,
         "line_number": 524,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5447,7 +5938,7 @@
         "hashed_secret": "03546202d2aee0b0998d1518625a6b271c345de1",
         "is_verified": false,
         "line_number": 529,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5455,7 +5946,7 @@
         "hashed_secret": "753c0fdfc1e518b8c44cd464fb28080f3f94a9f4",
         "is_verified": false,
         "line_number": 534,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5463,7 +5954,7 @@
         "hashed_secret": "ab9b46808af9e1164b7a21d946a2cefcbfa9b769",
         "is_verified": false,
         "line_number": 544,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5471,7 +5962,7 @@
         "hashed_secret": "f4a6791157ee757125b9f46c2cf72ea19cdfb50e",
         "is_verified": false,
         "line_number": 554,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5479,14 +5970,15 @@
         "hashed_secret": "23a1f3524f7b992e6a225072ec63fc780f21da34",
         "is_verified": false,
         "line_number": 564,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "6e81bc86a17e501523832acc9a7ee79033f03bd9",
+        "hashed_secret": "85080cbcb6a89304476c8a35d0c1e522afc56c47",
         "is_verified": false,
-        "line_number": 579
+        "line_number": 579,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5494,7 +5986,7 @@
         "hashed_secret": "3179ea06ef24aee254dce7a4a3d7a02bcc6cb77f",
         "is_verified": false,
         "line_number": 584,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5502,7 +5994,7 @@
         "hashed_secret": "6ea8490b9c5872990ccc69e5d54fe850c28796b0",
         "is_verified": false,
         "line_number": 589,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5510,7 +6002,7 @@
         "hashed_secret": "9a96eb0a8598688b358bdb4b37cdd0019f9934c7",
         "is_verified": false,
         "line_number": 594,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5518,7 +6010,7 @@
         "hashed_secret": "f846d79058594083280ddae8a1dbce083aaf6427",
         "is_verified": false,
         "line_number": 604,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5526,7 +6018,7 @@
         "hashed_secret": "fb0e32db4013340e8e096da4d7cba00c099d9542",
         "is_verified": false,
         "line_number": 609,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5534,7 +6026,7 @@
         "hashed_secret": "cc008700c5e02d5c9a7ca24219677922a3f82f17",
         "is_verified": false,
         "line_number": 624,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5542,7 +6034,7 @@
         "hashed_secret": "7863a3a0eb2ed4e19329374549df3cef1ab7ed16",
         "is_verified": false,
         "line_number": 634,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5550,7 +6042,7 @@
         "hashed_secret": "41da17b522aa582bfb292d52e8dd307bada14400",
         "is_verified": false,
         "line_number": 639,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5558,7 +6050,15 @@
         "hashed_secret": "3632913dea26578a835e7c77ab7f4293d6ec1fe6",
         "is_verified": false,
         "line_number": 644,
-        "is_secret": true
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "e054a834b866b974a3c4802bab3a96e64226dc2e",
+        "is_verified": false,
+        "line_number": 654,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5566,7 +6066,7 @@
         "hashed_secret": "d33546b1bd9d0542435f0f0946a6231edc175701",
         "is_verified": false,
         "line_number": 664,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5574,7 +6074,7 @@
         "hashed_secret": "0321ad34ab13e2dee03faa30b7645b932f24c4d6",
         "is_verified": false,
         "line_number": 684,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5582,7 +6082,7 @@
         "hashed_secret": "cb2623c527dbce4b4e4ac56407979cad7149ea9a",
         "is_verified": false,
         "line_number": 689,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5590,7 +6090,7 @@
         "hashed_secret": "f9ca36cde6942f27b76eac83290189854ff3acd5",
         "is_verified": false,
         "line_number": 694,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5598,14 +6098,15 @@
         "hashed_secret": "cf2179b851fcddc8328e4f40e46bec14a56747f8",
         "is_verified": false,
         "line_number": 699,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "0839ff6d12baf1682b362b287997db739ee07350",
+        "hashed_secret": "427a8b3d029b9d8020cf1648330b5b0a01eb7e65",
         "is_verified": false,
-        "line_number": 709
+        "line_number": 719,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5613,21 +6114,15 @@
         "hashed_secret": "a0e9cb28c049bc9f6680cd51dbef7f227f556e50",
         "is_verified": false,
         "line_number": 724,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "9d96bf4bfa3991d6ddafe69d58248b75905775cc",
+        "hashed_secret": "b5c86792f89b5c8eb61c92e9940a014475247b23",
         "is_verified": false,
-        "line_number": 739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "110175c16ed3cc17e9b0bceed842a0b83f89ba75",
-        "is_verified": false,
-        "line_number": 744
+        "line_number": 739,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5635,7 +6130,7 @@
         "hashed_secret": "5bc62a0f48f3bd1f4c9aa548fba2a0b0234fbbd8",
         "is_verified": false,
         "line_number": 754,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5643,7 +6138,7 @@
         "hashed_secret": "af246ca4758a5700d172533c40ff71522ae42d99",
         "is_verified": false,
         "line_number": 759,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5651,14 +6146,15 @@
         "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
         "is_verified": false,
         "line_number": 769,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "199d0299098f4097fd8926648d9977fe2d08fb15",
+        "hashed_secret": "baacde28e4cf5095a02fd332813556fb52842d7b",
         "is_verified": false,
-        "line_number": 779
+        "line_number": 779,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5666,7 +6162,7 @@
         "hashed_secret": "53d87de97f77c9ea8b7795228a6ce24ed3dc0781",
         "is_verified": false,
         "line_number": 784,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5674,7 +6170,7 @@
         "hashed_secret": "70fb06614f8b86a3daac0c88f0409b40d689689c",
         "is_verified": false,
         "line_number": 799,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5682,7 +6178,7 @@
         "hashed_secret": "21c64dba6f59dad4f7f4934d4416f2805cefbd5a",
         "is_verified": false,
         "line_number": 804,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5690,14 +6186,7 @@
         "hashed_secret": "1d3051aec8271f45991f72a68fc9be099d3e92c1",
         "is_verified": false,
         "line_number": 809,
-        "is_secret": true
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "d985ccfa99e2931b452a8fc1106b44ab1fa129a3",
-        "is_verified": false,
-        "line_number": 829
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5705,7 +6194,7 @@
         "hashed_secret": "9f99b00169e0298e86716cdca88d9e546f9de36c",
         "is_verified": false,
         "line_number": 834,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5713,7 +6202,7 @@
         "hashed_secret": "d377ef5b36367a118f28c20eb126e6ec376e02ea",
         "is_verified": false,
         "line_number": 844,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5721,7 +6210,7 @@
         "hashed_secret": "b521ee08d1454bfeda09d831eaae591d8c12404c",
         "is_verified": false,
         "line_number": 854,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5729,7 +6218,7 @@
         "hashed_secret": "face7337620d002b928dc0088e5617aafb67b966",
         "is_verified": false,
         "line_number": 864,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5737,7 +6226,7 @@
         "hashed_secret": "19b7d99d9b41aa84e4779f676bd2b22ce574906f",
         "is_verified": false,
         "line_number": 869,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5745,7 +6234,7 @@
         "hashed_secret": "f0b2022fc412b5599ddcb48c6f8f87c5a53c26af",
         "is_verified": false,
         "line_number": 874,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5753,7 +6242,7 @@
         "hashed_secret": "446fa65c4cc6c235fabac8cb7d9241fb018514b8",
         "is_verified": false,
         "line_number": 909,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5761,7 +6250,7 @@
         "hashed_secret": "9cc81943eb951dbf87e0fbb52da90903304b8db9",
         "is_verified": false,
         "line_number": 919,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5769,7 +6258,7 @@
         "hashed_secret": "c69107ff29daaa4b30788f9cecd01d67bfc29b71",
         "is_verified": false,
         "line_number": 924,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5777,7 +6266,7 @@
         "hashed_secret": "60f948a394e2811370ba0bb6849777f217ab5274",
         "is_verified": false,
         "line_number": 929,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5785,7 +6274,7 @@
         "hashed_secret": "54be28b91891ca9ef7b85502a59b32a2a03a5cb9",
         "is_verified": false,
         "line_number": 934,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5793,7 +6282,7 @@
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 954,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5801,7 +6290,7 @@
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
         "line_number": 959,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5809,7 +6298,7 @@
         "hashed_secret": "303d5144ff32301287cc201ecc9243e2d73850bf",
         "is_verified": false,
         "line_number": 974,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5817,7 +6306,7 @@
         "hashed_secret": "8b7be7f7fae86960989b939578d36ce617b498c6",
         "is_verified": false,
         "line_number": 979,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5825,7 +6314,7 @@
         "hashed_secret": "a6c79dfeb177d34d195c2be48cc62800e629f115",
         "is_verified": false,
         "line_number": 994,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5833,7 +6322,7 @@
         "hashed_secret": "ef417aa1e71aee527bd6fa12f4490f7d960ec54f",
         "is_verified": false,
         "line_number": 999,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5841,14 +6330,7 @@
         "hashed_secret": "a356ce34c2d87126e0170adbec7077e4421af5a5",
         "is_verified": false,
         "line_number": 1019,
-        "is_secret": true
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "e2bef388cd098d7468b82db3fbb8eb2f90683de2",
-        "is_verified": false,
-        "line_number": 1044
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5856,7 +6338,7 @@
         "hashed_secret": "d3acb69a725a514fb55033e2920abcc24e0162cc",
         "is_verified": false,
         "line_number": 1054,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5864,7 +6346,7 @@
         "hashed_secret": "797b61cd33f73538a622541ccdb8eee79c4b51c2",
         "is_verified": false,
         "line_number": 1074,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5872,21 +6354,15 @@
         "hashed_secret": "871ca8e6c9f88aba0a0e921f9d2f47120b55bdfc",
         "is_verified": false,
         "line_number": 1079,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "fd9c33bb8d9004eaf453d9be4de583758d69a025",
+        "hashed_secret": "f746c3a4610d3b777453c50c95dc93598c8ad694",
         "is_verified": false,
-        "line_number": 1094
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "9783a191c8c2f45497db9684e7fafe06b95f83e9",
-        "is_verified": false,
-        "line_number": 1099
+        "line_number": 1094,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5894,7 +6370,7 @@
         "hashed_secret": "1f7c6ecf67ba34903861aad770957fdbfa774269",
         "is_verified": false,
         "line_number": 1104,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5902,14 +6378,7 @@
         "hashed_secret": "cd37616882a8287de17e49c9f91ecad00e0b0eae",
         "is_verified": false,
         "line_number": 1109,
-        "is_secret": true
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "6a49a2f5d4cb2f215b8c8a61024903ea314f9916",
-        "is_verified": false,
-        "line_number": 1129
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5917,7 +6386,7 @@
         "hashed_secret": "9373f1ccd9980640fbcec9c685d34eac3c4b9867",
         "is_verified": false,
         "line_number": 1134,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5925,14 +6394,23 @@
         "hashed_secret": "227af0d6a86c8c8619233794dcb4ea5ed1195be3",
         "is_verified": false,
         "line_number": 1139,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "1f46a509c4dbc5802c9541bef7ae6ae30807f3c3",
+        "hashed_secret": "e907fb1ce9090d3555f18d6b2f2ea364d94c6217",
         "is_verified": false,
-        "line_number": 1144
+        "line_number": 1144,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "bd773713e294c76ec00f052b4aa03f8501b74ee7",
+        "is_verified": false,
+        "line_number": 1169,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5940,7 +6418,7 @@
         "hashed_secret": "34e009441a3d84fe6d22ef3faceb9229532f0c69",
         "is_verified": false,
         "line_number": 1174,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5948,7 +6426,7 @@
         "hashed_secret": "15978126ab20054ba1215d2250564590cb6ba403",
         "is_verified": false,
         "line_number": 1179,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5956,7 +6434,7 @@
         "hashed_secret": "7bdcea8d073c580f79a0a1982007a226a2439dbb",
         "is_verified": false,
         "line_number": 1184,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5964,7 +6442,7 @@
         "hashed_secret": "2a296c37a4e26df0a86488d15b17ac9d8ec0dfcd",
         "is_verified": false,
         "line_number": 1189,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5972,7 +6450,7 @@
         "hashed_secret": "3b991cdd2510d7fd1de8b025f0c7cbb9ac84b931",
         "is_verified": false,
         "line_number": 1194,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -5980,21 +6458,15 @@
         "hashed_secret": "573b6322edd45ab8e47491791f0909764e4a2f37",
         "is_verified": false,
         "line_number": 1204,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "cf0d9ce83080dd2d9110b1c6e260b2fc1f6180f2",
+        "hashed_secret": "591e20afc4fe981a10fed4cff9ea150e520d8585",
         "is_verified": false,
-        "line_number": 1234
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "cef0406c8a7b2f61138425016c06ffa5b7a30112",
-        "is_verified": false,
-        "line_number": 1239
+        "line_number": 1234,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6002,7 +6474,7 @@
         "hashed_secret": "47ce443fa2c6d2894c896af5bf215e058b9211a7",
         "is_verified": false,
         "line_number": 1254,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6010,7 +6482,7 @@
         "hashed_secret": "4676cd86733e19676c0704d55f548833f5273643",
         "is_verified": false,
         "line_number": 1259,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6018,7 +6490,7 @@
         "hashed_secret": "f16b56e2e46c4df6bf412a7a9b90c86957016575",
         "is_verified": false,
         "line_number": 1264,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6026,7 +6498,7 @@
         "hashed_secret": "a60fc256aaca59a332b08d58bd88404348a8bcb9",
         "is_verified": false,
         "line_number": 1269,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6034,7 +6506,7 @@
         "hashed_secret": "04d0a3a2f4c5f2e29f293507958a27b53728c4e8",
         "is_verified": false,
         "line_number": 1279,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6042,7 +6514,7 @@
         "hashed_secret": "dede8930d7418d092a12d114de08e444bf0dd82e",
         "is_verified": false,
         "line_number": 1294,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6050,7 +6522,15 @@
         "hashed_secret": "2a6863fb102cdb7c5f83b6afd00a794efb701566",
         "is_verified": false,
         "line_number": 1304,
-        "is_secret": true
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "4048123bacfc4d262ce85016a54ae55c8063edeb",
+        "is_verified": false,
+        "line_number": 1314,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6058,7 +6538,7 @@
         "hashed_secret": "3de7722ca43ab9676c384eb479950083fb2385bb",
         "is_verified": false,
         "line_number": 1319,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6066,7 +6546,7 @@
         "hashed_secret": "5ab5903f6c15a46a71c8db55e70119352304cc15",
         "is_verified": false,
         "line_number": 1334,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6074,7 +6554,7 @@
         "hashed_secret": "4311a7e1eaf728d4f31467084f690eff7493a9e4",
         "is_verified": false,
         "line_number": 1344,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6082,7 +6562,7 @@
         "hashed_secret": "c6654393d0b0f14057873630031d040e3dea115d",
         "is_verified": false,
         "line_number": 1349,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6090,7 +6570,7 @@
         "hashed_secret": "a229317aa176166d90f06d566b71932cff018638",
         "is_verified": false,
         "line_number": 1354,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6098,7 +6578,15 @@
         "hashed_secret": "25118f28f0772791b1febea557df6f8eb10d0dd8",
         "is_verified": false,
         "line_number": 1359,
-        "is_secret": true
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "08e984ad7dce0d92490e6fc8fe01910c8951109e",
+        "is_verified": false,
+        "line_number": 1374,
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6106,14 +6594,7 @@
         "hashed_secret": "3d442b2ea6e64698db1e44f7bd5ecb36daebc8a9",
         "is_verified": false,
         "line_number": 1379,
-        "is_secret": true
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "244a01453acc60cca4380edd62539519c250d395",
-        "is_verified": false,
-        "line_number": 1384
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6121,7 +6602,7 @@
         "hashed_secret": "ef4b28ff7563e530637c74c37555b1fb5a6966f0",
         "is_verified": false,
         "line_number": 1399,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6129,7 +6610,7 @@
         "hashed_secret": "6516fc2579d674314a52e49462a84159df8479d9",
         "is_verified": false,
         "line_number": 1409,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6137,7 +6618,7 @@
         "hashed_secret": "8ab07507a1c24711ad94bb37308e838447d4a5ca",
         "is_verified": false,
         "line_number": 1414,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6145,7 +6626,7 @@
         "hashed_secret": "c89fdd11b805574e2ba8910cf63c4273044b887c",
         "is_verified": false,
         "line_number": 1424,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6153,7 +6634,7 @@
         "hashed_secret": "f2dd454db702c939d54193f0be69d772368ac676",
         "is_verified": false,
         "line_number": 1434,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6161,7 +6642,7 @@
         "hashed_secret": "898a6c0a313f6e776b073bbc1b1e6010381c5d2b",
         "is_verified": false,
         "line_number": 1444,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6169,7 +6650,7 @@
         "hashed_secret": "30ddcbfccd38de28196e92b6fcf77e65d122294d",
         "is_verified": false,
         "line_number": 1454,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6177,7 +6658,7 @@
         "hashed_secret": "c2dc8a1d72a39ee9da360d47dcadfd7a5560ee7f",
         "is_verified": false,
         "line_number": 1459,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6185,7 +6666,7 @@
         "hashed_secret": "efa90513d8e6348d4005c33485f2981bb2cc3411",
         "is_verified": false,
         "line_number": 1464,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6193,7 +6674,7 @@
         "hashed_secret": "eb2f1f46999a581c6a1b8a2279963002e4effd2d",
         "is_verified": false,
         "line_number": 1469,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6201,7 +6682,7 @@
         "hashed_secret": "240cd2b6629abde66f97f1955dd87fab8e045258",
         "is_verified": false,
         "line_number": 1474,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6209,7 +6690,7 @@
         "hashed_secret": "cd50293b35634a61add9cbfeb9e48fbd44e78bc3",
         "is_verified": false,
         "line_number": 1494,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6217,7 +6698,7 @@
         "hashed_secret": "b016c72dac43dd6eec034d8b49aa1ded1cc0c6fa",
         "is_verified": false,
         "line_number": 1499,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6225,7 +6706,7 @@
         "hashed_secret": "f59912210d43c78fe803463f6bfb35688508a2bf",
         "is_verified": false,
         "line_number": 1509,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6233,7 +6714,7 @@
         "hashed_secret": "b0e82a9a7bedac4135f97637be0c11faa2122599",
         "is_verified": false,
         "line_number": 1514,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6241,7 +6722,7 @@
         "hashed_secret": "5bf984f56eac13589ac2369cb0bae2f61869810a",
         "is_verified": false,
         "line_number": 1519,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6249,7 +6730,7 @@
         "hashed_secret": "9f29336453dfa317f190f570b08116937a529f0b",
         "is_verified": false,
         "line_number": 1534,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6257,7 +6738,7 @@
         "hashed_secret": "1579aca9caa27162a684e977c56693b37243d1b4",
         "is_verified": false,
         "line_number": 1539,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6265,7 +6746,7 @@
         "hashed_secret": "2acd680fbb8b14e98aea68cfef28ce81eba86c71",
         "is_verified": false,
         "line_number": 1544,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6273,7 +6754,7 @@
         "hashed_secret": "2dd96ae1cb8802018fb2f6a27926bb5f78957fb0",
         "is_verified": false,
         "line_number": 1549,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6281,7 +6762,7 @@
         "hashed_secret": "3b61d62768cfb3c63d994d7988306f1ebd2acd6b",
         "is_verified": false,
         "line_number": 1554,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6289,7 +6770,7 @@
         "hashed_secret": "d17b2d823c9310229ad18c83ffe543f49406ff9b",
         "is_verified": false,
         "line_number": 1564,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6297,7 +6778,7 @@
         "hashed_secret": "e7d0065af9edfc8b2de193bbe26faf5a636e0e9f",
         "is_verified": false,
         "line_number": 1574,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6305,7 +6786,7 @@
         "hashed_secret": "1bfed9fbd700374425b35a35ddf0f49a1e2469c2",
         "is_verified": false,
         "line_number": 1579,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6313,7 +6794,7 @@
         "hashed_secret": "28ab1b1b9c8f05c055b6741bcaeab7337f5b5dc7",
         "is_verified": false,
         "line_number": 1584,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6321,7 +6802,7 @@
         "hashed_secret": "76377d63ef7d864c0cefc5b38c762e16d3ab39b5",
         "is_verified": false,
         "line_number": 1589,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6329,7 +6810,7 @@
         "hashed_secret": "562c0bc758bca6446fabf1aacf71f63d47bc62ed",
         "is_verified": false,
         "line_number": 1594,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6337,7 +6818,7 @@
         "hashed_secret": "0113110e3d49f7b3a48e00192d478584449800e7",
         "is_verified": false,
         "line_number": 1599,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6345,7 +6826,7 @@
         "hashed_secret": "8e201f749e20ab2d51d0de3da73effa5f616448d",
         "is_verified": false,
         "line_number": 1609,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6353,7 +6834,7 @@
         "hashed_secret": "4ffc5d8cd514be957c9b87ac84c66205ab6d08d3",
         "is_verified": false,
         "line_number": 1644,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6361,7 +6842,7 @@
         "hashed_secret": "236783f531bb4cc03a0f4a3e892b5c89e9f45881",
         "is_verified": false,
         "line_number": 1649,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6369,7 +6850,7 @@
         "hashed_secret": "c0576697d180e97695dd29883a4e1ccb01b2f653",
         "is_verified": false,
         "line_number": 1654,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6377,7 +6858,7 @@
         "hashed_secret": "497af5dcf573db44fc30ac071ebb008e7ac37669",
         "is_verified": false,
         "line_number": 1669,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6385,7 +6866,7 @@
         "hashed_secret": "7d770d0728208206c486b536b06077c9953d21f2",
         "is_verified": false,
         "line_number": 1684,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6393,7 +6874,7 @@
         "hashed_secret": "6a5f46048b547457e72572c2d38fb1046591ca71",
         "is_verified": false,
         "line_number": 1689,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6401,7 +6882,7 @@
         "hashed_secret": "270c9abba84329e1be2fa7130b44134c23891f1f",
         "is_verified": false,
         "line_number": 1694,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6409,7 +6890,7 @@
         "hashed_secret": "6fb5a96582d72c338a3f3a7d8144190630d64133",
         "is_verified": false,
         "line_number": 1699,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6417,7 +6898,7 @@
         "hashed_secret": "a781a6064ef5e2cb085282bb1912e65232fb55d1",
         "is_verified": false,
         "line_number": 1704,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6425,7 +6906,7 @@
         "hashed_secret": "ef3435e29e3a2c5dcbbb633856c85561848cd995",
         "is_verified": false,
         "line_number": 1744,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6433,7 +6914,7 @@
         "hashed_secret": "be1df677c309419f4efa0ac48afb2a573beeb95d",
         "is_verified": false,
         "line_number": 1759,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6441,7 +6922,7 @@
         "hashed_secret": "5d65cf087adec89fb18354508030304fc3809586",
         "is_verified": false,
         "line_number": 1764,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
@@ -6449,14 +6930,47 @@
         "hashed_secret": "76913f65d6da6c5660de587c8a3e807aafa039dd",
         "is_verified": false,
         "line_number": 1774,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
-        "hashed_secret": "e404b5cd5a9b9314fa22ecbd85a89defdaeafacb",
+        "hashed_secret": "a71266907512ba33211f8ee38accedd3b84bf81a",
         "is_verified": false,
-        "line_number": 1779
+        "line_number": 1779,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "f261488408e7c6c4f5e9721426e652052ff36092",
+        "is_verified": false,
+        "line_number": 1789,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "e47929f0dc35b0d4eea6b4c80fa8fcdedd506d23",
+        "is_verified": false,
+        "line_number": 1794,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "a1d4fff4042a2dcb8c40293e53611f28a8721d8d",
+        "is_verified": false,
+        "line_number": 1799,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "1f01a7c11bde62eaf153d74394c282aa11574f2a",
+        "is_verified": false,
+        "line_number": 1804,
+        "is_secret": false
       }
     ],
     "src/lfx/src/lfx/base/models/unified_models.py": [
@@ -6465,56 +6979,24 @@
         "filename": "src/lfx/src/lfx/base/models/unified_models.py",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 159
+        "line_number": 1125,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lfx/src/lfx/base/models/unified_models.py",
         "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
         "is_verified": false,
-        "line_number": 177
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
-        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
-        "is_verified": false,
-        "line_number": 186
+        "line_number": 1136,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lfx/src/lfx/base/models/unified_models.py",
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
-        "line_number": 196
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
-        "hashed_secret": "a19ee5a9fdc191092796cd9bfa97c55fe5631695",
-        "is_verified": false,
-        "line_number": 470
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
-        "hashed_secret": "b780a23b530ef6bb5c3b722a0c9c5e3abf222e8b",
-        "is_verified": false,
-        "line_number": 471
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
-        "hashed_secret": "ed96761b106155514463a9f82d02b14042e75b61",
-        "is_verified": false,
-        "line_number": 472
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/lfx/src/lfx/base/models/unified_models.py",
-        "hashed_secret": "ac579e82cacca3f9c1a8b18bdfdad78e8b6140f8",
-        "is_verified": false,
-        "line_number": 473
+        "line_number": 1150,
+        "is_secret": false
       }
     ],
     "src/lfx/src/lfx/cli/serve_app.py": [
@@ -6524,7 +7006,7 @@
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
         "is_verified": false,
         "line_number": 40,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/src/lfx/components/mem0/mem0_chat_memory.py": [
@@ -6534,7 +7016,7 @@
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
         "line_number": 34,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/src/lfx/components/mongodb/mongodb_atlas.py": [
@@ -6544,7 +7026,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
         "line_number": 31,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/src/lfx/inputs/input_mixin.py": [
@@ -6564,7 +7046,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
         "line_number": 114,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Basic Prompting.json": [
@@ -6574,7 +7056,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 343,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Blog Writer.json": [
@@ -6584,7 +7066,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 180,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Custom Component Generator.json": [
@@ -6594,7 +7076,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 563,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Document Q&A.json": [
@@ -6604,7 +7086,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 635,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Hybrid Search RAG.json": [
@@ -6614,7 +7096,7 @@
         "hashed_secret": "da3146ee22694a3b79bedbeae8842f85384f3431",
         "is_verified": false,
         "line_number": 1039,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Image Sentiment Analysis.json": [
@@ -6624,7 +7106,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 725,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Instagram Copywriter.json": [
@@ -6634,7 +7116,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 552,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Invoice Summarizer.json": [
@@ -6644,7 +7126,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 174,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Meeting Summary.json": [
@@ -6654,7 +7136,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 470,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Memory Chatbot.json": [
@@ -6664,7 +7146,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 645,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Research Agent.json": [
@@ -6674,7 +7156,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 319,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/SEO Keyword Generator.json": [
@@ -6684,7 +7166,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 122,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/SaaS Pricing.json": [
@@ -6694,7 +7176,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 119,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Sequential Tasks Agents.json": [
@@ -6704,7 +7186,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 1649,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Twitter Thread Generator.json": [
@@ -6714,7 +7196,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 1433,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Vector Store RAG.json": [
@@ -6724,7 +7206,7 @@
         "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
         "is_verified": false,
         "line_number": 551,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/data/vector_store_grouped.json": [
@@ -6734,7 +7216,7 @@
         "hashed_secret": "235edeaf33250eafce9270c364af8a7fcbb9b110",
         "is_verified": false,
         "line_number": 1,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -6742,7 +7224,7 @@
         "hashed_secret": "99dd7eb59ef1cd6c5a11e6c737bda80db54612a2",
         "is_verified": false,
         "line_number": 1,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
@@ -6750,7 +7232,7 @@
         "hashed_secret": "a6865946da108064ab17a0cf4518c151a006b810",
         "is_verified": false,
         "line_number": 1,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/unit/cli/test_serve_simple.py": [
@@ -6760,7 +7242,17 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
         "line_number": 67,
-        "is_secret": true
+        "is_secret": false
+      }
+    ],
+    "src/lfx/tests/unit/components/langchain_utilities/test_csv_agent.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/tests/unit/components/langchain_utilities/test_csv_agent.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 28,
+        "is_secret": false
       }
     ],
     "src/lfx/tests/unit/run/test_base.py": [
@@ -6770,7 +7262,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
         "line_number": 326,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/unit/run/test_base_integration.py": [
@@ -6780,7 +7272,7 @@
         "hashed_secret": "1e7772b7ee7a12f8dbb12351cabcb9dcd43221e8",
         "is_verified": false,
         "line_number": 83,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/unit/services/settings/test_mcp_composer.py": [
@@ -6790,7 +7282,7 @@
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
         "line_number": 162,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -6798,7 +7290,7 @@
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
         "line_number": 202,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -6806,7 +7298,7 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 335,
-        "is_secret": true
+        "is_secret": false
       }
     ],
     "src/lfx/tests/unit/services/settings/test_mcp_composer_windows.py": [
@@ -6816,7 +7308,7 @@
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
         "line_number": 217,
-        "is_secret": true
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
@@ -6824,9 +7316,67 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 536,
-        "is_secret": true
+        "is_secret": false
+      }
+    ],
+    "src/lfx/tests/unit/utils/test_database_url_sanitization.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lfx/tests/unit/utils/test_database_url_sanitization.py",
+        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
+        "is_verified": false,
+        "line_number": 22,
+        "is_secret": false
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lfx/tests/unit/utils/test_database_url_sanitization.py",
+        "hashed_secret": "76eb91cead5c8bebc32b38463c1f6ece5c973f5a",
+        "is_verified": false,
+        "line_number": 27,
+        "is_secret": false
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lfx/tests/unit/utils/test_database_url_sanitization.py",
+        "hashed_secret": "2ecb1536b904e1e7213bdf65b5344e12dca84e76",
+        "is_verified": false,
+        "line_number": 32,
+        "is_secret": false
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lfx/tests/unit/utils/test_database_url_sanitization.py",
+        "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
+        "is_verified": false,
+        "line_number": 86,
+        "is_secret": false
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lfx/tests/unit/utils/test_database_url_sanitization.py",
+        "hashed_secret": "a761ce3a45d97e41840a788495e85a70d1bb3815",
+        "is_verified": false,
+        "line_number": 101,
+        "is_secret": false
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lfx/tests/unit/utils/test_database_url_sanitization.py",
+        "hashed_secret": "fc2eed3863d826b52f384b90d3ad4509a2dd734a",
+        "is_verified": false,
+        "line_number": 126,
+        "is_secret": false
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lfx/tests/unit/utils/test_database_url_sanitization.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 180,
+        "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-03-06T17:16:40Z"
+  "generated_at": "2026-03-10T15:42:06Z"
 }


### PR DESCRIPTION
our secrets.baseline was outdated that `detect-secrets scan --update .secrets.baseline` did not work correctly It was throwing back many (100s) "this line does not exist anymore" warnings during `detect-secrets audit .secrets.baseline` making it very complex to deal with.

process of cleaning up:
rm -f .secrets.baseline - delete old baseline
detect-secrets scan > .secrets.baseline - create new baseline 
detect-secrets audit .secrets.baseline - manually go through all possible secrets and either allow commit or disallow commit (everything looked good to commit to me)