### PR TITLE
feat(tracing): Support sending traces to a generic OTLP trace endpoint

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -464,7 +464,7 @@
                   },
                   {
                     "name": "OpenDsStar",
-                    "version": "1.0.26"
+                    "version": null
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -464,7 +464,7 @@
                   },
                   {
                     "name": "OpenDsStar",
-                    "version": null
+                    "version": "1.0.26"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -288,7 +288,7 @@ class ArizePhoenixTracer(OTLPTracerBase):
         metadata: dict[str, Any] | None = None,
         vertex: Vertex | None = None,
     ) -> None:
-        if not self._ready:
+        if not self._ready or self.tracer is None:
             return
 
         span_context = self.propagator.extract(carrier=self.carrier)

--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
-import json
-import math
 import os
 import threading
 import traceback
-import types
 import uuid
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
-from langchain_core.documents import Document
-from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from lfx.log.logger import logger
-from lfx.schema.data import Data
 from openinference.semconv.trace import OpenInferenceMimeTypeValues, SpanAttributes
 from opentelemetry.sdk.trace.export import SpanProcessor
 from opentelemetry.semconv.trace import SpanAttributes as OTELSpanAttributes
@@ -21,8 +14,7 @@ from opentelemetry.trace import Span, Status, StatusCode, use_span
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from typing_extensions import override
 
-from langflow.schema.message import Message
-from langflow.services.tracing.base import BaseTracer
+from langflow.services.tracing.otlp_base import OTLPTracerBase
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -30,7 +22,6 @@ if TYPE_CHECKING:
 
     from langchain_core.callbacks.base import BaseCallbackHandler
     from lfx.graph.vertex.base import Vertex
-    from opentelemetry.propagators.textmap import CarrierT
     from opentelemetry.util.types import AttributeValue
 
     from langflow.services.tracing.schema import Log
@@ -64,7 +55,7 @@ class CollectingSpanProcessor(SpanProcessor):
         pass
 
 
-class ArizePhoenixTracer(BaseTracer):
+class ArizePhoenixTracer(OTLPTracerBase):
     flow_name: str
     flow_id: str
     chat_input_value: str
@@ -74,6 +65,7 @@ class ArizePhoenixTracer(BaseTracer):
         self, trace_name: str, trace_type: str, project_name: str, trace_id: UUID, session_id: str | None = None
     ):
         """Initializes the ArizePhoenixTracer instance and sets up a root span."""
+        super().__init__()
         self.trace_name = trace_name
         self.trace_type = trace_type
         self.project_name = project_name
@@ -91,7 +83,7 @@ class ArizePhoenixTracer(BaseTracer):
 
             self.tracer = self.tracer_provider.get_tracer(__name__)
             self.propagator = TraceContextTextMapPropagator()
-            self.carrier: dict[Any, CarrierT] = {}
+            self.carrier = {}
 
             self.root_span = self.tracer.start_span(
                 name="Langflow",
@@ -110,16 +102,9 @@ class ArizePhoenixTracer(BaseTracer):
             with use_span(self.root_span, end_on_exit=False):
                 self.propagator.inject(carrier=self.carrier)
 
-            self.child_spans: dict[str, Span] = {}
-
         except Exception as e:  # noqa: BLE001
             logger.error("[Arize/Phoenix] Error Setting Up Tracer: %s", str(e), exc_info=True)
             self._ready = False
-
-    @property
-    def ready(self):
-        """Indicates if the tracer is ready for usage."""
-        return self._ready
 
     def setup_arize_phoenix(self) -> bool:
         """Configures Arize/Phoenix specific environment variables and registers the tracer provider."""
@@ -249,12 +234,12 @@ class ArizePhoenixTracer(BaseTracer):
         else:
             child_span.set_attribute(SpanAttributes.OPENINFERENCE_SPAN_KIND, trace_type)
 
-        processed_inputs = self._convert_to_arize_phoenix_types(inputs) if inputs else {}
+        processed_inputs = self._convert_to_otlp_dict(inputs) if inputs else {}
         if processed_inputs:
             child_span.set_attribute(SpanAttributes.INPUT_VALUE, self._safe_json_dumps(processed_inputs))
             child_span.set_attribute(SpanAttributes.INPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value)
 
-        processed_metadata = self._convert_to_arize_phoenix_types(metadata) if metadata else {}
+        processed_metadata = self._convert_to_otlp_dict(metadata) if metadata else {}
         if processed_metadata:
             for key, value in processed_metadata.items():
                 child_span.set_attribute(f"{SpanAttributes.METADATA}.{key}", value)
@@ -285,15 +270,13 @@ class ArizePhoenixTracer(BaseTracer):
 
         child_span = self.child_spans[trace_id]
 
-        processed_outputs = self._convert_to_arize_phoenix_types(outputs) if outputs else {}
+        processed_outputs = self._convert_to_otlp_dict(outputs) if outputs else {}
         if processed_outputs:
             child_span.set_attribute(SpanAttributes.OUTPUT_VALUE, self._safe_json_dumps(processed_outputs))
             child_span.set_attribute(SpanAttributes.OUTPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value)
 
         logs_dicts = [log if isinstance(log, dict) else log.model_dump() for log in logs]
-        processed_logs = (
-            self._convert_to_arize_phoenix_types({log.get("name"): log for log in logs_dicts}) if logs else {}
-        )
+        processed_logs = self._convert_to_otlp_dict({log.get("name"): log for log in logs_dicts}) if logs else {}
         if processed_logs:
             child_span.set_attribute("logs", self._safe_json_dumps(processed_logs))
 
@@ -319,7 +302,7 @@ class ArizePhoenixTracer(BaseTracer):
             self.root_span.set_attribute(SpanAttributes.OUTPUT_VALUE, self.chat_output_value)
             self.root_span.set_attribute(SpanAttributes.OUTPUT_MIME_TYPE, OpenInferenceMimeTypeValues.TEXT.value)
 
-            processed_metadata = self._convert_to_arize_phoenix_types(metadata) if metadata else {}
+            processed_metadata = self._convert_to_otlp_dict(metadata) if metadata else {}
             if processed_metadata:
                 for key, value in processed_metadata.items():
                     self.root_span.set_attribute(f"{SpanAttributes.METADATA}.{key}", value)
@@ -340,41 +323,6 @@ class ArizePhoenixTracer(BaseTracer):
 
         get_http_instrumentation_manager().disable()
 
-    def _convert_to_arize_phoenix_types(self, io_dict: dict[str | Any, Any]) -> dict[str, Any]:
-        """Converts data types to Arize/Phoenix compatible formats."""
-        return {
-            str(key): self._convert_to_arize_phoenix_type(value) for key, value in io_dict.items() if key is not None
-        }
-
-    def _convert_to_arize_phoenix_type(self, value):
-        """Recursively converts a value to a Arize/Phoenix compatible type."""
-        if isinstance(value, dict):
-            value = {key: self._convert_to_arize_phoenix_type(val) for key, val in value.items()}
-
-        elif isinstance(value, list):
-            value = [self._convert_to_arize_phoenix_type(v) for v in value]
-
-        elif isinstance(value, Message):
-            value = value.text
-
-        elif isinstance(value, Data):
-            data = value.data
-            value = self._convert_to_arize_phoenix_type(data) if isinstance(data, (dict, list)) else value.get_text()
-
-        elif isinstance(value, (BaseMessage | HumanMessage | SystemMessage)):
-            value = value.content
-
-        elif isinstance(value, Document):
-            value = value.page_content
-
-        elif isinstance(value, (types.GeneratorType, type(None))):
-            value = str(value)
-
-        elif isinstance(value, float) and not math.isfinite(value):
-            value = "NaN"
-
-        return value
-
     @staticmethod
     def _error_to_string(error: Exception | None):
         """Converts an error to a string with traceback details."""
@@ -383,16 +331,6 @@ class ArizePhoenixTracer(BaseTracer):
             string_stacktrace = traceback.format_exception(error)
             error_message = f"{error.__class__.__name__}: {error}\n\n{string_stacktrace}"
         return error_message
-
-    @staticmethod
-    def _get_current_timestamp() -> int:
-        """Gets the current UTC timestamp in nanoseconds."""
-        return int(datetime.now(timezone.utc).timestamp() * 1_000_000_000)
-
-    @staticmethod
-    def _safe_json_dumps(obj: Any, **kwargs: Any) -> str:
-        """A convenience wrapper around `json.dumps` that ensures that any object can be safely encoded."""
-        return json.dumps(obj, default=str, ensure_ascii=False, **kwargs)
 
     def _set_span_status(self, current_span: Span, error: Exception | None = None):
         """Sets the status and attributes of the current span based on the presence of an error."""
@@ -430,7 +368,3 @@ class ArizePhoenixTracer(BaseTracer):
                 self.tracer_provider.force_flush(timeout_millis=3000)
         except (ValueError, RuntimeError, OSError) as e:
             logger.error("[Arize/Phoenix] Error Flushing Spans: %s", str(e), exc_info=True)
-
-    def __del__(self):
-        """Ensure tracer provider flushes on object destruction."""
-        self.close()

--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 
 from lfx.log.logger import logger
 from openinference.semconv.trace import OpenInferenceMimeTypeValues, SpanAttributes
-from opentelemetry.sdk.trace.export import SpanProcessor
 from opentelemetry.semconv.trace import SpanAttributes as OTELSpanAttributes
 from opentelemetry.trace import Span, Status, StatusCode, use_span
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
@@ -27,35 +26,204 @@ if TYPE_CHECKING:
     from langflow.services.tracing.schema import Log
 
 
-class CollectingSpanProcessor(SpanProcessor):
-    def __init__(self):
-        self.correlation_id = None
-        self._lock = threading.Lock()
+# ---------------------------------------------------------------------------
+# Module-level shared provider singleton
+# ---------------------------------------------------------------------------
 
-    def on_start(self, span, parent_context=None):
-        # Silence unused variable warnings
-        _ = parent_context
+_arize_lock = threading.Lock()
+_shared_provider = None
+_shared_tracer = None
+_instrumentor_applied = False
 
-        # Generate the correlation ID once (thread-safe)
-        with self._lock:
-            if self.correlation_id is None:
-                self.correlation_id = str(uuid.uuid4())
 
-        # Inject into the CHAIN & LLM spans
-        if span.name in ("Langflow", "Language Model"):
-            span.set_attribute("langflow.correlation_id", self.correlation_id)
+def _get_arize_shared_provider(flow_name: str, project_name: str):
+    """Return the shared Arize/Phoenix TracerProvider and Tracer.
 
-    def on_end(self, span):
-        pass
+    Created on first call and reused for all subsequent graph runs to
+    avoid per-run BatchSpanProcessor thread accumulation.
 
-    def shutdown(self):
-        pass
+    Args:
+        flow_name: Flow name (used for project naming on first init only).
+        project_name: Langflow project name.
 
-    def force_flush(self, timeout_millis=30000):
-        pass
+    Returns:
+        Tuple of (TracerProvider, Tracer) or (None, None) if not configured.
+    """
+    global _shared_provider, _shared_tracer, _instrumentor_applied  # noqa: PLW0603
+
+    if _shared_tracer is not None:
+        return _shared_provider, _shared_tracer
+
+    with _arize_lock:
+        if _shared_tracer is not None:
+            return _shared_provider, _shared_tracer
+
+        provider = _create_arize_provider(flow_name, project_name)
+        if provider is None:
+            return None, None
+
+        _shared_provider = provider
+        _shared_tracer = provider.get_tracer(__name__)
+
+        # Instrument LangChain once with the shared provider
+        if not _instrumentor_applied:
+            try:
+                from openinference.instrumentation.langchain import LangChainInstrumentor
+
+                LangChainInstrumentor().instrument(tracer_provider=_shared_provider, skip_dep_check=True)
+                _instrumentor_applied = True
+            except ImportError:
+                logger.exception(
+                    "[Arize/Phoenix] Could not import LangChainInstrumentor."
+                    "Please install it with `pip install openinference-instrumentation-langchain`."
+                )
+                _shared_provider = None
+                _shared_tracer = None
+                return None, None
+
+        return _shared_provider, _shared_tracer
+
+
+def _create_arize_provider(flow_name: str, project_name: str):
+    """Create the TracerProvider with Arize and/or Phoenix exporters.
+
+    Returns:
+        TracerProvider or None if tracing is not configured.
+    """
+    arize_phoenix_batch = os.getenv("ARIZE_PHOENIX_BATCH", "False").lower() in {
+        "true",
+        "t",
+        "yes",
+        "y",
+        "1",
+    }
+
+    # Arize Config
+    arize_api_key = os.getenv("ARIZE_API_KEY", None)
+    arize_space_id = os.getenv("ARIZE_SPACE_ID", None)
+    arize_collector_endpoint = os.getenv("ARIZE_COLLECTOR_ENDPOINT", "https://otlp.arize.com")
+    enable_arize_tracing = bool(arize_api_key and arize_space_id)
+    arize_endpoint = f"{arize_collector_endpoint}/v1"
+    arize_headers = {
+        "api_key": arize_api_key,
+        "space_id": arize_space_id,
+        "authorization": f"Bearer {arize_api_key}",
+    }
+
+    # Phoenix Config
+    phoenix_api_key = os.getenv("PHOENIX_API_KEY", None)
+    phoenix_collector_endpoint = os.getenv("PHOENIX_COLLECTOR_ENDPOINT", "https://app.phoenix.arize.com")
+    phoenix_auth_disabled = "localhost" in phoenix_collector_endpoint or "127.0.0.1" in phoenix_collector_endpoint
+    enable_phoenix_tracing = bool(phoenix_api_key) or phoenix_auth_disabled
+    phoenix_endpoint = f"{phoenix_collector_endpoint}/v1/traces"
+    phoenix_headers = (
+        {
+            "api_key": phoenix_api_key,
+            "authorization": f"Bearer {phoenix_api_key}",
+        }
+        if phoenix_api_key
+        else {}
+    )
+
+    if not (enable_arize_tracing or enable_phoenix_tracing):
+        return None
+
+    try:
+        from phoenix.otel import (
+            PROJECT_NAME,
+            BatchSpanProcessor,
+            GRPCSpanExporter,
+            HTTPSpanExporter,
+            Resource,
+            SimpleSpanProcessor,
+            TracerProvider,
+        )
+
+        name_without_space = flow_name.replace(" ", "-")
+        resolved_project = project_name if name_without_space == "None" else name_without_space
+        attributes = {PROJECT_NAME: resolved_project, "model_id": resolved_project}
+        resource = Resource.create(attributes=attributes)
+        provider = TracerProvider(resource=resource, verbose=False)
+        span_processor = BatchSpanProcessor if arize_phoenix_batch else SimpleSpanProcessor
+
+        if enable_arize_tracing:
+            provider.add_span_processor(
+                span_processor=span_processor(
+                    span_exporter=GRPCSpanExporter(endpoint=arize_endpoint, headers=arize_headers),
+                )
+            )
+
+        if enable_phoenix_tracing:
+            provider.add_span_processor(
+                span_processor=span_processor(
+                    span_exporter=HTTPSpanExporter(
+                        endpoint=phoenix_endpoint,
+                        headers=phoenix_headers,
+                    ),
+                )
+            )
+
+    except ImportError:
+        logger.exception(
+            "[Arize/Phoenix] Could not import Arize Phoenix OTEL packages."
+            "Please install it with `pip install arize-phoenix-otel`."
+        )
+        return None
+
+    return provider
+
+
+def shutdown_arize_provider() -> None:
+    """Shutdown the shared Arize/Phoenix TracerProvider, flushing pending spans.
+
+    Safe to call multiple times or when no provider has been created.
+    Should be called at process/service shutdown.
+    """
+    global _shared_provider, _shared_tracer, _instrumentor_applied  # noqa: PLW0603
+
+    with _arize_lock:
+        if _instrumentor_applied:
+            try:
+                from openinference.instrumentation.langchain import LangChainInstrumentor
+
+                LangChainInstrumentor().uninstrument(skip_dep_check=True)
+            except Exception:  # noqa: BLE001
+                logger.debug("[Arize/Phoenix] Error uninstrumenting LangChain", exc_info=True)
+            _instrumentor_applied = False
+
+        if _shared_provider is not None:
+            try:
+                _shared_provider.shutdown()
+            except (ValueError, RuntimeError, OSError) as e:
+                logger.warning(f"[Arize/Phoenix] Error shutting down tracer provider: {e}")
+            finally:
+                _shared_provider = None
+                _shared_tracer = None
+
+
+def _reset_arize_provider() -> None:
+    """Reset the shared provider without calling shutdown. For tests only."""
+    global _shared_provider, _shared_tracer, _instrumentor_applied  # noqa: PLW0603
+
+    with _arize_lock:
+        _shared_provider = None
+        _shared_tracer = None
+        _instrumentor_applied = False
+
+
+# ---------------------------------------------------------------------------
+# Per-run tracer
+# ---------------------------------------------------------------------------
 
 
 class ArizePhoenixTracer(OTLPTracerBase):
+    """Arize/Phoenix tracer using OpenTelemetry.
+
+    The TracerProvider and span processors are shared across all graph runs
+    to avoid per-run thread accumulation. Each ArizePhoenixTracer instance
+    creates only its own root span and child spans.
+    """
+
     flow_name: str
     flow_id: str
     chat_input_value: str
@@ -64,7 +232,6 @@ class ArizePhoenixTracer(OTLPTracerBase):
     def __init__(
         self, trace_name: str, trace_type: str, project_name: str, trace_id: UUID, session_id: str | None = None
     ):
-        """Initializes the ArizePhoenixTracer instance and sets up a root span."""
         super().__init__()
         self.trace_name = trace_name
         self.trace_type = trace_type
@@ -77,11 +244,12 @@ class ArizePhoenixTracer(OTLPTracerBase):
         self.chat_output_value = ""
 
         try:
-            self._ready = self.setup_arize_phoenix()
-            if not self._ready:
+            provider, tracer = _get_arize_shared_provider(self.flow_name, self.project_name)
+            if provider is None or tracer is None:
+                self._ready = False
                 return
 
-            self.tracer = self.tracer_provider.get_tracer(__name__)
+            self.tracer = tracer
             self.propagator = TraceContextTextMapPropagator()
             self.carrier = {}
 
@@ -89,6 +257,8 @@ class ArizePhoenixTracer(OTLPTracerBase):
                 name="Langflow",
                 start_time=self._get_current_timestamp(),
             )
