### PR TITLE
fix: avoid Linux AIO context leak in convert_image_to_base64

### DIFF
--- a/src/lfx/src/lfx/utils/image.py
+++ b/src/lfx/src/lfx/utils/image.py
@@ -31,6 +31,21 @@ def convert_image_to_base64(image_path: str | Path) -> str:
     storage_service = get_storage_service()
     if storage_service:
         flow_id, file_name = storage_service.parse_file_path(str(image_path))
+
+        # For local storage, read the file directly with synchronous I/O to avoid
+        # creating a new event loop via run_until_complete. The async path uses
+        # aiofile/caio which allocates a Linux AIO context (io_setup syscall) per
+        # call. These contexts are not released when the temporary event loop is
+        # destroyed, causing a kernel AIO context leak that eventually exhausts
+        # fs.aio-max-nr and breaks all subsequent file reads with EAGAIN.
+        try:
+            full_path = Path(storage_service.build_full_path(flow_id, file_name))
+            if full_path.is_file():
+                with full_path.open("rb") as f:
+                    return base64.b64encode(f.read()).decode("utf-8")
+        except (AttributeError, OSError):
+            pass  # Not local storage (e.g. S3), fall through to async path
+
         try:
             file_content = run_until_complete(
                 storage_service.get_file(flow_id=flow_id, file_name=file_name)  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

- **Bug**: `convert_image_to_base64()` uses `run_until_complete()` to call the async storage service from a synchronous context. This creates a temporary event loop, and `aiofile`/`caio` allocates a Linux AIO context (`io_setup` syscall) for each call. These contexts are **never released** when the temporary event loop is destroyed, causing a kernel-level resource leak.
- **Impact**: After enough image reads (typically a few hundred), the system-wide `fs.aio-max-nr` limit (default 65536) is exhausted. All subsequent file operations fail with `SystemError: (11, 'Resource temporarily unavailable')`, breaking image processing entirely until the container is restarted.
- **Fix**: Adds a synchronous fast path for local storage — when the storage service has `build_full_path` (i.e. `LocalStorageService`), the file is read directly with standard `open()` instead of going through the async `aiofile` path. The async path is preserved as fallback for non-local backends (e.g. S3).

## Error trace

```
File "lfx/utils/image.py", line 35, in convert_image_to_base64
    file_content = run_until_complete(storage_service.get_file(...))
File "aiofile/aio.py", line 329, in get_default_context
    return create_context()
File "caio/linux_aio_asyncio.py", line 10, in _create_context
    context = super()._create_context(max_requests)
SystemError: (11, 'Resource temporarily unavailable')
```

## Test plan

- [x] Verified that `LocalStorageService.build_full_path()` returns the correct absolute path
- [x] Verified that the fix bypasses `aiofile`/`caio` entirely for local storage reads
- [x] S3 storage path is unchanged (falls through to existing async code via `AttributeError` catch)
- [ ] Integration test: confirm `aio-nr` does not increase after repeated image reads with local storage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Image processing now executes faster with optimized local file access
  * Enhanced error handling with automatic fallback mechanisms for increased reliability and stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->