### PR TITLE
fix: add security sandbox to prevent RCE during custom component validation

### DIFF
--- a/src/lfx/src/lfx/custom/code_parser/code_parser.py
+++ b/src/lfx/src/lfx/custom/code_parser/code_parser.py
@@ -342,8 +342,12 @@ class CodeParser:
         self.data["global_vars"].append(global_var)
 
     def execute_and_inspect_classes(self, code: str):
-        custom_component_class = eval_custom_component_code(code)
-        custom_component = custom_component_class(_code=code)
+        custom_component_class = eval_custom_component_code(code, sandbox=True)
+        # Use __new__ to avoid running user-defined __init__
+        from lfx.custom.custom_component.component import Component
+
+        custom_component = custom_component_class.__new__(custom_component_class)
+        Component.__init__(custom_component, _code=code)
         dunder_class = custom_component.__class__
         # Get the base classes at two levels of inheritance
         bases = []

--- a/src/lfx/src/lfx/custom/code_sandbox.py
+++ b/src/lfx/src/lfx/custom/code_sandbox.py
@@ -1,0 +1,234 @@
+"""Security sandbox for custom component code validation.
+
+Validates user-supplied Python code before execution during component
+template building. Blocks dangerous module imports, restricts builtins,
+and sanitizes AST nodes to prevent arbitrary code execution during the
+validation phase.
+
+Runtime execution (when flows are actually run) is NOT affected by these
+checks — components can still use any module at runtime.
+
+Configuration:
+    Set LANGFLOW_SANDBOX_CUSTOM_CODE=false to disable sandbox checks
+    (not recommended for production).
+"""
+
+import ast
+import builtins
+import os
+
+# ---------------------------------------------------------------------------
+# Blocked modules — never needed during *validation* (template building).
+# Users who need these at runtime should keep them; the sandbox only applies
+# to the validation path.
+# ---------------------------------------------------------------------------
+BLOCKED_MODULES: frozenset[str] = frozenset(
+    {
+        "subprocess",
+        "socket",
+        "pty",
+        "shutil",
+        "ctypes",
+        "multiprocessing",
+        "signal",
+        "commands",
+        "pdb",
+        "code",
+        "codeop",
+        "http.server",
+        "xmlrpc.server",
+        "ftplib",
+        "smtplib",
+        "telnetlib",
+        "poplib",
+        "imaplib",
+        "nntplib",
+        "webbrowser",
+        "antigravity",
+        "turtle",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Builtins that are removed from the exec scope during sandboxed validation.
+# ---------------------------------------------------------------------------
+BLOCKED_BUILTINS: frozenset[str] = frozenset(
+    {
+        "__import__",
+        "exec",
+        "eval",
+        "compile",
+        "open",
+        "breakpoint",
+        "exit",
+        "quit",
+    }
+)
+
+SANDBOX_ENABLED: bool = os.getenv("LANGFLOW_SANDBOX_CUSTOM_CODE", "true").lower() in (
+    "true",
+    "1",
+    "yes",
+)
+
+
+class CodeSafetyError(Exception):
+    """Raised when user-supplied code fails safety validation."""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def validate_code_safety(code: str) -> None:
+    """Run all safety checks on user-supplied component code.
+
+    Raises CodeSafetyError if any check fails.
+    Does nothing when the sandbox is disabled via environment variable.
+    """
+    if not SANDBOX_ENABLED:
+        return
+
+    _validate_imports(code)
+    _validate_no_dangerous_builtins(code)
+
+
+def create_restricted_builtins() -> dict:
+    """Return a copy of Python builtins with dangerous names removed."""
+    return {k: v for k, v in vars(builtins).items() if k not in BLOCKED_BUILTINS}
+
+
+def filter_safe_definitions(definitions: list[ast.stmt]) -> list[ast.stmt]:
+    """Filter a list of AST definition nodes, keeping only safe ones.
+
+    Safe definitions:
+    - ``ast.FunctionDef`` / ``ast.AsyncFunctionDef`` (method bodies are not
+      executed during definition)
+    - ``ast.Assign`` / ``ast.AnnAssign`` whose value does NOT contain any
+      ``ast.Call`` node (i.e. no function/method invocations)
+
+    ``ast.ClassDef`` nodes are **excluded** — they are handled separately via
+    ``sanitize_class_body`` + ``build_class_constructor`` to ensure their
+    bodies are sanitized before execution.
+
+    This prevents top-level assignments like
+    ``result = subprocess.check_output(...)`` from being executed, and
+    prevents unsanitized class body code from running.
+    """
+    if not SANDBOX_ENABLED:
+        return definitions
+
+    safe: list[ast.stmt] = []
+    for node in definitions:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            safe.append(node)
+        elif isinstance(node, ast.Assign):
+            if not _contains_call(node.value):
+                safe.append(node)
+        elif isinstance(node, ast.AnnAssign):
+            if node.value is None or not _contains_call(node.value):
+                safe.append(node)
+        # ClassDef is intentionally excluded — handled via sanitize_class_body
+        # Skip anything else (bare expressions, etc.)
+    return safe
+
+
+def sanitize_class_body(class_node: ast.ClassDef) -> ast.ClassDef:
+    """Remove dangerous statements from a class body before exec.
+
+    Keeps:
+    - Method definitions (``FunctionDef``, ``AsyncFunctionDef``)
+    - Safe assignments (no function calls in the value)
+    - Nested class definitions
+    - Docstrings (``Expr`` wrapping a ``Constant``)
+
+    Removes:
+    - Assignments whose value contains function calls
+      (e.g. ``os.system("id")``)
+    - Bare expression statements with function calls
+    """
+    if not SANDBOX_ENABLED:
+        return class_node
+
+    safe_body: list[ast.stmt] = []
+    for node in class_node.body:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            safe_body.append(node)
+        elif isinstance(node, ast.Assign):
+            if not _contains_call(node.value):
+                safe_body.append(node)
+            # else: skip — e.g. ``os.system("id")`` assigned to a variable
+        elif isinstance(node, ast.AnnAssign):
+            if node.value is None or not _contains_call(node.value):
+                safe_body.append(node)
+        elif isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+            safe_body.append(node)  # docstring
+        # Skip bare function calls, attribute calls, etc.
+
+    # A class body must have at least one statement
+    if not safe_body:
+        safe_body = [ast.Pass()]
+
+    class_node.body = safe_body
+    ast.fix_missing_locations(class_node)
+    return class_node
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_imports(code: str) -> None:
+    """Check that the code does not import any blocked module."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return  # syntax errors are caught later by the compiler
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                _check_module_blocked(alias.name, node.lineno)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            _check_module_blocked(node.module, node.lineno)
+
+
+def _validate_no_dangerous_builtins(code: str) -> None:
+    """Detect calls to dangerous builtins like __import__, exec, eval."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return
+
+    dangerous_names = {"__import__", "exec", "eval", "compile"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id in dangerous_names:
+                raise CodeSafetyError(
+                    f"Call to '{node.func.id}()' is not allowed in custom component code "
+                    f"(line {node.lineno}). This function can execute arbitrary code."
+                )
+
+
+def _check_module_blocked(module_name: str, lineno: int) -> None:
+    """Raise CodeSafetyError if *module_name* matches any blocked module."""
+    # Check the module name and all its parent packages
+    parts = module_name.split(".")
+    for i in range(len(parts)):
+        prefix = ".".join(parts[: i + 1])
+        if prefix in BLOCKED_MODULES:
+            raise CodeSafetyError(
+                f"Import of '{module_name}' is blocked during component validation "
+                f"(line {lineno}). If this import is needed at runtime, keep it in "
+                f"your component — it will work when the flow is executed."
+            )
+
+
+def _contains_call(node: ast.AST) -> bool:
+    """Return True if *node* or any descendant is an ``ast.Call``."""
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            return True
+    return False

--- a/src/lfx/src/lfx/custom/custom_component/base_component.py
+++ b/src/lfx/src/lfx/custom/custom_component/base_component.py
@@ -113,7 +113,7 @@ class BaseComponent:
             return {}
 
         try:
-            cc_class = eval_custom_component_code(self._code)
+            cc_class = eval_custom_component_code(self._code, sandbox=True)
 
         except AttributeError as e:
             pattern = r"module '.*?' has no attribute '.*?'"
@@ -121,7 +121,13 @@ class BaseComponent:
                 raise ImportError(e) from e
             raise
 
-        component_instance = cc_class(_code=self._code)
+        # Use __new__ to create the instance WITHOUT running the user-defined
+        # __init__.  Then call the base Component.__init__ directly so that
+        # required internal state is initialised safely.
+        from lfx.custom.custom_component.component import Component
+
+        component_instance = cc_class.__new__(cc_class)
+        Component.__init__(component_instance, _code=self._code)
         return self.get_template_config(component_instance)
 
     def build(self, *args: Any, **kwargs: Any) -> Any:

--- a/src/lfx/src/lfx/custom/eval.py
+++ b/src/lfx/src/lfx/custom/eval.py
@@ -6,7 +6,14 @@ if TYPE_CHECKING:
     from lfx.custom.custom_component.custom_component import CustomComponent
 
 
-def eval_custom_component_code(code: str) -> type["CustomComponent"]:
-    """Evaluate custom component code."""
+def eval_custom_component_code(code: str, *, sandbox: bool = False) -> type["CustomComponent"]:
+    """Evaluate custom component code.
+
+    Args:
+        code: Python source code defining a custom component class.
+        sandbox: When True, apply security sandbox restrictions to prevent
+                 arbitrary code execution. Should be True during validation
+                 (template building) and False during runtime (flow execution).
+    """
     class_name = validate.extract_class_name(code)
-    return validate.create_class(code, class_name)
+    return validate.create_class(code, class_name, sandbox=sandbox)

--- a/src/lfx/src/lfx/custom/utils.py
+++ b/src/lfx/src/lfx/custom/utils.py
@@ -316,7 +316,7 @@ def get_component_instance(custom_component: CustomComponent | Component, user_i
 
     # Only now, try to process expensive exception/log traceback only *if needed*
     try:
-        custom_class = eval_custom_component_code(code)
+        custom_class = eval_custom_component_code(code, sandbox=True)
     except Exception as exc:
         # Only generate traceback if an error occurs (save time on success)
         tb = traceback.format_exc()
@@ -330,7 +330,10 @@ def get_component_instance(custom_component: CustomComponent | Component, user_i
         ) from exc
 
     try:
-        return custom_class(_user_id=user_id, _code=code)
+        # Use __new__ to avoid running user-defined __init__
+        instance = custom_class.__new__(custom_class)
+        Component.__init__(instance, _user_id=user_id, _code=code)
+        return instance
     except Exception as exc:
         tb = traceback.format_exc()
         logger.error("Error while instantiating custom component\n%s", tb)
@@ -376,7 +379,7 @@ def run_build_config(
         error = "Invalid code type"
     else:
         try:
-            custom_class = eval_custom_component_code(custom_component._code)
+            custom_class = eval_custom_component_code(custom_component._code, sandbox=True)
         except Exception as exc:
             logger.exception("Error while evaluating custom component code")
             raise HTTPException(
@@ -388,7 +391,9 @@ def run_build_config(
             ) from exc
 
         try:
-            custom_instance = custom_class(_user_id=user_id)
+            # Use __new__ to avoid running user-defined __init__
+            custom_instance = custom_class.__new__(custom_class)
+            Component.__init__(custom_instance, _user_id=user_id)
             build_config: dict = custom_instance.build_config()
 
             for field_name, field in build_config.copy().items():

--- a/src/lfx/src/lfx/custom/validate.py
+++ b/src/lfx/src/lfx/custom/validate.py
@@ -238,21 +238,30 @@ def create_function(code, function_name):
     return wrapped_function
 
 
-def create_class(code, class_name):
+def create_class(code, class_name, *, sandbox=False):
     """Dynamically create a class from a string of code and a specified class name.
 
     Args:
         code: String containing the Python code defining the class
         class_name: Name of the class to be created
+        sandbox: When True, apply security sandbox restrictions to prevent
+                 arbitrary code execution during validation. Import blocklists,
+                 restricted builtins, and AST sanitization are applied.
 
     Returns:
          A function that, when called, returns an instance of the created class
 
     Raises:
         ValueError: If the code contains syntax errors or the class definition is invalid
+        CodeSafetyError: If sandbox is True and the code contains dangerous patterns
     """
     if not hasattr(ast, "TypeIgnore"):
         ast.TypeIgnore = create_type_ignore_class()
+
+    if sandbox:
+        from lfx.custom.code_sandbox import validate_code_safety
+
+        validate_code_safety(code)
 
     code = code.replace("from langflow import CustomComponent", "from langflow.custom import CustomComponent")
     code = code.replace(
@@ -263,12 +272,18 @@ def create_class(code, class_name):
     code = DEFAULT_IMPORT_STRING + "\n" + code
     try:
         module = ast.parse(code)
-        exec_globals = prepare_global_scope(module)
+        exec_globals = prepare_global_scope(module, sandbox=sandbox)
 
         class_code = extract_class_code(module, class_name)
+
+        if sandbox:
+            from lfx.custom.code_sandbox import sanitize_class_body
+
+            class_code = sanitize_class_body(class_code)
+
         compiled_class = compile_class_code(class_code)
 
-        return build_class_constructor(compiled_class, exec_globals, class_name)
+        return build_class_constructor(compiled_class, exec_globals, class_name, sandbox=sandbox)
 
     except SyntaxError as e:
         msg = f"Syntax error in code: {e!s}"
@@ -320,11 +335,13 @@ def _handle_module_attributes(imported_module, node, module_name, exec_globals):
             exec_globals[alias.name] = importlib.import_module(full_module_path)
 
 
-def prepare_global_scope(module):
+def prepare_global_scope(module, *, sandbox=False):
     """Prepares the global scope with necessary imports from the provided code module.
 
     Args:
         module: AST parsed module
+        sandbox: When True, filter out assignments containing function calls
+                 and use restricted builtins.
 
     Returns:
         Dictionary representing the global scope with imported modules
@@ -333,6 +350,12 @@ def prepare_global_scope(module):
         ModuleNotFoundError: If a module is not found in the code
     """
     exec_globals = globals().copy()
+
+    if sandbox:
+        from lfx.custom.code_sandbox import create_restricted_builtins
+
+        exec_globals["__builtins__"] = create_restricted_builtins()
+
     imports = []
     import_froms = []
     definitions = []
@@ -392,9 +415,15 @@ def prepare_global_scope(module):
             raise ModuleNotFoundError(msg)
 
     if definitions:
-        combined_module = ast.Module(body=definitions, type_ignores=[])
-        compiled_code = compile(combined_module, "<string>", "exec")
-        exec(compiled_code, exec_globals)
+        if sandbox:
+            from lfx.custom.code_sandbox import filter_safe_definitions
+
+            definitions = filter_safe_definitions(definitions)
+
+        if definitions:
+            combined_module = ast.Module(body=definitions, type_ignores=[])
+            compiled_code = compile(combined_module, "<string>", "exec")
+            exec(compiled_code, exec_globals)
 
     return exec_globals
 
@@ -427,28 +456,40 @@ def compile_class_code(class_code):
     return compile(ast.Module(body=[class_code], type_ignores=[]), "<string>", "exec")
 
 
-def build_class_constructor(compiled_class, exec_globals, class_name):
+def build_class_constructor(compiled_class, exec_globals, class_name, *, sandbox=False):
     """Builds a constructor function for the dynamically created class.
 
     Args:
         compiled_class: Compiled code object of the class
         exec_globals: Global scope with necessary imports
         class_name: Name of the class
+        sandbox: When True, use restricted builtins for the exec scope.
 
     Returns:
          Constructor function for the class
     """
     exec_locals = dict(locals())
-    exec(compiled_class, exec_globals, exec_locals)
-    exec_globals[class_name] = exec_locals[class_name]
+
+    if sandbox:
+        from lfx.custom.code_sandbox import create_restricted_builtins
+
+        safe_globals = exec_globals.copy()
+        safe_globals["__builtins__"] = create_restricted_builtins()
+        exec(compiled_class, safe_globals, exec_locals)
+        safe_globals[class_name] = exec_locals[class_name]
+        target_globals = safe_globals
+    else:
+        exec(compiled_class, exec_globals, exec_locals)
+        exec_globals[class_name] = exec_locals[class_name]
+        target_globals = exec_globals
 
     # Return a function that imports necessary modules and creates an instance of the target class
     def build_custom_class():
-        for module_name, module in exec_globals.items():
+        for module_name, module in target_globals.items():
             if isinstance(module, type(importlib)):
                 globals()[module_name] = module
 
-        return exec_globals[class_name]
+        return target_globals[class_name]
 
     return build_custom_class()
 

--- a/src/lfx/tests/unit/custom/component/test_code_sandbox.py
+++ b/src/lfx/tests/unit/custom/component/test_code_sandbox.py
@@ -1,0 +1,424 @@
+"""Tests for the code_sandbox module — security sandbox for custom component validation."""
+
+import ast
+from textwrap import dedent
+
+import pytest
+
+from lfx.custom.code_sandbox import (
+    CodeSafetyError,
+    _contains_call,
+    create_restricted_builtins,
+    filter_safe_definitions,
+    sanitize_class_body,
+    validate_code_safety,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_code_safety — blocked imports
+# ---------------------------------------------------------------------------
+
+
+class TestBlockedImports:
+    def test_blocks_subprocess_import(self):
+        code = "import subprocess"
+        with pytest.raises(CodeSafetyError, match="subprocess"):
+            validate_code_safety(code)
+
+    def test_blocks_subprocess_from_import(self):
+        code = "from subprocess import check_output"
+        with pytest.raises(CodeSafetyError, match="subprocess"):
+            validate_code_safety(code)
+
+    def test_blocks_socket_import(self):
+        code = "import socket"
+        with pytest.raises(CodeSafetyError, match="socket"):
+            validate_code_safety(code)
+
+    def test_blocks_pty_import(self):
+        code = "import pty"
+        with pytest.raises(CodeSafetyError, match="pty"):
+            validate_code_safety(code)
+
+    def test_blocks_ctypes_import(self):
+        code = "import ctypes"
+        with pytest.raises(CodeSafetyError, match="ctypes"):
+            validate_code_safety(code)
+
+    def test_blocks_shutil_import(self):
+        code = "import shutil"
+        with pytest.raises(CodeSafetyError, match="shutil"):
+            validate_code_safety(code)
+
+    def test_blocks_nested_blocked_module(self):
+        code = "from http.server import HTTPServer"
+        with pytest.raises(CodeSafetyError, match="http.server"):
+            validate_code_safety(code)
+
+    def test_allows_safe_imports(self):
+        code = dedent("""\
+            import os
+            import json
+            import re
+            from pathlib import Path
+            from typing import Optional
+        """)
+        # Should not raise
+        validate_code_safety(code)
+
+    def test_allows_langflow_imports(self):
+        code = dedent("""\
+            from langflow.custom import Component
+            from langflow.io import Output
+        """)
+        validate_code_safety(code)
+
+
+# ---------------------------------------------------------------------------
+# validate_code_safety — dangerous builtin calls
+# ---------------------------------------------------------------------------
+
+
+class TestDangerousBuiltinCalls:
+    def test_blocks_dunder_import_call(self):
+        code = '__import__("os").system("id")'
+        with pytest.raises(CodeSafetyError, match="__import__"):
+            validate_code_safety(code)
+
+    def test_blocks_exec_call(self):
+        code = 'exec("print(1)")'
+        with pytest.raises(CodeSafetyError, match="exec"):
+            validate_code_safety(code)
+
+    def test_blocks_eval_call(self):
+        code = 'eval("1+1")'
+        with pytest.raises(CodeSafetyError, match="eval"):
+            validate_code_safety(code)
+
+    def test_blocks_compile_call(self):
+        code = 'compile("print(1)", "<string>", "exec")'
+        with pytest.raises(CodeSafetyError, match="compile"):
+            validate_code_safety(code)
+
+    def test_allows_safe_function_calls(self):
+        code = dedent("""\
+            x = len([1, 2, 3])
+            y = str(42)
+            z = list(range(10))
+        """)
+        validate_code_safety(code)
+
+
+# ---------------------------------------------------------------------------
+# create_restricted_builtins
+# ---------------------------------------------------------------------------
+
+
+class TestRestrictedBuiltins:
+    def test_removes_import(self):
+        restricted = create_restricted_builtins()
+        assert "__import__" not in restricted
+
+    def test_removes_exec(self):
+        restricted = create_restricted_builtins()
+        assert "exec" not in restricted
+
+    def test_removes_eval(self):
+        restricted = create_restricted_builtins()
+        assert "eval" not in restricted
+
+    def test_removes_open(self):
+        restricted = create_restricted_builtins()
+        assert "open" not in restricted
+
+    def test_removes_compile(self):
+        restricted = create_restricted_builtins()
+        assert "compile" not in restricted
+
+    def test_keeps_safe_builtins(self):
+        restricted = create_restricted_builtins()
+        for name in ("len", "str", "int", "float", "list", "dict", "print", "range", "isinstance"):
+            assert name in restricted, f"{name} should be in restricted builtins"
+
+
+# ---------------------------------------------------------------------------
+# filter_safe_definitions
+# ---------------------------------------------------------------------------
+
+
+class TestFilterSafeDefinitions:
+    def test_excludes_class_def(self):
+        """ClassDef is excluded — handled separately via sanitize_class_body."""
+        code = "class Foo: pass"
+        module = ast.parse(code)
+        result = filter_safe_definitions(module.body)
+        assert len(result) == 0
+
+    def test_keeps_function_def(self):
+        code = "def foo(): pass"
+        module = ast.parse(code)
+        result = filter_safe_definitions(module.body)
+        assert len(result) == 1
+        assert isinstance(result[0], ast.FunctionDef)
+
+    def test_keeps_safe_assignment(self):
+        code = 'X = 42\nY = "hello"'
+        module = ast.parse(code)
+        result = filter_safe_definitions(module.body)
+        assert len(result) == 2
+
+    def test_removes_assignment_with_call(self):
+        code = 'result = subprocess.check_output("id", shell=True)'
+        module = ast.parse(code)
+        result = filter_safe_definitions(module.body)
+        assert len(result) == 0
+
+    def test_keeps_annotated_assignment_without_value(self):
+        code = "x: int"
+        module = ast.parse(code)
+        result = filter_safe_definitions(module.body)
+        assert len(result) == 1
+
+    def test_removes_annotated_assignment_with_call(self):
+        code = "x: str = os.getcwd()"
+        module = ast.parse(code)
+        result = filter_safe_definitions(module.body)
+        assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# sanitize_class_body
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeClassBody:
+    def test_keeps_methods(self):
+        code = dedent("""\
+            class Foo:
+                def run(self):
+                    return "ok"
+        """)
+        tree = ast.parse(code)
+        class_node = tree.body[0]
+        sanitized = sanitize_class_body(class_node)
+        assert any(isinstance(n, ast.FunctionDef) for n in sanitized.body)
+
+    def test_keeps_safe_assignments(self):
+        code = dedent("""\
+            class Foo:
+                display_name = "Foo"
+                x = 42
+        """)
+        tree = ast.parse(code)
+        class_node = tree.body[0]
+        sanitized = sanitize_class_body(class_node)
+        assert len(sanitized.body) == 2
+
+    def test_removes_dangerous_call_in_body(self):
+        code = dedent("""\
+            class Foo:
+                os.system("id")
+                display_name = "Foo"
+        """)
+        tree = ast.parse(code)
+        class_node = tree.body[0]
+        sanitized = sanitize_class_body(class_node)
+        # Only display_name assignment should remain
+        assert len(sanitized.body) == 1
+        assert isinstance(sanitized.body[0], ast.Assign)
+
+    def test_removes_assignment_with_call_in_body(self):
+        code = dedent("""\
+            class Foo:
+                result = subprocess.check_output("id", shell=True)
+                display_name = "Foo"
+        """)
+        tree = ast.parse(code)
+        class_node = tree.body[0]
+        sanitized = sanitize_class_body(class_node)
+        assert len(sanitized.body) == 1
+
+    def test_keeps_docstring(self):
+        code = dedent('''\
+            class Foo:
+                """This is a docstring."""
+                pass
+        ''')
+        tree = ast.parse(code)
+        class_node = tree.body[0]
+        sanitized = sanitize_class_body(class_node)
+        assert any(
+            isinstance(n, ast.Expr) and isinstance(n.value, ast.Constant) for n in sanitized.body
+        )
+
+    def test_empty_body_gets_pass(self):
+        code = dedent("""\
+            class Foo:
+                os.system("id")
+        """)
+        tree = ast.parse(code)
+        class_node = tree.body[0]
+        sanitized = sanitize_class_body(class_node)
+        assert len(sanitized.body) == 1
+        assert isinstance(sanitized.body[0], ast.Pass)
+
+
+# ---------------------------------------------------------------------------
+# _contains_call helper
+# ---------------------------------------------------------------------------
+
+
+class TestContainsCall:
+    def test_constant_has_no_call(self):
+        node = ast.parse("42", mode="eval").body
+        assert not _contains_call(node)
+
+    def test_function_call_detected(self):
+        node = ast.parse("foo()", mode="eval").body
+        assert _contains_call(node)
+
+    def test_method_call_detected(self):
+        node = ast.parse("os.system('id')", mode="eval").body
+        assert _contains_call(node)
+
+    def test_nested_call_detected(self):
+        node = ast.parse("[foo()]", mode="eval").body
+        assert _contains_call(node)
+
+    def test_name_has_no_call(self):
+        node = ast.parse("x", mode="eval").body
+        assert not _contains_call(node)
+
+
+# ---------------------------------------------------------------------------
+# Integration: create_class with sandbox=True
+# ---------------------------------------------------------------------------
+
+
+class TestCreateClassSandbox:
+    def test_legitimate_component_passes(self):
+        from lfx.custom.validate import create_class
+
+        code = dedent("""\
+            from langflow.custom import Component
+            from langflow.io import Output
+
+            class TestComp(Component):
+                display_name = "TestComp"
+                outputs = [Output(display_name="O", name="o", method="run")]
+                def run(self):
+                    return "hello"
+        """)
+        result = create_class(code, "TestComp", sandbox=True)
+        assert result.__name__ == "TestComp"
+
+    def test_subprocess_import_blocked(self):
+        from lfx.custom.validate import create_class
+
+        code = dedent("""\
+            from langflow.custom import Component
+            from langflow.io import Output
+            import subprocess
+
+            class Evil(Component):
+                display_name = "Evil"
+                outputs = [Output(display_name="O", name="o", method="run")]
+                def run(self):
+                    return "ok"
+        """)
+        with pytest.raises((ValueError, CodeSafetyError)):
+            create_class(code, "Evil", sandbox=True)
+
+    def test_socket_import_blocked(self):
+        from lfx.custom.validate import create_class
+
+        code = dedent("""\
+            from langflow.custom import Component
+            from langflow.io import Output
+            import socket
+
+            class Evil(Component):
+                display_name = "Evil"
+                outputs = [Output(display_name="O", name="o", method="run")]
+                def run(self):
+                    return "ok"
+        """)
+        with pytest.raises((ValueError, CodeSafetyError)):
+            create_class(code, "Evil", sandbox=True)
+
+    def test_dunder_import_blocked(self):
+        from lfx.custom.validate import create_class
+
+        code = dedent("""\
+            from langflow.custom import Component
+            from langflow.io import Output
+
+            class Evil(Component):
+                display_name = "Evil"
+                outputs = [Output(display_name="O", name="o", method="run")]
+                def run(self):
+                    return __import__("os").system("id")
+        """)
+        with pytest.raises((ValueError, CodeSafetyError)):
+            create_class(code, "Evil", sandbox=True)
+
+    def test_class_body_call_removed(self):
+        """Class-body code with function calls should be stripped during sandbox."""
+        from lfx.custom.validate import create_class
+
+        code = dedent("""\
+            from langflow.custom import Component
+            from langflow.io import Output
+            import os
+
+            class Evil(Component):
+                display_name = "Evil"
+                os.system("touch /tmp/sandbox_test_classbody")
+                outputs = [Output(display_name="O", name="o", method="run")]
+                def run(self):
+                    return "ok"
+        """)
+        # The class should be created but the os.system call should be stripped
+        result = create_class(code, "Evil", sandbox=True)
+        assert result.__name__ == "Evil"
+
+    def test_toplevel_assignment_with_call_filtered(self):
+        """Top-level assignments containing function calls should be filtered."""
+        from lfx.custom.validate import create_class
+
+        code = dedent("""\
+            from langflow.custom import Component
+            from langflow.io import Output
+            import os
+
+            result = os.getcwd()
+
+            class Benign(Component):
+                display_name = "Benign"
+                outputs = [Output(display_name="O", name="o", method="run")]
+                def run(self):
+                    return "ok"
+        """)
+        # Should succeed — the dangerous assignment is filtered out
+        result = create_class(code, "Benign", sandbox=True)
+        assert result.__name__ == "Benign"
+
+    def test_runtime_mode_allows_everything(self):
+        """Without sandbox, all code should execute normally."""
+        from lfx.custom.validate import create_class
+
+        code = dedent("""\
+            from langflow.custom import Component
+            from langflow.io import Output
+            import os
+
+            class RuntimeComp(Component):
+                display_name = "RuntimeComp"
+                outputs = [Output(display_name="O", name="o", method="run")]
+                def run(self):
+                    return os.getcwd()
+        """)
+        # sandbox=False (default) should not block anything
+        result = create_class(code, "RuntimeComp", sandbox=False)
+        assert result.__name__ == "RuntimeComp"


### PR DESCRIPTION
Add a code sandbox that prevents arbitrary code execution when validating custom component code via /api/v1/custom_component.

The vulnerability allowed authenticated attackers to execute arbitrary Python and OS commands through three vectors during component validation (template building):

1. __init__() constructor execution during class instantiation
2. Class-body code execution during exec() of the class definition
3. Top-level assignment execution in prepare_global_scope()

Changes:

- New module: lfx/custom/code_sandbox.py
  - Blocked module imports (subprocess, socket, pty, ctypes, etc.)
  - Restricted builtins (no __import__, exec, eval, open, compile)
  - AST-based class body sanitization (strips function calls)
  - Top-level assignment filtering (blocks assignments with calls)
  - Configurable via LANGFLOW_SANDBOX_CUSTOM_CODE env var (default: on)

- Modified: validate.py
  - create_class(), prepare_global_scope(), build_class_constructor() accept sandbox=True to enable security restrictions

- Modified: eval.py
  - eval_custom_component_code() accepts sandbox parameter

- Modified: base_component.py, utils.py, code_parser.py
  - All validation-path callers use sandbox=True
  - Class instantiation uses __new__ + Component.__init__ to skip user-defined __init__()

- Runtime execution paths (flow execution via loading.py) are unaffected — components can still use all modules at runtime.

- 44 new tests covering all sandbox features and integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added code validation sandbox for custom components that restricts dangerous operations and unsafe imports, improving security.

* **Tests**
  * Added comprehensive test coverage for code sandbox validation and safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->