+            # Per-run correlation ID set directly on root span
+            self.root_span.set_attribute("langflow.correlation_id", str(uuid.uuid4()))
             self.root_span.set_attribute(SpanAttributes.SESSION_ID, self.session_id or self.flow_id)
             self.root_span.set_attribute(SpanAttributes.OPENINFERENCE_SPAN_KIND, self.trace_type)
             self.root_span.set_attribute("langflow.trace_name", self.trace_name)
@@ -102,111 +272,11 @@ class ArizePhoenixTracer(OTLPTracerBase):
             with use_span(self.root_span, end_on_exit=False):
                 self.propagator.inject(carrier=self.carrier)
 
+            self._ready = True
+
         except Exception as e:  # noqa: BLE001
             logger.error("[Arize/Phoenix] Error Setting Up Tracer: %s", str(e), exc_info=True)
             self._ready = False
-
-    def setup_arize_phoenix(self) -> bool:
-        """Configures Arize/Phoenix specific environment variables and registers the tracer provider."""
-        arize_phoenix_batch = os.getenv("ARIZE_PHOENIX_BATCH", "False").lower() in {
-            "true",
-            "t",
-            "yes",
-            "y",
-            "1",
-        }
-
-        # Arize Config
-        arize_api_key = os.getenv("ARIZE_API_KEY", None)
-        arize_space_id = os.getenv("ARIZE_SPACE_ID", None)
-        arize_collector_endpoint = os.getenv("ARIZE_COLLECTOR_ENDPOINT", "https://otlp.arize.com")
-        enable_arize_tracing = bool(arize_api_key and arize_space_id)
-        arize_endpoint = f"{arize_collector_endpoint}/v1"
-        arize_headers = {
-            "api_key": arize_api_key,
-            "space_id": arize_space_id,
-            "authorization": f"Bearer {arize_api_key}",
-        }
-
-        # Phoenix Config
-        phoenix_api_key = os.getenv("PHOENIX_API_KEY", None)
-        phoenix_collector_endpoint = os.getenv("PHOENIX_COLLECTOR_ENDPOINT", "https://app.phoenix.arize.com")
-        phoenix_auth_disabled = "localhost" in phoenix_collector_endpoint or "127.0.0.1" in phoenix_collector_endpoint
-        enable_phoenix_tracing = bool(phoenix_api_key) or phoenix_auth_disabled
-        phoenix_endpoint = f"{phoenix_collector_endpoint}/v1/traces"
-        phoenix_headers = (
-            {
-                "api_key": phoenix_api_key,
-                "authorization": f"Bearer {phoenix_api_key}",
-            }
-            if phoenix_api_key
-            else {}
-        )
-
-        if not (enable_arize_tracing or enable_phoenix_tracing):
-            return False
-
-        try:
-            from phoenix.otel import (
-                PROJECT_NAME,
-                BatchSpanProcessor,
-                GRPCSpanExporter,
-                HTTPSpanExporter,
-                Resource,
-                SimpleSpanProcessor,
-                TracerProvider,
-            )
-
-            name_without_space = self.flow_name.replace(" ", "-")
-            project_name = self.project_name if name_without_space == "None" else name_without_space
-            attributes = {PROJECT_NAME: project_name, "model_id": project_name}
-            resource = Resource.create(attributes=attributes)
-            tracer_provider = TracerProvider(resource=resource, verbose=False)
-            span_processor = BatchSpanProcessor if arize_phoenix_batch else SimpleSpanProcessor
-
-            if enable_arize_tracing:
-                tracer_provider.add_span_processor(
-                    span_processor=span_processor(
-                        span_exporter=GRPCSpanExporter(endpoint=arize_endpoint, headers=arize_headers),
-                    )
-                )
-
-            if enable_phoenix_tracing:
-                tracer_provider.add_span_processor(
-                    span_processor=span_processor(
-                        span_exporter=HTTPSpanExporter(
-                            endpoint=phoenix_endpoint,
-                            headers=phoenix_headers,
-                        ),
-                    )
-                )
-
-            tracer_provider.add_span_processor(CollectingSpanProcessor())
-            self.tracer_provider = tracer_provider
-        except ImportError:
-            logger.exception(
-                "[Arize/Phoenix] Could not import Arize Phoenix OTEL packages."
-                "Please install it with `pip install arize-phoenix-otel`."
-            )
-            return False
-
-        try:
-            from openinference.instrumentation.langchain import LangChainInstrumentor
-
-            LangChainInstrumentor().instrument(tracer_provider=self.tracer_provider, skip_dep_check=True)
-        except ImportError:
-            logger.exception(
-                "[Arize/Phoenix] Could not import LangChainInstrumentor."
-                "Please install it with `pip install openinference-instrumentation-langchain`."
-            )
-            return False
-
-        # Instrument HTTP clients to propagate W3C TraceContext on outgoing requests
-        from langflow.services.tracing.http_instrumentation import get_http_instrumentation_manager
-
-        get_http_instrumentation_manager().enable(self.tracer_provider)
-
-        return True
 
     @override
     def add_trace(
@@ -218,7 +288,6 @@ class ArizePhoenixTracer(OTLPTracerBase):
         metadata: dict[str, Any] | None = None,
         vertex: Vertex | None = None,
     ) -> None:
-        """Adds a trace span, attaching inputs and metadata as attributes."""
         if not self._ready:
             return
 
@@ -264,7 +333,6 @@ class ArizePhoenixTracer(OTLPTracerBase):
         error: Exception | None = None,
         logs: Sequence[Log | dict] = (),
     ) -> None:
-        """Ends a trace span, attaching outputs, errors, and logs as attributes."""
         if not self._ready or trace_id not in self.child_spans:
             return
 
@@ -292,7 +360,6 @@ class ArizePhoenixTracer(OTLPTracerBase):
         error: Exception | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> None:
-        """Ends tracing with the specified inputs, outputs, errors, and metadata as attributes."""
         if not self._ready:
             return
 
@@ -309,15 +376,6 @@ class ArizePhoenixTracer(OTLPTracerBase):
 
             self._set_span_status(self.root_span, error)
             self.root_span.end(end_time=self._get_current_timestamp())
-        try:
-            from openinference.instrumentation.langchain import LangChainInstrumentor
-
-            LangChainInstrumentor().uninstrument(tracer_provider=self.tracer_provider, skip_dep_check=True)
-        except ImportError:
-            logger.exception(
-                "[Arize/Phoenix] Could not import LangChainInstrumentor."
-                "Please install it with `pip install openinference-instrumentation-langchain`."
-            )
 
         from langflow.services.tracing.http_instrumentation import get_http_instrumentation_manager
 
@@ -325,7 +383,6 @@ class ArizePhoenixTracer(OTLPTracerBase):
 
     @staticmethod
     def _error_to_string(error: Exception | None):
-        """Converts an error to a string with traceback details."""
         error_message = None
         if error:
             string_stacktrace = traceback.format_exception(error)
@@ -333,7 +390,6 @@ class ArizePhoenixTracer(OTLPTracerBase):
         return error_message
 
     def _set_span_status(self, current_span: Span, error: Exception | None = None):
-        """Sets the status and attributes of the current span based on the presence of an error."""
         if error:
             error_string = self._error_to_string(error)
             current_span.set_status(Status(StatusCode.ERROR, error_string))
@@ -358,13 +414,4 @@ class ArizePhoenixTracer(OTLPTracerBase):
 
     @override
     def get_langchain_callback(self) -> BaseCallbackHandler | None:
-        """Returns the LangChain callback handler if applicable."""
         return None
-
-    def close(self):
-        """Flush tracer provider spans safely before shutdown."""
-        try:
-            if hasattr(self, "tracer_provider") and hasattr(self.tracer_provider, "force_flush"):
-                self.tracer_provider.force_flush(timeout_millis=3000)
-        except (ValueError, RuntimeError, OSError) as e:
-            logger.error("[Arize/Phoenix] Error Flushing Spans: %s", str(e), exc_info=True)

--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -250,6 +250,7 @@ class ArizePhoenixTracer(OTLPTracerBase):
                 return
 
             self.tracer = tracer
+            self._enable_http_context_propagation(provider)
             self.propagator = TraceContextTextMapPropagator()
             self.carrier = {}
 
@@ -377,9 +378,7 @@ class ArizePhoenixTracer(OTLPTracerBase):
             self._set_span_status(self.root_span, error)
             self.root_span.end(end_time=self._get_current_timestamp())
 
-        from langflow.services.tracing.http_instrumentation import get_http_instrumentation_manager
-
-        get_http_instrumentation_manager().disable()
+        self._disable_http_context_propagation()
 
     @staticmethod
     def _error_to_string(error: Exception | None):

--- a/src/backend/base/langflow/services/tracing/http_instrumentation.py
+++ b/src/backend/base/langflow/services/tracing/http_instrumentation.py
@@ -112,3 +112,8 @@ class HTTPClientInstrumentationManager:
 def get_http_instrumentation_manager() -> HTTPClientInstrumentationManager:
     """Get the singleton HTTP client instrumentation manager."""
     return HTTPClientInstrumentationManager()
+
+
+def _reset_http_instrumentation_manager() -> None:
+    """Reset the HTTP instrumentation manager singleton. For tests only."""
+    HTTPClientInstrumentationManager._instance = None

--- a/src/backend/base/langflow/services/tracing/langwatch.py
+++ b/src/backend/base/langflow/services/tracing/langwatch.py
@@ -12,7 +12,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from typing_extensions import override
 
 from langflow.schema.data import Data
-from langflow.services.tracing.base import BaseTracer
+from langflow.services.tracing.otlp_base import OTLPTracerBase
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from langflow.services.tracing.schema import Log
 
 
-class LangWatchTracer(BaseTracer):
+class LangWatchTracer(OTLPTracerBase):
     flow_id: str
     tracer_provider = None
     # Guards the missing-``langwatch``-package warning so it is logged once per process
@@ -33,6 +33,7 @@ class LangWatchTracer(BaseTracer):
     _missing_dependency_warned = False
 
     def __init__(self, trace_name: str, trace_type: str, project_name: str, trace_id: UUID):
+        super().__init__()
         self.trace_name = trace_name
         self.trace_type = trace_type
         self.project_name = project_name
@@ -40,7 +41,7 @@ class LangWatchTracer(BaseTracer):
         self.flow_id = trace_name.split(" - ")[-1]
 
         try:
-            self._ready: bool = self.setup_langwatch()
+            self._ready = self.setup_langwatch()
             if not self._ready:
                 return
 
@@ -60,10 +61,6 @@ class LangWatchTracer(BaseTracer):
         except Exception:  # noqa: BLE001
             logger.debug("Error setting up LangWatch tracer")
             self._ready = False
-
-    @property
-    def ready(self):
-        return self._ready
 
     def setup_langwatch(self) -> bool:
         if "LANGWATCH_API_KEY" not in os.environ:

--- a/src/backend/base/langflow/services/tracing/langwatch.py
+++ b/src/backend/base/langflow/services/tracing/langwatch.py
@@ -138,11 +138,7 @@ class LangWatchTracer(OTLPTracerBase):
                         _shared_provider = provider
 
             self._client = langwatch
-
-            # Instrument HTTP clients to propagate W3C TraceContext on outgoing requests
-            from langflow.services.tracing.http_instrumentation import get_http_instrumentation_manager
-
-            get_http_instrumentation_manager().enable(self.tracer_provider)
+            self._enable_http_context_propagation(_shared_provider)
         except ImportError as e:
             self._warn_langwatch_unavailable()
             logger.debug(f"LangWatch tracing disabled; 'langwatch' import failed: {e}")
@@ -253,9 +249,7 @@ class LangWatchTracer(OTLPTracerBase):
                 # Ignore "token was created in a different Context" errors
                 self.trace.__exit__(None, None, None)
 
-        from langflow.services.tracing.http_instrumentation import get_http_instrumentation_manager
-
-        get_http_instrumentation_manager().disable()
+        self._disable_http_context_propagation()
 
     def _convert_to_langwatch_types(self, io_dict: dict[str, Any] | None):
         from langwatch.utils import autoconvert_typed_values

--- a/src/backend/base/langflow/services/tracing/langwatch.py
+++ b/src/backend/base/langflow/services/tracing/langwatch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 from typing import TYPE_CHECKING, Any, cast
 
 import nanoid
@@ -25,6 +26,45 @@ if TYPE_CHECKING:
     from langflow.services.tracing.schema import Log
 
 
+# ---------------------------------------------------------------------------
+# Module-level shared provider singleton
+# ---------------------------------------------------------------------------
+
+_langwatch_lock = threading.Lock()
+_shared_provider: TracerProvider | None = None
+
+
+def shutdown_langwatch_provider() -> None:
+    """Shutdown the shared LangWatch TracerProvider, flushing pending spans.
+
+    Safe to call multiple times or when no provider has been created.
+    Should be called at process/service shutdown.
+    """
+    global _shared_provider  # noqa: PLW0603
+
+    with _langwatch_lock:
+        if _shared_provider is not None:
+            try:
+                _shared_provider.shutdown()
+            except (ValueError, RuntimeError, OSError) as e:
+                logger.warning(f"Error shutting down LangWatch tracer provider: {e}")
+            finally:
+                _shared_provider = None
+
+
+def _reset_langwatch_provider() -> None:
+    """Reset the shared provider without calling shutdown. For tests only."""
+    global _shared_provider  # noqa: PLW0603
+
+    with _langwatch_lock:
+        _shared_provider = None
+
+
+# ---------------------------------------------------------------------------
+# Per-run tracer
+# ---------------------------------------------------------------------------
+
+
 class LangWatchTracer(OTLPTracerBase):
     flow_id: str
     tracer_provider = None
@@ -41,12 +81,12 @@ class LangWatchTracer(OTLPTracerBase):
         self.flow_id = trace_name.split(" - ")[-1]
 
         try:
-            self._ready = self.setup_langwatch()
+            self._ready = self._setup_langwatch()
             if not self._ready:
                 return
 
             # Pass the dedicated tracer_provider here
-            self.trace = self._client.trace(trace_id=str(self.trace_id), tracer_provider=self.tracer_provider)
+            self.trace = self._client.trace(trace_id=str(self.trace_id), tracer_provider=_shared_provider)
             self.trace.__enter__()
             self.spans: dict[str, ContextSpan] = {}
 
@@ -62,33 +102,38 @@ class LangWatchTracer(OTLPTracerBase):
             logger.debug("Error setting up LangWatch tracer")
             self._ready = False
 
-    def setup_langwatch(self) -> bool:
+    def _setup_langwatch(self) -> bool:
+        global _shared_provider  # noqa: PLW0603
+
         if "LANGWATCH_API_KEY" not in os.environ:
             return False
         try:
             import langwatch
             from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
-            # Initialize the shared provider if it doesn't exist
-            if self.tracer_provider is None:
-                api_key = os.environ["LANGWATCH_API_KEY"]
-                endpoint = os.environ.get("LANGWATCH_ENDPOINT", "https://app.langwatch.ai")
+            # Initialize the shared provider if it doesn't exist (thread-safe)
+            if _shared_provider is None:
+                with _langwatch_lock:
+                    if _shared_provider is None:
+                        api_key = os.environ["LANGWATCH_API_KEY"]
+                        endpoint = os.environ.get("LANGWATCH_ENDPOINT", "https://app.langwatch.ai")
 
-                resource = Resource.create(attributes={"service.name": "langflow"})
-                exporter = OTLPSpanExporter(
-                    endpoint=f"{endpoint}/api/otel/v1/traces", headers={"Authorization": f"Bearer {api_key}"}
-                )
-                provider = TracerProvider(resource=resource)
-                provider.add_span_processor(BatchSpanProcessor(exporter))
-                LangWatchTracer.tracer_provider = provider
+                        resource = Resource.create(attributes={"service.name": "langflow"})
+                        exporter = OTLPSpanExporter(
+                            endpoint=f"{endpoint}/api/otel/v1/traces",
+                            headers={"Authorization": f"Bearer {api_key}"},
+                        )
+                        provider = TracerProvider(resource=resource)
+                        provider.add_span_processor(BatchSpanProcessor(exporter))
+                        _shared_provider = provider
 
