### PR TITLE
fix: Disable tool calling for Gemini 3 models

### DIFF
--- a/src/lfx/src/lfx/base/models/google_generative_ai_constants.py
+++ b/src/lfx/src/lfx/base/models/google_generative_ai_constants.py
@@ -70,28 +70,28 @@ GOOGLE_GENERATIVE_AI_MODELS_DETAILED = [
         provider="Google Generative AI",
         name="gemini-3.1-pro-preview",
         icon="GoogleGenerativeAI",
-        tool_calling=True,
+        tool_calling=False,  # TODO: When Google GenAI has been upgraded, tool calling should be enabled for Gemini 3
         preview=True,
     ),
     create_model_metadata(
         provider="Google Generative AI",
         name="gemini-3-pro-preview",
         icon="GoogleGenerativeAI",
-        tool_calling=True,
+        tool_calling=False,
         preview=True,
     ),
     create_model_metadata(
         provider="Google Generative AI",
         name="gemini-3-flash-preview",
         icon="GoogleGenerativeAI",
-        tool_calling=True,
+        tool_calling=False,
         preview=True,
     ),
     create_model_metadata(
         provider="Google Generative AI",
         name="gemini-3-pro-image-preview",
         icon="GoogleGenerativeAI",
-        tool_calling=True,
+        tool_calling=False,
         preview=True,
     ),
 ]


### PR DESCRIPTION
This pull request makes a targeted adjustment to the Google Generative AI model metadata by disabling the `tool_calling` capability for several Gemini 3 preview models. This is a temporary change, as indicated by the comment, and is intended to prevent tool calling until the Google GenAI upgrade is complete.

Key change:

* Disabled `tool_calling` for all Gemini 3 preview models (`gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-3-pro-image-preview`) in `google_generative_ai_constants.py`, with a note to re-enable once the upgrade is finished.