### PR TITLE
fix(traces): use SQLEnum with values_callable for SpanStatus to fix PostgreSQL enum constraint violation

### DIFF
--- a/src/backend/base/langflow/services/database/models/traces/model.py
+++ b/src/backend/base/langflow/services/database/models/traces/model.py
@@ -6,7 +6,9 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
 from pydantic import Field as PydanticField
 from pydantic.alias_generators import to_camel
-from sqlmodel import JSON, Column, Field, Relationship, SQLModel, Text
+from sqlalchemy import Column
+from sqlalchemy import Enum as SQLEnum
+from sqlmodel import JSON, Field, Relationship, SQLModel, Text
 
 from langflow.serialization.serialization import serialize
 
@@ -60,7 +62,14 @@ class TraceBase(SQLModel):
     """Base model for traces."""
 
     name: str = Field(nullable=False, description="Name of the trace (usually flow name)")
-    status: SpanStatus = Field(default=SpanStatus.UNSET, description="Overall trace status")
+    status: SpanStatus = Field(
+        default=SpanStatus.UNSET,
+        description="Overall trace status",
+        sa_column=Column(
+            SQLEnum(SpanStatus, name="spanstatus", values_callable=lambda obj: [item.value for item in obj]),
+            nullable=False,
+        ),
+    )
     start_time: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         description="When the trace started",
@@ -204,7 +213,14 @@ class SpanBase(SQLModel):
 
     name: str = Field(nullable=False, description="Name of the span following OTel convention: '{operation} {model}'")
     span_type: SpanType = Field(default=SpanType.CHAIN, description="Type of operation")
-    status: SpanStatus = Field(default=SpanStatus.UNSET, description="Execution status")
+    status: SpanStatus = Field(
+        default=SpanStatus.UNSET,
+        description="Execution status",
+        sa_column=Column(
+            SQLEnum(SpanStatus, name="spanstatus", values_callable=lambda obj: [item.value for item in obj]),
+            nullable=False,
+        ),
+    )
     start_time: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         description="When the span started",


### PR DESCRIPTION
## Bug Description

When using PostgreSQL, the trace feature throws a \"psycopg.errors.InvalidTextRepresentation\" error when trying to insert records into the \"trace\" table. The error indicates that the value \"OK\" or \"ERROR\" for the \"status\" field is invalid for the \"spanstatus\" enum type.

## Root Cause

The PostgreSQL \"spanstatus\" enum (created in migration \"3478f0bd6ccb\") is defined with lowercase values:
- \"unset\"
- \"ok\"
- \"error\"

However, SQLModel was inserting uppercase enum names (\"OK\", \"ERROR\") instead of the lowercase values, causing the constraint violation.

## Fix

Added \"sa_column\" configuration with \"SQLEnum\" and \"values_callable\" to both \"TraceBase\" and \"SpanBase\" status fields. This ensures SQLAlchemy uses the enum values (lowercase) instead of enum names (uppercase) when inserting into PostgreSQL.

This follows the same pattern already used in \"jobs/model.py\" for the \"JobStatus\" enum.

## Changes

- Import \"Column\" and \"SQLEnum\" from SQLAlchemy
- Update \"TraceBase.status\" field with proper enum configuration
- Update \"SpanBase.status\" field with proper enum configuration

Fixes #12194

---

**Note:** This contribution was made by [ClawOSS](https://github.com/billion-token-one-task/ClawOSS), an autonomous codebase helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced database-level validation for trace and span status values, ensuring consistent data integrity and preventing invalid status entries from being stored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->