### PR TITLE
fix: enforce ownership check on message delete endpoints

### DIFF
--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -215,7 +215,8 @@ async def delete_messages_session(
 
     if owned_ids != all_ids:
         raise HTTPException(
-            status_code=403, detail="You don't have permission to delete one or more messages in this session"
+            status_code=403,
+            detail="You don't have permission to delete one or more messages in this session",
         )
 
     try:

--- a/src/backend/tests/unit/test_messages_endpoints.py
+++ b/src/backend/tests/unit/test_messages_endpoints.py
@@ -294,7 +294,7 @@ async def other_user(client):  # noqa: ARG001
             db_user = await session.get(User, user.id)
             if db_user:
                 await session.delete(db_user)
-    except Exception:
+    except Exception:  # noqa: S110
         pass
 
 


### PR DESCRIPTION
## Summary                                                                                                                   
                                                                                                                               
  - Add ownership validation to `DELETE /monitor/messages` and `DELETE /monitor/messages/session/{session_id}`                 
  - Both endpoints now return `403` if any message in the request does not belong to the authenticated user                    
  - Fix `delete_messages_session` returning a response body with status 204 (invalid per HTTP spec)                            
                                                                                                                               
  ## Changes

  - `src/backend/base/langflow/api/v1/monitor.py`: inject `current_user` into both delete endpoints and verify ownership before
   executing the delete
  - `src/backend/tests/unit/test_messages_endpoints.py`: add ownership tests covering:
    - User trying to delete another user's messages → 403
    - User sending a mixed list (own + foreign IDs) → 403, nothing deleted
    - User trying to delete another user's session → 403, messages remain intact

  ## How to test

  **Setup:**
  ```bash
  cd src/backend
  uv run pytest tests/unit/test_messages_endpoints.py -v -k "cannot_delete or mixed_ownership"

  Manual test:

  1. Create two users (user A and user B)
  2. Create a flow and messages as user B
  3. Authenticate as user A and call:
  DELETE /api/v1/monitor/messages
  Body: [<id of user B's message>]
  4. Expect 403 Forbidden
  5. Repeat for DELETE /api/v1/monitor/messages/session/{session_id} with user B's session
  6. Expect 403 Forbidden
  7. Confirm user B's messages still exist via GET /api/v1/monitor/messages
