### PR TITLE
fix: allow bool, int, float, and list types in root-level Tweaks values

### DIFF
--- a/src/backend/base/langflow/processing/process.py
+++ b/src/backend/base/langflow/processing/process.py
@@ -122,7 +122,7 @@ async def run_graph(
 
 
 def validate_input(
-    graph_data: dict[str, Any], tweaks: Tweaks | dict[str, str | dict[str, Any]]
+    graph_data: dict[str, Any], tweaks: Tweaks | dict[str, bool | int | float | str | list[Any] | dict[str, Any]]
 ) -> list[dict[str, Any]]:
     if not isinstance(graph_data, dict) or not isinstance(tweaks, dict):
         msg = "graph_data and tweaks should be dictionaries"
@@ -216,7 +216,7 @@ def process_tweaks(
     tweaks_dict = cast("dict[str, Any]", tweaks.model_dump()) if not isinstance(tweaks, dict) else tweaks
     if "stream" not in tweaks_dict:
         tweaks_dict |= {"stream": stream}
-    nodes = validate_input(graph_data, cast("dict[str, str | dict[str, Any]]", tweaks_dict))
+    nodes = validate_input(graph_data, cast("dict[str, bool | int | float | str | list[Any] | dict[str, Any]]", tweaks_dict))
     nodes_map = {node.get("id"): node for node in nodes}
     nodes_display_name_map = {node.get("data", {}).get("node", {}).get("display_name"): node for node in nodes}
 

--- a/src/backend/base/langflow/processing/process.py
+++ b/src/backend/base/langflow/processing/process.py
@@ -216,7 +216,9 @@ def process_tweaks(
     tweaks_dict = cast("dict[str, Any]", tweaks.model_dump()) if not isinstance(tweaks, dict) else tweaks
     if "stream" not in tweaks_dict:
         tweaks_dict |= {"stream": stream}
-    nodes = validate_input(graph_data, cast("dict[str, bool | int | float | str | list[Any] | dict[str, Any]]", tweaks_dict))
+    nodes = validate_input(
+        graph_data, cast("dict[str, bool | int | float | str | list[Any] | dict[str, Any]]", tweaks_dict)
+    )
     nodes_map = {node.get("id"): node for node in nodes}
     nodes_display_name_map = {node.get("data", {}).get("node", {}).get("display_name"): node for node in nodes}
 

--- a/src/lfx/src/lfx/processing/process.py
+++ b/src/lfx/src/lfx/processing/process.py
@@ -241,7 +241,9 @@ def process_tweaks(
     tweaks_dict = cast("dict[str, Any]", tweaks.model_dump()) if not isinstance(tweaks, dict) else tweaks
     if "stream" not in tweaks_dict:
         tweaks_dict |= {"stream": stream}
-    nodes = validate_input(graph_data, cast("dict[str, bool | int | float | str | list[Any] | dict[str, Any]]", tweaks_dict))
+    nodes = validate_input(
+        graph_data, cast("dict[str, bool | int | float | str | list[Any] | dict[str, Any]]", tweaks_dict)
+    )
     nodes_map = {node.get("id"): node for node in nodes}
     nodes_display_name_map = {node.get("data", {}).get("node", {}).get("display_name"): node for node in nodes}
 

--- a/src/lfx/src/lfx/processing/process.py
+++ b/src/lfx/src/lfx/processing/process.py
@@ -147,7 +147,7 @@ async def run_graph(
 
 
 def validate_input(
-    graph_data: dict[str, Any], tweaks: Tweaks | dict[str, str | dict[str, Any]]
+    graph_data: dict[str, Any], tweaks: Tweaks | dict[str, bool | int | float | str | list[Any] | dict[str, Any]]
 ) -> list[dict[str, Any]]:
     if not isinstance(graph_data, dict) or not isinstance(tweaks, dict):
         msg = "graph_data and tweaks should be dictionaries"
@@ -241,7 +241,7 @@ def process_tweaks(
     tweaks_dict = cast("dict[str, Any]", tweaks.model_dump()) if not isinstance(tweaks, dict) else tweaks
     if "stream" not in tweaks_dict:
         tweaks_dict |= {"stream": stream}
-    nodes = validate_input(graph_data, cast("dict[str, str | dict[str, Any]]", tweaks_dict))
+    nodes = validate_input(graph_data, cast("dict[str, bool | int | float | str | list[Any] | dict[str, Any]]", tweaks_dict))
     nodes_map = {node.get("id"): node for node in nodes}
     nodes_display_name_map = {node.get("data", {}).get("node", {}).get("display_name"): node for node in nodes}
 

--- a/src/lfx/src/lfx/schema/graph.py
+++ b/src/lfx/src/lfx/schema/graph.py
@@ -16,7 +16,7 @@ class InputValue(BaseModel):
 
 
 class Tweaks(RootModel):
-    root: dict[str, str | dict[str, Any]] = Field(
+    root: dict[str, bool | int | float | str | list[Any] | dict[str, Any]] = Field(
         description="A dictionary of tweaks to adjust the flow's execution. "
         "Allows customizing flow behavior dynamically. "
         "All tweaks are overridden by the input values.",


### PR DESCRIPTION
## Summary

- Widen the `Tweaks` RootModel type from `dict[str, str | dict[str, Any]]` to `dict[str, bool | int | float | str | list[Any] | dict[str, Any]]` so that root-level tweaks like `"stream": false` or `"temperature": 0.7` pass Pydantic validation
- Update matching type hints in `validate_input()` and `process_tweaks()` in both `lfx` and `backend` processing modules for consistency
- No behavioral change to the processing logic itself -- `process_tweaks()` already handles non-dict scalar values by broadcasting them to all nodes

## Motivation

The downstream `process_tweaks` function (lines 249-257 in `lfx/processing/process.py`) distinguishes between dict values (applied to a specific node) and non-dict values (broadcast to all nodes). This logic works correctly for booleans, numbers, and lists, but the `Tweaks` Pydantic model rejects them at the API validation layer before they ever reach the processing code.

This is a one-line type annotation fix (plus corresponding hint updates) that unblocks a valid and documented use case.

Fixes #12191
Relates to #11830

## Test plan

- [ ] Verify existing `test_process.py` tests still pass (no behavioral change)
- [ ] Send `{"tweaks": {"stream": false}}` to `/api/v1/run/<flow_id>` and confirm it no longer returns a validation error
- [ ] Send `{"tweaks": {"temperature": 0.7}}` and confirm it passes validation
- [ ] Verify node-specific dict tweaks (e.g., `{"node_id": {"param": "value"}}`) continue to work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for additional data types (boolean, integer, float, list) in flow configuration tweaks, expanding beyond previously supported types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->