### PR TITLE
fix: Resolve CodeQL false positives for path injection and URL substring sanitization                                                     

### DIFF
--- a/src/backend/base/langflow/agentic/services/helpers/flow_loader.py
+++ b/src/backend/base/langflow/agentic/services/helpers/flow_loader.py
@@ -77,6 +77,11 @@ def resolve_flow_path(flow_filename: str) -> tuple[Path, str]:
     Raises:
         HTTPException: If flow file not found or path traversal detected.
     """
+    # Early rejection of path traversal sequences before any path construction.
+    # This complements _validate_path_within_base as defense-in-depth.
+    if ".." in flow_filename or "\\" in flow_filename:
+        raise HTTPException(status_code=400, detail=f"Invalid flow filename: '{flow_filename}'")
+
     if flow_filename.endswith(".json"):
         flow_path = _validate_path_within_base(FLOWS_BASE_PATH / flow_filename, flow_filename)
         if flow_path.exists():

--- a/src/backend/tests/unit/agentic/flows/test_langflow_assistant.py
+++ b/src/backend/tests/unit/agentic/flows/test_langflow_assistant.py
@@ -259,7 +259,9 @@ class TestAssistantPrompt:
     def test_should_contain_langflow_references(self):
         """Should contain Langflow documentation references."""
         assert "langflow" in ASSISTANT_PROMPT.lower()
-        assert "docs.langflow.org" in ASSISTANT_PROMPT
+        # Use full URL with scheme to avoid CodeQL py/incomplete-url-substring-sanitization
+        # This is not URL validation — it verifies the static prompt contains doc references
+        assert "https://docs.langflow.org/" in ASSISTANT_PROMPT
 
     def test_should_contain_code_requirements(self):
         """Should contain code requirements for components."""

--- a/src/backend/tests/unit/agentic/services/helpers/test_flow_loader.py
+++ b/src/backend/tests/unit/agentic/services/helpers/test_flow_loader.py
@@ -149,6 +149,24 @@ class TestResolveFlowPath:
             assert result_type == "json"
             assert result_path == json_file.resolve()
 
+    def test_should_reject_filename_with_path_traversal_sequences(self, tmp_path):
+        """Should reject filenames containing '..' before any path construction."""
+        with patch("langflow.agentic.services.helpers.flow_loader.FLOWS_BASE_PATH", tmp_path):
+            with pytest.raises(HTTPException) as exc_info:
+                resolve_flow_path("../../etc/passwd")
+
+            assert exc_info.value.status_code == 400
+            assert "Invalid flow filename" in exc_info.value.detail
+
+    def test_should_reject_filename_with_backslash_traversal(self, tmp_path):
+        """Should reject filenames containing backslash path separators."""
+        with patch("langflow.agentic.services.helpers.flow_loader.FLOWS_BASE_PATH", tmp_path):
+            with pytest.raises(HTTPException) as exc_info:
+                resolve_flow_path("..\\..\\etc\\passwd")
+
+            assert exc_info.value.status_code == 400
+            assert "Invalid flow filename" in exc_info.value.detail
+
     def test_should_raise_404_when_flow_not_found(self, tmp_path):
         """Should raise HTTPException 404 when flow file doesn't exist."""
         with patch("langflow.agentic.services.helpers.flow_loader.FLOWS_BASE_PATH", tmp_path):


### PR DESCRIPTION
Objective
Address CodeQL security scanning warnings for incomplete URL substring sanitization and uncontrolled path expression in agentic services.

Changes
  - Add early path traversal rejection (.. and \\) in resolve_flow_path as defense-in-depth before path construction
  - Update test_langflow_assistant.py assertion to use full URL with scheme (https://docs.langflow.org/) instead of bare domain substring