-                # Initialize LangWatch client but skip OTEL setup to avoid touching the global provider
-                # causing it to not receive traces from FastAPIInstrumentor
-                langwatch.setup(
-                    api_key=api_key,
-                    endpoint_url=endpoint,
-                    skip_open_telemetry_setup=True,
-                )
+                        # Initialize LangWatch client but skip OTEL setup to avoid touching the global provider
+                        # causing it to not receive traces from FastAPIInstrumentor
+                        langwatch.setup(
+                            api_key=api_key,
+                            endpoint_url=endpoint,
+                            skip_open_telemetry_setup=True,
+                        )
 
             self._client = langwatch
 

--- a/src/backend/base/langflow/services/tracing/langwatch.py
+++ b/src/backend/base/langflow/services/tracing/langwatch.py
@@ -125,7 +125,6 @@ class LangWatchTracer(OTLPTracerBase):
                         )
                         provider = TracerProvider(resource=resource)
                         provider.add_span_processor(BatchSpanProcessor(exporter))
-                        _shared_provider = provider
 
                         # Initialize LangWatch client but skip OTEL setup to avoid touching the global provider
                         # causing it to not receive traces from FastAPIInstrumentor
@@ -134,6 +133,9 @@ class LangWatchTracer(OTLPTracerBase):
                             endpoint_url=endpoint,
                             skip_open_telemetry_setup=True,
                         )
+
+                        # Assign only after setup succeeds
+                        _shared_provider = provider
 
             self._client = langwatch
 

--- a/src/backend/base/langflow/services/tracing/otlp.py
+++ b/src/backend/base/langflow/services/tracing/otlp.py
@@ -1,4 +1,19 @@
-"""Generic OpenTelemetry tracer using standard OTLP configuration via environment variables."""
+"""Generic OpenTelemetry tracer using standard OTLP configuration via environment variables.
+
+OpenTelemetry GenAI Semantic Conventions
+----------------------------------------
+This tracer does NOT implement the OpenTelemetry GenAI semantic conventions
+(https://opentelemetry.io/docs/specs/semconv/gen-ai/). Those conventions define
+attributes like ``gen_ai.request.model``, ``gen_ai.usage.input_tokens``, and
+``gen_ai.operation.name`` for instrumenting LLM API calls.
+
+This tracer operates at the workflow orchestration level, tracing Langflow
+component execution rather than individual LLM calls. The LLM-specific details
+(model name, token counts, request parameters) are encapsulated within
+components and not directly accessible at trace time.
+
+Attributes emitted use the ``langflow.*`` namespace for workflow context.
+"""
 
 from __future__ import annotations
 
@@ -249,7 +264,7 @@ class OTLPTracer(OTLPTracerBase):
             start_time=self._get_current_timestamp(),
         )
 
-        # Set standard attributes
+        # Set Langflow workflow attributes (see module docstring for rationale)
         self.root_span.set_attribute("langflow.trace_id", str(self.trace_id))
         self.root_span.set_attribute("langflow.trace_name", self.trace_name)
         self.root_span.set_attribute("langflow.trace_type", self.trace_type)

--- a/src/backend/base/langflow/services/tracing/otlp.py
+++ b/src/backend/base/langflow/services/tracing/otlp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 from typing import TYPE_CHECKING, Any
 
 from lfx.log.logger import logger
@@ -18,9 +19,167 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from langchain.callbacks.base import BaseCallbackHandler
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.trace import Tracer
 
     from langflow.graph.vertex.base import Vertex
     from langflow.services.tracing.schema import Log
+
+
+# ---------------------------------------------------------------------------
+# Module-level shared provider singleton
+# ---------------------------------------------------------------------------
+
+_provider_lock = threading.Lock()
+_shared_provider: TracerProvider | None = None
+_shared_tracer: Tracer | None = None
+
+
+def _validate_otlp_env() -> bool:
+    """Check whether OTLP tracing is configured via environment variables.
+
+    Returns:
+        True if at least one endpoint env var is set and the SDK is not disabled.
+    """
+    if os.getenv("OTEL_SDK_DISABLED", "").strip().lower() == "true":
+        logger.debug("OTLP tracer disabled via OTEL_SDK_DISABLED=true")
+        return False
+
+    traces_endpoint = os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+    generic_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not traces_endpoint and not generic_endpoint:
+        logger.debug(
+            "OTLP tracer not configured: neither OTEL_EXPORTER_OTLP_TRACES_ENDPOINT "
+            "nor OTEL_EXPORTER_OTLP_ENDPOINT is set"
+        )
+        return False
+
+    return True
+
+
+def _create_exporter():
+    """Resolve the OTLP span exporter from installed entry points.
+
+    Reads ``OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`` first (trace-specific
+    override), falling back to ``OTEL_EXPORTER_OTLP_PROTOCOL`` (generic),
+    then defaulting to ``http/protobuf``.  Only ``grpc`` and
+    ``http/protobuf`` are supported trace protocols in the OpenTelemetry
+    Python SDK.
+
+    Falls back to the HTTP/protobuf exporter when no matching entry point
+    is found (e.g. only one transport package is installed).
+    """
+    import importlib.metadata
+
+    protocol = os.getenv(
+        "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+        os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
+    )
+    ep_name_map = {
+        "grpc": "otlp_proto_grpc",
+        "http/protobuf": "otlp_proto_http",
+    }
+    entry_point_name = ep_name_map.get(protocol, "otlp_proto_http")
+
+    eps = importlib.metadata.entry_points()
+    if hasattr(eps, "select"):
+        matches = list(eps.select(group="opentelemetry_traces_exporter", name=entry_point_name))
+    else:
+        matches = [ep for ep in eps.get("opentelemetry_traces_exporter", []) if ep.name == entry_point_name]
+
+    if matches:
+        exporter_class = matches[0].load()
+    else:
+        logger.warning(
+            "No entry point '%s' found for opentelemetry_traces_exporter, falling back to http/protobuf exporter",
+            entry_point_name,
+        )
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter as FallbackExporter,
+        )
+
+        exporter_class = FallbackExporter
+
+    # OTLPSpanExporter() auto-reads OTEL_EXPORTER_OTLP_* env vars
+    return exporter_class()
+
+
+def _get_shared_provider(project_name: str) -> tuple[TracerProvider, Tracer]:
+    """Return the shared TracerProvider and Tracer, creating them on first call.
+
+    Thread-safe via module-level lock.  The provider is created once and
+    reused across all graph runs, avoiding per-run ``BatchSpanProcessor``
+    thread allocation.
+
+    Args:
+        project_name: Langflow project name added as a resource attribute.
+
+    Returns:
+        Tuple of (TracerProvider, Tracer).
+    """
+    global _shared_provider, _shared_tracer  # noqa: PLW0603
+
+    if _shared_tracer is not None:
+        return _shared_provider, _shared_tracer
+
+    with _provider_lock:
+        # Double-checked locking
+        if _shared_tracer is not None:
+            return _shared_provider, _shared_tracer
+
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider as _TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        span_exporter = _create_exporter()
+
+        # Resource.create() auto-merges OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES,
+        # and SDK metadata with any explicit attributes we pass.
+        resource = Resource.create({"langflow.project_name": project_name})
+
+        provider = _TracerProvider(resource=resource)
+        provider.add_span_processor(BatchSpanProcessor(span_exporter))
+
+        _shared_provider = provider
+        _shared_tracer = provider.get_tracer(__name__)
+
+        return _shared_provider, _shared_tracer
+
+
+def shutdown_otlp_provider() -> None:
+    """Shutdown the shared OTLP TracerProvider, flushing pending spans.
+
+    Safe to call multiple times or when no provider has been created.
+    Should be called at process/service shutdown.
+    """
+    global _shared_provider, _shared_tracer  # noqa: PLW0603
+
+    with _provider_lock:
+        if _shared_provider is not None:
+            try:
+                _shared_provider.shutdown()
+            except (ValueError, RuntimeError, OSError) as e:
+                logger.warning(f"Error shutting down OTLP tracer provider: {e}")
+            finally:
+                _shared_provider = None
+                _shared_tracer = None
+
+
+def _reset_shared_provider() -> None:
+    """Reset the shared provider without calling shutdown.
+
+    Intended for tests only — allows re-creation with different env vars.
+    """
+    global _shared_provider, _shared_tracer  # noqa: PLW0603
+
+    with _provider_lock:
+        _shared_provider = None
+        _shared_tracer = None
+
+
+# ---------------------------------------------------------------------------
+# Per-run tracer
+# ---------------------------------------------------------------------------
 
 
 class OTLPTracer(OTLPTracerBase):
@@ -31,12 +190,13 @@ class OTLPTracer(OTLPTracerBase):
 
     - OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
     - OTEL_EXPORTER_OTLP_HEADERS or OTEL_EXPORTER_OTLP_TRACES_HEADERS
-    - OTEL_EXPORTER_OTLP_PROTOCOL (http/protobuf, grpc, or http/json)
+    - OTEL_EXPORTER_OTLP_PROTOCOL (http/protobuf or grpc)
     - OTEL_SERVICE_NAME
     - OTEL_RESOURCE_ATTRIBUTES
 
-    No explicit configuration is needed in code - the OpenTelemetry SDK
-    automatically reads these standard environment variables.
+    The TracerProvider and BatchSpanProcessor are shared across all graph
+    runs to avoid per-run thread allocation.  Each OTLPTracer instance
+    creates only its own root span and child spans.
     """
 
     def __init__(
@@ -48,7 +208,7 @@ class OTLPTracer(OTLPTracerBase):
         user_id: str | None = None,
         session_id: str | None = None,
     ):
-        """Initialize the OTLP tracer with standard OpenTelemetry configuration.
+        """Initialize the OTLP tracer for a single graph run.
 
         Args:
             trace_name: Name of the trace
@@ -66,105 +226,20 @@ class OTLPTracer(OTLPTracerBase):
         self.user_id = user_id
         self.session_id = session_id
 
-        if not self._validate_configuration():
+        if not _validate_otlp_env():
             self._ready = False
             return
 
         try:
-            self._setup_otlp()
+            self._setup_spans()
         except Exception:  # noqa: BLE001
             logger.debug("Error setting up OTLP tracer", exc_info=True)
             self._ready = False
 
-    def _validate_configuration(self) -> bool:
-        """Validate that required OpenTelemetry environment variables are set.
-
-        Returns:
-            bool: True if configuration is valid, False otherwise
-        """
-        # Check for traces endpoint (specific) or generic endpoint
-        traces_endpoint = os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
-        generic_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-
-        if not traces_endpoint and not generic_endpoint:
-            logger.debug(
-                "OTLP tracer not configured: neither OTEL_EXPORTER_OTLP_TRACES_ENDPOINT "
-                "nor OTEL_EXPORTER_OTLP_ENDPOINT is set"
-            )
-            return False
-
-        return True
-
-    @staticmethod
-    def _create_exporter():
-        """Resolve the OTLP span exporter from installed entry points.
-
-        Reads ``OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`` first (trace-specific
-        override), falling back to ``OTEL_EXPORTER_OTLP_PROTOCOL`` (generic),
-        then defaulting to ``http/protobuf``.  Only ``grpc`` and
-        ``http/protobuf`` are supported trace protocols in the OpenTelemetry
-        Python SDK.
-
-        Falls back to the HTTP/protobuf exporter when no matching entry point
-        is found (e.g. only one transport package is installed).
-        """
-        import importlib.metadata
-
-        protocol = os.getenv(
-            "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
-            os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
-        )
-        ep_name_map = {
-            "grpc": "otlp_proto_grpc",
-            "http/protobuf": "otlp_proto_http",
-        }
-        entry_point_name = ep_name_map.get(protocol, "otlp_proto_http")
-
-        eps = importlib.metadata.entry_points()
-        if hasattr(eps, "select"):
-            matches = list(eps.select(group="opentelemetry_traces_exporter", name=entry_point_name))
-        else:
-            matches = [ep for ep in eps.get("opentelemetry_traces_exporter", []) if ep.name == entry_point_name]
-
-        if matches:
-            exporter_class = matches[0].load()
-        else:
-            logger.warning(
-                "No entry point '%s' found for opentelemetry_traces_exporter, falling back to http/protobuf exporter",
-                entry_point_name,
-            )
-            from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
-                OTLPSpanExporter as FallbackExporter,
-            )
-
-            exporter_class = FallbackExporter
-
-        # OTLPSpanExporter() auto-reads OTEL_EXPORTER_OTLP_* env vars
-        return exporter_class()
-
-    def _setup_otlp(self) -> None:
-        """Set up OpenTelemetry tracer provider with OTLP exporter.
-
-        Uses standard OpenTelemetry SDK which automatically discovers
-        configuration from environment variables. Resource.create() reads
-        OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES; OTLPSpanExporter()
-        reads endpoint, headers, and timeout settings.
-        """
-        from opentelemetry.sdk.resources import Resource
-        from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.sdk.trace.export import BatchSpanProcessor
-
-        span_exporter = self._create_exporter()
-
-        # Resource.create() auto-merges OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES,
-        # and SDK metadata with any explicit attributes we pass.
-        resource = Resource.create({"langflow.project_name": self.project_name})
-
-        tracer_provider = TracerProvider(resource=resource)
-        tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
-
-        self.tracer_provider = tracer_provider
-        self.tracer = tracer_provider.get_tracer(__name__)
+    def _setup_spans(self) -> None:
+        """Create root span and propagation carrier using the shared provider."""
+        _provider, tracer = _get_shared_provider(self.project_name)
+        self.tracer = tracer
         self.propagator = TraceContextTextMapPropagator()
         self.carrier = {}
 
@@ -309,11 +384,3 @@ class OTLPTracer(OTLPTracerBase):
             None: This tracer does not provide a LangChain callback
         """
         return None
-
-    def close(self):
-        """Flush tracer provider spans safely before shutdown."""
-        try:
-            if hasattr(self, "tracer_provider") and hasattr(self.tracer_provider, "force_flush"):
-                self.tracer_provider.force_flush(timeout_millis=3000)
-        except (ValueError, RuntimeError, OSError) as e:
-            logger.warning(f"Error flushing OTLP spans: {e}")

