### PR TITLE
feat(ui): Add custom build error message transform hook

### DIFF
--- a/src/frontend/src/customization/utils/custom-build-error-transform.ts
+++ b/src/frontend/src/customization/utils/custom-build-error-transform.ts
@@ -1,0 +1,8 @@
+/**
+ * Transforms build error messages before displaying to the user.
+ * Override this in desktop/custom builds to replace OSS-specific
+ * messages with platform-appropriate instructions.
+ */
+export function transformBuildErrorMessages(messages: string[]): string[] {
+  return messages;
+}

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -16,6 +16,7 @@ import {
 } from "@/customization/utils/custom-buildUtils";
 import { customPollBuildEvents } from "@/customization/utils/custom-poll-build-events";
 import { getFetchCredentials } from "@/customization/utils/get-fetch-credentials";
+import { transformBuildErrorMessages } from "@/customization/utils/custom-build-error-transform";
 import { BuildStatus, EventDeliveryType } from "../constants/enums";
 import { getVerticesOrder, postBuildVertex } from "../controllers/API";
 import useAlertStore from "../stores/alertStore";
@@ -470,9 +471,11 @@ export function processEndVertexEvent(
         },
       );
       onBuildError &&
-        onBuildError("Error Building Component", errorMessages, [
-          { id: buildData.id },
-        ]);
+        onBuildError(
+          "Error Building Component",
+          transformBuildErrorMessages(errorMessages),
+          [{ id: buildData.id }],
+        );
       onBuildUpdate(buildData, BuildStatus.ERROR, "");
       buildResults.push(false);
       return false;
@@ -958,7 +961,7 @@ async function buildVertex({
         });
         onBuildError!(
           "Error Building Component",
-          errorMessages,
+          transformBuildErrorMessages(errorMessages.flat()),
           verticesIds.map((id) => ({ id })),
         );
         stopBuild();
@@ -980,7 +983,7 @@ async function buildVertex({
     }
     onBuildError!(
       "Error Building Component",
-      errorMessage,
+      transformBuildErrorMessages(errorMessage),
       verticesIds.map((id) => ({ id })),
     );
     buildResults.push(false);


### PR DESCRIPTION
OBJECTIVE: Allow desktop/custom builds to override build error messages with platform-appropriate instructions.

CHANGES:
  - Add transformBuildErrorMessages utility in customization layer
  - Integrate error message transform into buildUtils pipeline