### PR TITLE
feat: add LobsterMail component — email for AI agents

### DIFF
--- a/src/lfx/src/lfx/components/lobstermail/__init__.py
+++ b/src/lfx/src/lfx/components/lobstermail/__init__.py
@@ -1,0 +1,6 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lfx.components.lobstermail.lobstermail_component import LobsterMailComponent
+
+__all__ = ["LobsterMailComponent"]

--- a/src/lfx/src/lfx/components/lobstermail/__init__.py
+++ b/src/lfx/src/lfx/components/lobstermail/__init__.py
@@ -1,6 +1,34 @@
-from typing import TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from lfx.components._importing import import_mod
 
 if TYPE_CHECKING:
     from lfx.components.lobstermail.lobstermail_component import LobsterMailComponent
 
-__all__ = ["LobsterMailComponent"]
+_dynamic_imports = {
+    "LobsterMailComponent": "lobstermail_component",
+}
+
+__all__ = [
+    "LobsterMailComponent",
+]
+
+
+def __getattr__(attr_name: str) -> Any:
+    """Lazily import lobstermail components on attribute access."""
+    if attr_name not in _dynamic_imports:
+        msg = f"module '{__name__}' has no attribute '{attr_name}'"
+        raise AttributeError(msg)
+    try:
+        result = import_mod(attr_name, _dynamic_imports[attr_name], __spec__.parent)
+    except (ModuleNotFoundError, ImportError, AttributeError) as e:
+        msg = f"Could not import '{attr_name}' from '{__name__}': {e}"
+        raise AttributeError(msg) from e
+    globals()[attr_name] = result
+    return result
+
+
+def __dir__() -> list[str]:
+    return list(__all__)

--- a/src/lfx/src/lfx/components/lobstermail/lobstermail_component.py
+++ b/src/lfx/src/lfx/components/lobstermail/lobstermail_component.py
@@ -28,10 +28,7 @@ BASE_URL = "https://api.lobstermail.ai"
 
 class LobsterMailComponent(Component):
     display_name = "LobsterMail"
-    description = (
-        "Email infrastructure for AI agents — create inboxes, send and receive email, "
-        "and search messages."
-    )
+    description = "Email infrastructure for AI agents — create inboxes, send and receive email, and search messages."
     documentation = "https://lobstermail.ai/docs"
     icon = "Mail"
     name = "LobsterMail"
@@ -135,7 +132,7 @@ class LobsterMailComponent(Component):
         """Execute the selected LobsterMail operation."""
         operation = self.operation
         headers = {
-            "Authorization": f"Bearer {str(self.api_key)}",
+            "Authorization": f"Bearer {self.api_key!s}",
             "Content-Type": "application/json",
         }
 

