### PR TITLE
fix(ui): Correct AstraDB icon size to use relative units

### DIFF
--- a/src/frontend/src/icons/AstraDB/AstraDB.jsx
+++ b/src/frontend/src/icons/AstraDB/AstraDB.jsx
@@ -1,8 +1,9 @@
 const AstraSVG = (props) => (
   <svg
-    width="167"
-    height="68"
+    width="1em"
+    height="1em"
     viewBox="0 0 167 68"
+    preserveAspectRatio="xMidYMid meet"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
     {...props}


### PR DESCRIPTION
Objective                                                                                                                                                                              
Fix AstraDB icon rendering at an incorrect fixed size by switching to scalable relative units.

Changes
  - Replace hardcoded width="167" and height="68" with 1em for consistent icon sizing
  - Add preserveAspectRatio="xMidYMid meet" to maintain proper proportions when scaled