--- a/src/backend/base/langflow/services/tracing/otlp.py
+++ b/src/backend/base/langflow/services/tracing/otlp.py
@@ -1,0 +1,319 @@
+"""Generic OpenTelemetry tracer using standard OTLP configuration via environment variables."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING, Any
+
+from lfx.log.logger import logger
+from opentelemetry.trace import use_span
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from typing_extensions import override
+
+from langflow.services.tracing.otlp_base import OTLPTracerBase
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from uuid import UUID
+
+    from langchain.callbacks.base import BaseCallbackHandler
+
+    from langflow.graph.vertex.base import Vertex
+    from langflow.services.tracing.schema import Log
+
+
+class OTLPTracer(OTLPTracerBase):
+    """Generic OpenTelemetry tracer using standard OTLP configuration.
+
+    This tracer uses the standard OpenTelemetry SDK and automatically discovers
+    configuration from standard environment variables:
+
+    - OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    - OTEL_EXPORTER_OTLP_HEADERS or OTEL_EXPORTER_OTLP_TRACES_HEADERS
+    - OTEL_EXPORTER_OTLP_PROTOCOL (http/protobuf, grpc, or http/json)
+    - OTEL_SERVICE_NAME
+    - OTEL_RESOURCE_ATTRIBUTES
+
+    No explicit configuration is needed in code - the OpenTelemetry SDK
+    automatically reads these standard environment variables.
+    """
+
+    def __init__(
+        self,
+        trace_name: str,
+        trace_type: str,
+        project_name: str,
+        trace_id: UUID,
+        user_id: str | None = None,
+        session_id: str | None = None,
+    ):
+        """Initialize the OTLP tracer with standard OpenTelemetry configuration.
+
+        Args:
+            trace_name: Name of the trace
+            trace_type: Type of trace (e.g., "chain")
+            project_name: Name of the project
+            trace_id: Unique identifier for the trace
+            user_id: Optional user identifier
+            session_id: Optional session identifier
+        """
+        super().__init__()
+        self.trace_id = trace_id
+        self.trace_name = trace_name
+        self.trace_type = trace_type
+        self.project_name = project_name
+        self.user_id = user_id
+        self.session_id = session_id
+
+        if not self._validate_configuration():
+            self._ready = False
+            return
+
+        try:
+            self._setup_otlp()
+        except Exception:  # noqa: BLE001
+            logger.debug("Error setting up OTLP tracer", exc_info=True)
+            self._ready = False
+
+    def _validate_configuration(self) -> bool:
+        """Validate that required OpenTelemetry environment variables are set.
+
+        Returns:
+            bool: True if configuration is valid, False otherwise
+        """
+        # Check for traces endpoint (specific) or generic endpoint
+        traces_endpoint = os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+        generic_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+
+        if not traces_endpoint and not generic_endpoint:
+            logger.debug(
+                "OTLP tracer not configured: neither OTEL_EXPORTER_OTLP_TRACES_ENDPOINT "
+                "nor OTEL_EXPORTER_OTLP_ENDPOINT is set"
+            )
+            return False
+
+        return True
+
+    @staticmethod
+    def _create_exporter():
+        """Resolve the OTLP span exporter from installed entry points.
+
+        Reads ``OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`` first (trace-specific
+        override), falling back to ``OTEL_EXPORTER_OTLP_PROTOCOL`` (generic),
+        then defaulting to ``http/protobuf``.  Only ``grpc`` and
+        ``http/protobuf`` are supported trace protocols in the OpenTelemetry
+        Python SDK.
+
+        Falls back to the HTTP/protobuf exporter when no matching entry point
+        is found (e.g. only one transport package is installed).
+        """
+        import importlib.metadata
+
+        protocol = os.getenv(
+            "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+            os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"),
+        )
+        ep_name_map = {
+            "grpc": "otlp_proto_grpc",
+            "http/protobuf": "otlp_proto_http",
+        }
+        entry_point_name = ep_name_map.get(protocol, "otlp_proto_http")
+
+        eps = importlib.metadata.entry_points()
+        if hasattr(eps, "select"):
+            matches = list(eps.select(group="opentelemetry_traces_exporter", name=entry_point_name))
+        else:
+            matches = [ep for ep in eps.get("opentelemetry_traces_exporter", []) if ep.name == entry_point_name]
+
+        if matches:
+            exporter_class = matches[0].load()
+        else:
+            logger.warning(
+                "No entry point '%s' found for opentelemetry_traces_exporter, falling back to http/protobuf exporter",
+                entry_point_name,
+            )
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+                OTLPSpanExporter as FallbackExporter,
+            )
+
+            exporter_class = FallbackExporter
+
+        # OTLPSpanExporter() auto-reads OTEL_EXPORTER_OTLP_* env vars
+        return exporter_class()
+
+    def _setup_otlp(self) -> None:
+        """Set up OpenTelemetry tracer provider with OTLP exporter.
+
+        Uses standard OpenTelemetry SDK which automatically discovers
+        configuration from environment variables. Resource.create() reads
+        OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES; OTLPSpanExporter()
+        reads endpoint, headers, and timeout settings.
+        """
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        span_exporter = self._create_exporter()
+
+        # Resource.create() auto-merges OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES,
+        # and SDK metadata with any explicit attributes we pass.
+        resource = Resource.create({"langflow.project_name": self.project_name})
+
+        tracer_provider = TracerProvider(resource=resource)
+        tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+
+        self.tracer_provider = tracer_provider
+        self.tracer = tracer_provider.get_tracer(__name__)
+        self.propagator = TraceContextTextMapPropagator()
+        self.carrier = {}
+
+        # Create root span
+        self.root_span = self.tracer.start_span(
+            name=self.trace_name,
+            start_time=self._get_current_timestamp(),
+        )
+
+        # Set standard attributes
+        self.root_span.set_attribute("langflow.trace_id", str(self.trace_id))
+        self.root_span.set_attribute("langflow.trace_name", self.trace_name)
+        self.root_span.set_attribute("langflow.trace_type", self.trace_type)
+        self.root_span.set_attribute("langflow.project_name", self.project_name)
+
+        if self.user_id:
+            self.root_span.set_attribute("langflow.user_id", str(self.user_id))
+        if self.session_id:
+            self.root_span.set_attribute("langflow.session_id", str(self.session_id))
+
+        # Inject context for propagation
+        with use_span(self.root_span, end_on_exit=False):
+            self.propagator.inject(carrier=self.carrier)
+
+        self._ready = True
+
+    @override
+    def add_trace(
+        self,
+        trace_id: str,
+        trace_name: str,
+        trace_type: str,
+        inputs: dict[str, Any],
+        metadata: dict[str, Any] | None = None,
+        vertex: Vertex | None = None,
+    ) -> None:
+        """Add a child trace span.
+
+        Args:
+            trace_id: Unique identifier for this trace
+            trace_name: Name of the trace
+            trace_type: Type of trace
+            inputs: Input data
+            metadata: Optional metadata
+            vertex: Optional vertex information
+        """
+        if not self.ready or self.tracer is None:
+            return
+
+        span_context = self.propagator.extract(carrier=self.carrier)
+        child_span = self.tracer.start_span(
+            name=trace_name,
+            context=span_context,
+            start_time=self._get_current_timestamp(),
+        )
+
+        # Set attributes
+        child_span.set_attribute("trace_id", trace_id)
+        child_span.set_attribute("trace_name", trace_name)
+        child_span.set_attribute("trace_type", trace_type)
+        child_span.set_attribute("inputs", json.dumps(self._convert_to_otlp_dict(inputs), default=str))
+
+        if metadata:
+            for key, value in self._to_span_attributes(metadata).items():
+                child_span.set_attribute(f"metadata.{key}", value)
+
+        if vertex and vertex.id is not None:
+            child_span.set_attribute("vertex_id", vertex.id)
+
+        self.child_spans[trace_id] = child_span
+
+    @override
+    def end_trace(
+        self,
+        trace_id: str,
+        trace_name: str,
+        outputs: dict[str, Any] | None = None,
+        error: Exception | None = None,
+        logs: Sequence[Log | dict] = (),
+    ) -> None:
+        """End a child trace span.
+
+        Args:
+            trace_id: Unique identifier for the trace
+            trace_name: Name of the trace
+            outputs: Optional output data
+            error: Optional error that occurred
+            logs: Optional log entries
+        """
+        if not self._ready or trace_id not in self.child_spans:
+            return
+
+        child_span = self.child_spans.pop(trace_id)
+
+        if outputs:
+            child_span.set_attribute("outputs", json.dumps(self._convert_to_otlp_dict(outputs), default=str))
+
+        if logs:
+            child_span.set_attribute("logs", json.dumps(self._convert_to_otlp_dict(list(logs)), default=str))
+
+        if error:
+            child_span.record_exception(error)
+
+        child_span.end(end_time=self._get_current_timestamp())
+
+    @override
+    def end(
+        self,
+        inputs: dict[str, Any],
+        outputs: dict[str, Any],
+        error: Exception | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """End the root trace.
+
+        Args:
+            inputs: Input data for the entire trace
+            outputs: Output data for the entire trace
+            error: Optional error that occurred
+            metadata: Optional metadata
+        """
+        if not self.ready or self.root_span is None:
+            return
+
+        safe_outputs = self._convert_to_otlp_dict(outputs)
+
+        self.root_span.set_attribute("outputs", json.dumps(safe_outputs, default=str))
+
+        for key, value in self._to_span_attributes(metadata or {}).items():
+            self.root_span.set_attribute(f"metadata.{key}", value)
+
+        if error:
+            self.root_span.record_exception(error)
+
+        self.root_span.end(end_time=self._get_current_timestamp())
+
+    @override
+    def get_langchain_callback(self) -> BaseCallbackHandler | None:
+        """Get LangChain callback handler.
+
+        Returns:
+            None: This tracer does not provide a LangChain callback
+        """
+        return None
+
+    def close(self):
+        """Flush tracer provider spans safely before shutdown."""
+        try:
+            if hasattr(self, "tracer_provider") and hasattr(self.tracer_provider, "force_flush"):
+                self.tracer_provider.force_flush(timeout_millis=3000)
+        except (ValueError, RuntimeError, OSError) as e:
+            logger.warning(f"Error flushing OTLP spans: {e}")

--- a/src/backend/base/langflow/services/tracing/otlp_base.py
+++ b/src/backend/base/langflow/services/tracing/otlp_base.py
@@ -86,7 +86,8 @@ class OTLPTracerBase(BaseTracer):
                 return value.text
 
             if isinstance(value, Data):
-                return value.get_text()
+                data = value.data
+                return self._convert_langflow_type(data) if isinstance(data, (dict, list)) else value.get_text()
 
             if isinstance(value, (BaseMessage, HumanMessage, SystemMessage)):
                 return str(value.content) if value.content is not None else ""

--- a/src/backend/base/langflow/services/tracing/otlp_base.py
+++ b/src/backend/base/langflow/services/tracing/otlp_base.py
@@ -1,0 +1,161 @@
+"""Base class for OpenTelemetry-based tracers."""
+
+from __future__ import annotations
+
+import json
+import math
+import types
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.documents import Document
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from lfx.log.logger import logger
+from lfx.schema.data import Data
+
+from langflow.schema.message import Message
+from langflow.services.tracing.base import BaseTracer
+
+if TYPE_CHECKING:
+    from opentelemetry.propagators.textmap import CarrierT
+    from opentelemetry.trace import Span, Tracer
+
+
+class OTLPTracerBase(BaseTracer):
+    """Base class for OpenTelemetry Protocol (OTLP) tracers.
+
+    Provides common functionality for tracers that use OpenTelemetry,
+    including span management, type conversion, and timestamp utilities.
+    """
+
+    def __init__(self) -> None:
+        """Initialize common OTLP tracer attributes."""
+        self._ready: bool = False
+        self.tracer: Tracer | None = None
+        self.root_span: Span | None = None
+        self.child_spans: dict[str, Span] = {}
+        self.carrier: CarrierT | dict = {}
+
+    @property
+    def ready(self) -> bool:
+        """Indicates if the tracer is ready for usage."""
+        return self._ready
+
+    @staticmethod
+    def _get_current_timestamp() -> int:
+        """Gets the current UTC timestamp in nanoseconds.
+
+        Returns:
+            int: Current timestamp in nanoseconds since epoch.
+        """
+        return int(datetime.now(timezone.utc).timestamp() * 1_000_000_000)
+
+    @staticmethod
+    def _safe_json_dumps(obj: Any, **kwargs: Any) -> str:
+        """A convenience wrapper around json.dumps that ensures any object can be safely encoded.
+
+        Args:
+            obj: The object to serialize.
+            **kwargs: Additional arguments to pass to json.dumps.
+
+        Returns:
+            str: JSON string representation of the object.
+        """
+        return json.dumps(obj, default=str, ensure_ascii=False, **kwargs)
+
+    def _convert_langflow_type(self, value: Any) -> Any:
+        """Recursively converts a Langflow value to an OTLP-compatible type.
+
+        Handles conversion of Langflow-specific types like Message and Data,
+        as well as LangChain types like BaseMessage and Document.
+
+        Args:
+            value: The value to convert.
+
+        Returns:
+            Any: The converted value in an OTLP-compatible format.
+        """
+        try:
+            if isinstance(value, dict):
+                return {key: self._convert_langflow_type(val) for key, val in value.items()}
+
+            if isinstance(value, list):
+                return [self._convert_langflow_type(v) for v in value]
+
+            if isinstance(value, Message):
+                return value.text
+
+            if isinstance(value, Data):
+                return value.get_text()
+
+            if isinstance(value, (BaseMessage, HumanMessage, SystemMessage)):
+                return str(value.content) if value.content is not None else ""
+
+            if isinstance(value, Document):
+                return value.page_content
+
+            if isinstance(value, (types.GeneratorType, types.NoneType)):
+                return str(value)
+
+            if isinstance(value, float) and not math.isfinite(value):
+                return "NaN"
+        except (TypeError, ValueError) as e:
+            logger.warning(f"Failed to convert langflow value {value!r} to otel type: {e}")
+            return str(value)
+        else:
+            return value
+
+        return value
+
+    def _convert_to_otlp_dict(self, io_dict: dict[str, Any] | Any) -> dict[str, Any]:
+        """Converts a dict to OTLP-compatible format.
+
+        Ensures all keys are strings and all values are OTLP-compatible types.
+        Note: returned values may still contain nested dicts/lists. Use
+        ``_to_span_attributes`` when values will be passed directly to
+        ``Span.set_attribute()``.
+
+        Args:
+            io_dict: The dictionary to convert, or other value to wrap in a dict.
+
+        Returns:
+            dict[str, Any]: Dictionary with string keys and OTLP-compatible values.
+        """
+        if isinstance(io_dict, dict):
+            return {str(k): self._convert_langflow_type(v) for k, v in io_dict.items() if k is not None}
+        if isinstance(io_dict, list):
+            return {"list": json.dumps([self._convert_langflow_type(v) for v in io_dict], default=str)}
+        return {"value": self._convert_langflow_type(io_dict)}
+
+    def _to_span_attributes(self, data: dict[str, Any] | Any) -> dict[str, str | bool | int | float]:
+        """Convert a dict to span-attribute-safe key/value pairs.
+
+        OpenTelemetry span attributes only accept primitive types (str, bool,
+        int, float) and homogeneous sequences of primitives.  Any nested
+        container (dict or list) is JSON-stringified so that ``set_attribute``
+        never receives an unsupported type.
+
+        Args:
+            data: The dictionary (or other value) to convert.
+
+        Returns:
+            dict: Flat dictionary safe for ``Span.set_attribute()`` calls.
+        """
+        converted = self._convert_to_otlp_dict(data)
+        result: dict[str, str | bool | int | float] = {}
+        for key, value in converted.items():
+            if isinstance(value, (dict, list)):
+                result[key] = json.dumps(value, default=str, ensure_ascii=False)
+            else:
+                result[key] = value
+        return result
+
+    def close(self) -> None:
+        """Flush spans safely before shutdown.
+
+        Subclasses should override this to implement provider-specific flushing.
+        """
+
+    def __del__(self) -> None:
+        """Ensure tracer provider flushes on object destruction."""
+        self.close()

--- a/src/backend/base/langflow/services/tracing/otlp_base.py
+++ b/src/backend/base/langflow/services/tracing/otlp_base.py
@@ -100,7 +100,7 @@ class OTLPTracerBase(BaseTracer):
             if isinstance(value, float) and not math.isfinite(value):
                 return "NaN"
         except (TypeError, ValueError) as e:
-            logger.warning(f"Failed to convert langflow value {value!r} to otel type: {e}")
+            logger.warning(f"Failed to convert langflow value of type {type(value).__name__} to otel type: {e}")
             return str(value)
         else:
             return value

--- a/src/backend/base/langflow/services/tracing/otlp_base.py
+++ b/src/backend/base/langflow/services/tracing/otlp_base.py
@@ -105,8 +105,6 @@ class OTLPTracerBase(BaseTracer):
         else:
             return value
 
-        return value
-
     def _convert_to_otlp_dict(self, io_dict: dict[str, Any] | Any) -> dict[str, Any]:
         """Converts a dict to OTLP-compatible format.
 

--- a/src/backend/base/langflow/services/tracing/otlp_base.py
+++ b/src/backend/base/langflow/services/tracing/otlp_base.py
@@ -148,6 +148,28 @@ class OTLPTracerBase(BaseTracer):
                 result[key] = value
         return result
 
+    def _enable_http_context_propagation(self, provider: Any) -> None:
+        """Enable W3C TraceContext propagation on outgoing HTTP requests.
+
+        Uses reference counting - safe to call multiple times. Each enable()
+        must be paired with a disable() call.
+
+        Args:
+            provider: The TracerProvider to use for instrumentation.
+        """
+        from langflow.services.tracing.http_instrumentation import get_http_instrumentation_manager
+
+        get_http_instrumentation_manager().enable(provider)
+
+    def _disable_http_context_propagation(self) -> None:
+        """Disable HTTP context propagation (decrements ref count).
+
+        Only actually uninstruments when the reference count reaches zero.
+        """
+        from langflow.services.tracing.http_instrumentation import get_http_instrumentation_manager
+
+        get_http_instrumentation_manager().disable()
+
     def close(self) -> None:
         """Flush spans safely before shutdown.
 

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -158,10 +158,12 @@ class TracingService(Service):
     async def teardown(self) -> None:
         """Shutdown shared tracer providers at service teardown."""
         from langflow.services.tracing.arize_phoenix import shutdown_arize_provider
+        from langflow.services.tracing.langwatch import shutdown_langwatch_provider
         from langflow.services.tracing.otlp import shutdown_otlp_provider
 
         shutdown_otlp_provider()
         shutdown_arize_provider()
+        shutdown_langwatch_provider()
 
     async def _trace_worker(self, trace_context: TraceContext) -> None:
         while trace_context.running or not trace_context.traces_queue.empty():

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -71,6 +71,13 @@ def _get_openlayer_tracer():
     return OpenlayerTracer
 
 
+def _get_otlp_tracer():
+    """Lazily import and return the OTLPTracer class."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    return OTLPTracer
+
+
 trace_context_var: ContextVar[TraceContext | None] = ContextVar("trace_context", default=None)
 component_context_var: ContextVar[ComponentTraceContext | None] = ContextVar("component_trace_context", default=None)
 