--- a/src/lfx/src/lfx/components/lobstermail/lobstermail_component.py
+++ b/src/lfx/src/lfx/components/lobstermail/lobstermail_component.py
@@ -1,0 +1,199 @@
+"""LobsterMail component for Langflow.
+
+Email infrastructure for AI agents — create inboxes, send/receive email,
+search messages, and manage webhooks via the LobsterMail API.
+
+API docs: https://lobstermail.ai/docs
+OpenAPI spec: https://api.lobstermail.ai/v1/docs/openapi
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from lfx.custom.custom_component.component import Component
+from lfx.io import (
+    DropdownInput,
+    MessageTextInput,
+    MultilineInput,
+    Output,
+    SecretStrInput,
+)
+from lfx.schema.data import Data
+
+BASE_URL = "https://api.lobstermail.ai"
+
+
+class LobsterMailComponent(Component):
+    display_name = "LobsterMail"
+    description = (
+        "Email infrastructure for AI agents — create inboxes, send and receive email, "
+        "search messages, and configure webhooks."
+    )
+    documentation = "https://lobstermail.ai/docs"
+    icon = "Mail"
+    name = "LobsterMail"
+
+    inputs = [
+        SecretStrInput(
+            name="api_key",
+            display_name="API Key",
+            info=(
+                "LobsterMail API key (lm_sk_test_... or lm_sk_live_...). "
+                "Get one free at https://lobstermail.ai"
+            ),
+            required=True,
+        ),
+        DropdownInput(
+            name="operation",
+            display_name="Operation",
+            options=[
+                "Create Inbox",
+                "List Inboxes",
+                "Send Email",
+                "List Emails",
+                "Get Email",
+                "Search Emails",
+                "Get Account",
+            ],
+            value="Create Inbox",
+            info="The LobsterMail operation to perform.",
+            real_time_refresh=True,
+        ),
+        # ── Create Inbox fields ────────────────────────────────────────
+        MessageTextInput(
+            name="display_name_field",
+            display_name="Display Name",
+            info="Human-friendly name for the inbox (optional).",
+            required=False,
+            advanced=True,
+        ),
+        MessageTextInput(
+            name="local_part",
+            display_name="Local Part",
+            info="Local part of the address (before @). Auto-generated if empty.",
+            required=False,
+            advanced=True,
+        ),
+        # ── Send Email fields ──────────────────────────────────────────
+        MessageTextInput(
+            name="from_address",
+            display_name="From",
+            info="Sender email address (must be an active inbox).",
+            required=False,
+        ),
+        MessageTextInput(
+            name="to_addresses",
+            display_name="To",
+            info="Recipient email addresses (comma-separated).",
+            required=False,
+        ),
+        MessageTextInput(
+            name="subject",
+            display_name="Subject",
+            info="Email subject line.",
+            required=False,
+        ),
+        MultilineInput(
+            name="body_text",
+            display_name="Body (Text)",
+            info="Plain text email body.",
+            required=False,
+        ),
+        MultilineInput(
+            name="body_html",
+            display_name="Body (HTML)",
+            info="HTML email body (optional).",
+            required=False,
+            advanced=True,
+        ),
+        # ── List/Get/Search fields ─────────────────────────────────────
+        MessageTextInput(
+            name="inbox_id",
+            display_name="Inbox ID",
+            info="The inbox ID (e.g. ibx_...).",
+            required=False,
+        ),
+        MessageTextInput(
+            name="email_id",
+            display_name="Email ID",
+            info="The email ID (e.g. eml_...). Required for Get Email.",
+            required=False,
+        ),
+        MessageTextInput(
+            name="search_query",
+            display_name="Search Query",
+            info="Full-text search query. Required for Search Emails.",
+            required=False,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Result", name="result", method="execute_operation"),
+    ]
+
+    async def execute_operation(self) -> Data:
+        """Execute the selected LobsterMail operation."""
+        operation = self.operation
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        async with httpx.AsyncClient(base_url=BASE_URL, headers=headers) as client:
+            result = await self._dispatch(client, operation)
+
+        return Data(data=result)
+
+    async def _dispatch(self, client: httpx.AsyncClient, operation: str) -> dict[str, Any]:
+        if operation == "Create Inbox":
+            body: dict[str, str] = {}
+            if self.display_name_field:
+                body["displayName"] = self.display_name_field
+            if self.local_part:
+                body["localPart"] = self.local_part
+            resp = await client.post("/v1/inboxes", json=body)
+
+        elif operation == "List Inboxes":
+            resp = await client.get("/v1/inboxes")
+
+        elif operation == "Send Email":
+            to_list = [a.strip() for a in self.to_addresses.split(",") if a.strip()]
+            body_inner: dict[str, str] = {}
+            if self.body_text:
+                body_inner["text"] = self.body_text
+            if self.body_html:
+                body_inner["html"] = self.body_html
+            payload: dict[str, Any] = {
+                "from": self.from_address,
+                "to": to_list,
+                "subject": self.subject,
+                "body": body_inner,
+            }
+            resp = await client.post("/v1/emails/send", json=payload)
+
+        elif operation == "List Emails":
+            resp = await client.get(f"/v1/inboxes/{self.inbox_id}/emails")
+
+        elif operation == "Get Email":
+            resp = await client.get(
+                f"/v1/inboxes/{self.inbox_id}/emails/{self.email_id}"
+            )
+
+        elif operation == "Search Emails":
+            params: dict[str, str] = {"q": self.search_query}
+            if self.inbox_id:
+                params["inboxId"] = self.inbox_id
+            resp = await client.get("/v1/emails/search", params=params)
+
+        elif operation == "Get Account":
+            resp = await client.get("/v1/account")
+
+        else:
+            msg = f"Unknown operation: {operation}"
+            raise ValueError(msg)
+
+        resp.raise_for_status()
+        return resp.json()  # type: ignore[no-any-return]

--- a/src/lfx/src/lfx/components/lobstermail/lobstermail_component.py
+++ b/src/lfx/src/lfx/components/lobstermail/lobstermail_component.py
@@ -40,10 +40,7 @@ class LobsterMailComponent(Component):
         SecretStrInput(
             name="api_key",
             display_name="API Key",
-            info=(
-                "LobsterMail API key (lm_sk_test_... or lm_sk_live_...). "
-                "Get one free at https://lobstermail.ai"
-            ),
+            info=("LobsterMail API key (lm_sk_test_... or lm_sk_live_...). Get one free at https://lobstermail.ai"),
             required=True,
         ),
         DropdownInput(
@@ -178,9 +175,7 @@ class LobsterMailComponent(Component):
             resp = await client.get(f"/v1/inboxes/{self.inbox_id}/emails")
 
         elif operation == "Get Email":
-            resp = await client.get(
-                f"/v1/inboxes/{self.inbox_id}/emails/{self.email_id}"
-            )
+            resp = await client.get(f"/v1/inboxes/{self.inbox_id}/emails/{self.email_id}")
 
         elif operation == "Search Emails":
             params: dict[str, str] = {"q": self.search_query}

--- a/src/lfx/src/lfx/components/lobstermail/lobstermail_component.py
+++ b/src/lfx/src/lfx/components/lobstermail/lobstermail_component.py
@@ -1,7 +1,7 @@
 """LobsterMail component for Langflow.
 
 Email infrastructure for AI agents — create inboxes, send/receive email,
