### PR TITLE
fix: filter Docker Hub tag queries to prevent rc0 overwrite (LE-515)

### DIFF
--- a/.github/workflows/docker-build-v2.yml
+++ b/.github/workflows/docker-build-v2.yml
@@ -82,12 +82,12 @@ jobs:
           echo "Base version from pyproject.toml: $version"
 
           if [ ${{inputs.pre_release}} == "true" ]; then
-            last_released_version=$(curl -s "https://registry.hub.docker.com/v2/repositories/langflowai/langflow/tags?page_size=100" | jq -r '.results[].name' | grep -E '\.rc[0-9]+' | sort -V | tail -n 1)
+            last_released_version=$(curl -s "https://registry.hub.docker.com/v2/repositories/langflowai/langflow/tags?page_size=100" | jq -r '.results[].name' | grep -E '^base-.*\.rc[0-9]+' | grep -vE '\-(amd64|arm64)$' | sed 's/^base-//' | sort -V | tail -n 1)
             version="$(uv run ./scripts/ci/langflow_pre_release_tag.py "$version" "$last_released_version")"
             echo "Latest base pre-release version: $last_released_version"
             echo "Base pre-release version to be released: $version"
           else
-            last_released_version=$(curl -s "https://registry.hub.docker.com/v2/repositories/langflowai/langflow/tags?page_size=100" | jq -r '.results[].name' | grep -v 'latest' | sort -V | tail -n 1)
+            last_released_version=$(curl -s "https://registry.hub.docker.com/v2/repositories/langflowai/langflow/tags?page_size=100" | jq -r '.results[].name' | grep -E '^base-' | grep -vE '\-(amd64|arm64)$' | grep -v 'latest' | sed 's/^base-//' | sort -V | tail -n 1)
             echo "Latest base release version: $last_released_version"
           fi
 
@@ -128,12 +128,12 @@ jobs:
           echo "Main version from pyproject.toml: $version"
 
           if [ ${{inputs.pre_release}} == "true" ]; then
-            last_released_version=$(curl -s "https://registry.hub.docker.com/v2/repositories/langflowai/langflow/tags?page_size=100" | jq -r '.results[].name' | grep -E '\.rc[0-9]+' | sort -V | tail -n 1)
+            last_released_version=$(curl -s "https://registry.hub.docker.com/v2/repositories/langflowai/langflow/tags?page_size=100" | jq -r '.results[].name' | grep -E '\.rc[0-9]+' | grep -v '^base-' | grep -vE '\-(amd64|arm64)$' | sort -V | tail -n 1)
             version="$(uv run ./scripts/ci/langflow_pre_release_tag.py "$version" "$last_released_version")"
             echo "Latest main pre-release version: $last_released_version"
             echo "Main pre-release version to be released: $version"
           else
-            last_released_version=$(curl -s "https://registry.hub.docker.com/v2/repositories/langflowai/langflow/tags?page_size=100" | jq -r '.results[].name' | grep -v 'latest' | sort -V | tail -n 1)
+            last_released_version=$(curl -s "https://registry.hub.docker.com/v2/repositories/langflowai/langflow/tags?page_size=100" | jq -r '.results[].name' | grep -v '^base-' | grep -vE '\-(amd64|arm64)$' | grep -v 'latest' | sort -V | tail -n 1)
             echo "Latest main release version: $last_released_version"
           fi
 


### PR DESCRIPTION
## Problem
Docker Hub pre-releases always overwrite `rc0` instead of incrementing (`rc0` → `rc1` → `rc2`).

## Root Cause
The Docker Hub tag queries in `docker-build-v2.yml` return architecture-suffixed and base-prefixed tags (e.g. `base-0.8.0.rc0-arm64`). After `sort -V | tail -n 1`, this polluted tag is passed to `langflow_pre_release_tag.py`, whose regex fails to match the suffix and defaults back to `rc0`.

## Fix
- **determine-main-version**: exclude `^base-` tags and `-(amd64|arm64)$` suffixes
- **determine-base-version**: select only `^base-` tags, exclude arch suffixes, strip `base-` prefix
- Applied same filtering to non-pre-release queries for consistency



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build workflow to skip redundant builds when versions remain unchanged.
  * Enhanced release version filtering to more accurately identify and use the latest released versions.
  * Improved multi-architecture Docker manifest creation with refined tag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->