### PR TITLE
fix: nightly now properly gets 1.9.0 branch

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -60,6 +60,7 @@ jobs:
           git ls-remote --heads https://github.com/${{ github.repository }} 'refs/heads/release-*' \
           | awk '{print $2}' \
           | sed 's|refs/heads/||' \
+          | grep -E '^release-[0-9]+\.[0-9]+\.[0-9]+$' \
           | sort -V \
           | tail -n 1 > branch.txt
 
@@ -90,6 +91,8 @@ jobs:
         with:
           ref: ${{ needs.resolve-release-branch.outputs.branch }}
           persist-credentials: true
+      - name: Confirm branch
+        run: git branch --show-current
       - name: "Setup Environment"
         uses: astral-sh/setup-uv@v6
         with:
@@ -99,7 +102,10 @@ jobs:
           prune-cache: false
       - name: Install the project
         run: uv sync
-
+      - name: Check script location
+        run: |
+          echo "PWD: $(pwd)"
+          find . -name "pypi_nightly_tag.py"
       - name: Generate main nightly tag
         id: generate_release_tag
         run: |

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -153,7 +153,7 @@
         "filename": ".github/workflows/nightly_build.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 257,
+        "line_number": 263,
         "is_secret": false
       }
     ],
@@ -5674,5 +5674,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-16T13:08:35Z"
+  "generated_at": "2026-03-17T14:09:34Z"
 }


### PR DESCRIPTION
before it was attempting to pull release-notes as letters are alphanumerically after numbers when we sort -V then grab tail now we only look at branch names that follow the pattern '^release-[0-9]+\.[0-9]+\.[0-9]+$'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved nightly build workflow stability with enhanced branch validation and script verification checks.
  * Updated security baseline configuration for build infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->