@@ -265,6 +272,20 @@ class TracingService(Service):
             return
         openlayer_tracer = _get_openlayer_tracer()
         trace_context.tracers["openlayer"] = openlayer_tracer(
+            trace_name=trace_context.run_name,
+            trace_type="chain",
+            project_name=trace_context.project_name,
+            trace_id=trace_context.run_id,
+            user_id=trace_context.user_id,
+            session_id=trace_context.session_id,
+        )
+
+    def _initialize_otlp_tracer(self, trace_context: TraceContext) -> None:
+        """Create and register an OTLPTracer in the given trace context."""
+        if self.deactivated:
+            return
+        otlp_tracer = _get_otlp_tracer()
+        trace_context.tracers["otlp"] = otlp_tracer(
             trace_name=trace_context.run_name,
             trace_type="chain",
             project_name=trace_context.project_name,

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -318,6 +318,7 @@ class TracingService(Service):
             self._initialize_traceloop_tracer(trace_context)
             self._initialize_native_tracer(trace_context)
             self._initialize_openlayer_tracer(trace_context)
+            self._initialize_otlp_tracer(trace_context)
         except Exception as e:  # noqa: BLE001
             await logger.adebug(f"Error initializing tracers: {e}")
 

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -155,6 +155,14 @@ class TracingService(Service):
         self.settings_service = settings_service
         self.deactivated = self.settings_service.settings.deactivate_tracing
 
+    async def teardown(self) -> None:
+        """Shutdown shared tracer providers at service teardown."""
+        from langflow.services.tracing.arize_phoenix import shutdown_arize_provider
+        from langflow.services.tracing.otlp import shutdown_otlp_provider
+
+        shutdown_otlp_provider()
+        shutdown_arize_provider()
+
     async def _trace_worker(self, trace_context: TraceContext) -> None:
         while trace_context.running or not trace_context.traces_queue.empty():
             trace_func, args = await trace_context.traces_queue.get()

--- a/src/backend/base/langflow/services/tracing/traceloop.py
+++ b/src/backend/base/langflow/services/tracing/traceloop.py
@@ -3,34 +3,30 @@ from __future__ import annotations
 import json
 import math
 import os
-import types
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from lfx.log.logger import logger
 from opentelemetry import trace
-from opentelemetry.trace import Span, use_span
+from opentelemetry.trace import use_span
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from traceloop.sdk import Traceloop
 from traceloop.sdk.instruments import Instruments
 from typing_extensions import override
 
-from langflow.services.tracing.base import BaseTracer
+from langflow.services.tracing.otlp_base import OTLPTracerBase
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from uuid import UUID
 
-    from langchain_core.callbacks.base import BaseCallbackHandler
-    from opentelemetry.propagators.textmap import CarrierT
-    from opentelemetry.trace import Span
+    from langchain.callbacks.base import BaseCallbackHandler
 
     from langflow.graph.vertex.base import Vertex
     from langflow.services.tracing.schema import Log
 
 
-class TraceloopTracer(BaseTracer):
+class TraceloopTracer(OTLPTracerBase):
     """Traceloop tracer for Langflow."""
 
     def __init__(
@@ -42,13 +38,13 @@ class TraceloopTracer(BaseTracer):
         user_id: str | None = None,
         session_id: str | None = None,
     ):
+        super().__init__()
         self.trace_id = trace_id
         self.trace_name = trace_name
         self.trace_type = trace_type
         self.project_name = project_name
         self.user_id = user_id
         self.session_id = session_id
-        self.child_spans: dict[str, Span] = {}
 
         if not self._validate_configuration():
             self._ready = False
@@ -64,11 +60,11 @@ class TraceloopTracer(BaseTracer):
                 api_endpoint=os.getenv("TRACELOOP_BASE_URL", "https://api.traceloop.com"),
             )
             self._ready = True
-            self._tracer = trace.get_tracer("langflow")
+            self.tracer = trace.get_tracer("langflow")
             self.propagator = TraceContextTextMapPropagator()
-            self.carrier: CarrierT = {}
+            self.carrier = {}
 
-            self.root_span = self._tracer.start_span(
+            self.root_span = self.tracer.start_span(
                 name=trace_name,
                 start_time=self._get_current_timestamp(),
             )
@@ -79,10 +75,6 @@ class TraceloopTracer(BaseTracer):
         except Exception:  # noqa: BLE001
             logger.debug("Error setting up Traceloop tracer", exc_info=True)
             self._ready = False
-
-    @property
-    def ready(self) -> bool:
-        return self._ready
 
     def _validate_configuration(self) -> bool:
         api_key = os.getenv("TRACELOOP_API_KEY", "").strip()
@@ -155,7 +147,7 @@ class TraceloopTracer(BaseTracer):
             return
 
         span_context = self.propagator.extract(carrier=self.carrier)
-        child_span = self._tracer.start_span(
+        child_span = self.tracer.start_span(
             name=trace_name,
             context=span_context,
             start_time=self._get_current_timestamp(),
@@ -165,8 +157,8 @@ class TraceloopTracer(BaseTracer):
             "trace_id": trace_id,
             "trace_name": trace_name,
             "trace_type": trace_type,
-            "inputs": json.dumps(self._convert_to_traceloop_dict(inputs), default=str),
-            **self._convert_to_traceloop_dict(metadata or {}),
+            "inputs": json.dumps(self._convert_to_otlp_dict(inputs), default=str),
+            **self._convert_to_otlp_dict(metadata or {}),
         }
         if vertex and vertex.id is not None:
             attributes["vertex_id"] = vertex.id
@@ -190,9 +182,9 @@ class TraceloopTracer(BaseTracer):
         child_span = self.child_spans.pop(trace_id)
 
         if outputs:
-            child_span.set_attribute("outputs", json.dumps(self._convert_to_traceloop_dict(outputs), default=str))
+            child_span.set_attribute("outputs", json.dumps(self._convert_to_otlp_dict(outputs), default=str))
         if logs:
-            child_span.set_attribute("logs", json.dumps(self._convert_to_traceloop_dict(list(logs)), default=str))
+            child_span.set_attribute("logs", json.dumps(self._convert_to_otlp_dict(list(logs)), default=str))
         if error:
             child_span.record_exception(error)
 
@@ -209,8 +201,8 @@ class TraceloopTracer(BaseTracer):
         if not self.ready:
             return
 
-        safe_outputs = self._convert_to_traceloop_dict(outputs)
-        safe_metadata = self._convert_to_traceloop_dict(metadata or {})
+        safe_outputs = self._convert_to_otlp_dict(outputs)
+        safe_metadata = self._convert_to_otlp_dict(metadata or {})
 
         self.root_span.set_attributes(
             {
@@ -225,21 +217,15 @@ class TraceloopTracer(BaseTracer):
 
         self.root_span.end()
 
-    @staticmethod
-    def _get_current_timestamp() -> int:
-        return int(datetime.now(timezone.utc).timestamp() * 1_000_000_000)
-
     @override
     def get_langchain_callback(self) -> BaseCallbackHandler | None:
         return None
 
     def close(self):
+        """Flush tracer provider spans safely before shutdown."""
         try:
             provider = trace.get_tracer_provider()
             if hasattr(provider, "force_flush"):
                 provider.force_flush(timeout_millis=3000)
         except (ValueError, RuntimeError, OSError) as e:
             logger.warning(f"Error flushing spans: {e}")
-
-    def __del__(self):
-        self.close()

--- a/src/backend/base/langflow/services/tracing/traceloop.py
+++ b/src/backend/base/langflow/services/tracing/traceloop.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import types
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -143,7 +144,7 @@ class TraceloopTracer(OTLPTracerBase):
         metadata: dict[str, Any] | None = None,
         vertex: Vertex | None = None,
     ) -> None:
-        if not self.ready:
+        if not self.ready or self.tracer is None:
             return
 
         span_context = self.propagator.extract(carrier=self.carrier)
@@ -198,7 +199,7 @@ class TraceloopTracer(OTLPTracerBase):
         error: Exception | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> None:
-        if not self.ready:
+        if not self.ready or self.root_span is None:
             return
 
         safe_outputs = self._convert_to_otlp_dict(outputs)

--- a/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
+++ b/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
@@ -11,7 +11,7 @@ def tracer():
 def test_data_dict_conversion(tracer):
     value = Data(data={"a": 1, "b": "x"})
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == {"a": 1, "b": "x"}
 
@@ -19,7 +19,7 @@ def test_data_dict_conversion(tracer):
 def test_data_list_conversion(tracer):
     value = Data.model_construct(data=[1, Data(data={"x": 2})], text_key="text", default_value="")
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == [1, {"x": 2}]
 
@@ -27,7 +27,7 @@ def test_data_list_conversion(tracer):
 def test_data_text_payload_preserved(tracer):
     value = Data(data={"text": "hello"})
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == {"text": "hello"}
 
@@ -35,7 +35,7 @@ def test_data_text_payload_preserved(tracer):
 def test_data_nested_structure(tracer):
     value = Data(data={"nested": [1, Data(data={"x": float("inf")})]})
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == {"nested": [1, {"x": "NaN"}]}
 
@@ -43,7 +43,7 @@ def test_data_nested_structure(tracer):
 def test_data_none(tracer):
     value = Data(data=None)
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == {}
 
@@ -54,7 +54,7 @@ def test_dict_recursive_conversion(tracer):
         "c": [Data(data={"text": "text"}), 2],
     }
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == {
         "a": {"b": 1},
@@ -68,7 +68,7 @@ def test_list_recursive_conversion(tracer):
         Data(data={"text": "y"}),
     ]
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == [{"x": 1}, {"text": "y"}]
 
@@ -76,7 +76,7 @@ def test_list_recursive_conversion(tracer):
 def test_float_nan_conversion(tracer):
     value = float("nan")
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == "NaN"
 
@@ -84,7 +84,7 @@ def test_float_nan_conversion(tracer):
 def test_float_inf_conversion(tracer):
     value = float("inf")
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == "NaN"
 
@@ -92,7 +92,7 @@ def test_float_inf_conversion(tracer):
 def test_none_type_conversion(tracer):
     value = None
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == "None"
 
@@ -103,7 +103,7 @@ def test_generator_conversion(tracer):
 
     value = gen()
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert isinstance(result, str)
 
@@ -111,7 +111,7 @@ def test_generator_conversion(tracer):
 def test_plain_dict_unchanged(tracer):
     value = {"a": 1, "b": 2}
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == value
 
@@ -119,6 +119,6 @@ def test_plain_dict_unchanged(tracer):
 def test_plain_list_unchanged(tracer):
     value = [1, 2, 3]
 
-    result = tracer._convert_to_arize_phoenix_type(value)
+    result = tracer._convert_langflow_type(value)
 
     assert result == value

--- a/src/backend/tests/unit/services/tracing/test_http_context_propagation.py
+++ b/src/backend/tests/unit/services/tracing/test_http_context_propagation.py
@@ -129,13 +129,16 @@ class TestArizePhoenixHttpInstrumentation:
     """Test HTTP client instrumentation in ArizePhoenixTracer."""
 
     @pytest.fixture(autouse=True)
-    def reset_manager(self):
-        """Reset the singleton manager between tests."""
+    def reset_singletons(self):
+        """Reset singleton managers between tests."""
+        from langflow.services.tracing.arize_phoenix import _reset_arize_provider
         from langflow.services.tracing.http_instrumentation import HTTPClientInstrumentationManager
 
         HTTPClientInstrumentationManager._instance = None
+        _reset_arize_provider()
         yield
         HTTPClientInstrumentationManager._instance = None
+        _reset_arize_provider()
 
     @pytest.fixture
     def mock_phoenix_imports(self):

--- a/src/backend/tests/unit/services/tracing/test_tracer_regression.py
+++ b/src/backend/tests/unit/services/tracing/test_tracer_regression.py
@@ -1,0 +1,306 @@
+"""Regression tests for tracer configuration.
+
+These tests verify that the refactoring of OTLP tracers does not change:
+- Span attributes
+- Endpoint URIs
+- Headers sent to backends
+
+Run on both base and refactored branches to validate no behavioral changes.
+"""
+
+import os
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+class TestArizePhoenixConfiguration:
+    """Test Arize/Phoenix tracer configuration is unchanged."""
+
+    @pytest.fixture(autouse=True)
+    def reset_singletons(self):
+        """Reset singleton state between tests."""
+        # Reset HTTP instrumentation manager
+        from langflow.services.tracing.http_instrumentation import HTTPClientInstrumentationManager
+
+        HTTPClientInstrumentationManager._instance = None
+
+        # Reset arize shared provider
+        try:
+            from langflow.services.tracing.arize_phoenix import _reset_arize_provider
+
+            _reset_arize_provider()
+        except ImportError:
+            # Older versions may not have this function
+            import langflow.services.tracing.arize_phoenix as arize_mod
+
+            arize_mod._shared_provider = None
+            arize_mod._shared_tracer = None
+            arize_mod._instrumentor_applied = False
+
+        yield
+
+        HTTPClientInstrumentationManager._instance = None
+        try:
+            from langflow.services.tracing.arize_phoenix import _reset_arize_provider
+
+            _reset_arize_provider()
+        except ImportError:
+            arize_mod._shared_provider = None
+            arize_mod._shared_tracer = None
+            arize_mod._instrumentor_applied = False
+
+    def test_arize_endpoint_configuration(self):
+        """Verify Arize endpoint and headers are correctly configured."""
+        captured_config = {}
+
+        def capture_grpc_exporter(endpoint, headers):
+            captured_config["arize_endpoint"] = endpoint
+            captured_config["arize_headers"] = headers
+            return MagicMock()
+
+        def capture_http_exporter(endpoint, headers):
+            captured_config["phoenix_endpoint"] = endpoint
+            captured_config["phoenix_headers"] = headers
+            return MagicMock()
+
+        mock_provider = MagicMock(spec=TracerProvider)
+        mock_provider.get_tracer.return_value = MagicMock()
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "ARIZE_API_KEY": "test-arize-key",  # pragma: allowlist secret
+                    "ARIZE_SPACE_ID": "test-space-id",
+                    "ARIZE_COLLECTOR_ENDPOINT": "https://otlp.arize.com",
+                    "PHOENIX_API_KEY": "test-phoenix-key",  # pragma: allowlist secret
+                    "PHOENIX_COLLECTOR_ENDPOINT": "https://app.phoenix.arize.com",
+                },
+            ),
+            patch("phoenix.otel.TracerProvider", return_value=mock_provider),
+            patch("phoenix.otel.Resource"),
+            patch("phoenix.otel.SimpleSpanProcessor"),
+            patch("phoenix.otel.BatchSpanProcessor"),
+            patch("phoenix.otel.GRPCSpanExporter", side_effect=capture_grpc_exporter),
+            patch("phoenix.otel.HTTPSpanExporter", side_effect=capture_http_exporter),
+            patch("phoenix.otel.PROJECT_NAME", "test"),
+            patch("openinference.instrumentation.langchain.LangChainInstrumentor"),
+            patch("opentelemetry.instrumentation.requests.RequestsInstrumentor"),
+            patch("opentelemetry.instrumentation.urllib3.URLLib3Instrumentor"),
+        ):
+            from langflow.services.tracing.arize_phoenix import ArizePhoenixTracer
+
+            tracer = ArizePhoenixTracer(
+                trace_name="Test Flow - abc123",
+                trace_type="chain",
+                project_name="test-project",
+                trace_id=uuid.uuid4(),
+            )
+            _ = tracer  # Suppress unused warning
+
+        # Verify Arize configuration
+        assert captured_config["arize_endpoint"] == "https://otlp.arize.com/v1"
+        assert captured_config["arize_headers"] == {
+            "api_key": "test-arize-key",  # pragma: allowlist secret
+            "space_id": "test-space-id",
+            "authorization": "Bearer test-arize-key",
+        }
+
+        # Verify Phoenix configuration
+        assert captured_config["phoenix_endpoint"] == "https://app.phoenix.arize.com/v1/traces"
+        assert captured_config["phoenix_headers"] == {
+            "api_key": "test-phoenix-key",  # pragma: allowlist secret
+            "authorization": "Bearer test-phoenix-key",
+        }
+
+
+class TestLangWatchConfiguration:
+    """Test LangWatch tracer configuration is unchanged."""
+
+    @pytest.fixture(autouse=True)
+    def reset_singletons(self):
+        """Reset singleton state between tests."""
+        from langflow.services.tracing.http_instrumentation import HTTPClientInstrumentationManager
+
+        HTTPClientInstrumentationManager._instance = None
+
+        try:
+            from langflow.services.tracing.langwatch import _reset_langwatch_provider
+
+            _reset_langwatch_provider()
+        except ImportError:
+            import langflow.services.tracing.langwatch as lw_mod
+
+            lw_mod._shared_provider = None
+
+        yield
+
+        HTTPClientInstrumentationManager._instance = None
+        try:
+            from langflow.services.tracing.langwatch import _reset_langwatch_provider
+
+            _reset_langwatch_provider()
+        except ImportError:
+            lw_mod._shared_provider = None
+
+    def test_langwatch_endpoint_configuration(self):
+        """Verify LangWatch endpoint and headers are correctly configured."""
+        captured_config = {}
+
+        def capture_exporter(*_args, **kwargs):
+            captured_config["endpoint"] = kwargs.get("endpoint")
+            captured_config["headers"] = kwargs.get("headers")
+            return MagicMock()
+
+        mock_langwatch = MagicMock()
+        mock_langwatch.trace.return_value.__enter__ = MagicMock()
+        mock_langwatch.trace.return_value.__exit__ = MagicMock()
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "LANGWATCH_API_KEY": "test-langwatch-key",  # pragma: allowlist secret
+                    "LANGWATCH_ENDPOINT": "https://app.langwatch.ai",
+                },
+            ),
+            patch.dict("sys.modules", {"langwatch": mock_langwatch}),
+            patch("opentelemetry.sdk.trace.TracerProvider"),
+            patch("opentelemetry.sdk.resources.Resource"),
+            patch("opentelemetry.sdk.trace.export.BatchSpanProcessor"),
+            patch(
+                "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+                side_effect=capture_exporter,
+            ),
+            patch("opentelemetry.instrumentation.requests.RequestsInstrumentor"),
+            patch("opentelemetry.instrumentation.urllib3.URLLib3Instrumentor"),
+        ):
+            from langflow.services.tracing.langwatch import LangWatchTracer
+
+            tracer = LangWatchTracer(
+                trace_name="Test Flow - abc123",
+                trace_type="chain",
+                project_name="test-project",
+                trace_id=uuid.uuid4(),
+            )
+            _ = tracer
+
+        # Verify endpoint configuration
+        assert captured_config["endpoint"] == "https://app.langwatch.ai/api/otel/v1/traces"
+        assert captured_config["headers"] == {"Authorization": "Bearer test-langwatch-key"}
+
+
+class TestOTLPTracerConfiguration:
+    """Test generic OTLP tracer configuration is unchanged."""
+
+    @pytest.fixture(autouse=True)
+    def reset_singletons(self):
+        """Reset singleton state between tests."""
+        try:
+            from langflow.services.tracing.otlp import _reset_shared_provider
+
+            _reset_shared_provider()
+        except (ImportError, AttributeError):
+            # May not exist on all versions
+            pass
+
+        yield
+
+        try:
+            from langflow.services.tracing.otlp import _reset_shared_provider
+
+            _reset_shared_provider()
+        except (ImportError, AttributeError):
+            pass
+
+    def test_otlp_tracer_uses_standard_env_vars(self):
+        """Verify OTLP tracer respects standard OpenTelemetry env vars."""
+        from langflow.services.tracing.otlp import _validate_otlp_env
+
+        # Test with no env vars - need to clear them
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "",
+                "OTEL_SDK_DISABLED": "",
+            },
+            clear=False,
+        ):
+            os.environ.pop("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None)
+            os.environ.pop("OTEL_EXPORTER_OTLP_ENDPOINT", None)
+            os.environ.pop("OTEL_SDK_DISABLED", None)
+            assert _validate_otlp_env() is False
+
+        # Test with traces endpoint
+        with patch.dict(
+            os.environ,
+            {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+            clear=False,
+        ):
+            assert _validate_otlp_env() is True
+
+        # Test with generic endpoint
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+            },
+            clear=False,
+        ):
+            os.environ.pop("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None)
+            assert _validate_otlp_env() is True
+
+    def test_otlp_root_span_attributes(self):
+        """Verify OTLP tracer sets expected root span attributes."""
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+        test_trace_id = uuid.uuid4()
+        test_session_id = "test-session-456"
+        test_user_id = uuid.uuid4()
+
+        with (
+            patch.dict(
+                os.environ,
+                {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+            ),
+            patch(
+                "langflow.services.tracing.otlp._get_shared_provider",
+                return_value=(provider, provider.get_tracer(__name__)),
+            ),
+        ):
+            from langflow.services.tracing.otlp import OTLPTracer
+
+            tracer = OTLPTracer(
+                trace_name="Test Flow - flow123",
+                trace_type="chain",
+                project_name="test-project",
+                trace_id=test_trace_id,
+                session_id=test_session_id,
+                user_id=test_user_id,
+            )
+
+            # End the trace to flush spans
+            tracer.end(inputs={"test": "input"}, outputs={"test": "output"})
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) >= 1
+
+        root_span = spans[0]
+        attrs = dict(root_span.attributes)
+
+        # Verify Langflow workflow attributes
+        assert attrs.get("langflow.trace_id") == str(test_trace_id)
+        assert attrs.get("langflow.trace_name") == "Test Flow - flow123"
+        assert attrs.get("langflow.trace_type") == "chain"
+        assert attrs.get("langflow.project_name") == "test-project"
+        assert attrs.get("langflow.session_id") == test_session_id
+        assert attrs.get("langflow.user_id") == str(test_user_id)

--- a/src/backend/tests/unit/services/tracing/test_tracing_service.py
+++ b/src/backend/tests/unit/services/tracing/test_tracing_service.py
@@ -158,6 +158,10 @@ def mock_tracers():
             "langflow.services.tracing.service._get_openlayer_tracer",
             return_value=MockTracer,
         ),