-search messages, and manage webhooks via the LobsterMail API.
+and search messages via the LobsterMail API.
 
 API docs: https://lobstermail.ai/docs
 OpenAPI spec: https://api.lobstermail.ai/v1/docs/openapi
@@ -30,7 +30,7 @@ class LobsterMailComponent(Component):
     display_name = "LobsterMail"
     description = (
         "Email infrastructure for AI agents — create inboxes, send and receive email, "
-        "search messages, and configure webhooks."
+        "and search messages."
     )
     documentation = "https://lobstermail.ai/docs"
     icon = "Mail"
@@ -135,11 +135,11 @@ class LobsterMailComponent(Component):
         """Execute the selected LobsterMail operation."""
         operation = self.operation
         headers = {
-            "Authorization": f"Bearer {self.api_key}",
+            "Authorization": f"Bearer {str(self.api_key)}",
             "Content-Type": "application/json",
         }
 
-        async with httpx.AsyncClient(base_url=BASE_URL, headers=headers) as client:
+        async with httpx.AsyncClient(base_url=BASE_URL, headers=headers, timeout=30.0) as client:
             result = await self._dispatch(client, operation)
 
         return Data(data=result)
@@ -157,6 +157,15 @@ class LobsterMailComponent(Component):
             resp = await client.get("/v1/inboxes")
 
         elif operation == "Send Email":
+            if not self.from_address:
+                msg = "Send Email requires a 'From' address."
+                raise ValueError(msg)
+            if not self.to_addresses:
+                msg = "Send Email requires at least one 'To' address."
+                raise ValueError(msg)
+            if not self.subject:
+                msg = "Send Email requires a 'Subject'."
+                raise ValueError(msg)
             to_list = [a.strip() for a in self.to_addresses.split(",") if a.strip()]
             body_inner: dict[str, str] = {}
             if self.body_text:
@@ -172,12 +181,24 @@ class LobsterMailComponent(Component):
             resp = await client.post("/v1/emails/send", json=payload)
 
         elif operation == "List Emails":
+            if not self.inbox_id:
+                msg = "List Emails requires an 'Inbox ID'."
+                raise ValueError(msg)
             resp = await client.get(f"/v1/inboxes/{self.inbox_id}/emails")
 
         elif operation == "Get Email":
+            if not self.inbox_id:
+                msg = "Get Email requires an 'Inbox ID'."
+                raise ValueError(msg)
+            if not self.email_id:
+                msg = "Get Email requires an 'Email ID'."
+                raise ValueError(msg)
             resp = await client.get(f"/v1/inboxes/{self.inbox_id}/emails/{self.email_id}")
 
         elif operation == "Search Emails":
+            if not self.search_query:
+                msg = "Search Emails requires a 'Search Query'."
+                raise ValueError(msg)
             params: dict[str, str] = {"q": self.search_query}
             if self.inbox_id:
                 params["inboxId"] = self.inbox_id


### PR DESCRIPTION
## Summary

Adds a [LobsterMail](https://lobstermail.ai) component to Langflow — email infrastructure purpose-built for AI agents. Agents can self-provision email inboxes, send/receive email, and search messages through a simple REST API.

## Operations

| Operation | Description |
|-----------|-------------|
| Create Inbox | Create a new @lobstermail.ai email address |
| List Inboxes | List all inboxes on the account |
| Send Email | Send email from a verified inbox (Tier 1+) |
| List Emails | List emails in a specific inbox |
| Get Email | Get a single email with full body |
| Search Emails | Full-text search across inboxes |
| Get Account | Account tier, limits, usage |

## Auth

Bearer token via `SecretStrInput`. Keys prefixed `lm_sk_test_` (sandbox) or `lm_sk_live_` (production). Free accounts available instantly via API.

## Implementation

- Uses `httpx.AsyncClient` for async HTTP
- Single component with operation dropdown
- All fields available with contextual relevance per operation

## Links

- [LobsterMail](https://lobstermail.ai)
- [API docs](https://lobstermail.ai/docs)
- [OpenAPI spec](https://api.lobstermail.ai/v1/docs/openapi)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LobsterMail email integration component with comprehensive inbox and email management capabilities, including inbox creation, email sending, message retrieval and listing, email search functionality, and account access. Component library expanded to 360 components across 98 modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->