### PR TITLE
fix: NameError in kubernetes.py exception handler when variables list is empty

### DIFF
--- a/src/backend/base/langflow/services/variable/kubernetes.py
+++ b/src/backend/base/langflow/services/variable/kubernetes.py
@@ -52,7 +52,7 @@ class KubernetesSecretService(VariableService, Service):
                     data=variables,
                 )
             except Exception:  # noqa: BLE001
-                logger.exception(f"Error creating {var} variable")
+                logger.exception("Error creating Kubernetes secret for user variables")
 
         else:
             logger.info("Skipping environment variable storage.")


### PR DESCRIPTION
## Summary

- Fix potential `NameError` in `KubernetesSecretService.initialize_user_variables` where the exception handler references loop variable `var` outside the `for` loop scope

## Problem

In `kubernetes.py` line 55, the `except` block uses `f"Error creating {var} variable"`, but the `try/except` is **outside** the `for var in ...` loop. If `variables_to_get_from_environment` is an empty list:

1. The `for` loop never executes, so `var` is never assigned
2. The `try` block runs `encode_user_id()` and `create_secret()` 
3. If either raises an exception, the `except` handler triggers
4. `f"Error creating {var} variable"` raises a secondary `NameError: name 'var' is not defined`
5. The original exception is masked

```python
for var in self.settings_service.settings.variables_to_get_from_environment:
    ...  # var is only defined if this loop executes

try:
    secret_name = encode_user_id(user_id)
    await asyncio.to_thread(self.kubernetes_secrets.create_secret, ...)
except Exception:  # noqa: BLE001
    logger.exception(f"Error creating {var} variable")  # NameError if loop was empty
```

## Fix

Replace the variable-specific error message with one that accurately describes the failing operation (creating a Kubernetes secret), which doesn't depend on the loop variable:

```python
logger.exception("Error creating Kubernetes secret for user variables")
```

## Test plan

- [ ] Verify with empty `variables_to_get_from_environment` list
- [ ] Verify existing tests pass
- [ ] Confirm error logging still works correctly when secrets creation fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated error logging for Kubernetes secret creation failures to provide more consistent messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->