+        patch(
+            "langflow.services.tracing.service._get_otlp_tracer",
+            return_value=MockTracer,
+        ),
     ):
         yield
 
@@ -192,6 +196,7 @@ async def test_start_end_tracers(tracing_service):
     assert "traceloop" in trace_context.tracers
     assert "native" in trace_context.tracers
     assert "openlayer" in trace_context.tracers
+    assert "otlp" in trace_context.tracers
 
     await tracing_service.end_tracers(outputs)
 
@@ -696,3 +701,770 @@ def test_set_outputs_without_component_context(tracing_service):
     component_context_var.set(None)
     # Should not raise
     tracing_service.set_outputs("some_trace", {"key": "value"})
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_with_valid_endpoint():
+    """Test OTLP tracer initialization with valid endpoint."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict(
+        "os.environ",
+        {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+        clear=True,
+    ):
+        test_trace_id = uuid.uuid4()
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=test_trace_id,
+            user_id="test_user",
+            session_id="test_session",
+        )
+        assert tracer.ready is True
+        assert tracer.tracer is not None
+        assert tracer.root_span is not None
+        assert tracer.root_span.name == "test_trace"
+        assert tracer.root_span.is_recording()
+        # Verify trace context propagation carrier
+        assert tracer.carrier != {}
+        assert "traceparent" in tracer.carrier
+        # Verify traceparent contains valid trace_id from root span
+        parts = tracer.carrier["traceparent"].split("-")
+        assert len(parts) == 4
+        assert parts[1] == format(tracer.root_span.context.trace_id, "032x")
+        tracer.close()
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_with_generic_endpoint():
+    """Test OTLP tracer initialization with generic OTEL_EXPORTER_OTLP_ENDPOINT."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"}, clear=True):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready is True
+        assert tracer.tracer is not None
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_without_endpoint():
+    """Test OTLP tracer fails gracefully when no endpoint is configured."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict("os.environ", {}, clear=True):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready is False
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_protocol_http_protobuf():
+    """Test OTLP tracer with HTTP protobuf protocol."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces",
+                "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+            },
+            clear=True,
+        ),
+        patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter") as mock_http_exporter,
+    ):
+        mock_http_exporter.return_value = MagicMock()
+
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready is True
+        # Verify HTTP exporter was used
+        mock_http_exporter.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_protocol_grpc():
+    """Test OTLP tracer with gRPC protocol."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4317",
+                "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+            },
+            clear=True,
+        ),
+        patch("opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter") as mock_grpc_exporter,
+    ):
+        mock_grpc_exporter.return_value = MagicMock()
+
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready is True
+        # Verify gRPC exporter was used
+        mock_grpc_exporter.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_service_name():
+    """Test OTLP tracer respects OTEL_SERVICE_NAME."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict(
+        "os.environ",
+        {
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces",
+            "OTEL_SERVICE_NAME": "custom-service",
+        },
+        clear=True,
+    ):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready is True
+        # Verify service name in resource attributes
+        assert tracer.tracer_provider.resource.attributes["service.name"] == "custom-service"
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_resource_attributes():
+    """Test OTLP tracer includes resource attributes from environment."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict(
+        "os.environ",
+        {
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces",
+            "OTEL_RESOURCE_ATTRIBUTES": "environment=production,version=1.0",
+        },
+        clear=True,
+    ):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready is True
+        # Verify resource attributes were parsed and included
+        resource_attrs = tracer.tracer_provider.resource.attributes
+        assert resource_attrs["environment"] == "production"
+        assert resource_attrs["version"] == "1.0"
+        assert resource_attrs["langflow.project_name"] == "test_project"
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_add_and_end_trace():
+    """Test OTLP tracer add_trace and end_trace methods."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict(
+        "os.environ",
+        {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+        clear=True,
+    ):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+
+        trace_id = "test_child_trace_id"
+        inputs = {"input_key": "input_value"}
+        outputs = {"output_key": "output_value"}
+
+        # Add trace
+        tracer.add_trace(
+            trace_id=trace_id,
+            trace_name="child_trace",
+            trace_type="component",
+            inputs=inputs,
+            metadata={"meta_key": "meta_value"},
+        )
+
+        assert trace_id in tracer.child_spans
+
+        # Verify span attributes were set
+        child_span = tracer.child_spans[trace_id]
+        assert child_span.name == "child_trace"
+        # Note: attributes are set but not easily accessible from the span object
+        # The span.attributes property is internal and may not be directly testable
+
+        # End trace
+        tracer.end_trace(
+            trace_id=trace_id,
+            trace_name="child_trace",
+            outputs=outputs,
+        )
+
+        assert trace_id not in tracer.child_spans
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_end_with_error():
+    """Test OTLP tracer end method with error."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict(
+        "os.environ",
+        {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+        clear=True,
+    ):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+
+        # Mock record_exception to verify it's called
+        tracer.root_span.record_exception = MagicMock()
+
+        test_error = ValueError("Test error")
+        tracer.end(
+            inputs={"input_key": "input_value"},
+            outputs={"output_key": "output_value"},
+            error=test_error,
+        )
+
+        # Verify the tracer handled the error without raising
+        assert tracer.ready is True
+        # Verify exception was recorded
+        tracer.root_span.record_exception.assert_called_once_with(test_error)
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_child_trace_with_error():
+    """Test OTLP tracer end_trace method with error."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict(
+        "os.environ",
+        {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+        clear=True,
+    ):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+
+        trace_id = "test_child_trace_id"
+
+        # Add trace
+        tracer.add_trace(
+            trace_id=trace_id,
+            trace_name="child_trace",
+            trace_type="component",
+            inputs={"input_key": "input_value"},
+        )
+
+        # Mock record_exception
+        child_span = tracer.child_spans[trace_id]
+        child_span.record_exception = MagicMock()
+
+        # End trace with error
+        test_error = ValueError("Child trace error")
+        tracer.end_trace(
+            trace_id=trace_id,
+            trace_name="child_trace",
+            error=test_error,
+        )
+
+        # Verify exception was recorded
+        child_span.record_exception.assert_called_once_with(test_error)
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_close():
+    """Test OTLP tracer close method flushes spans."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict(
+        "os.environ",
+        {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+        clear=True,
+    ):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+
+        # Mock the tracer_provider force_flush
+        tracer.tracer_provider.force_flush = MagicMock()
+
+        tracer.close()
+
+        # Verify force_flush was called
+        tracer.tracer_provider.force_flush.assert_called_once_with(timeout_millis=3000)
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_not_ready_operations():
+    """Test that OTLP tracer operations are no-ops when not ready."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict("os.environ", {}, clear=True):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready is False
+
+        # These should not raise exceptions
+        tracer.add_trace(
+            trace_id="test_id",
+            trace_name="test_name",
+            trace_type="test_type",
+            inputs={"key": "value"},
+        )
+
+        tracer.end_trace(
+            trace_id="test_id",
+            trace_name="test_name",
+            outputs={"key": "value"},
+        )
+
+        tracer.end(
+            inputs={"key": "value"},
+            outputs={"key": "value"},
+        )
+
+        # Verify tracer remains not ready after all operations
+        assert tracer.ready is False
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_setup_failure():
+    """Test OTLP tracer handles setup failures gracefully."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+            clear=True,
+        ),
+        patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter") as mock_exporter,
+    ):
+        # Make the exporter instantiation fail
+        mock_exporter.side_effect = Exception("Connection refused")
+
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        # Tracer should not be ready when setup fails
+        assert tracer.ready is False
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_optional_params():
+    """Test OTLP tracer with optional user_id and session_id."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict(
+        "os.environ",
+        {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+        clear=True,
+    ):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+            # user_id and session_id are omitted
+        )
+        assert tracer.ready is True
+        assert tracer.user_id is None
+        assert tracer.session_id is None
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_span_attributes():
+    """Test that OTLP tracer sets correct span attributes."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    # Create a mock exporter to capture spans
+    class SpanCapturingExporter:
+        """In-memory span exporter that records exported spans for test assertions."""
+
+        def __init__(self):
+            self.exported_spans = []
+
+        def export(self, spans):
+            """Append finished spans to the internal list."""
+            self.exported_spans.extend(spans)
+            return MagicMock()
+
+        def shutdown(self):
+            """No-op shutdown."""
+
+        def force_flush(self, _timeout_millis=None):
+            """No-op flush; all spans are already stored synchronously."""
+            return True
+
+    with patch.dict(
+        "os.environ",
+        {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+        clear=True,
+    ):
+        # Patch the OTLPSpanExporter to use our capturing exporter instead
+        span_exporter = SpanCapturingExporter()
+        with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter") as mock_exporter:
+            mock_exporter.return_value = span_exporter
+
+            test_trace_id = uuid.uuid4()
+            tracer = OTLPTracer(
+                trace_name="test_trace",
+                trace_type="chain",
+                project_name="test_project",
+                trace_id=test_trace_id,
+                user_id="test_user",
+                session_id="test_session",
+            )
+
+            # Add a child trace
+            tracer.add_trace(
+                trace_id="child_1",
+                trace_name="child_trace",
+                trace_type="component",
+                inputs={"input_key": "input_value"},
+                metadata={"meta_key": "meta_value"},
+            )
+
+            # End the child trace
+            tracer.end_trace(
+                trace_id="child_1",
+                trace_name="child_trace",
+                outputs={"output_key": "output_value"},
+            )
+
+            # End the root trace
+            tracer.end(
+                inputs={"root_input": "value"},
+                outputs={"root_output": "value"},
+            )
+
+            # Force flush to export spans
+            tracer.tracer_provider.force_flush()
+
+            # Verify spans were exported
+            assert len(span_exporter.exported_spans) == 2  # root + child
+
+            # Find the root span
+            root_spans = [s for s in span_exporter.exported_spans if s.name == "test_trace"]
+            assert len(root_spans) == 1
+            root_span = root_spans[0]
+
+            # Verify root span attributes
+            assert root_span.attributes["langflow.trace_id"] == str(test_trace_id)
+            assert root_span.attributes["langflow.trace_name"] == "test_trace"
+            assert root_span.attributes["langflow.trace_type"] == "chain"
+            assert root_span.attributes["langflow.project_name"] == "test_project"
+            assert root_span.attributes["langflow.user_id"] == "test_user"
+            assert root_span.attributes["langflow.session_id"] == "test_session"
+
+            # Find the child span
+            child_spans = [s for s in span_exporter.exported_spans if s.name == "child_trace"]
+            assert len(child_spans) == 1
+            child_span = child_spans[0]
+
+            # Verify child span attributes
+            assert child_span.attributes["trace_id"] == "child_1"
+            assert child_span.attributes["trace_name"] == "child_trace"
+            assert child_span.attributes["trace_type"] == "component"
+            assert "inputs" in child_span.attributes
+            assert "outputs" in child_span.attributes
+
+            # Verify parent-child relationship via trace IDs
+            root_trace_id = format(root_span.context.trace_id, "032x")
+            child_trace_id = format(child_span.context.trace_id, "032x")
+            assert child_trace_id == root_trace_id, (
+                f"Child trace_id {child_trace_id} should match root trace_id {root_trace_id}"
+            )
+
+            # Child span's parent should be the root span
+            assert child_span.parent is not None, "Child span should have a parent"
+            child_parent_span_id = format(child_span.parent.span_id, "016x")
+            root_span_id = format(root_span.context.span_id, "016x")
+            assert child_parent_span_id == root_span_id, (
+                f"Child parent span_id {child_parent_span_id} should match root span_id {root_span_id}"
+            )
+
+            # Verify outputs are JSON-encoded strings
+            import json
+
+            root_outputs = json.loads(root_span.attributes["outputs"])
+            assert root_outputs["root_output"] == "value"
+            child_outputs = json.loads(child_span.attributes["outputs"])
+            assert child_outputs["output_key"] == "output_value"
+            child_inputs = json.loads(child_span.attributes["inputs"])
+            assert child_inputs["input_key"] == "input_value"
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_missing_both_endpoints():
+    """Test OTLP tracer is not ready when neither endpoint env var is set."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict("os.environ", {}, clear=True):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready is False
+        assert tracer.root_span is None
+        assert tracer.tracer is None
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_generic_endpoint_fallback():
+    """Test OTLP tracer works with OTEL_EXPORTER_OTLP_ENDPOINT (generic) when traces-specific is absent."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict(
+        "os.environ",
+        {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"},
+        clear=True,
+    ):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready is True
+        assert tracer.root_span is not None
+        tracer.close()
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_traces_protocol_overrides_generic():
+    """Test OTEL_EXPORTER_OTLP_TRACES_PROTOCOL takes priority over OTEL_EXPORTER_OTLP_PROTOCOL."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4317",
+                "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+                "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "grpc",
+            },
+            clear=True,
+        ),
+        patch("opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter") as mock_grpc,
+    ):
+        mock_grpc.return_value = MagicMock()
+
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready is True
+        # gRPC exporter should be used despite generic protocol saying http/protobuf
+        mock_grpc.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_unsupported_protocol_falls_back():
+    """Test OTLP tracer falls back to http/protobuf for unsupported protocol values (including http/json)."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    for bad_protocol in ("invalid_protocol", "http/json"):
+        with patch.dict(
+            "os.environ",
+            {
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces",
+                "OTEL_EXPORTER_OTLP_PROTOCOL": bad_protocol,
+            },
+            clear=True,
+        ):
+            tracer = OTLPTracer(
+                trace_name="test_trace",
+                trace_type="chain",
+                project_name="test_project",
+                trace_id=uuid.uuid4(),
+            )
+            assert tracer.ready is True, f"Tracer should fall back gracefully for protocol={bad_protocol}"
+            tracer.close()
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_setup_exception_types():
+    """Test OTLP tracer catches various exception types during setup."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    for exc_cls in (RuntimeError, ConnectionError, OSError, TypeError):
+        with (
+            patch.dict(
+                "os.environ",
+                {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+                clear=True,
+            ),
+            patch(
+                "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+                side_effect=exc_cls("setup failed"),
+            ),
+        ):
+            tracer = OTLPTracer(
+                trace_name="test_trace",
+                trace_type="chain",
+                project_name="test_project",
+                trace_id=uuid.uuid4(),
+            )
+            assert tracer.ready is False, f"Tracer should not be ready after {exc_cls.__name__}"
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_end_trace_unknown_id():
+    """Test that ending a trace with an unknown ID is a safe no-op."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with patch.dict(
+        "os.environ",
+        {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+        clear=True,
+    ):
+        tracer = OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready is True
+
+        # Ending a non-existent child trace should not raise
+        tracer.end_trace(
+            trace_id="nonexistent_id",
+            trace_name="nonexistent",
+            outputs={"key": "value"},
+        )
+
+        # Tracer should still be functional
+        assert tracer.ready is True
+        tracer.close()
+
+
+@pytest.mark.asyncio
+async def test_otlp_tracer_nested_metadata_stringified():
+    """Test that nested dicts/lists in metadata are JSON-stringified for span attributes."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    class SpanCapturingExporter:
+        """In-memory span exporter that records exported spans for test assertions."""
+
+        def __init__(self):
+            self.exported_spans = []
+
+        def export(self, spans):
+            """Append finished spans to the internal list."""
+            self.exported_spans.extend(spans)
+            return MagicMock()
+
+        def shutdown(self):
+            """No-op shutdown."""
+
+        def force_flush(self, _timeout_millis=None):
+            """No-op flush; all spans are already stored synchronously."""
+            return True
+
+    with patch.dict(
+        "os.environ",
+        {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+        clear=True,
+    ):
+        span_exporter = SpanCapturingExporter()
+        with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter") as mock_exp:
+            mock_exp.return_value = span_exporter
+
+            tracer = OTLPTracer(
+                trace_name="test_trace",
+                trace_type="chain",
+                project_name="test_project",
+                trace_id=uuid.uuid4(),
+            )
+
+            nested_metadata = {
+                "simple_key": "simple_value",
+                "nested_dict": {"inner_key": "inner_value", "deep": {"a": 1}},
+                "nested_list": [1, {"b": 2}, [3, 4]],
+                "number": 42,
+            }
+
+            # Test via add_trace (child span metadata)
+            tracer.add_trace(
+                trace_id="child_1",
+                trace_name="child",
+                trace_type="component",
+                inputs={"x": "y"},
+                metadata=nested_metadata,
+            )
+            tracer.end_trace(trace_id="child_1", trace_name="child")
+
+            # Test via end() (root span metadata)
+            tracer.end(
+                inputs={},
+                outputs={},
+                metadata=nested_metadata,
+            )
+
+            tracer.tracer_provider.force_flush()
+
+            import json
+
+            # Verify child span metadata attributes
+            child_span = next(s for s in span_exporter.exported_spans if s.name == "child")
+            assert child_span.attributes["metadata.simple_key"] == "simple_value"
+            assert child_span.attributes["metadata.number"] == 42
+            # Nested dict should be JSON-stringified
+            parsed_dict = json.loads(child_span.attributes["metadata.nested_dict"])
+            assert parsed_dict["inner_key"] == "inner_value"
+            assert parsed_dict["deep"]["a"] == 1
+            # Nested list should be JSON-stringified
+            parsed_list = json.loads(child_span.attributes["metadata.nested_list"])
+            assert parsed_list == [1, {"b": 2}, [3, 4]]
+
+            # Verify root span metadata attributes
+            root_span = next(s for s in span_exporter.exported_spans if s.name == "test_trace")
+            assert root_span.attributes["metadata.simple_key"] == "simple_value"
+            assert root_span.attributes["metadata.number"] == 42
+            parsed_dict = json.loads(root_span.attributes["metadata.nested_dict"])
+            assert parsed_dict["deep"]["a"] == 1

--- a/src/backend/tests/unit/services/tracing/test_tracing_service.py
+++ b/src/backend/tests/unit/services/tracing/test_tracing_service.py
@@ -640,9 +640,8 @@ async def test_concurrent_tracing(tracing_service, mock_component):
                 ts.set_outputs(trace_name, outputs)
 
         task1 = asyncio.create_task(run_component_task(mock_component, f"{run_id} trace_name1", f"{run_id} component1"))
-        await task1
         task2 = asyncio.create_task(run_component_task(mock_component, f"{run_id} trace_name2", f"{run_id} component2"))
-        await task2
+        await asyncio.gather(task1, task2)
 
         await tracing_service.end_tracers({"final_output": f"{task_prefix}_final_output"})
         trace_context = trace_context_var.get()

--- a/src/backend/tests/unit/services/tracing/test_tracing_service.py
+++ b/src/backend/tests/unit/services/tracing/test_tracing_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langflow.services.tracing.base import BaseTracer
+from langflow.services.tracing.otlp import _reset_shared_provider
 from langflow.services.tracing.service import (
     TracingService,
     component_context_var,
@@ -12,6 +13,17 @@ from langflow.services.tracing.service import (
 )
 from lfx.services.settings.base import Settings
 from lfx.services.settings.service import SettingsService
+
+
+@pytest.fixture(autouse=True)
+def _reset_otlp_provider():
+    """Reset the shared OTLP TracerProvider before and after each test.
+
+    Ensures test isolation since the singleton persists across test runs.
+    """
+    _reset_shared_provider()
+    yield
+    _reset_shared_provider()
 
 
 class MockTracer(BaseTracer):
@@ -846,8 +858,10 @@ async def test_otlp_tracer_service_name():
             trace_id=uuid.uuid4(),
         )
         assert tracer.ready is True
-        # Verify service name in resource attributes
-        assert tracer.tracer_provider.resource.attributes["service.name"] == "custom-service"
+        # Verify service name in resource attributes via the shared provider
+        from langflow.services.tracing import otlp as otlp_mod
+
+        assert otlp_mod._shared_provider.resource.attributes["service.name"] == "custom-service"
 
 
 @pytest.mark.asyncio
@@ -871,7 +885,9 @@ async def test_otlp_tracer_resource_attributes():
         )
         assert tracer.ready is True
         # Verify resource attributes were parsed and included
-        resource_attrs = tracer.tracer_provider.resource.attributes
+        from langflow.services.tracing import otlp as otlp_mod
+
+        resource_attrs = otlp_mod._shared_provider.resource.attributes
         assert resource_attrs["environment"] == "production"
         assert resource_attrs["version"] == "1.0"
         assert resource_attrs["langflow.project_name"] == "test_project"
@@ -1002,8 +1018,8 @@ async def test_otlp_tracer_child_trace_with_error():
 
 
 @pytest.mark.asyncio
-async def test_otlp_tracer_close():
-    """Test OTLP tracer close method flushes spans."""
+async def test_otlp_tracer_close_is_noop():
+    """Test OTLP tracer close() is a no-op (provider lifecycle is module-level)."""
     from langflow.services.tracing.otlp import OTLPTracer
 
     with patch.dict(
@@ -1018,13 +1034,34 @@ async def test_otlp_tracer_close():
             trace_id=uuid.uuid4(),
         )
 
-        # Mock the tracer_provider force_flush
-        tracer.tracer_provider.force_flush = MagicMock()
-
+        # close() should not raise and should be a no-op
         tracer.close()
+        assert tracer.ready is True
 
-        # Verify force_flush was called
-        tracer.tracer_provider.force_flush.assert_called_once_with(timeout_millis=3000)
+
+@pytest.mark.asyncio
+async def test_otlp_shutdown_provider():
+    """Test shutdown_otlp_provider flushes and clears the shared provider."""
+    from langflow.services.tracing import otlp as otlp_mod
+    from langflow.services.tracing.otlp import OTLPTracer, shutdown_otlp_provider
+
+    with patch.dict(
+        "os.environ",
+        {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces"},
+        clear=True,
+    ):
+        OTLPTracer(
+            trace_name="test_trace",
+            trace_type="chain",
+            project_name="test_project",
+            trace_id=uuid.uuid4(),
+        )
+        assert otlp_mod._shared_provider is not None
+
+        shutdown_otlp_provider()
+
+        assert otlp_mod._shared_provider is None
+        assert otlp_mod._shared_tracer is None
 
 
 @pytest.mark.asyncio
@@ -1179,7 +1216,9 @@ async def test_otlp_tracer_span_attributes():
             )
 
             # Force flush to export spans
-            tracer.tracer_provider.force_flush()
+            from langflow.services.tracing import otlp as otlp_mod
+
+            otlp_mod._shared_provider.force_flush()
 
             # Verify spans were exported
             assert len(span_exporter.exported_spans) == 2  # root + child
@@ -1446,7 +1485,9 @@ async def test_otlp_tracer_nested_metadata_stringified():
                 metadata=nested_metadata,
             )
 
