### PR TITLE
fix: add [proxy] extra to litellm dependency for langflow-ide

### DIFF
--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -278,7 +278,15 @@ aws = ["boto3>=1.34.162,<2.0.0", "langchain-aws~=1.1.0"]
 numexpr = ["numexpr==2.10.2"]
 qianfan = ["qianfan==0.3.5"]
 pgvector = ["pgvector>=0.4.2"]
-litellm = ["litellm>=1.83.0"]
+litellm = [
+    "litellm>=1.83.0",
+    # Runtime deps from litellm[proxy] that langflow-ide hits when logging
+    # to langfuse via litellm.proxy.proxy_server (issue #12228). The full
+    # [proxy] extra pins boto3>=1.40.76, which conflicts with our aioboto3
+    # transitive cap, so we pull in just the missing modules instead.
+    "apscheduler>=3.10.4,<4.0.0",
+    "cryptography",
+]
 zep = ["zep-python==2.0.2"]
 youtube = ["youtube-transcript-api>=1.0.0,<2.0.0"]
 markdown = ["Markdown>=3.8.0"]

--- a/src/backend/tests/unit/test_litellm_proxy_extra.py
+++ b/src/backend/tests/unit/test_litellm_proxy_extra.py
@@ -1,0 +1,52 @@
+"""Regression test for #12228.
+
+When langflow-ide logs through litellm (e.g. to langfuse), litellm imports
+its proxy server module, which in turn needs `apscheduler` and `cryptography`
+at runtime. These are normally shipped via `litellm[proxy]`, but that extra
+pins `boto3` in a way that conflicts with our `aioboto3` transitives. We
+therefore add the specific modules directly to the `litellm` optional
+dependency group — this test guards against them being dropped.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+REQUIRED_PACKAGES = ("apscheduler", "cryptography")
+
+
+def _load_base_pyproject() -> dict:
+    pyproject_path = Path(__file__).resolve().parents[2] / "base" / "pyproject.toml"
+    assert pyproject_path.is_file(), f"pyproject.toml not found at {pyproject_path}"
+    with pyproject_path.open("rb") as f:
+        return tomllib.load(f)
+
+
+def _package_name(spec: str) -> str:
+    # Strip extras, version specifiers, and markers.
+    for sep in ("[", " ", ";", "=", "<", ">", "!", "~"):
+        if sep in spec:
+            spec = spec.split(sep, 1)[0]
+    return spec.strip().lower()
+
+
+def test_litellm_optional_dependency_includes_runtime_proxy_modules() -> None:
+    pyproject = _load_base_pyproject()
+    optional = pyproject["project"]["optional-dependencies"]
+    assert "litellm" in optional, "Expected `litellm` optional-dependency group in base/pyproject.toml"
+
+    litellm_specs = optional["litellm"]
+    names = {_package_name(s) for s in litellm_specs}
+
+    missing = [pkg for pkg in REQUIRED_PACKAGES if pkg not in names]
+    assert not missing, (
+        f"The `litellm` optional-dependency group is missing required runtime packages: {missing}. "
+        f"These are needed when langflow-ide invokes litellm's proxy server module for logging "
+        f"(see issue #12228). Current specs: {litellm_specs}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -473,6 +473,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -6633,6 +6645,7 @@ all = [
     { name = "agent-lifecycle-toolkit", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "aioboto3" },
     { name = "apify-client" },
+    { name = "apscheduler" },
     { name = "arize-phoenix-otel" },
     { name = "assemblyai" },
     { name = "astrapy" },
@@ -6646,6 +6659,7 @@ all = [
     { name = "composio" },
     { name = "composio-langchain" },
     { name = "couchbase" },
+    { name = "cryptography" },
     { name = "cuga", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
     { name = "datasets" },
     { name = "ddgs" },
@@ -6797,6 +6811,7 @@ complete = [
     { name = "agent-lifecycle-toolkit", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "aioboto3" },
     { name = "apify-client" },
+    { name = "apscheduler" },
     { name = "arize-phoenix-otel" },
     { name = "assemblyai" },
     { name = "astrapy" },
@@ -6810,6 +6825,7 @@ complete = [
     { name = "composio" },
     { name = "composio-langchain" },
     { name = "couchbase" },
+    { name = "cryptography" },
     { name = "cuga", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
     { name = "datasets" },
     { name = "ddgs" },
@@ -7017,6 +7033,8 @@ lark = [
     { name = "lark" },
 ]
 litellm = [
+    { name = "apscheduler" },
+    { name = "cryptography" },
     { name = "litellm" },
 ]
 local = [
@@ -7215,6 +7233,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0,<1.0.0" },
     { name = "alembic", specifier = ">=1.13.0,<2.0.0" },
     { name = "apify-client", marker = "extra == 'apify'", specifier = ">=1.8.1" },
+    { name = "apscheduler", marker = "extra == 'litellm'", specifier = ">=3.10.4,<4.0.0" },
     { name = "arize-phoenix-otel", marker = "extra == 'arize'", specifier = ">=0.6.1" },
     { name = "assemblyai", specifier = ">=0.33.0,<1.0.0" },
     { name = "assemblyai", marker = "extra == 'assemblyai'", specifier = "==0.35.1" },
@@ -7235,6 +7254,7 @@ requires-dist = [
     { name = "composio-langchain", marker = "extra == 'composio'", specifier = "==0.9.2" },
     { name = "couchbase", marker = "extra == 'couchbase'", specifier = ">=4.2.1" },
     { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "cryptography", marker = "extra == 'litellm'" },
     { name = "ctransformers", marker = "extra == 'ctransformers'", specifier = ">=0.2.10" },
     { name = "ctransformers", marker = "extra == 'local'", specifier = ">=0.2" },
     { name = "cuga", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'cuga'", specifier = ">=0.2.20,<0.3.0" },
@@ -15837,6 +15857,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the  extra to the litellm dependency to fix  when running .

## Problem

When using langflow-ide with litellm as an OpenAI endpoint and logging enabled (e.g., to langfuse), it throws errors for missing packages:
- 
- 

These packages are included in litellm's  extra but not in the base litellm package.

## Solution

Changed in :


This ensures all required packages for logging and SSO features are installed.

## Testing

Verified the change is syntactically correct by checking pyproject.toml parsing.

Fixes #12228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency specifications to enable required additional functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->