### PR TITLE
fix: gate PyPI publish jobs on CI completion in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -599,7 +599,7 @@ jobs:
   publish-base:
     name: Publish Langflow Base to PyPI
     if: ${{ inputs.release_package_base }}
-    needs: [build-base, test-cross-platform]
+    needs: [build-base, test-cross-platform, ci]
     runs-on: ubuntu-latest
     steps:
       - name: Download base artifact
@@ -622,7 +622,7 @@ jobs:
   publish-main:
     name: Publish Langflow Main to PyPI
     if: ${{ inputs.release_package_main }}
-    needs: [build-main, test-cross-platform, publish-base]
+    needs: [build-main, test-cross-platform, publish-base, ci]
     runs-on: ubuntu-latest
     steps:
       - name: Download main artifact
@@ -645,7 +645,7 @@ jobs:
   publish-lfx:
     name: Publish LFX to PyPI
     if: ${{ inputs.release_lfx }}
-    needs: [build-lfx, test-cross-platform]
+    needs: [build-lfx, test-cross-platform, ci]
     runs-on: ubuntu-latest
     steps:
       - name: Download LFX artifact


### PR DESCRIPTION
## Problem

The `publish-base`, `publish-main`, and `publish-lfx` jobs in the release workflow did not depend on the `ci` job. This meant packages could be published to PyPI before CI completed — or even if CI failed.

Since PyPI versions are immutable (cannot be re-uploaded), a broken release would require yanking the version and bumping to a new version number.

Docker builds already correctly gate on CI via `needs: [ci]`, but the PyPI publish path had no such gate.

## Changes

Added `ci` to the `needs` array of all three publish jobs:

- `publish-base`: `needs: [build-base, test-cross-platform]` → `needs: [build-base, test-cross-platform, ci]`
- `publish-main`: `needs: [build-main, test-cross-platform, publish-base]` → `needs: [build-main, test-cross-platform, publish-base, ci]`
- `publish-lfx`: `needs: [build-lfx, test-cross-platform]` → `needs: [build-lfx, test-cross-platform, ci]`

## Impact

- No change to the build or Docker paths
- No added latency — CI already runs in parallel with the build chain; this just blocks the final publish step until CI succeeds
- PyPI publishing now waits for the full test suite (Python 3.10–3.13, frontend tests, all backend tests) before proceeding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to ensure continuous integration checks complete before publishing releases to package repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->