-            tracer.tracer_provider.force_flush()
+            from langflow.services.tracing import otlp as otlp_mod
+
+            otlp_mod._shared_provider.force_flush()
 
             import json
 

--- a/src/backend/tests/unit/services/tracing/test_w3c_trace_context.py
+++ b/src/backend/tests/unit/services/tracing/test_w3c_trace_context.py
@@ -450,26 +450,13 @@ def test_concurrent_otlp_tracers_have_isolated_contexts():
             # Wait until both threads have attached their context
             barrier.wait(timeout=5)
 
-            with (
-                patch.dict(
-                    os.environ,
-                    {
-                        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
-                    },
-                    clear=True,
-                ),
-                patch(
-                    "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
-                    return_value=CollectingExporter(),
-                ),
-            ):
-                tracer = OTLPTracer(
-                    trace_name=f"flow-{label}",
-                    trace_type="chain",
-                    project_name="test",
-                    trace_id=uuid.uuid4(),
-                )
-                assert tracer.ready
+            tracer = OTLPTracer(
+                trace_name=f"flow-{label}",
+                trace_type="chain",
+                project_name="test",
+                trace_id=uuid.uuid4(),
+            )
+            assert tracer.ready
 
             results[label] = {
                 "trace_id": format(tracer.root_span.context.trace_id, "032x"),
@@ -487,12 +474,25 @@ def test_concurrent_otlp_tracers_have_isolated_contexts():
     expected_b_trace = format(span_b.get_span_context().trace_id, "032x")
     expected_b_span = format(span_b.get_span_context().span_id, "016x")
 
-    t1 = threading.Thread(target=_create_tracer, args=("A", span_a))
-    t2 = threading.Thread(target=_create_tracer, args=("B", span_b))
-    t1.start()
-    t2.start()
-    t1.join(timeout=10)
-    t2.join(timeout=10)
+    with (
+        patch.dict(
+            os.environ,
+            {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"},
+            clear=True,
+        ),
+        patch(
+            "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+            side_effect=lambda *_args, **_kwargs: CollectingExporter(),
+        ),
+    ):
+        t1 = threading.Thread(target=_create_tracer, args=("A", span_a))
+        t2 = threading.Thread(target=_create_tracer, args=("B", span_b))
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+    assert not t1.is_alive()
+    assert not t2.is_alive()
 
     span_a.end()
     span_b.end()

--- a/src/backend/tests/unit/services/tracing/test_w3c_trace_context.py
+++ b/src/backend/tests/unit/services/tracing/test_w3c_trace_context.py
@@ -21,6 +21,7 @@ import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from langflow.services.tracing.otlp import _reset_shared_provider
 from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -28,6 +29,14 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+
+@pytest.fixture(autouse=True)
+def _reset_otlp_provider():
+    """Reset the shared OTLP TracerProvider before and after each test."""
+    _reset_shared_provider()
+    yield
+    _reset_shared_provider()
 
 
 class CollectingExporter(SpanExporter):

--- a/src/backend/tests/unit/services/tracing/test_w3c_trace_context.py
+++ b/src/backend/tests/unit/services/tracing/test_w3c_trace_context.py
@@ -1,0 +1,503 @@
+"""Test W3C trace context propagation behavior.
+
+Tests cover:
+- FastAPIInstrumentor inbound extraction
+- Langflow-specific tracers inheriting extracted context via global OTel context
+- Outbound httpx propagation with and without HTTPXClientInstrumentor
+- Concurrent request isolation (no cross-request trace context leakage)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import uuid
+from collections import defaultdict
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+
+class CollectingExporter(SpanExporter):
+    """In-memory span exporter that collects finished spans for assertions."""
+
+    def __init__(self):
+        """Initialize with an empty span list and a lock for thread safety."""
+        self.spans: list[Any] = []
+        self._lock = threading.Lock()
+
+    def export(self, spans):
+        """Append finished spans to the internal list (thread-safe)."""
+        with self._lock:
+            self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self):
+        """No-op shutdown."""
+
+    def force_flush(self, _timeout_millis=30000):
+        """No-op flush; all spans are stored synchronously on export."""
+        return True
+
+
+@pytest.fixture
+def otel_app():
+    """Create a minimal FastAPI app instrumented the same way as main.py."""
+    exporter = CollectingExporter()
+    provider = TracerProvider(resource=Resource.create({"service.name": "test"}))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health():
+        """Minimal health endpoint for testing."""
+        return {"status": "ok"}
+
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=provider)
+
+    yield app, exporter, provider
+
+    FastAPIInstrumentor.uninstrument_app(app)
+    provider.shutdown()
+
+
+def test_traceparent_header_propagated(otel_app):
+    """Server span inherits the trace-id and parent-span-id from an incoming traceparent header."""
+    app, exporter, _provider = otel_app
+
+    # Craft a known W3C traceparent: version-trace_id-parent_id-flags
+    incoming_trace_id = "0af7651916cd43dd8448eb211c80319c"
+    incoming_span_id = "b7ad6b7169203331"
+    traceparent = f"00-{incoming_trace_id}-{incoming_span_id}-01"
+
+    client = TestClient(app)
+    response = client.get("/health", headers={"traceparent": traceparent})
+    assert response.status_code == 200
+
+    spans = exporter.spans
+    assert len(spans) >= 1, "Expected at least one server span"
+
+    # Find the root-most span in the trace (the one whose parent is the remote incoming span)
+    matching = [s for s in spans if format(s.context.trace_id, "032x") == incoming_trace_id]
+    assert matching, f"No spans found with trace_id {incoming_trace_id}"
+
+    # The outermost span should have a remote parent matching the incoming span_id
+    root_span = next(
+        (s for s in matching if s.parent and s.parent.is_remote),
+        None,
+    )
+    assert root_span is not None, (
+        "Expected a span with a remote parent (from the incoming traceparent). "
+        f"Span parents: {[(s.name, s.parent) for s in matching]}"
+    )
+
+    actual_parent_id = format(root_span.parent.span_id, "016x")
+    assert actual_parent_id == incoming_span_id, (
+        f"Root span parent_span_id {actual_parent_id} != incoming {incoming_span_id}"
+    )
+
+
+def test_no_traceparent_generates_new_trace(otel_app):
+    """Without a traceparent header, the server span starts a fresh trace with no parent."""
+    app, exporter, _provider = otel_app
+
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+
+    spans = exporter.spans
+    assert len(spans) >= 1
+
+    # Find the outermost span (no remote parent)
+    root_spans = [s for s in spans if s.parent is None or not s.parent.is_remote]
+    assert root_spans, "Expected at least one span without a remote parent"
+
+    # None of the spans should have a remote parent
+    remote_parent_spans = [s for s in spans if s.parent and s.parent.is_remote]
+    assert not remote_parent_spans, "Expected no spans with remote parents when traceparent header is absent"
+
+
+# ---------------------------------------------------------------------------
+# Langflow-specific tracers inherit the FastAPI-extracted context
+# ---------------------------------------------------------------------------
+
+
+def test_otlp_tracer_root_span_inherits_active_context():
+    """OTLPTracer root span inherits the active OTel context even with its own TracerProvider.
+
+    OpenTelemetry's start_span() reads the global context (not the provider) to find a
+    parent span. So when FastAPIInstrumentor has set an active span from an incoming
+    traceparent header, the OTLPTracer's root span becomes a child of that span,
+    sharing the same trace_id.
+    """
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    # Set up a "global" provider to simulate FastAPIInstrumentor's active span
+    global_provider = TracerProvider(resource=Resource.create({"service.name": "global"}))
+    global_provider.add_span_processor(SimpleSpanProcessor(CollectingExporter()))
+    global_tracer = global_provider.get_tracer("test")
+
+    # Simulate what FastAPIInstrumentor does: start a span and make it the active context
+    fastapi_span = global_tracer.start_span("GET /api/v1/run/flow-id")
+    ctx = trace.set_span_in_context(fastapi_span)
+    token = otel_context.attach(ctx)
+
+    try:
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+                },
+                clear=True,
+            ),
+            patch(
+                "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+                return_value=CollectingExporter(),
+            ),
+        ):
+            tracer = OTLPTracer(
+                trace_name="test-flow - abc123",
+                trace_type="chain",
+                project_name="test-project",
+                trace_id=uuid.uuid4(),
+            )
+            assert tracer.ready
+
+        fastapi_trace_id = format(fastapi_span.get_span_context().trace_id, "032x")
+        fastapi_span_id = format(fastapi_span.get_span_context().span_id, "016x")
+        otlp_trace_id = format(tracer.root_span.context.trace_id, "032x")
+
+        # The OTLPTracer root span shares the same trace_id as the FastAPI span
+        assert otlp_trace_id == fastapi_trace_id, (
+            f"OTLPTracer root span trace_id {otlp_trace_id} should match FastAPI span trace_id {fastapi_trace_id}"
+        )
+
+        # The OTLPTracer root span's parent is the FastAPI span
+        assert tracer.root_span.parent is not None, "OTLPTracer root span should have a parent"
+        actual_parent_id = format(tracer.root_span.parent.span_id, "016x")
+        assert actual_parent_id == fastapi_span_id, (
+            f"OTLPTracer root span parent {actual_parent_id} should be FastAPI span {fastapi_span_id}"
+        )
+    finally:
+        otel_context.detach(token)
+        fastapi_span.end()
+        global_provider.shutdown()
+        tracer.close()
+
+
+def test_otlp_tracer_root_span_independent_without_active_context():
+    """Without an active OTel context, the OTLPTracer root span starts an independent trace."""
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+            },
+            clear=True,
+        ),
+        patch(
+            "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+            return_value=CollectingExporter(),
+        ),
+    ):
+        tracer = OTLPTracer(
+            trace_name="test-flow - abc123",
+            trace_type="chain",
+            project_name="test-project",
+            trace_id=uuid.uuid4(),
+        )
+        assert tracer.ready
+
+    assert tracer.root_span.parent is None, "OTLPTracer root span should have no parent when no active context exists"
+    tracer.close()
+
+
+# ---------------------------------------------------------------------------
+# Outbound httpx trace context propagation
+# ---------------------------------------------------------------------------
+
+
+def test_outbound_httpx_without_instrumentation_does_not_inject_traceparent(otel_app):
+    """Without HTTPXClientInstrumentor, outbound httpx requests have no traceparent."""
+    app, _exporter, _provider = otel_app
+    captured_headers: dict[str, str] = {}
+
+    @app.get("/call-external-uninstrumented")
+    async def call_external():
+        """Make an outbound httpx call using MockTransport (no instrumentation)."""
+
+        async def capture_handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json={"ok": True})
+
+        transport = httpx.MockTransport(capture_handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            await client.get("http://external-service.example.com/api/data")
+        return {"status": "called"}
+
+    incoming_trace_id = "0af7651916cd43dd8448eb211c80319c"
+    incoming_span_id = "b7ad6b7169203331"
+    traceparent = f"00-{incoming_trace_id}-{incoming_span_id}-01"
+
+    client = TestClient(app)
+    response = client.get("/call-external-uninstrumented", headers={"traceparent": traceparent})
+    assert response.status_code == 200
+
+    assert "traceparent" not in captured_headers, (
+        "Outbound httpx request should NOT contain traceparent without instrumentation"
+    )
+
+
+def test_outbound_httpx_with_instrumentation_injects_traceparent(otel_app):
+    """With HTTPXClientInstrumentor enabled, outbound httpx requests carry traceparent."""
+    respx = pytest.importorskip("respx")
+    otel_httpx = pytest.importorskip("opentelemetry.instrumentation.httpx")
+    httpx_instrumentor_cls = otel_httpx.HTTPXClientInstrumentor
+
+    app, _exporter, provider = otel_app
+    captured_headers: dict[str, str] = {}
+
+    httpx_instrumentor_cls().instrument(tracer_provider=provider)
+
+    try:
+
+        @app.get("/call-external-instrumented")
+        async def call_external():
+            """Make an outbound httpx call through respx mock (with instrumentation)."""
+            with respx.mock:
+                route = respx.get("http://external-service.example.com/api/data").mock(
+                    return_value=httpx.Response(200, json={"ok": True})
+                )
+                async with httpx.AsyncClient() as client:
+                    await client.get("http://external-service.example.com/api/data")
+                # Capture the headers from the actual request that was sent
+                captured_headers.update(dict(route.calls[0].request.headers))
+            return {"status": "called"}
+
+        incoming_trace_id = "0af7651916cd43dd8448eb211c80319c"
+        incoming_span_id = "b7ad6b7169203331"
+        traceparent = f"00-{incoming_trace_id}-{incoming_span_id}-01"
+
+        client = TestClient(app)
+        response = client.get("/call-external-instrumented", headers={"traceparent": traceparent})
+        assert response.status_code == 200
+
+        # The outbound httpx request should now have a traceparent header
+        assert "traceparent" in captured_headers, (
+            "Outbound httpx request should contain traceparent with HTTPXClientInstrumentor"
+        )
+
+        # The outbound traceparent should carry the same trace_id as the incoming one
+        parts = captured_headers["traceparent"].split("-")
+        assert parts[1] == incoming_trace_id, f"Outbound trace_id {parts[1]} should match incoming {incoming_trace_id}"
+    finally:
+        httpx_instrumentor_cls().uninstrument()
+
+
+def test_manual_propagator_inject_works_inside_active_context(otel_app):
+    """Manual TraceContextTextMapPropagator.inject() works inside an active span context."""
+    app, _exporter, _provider = otel_app
+    injected_carrier: dict[str, str] = {}
+
+    @app.get("/manual-inject")
+    async def manual_inject():
+        propagator = TraceContextTextMapPropagator()
+        propagator.inject(carrier=injected_carrier)
+        return {"status": "injected"}
+
+    incoming_trace_id = "0af7651916cd43dd8448eb211c80319c"
+    incoming_span_id = "b7ad6b7169203331"
+    traceparent = f"00-{incoming_trace_id}-{incoming_span_id}-01"
+
+    client = TestClient(app)
+    response = client.get("/manual-inject", headers={"traceparent": traceparent})
+    assert response.status_code == 200
+
+    assert "traceparent" in injected_carrier, "Manual propagator.inject() should produce a traceparent header"
+    parts = injected_carrier["traceparent"].split("-")
+    assert parts[1] == incoming_trace_id, f"Injected trace_id {parts[1]} should match incoming {incoming_trace_id}"
+
+
+# ---------------------------------------------------------------------------
+# Concurrent request isolation
+# ---------------------------------------------------------------------------
+
+
+def _make_trace_ids(n: int) -> list[tuple[str, str]]:
+    """Generate n pairs of (trace_id, span_id) for use in traceparent headers."""
+    return [(uuid.uuid4().hex, uuid.uuid4().hex[:16]) for _ in range(n)]
+
+
+def test_concurrent_requests_have_isolated_trace_contexts():
+    """Concurrent requests each carry their own traceparent; spans must not leak across requests.
+
+    Sends multiple simultaneous requests with distinct trace-ids through an async
+    endpoint that includes an asyncio.sleep (to force overlapping execution), then
+    verifies every collected span belongs to exactly the trace-id that its request
+    carried.
+    """
+    exporter = CollectingExporter()
+    provider = TracerProvider(resource=Resource.create({"service.name": "test-concurrent"}))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    app = FastAPI()
+
+    # Barrier-style endpoint: all requests sleep so their handling overlaps
+    @app.get("/slow")
+    async def slow():
+        await asyncio.sleep(0.05)
+        return {"status": "ok"}
+
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=provider)
+
+    try:
+        pairs = _make_trace_ids(10)
+
+        # httpx.AsyncClient honours the ASGI transport and runs truly async
+        async def _fire_all():
+            """Send concurrent requests via ASGI transport and assert all succeed."""
+            from httpx import ASGITransport, AsyncClient
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                tasks = [
+                    client.get(
+                        "/slow",
+                        headers={"traceparent": f"00-{tid}-{sid}-01"},
+                    )
+                    for tid, sid in pairs
+                ]
+                responses = await asyncio.gather(*tasks)
+                for r in responses:
+                    assert r.status_code == 200
+
+        asyncio.run(_fire_all())
+
+        # Group finished spans by trace_id
+        spans_by_trace: dict[str, list] = defaultdict(list)
+        for span in exporter.spans:
+            tid = format(span.context.trace_id, "032x")
+            spans_by_trace[tid].append(span)
+
+        expected_trace_ids = {tid for tid, _ in pairs}
+
+        # Every span must belong to one of the incoming trace-ids
+        for tid in spans_by_trace:
+            assert tid in expected_trace_ids, f"Span with trace_id {tid} does not match any incoming traceparent"
+
+        # Each incoming trace-id must have produced at least one span
+        for tid, sid in pairs:
+            assert tid in spans_by_trace, f"No spans found for incoming trace_id {tid}"
+            # The outermost span for this trace must have a remote parent
+            # whose span_id matches the incoming span_id
+            root = next(
+                (s for s in spans_by_trace[tid] if s.parent and s.parent.is_remote),
+                None,
+            )
+            assert root is not None, f"Trace {tid} has no span with a remote parent"
+            actual_parent = format(root.parent.span_id, "016x")
+            assert actual_parent == sid, f"Trace {tid}: root span parent {actual_parent} != incoming span_id {sid}"
+    finally:
+        FastAPIInstrumentor.uninstrument_app(app)
+        provider.shutdown()
+
+
+def test_concurrent_otlp_tracers_have_isolated_contexts():
+    """OTLPTracers created inside different active contexts get the correct parent.
+
+    Simulates what happens when the tracing service initialises OTLPTracer
+    instances for two concurrent requests, each with a different active span.
+    """
+    from langflow.services.tracing.otlp import OTLPTracer
+
+    global_provider = TracerProvider(resource=Resource.create({"service.name": "global"}))
+    global_provider.add_span_processor(SimpleSpanProcessor(CollectingExporter()))
+    global_tracer = global_provider.get_tracer("test")
+
+    results: dict[str, dict[str, str]] = {}
+    barrier = threading.Barrier(2)
+
+    def _create_tracer(label: str, parent_span) -> None:
+        """Attach *parent_span* as active context and create an OTLPTracer, storing results."""
+        ctx = trace.set_span_in_context(parent_span)
+        token = otel_context.attach(ctx)
+        try:
+            # Wait until both threads have attached their context
+            barrier.wait(timeout=5)
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+                    },
+                    clear=True,
+                ),
+                patch(
+                    "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+                    return_value=CollectingExporter(),
+                ),
+            ):
+                tracer = OTLPTracer(
+                    trace_name=f"flow-{label}",
+                    trace_type="chain",
+                    project_name="test",
+                    trace_id=uuid.uuid4(),
+                )
+                assert tracer.ready
+
+            results[label] = {
+                "trace_id": format(tracer.root_span.context.trace_id, "032x"),
+                "parent_span_id": format(tracer.root_span.parent.span_id, "016x") if tracer.root_span.parent else None,
+            }
+            tracer.close()
+        finally:
+            otel_context.detach(token)
+
+    span_a = global_tracer.start_span("request-A")
+    span_b = global_tracer.start_span("request-B")
+
+    expected_a_trace = format(span_a.get_span_context().trace_id, "032x")
+    expected_a_span = format(span_a.get_span_context().span_id, "016x")
+    expected_b_trace = format(span_b.get_span_context().trace_id, "032x")
+    expected_b_span = format(span_b.get_span_context().span_id, "016x")
+
+    t1 = threading.Thread(target=_create_tracer, args=("A", span_a))
+    t2 = threading.Thread(target=_create_tracer, args=("B", span_b))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    span_a.end()
+    span_b.end()
+    global_provider.shutdown()
+
+    assert results["A"]["trace_id"] == expected_a_trace, (
+        f"Tracer A trace_id {results['A']['trace_id']} != expected {expected_a_trace}"
+    )
+    assert results["A"]["parent_span_id"] == expected_a_span, (
+        f"Tracer A parent {results['A']['parent_span_id']} != expected {expected_a_span}"
+    )
+    assert results["B"]["trace_id"] == expected_b_trace, (
+        f"Tracer B trace_id {results['B']['trace_id']} != expected {expected_b_trace}"
+    )
+    assert results["B"]["parent_span_id"] == expected_b_span, (
+        f"Tracer B parent {results['B']['parent_span_id']} != expected {expected_b_span}"
+    )


### PR DESCRIPTION
Add support for sending OpenTelemetry traces to a generic OTLP trace destination using the standard OpenTelemetry trace configuration environment variables. Implements https://github.com/langflow-ai/langflow/issues/12117 

## Changes

(Changes are split into logical commits for easier review.)

Logic common to the various otel-based tracing exporters is extracted from the existing providers `traceloop.py`, `arize_phoenix.py` and `langwatch.py` into a new `otlp_base.py` skeleton provider. This handles attribute transformation, trace-context propagation and other common logic.

A new provider `otlp.py` is added and registered with tracing `service.py`.  The generic OpenTelemetry provider activates if either of the `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT` env-var is set. Configuration follows the conventions set out in [OTLP Exporter Configuration
](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter) and [the go otel SDK docs](https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html) . Some test cover is added to exercise the tracer.

An additional test is added to check that trace context propagation works in the expected manner as requests flow through Langflow.

(Subsequent changes arising from automated review, rebases and merges):

Cache and reuse OpenTelemetry based tracers. The Arize/Phoenix tracer and the new generic OpenTelemetry tracer were constructing a new trace engine, batch span processor etc for every graph evaluation, then orphaning them. These would leak and remain running in the background, as well as failing to properly flush on shutdown. Address by using a module-level singleton to initialize the traceprovider only once, and only construct a new tracer for each invocation. Other providers are unaffected; either they internally use a singleton already, or they don't have a long-lived trace engine to preserve.

Update langwatch trace provider initialization to use the updated singleton pattern. The langwatch tracer already used a singleton, but it didn't have a shutdown hook or any locking to prevent races between concurrent initializations. Update it to work the same way as the other otel-based tracers.

Rebase on top of https://github.com/langflow-ai/langflow/pull/12962 which added trace context propagation for the otel-flavoured exporters and de-duplicate functionality.

Update generic OTLP instrumentation to ensure it follows the [otel semantic conventions for GenAI/LLM](https://opentelemetry.io/docs/specs/semconv/gen-ai/).

Extend test cover to validate that the expected attributes are emitted by each provider.

## Usage

1. Add at least `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT` env-var, pointing to your OTLP endpoint
2. Set env-var `OTEL_EXPORTER_OTLP_PROTOCOL` to the exporter protocol (`grpc`, `http/protobuf` or `http/json`)
3. Preferably set `OTEL_SERVICE_NAME` to something suitable (`langflow` will do if nothing more specific applies in your environment).

Optionally define additional SDK env-vars to control server and client certificates, additional headers, timeouts, sampling, etc.

## Related issues

Fixes https://github.com/langflow-ai/langflow/issues/12117

## Context

This patch series was developed with assistance from Claude Code, but all non-test code changes have been manually reviewed and inspected to the best of my (not amazing) ability and modified where appropriate.

The instrumentation is explicitly created in code because the Langflow multi-provider tracing abstraction doesn't fit very well with the python otel SDK's auto-instrumentation and `opentelemetry-instrument` too. I also didn't want to impose the requirement of wrapping the langflow backend execution in the `opentelemetry-instrument` command.

I omitted various additional, verbose test cover for things like asserting that all the otel env-vars are respected as they didn't seem useful enough or langflow-specific enough.

## Testing

Using the existing tests for the current tracers and some additions made to ensure they properly cover the emitted attributes etc, run the tests against `release-1.10.0` and against this PR branch `HEAD`. Compare. [REGRESSION_TEST_RESULTS.md](https://github.com/user-attachments/files/28038279/REGRESSION_TEST_RESULTS.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OTLP (OpenTelemetry) tracing support configurable via environment variables.
  * Improved W3C Trace Context propagation for reliable distributed tracing and concurrent-request isolation.
  * Centralized tracer provider lifecycle and explicit shutdown for more reliable startup/shutdown and global instrumentation.

* **Bug Fixes / Reliability**
  * Safer correlation handling and reduced per-instance resource churn to avoid cross-run interference.

* **Tests**
  * New comprehensive tests covering OTLP setup, exporter selection, propagation, concurrency isolation, and provider shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->