### PR TITLE
ci: allow docs-only pull requests to skip tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,11 @@ jobs:
       always() &&
       !cancelled() &&
       needs.set-ci-condition.outputs.should-run-tests == 'true' &&
-      needs.path-filter.outputs.docs-only != 'true'
+      (
+        inputs.run-all-tests ||
+        (needs.path-filter.result != 'skipped' &&
+        needs.path-filter.outputs.docs-only != 'true')
+      )
     uses: ./.github/workflows/python_test.yml
     with:
       python-versions: ${{ inputs.python-versions || '["3.10"]' }}
@@ -255,7 +259,11 @@ jobs:
       always() &&
       !cancelled() &&
       needs.set-ci-condition.outputs.should-run-tests == 'true' &&
-      needs.path-filter.outputs.docs-only != 'true'
+      (
+        inputs.run-all-tests ||
+        (needs.path-filter.result != 'skipped' &&
+        needs.path-filter.outputs.docs-only != 'true')
+      )
     uses: ./.github/workflows/jest_test.yml
     with:
       ref: ${{ inputs.ref || github.ref }}
@@ -269,7 +277,11 @@ jobs:
       always() &&
       !cancelled() &&
       needs.set-ci-condition.outputs.should-run-tests == 'true' &&
-      needs.path-filter.outputs.docs-only != 'true'
+      (
+        inputs.run-all-tests ||
+        (needs.path-filter.result != 'skipped' &&
+        needs.path-filter.outputs.docs-only != 'true')
+      )
     uses: ./.github/workflows/typescript_test.yml
     with:
       tests_folder: ${{ inputs.frontend-tests-folder }}


### PR DESCRIPTION
If a pull request only changes files at `docs/**`, the workflow will skip running Python, Jest, and TypeScript tests, saving CI resources and time. The docs PR can also still merge if the nightly build is failing.

The `docs-only` path filter is defined in [ci.yml](https://github.com/langflow-ai/langflow/blob/main/.github/workflows/ci.yml#L189).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI pipeline to skip test runs when only documentation updates are made, improving workflow efficiency and reducing unnecessary processing time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->