### PR TITLE
docs: Add AI coding agent skills for code review, testing, and refactoring

### DIFF
--- a/.agents/skills/backend-code-review/SKILL.md
+++ b/.agents/skills/backend-code-review/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: backend-code-review
+description: Review backend code for quality, security, maintainability, and best practices based on established checklist rules. Use when the user requests a review, analysis, or improvement of backend files (e.g., `.py`) under the `src/backend/` directory. Do NOT use for frontend files (e.g., `.tsx`, `.ts`, `.js`). Supports pending-change review, code snippets review, and file-focused review.
+---
+
+# Backend Code Review
+
+## When to use this skill
+
+Use this skill whenever the user asks to **review, analyze, or improve** backend code (e.g., `.py`) under the `src/backend/` directory. Supports the following review modes:
+
+- **Pending-change review**: when the user asks to review current changes (inspect staged/working-tree files slated for commit to get the changes).
+- **Code snippets review**: when the user pastes code snippets (e.g., a function/class/module excerpt) into the chat and asks for a review.
+- **File-focused review**: when the user points to specific files and asks for a review of those files (one file or a small, explicit set of files, e.g., `src/backend/base/langflow/api/v1/flows.py`).
+
+Do NOT use this skill when:
+
+- The request is about frontend code or UI (e.g., `.tsx`, `.ts`, `.js`, `src/frontend/`).
+- The user is not asking for a review/analysis/improvement of backend code.
+- The scope is not under `src/backend/` (unless the user explicitly asks to review backend-related changes outside `src/backend/`).
+
+## How to use this skill
+
+Follow these steps when using this skill:
+
+1. **Identify the review mode** (pending-change vs snippet vs file-focused) based on the user's input. Keep the scope tight: review only what the user provided or explicitly referenced.
+2. Follow the rules defined in **Checklist** to perform the review. If no Checklist rule matches, apply **General Review Rules** as a fallback to perform the best-effort review.
+3. Compose the final output strictly following the **Required Output Format**.
+
+Notes when using this skill:
+- Always include actionable fixes or suggestions (including possible code snippets).
+- Use best-effort `File:Line` references when a file path and line numbers are available; otherwise, use the most specific identifier you can.
+
+## Checklist
+
+- db schema design: if the review scope includes code/files under `src/backend/base/langflow/services/database/models/` or Alembic migrations under `src/backend/base/langflow/alembic/versions/`, follow [references/db-schema-rule.md](references/db-schema-rule.md) to perform the review
+- architecture: if the review scope involves route/service/model layering, dependency direction, or moving responsibilities across modules, follow [references/architecture-rule.md](references/architecture-rule.md) to perform the review
+- service abstraction: if the review scope contains table/model operations (e.g., `select(...)`, `session.execute(...)`, joins, CRUD) and is not already inside a service under `src/backend/base/langflow/services/`, follow [references/repositories-rule.md](references/repositories-rule.md) to perform the review
+- sqlalchemy patterns: if the review scope involves SQLAlchemy/SQLModel session/query usage, db transaction/crud usage, `session_scope()` usage, or raw SQL usage, follow [references/sqlalchemy-rule.md](references/sqlalchemy-rule.md) to perform the review
+
+## General Review Rules
+
+### 1. Security Review
+
+Check for:
+- SQL injection vulnerabilities (especially raw `text()` queries with string interpolation). Consequence: attacker can read/modify/delete any data in the database.
+- Server-Side Request Forgery (SSRF) in component HTTP calls. Consequence: attacker uses the server to scan internal networks or access cloud metadata endpoints.
+- Command injection (especially in subprocess or shell-executing components). Consequence: attacker gains shell access to the server.
+- Insecure deserialization (pickle, yaml.load without SafeLoader). Consequence: arbitrary code execution on the server.
+- Hardcoded secrets/credentials. Consequence: secrets leak via git history and are impossible to fully revoke.
+- Improper authentication/authorization (missing `CurrentActiveUser` dependency). Consequence: unauthenticated users can access protected endpoints.
+- Insecure direct object references (missing `user_id` scoping on queries). Consequence: user A can read/modify user B's flows, variables, API keys.
+- Path traversal in file storage operations. Consequence: attacker reads arbitrary server files (e.g., `/etc/passwd`, `.env`).
+
+### 2. Performance Review
+
+Check for:
+- N+1 queries (especially in loops calling `session.execute()`). Consequence: 100 flows = 101 DB queries instead of 2; page load goes from 50ms to 5s.
+- Missing database indexes on frequently queried columns. Consequence: full table scans on large datasets; queries degrade from O(log n) to O(n).
+- Memory leaks (unbounded caches, retained references in long-lived services). Consequence: server OOM after hours of operation; pods restart in production.
+- Blocking operations in async code (`time.sleep()`, synchronous I/O, CPU-bound work without `run_in_executor`). Consequence: entire event loop stalls; all concurrent requests hang until the blocking call completes.
+- Missing caching opportunities for expensive computations. Consequence: repeated computation of the same result on every request.
+- Large result sets loaded entirely into memory without pagination. Consequence: memory spike + slow response when user has 10K+ flows.
+
+### 3. Code Quality Review
+
+Check for:
+- Code forward compatibility with Python 3.10-3.13
+- Code duplication (DRY violations — extract when the *exact same business rule* is duplicated in 3+ places)
+- Functions doing too much (SRP violations — if you need "and" to describe it, split it)
+- Deep nesting / complex conditionals (prefer early returns and guard clauses)
+- Magic numbers/strings (extract to named constants or enums)
+- Poor naming: unclear abbreviations, misleading names, generic names (`data`, `result`, `obj`, `temp`). Functions should use verbs (`get`, `create`, `validate`). Booleans should use prefixes (`is_`, `has_`, `can_`, `should_`).
+- Missing error handling (bare `except`, swallowed exceptions, silent failures)
+- Incomplete type coverage (use strong typing, avoid `Any` where a concrete type is known)
+- Use Python 3.10+ union syntax (`X | Y` not `Union[X, Y]`, `X | None` not `Optional[X]`)
+- Use `TYPE_CHECKING` guard for imports only needed for type annotations (prevents circular imports)
+- Use `Annotated[Type, Depends(...)]` with project aliases (`CurrentActiveUser`, `DbSession`, `DbSessionReadOnly`) for FastAPI DI
+- Google-style docstrings (enforced by Ruff): `Args:`, `Returns:`, `Raises:` sections for public functions
+- Violations of SOLID principles
+- YAGNI violations (code that anticipates future needs without a present requirement)
+- Line length exceeding 120 characters (project Ruff config)
+- Comments that explain WHAT instead of WHY (comments should only explain reasoning, not restate code)
+- Commented-out code (use version control instead)
+- Boolean parameters that switch function behavior (split into two named functions instead)
+- Mutable shared state where immutable alternatives exist (prefer returning new objects over mutation)
+
+### 4. File Structure Review
+
+Check for:
+- Production files exceeding ~500 lines of code (excluding imports, types, and docstrings). Files above 600 lines are a red flag and should be split by responsibility. Why: Files above 500 lines have statistically higher defect rates and take longer to review. They signal multiple responsibilities (SRP violation). In Langflow, services like `DatabaseService` that grow beyond this limit should have their CRUD operations extracted to dedicated modules.
+- Test files exceeding ~1000 lines. Split by logical grouping if exceeded.
+- No more than 5 functions with different responsibilities in a single file (per AGENTS-example.md).
+- Each file has a single reason to exist and a single reason to change (SRP).
+- No generic file names: `utils.py`, `helpers.py`, `misc.py`, `common.py` as standalone files. Why: A file named `utils.py` becomes a dumping ground for unrelated functions. Within months it has 50+ functions covering formatting, validation, parsing, and HTTP calls — violating SRP. Each function group should be in a file named after its responsibility (`formatting.py`, `validation.py`).
+
+### 5. Testing Review
+
+Check for:
+- Missing test coverage for new code paths
+- Tests that don't test behavior (testing implementation details)
+- Flaky test patterns (time-dependent, order-dependent, external-service-dependent)
+- Proper use of `pytest.mark.asyncio` for async tests
+- Excessive mocking (prefer real integrations per project conventions)
+- Coverage target: 80% (minimum acceptable: 75%)
+- Test anti-patterns: The Liar (passes but doesn't verify claimed behavior), The Mirror (asserts exactly what code does), The Giant (50+ lines setup), The Mockery (tests only mock setup), The Inspector (coupled to implementation), The Chain Gang (depends on execution order), The Flaky (inconsistent results)
+
+**Happy path tests are the foundation but are NOT enough.** Tests MUST also challenge the code to find real defects:
+
+- **Unexpected inputs**: `None`, `""`, `[]`, `{}`, `0`, `-1`, `UUID("00000000-0000-0000-0000-000000000000")`
+- **Boundary values**: max length strings, exactly at the limit, one past the limit, zero items, max items
+- **Malformed data**: missing required fields, extra unexpected fields, wrong types, invalid formats
+- **Error states**: what happens when the database is down? When an external API returns 500? When the user doesn't exist?
+- **What should NOT happen**: verify that user A CANNOT access user B's flows. Verify that a deleted flow returns 404. Verify that invalid `endpoint_name` is rejected with 422.
+- **Error messages and types**: not just that it fails, but that it fails with the RIGHT exception and the RIGHT message
+- **Concurrency**: what happens when two requests try to update the same flow simultaneously?
+
+**Write tests based on REQUIREMENTS/SPEC, not on what the source code currently does.** This is how you catch bugs where the code diverges from expected behavior.
+
+**When a test fails:** first ask if the CODE is wrong, not the test. Do NOT silently change a failing assertion to match the current code without understanding WHY.
+
+### 6. Observability Review
+
+Check for:
+- Use the async logger from `lfx.log.logger` with `a`-prefixed methods (`adebug`, `ainfo`, `awarning`, `aerror`, `aexception`). Never use `print()` or stdlib `logging`.
+- Log at key decision points and boundaries, not inside tight loops
+- Include: operation name, relevant IDs, outcome (success/failure), duration if relevant
+- Correct log levels: ERROR (broken, needs attention), WARN (degraded but recoverable), INFO (significant events), DEBUG (diagnostic, off in prod)
+- **ZERO PII TOLERANCE**: Never log email addresses, user names, phone numbers, tokens, passwords. Only approved identifiers: `user_id`, `flow_id`, `session_id`
+- No `print()` statements — these go to production logs
+- Use `{e!s}` for string representation of exceptions in log messages
+
+### 7. Pre-Commit Verification
+
+For pending-change reviews, verify the author has run:
+- `make format_backend` (Ruff formatter) — inconsistent formatting creates noisy diffs that hide real changes in code review. Format first, review second.
+- `make lint` (MyPy type checking) — type errors caught at lint time are 10x cheaper to fix than runtime crashes in production. Langflow services use duck typing via `Service` base class; MyPy catches mismatches early.
+- `make unit_tests` (pytest) — a failing test means the change breaks existing behavior. Never merge with failing tests; investigate whether the code or the test is wrong.
+
+## Required Output Format
+
+When this skill is invoked, the response must exactly follow one of the two templates:
+
+### Template A (any findings)
+
+```markdown
+# Code Review Summary
+
+Found <X> critical issues need to be fixed:
+
+## 🔴 Critical (Must Fix)
+
+### 1. <brief description of the issue>
+
+FilePath: <path> line <line>
+<relevant code snippet or pointer>
+
+#### Explanation
+
+<detailed explanation and references of the issue>
+
+#### Suggested Fix
+
+1. <brief description of suggested fix>
+2. <code example> (optional, omit if not applicable)
+
+---
+... (repeat for each critical issue) ...
+
+Found <Y> suggestions for improvement:
+
+## 🟡 Suggestions (Should Consider)
+
+### 1. <brief description of the suggestion>
+
+FilePath: <path> line <line>
+<relevant code snippet or pointer>
+
+#### Explanation
+
+<detailed explanation and references of the suggestion>
+
+#### Suggested Fix
+
+1. <brief description of suggested fix>
+2. <code example> (optional, omit if not applicable)
+
+---
+... (repeat for each suggestion) ...
+
+Found <Z> optional nits:
+
+## 🟢 Nits (Optional)
+### 1. <brief description of the nit>
+
+FilePath: <path> line <line>
+<relevant code snippet or pointer>
+
+#### Explanation
+
+<explanation and references of the optional nit>
+
+#### Suggested Fix
+
+- <minor suggestions>
+
+---
+... (repeat for each nits) ...
+
+## ✅ What's Good
+
+- <Positive feedback on good patterns>
+```
+
+- If there are no critical issues or suggestions or optional nits or good points, just omit that section.
+- If the issue number is more than 10, summarize as "Found 10+ critical issues/suggestions/optional nits" and only output the first 10 items.
+- Don't compress the blank lines between sections; keep them as-is for readability.
+- If there is any issue that requires code changes, append a brief follow-up question to ask whether the user wants to apply the fix(es) after the structured output. For example: "Would you like me to use the Suggested fix(es) to address these issues?"
+
+### Template B (no issues)
+
+```markdown
+## Code Review Summary
+✅ No issues found.
+```

--- a/.agents/skills/backend-code-review/references/architecture-rule.md
+++ b/.agents/skills/backend-code-review/references/architecture-rule.md
@@ -1,0 +1,243 @@
+# Rule Catalog — Architecture
+
+## Scope
+- Covers: route handler/service/model layering, dependency direction, responsibility placement, helper module purity, and observability-friendly flow.
+- Key directories:
+  - Routes: `src/backend/base/langflow/api/v1/`, `src/backend/base/langflow/api/v2/`
+  - Services: `src/backend/base/langflow/services/`
+  - Models: `src/backend/base/langflow/services/database/models/`
+  - Helpers: `src/backend/base/langflow/helpers/`
+  - Components: `src/backend/base/langflow/components/`
+
+## Rules
+
+### Keep business logic out of route handlers
+- Category: maintainability
+- Severity: critical
+- Description: Route handlers (FastAPI endpoint functions) should parse input, delegate to a service, and return a serialized response. Business decisions inside route handlers make behavior hard to reuse, test, and maintain. Langflow uses FastAPI with `Depends()` for dependency injection and async handlers throughout.
+- Suggested fix: Move domain/business logic into the appropriate service under `src/backend/base/langflow/services/`. Keep route handlers thin and orchestration-focused.
+- Example:
+  - Bad:
+    ```python
+    @router.post("/flows/{flow_id}/publish")
+    async def publish_flow(
+        flow_id: UUID,
+        session: AsyncSession = Depends(injectable_session_scope),
+        current_user: User = Depends(get_current_active_user),
+    ):
+        stmt = select(Flow).where(Flow.id == flow_id, Flow.user_id == current_user.id)
+        flow = (await session.execute(stmt)).scalar_one_or_none()
+        if not flow:
+            raise HTTPException(status_code=404, detail="Flow not found")
+        if flow.access_type == AccessTypeEnum.PUBLIC:
+            raise HTTPException(status_code=400, detail="Already published")
+        flow.access_type = AccessTypeEnum.PUBLIC
+        flow.updated_at = datetime.now(timezone.utc)
+        session.add(flow)
+        await session.commit()
+        await session.refresh(flow)
+        return FlowRead.model_validate(flow, from_attributes=True)
+    ```
+  - Good:
+    ```python
+    @router.post("/flows/{flow_id}/publish")
+    async def publish_flow(
+        flow_id: UUID,
+        session: AsyncSession = Depends(injectable_session_scope),
+        current_user: User = Depends(get_current_active_user),
+    ):
+        flow = await flow_service.publish_flow(
+            flow_id=flow_id, user_id=current_user.id, session=session
+        )
+        return FlowRead.model_validate(flow, from_attributes=True)
+    ```
+
+### Preserve layer dependency direction
+- Category: best practices
+- Severity: critical
+- Description: Routes may depend on services, and services may depend on models and domain abstractions. Reversing this direction (for example, a model or service importing from `langflow.api`) creates cycles and leaks transport concerns into domain code. The dependency flow must be: Routes -> Services -> Models (never reverse).
+- Suggested fix: Extract shared contracts into service-level or model-level modules and make upper layers depend on lower, not the reverse.
+- Example:
+  - Bad:
+    ```python
+    # src/backend/base/langflow/services/database/models/flow/model.py
+    from langflow.api.v1.schemas import FlowListCreate  # Model importing from API layer
+
+    class Flow(FlowBase, table=True):
+        def to_api_response(self) -> FlowListCreate:
+            return FlowListCreate(...)
+    ```
+  - Good:
+    ```python
+    # src/backend/base/langflow/services/database/models/flow/model.py
+    class Flow(FlowBase, table=True):
+        pass  # No API-layer imports
+
+    # src/backend/base/langflow/api/v1/flows.py (route layer handles serialization)
+    flow = await get_flow(flow_id, session)
+    return FlowRead.model_validate(flow, from_attributes=True)
+    ```
+
+### Keep helpers business-agnostic
+- Category: maintainability
+- Severity: critical
+- Description: Modules under `src/backend/base/langflow/helpers/` should remain reusable, business-agnostic building blocks. They must not encode product/domain-specific rules, workflow orchestration, or business decisions. Helpers may contain thin wrappers for user lookups or data transformation but must not implement business policy.
+- Suggested fix:
+  - If business logic appears in `src/backend/base/langflow/helpers/`, extract it into the appropriate service under `src/backend/base/langflow/services/` and keep helpers focused on generic, cross-cutting utilities.
+  - Keep helper dependencies clean: avoid importing service or route modules into helpers.
+- Example:
+  - Bad:
+    ```python
+    # src/backend/base/langflow/helpers/flow.py
+    from langflow.services.variable.service import DatabaseVariableService
+
+    def should_archive_flow(flow: Flow, user_id: UUID) -> bool:
+        # Domain policy and service dependency are leaking into helpers.
+        service = DatabaseVariableService(get_settings_service())
+        if service.has_premium_plan(user_id):
+            return flow.idle_days > 90
+        return flow.idle_days > 30
+    ```
+  - Good:
+    ```python
+    # src/backend/base/langflow/helpers/flow.py (business-agnostic helper)
+    def is_older_than_days(updated_at: datetime, threshold_days: int) -> bool:
+        delta = datetime.now(timezone.utc) - updated_at
+        return delta.days > threshold_days
+
+    # src/backend/base/langflow/services/flow_service.py (business logic stays in service)
+    from langflow.helpers.flow import is_older_than_days
+
+    async def should_archive_flow(flow: Flow, user_id: UUID) -> bool:
+        threshold_days = 90 if await has_premium_plan(user_id) else 30
+        return is_older_than_days(flow.updated_at, threshold_days)
+    ```
+
+### Domain logic must not import from FastAPI/HTTP layers
+- Category: best practices
+- Severity: critical
+- Description: Service classes and model definitions must never import FastAPI-specific constructs such as `Request`, `Response`, `HTTPException`, `APIRouter`, or `Depends`. This keeps the domain layer transport-agnostic and testable without spinning up an HTTP server. Langflow services inherit from `langflow.services.base.Service` and receive dependencies through their factory's `create()` method or via constructor injection, not through FastAPI's `Depends()`.
+- Suggested fix: Raise domain-specific exceptions in services (e.g., `FlowNotFoundError`, `PermissionDeniedError`) and let the route handler translate them into HTTP responses.
+- Example:
+  - Bad:
+    ```python
+    # src/backend/base/langflow/services/variable/service.py
+    from fastapi import HTTPException
+
+    class DatabaseVariableService(VariableService, Service):
+        async def get_variable(self, variable_id: UUID, user_id: UUID, session: AsyncSession):
+            variable = await session.get(Variable, variable_id)
+            if not variable or variable.user_id != user_id:
+                raise HTTPException(status_code=404, detail="Variable not found")
+            return variable
+    ```
+  - Good:
+    ```python
+    # src/backend/base/langflow/services/variable/service.py
+    class VariableNotFoundError(Exception):
+        pass
+
+    class DatabaseVariableService(VariableService, Service):
+        async def get_variable(self, variable_id: UUID, user_id: UUID, session: AsyncSession):
+            variable = await session.get(Variable, variable_id)
+            if not variable or variable.user_id != user_id:
+                raise VariableNotFoundError(f"Variable {variable_id} not found for user {user_id}")
+            return variable
+
+    # src/backend/base/langflow/api/v1/variables.py (route translates to HTTP)
+    @router.get("/variables/{variable_id}")
+    async def get_variable(variable_id: UUID, ...):
+        try:
+            return await variable_service.get_variable(variable_id, current_user.id, session)
+        except VariableNotFoundError:
+            raise HTTPException(status_code=404, detail="Variable not found")
+    ```
+
+### Components are leaf nodes in the dependency graph
+- Category: best practices
+- Severity: suggestion
+- Description: Components under `src/backend/base/langflow/components/` represent flow nodes and are instantiated dynamically by the graph engine. They should depend on services and models but no other component should import from them. Component class names are stable identifiers used to match components in saved flows; renaming a component class is a breaking change.
+- Suggested fix: If shared logic exists between components, extract it into a helper or a base class under `src/backend/base/langflow/custom/` rather than creating cross-component imports.
+
+### Use Google-style docstrings
+- Category: best practices
+- Severity: suggestion
+- Description: The project enforces Google-style docstrings via Ruff (`pydocstyle.convention = "google"`). Public functions and classes should have docstrings with `Args:`, `Returns:`, and `Raises:` sections. Route handlers need at minimum a one-line summary. Private helpers (`_func`) can use simpler docstrings.
+- Example:
+  - Bad:
+    ```python
+    def timestamp_to_str(timestamp):
+        # converts timestamp to string
+        ...
+    ```
+  - Good:
+    ```python
+    def timestamp_to_str(timestamp: datetime | str) -> str:
+        """Convert timestamp to standardized string format.
+
+        Args:
+            timestamp: Input timestamp as datetime object or string.
+
+        Returns:
+            Formatted timestamp string in 'YYYY-MM-DD HH:MM:SS UTC' format.
+
+        Raises:
+            ValueError: If string timestamp is in invalid format.
+        """
+        ...
+    ```
+
+### Use the async logger from `lfx.log.logger`
+- Category: best practices
+- Severity: critical
+- Description: Langflow uses an async-aware logger from `lfx.log.logger`. In async code, always use the `a`-prefixed methods (`adebug`, `ainfo`, `awarning`, `aerror`, `aexception`) to avoid blocking the event loop. Never use `print()` or stdlib `logging` directly. Use `aexception` for errors (auto-includes traceback). Use `{e!s}` for string representation of exceptions.
+- Example:
+  - Bad:
+    ```python
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.info(f"Processing flow {flow_id}")
+    print(f"Error: {e}")
+    ```
+  - Good:
+    ```python
+    from lfx.log.logger import logger
+
+    await logger.ainfo(f"Processing flow {flow_id}")
+    await logger.aexception(f"Error processing flow {flow_id}: {e!s}")
+    await logger.adebug("Skipping environment variable storage.")
+    await logger.awarning(f"Session rolled back during {var_name} query.")
+    ```
+
+### Use Python 3.10+ type syntax and FastAPI DI aliases
+- Category: best practices
+- Severity: suggestion
+- Description: Use modern Python 3.10+ union syntax (`X | Y` instead of `Union[X, Y]`, `X | None` instead of `Optional[X]`). Use `TYPE_CHECKING` guard for imports only needed for type annotations (prevents circular imports). Use `Annotated[Type, Depends(...)]` for FastAPI dependency injection with project type aliases like `CurrentActiveUser`, `DbSession`, `DbSessionReadOnly`.
+- Example:
+  - Bad:
+    ```python
+    from typing import Optional, Union
+    from fastapi import Depends
+
+    async def get_flow(
+        flow_id: UUID,
+        session: AsyncSession = Depends(injectable_session_scope),
+        user: User = Depends(get_current_active_user),
+    ) -> Optional[Flow]:
+        ...
+    ```
+  - Good:
+    ```python
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from langflow.services.database.models.user.model import User
+
+    async def get_flow(
+        *,
+        flow_id: UUID,
+        session: DbSession,          # Annotated[AsyncSession, Depends(injectable_session_scope)]
+        current_user: CurrentActiveUser,  # Annotated[User, Depends(get_current_active_user)]
+    ) -> Flow | None:
+        ...
+    ```

--- a/.agents/skills/backend-code-review/references/db-schema-rule.md
+++ b/.agents/skills/backend-code-review/references/db-schema-rule.md
@@ -1,0 +1,261 @@
+# Rule Catalog — DB Schema Design
+
+## Scope
+- Covers: SQLModel model definitions, schema boundaries in model properties, user-scoped schema design, index redundancy checks, dialect portability in models (SQLite + PostgreSQL), and cross-database compatibility in Alembic migrations.
+- Key directories:
+  - Models: `src/backend/base/langflow/services/database/models/`
+  - Migrations: `src/backend/base/langflow/alembic/versions/`
+- Does NOT cover: session lifecycle, transaction boundaries, and query execution patterns (handled by `sqlalchemy-rule.md`).
+
+## Rules
+
+### Do not query other tables inside `@property`
+- Category: [maintainability, performance]
+- Severity: critical
+- Description: A model `@property` must not open sessions or query other tables. This hides dependencies across models, tightly couples schema objects to data access, and can cause N+1 query explosions when iterating collections. Langflow uses SQLModel which combines SQLAlchemy table models with Pydantic validation; properties should only derive values from already-loaded fields.
+- Suggested fix:
+  - Keep model properties pure and local to already-loaded fields.
+  - Move cross-table data fetching to service methods or CRUD functions under the model's module (e.g., `models/flow/utils.py`).
+  - For list/batch reads, fetch required related data explicitly (join/preload/bulk query) before rendering derived values.
+- Example:
+  - Bad:
+    ```python
+    class Flow(FlowBase, table=True):
+        __tablename__ = "flow"
+
+        @property
+        def folder_name(self) -> str:
+            from lfx.services.deps import session_scope
+            import asyncio
+            loop = asyncio.get_event_loop()
+            async def _get():
+                async with session_scope() as session:
+                    folder = (await session.execute(
+                        select(Folder).where(Folder.id == self.folder_id)
+                    )).scalar_one()
+                    return folder.name
+            return loop.run_until_complete(_get())
+    ```
+  - Good:
+    ```python
+    class Flow(FlowBase, table=True):
+        __tablename__ = "flow"
+
+        @property
+        def display_name(self) -> str:
+            return self.name or "Untitled Flow"
+
+    # Service or CRUD layer performs explicit fetch for related Folder rows.
+    async def get_flow_with_folder(flow_id: UUID, session: AsyncSession) -> tuple[Flow, Folder]:
+        stmt = select(Flow, Folder).join(Folder, Flow.folder_id == Folder.id).where(Flow.id == flow_id)
+        result = (await session.execute(stmt)).one_or_none()
+        return result
+    ```
+
+### Use `user_id` for user-scoped data
+- Category: maintainability
+- Severity: suggestion
+- Description: Langflow scopes user-owned data by `user_id` (not `tenant_id`). When an entity belongs to a specific user, include `user_id` in the model definition. This improves data isolation safety and keeps future multi-user or partitioning strategies practical. The `user_id` column should reference `user.id` via a foreign key where appropriate.
+- Suggested fix:
+  - Add a `user_id` column and ensure related unique/index constraints include the user dimension when applicable.
+  - Propagate `user_id` through service interfaces to keep access paths user-scoped.
+  - Exception: if a table is explicitly designed as globally shared metadata (e.g., system settings), document that design decision clearly.
+- Example:
+  - Bad:
+    ```python
+    class CustomComponent(SQLModel, table=True):
+        __tablename__ = "custom_component"
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        name: str = Field(index=True)
+        code: str = Field(sa_column=Column(Text))
+        # Missing user_id: any user can see/modify any custom component
+    ```
+  - Good:
+    ```python
+    class CustomComponent(SQLModel, table=True):
+        __tablename__ = "custom_component"
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        user_id: UUID = Field(foreign_key="user.id", index=True)
+        name: str = Field(index=True)
+        code: str = Field(sa_column=Column(Text))
+    ```
+
+### Detect and avoid duplicate/redundant indexes
+- Category: performance
+- Severity: suggestion
+- Description: Review index definitions for leftmost-prefix redundancy. For example, index `(a, b, c)` can safely cover most lookups for `(a, b)`. Keeping both may increase write overhead and can mislead the optimizer into suboptimal execution plans. This applies to both SQLModel `Field(index=True)` declarations and explicit `__table_args__` index definitions.
+- Suggested fix:
+  - Before adding an index, compare against existing composite indexes by leftmost-prefix rules.
+  - Drop or avoid creating redundant prefixes unless there is a proven query-pattern need.
+  - Apply the same review standard in both model `__table_args__` and Alembic migration index DDL.
+- Example:
+  - Bad:
+    ```python
+    class Message(SQLModel, table=True):
+        __tablename__ = "message"
+        __table_args__ = (
+            sa.Index("idx_msg_user_flow", "user_id", "flow_id"),
+            sa.Index("idx_msg_user_flow_created", "user_id", "flow_id", "created_at"),
+        )
+    ```
+  - Good:
+    ```python
+    class Message(SQLModel, table=True):
+        __tablename__ = "message"
+        __table_args__ = (
+            # Keep the wider index unless profiling proves a dedicated short index is needed.
+            sa.Index("idx_msg_user_flow_created", "user_id", "flow_id", "created_at"),
+        )
+    ```
+
+### Avoid dialect-specific constructs directly in models; use portable types
+- Category: maintainability
+- Severity: critical
+- Description: Langflow supports both SQLite (development) and PostgreSQL 15+ (production). Model/schema definitions should avoid PostgreSQL-only or SQLite-only constructs directly in business models. When database-specific behavior is required, encapsulate it behind a portable abstraction. SQLModel's `Field()` and `Column()` already provide most portability, but direct use of dialect-specific types (e.g., `postgresql.JSONB`, `postgresql.ARRAY`) breaks SQLite compatibility.
+- Suggested fix:
+  - Use SQLModel's `JSON` column type (which maps to the appropriate dialect type) instead of `postgresql.JSONB`.
+  - Use `sa.Text` or `sa.String` instead of dialect-specific text types.
+  - If a dialect-specific feature is truly needed, add a conditional wrapper and document the rationale.
+- Example:
+  - Bad:
+    ```python
+    from sqlalchemy.dialects.postgresql import JSONB
+
+    class ToolConfig(SQLModel, table=True):
+        __tablename__ = "tool_config"
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        config: dict = Field(sa_column=Column(JSONB, nullable=False))  # Breaks on SQLite
+    ```
+  - Good:
+    ```python
+    from sqlmodel import JSON
+
+    class ToolConfig(SQLModel, table=True):
+        __tablename__ = "tool_config"
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        config: dict | None = Field(default=None, sa_column=Column(JSON))  # Works on both dialects
+    ```
+
+### Guard migration incompatibilities with dialect checks
+- Category: maintainability
+- Severity: critical
+- Description: Alembic migration scripts under `src/backend/base/langflow/alembic/versions/` must account for SQLite/PostgreSQL incompatibilities explicitly. SQLite has limited ALTER TABLE support (no DROP COLUMN before 3.35, no ADD CONSTRAINT). For dialect-sensitive DDL or defaults, branch on the active dialect or use `op.batch_alter_table()` for SQLite compatibility.
+- Suggested fix:
+  - In migration upgrades/downgrades, bind connection and branch by dialect for incompatible SQL fragments.
+  - Use `op.batch_alter_table()` for column modifications on SQLite.
+  - Avoid one-dialect-only migration logic unless there is a documented, deliberate compatibility exception.
+- Example:
+  - Bad:
+    ```python
+    def upgrade():
+        op.add_column("flow", sa.Column(
+            "access_type",
+            sa.String(50),
+            server_default=sa.text("'PRIVATE'::character varying"),  # PostgreSQL-only cast
+            nullable=False,
+        ))
+    ```
+  - Good:
+    ```python
+    def upgrade():
+        conn = op.get_bind()
+        if conn.dialect.name == "postgresql":
+            default_expr = sa.text("'PRIVATE'::character varying")
+        else:
+            default_expr = sa.text("'PRIVATE'")
+
+        with op.batch_alter_table("flow") as batch_op:
+            batch_op.add_column(sa.Column(
+                "access_type",
+                sa.String(50),
+                server_default=default_expr,
+                nullable=False,
+            ))
+    ```
+
+### SQLModel-specific patterns
+- Category: best practices
+- Severity: suggestion
+- Description: Langflow uses SQLModel which merges SQLAlchemy ORM and Pydantic validation into a single class hierarchy. Follow these conventions for model definitions:
+  - Use `SQLModel` as the base class with `table=True` for database-backed models.
+  - Use `SQLModel` without `table=True` for schema/validation-only models (e.g., `FlowCreate`, `FlowRead`, `FlowUpdate`).
+  - Use `Field()` for column definitions; use `sa_column=Column(...)` only when `Field()` alone cannot express the constraint.
+  - Use `Relationship()` for ORM relationships; put related model type hints behind `TYPE_CHECKING` to avoid circular imports.
+- Suggested fix: Follow the existing patterns in `src/backend/base/langflow/services/database/models/flow/model.py` for reference on how to define base models, table models, and CRUD schema models.
+- Example:
+  - Bad:
+    ```python
+    # Mixing table model and API schema in one class
+    class Flow(SQLModel, table=True):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        name: str
+        data: dict | None = None
+        # API-only fields mixed in
+        component_count: int = 0  # Not a DB column, computed at API time
+    ```
+  - Good:
+    ```python
+    # Table model: only DB columns
+    class Flow(FlowBase, table=True):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        user_id: UUID = Field(foreign_key="user.id", index=True)
+
+    # Schema model: includes computed fields for API responses
+    class FlowRead(FlowBase):
+        id: UUID
+        user_id: UUID
+        component_count: int = 0
+    ```
+
+### Follow the Base → Table → Create → Read → Update schema pattern
+- Category: best practices
+- Severity: suggestion
+- Description: Langflow uses a layered SQLModel schema pattern. `{Entity}Base(SQLModel)` defines shared fields, validators (`@field_validator`), and serializers (`@field_serializer`). `{Entity}(Base, table=True)` adds primary key and relationships. Separate `Create`, `Read`, and `Update` schemas control API boundaries. Use `model_dump(exclude_unset=True, exclude_none=True)` for partial updates. Use `FlowRead.model_validate(db_flow, from_attributes=True)` to convert ORM→schema while session is active.
+- Suggested fix:
+  - Define Base → Table → Create → Read → Update for every entity.
+  - Put `@field_validator` and `@field_serializer` on the Base so they apply everywhere.
+  - Never return the Table model directly from a route — always convert to the Read schema.
+- Example:
+  - Bad:
+    ```python
+    # Returning the table model directly (leaks internal fields, relationships)
+    @router.get("/{flow_id}")
+    async def get_flow(flow_id: UUID, session: DbSession) -> Flow:
+        return (await session.execute(select(Flow).where(Flow.id == flow_id))).scalar_one()
+    ```
+  - Good:
+    ```python
+    class FlowBase(SQLModel):
+        name: str = Field(index=True)
+        description: str | None = Field(default=None)
+
+        @field_validator("endpoint_name")
+        @classmethod
+        def validate_endpoint_name(cls, v):
+            if v is not None and not re.match(r"^[a-zA-Z0-9_-]+$", v):
+                raise HTTPException(status_code=422, detail="Invalid endpoint name")
+            return v
+
+        @field_serializer("updated_at")
+        def serialize_datetime(self, value):
+            if isinstance(value, datetime):
+                return value.replace(microsecond=0).isoformat()
+            return value
+
+    class Flow(FlowBase, table=True):
+        id: UUID = Field(default_factory=uuid4, primary_key=True)
+        user_id: UUID = Field(foreign_key="user.id")
+
+    class FlowCreate(FlowBase):
+        user_id: UUID | None = None
+        folder_id: UUID | None = None
+
+    class FlowRead(FlowBase):
+        id: UUID
+        user_id: UUID | None = Field()
+
+    @router.get("/{flow_id}", response_model=FlowRead)
+    async def get_flow(*, flow_id: UUID, session: DbSession, current_user: CurrentActiveUser) -> FlowRead:
+        flow = (await session.execute(select(Flow).where(Flow.id == flow_id, Flow.user_id == current_user.id))).scalar_one()
+        return FlowRead.model_validate(flow, from_attributes=True)
+    ```

--- a/.agents/skills/backend-code-review/references/repositories-rule.md
+++ b/.agents/skills/backend-code-review/references/repositories-rule.md
@@ -1,0 +1,217 @@
+# Rule Catalog — Service Abstraction
+
+## Scope
+- Covers: when to reuse existing service abstractions, when to introduce new services, how to preserve dependency direction between route handlers and service/infrastructure implementations, and the ServiceFactory pattern.
+- Key directories:
+  - Services: `src/backend/base/langflow/services/` (each service has `service.py` and `factory.py`)
+  - Model CRUD functions: `src/backend/base/langflow/services/database/models/*/crud.py`
+  - Service base class: `langflow.services.base.Service`
+  - Service factory base: `langflow.services.factory.ServiceFactory`
+  - Service registry: `langflow.services.manager.ServiceManager`
+  - Service types: `langflow.services.schema.ServiceType`
+  - Dependency helpers: `langflow.services.deps` (provides `get_service()`, `get_xxx_service()` functions)
+- Does NOT cover: SQLAlchemy session lifecycle and query-shape specifics (handled by `sqlalchemy-rule.md`), and table schema/migration design (handled by `db-schema-rule.md`).
+
+## Rules
+
+### Use existing services for DB operations; do not bypass with ad-hoc queries
+- Category: maintainability
+- Severity: suggestion
+- Description: Langflow uses a service layer pattern rather than a repository pattern. Each service under `src/backend/base/langflow/services/` encapsulates business logic and data access for its domain. If a service already handles operations for a given model/table, all reads/writes/queries for that table should go through the existing service (or its associated CRUD module). Additionally, many models have CRUD utility functions in `src/backend/base/langflow/services/database/models/<model>/crud.py` that should be reused rather than duplicated.
+- Suggested fix:
+  - First check `src/backend/base/langflow/services/` and `src/backend/base/langflow/services/database/models/<model>/crud.py` to verify whether the table/model already has a service or CRUD abstraction. If it exists, route all operations through it and add missing methods instead of bypassing it with ad-hoc SQLAlchemy queries.
+  - If no service or CRUD module exists, add methods to the most closely related existing service or CRUD module rather than scattering inline queries across route handlers.
+- Example:
+  - Bad:
+    ```python
+    # Route handler bypasses the existing variable service with inline queries
+    @router.get("/variables")
+    async def list_variables(
+        session: AsyncSession = Depends(injectable_session_scope_readonly),
+        current_user: User = Depends(get_current_active_user),
+    ):
+        stmt = select(Variable).where(Variable.user_id == current_user.id)
+        variables = (await session.execute(stmt)).scalars().all()
+        return [VariableRead.model_validate(v, from_attributes=True) for v in variables]
+    ```
+  - Good:
+    ```python
+    # Route handler delegates to the variable service
+    @router.get("/variables")
+    async def list_variables(
+        session: AsyncSession = Depends(injectable_session_scope_readonly),
+        current_user: User = Depends(get_current_active_user),
+    ):
+        variable_service = get_variable_service()
+        variables = await variable_service.list_variables(user_id=current_user.id, session=session)
+        return [VariableRead.model_validate(v, from_attributes=True) for v in variables]
+    ```
+
+### Follow the ServiceFactory pattern for new services
+- Category: best practices
+- Severity: critical
+- Description: Langflow manages services through `ServiceManager` which uses `ServiceFactory` instances to create and configure services. Each service consists of:
+  1. A base class or protocol (optional, for abstraction) inheriting from `langflow.services.base.Service`
+  2. A concrete implementation in `service.py`
+  3. A factory class in `factory.py` inheriting from `langflow.services.factory.ServiceFactory`
+  4. A `ServiceType` enum entry in `langflow.services.schema`
+  5. A `get_xxx_service()` function in `langflow.services.deps`
+
+  New services must follow this pattern to integrate with the dependency injection system. The factory's `create()` method receives other services as arguments (resolved by name from the ServiceManager).
+- Suggested fix: When introducing a new service, create all required files following the existing pattern. Register the factory in `ServiceManager.get_factories()` and add a convenience getter in `langflow.services.deps`.
+- Example:
+  - Bad:
+    ```python
+    # Ad-hoc singleton without factory integration
+    class NotificationService:
+        _instance = None
+
+        @classmethod
+        def get_instance(cls):
+            if cls._instance is None:
+                cls._instance = cls()
+            return cls._instance
+
+        def notify(self, user_id: UUID, message: str):
+            ...
+    ```
+  - Good:
+    ```python
+    # src/backend/base/langflow/services/notification/service.py
+    from langflow.services.base import Service
+
+    class NotificationService(Service):
+        name = "notification_service"
+
+        def __init__(self, settings_service: SettingsService):
+            self.settings_service = settings_service
+
+        async def notify(self, user_id: UUID, message: str, session: AsyncSession) -> None:
+            ...
+
+    # src/backend/base/langflow/services/notification/factory.py
+    from langflow.services.factory import ServiceFactory
+    from langflow.services.notification.service import NotificationService
+
+    class NotificationServiceFactory(ServiceFactory):
+        def __init__(self) -> None:
+            super().__init__(NotificationService)
+
+        def create(self, settings_service: SettingsService):
+            return NotificationService(settings_service)
+
+    # Register in ServiceManager.get_factories() and add getter in deps.py
+    ```
+
+### When to introduce a new service vs. extend an existing one
+- Category: best practices
+- Severity: suggestion
+- Description: Not every new feature needs a new service. Introduce a new service only when:
+  1. The domain is distinct enough that mixing it into an existing service would violate single responsibility.
+  2. The service manages its own lifecycle (e.g., connections, background tasks, caches).
+  3. Multiple other services or route modules need to depend on this functionality.
+  4. The data access patterns are sufficiently different from existing services.
+
+  Otherwise, extend an existing service by adding methods to its `service.py` and corresponding CRUD functions.
+- Suggested fix:
+  - For small, related features: add methods to the closest existing service.
+  - For distinct domains with their own lifecycle: create a new service following the ServiceFactory pattern.
+  - When in doubt, start by extending an existing service; extract into a new service later when complexity warrants it (YAGNI principle).
+- Example:
+  - Bad:
+    ```python
+    # Unnecessary new service for a simple feature that belongs in an existing service
+    # src/backend/base/langflow/services/flow_stats/service.py
+    class FlowStatsService(Service):
+        name = "flow_stats_service"
+
+        async def get_flow_component_count(self, flow_id: UUID, session: AsyncSession) -> int:
+            flow = (await session.execute(select(Flow).where(Flow.id == flow_id))).scalar_one()
+            return len(flow.data.get("nodes", []))
+    ```
+  - Good:
+    ```python
+    # Add to existing flow-related code or a utility function
+    # src/backend/base/langflow/services/database/models/flow/utils.py
+    def count_components(flow_data: dict | None) -> int:
+        if not flow_data:
+            return 0
+        return len(flow_data.get("nodes", []))
+    ```
+
+### Access services through `get_service()` or dependency getters, not direct instantiation
+- Category: maintainability
+- Severity: critical
+- Description: Services are singletons managed by `ServiceManager`. They must be accessed through `get_service(ServiceType.XXX)` or the convenience functions in `langflow.services.deps` (e.g., `get_settings_service()`, `get_variable_service()`). Direct instantiation bypasses the factory pattern, ignores lifecycle management, and can create multiple conflicting instances.
+- Suggested fix: Always use the provided dependency functions. In route handlers, use FastAPI's `Depends()` with the appropriate getter. In service-to-service calls, use `get_service()` or accept the dependency through the factory's `create()` method.
+- Example:
+  - Bad:
+    ```python
+    # Direct instantiation bypasses the service manager
+    from langflow.services.variable.service import DatabaseVariableService
+
+    async def some_function():
+        settings = get_settings_service()
+        variable_service = DatabaseVariableService(settings)  # Wrong: creates a new instance
+        await variable_service.get_variable(...)
+    ```
+  - Good:
+    ```python
+    # Use the dependency getter
+    from langflow.services.deps import get_variable_service
+
+    async def some_function():
+        variable_service = get_variable_service()
+        await variable_service.get_variable(...)
+
+    # In route handlers, use Depends()
+    @router.get("/variables/{variable_id}")
+    async def get_variable(
+        variable_id: UUID,
+        session: AsyncSession = Depends(injectable_session_scope_readonly),
+        current_user: User = Depends(get_current_active_user),
+    ):
+        variable_service = get_variable_service()
+        return await variable_service.get_variable(variable_id, current_user.id, session)
+    ```
+
+### CRUD modules complement services, not replace them
+- Category: best practices
+- Severity: suggestion
+- Description: Many Langflow models have a `crud.py` file alongside their model definition (e.g., `models/message/crud.py`, `models/user/crud.py`). These CRUD modules contain reusable async functions for common database operations (get, list, create, update, delete). They are lower-level building blocks that services call internally. Route handlers should prefer calling service methods rather than CRUD functions directly, unless the operation is trivially simple and the model has no associated service.
+- Suggested fix:
+  - Services should call CRUD functions internally to avoid duplicating query logic.
+  - Route handlers should call services, not CRUD functions, to maintain the layering.
+  - New CRUD functions should accept an `AsyncSession` parameter and stay stateless (pure data access, no business logic).
+- Example:
+  - Bad:
+    ```python
+    # Route handler calling CRUD directly, bypassing any business logic layer
+    from langflow.services.database.models.message.crud import get_messages_by_flow_id
+
+    @router.get("/flows/{flow_id}/messages")
+    async def list_messages(
+        flow_id: UUID,
+        session: AsyncSession = Depends(injectable_session_scope_readonly),
+        current_user: User = Depends(get_current_active_user),
+    ):
+        # No authorization check, no business logic, direct CRUD call
+        return await get_messages_by_flow_id(flow_id, session)
+    ```
+  - Good:
+    ```python
+    # Service wraps CRUD with authorization and business logic
+    class ChatService(Service):
+        async def get_messages(self, flow_id: UUID, user_id: UUID, session: AsyncSession):
+            # Verify user owns the flow
+            flow = await get_flow_by_id_and_user(flow_id, user_id, session)
+            if not flow:
+                raise FlowNotFoundError(f"Flow {flow_id} not found")
+            return await get_messages_by_flow_id(flow_id, session)
+
+    # Route handler delegates to service
+    @router.get("/flows/{flow_id}/messages")
+    async def list_messages(flow_id: UUID, ...):
+        chat_service = get_chat_service()
+        return await chat_service.get_messages(flow_id, current_user.id, session)
+    ```

--- a/.agents/skills/backend-code-review/references/sqlalchemy-rule.md
+++ b/.agents/skills/backend-code-review/references/sqlalchemy-rule.md
@@ -1,0 +1,222 @@
+# Rule Catalog — SQLAlchemy Patterns
+
+## Scope
+- Covers: SQLAlchemy/SQLModel async session and transaction lifecycle, query construction, user scoping, raw SQL boundaries, write-path concurrency safeguards, and async-specific pitfalls.
+- Key modules:
+  - Session management (canonical source): `lfx.services.deps.session_scope`, `lfx.services.deps.session_scope_readonly`
+  - Langflow wrappers (delegates to lfx): `langflow.services.deps.session_scope`, `langflow.services.deps.session_scope_readonly`
+  - Injectable dependencies: `lfx.services.deps.injectable_session_scope`, `lfx.services.deps.injectable_session_scope_readonly`
+  - Database service: `langflow.services.database.service.DatabaseService`
+  - Model CRUD functions: `src/backend/base/langflow/services/database/models/*/crud.py`
+- Import preference: Use `from langflow.services.deps import session_scope` in Langflow code for consistency. The Langflow wrappers are thin `@asynccontextmanager` functions that delegate to `lfx.services.deps`. Only import directly from `lfx` when working inside the `lfx` package itself.
+- Does NOT cover: table/model schema and migration design details (handled by `db-schema-rule.md`).
+
+## Rules
+
+### Use `session_scope()` context manager with explicit transaction awareness
+- Category: best practices
+- Severity: critical
+- Description: Langflow uses async sessions exclusively. The `session_scope()` context manager provides auto-commit on successful exit and auto-rollback on exception. For read-only paths, use `session_scope_readonly()` which skips commit overhead. In route handlers, use the injectable variants via `Depends(injectable_session_scope)`. Missing commits can silently drop intended updates, while ad-hoc or long-lived transactions increase contention and deadlock risk.
+- Suggested fix:
+  - For write operations in services/CRUD: use `async with session_scope() as session:` which auto-commits on success.
+  - For read-only operations: use `async with session_scope_readonly() as session:` to avoid unnecessary commit calls.
+  - In route handlers: use `session: AsyncSession = Depends(injectable_session_scope)` for writes or `Depends(injectable_session_scope_readonly)` for reads.
+  - Keep transaction windows short: avoid network I/O, heavy computation, or unrelated work inside the session scope.
+- Example:
+  - Bad:
+    ```python
+    # Creating a raw session without the context manager
+    from sqlmodel.ext.asyncio.session import AsyncSession
+    from langflow.services.deps import get_service
+
+    db_service = get_service(ServiceType.DATABASE_SERVICE)
+    session = AsyncSession(db_service.engine)
+    flow = (await session.execute(select(Flow).where(Flow.id == flow_id))).scalar_one()
+    flow.name = "Updated"
+    # Missing commit, session never closed properly
+    ```
+  - Good:
+    ```python
+    from langflow.services.deps import session_scope
+
+    async with session_scope() as session:
+        flow = (await session.execute(select(Flow).where(Flow.id == flow_id))).scalar_one()
+        flow.name = "Updated"
+        # session_scope auto-commits on successful exit
+
+    # For read-only operations:
+    from langflow.services.deps import session_scope_readonly
+
+    async with session_scope_readonly() as session:
+        flows = (await session.execute(select(Flow).where(Flow.user_id == user_id))).scalars().all()
+    ```
+
+### Enforce `user_id` scoping on user-owned queries
+- Category: security
+- Severity: critical
+- Description: Reads and writes against user-owned tables must be scoped by `user_id` to prevent cross-user data leakage or corruption. Langflow uses `user_id` (not `tenant_id`) for user-scoped data isolation. Every query on user-owned entities (flows, variables, folders, messages, API keys) must include a `user_id` filter.
+- Suggested fix: Add `user_id` predicate to all user-owned entity queries and propagate user context through service interfaces. The `current_user.id` is available from the `get_current_active_user` dependency in route handlers.
+- Example:
+  - Bad:
+    ```python
+    # Missing user_id scope: any authenticated user can read any flow
+    stmt = select(Flow).where(Flow.id == flow_id)
+    flow = (await session.execute(stmt)).scalar_one_or_none()
+    ```
+  - Good:
+    ```python
+    stmt = select(Flow).where(
+        Flow.id == flow_id,
+        Flow.user_id == current_user.id,
+    )
+    flow = (await session.execute(stmt)).scalar_one_or_none()
+    ```
+
+### Prefer SQLAlchemy/SQLModel expressions over raw SQL
+- Category: maintainability
+- Severity: suggestion
+- Description: Raw SQL via `text()` should be exceptional. ORM/Core expressions are easier to evolve, safer to compose, dialect-portable (SQLite + PostgreSQL), and more consistent with the codebase. Langflow uses `sqlmodel.select()` for queries which provides both type safety and dialect portability.
+- Suggested fix: Rewrite straightforward raw SQL into SQLModel `select/update/delete` expressions; keep raw SQL only when required by clear technical constraints (e.g., database-specific administrative queries).
+- Example:
+  - Bad:
+    ```python
+    from sqlmodel import text
+
+    result = await session.execute(
+        text("SELECT * FROM flow WHERE id = :id AND user_id = :user_id"),
+        {"id": str(flow_id), "user_id": str(user_id)},
+    )
+    row = result.first()
+    ```
+  - Good:
+    ```python
+    from sqlmodel import select
+
+    stmt = select(Flow).where(
+        Flow.id == flow_id,
+        Flow.user_id == user_id,
+    )
+    flow = (await session.execute(stmt)).scalar_one_or_none()
+    ```
+
+### Do not run blocking operations inside async session scopes
+- Category: performance
+- Severity: critical
+- Description: Langflow runs on an async event loop (uvicorn + FastAPI). Blocking calls inside a session scope (synchronous I/O, `time.sleep()`, CPU-bound computation, synchronous HTTP requests) block the entire event loop and starve other coroutines. This also extends transaction duration unnecessarily, increasing lock contention.
+- Suggested fix:
+  - Move blocking operations outside the session scope.
+  - Use `asyncio.to_thread()` or `anyio.to_thread.run_sync()` for CPU-bound or synchronous I/O work.
+  - Perform external API calls before or after the database transaction, not inside it.
+- Example:
+  - Bad:
+    ```python
+    async with session_scope() as session:
+        flow = (await session.execute(select(Flow).where(Flow.id == flow_id))).scalar_one()
+        # Blocking HTTP call inside transaction scope
+        import requests
+        response = requests.post("https://external-api.com/validate", json=flow.data)
+        flow.validated = response.ok
+    ```
+  - Good:
+    ```python
+    async with session_scope_readonly() as session:
+        flow = (await session.execute(select(Flow).where(Flow.id == flow_id))).scalar_one()
+        flow_data = flow.data
+
+    # External call outside transaction scope
+    import httpx
+    async with httpx.AsyncClient() as client:
+        response = await client.post("https://external-api.com/validate", json=flow_data)
+
+    async with session_scope() as session:
+        flow = (await session.execute(select(Flow).where(Flow.id == flow_id))).scalar_one()
+        flow.validated = response.is_success
+    ```
+
+### Protect write paths with concurrency safeguards
+- Category: quality
+- Severity: critical
+- Description: Multi-writer paths without explicit concurrency control can silently overwrite data. Choose the safeguard based on contention level, lock scope, and throughput cost instead of defaulting to one strategy. Langflow's async architecture means multiple coroutines may attempt concurrent writes.
+- Suggested fix:
+  - **Optimistic locking**: Use when contention is usually low and retries are acceptable. Add a version or `updated_at` guard in `WHERE` and treat `rowcount == 0` as a conflict.
+  - **SELECT ... FOR UPDATE**: Use when contention is high on the same rows and strict in-transaction serialization is required. Keep transactions short to reduce lock wait/deadlock risk.
+  - In all cases, scope by `user_id` and verify affected row counts for conditional writes.
+- Example:
+  - Bad:
+    ```python
+    # No user scope, no conflict detection on a contested write path
+    async with session_scope() as session:
+        await session.execute(
+            update(Flow).where(Flow.id == flow_id).values(name="Updated")
+        )
+    ```
+  - Good:
+    ```python
+    # Optimistic lock (low contention, retry on conflict)
+    from sqlmodel import update
+
+    async with session_scope() as session:
+        result = await session.execute(
+            update(Flow)
+            .where(
+                Flow.id == flow_id,
+                Flow.user_id == user_id,
+                Flow.updated_at == expected_updated_at,
+            )
+            .values(name="Updated", updated_at=datetime.now(timezone.utc))
+        )
+        if result.rowcount == 0:
+            raise FlowStateConflictError("Flow was modified concurrently, retry")
+
+    # Pessimistic lock with SELECT ... FOR UPDATE (high contention)
+    async with session_scope() as session:
+        flow = (await session.execute(
+            select(Flow)
+            .where(Flow.id == flow_id, Flow.user_id == user_id)
+            .with_for_update()
+        )).scalar_one()
+        flow.name = "Updated"
+        flow.updated_at = datetime.now(timezone.utc)
+    ```
+
+### Keep transactions short; no I/O inside transactions
+- Category: performance
+- Severity: suggestion
+- Description: Long transactions hold database locks and increase contention, especially on SQLite where write locking is database-wide. Structure code so that data is fetched, external operations are performed, and then the write transaction is opened as late as possible and closed as early as possible.
+- Suggested fix:
+  - Read data in one session scope, perform computation or external calls, then write results in a separate session scope.
+  - Avoid nesting `session_scope()` calls (the context manager is not reentrant).
+  - Batch related writes into a single session scope rather than opening multiple sequential scopes for related changes.
+- Example:
+  - Bad:
+    ```python
+    async with session_scope() as session:
+        flows = (await session.execute(select(Flow).where(Flow.user_id == user_id))).scalars().all()
+        for flow in flows:
+            # Expensive computation inside transaction
+            analysis = await analyze_flow_complexity(flow.data)
+            flow.complexity_score = analysis.score
+            flow.updated_at = datetime.now(timezone.utc)
+    ```
+  - Good:
+    ```python
+    # Read phase
+    async with session_scope_readonly() as session:
+        flows = (await session.execute(select(Flow).where(Flow.user_id == user_id))).scalars().all()
+        flow_data = [(f.id, f.data) for f in flows]
+
+    # Compute phase (outside transaction)
+    updates = {}
+    for flow_id, data in flow_data:
+        analysis = await analyze_flow_complexity(data)
+        updates[flow_id] = analysis.score
+
+    # Write phase (short transaction)
+    async with session_scope() as session:
+        for flow_id, score in updates.items():
+            await session.execute(
+                update(Flow)
+                .where(Flow.id == flow_id, Flow.user_id == user_id)
+                .values(complexity_score=score, updated_at=datetime.now(timezone.utc))
+            )
+    ```

--- a/.agents/skills/component-refactoring/SKILL.md
+++ b/.agents/skills/component-refactoring/SKILL.md
@@ -1,0 +1,435 @@
+---
+name: component-refactoring
+description: Refactor high-complexity React components in Langflow frontend. Use when manual complexity assessment shows complexity > 50 or lineCount > 300, when the user asks for code splitting, hook extraction, or complexity reduction; avoid for simple/well-structured components, third-party wrappers, or when the user explicitly wants testing without refactoring.
+---
+
+# Langflow Component Refactoring Skill
+
+Refactor high-complexity React components in the Langflow frontend codebase with the patterns and workflow below.
+
+> **Complexity Threshold**: Components with complexity > 50 (measured manually by counting conditionals, nesting levels, and lines) should be refactored before testing.
+
+## Quick Reference
+
+### Commands (run from `src/frontend/`)
+
+```bash
+cd src/frontend
+
+# Lint with Biome
+npm run lint
+
+# Type checking
+npm run type-check
+
+# Run tests
+npm test
+```
+
+### Manual Complexity Assessment
+
+Since Langflow does not have automated complexity analysis tools, assess components manually:
+
+1. **Count conditionals**: Each `if/else`, `switch/case`, ternary, `&&`/`||` chain adds +1.
+2. **Count nesting levels**: Each level of nesting within conditionals or loops adds +1.
+3. **Count total lines**: Target < 300 lines per component file.
+4. **Count state hooks**: More than 5 `useState` calls suggests hook extraction.
+5. **Count effects**: More than 3 `useEffect` calls suggests effect consolidation.
+
+### Complexity Score Interpretation
+
+| Score | Level | Action |
+|-------|-------|--------|
+| 0-25 | Simple | Ready for testing |
+| 26-50 | Medium | Consider minor refactoring |
+| 51-75 | Complex | **Refactor before testing** |
+| 76-100 | Very Complex | **Must refactor** |
+
+## Core Refactoring Patterns
+
+### Pattern 1: Extract Custom Hooks
+
+**When**: Component has complex state management, multiple `useState`/`useEffect`, or business logic mixed with UI.
+
+**Langflow Convention**: Place hooks in a `hooks/` subdirectory or alongside the component as `use-<feature>.ts`. Langflow uses kebab-case filenames with `use-` prefix.
+
+```typescript
+// Before: Complex state logic in component
+const FlowPage: FC = () => {
+  const [nodes, setNodes] = useState<Node[]>([])
+  const [edges, setEdges] = useState<Edge[]>([])
+  const [buildStatus, setBuildStatus] = useState<BuildStatus>(BuildStatus.IDLE)
+
+  // 50+ lines of state management logic...
+
+  return <div>...</div>
+}
+
+// After: Extract to custom hook
+// hooks/use-flow-state.ts
+export const useFlowState = (flowId: string) => {
+  const [nodes, setNodes] = useState<Node[]>([])
+  const [edges, setEdges] = useState<Edge[]>([])
+  const [buildStatus, setBuildStatus] = useState<BuildStatus>(BuildStatus.IDLE)
+
+  // Related state management logic here
+
+  return { nodes, setNodes, edges, setEdges, buildStatus, setBuildStatus }
+}
+
+// Component becomes cleaner
+const FlowPage: FC = () => {
+  const { nodes, setNodes, edges, setEdges } = useFlowState(flowId)
+  return <div>...</div>
+}
+```
+
+**Langflow Examples**:
+- `src/frontend/src/hooks/use-add-component.ts`
+- `src/frontend/src/hooks/use-unsaved-changes.ts`
+- `src/frontend/src/hooks/use-refresh-model-inputs.ts`
+
+### Pattern 2: Extract Sub-Components
+
+**When**: Single component has multiple UI sections, conditional rendering blocks, or repeated patterns.
+
+**Langflow Convention**: Place sub-components in subdirectories or as separate files in the same directory. UI primitives go in `components/ui/`, domain components in `components/core/`, reusable components in `components/common/`.
+
+```typescript
+// Before: Monolithic JSX with multiple sections
+const GenericNode = () => {
+  return (
+    <div>
+      {/* 100 lines of header UI */}
+      {/* 100 lines of parameter fields */}
+      {/* 100 lines of output handles */}
+    </div>
+  )
+}
+
+// After: Split into focused components
+// CustomNodes/GenericNode/
+//   generic-node.tsx       (orchestration only — kebab-case, descriptive name)
+//   components/
+//     node-header.tsx
+//     node-parameters.tsx
+//     node-outputs.tsx
+
+const GenericNode = () => {
+  return (
+    <div>
+      <NodeHeader nodeData={data} />
+      <NodeParameters fields={fields} />
+      <NodeOutputs outputs={outputs} />
+    </div>
+  )
+}
+```
+
+**Langflow Examples**:
+- `src/frontend/src/CustomNodes/GenericNode/components/`
+- `src/frontend/src/components/core/`
+- `src/frontend/src/components/ui/`
+
+### Pattern 3: Simplify Conditional Logic
+
+**When**: Deep nesting (> 3 levels), complex ternaries, or multiple `if/else` chains.
+
+```typescript
+// Before: Deeply nested conditionals
+const getFieldComponent = (field: InputFieldType) => {
+  if (field.type === "str") {
+    if (field.multiline) {
+      return <TextAreaComponent />
+    } else if (field.password) {
+      return <PasswordInput />
+    } else if (field.options?.length) {
+      return <Dropdown options={field.options} />
+    } else {
+      return <InputComponent />
+    }
+  } else if (field.type === "int") {
+    return <IntComponent />
+  } else if (field.type === "float") {
+    return <FloatComponent />
+  }
+  return null
+}
+
+// After: Use lookup tables + early returns
+const FIELD_COMPONENT_MAP: Record<string, FC<FieldProps>> = {
+  int: IntComponent,
+  float: FloatComponent,
+  bool: ToggleComponent,
+  code: CodeAreaComponent,
+}
+
+const STR_VARIANT_MAP: Record<string, FC<FieldProps>> = {
+  multiline: TextAreaComponent,
+  password: PasswordInput,
+  options: Dropdown,
+}
+
+const getFieldComponent = (field: InputFieldType) => {
+  if (field.type !== "str") {
+    const Component = FIELD_COMPONENT_MAP[field.type]
+    return Component ? <Component {...field} /> : null
+  }
+
+  const variant = field.multiline ? "multiline"
+    : field.password ? "password"
+    : field.options?.length ? "options"
+    : "default"
+
+  const Component = STR_VARIANT_MAP[variant] ?? InputComponent
+  return <Component {...field} />
+}
+```
+
+### Pattern 4: Extract API/Data Logic
+
+**When**: Component directly handles API calls, data transformation, or complex async operations.
+
+**Langflow Convention**:
+- This skill is for component decomposition, not query/mutation design.
+- When refactoring data fetching, use `frontend-query-mutation` for query patterns, `UseRequestProcessor`, cache invalidation, and mutation error handling.
+- Do not create thin passthrough `useQuery` wrappers during refactoring; only extract a custom hook when it truly orchestrates multiple queries/mutations or shared derived state.
+- API hooks live in `controllers/API/queries/{domain}/`.
+
+**Langflow Examples**:
+- `src/frontend/src/controllers/API/queries/flows/use-post-add-flow.ts`
+- `src/frontend/src/controllers/API/queries/variables/use-get-global-variables.ts`
+- `src/frontend/src/controllers/API/queries/folders/use-get-folders.ts`
+
+### Pattern 5: Extract Modal/Dialog Management
+
+**When**: Component manages multiple modals with complex open/close states.
+
+**Langflow Convention**: Modals should be extracted with their state management.
+
+```typescript
+// Before: Multiple modal states in component
+const FlowToolbar = () => {
+  const [showExportModal, setShowExportModal] = useState(false)
+  const [showShareModal, setShowShareModal] = useState(false)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [showApiModal, setShowApiModal] = useState(false)
+  // 5+ more modal states...
+}
+
+// After: Extract to modal management hook
+type ModalType = "export" | "share" | "delete" | "api" | null
+
+const useFlowToolbarModals = () => {
+  const [activeModal, setActiveModal] = useState<ModalType>(null)
+
+  const openModal = useCallback((type: ModalType) => setActiveModal(type), [])
+  const closeModal = useCallback(() => setActiveModal(null), [])
+
+  return {
+    activeModal,
+    openModal,
+    closeModal,
+    isOpen: (type: ModalType) => activeModal === type,
+  }
+}
+```
+
+### Pattern 6: Extract Form Logic
+
+**When**: Complex form validation, submission handling, or field transformation.
+
+**Langflow Convention**: Extract form state and validation into hooks.
+
+```typescript
+// Extract form validation and submission
+const useFlowSettingsForm = (initialValues: FlowSettings) => {
+  const [values, setValues] = useState(initialValues)
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const validate = useCallback(() => {
+    const newErrors: Record<string, string> = {}
+    if (!values.name?.trim()) newErrors.name = "Name is required"
+    if (values.endpoint_name && !/^[a-z0-9-]+$/.test(values.endpoint_name)) {
+      newErrors.endpoint_name = "Must be lowercase alphanumeric with hyphens"
+    }
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }, [values])
+
+  const handleChange = useCallback((field: string, value: any) => {
+    setValues((prev) => ({ ...prev, [field]: value }))
+  }, [])
+
+  return { values, errors, validate, handleChange }
+}
+```
+
+## Langflow-Specific Refactoring Guidelines
+
+### 1. Zustand Store Selectors
+
+**When**: Component reads many values from a Zustand store, causing unnecessary re-renders.
+
+```typescript
+// Before: Selecting too many values
+const Component = () => {
+  const flowStore = useFlowStore()
+  // Component re-renders on ANY store change
+}
+
+// After: Use individual selectors
+const Component = () => {
+  const nodes = useFlowStore((state) => state.nodes)
+  const edges = useFlowStore((state) => state.edges)
+  // Component only re-renders when nodes or edges change
+}
+```
+
+**Langflow Reference**: All stores in `src/frontend/src/stores/` follow this selector pattern.
+
+### 2. Custom Node Components
+
+**When**: Refactoring flow node components (`CustomNodes/GenericNode/`).
+
+**Conventions**:
+- Keep node logic in custom hooks
+- Extract parameter rendering to separate components
+- Use the existing `components/` subdirectory for sub-components
+
+```
+CustomNodes/GenericNode/
+  generic-node.tsx             # Node registration and main render (kebab-case, NOT index.tsx)
+  components/
+    handle-render.tsx           # Handle rendering
+    node-description.tsx        # Node description display
+    node-input-field.tsx        # Input field rendering
+    node-name.tsx               # Node name display
+    node-output-field.tsx       # Output field rendering
+    node-status.tsx             # Build status display
+```
+
+### 3. Flow Canvas Components
+
+**When**: Refactoring components related to the flow editor canvas.
+
+**Conventions**:
+- `@xyflow/react` v12 is the canvas library
+- Keep canvas event handlers separate from UI rendering
+- Use `useFlowStore` for flow state management
+- Use `useFlowsManagerStore` for multi-flow management
+
+### 4. API Query Hook Components
+
+**When**: Refactoring components that consume API data.
+
+**Conventions**:
+- Use existing query hooks from `controllers/API/queries/`
+- Access `UseRequestProcessor` for new queries/mutations
+- Use query key arrays like `["useGetGlobalVariables"]` for cache management
+- Cache invalidation belongs in mutation `onSettled` callbacks
+
+## Refactoring Workflow
+
+### Step 1: Assess Complexity
+
+Manually count:
+- Total conditionals (if/else, switch, ternary, &&/||)
+- Maximum nesting depth
+- Total lines of code
+- Number of useState/useEffect hooks
+- Number of distinct UI sections
+
+### Step 2: Plan
+
+Create a refactoring plan based on detected features:
+
+| Detected Feature | Refactoring Action |
+|------------------|-------------------|
+| 5+ `useState` hooks with related state | Extract custom hook |
+| API calls in component body | Extract to query hook |
+| 3+ event handlers with logic | Extract event handlers to hook |
+| 300+ lines | Split into sub-components |
+| Deep conditional nesting (>3) | Simplify conditional logic |
+| Multiple modal states | Extract modal management |
+
+### Step 3: Execute Incrementally
+
+1. **Extract one piece at a time**
+2. **Run lint, type-check, and tests after each extraction**
+3. **Verify functionality before next step**
+
+```
+For each extraction:
+  1. Extract code
+  2. Run: npm run lint
+  3. Run: npm run type-check
+  4. Run: npm test
+  5. Test functionality manually
+  6. PASS? -> Next extraction
+     FAIL? -> Fix before continuing
+```
+
+### Step 4: Verify
+
+After refactoring, re-assess complexity manually:
+
+- Target complexity < 50
+- Target line count < 300
+- Target max nesting depth <= 3
+- Target max function length < 30 lines
+
+## Common Mistakes to Avoid
+
+### Over-Engineering
+
+```typescript
+// Too many tiny hooks
+const useButtonText = () => useState("Click")
+const useButtonDisabled = () => useState(false)
+const useButtonLoading = () => useState(false)
+
+// Cohesive hook with related state
+const useButtonState = () => {
+  const [text, setText] = useState("Click")
+  const [disabled, setDisabled] = useState(false)
+  const [loading, setLoading] = useState(false)
+  return { text, setText, disabled, setDisabled, loading, setLoading }
+}
+```
+
+### Breaking Existing Patterns
+
+- Follow existing directory structures in `components/ui/`, `components/core/`, `components/common/`
+- Maintain naming conventions (kebab-case files, PascalCase components)
+- Preserve export patterns for compatibility
+- Keep Zustand store selector patterns consistent
+
+### Premature Abstraction
+
+- Only extract when there is clear complexity benefit
+- Do not create abstractions for single-use code
+- Keep refactored code in the same domain area
+
+### Bypassing UseRequestProcessor
+
+- Do not call `useQuery` or `useMutation` directly for API calls
+- Always use the `UseRequestProcessor` pattern for consistency with retry and invalidation logic
+- See `frontend-query-mutation` skill for API hook patterns
+
+## References
+
+### Langflow Codebase Examples
+
+- **Hook extraction**: `src/frontend/src/hooks/`
+- **Component splitting**: `src/frontend/src/CustomNodes/GenericNode/components/`
+- **UI components**: `src/frontend/src/components/ui/`
+- **Core components**: `src/frontend/src/components/core/`
+- **Common components**: `src/frontend/src/components/common/`
+- **API query hooks**: `src/frontend/src/controllers/API/queries/`
+- **Zustand stores**: `src/frontend/src/stores/`
+
+### Related Skills
+
+- `frontend-query-mutation` - For API query and mutation patterns
+- `frontend-testing` - For testing refactored components

--- a/.agents/skills/component-refactoring/references/complexity-patterns.md
+++ b/.agents/skills/component-refactoring/references/complexity-patterns.md
@@ -1,0 +1,519 @@
+# Complexity Reduction Patterns
+
+This document provides patterns for reducing cognitive complexity in Langflow React components.
+
+## Understanding Complexity
+
+### SonarJS Cognitive Complexity
+
+Langflow does not have automated complexity analysis tools. Assess complexity manually using SonarJS cognitive complexity rules:
+
+- **Total Complexity**: Sum of all functions' complexity in the file
+- **Max Complexity**: Highest single function complexity
+
+### What Increases Complexity
+
+| Pattern | Complexity Impact |
+|---------|-------------------|
+| `if/else` | +1 per branch |
+| Nested conditions | +1 per nesting level |
+| `switch/case` | +1 per case |
+| `for/while/do` | +1 per loop |
+| `&&`/`||` chains | +1 per operator |
+| Nested callbacks | +1 per nesting level |
+| `try/catch` | +1 per catch |
+| Ternary expressions | +1 per nesting |
+
+## Pattern 1: Replace Conditionals with Lookup Tables
+
+**Before** (complexity: ~15):
+
+```typescript
+const getParameterComponent = (field: InputFieldType) => {
+  if (field.type === "str") {
+    if (field.multiline) {
+      return <TextAreaComponent value={field.value} />
+    } else if (field.password) {
+      return <PasswordInput value={field.value} />
+    } else if (field.options?.length) {
+      return <Dropdown options={field.options} value={field.value} />
+    } else {
+      return <InputComponent value={field.value} />
+    }
+  }
+  if (field.type === "int") {
+    return <IntComponent value={field.value} />
+  }
+  if (field.type === "float") {
+    return <FloatComponent value={field.value} />
+  }
+  if (field.type === "bool") {
+    return <ToggleComponent value={field.value} />
+  }
+  if (field.type === "code") {
+    return <CodeAreaComponent value={field.value} />
+  }
+  return null
+}
+```
+
+**After** (complexity: ~3):
+
+```typescript
+// Define lookup table outside component
+const FIELD_TYPE_MAP: Record<string, FC<FieldProps>> = {
+  int: IntComponent,
+  float: FloatComponent,
+  bool: ToggleComponent,
+  code: CodeAreaComponent,
+  dict: DictComponent,
+  file: FileComponent,
+}
+
+const getStrVariant = (field: InputFieldType): FC<FieldProps> => {
+  if (field.multiline) return TextAreaComponent
+  if (field.password) return PasswordInput
+  if (field.options?.length) return Dropdown
+  return InputComponent
+}
+
+// Clean component logic
+const getParameterComponent = (field: InputFieldType) => {
+  const Component = field.type === "str"
+    ? getStrVariant(field)
+    : FIELD_TYPE_MAP[field.type]
+
+  if (!Component) return null
+  return <Component value={field.value} />
+}
+```
+
+## Pattern 2: Use Early Returns
+
+**Before** (complexity: ~10):
+
+```typescript
+const handleNodeBuild = () => {
+  if (isAuthenticated) {
+    if (hasValidFlow) {
+      if (!isBuilding) {
+        if (allInputsConnected) {
+          startBuild()
+        } else {
+          showMissingInputsError()
+        }
+      } else {
+        showBuildInProgressWarning()
+      }
+    } else {
+      showInvalidFlowError()
+    }
+  } else {
+    showAuthError()
+  }
+}
+```
+
+**After** (complexity: ~4):
+
+```typescript
+const handleNodeBuild = () => {
+  if (!isAuthenticated) {
+    showAuthError()
+    return
+  }
+
+  if (!hasValidFlow) {
+    showInvalidFlowError()
+    return
+  }
+
+  if (isBuilding) {
+    showBuildInProgressWarning()
+    return
+  }
+
+  if (!allInputsConnected) {
+    showMissingInputsError()
+    return
+  }
+
+  startBuild()
+}
+```
+
+## Pattern 3: Extract Complex Conditions
+
+**Before** (complexity: high):
+
+```typescript
+const canRunFlow = (() => {
+  if (flow.is_component) {
+    return false
+  }
+  if (!nodes.length) {
+    return false
+  }
+  if (isBuilding) {
+    return false
+  }
+  if (nodes.some((n) => n.data?.node?.error)) {
+    return false
+  }
+  if (
+    edges.some(
+      (e) =>
+        !e.sourceHandle ||
+        !e.targetHandle ||
+        (e.data?.isInvalid && e.data.isInvalid === true),
+    )
+  ) {
+    return false
+  }
+  return true
+})()
+```
+
+**After** (complexity: lower):
+
+```typescript
+// Extract to named functions
+const hasValidNodes = (nodes: Node[]) => {
+  return nodes.length > 0 && !nodes.some((n) => n.data?.node?.error)
+}
+
+const hasValidEdges = (edges: Edge[]) => {
+  return !edges.some(
+    (e) => !e.sourceHandle || !e.targetHandle || e.data?.isInvalid,
+  )
+}
+
+// Clean main logic
+const canRunFlow =
+  !flow.is_component &&
+  !isBuilding &&
+  hasValidNodes(nodes) &&
+  hasValidEdges(edges)
+```
+
+## Pattern 4: Replace Chained Ternaries
+
+**Before** (complexity: ~5):
+
+```typescript
+const buildStatusIcon = buildStatus === BuildStatus.BUILT
+  ? <CheckCircle className="text-green-500" />
+  : buildStatus === BuildStatus.BUILDING
+    ? <Loader className="animate-spin text-blue-500" />
+    : buildStatus === BuildStatus.ERROR
+      ? <XCircle className="text-red-500" />
+      : <Circle className="text-gray-400" />
+```
+
+**After** (complexity: ~2):
+
+```typescript
+const BUILD_STATUS_ICONS: Record<BuildStatus, ReactNode> = {
+  [BuildStatus.BUILT]: <CheckCircle className="text-green-500" />,
+  [BuildStatus.BUILDING]: <Loader className="animate-spin text-blue-500" />,
+  [BuildStatus.ERROR]: <XCircle className="text-red-500" />,
+  [BuildStatus.IDLE]: <Circle className="text-gray-400" />,
+}
+
+const buildStatusIcon = BUILD_STATUS_ICONS[buildStatus] ?? BUILD_STATUS_ICONS[BuildStatus.IDLE]
+```
+
+## Pattern 5: Flatten Nested Loops
+
+**Before** (complexity: high):
+
+```typescript
+const getConnectedNodes = (flow: FlowType) => {
+  const results: ConnectedNode[] = []
+
+  for (const node of flow.data.nodes) {
+    if (node.data?.node?.template) {
+      for (const [fieldName, field] of Object.entries(node.data.node.template)) {
+        if (field.type === "str" && field.load_from_db) {
+          for (const variable of globalVariables) {
+            if (variable.name === field.value) {
+              results.push({
+                nodeId: node.id,
+                fieldName,
+                variableName: variable.name,
+              })
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return results
+}
+```
+
+**After** (complexity: lower):
+
+```typescript
+// Use functional approach
+const getConnectedNodes = (flow: FlowType) => {
+  return flow.data.nodes
+    .filter((node) => node.data?.node?.template)
+    .flatMap((node) =>
+      Object.entries(node.data.node.template)
+        .filter(([, field]) => field.type === "str" && field.load_from_db)
+        .flatMap(([fieldName, field]) =>
+          globalVariables
+            .filter((variable) => variable.name === field.value)
+            .map((variable) => ({
+              nodeId: node.id,
+              fieldName,
+              variableName: variable.name,
+            })),
+        ),
+    )
+}
+```
+
+## Pattern 6: Extract Event Handler Logic
+
+**Before** (complexity: high in component):
+
+```typescript
+const FlowCanvas = () => {
+  const handleNodeDrop = useCallback(
+    (event: DragEvent) => {
+      event.preventDefault()
+      const nodeData = JSON.parse(event.dataTransfer.getData("application/json"))
+
+      if (!nodeData || !nodeData.type) return
+
+      const position = screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      })
+
+      // Validate the node type exists
+      const nodeType = types[nodeData.type]
+      if (!nodeType) {
+        setErrorData({ title: "Invalid node type" })
+        return
+      }
+
+      // Check for duplicates if component
+      if (nodeData.node?.is_component) {
+        const existingComponent = nodes.find(
+          (n) => n.data.node?.display_name === nodeData.node.display_name,
+        )
+        if (existingComponent) {
+          // 20 more lines of duplicate handling...
+        }
+      }
+
+      // Create the new node
+      const newNode = buildNodeFromData(nodeData, position)
+      setNodes((prev) => [...prev, newNode])
+
+      // 20 more lines of post-drop logic...
+    },
+    [nodes, types, screenToFlowPosition],
+  )
+
+  return <div>...</div>
+}
+```
+
+**After** (complexity: lower):
+
+```typescript
+// Extract to hook
+const useNodeDrop = (nodes: Node[], types: Record<string, any>) => {
+  const validateNodeData = useCallback(
+    (nodeData: any): boolean => {
+      if (!nodeData?.type) return false
+      if (!types[nodeData.type]) return false
+      return true
+    },
+    [types],
+  )
+
+  const checkDuplicateComponent = useCallback(
+    (nodeData: any): Node | undefined => {
+      if (!nodeData.node?.is_component) return undefined
+      return nodes.find(
+        (n) => n.data.node?.display_name === nodeData.node.display_name,
+      )
+    },
+    [nodes],
+  )
+
+  return { validateNodeData, checkDuplicateComponent }
+}
+
+// Component becomes cleaner
+const FlowCanvas = () => {
+  const { validateNodeData, checkDuplicateComponent } = useNodeDrop(nodes, types)
+
+  const handleNodeDrop = useCallback(
+    (event: DragEvent) => {
+      event.preventDefault()
+      const nodeData = JSON.parse(event.dataTransfer.getData("application/json"))
+
+      if (!validateNodeData(nodeData)) {
+        setErrorData({ title: "Invalid node type" })
+        return
+      }
+
+      const duplicate = checkDuplicateComponent(nodeData)
+      if (duplicate) {
+        handleDuplicate(duplicate, nodeData)
+        return
+      }
+
+      const position = screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      })
+      const newNode = buildNodeFromData(nodeData, position)
+      setNodes((prev) => [...prev, newNode])
+    },
+    [validateNodeData, checkDuplicateComponent, screenToFlowPosition],
+  )
+
+  return <div>...</div>
+}
+```
+
+## Pattern 7: Reduce Boolean Logic Complexity
+
+**Before** (complexity: ~8):
+
+```typescript
+const isNodeDisabled = !isAuthenticated
+  || flow.is_component
+  || isBuilding
+  || node.data?.node?.frozen
+  || (node.data?.node?.error && node.data.node.error !== "")
+  || (!hasConnectedInputs && node.type !== "genericNode")
+  || (isLocked && !isSuperUser)
+```
+
+**After** (complexity: ~3):
+
+```typescript
+// Extract meaningful boolean functions
+const hasNodeError = (node: Node) => {
+  return !!node.data?.node?.error && node.data.node.error !== ""
+}
+
+const isNodeAccessible = (node: Node, isLocked: boolean, isSuperUser: boolean) => {
+  if (isLocked && !isSuperUser) return false
+  if (node.data?.node?.frozen) return false
+  return true
+}
+
+const canInteractWithNode = (node: Node) => {
+  if (!isAuthenticated) return false
+  if (flow.is_component) return false
+  if (isBuilding) return false
+  if (hasNodeError(node)) return false
+  if (!isNodeAccessible(node, isLocked, isSuperUser)) return false
+  if (!hasConnectedInputs && node.type !== "genericNode") return false
+  return true
+}
+
+const isNodeDisabled = !canInteractWithNode(node)
+```
+
+## Pattern 8: Simplify useMemo/useCallback Dependencies
+
+**Before** (complexity: multiple recalculations):
+
+```typescript
+const processedNodes = useMemo(() => {
+  let result = nodes
+
+  if (searchTerm) {
+    result = result.filter(
+      (n) =>
+        n.data?.node?.display_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        n.data?.type?.toLowerCase().includes(searchTerm.toLowerCase()),
+    )
+  }
+
+  if (filterByType) {
+    result = result.filter((n) => n.data?.type === filterByType)
+  }
+
+  if (sortOrder === "name") {
+    result = [...result].sort((a, b) =>
+      (a.data?.node?.display_name ?? "").localeCompare(b.data?.node?.display_name ?? ""),
+    )
+  } else if (sortOrder === "type") {
+    result = [...result].sort((a, b) =>
+      (a.data?.type ?? "").localeCompare(b.data?.type ?? ""),
+    )
+  }
+
+  return result
+}, [nodes, searchTerm, filterByType, sortOrder])
+```
+
+**After** (complexity: separated concerns):
+
+```typescript
+// Separate filter and sort utilities
+const filterNodes = (nodes: Node[], searchTerm: string, filterByType?: string) => {
+  let result = nodes
+
+  if (searchTerm) {
+    const term = searchTerm.toLowerCase()
+    result = result.filter(
+      (n) =>
+        n.data?.node?.display_name?.toLowerCase().includes(term) ||
+        n.data?.type?.toLowerCase().includes(term),
+    )
+  }
+
+  if (filterByType) {
+    result = result.filter((n) => n.data?.type === filterByType)
+  }
+
+  return result
+}
+
+const SORT_COMPARATORS: Record<string, (a: Node, b: Node) => number> = {
+  name: (a, b) =>
+    (a.data?.node?.display_name ?? "").localeCompare(b.data?.node?.display_name ?? ""),
+  type: (a, b) =>
+    (a.data?.type ?? "").localeCompare(b.data?.type ?? ""),
+}
+
+const sortNodes = (nodes: Node[], sortOrder: string) => {
+  const comparator = SORT_COMPARATORS[sortOrder]
+  if (!comparator) return nodes
+  return [...nodes].sort(comparator)
+}
+
+// Clean component usage
+const filteredNodes = useMemo(
+  () => filterNodes(nodes, searchTerm, filterByType),
+  [nodes, searchTerm, filterByType],
+)
+
+const processedNodes = useMemo(
+  () => sortNodes(filteredNodes, sortOrder),
+  [filteredNodes, sortOrder],
+)
+```
+
+## Target Metrics After Refactoring
+
+| Metric | Target |
+|--------|--------|
+| Total Complexity | < 50 |
+| Max Function Complexity | < 30 |
+| Function Length | < 30 lines |
+| Nesting Depth | <= 3 levels |
+| Conditional Chains | <= 3 conditions |

--- a/.agents/skills/component-refactoring/references/component-splitting.md
+++ b/.agents/skills/component-refactoring/references/component-splitting.md
@@ -1,0 +1,635 @@
+# Component Splitting Patterns
+
+This document provides detailed guidance on splitting large components into smaller, focused components in Langflow.
+
+## When to Split Components
+
+Split a component when you identify:
+
+1. **Multiple UI sections** - Distinct visual areas with minimal coupling that can be composed independently
+1. **Conditional rendering blocks** - Large `{condition && <JSX />}` blocks
+1. **Repeated patterns** - Similar UI structures used multiple times
+1. **300+ lines** - Component exceeds manageable size
+1. **Modal clusters** - Multiple modals rendered in one component
+
+## Splitting Strategies
+
+### Strategy 1: Section-Based Splitting
+
+Identify visual sections and extract each as a component.
+
+```typescript
+// Before: Monolithic component (500+ lines)
+const FlowPage = () => {
+  return (
+    <div className="flex h-full w-full">
+      {/* Sidebar Section - 100 lines */}
+      <div className="w-64 border-r">
+        <input placeholder="Search components..." />
+        {categories.map((cat) => (
+          <div key={cat.name}>
+            <h3>{cat.name}</h3>
+            {cat.components.map((comp) => (
+              <div key={comp.name} draggable>
+                {comp.display_name}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Canvas Section - 200 lines */}
+      <div className="flex-1">
+        <ReactFlow nodes={nodes} edges={edges} onConnect={onConnect}>
+          {/* toolbar, minimap, controls */}
+        </ReactFlow>
+      </div>
+
+      {/* Inspect Panel Section - 150 lines */}
+      {showInspectPanel && (
+        <div className="w-80 border-l">
+          {selectedNode && <NodeInspector node={selectedNode} />}
+        </div>
+      )}
+
+      {/* Modals Section - 50 lines */}
+      {showExportModal && <ExportModal />}
+      {showShareModal && <ShareModal />}
+    </div>
+  )
+}
+
+// After: Split into focused components (kebab-case, descriptive names — NEVER index.tsx)
+// pages/FlowPage/
+//   flow-page.tsx              (orchestration)
+//   components/
+//     flow-sidebar.tsx
+//     flow-canvas.tsx
+//     flow-inspect-panel.tsx
+//     flow-modals.tsx
+
+// FlowSidebar.tsx
+interface FlowSidebarProps {
+  categories: Category[]
+  searchTerm: string
+  onSearchChange: (term: string) => void
+}
+
+const FlowSidebar: FC<FlowSidebarProps> = ({
+  categories,
+  searchTerm,
+  onSearchChange,
+}) => {
+  return (
+    <div className="w-64 border-r">
+      <input
+        placeholder="Search components..."
+        value={searchTerm}
+        onChange={(e) => onSearchChange(e.target.value)}
+      />
+      {categories.map((cat) => (
+        <SidebarCategory key={cat.name} category={cat} />
+      ))}
+    </div>
+  )
+}
+
+// flow-page.tsx (orchestration only — kebab-case, NOT index.tsx)
+const FlowPage = () => {
+  const { nodes, edges, onConnect } = useFlowState()
+  const { activeModal, openModal, closeModal } = useModalState()
+  const [searchTerm, setSearchTerm] = useState("")
+
+  return (
+    <div className="flex h-full w-full">
+      <FlowSidebar
+        categories={filteredCategories}
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
+      />
+      <FlowCanvas
+        nodes={nodes}
+        edges={edges}
+        onConnect={onConnect}
+      />
+      {showInspectPanel && (
+        <FlowInspectPanel selectedNode={selectedNode} />
+      )}
+      <FlowModals
+        activeModal={activeModal}
+        onClose={closeModal}
+      />
+    </div>
+  )
+}
+```
+
+### Strategy 2: Conditional Block Extraction
+
+Extract large conditional rendering blocks.
+
+```typescript
+// Before: Large conditional blocks
+const NodeField = ({ field }: { field: InputFieldType }) => {
+  return (
+    <div>
+      {field.show ? (
+        <div className="field-visible">
+          {field.load_from_db ? (
+            <div className="global-variable-badge">
+              <Badge>{field.value}</Badge>
+              <Button onClick={() => clearGlobalVariable(field.name)}>
+                Clear
+              </Button>
+            </div>
+          ) : field.type === "str" && field.multiline ? (
+            <TextAreaComponent
+              value={field.value}
+              onChange={(val) => handleChange(field.name, val)}
+            />
+          ) : field.type === "str" ? (
+            <InputComponent
+              value={field.value}
+              onChange={(val) => handleChange(field.name, val)}
+              password={field.password}
+            />
+          ) : field.type === "code" ? (
+            <CodeAreaComponent
+              value={field.value}
+              onChange={(val) => handleChange(field.name, val)}
+            />
+          ) : (
+            <GenericInput field={field} onChange={handleChange} />
+          )}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+// After: Separate rendering components
+const GlobalVariableBadge: FC<{ field: InputFieldType; onClear: () => void }> = ({
+  field,
+  onClear,
+}) => (
+  <div className="global-variable-badge">
+    <Badge>{field.value}</Badge>
+    <Button onClick={onClear}>Clear</Button>
+  </div>
+)
+
+const FieldInput: FC<{ field: InputFieldType; onChange: FieldChangeHandler }> = ({
+  field,
+  onChange,
+}) => {
+  if (field.load_from_db) {
+    return <GlobalVariableBadge field={field} onClear={() => onChange(field.name, "")} />
+  }
+
+  const Component = getFieldComponent(field)
+  return <Component value={field.value} onChange={(val) => onChange(field.name, val)} />
+}
+
+const NodeField = ({ field }: { field: InputFieldType }) => {
+  if (!field.show) return null
+
+  return (
+    <div className="field-visible">
+      <FieldInput field={field} onChange={handleChange} />
+    </div>
+  )
+}
+```
+
+### Strategy 3: Modal Extraction
+
+Extract modals with their trigger logic.
+
+```typescript
+// Before: Multiple modals in one component
+const FlowToolbar = () => {
+  const [showExport, setShowExport] = useState(false)
+  const [showShare, setShowShare] = useState(false)
+  const [showDelete, setShowDelete] = useState(false)
+  const [showApi, setShowApi] = useState(false)
+
+  const onExport = async (format: string) => { /* 20 lines */ }
+  const onShare = async (data: ShareData) => { /* 20 lines */ }
+  const onDelete = async () => { /* 15 lines */ }
+
+  return (
+    <div>
+      {/* Main toolbar content */}
+
+      {showExport && <ExportModal onConfirm={onExport} onClose={() => setShowExport(false)} />}
+      {showShare && <ShareModal onConfirm={onShare} onClose={() => setShowShare(false)} />}
+      {showDelete && <DeleteConfirm onConfirm={onDelete} onClose={() => setShowDelete(false)} />}
+      {showApi && <ApiModal flowId={flowId} onClose={() => setShowApi(false)} />}
+    </div>
+  )
+}
+
+// After: Modal manager component
+// flow-toolbar-modals.tsx
+type ToolbarModalType = "export" | "share" | "delete" | "api" | null
+
+interface FlowToolbarModalsProps {
+  flowId: string
+  activeModal: ToolbarModalType
+  onClose: () => void
+  onSuccess: () => void
+}
+
+const FlowToolbarModals: FC<FlowToolbarModalsProps> = ({
+  flowId,
+  activeModal,
+  onClose,
+  onSuccess,
+}) => {
+  const handleExport = async (format: string) => {
+    // export logic
+    onSuccess()
+  }
+
+  const handleShare = async (data: ShareData) => {
+    // share logic
+    onSuccess()
+  }
+
+  const handleDelete = async () => {
+    // delete logic
+    onSuccess()
+  }
+
+  return (
+    <>
+      {activeModal === "export" && (
+        <ExportModal onConfirm={handleExport} onClose={onClose} />
+      )}
+      {activeModal === "share" && (
+        <ShareModal onConfirm={handleShare} onClose={onClose} />
+      )}
+      {activeModal === "delete" && (
+        <DeleteConfirm onConfirm={handleDelete} onClose={onClose} />
+      )}
+      {activeModal === "api" && (
+        <ApiModal flowId={flowId} onClose={onClose} />
+      )}
+    </>
+  )
+}
+
+// Parent component
+const FlowToolbar = () => {
+  const { activeModal, openModal, closeModal } = useModalState()
+
+  return (
+    <div>
+      {/* Main toolbar with openModal triggers */}
+      <Button onClick={() => openModal("export")}>Export</Button>
+      <Button onClick={() => openModal("share")}>Share</Button>
+
+      <FlowToolbarModals
+        flowId={flowId}
+        activeModal={activeModal}
+        onClose={closeModal}
+        onSuccess={handleSuccess}
+      />
+    </div>
+  )
+}
+```
+
+### Strategy 4: List Item Extraction
+
+Extract repeated item rendering.
+
+```typescript
+// Before: Inline item rendering
+const ComponentList = () => {
+  return (
+    <div>
+      {components.map((comp) => (
+        <div key={comp.name} className="component-item">
+          <div className="flex items-center gap-2">
+            {comp.icon && <img src={comp.icon} className="h-5 w-5" />}
+            <span className="font-medium">{comp.display_name}</span>
+            {comp.beta && <Badge variant="secondary">Beta</Badge>}
+            {comp.legacy && <Badge variant="destructive">Legacy</Badge>}
+          </div>
+          <p className="text-sm text-muted-foreground">{comp.description}</p>
+          <div className="flex gap-1">
+            {comp.output_types?.map((type) => (
+              <Badge key={type} variant="outline">{type}</Badge>
+            ))}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => handleAddToCanvas(comp)}
+          >
+            Add
+          </Button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// After: Extracted item component
+interface ComponentItemProps {
+  component: APIClassType
+  onAdd: (component: APIClassType) => void
+}
+
+const ComponentItem: FC<ComponentItemProps> = ({ component, onAdd }) => {
+  return (
+    <div className="component-item">
+      <div className="flex items-center gap-2">
+        {component.icon && <img src={component.icon} className="h-5 w-5" />}
+        <span className="font-medium">{component.display_name}</span>
+        {component.beta && <Badge variant="secondary">Beta</Badge>}
+        {component.legacy && <Badge variant="destructive">Legacy</Badge>}
+      </div>
+      <p className="text-sm text-muted-foreground">{component.description}</p>
+      <div className="flex gap-1">
+        {component.output_types?.map((type) => (
+          <Badge key={type} variant="outline">{type}</Badge>
+        ))}
+      </div>
+      <Button variant="ghost" size="sm" onClick={() => onAdd(component)}>
+        Add
+      </Button>
+    </div>
+  )
+}
+
+const ComponentList = () => {
+  return (
+    <div>
+      {components.map((comp) => (
+        <ComponentItem
+          key={comp.display_name}
+          component={comp}
+          onAdd={handleAddToCanvas}
+        />
+      ))}
+    </div>
+  )
+}
+```
+
+## Directory Structure Patterns
+
+### Pattern A: Flat Structure (Simple Components)
+
+For components with 2-3 sub-components:
+
+```
+my-component/
+  my-component.tsx        # Main component (kebab-case, descriptive — NOT index.tsx)
+  sub-component-a.tsx
+  sub-component-b.tsx
+  my-component-types.ts   # Shared types
+```
+
+### Pattern B: Nested Structure (Complex Components)
+
+For components with many sub-components:
+
+```
+my-component/
+  my-component.tsx        # Main orchestration (NOT index.tsx)
+  my-component-types.ts   # Shared types
+  hooks/
+    use-feature-a.ts
+    use-feature-b.ts
+  components/
+    header-section.tsx
+    content-section.tsx
+    modals-section.tsx
+  helpers/
+    format-data.ts
+```
+
+> **IMPORTANT**: Never use `index.tsx` for new files. This is a legacy pattern. Use kebab-case file names that describe the component's purpose.
+
+### Pattern C: Page Structure
+
+Pages follow a standard directory layout with sub-pages, components, hooks, and helpers:
+
+```
+pages/SettingsPage/
+  settings-page.tsx          # Main page component
+  pages/                     # Sub-pages
+    ApiKeysPage/
+      api-keys-page.tsx
+      components/
+        api-key-header.tsx
+      helpers/
+        column-defs.ts
+        get-modal-props.tsx
+    GlobalVariablesPage/
+      global-variables-page.tsx
+  components/                # Shared page components
+  hooks/                     # Page-level hooks
+  utils/                     # Page-level utilities
+```
+
+### Pattern D: UI Components (shadcn — kebab-case files)
+
+```
+components/ui/
+  button.tsx
+  input.tsx
+  badge.tsx
+  dialog.tsx
+  popover.tsx
+  select.tsx
+  textarea.tsx
+  tooltip.tsx
+  dropdown-menu.tsx
+```
+
+### Pattern E: Legacy Codebase (existing — do NOT follow for new code)
+
+The existing codebase has `index.tsx` and mixed naming. When refactoring, migrate toward the new kebab-case standard:
+
+```
+// Legacy (existing — DO NOT create new files this way)
+components/core/appHeaderComponent/index.tsx
+components/common/loadingComponent/index.tsx
+CustomNodes/GenericNode/index.tsx
+
+// New standard (use this for all new code and refactors)
+components/core/app-header/app-header.tsx
+components/common/loading-indicator/loading-indicator.tsx
+CustomNodes/GenericNode/generic-node.tsx
+    NodeName/
+    NodeOutputField/
+    NodeStatus/
+```
+
+## Props Design
+
+### Minimal Props Principle
+
+Pass only what is needed:
+
+```typescript
+// Bad: Passing entire objects when only some fields needed
+<NodeHeader nodeData={nodeData} flowData={flowData} />
+
+// Good: Destructure to minimum required
+<NodeHeader
+  displayName={nodeData.node?.display_name ?? ""}
+  nodeType={nodeData.type}
+  isFrozen={nodeData.node?.frozen ?? false}
+  onNameChange={handleNameChange}
+/>
+```
+
+### Callback Props Pattern
+
+Use callbacks for child-to-parent communication:
+
+```typescript
+// Parent
+const GenericNode = () => {
+  const [showDescription, setShowDescription] = useState(false)
+
+  return (
+    <div>
+      <NodeHeader
+        displayName={data.node?.display_name ?? ""}
+        onToggleDescription={() => setShowDescription((prev) => !prev)}
+      />
+      {showDescription && (
+        <NodeDescription
+          description={data.node?.description ?? ""}
+          onChange={handleDescriptionChange}
+        />
+      )}
+    </div>
+  )
+}
+
+// Child
+interface NodeHeaderProps {
+  displayName: string
+  onToggleDescription: () => void
+}
+
+const NodeHeader: FC<NodeHeaderProps> = ({ displayName, onToggleDescription }) => {
+  return (
+    <div className="flex items-center justify-between">
+      <span>{displayName}</span>
+      <button onClick={onToggleDescription}>Toggle Description</button>
+    </div>
+  )
+}
+```
+
+### Render Props for Flexibility
+
+When sub-components need parent context:
+
+```typescript
+interface FieldListProps<T> {
+  fields: T[]
+  renderField: (field: T, index: number) => React.ReactNode
+  renderEmpty?: () => React.ReactNode
+}
+
+function FieldList<T>({ fields, renderField, renderEmpty }: FieldListProps<T>) {
+  if (fields.length === 0 && renderEmpty) {
+    return <>{renderEmpty()}</>
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {fields.map((field, index) => renderField(field, index))}
+    </div>
+  )
+}
+
+// Usage
+<FieldList
+  fields={visibleFields}
+  renderField={(field, i) => (
+    <NodeInputField key={field.name ?? i} field={field} onChange={handleChange} />
+  )}
+  renderEmpty={() => <span className="text-muted-foreground">No fields</span>}
+/>
+```
+
+## Langflow-Specific Splitting Guidelines
+
+### Splitting GenericNode Components
+
+The `GenericNode` component is one of the most complex components in Langflow. When splitting:
+
+1. Keep the main `index.tsx` as an orchestrator that composes sub-components.
+2. Parameter rendering goes in `components/NodeInputField/`.
+3. Handle rendering goes in `components/HandleRenderComponent/`.
+4. Status display goes in `components/NodeStatus/`.
+5. Keep node-level state in the parent; pass callbacks to children.
+
+### Splitting Flow Page Components
+
+The flow editor page has multiple distinct regions:
+
+1. **Sidebar** - Component library, search, categories
+2. **Canvas** - ReactFlow canvas with nodes and edges
+3. **Toolbar** - Build, save, export, share actions
+4. **Inspect Panel** - Node details when selected
+5. **Playground** - Chat/run interface
+6. **Modals** - Export, share, API, settings
+
+Each region should be its own component with clearly defined props.
+
+### Splitting Store-Connected Components
+
+When a component reads from multiple Zustand stores:
+
+1. Keep store selectors in the parent orchestrator.
+2. Pass data as props to presentational children.
+3. This makes children testable without mocking stores.
+
+```typescript
+// Parent: reads from stores
+const FlowToolbar = () => {
+  const isBuilding = useFlowStore((state) => state.isBuilding)
+  const currentFlow = useFlowsManagerStore((state) => state.currentFlow)
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+
+  return (
+    <ToolbarActions
+      isBuilding={isBuilding}
+      flowName={currentFlow?.name ?? ""}
+      canBuild={isAuthenticated && !isBuilding}
+      onBuild={handleBuild}
+      onSave={handleSave}
+    />
+  )
+}
+
+// Child: pure presentational
+const ToolbarActions: FC<ToolbarActionsProps> = ({
+  isBuilding,
+  flowName,
+  canBuild,
+  onBuild,
+  onSave,
+}) => {
+  return (
+    <div className="flex items-center gap-2">
+      <span>{flowName}</span>
+      <Button onClick={onBuild} disabled={!canBuild}>
+        {isBuilding ? "Building..." : "Build"}
+      </Button>
+      <Button onClick={onSave}>Save</Button>
+    </div>
+  )
+}
+```

--- a/.agents/skills/component-refactoring/references/hook-extraction.md
+++ b/.agents/skills/component-refactoring/references/hook-extraction.md
@@ -1,0 +1,470 @@
+# Hook Extraction Patterns
+
+This document provides detailed guidance on extracting custom hooks from complex components in Langflow.
+
+## When to Extract Hooks
+
+Extract a custom hook when you identify:
+
+1. **Coupled state groups** - Multiple `useState` hooks that are always used together
+1. **Complex effects** - `useEffect` with multiple dependencies or cleanup logic
+1. **Business logic** - Data transformations, validations, or calculations
+1. **Reusable patterns** - Logic that appears in multiple components
+
+## Extraction Process
+
+### Step 1: Identify State Groups
+
+Look for state variables that are logically related:
+
+```typescript
+// These belong together - extract to hook
+const [nodes, setNodes] = useState<Node[]>([])
+const [edges, setEdges] = useState<Edge[]>([])
+const [viewport, setViewport] = useState<Viewport>({ x: 0, y: 0, zoom: 1 })
+
+// These are canvas-related state that should be in useCanvasState()
+```
+
+### Step 2: Identify Related Effects
+
+Find effects that modify the grouped state:
+
+```typescript
+// These effects belong with the state above
+useEffect(() => {
+  if (flowData?.nodes) {
+    setNodes(flowData.nodes)
+    setEdges(flowData.edges ?? [])
+  }
+}, [flowData])
+
+useEffect(() => {
+  if (fitViewOnLoad && nodes.length > 0) {
+    reactFlowInstance?.fitView()
+  }
+}, [nodes.length, fitViewOnLoad, reactFlowInstance])
+```
+
+### Step 3: Create the Hook
+
+```typescript
+// hooks/use-canvas-state.ts
+import type { Edge, Node, Viewport } from "@xyflow/react"
+import { useEffect, useState } from "react"
+import type { FlowType } from "@/types/flow"
+
+interface UseCanvasStateParams {
+  flowData: FlowType | undefined
+  fitViewOnLoad?: boolean
+  reactFlowInstance?: any
+}
+
+interface UseCanvasStateReturn {
+  nodes: Node[]
+  setNodes: React.Dispatch<React.SetStateAction<Node[]>>
+  edges: Edge[]
+  setEdges: React.Dispatch<React.SetStateAction<Edge[]>>
+  viewport: Viewport
+  setViewport: React.Dispatch<React.SetStateAction<Viewport>>
+}
+
+export const useCanvasState = ({
+  flowData,
+  fitViewOnLoad = false,
+  reactFlowInstance,
+}: UseCanvasStateParams): UseCanvasStateReturn => {
+  const [nodes, setNodes] = useState<Node[]>([])
+  const [edges, setEdges] = useState<Edge[]>([])
+  const [viewport, setViewport] = useState<Viewport>({ x: 0, y: 0, zoom: 1 })
+
+  // Sync flow data to canvas state
+  useEffect(() => {
+    if (flowData?.nodes) {
+      setNodes(flowData.nodes)
+      setEdges(flowData.edges ?? [])
+    }
+  }, [flowData])
+
+  // Fit view on initial load
+  useEffect(() => {
+    if (fitViewOnLoad && nodes.length > 0) {
+      reactFlowInstance?.fitView()
+    }
+  }, [nodes.length, fitViewOnLoad, reactFlowInstance])
+
+  return {
+    nodes,
+    setNodes,
+    edges,
+    setEdges,
+    viewport,
+    setViewport,
+  }
+}
+```
+
+### Step 4: Update Component
+
+```typescript
+// Before: 50+ lines of state management
+const FlowPage: FC = () => {
+  const [nodes, setNodes] = useState<Node[]>([])
+  // ... lots of related state and effects
+}
+
+// After: Clean component
+const FlowPage: FC = () => {
+  const {
+    nodes,
+    setNodes,
+    edges,
+    setEdges,
+    viewport,
+  } = useCanvasState({
+    flowData,
+    fitViewOnLoad: true,
+    reactFlowInstance,
+  })
+
+  // Component now focuses on UI
+}
+```
+
+## Naming Conventions
+
+### Hook Names
+
+- Use `use` prefix: `useFlowState`, `useNodeDrag`, `useBuildStatus`
+- Be specific: `useRefreshModelInputs` not `useRefresh`
+- Include domain: `useFlowStore`, `useGlobalVariables`, `useAddComponent`
+- Match existing Langflow patterns: `useFlowsManagerStore`, `useFlowStore`
+
+### File Names
+
+- Kebab-case: `use-flow-state.ts`, `use-node-drag.ts`
+- Place in `hooks/` directory for globally reusable hooks: `src/frontend/src/hooks/use-debounce.ts`
+- Place alongside component for single-use hooks
+- Place in component's `hooks/` subdirectory when multiple hooks exist for one feature
+
+### Return Type Names
+
+- Suffix with `Return`: `UseCanvasStateReturn`
+- Suffix params with `Params`: `UseCanvasStateParams`
+
+## Common Hook Patterns in Langflow
+
+### 1. Zustand Store Derived State Hook
+
+When you need to compute derived state from a Zustand store, extract a hook rather than computing in the component.
+
+```typescript
+// Pattern: Derived state from store
+export const useFlowValidation = () => {
+  const nodes = useFlowStore((state) => state.nodes)
+  const edges = useFlowStore((state) => state.edges)
+
+  const hasErrors = useMemo(
+    () => nodes.some((n) => n.data?.node?.error),
+    [nodes],
+  )
+
+  const hasDisconnectedInputs = useMemo(
+    () =>
+      nodes.some((n) => {
+        const requiredInputs = Object.values(n.data?.node?.template ?? {}).filter(
+          (field) => field.required && field.show,
+        )
+        return requiredInputs.some(
+          (input) =>
+            !edges.some(
+              (e) => e.target === n.id && e.targetHandle === input.name,
+            ),
+        )
+      }),
+    [nodes, edges],
+  )
+
+  return {
+    hasErrors,
+    hasDisconnectedInputs,
+    isValid: !hasErrors && !hasDisconnectedInputs,
+  }
+}
+```
+
+### 2. API Data Hooks
+
+When hook extraction touches query or mutation code, do not use this reference as the source of truth for data-layer patterns.
+
+- Use `frontend-query-mutation` for `UseRequestProcessor`, query patterns, cache invalidation, and mutation error handling.
+- Do not create thin passthrough `useQuery` hooks; only extract orchestration hooks that combine multiple queries or shared derived state.
+- API hooks live in `controllers/API/queries/{domain}/` and follow the `UseRequestProcessor` pattern.
+
+Example of an orchestration hook (acceptable to extract):
+
+```typescript
+// hooks/use-flow-with-variables.ts
+// This combines multiple API queries with derived state - worth extracting
+export const useFlowWithVariables = (flowId: string) => {
+  const { data: flow } = useGetFlow({ id: flowId })
+  const { data: globalVariables } = useGetGlobalVariables()
+
+  const resolvedVariables = useMemo(() => {
+    if (!flow || !globalVariables) return {}
+    return resolveFlowVariables(flow, globalVariables)
+  }, [flow, globalVariables])
+
+  return {
+    flow,
+    globalVariables,
+    resolvedVariables,
+    isLoading: !flow || !globalVariables,
+  }
+}
+```
+
+### 3. Form State Hook
+
+```typescript
+// Pattern: Form state + validation + submission
+export const useFlowSettingsForm = (initialValues: FlowSettings) => {
+  const [values, setValues] = useState(initialValues)
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const validate = useCallback(() => {
+    const newErrors: Record<string, string> = {}
+    if (!values.name?.trim()) newErrors.name = "Name is required"
+    if (values.endpoint_name && !/^[a-z0-9_-]+$/.test(values.endpoint_name)) {
+      newErrors.endpoint_name = "Must be lowercase alphanumeric with hyphens or underscores"
+    }
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }, [values])
+
+  const handleChange = useCallback((field: string, value: any) => {
+    setValues((prev) => ({ ...prev, [field]: value }))
+    // Clear error on field change
+    setErrors((prev) => {
+      const next = { ...prev }
+      delete next[field]
+      return next
+    })
+  }, [])
+
+  const handleSubmit = useCallback(
+    async (onSubmit: (values: FlowSettings) => Promise<void>) => {
+      if (!validate()) return
+      setIsSubmitting(true)
+      try {
+        await onSubmit(values)
+      } finally {
+        setIsSubmitting(false)
+      }
+    },
+    [values, validate],
+  )
+
+  return { values, errors, isSubmitting, handleChange, handleSubmit }
+}
+```
+
+### 4. Modal State Hook
+
+```typescript
+// Pattern: Multiple modal management
+type ModalType = "edit" | "delete" | "duplicate" | "export" | null
+
+export const useModalState = <T = any>() => {
+  const [activeModal, setActiveModal] = useState<ModalType>(null)
+  const [modalData, setModalData] = useState<T | null>(null)
+
+  const openModal = useCallback((type: ModalType, data?: T) => {
+    setActiveModal(type)
+    setModalData(data ?? null)
+  }, [])
+
+  const closeModal = useCallback(() => {
+    setActiveModal(null)
+    setModalData(null)
+  }, [])
+
+  return {
+    activeModal,
+    modalData,
+    openModal,
+    closeModal,
+    isOpen: useCallback(
+      (type: ModalType) => activeModal === type,
+      [activeModal],
+    ),
+  }
+}
+```
+
+### 5. Toggle/Boolean Hook
+
+```typescript
+// Pattern: Boolean state with convenience methods
+export const useToggle = (initialValue = false) => {
+  const [value, setValue] = useState(initialValue)
+
+  const toggle = useCallback(() => setValue((v) => !v), [])
+  const setTrue = useCallback(() => setValue(true), [])
+  const setFalse = useCallback(() => setValue(false), [])
+
+  return [value, { toggle, setTrue, setFalse, set: setValue }] as const
+}
+
+// Usage
+const [isExpanded, { toggle, setTrue: expand, setFalse: collapse }] = useToggle()
+```
+
+### 6. Keyboard Shortcut Hook
+
+Langflow has keyboard shortcut support. Extract shortcut handling to hooks.
+
+```typescript
+// Pattern: Keyboard shortcut registration
+export const useFlowShortcuts = (handlers: {
+  onSave?: () => void
+  onUndo?: () => void
+  onRedo?: () => void
+  onDelete?: () => void
+}) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isModKey = event.metaKey || event.ctrlKey
+
+      if (isModKey && event.key === "s") {
+        event.preventDefault()
+        handlers.onSave?.()
+      } else if (isModKey && event.key === "z" && !event.shiftKey) {
+        event.preventDefault()
+        handlers.onUndo?.()
+      } else if (isModKey && event.key === "z" && event.shiftKey) {
+        event.preventDefault()
+        handlers.onRedo?.()
+      } else if (event.key === "Delete" || event.key === "Backspace") {
+        handlers.onDelete?.()
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [handlers])
+}
+```
+
+## Testing Extracted Hooks
+
+After extraction, test hooks in isolation using `@testing-library/react`:
+
+```typescript
+// use-canvas-state.test.ts
+import { act, renderHook } from "@testing-library/react"
+import { useCanvasState } from "./use-canvas-state"
+
+describe("useCanvasState", () => {
+  it("should initialize with empty state", () => {
+    const { result } = renderHook(() =>
+      useCanvasState({
+        flowData: undefined,
+        fitViewOnLoad: false,
+      }),
+    )
+
+    expect(result.current.nodes).toEqual([])
+    expect(result.current.edges).toEqual([])
+    expect(result.current.viewport).toEqual({ x: 0, y: 0, zoom: 1 })
+  })
+
+  it("should sync flow data to canvas state", () => {
+    const flowData = {
+      nodes: [{ id: "node-1", type: "genericNode", position: { x: 0, y: 0 }, data: {} }],
+      edges: [{ id: "edge-1", source: "node-1", target: "node-2" }],
+    }
+
+    const { result } = renderHook(() =>
+      useCanvasState({
+        flowData: flowData as any,
+        fitViewOnLoad: false,
+      }),
+    )
+
+    expect(result.current.nodes).toEqual(flowData.nodes)
+    expect(result.current.edges).toEqual(flowData.edges)
+  })
+
+  it("should update nodes via setNodes", () => {
+    const { result } = renderHook(() =>
+      useCanvasState({
+        flowData: undefined,
+        fitViewOnLoad: false,
+      }),
+    )
+
+    act(() => {
+      result.current.setNodes([
+        { id: "new-node", type: "genericNode", position: { x: 100, y: 200 }, data: {} } as any,
+      ])
+    })
+
+    expect(result.current.nodes).toHaveLength(1)
+    expect(result.current.nodes[0].id).toBe("new-node")
+  })
+})
+```
+
+## Anti-Patterns to Avoid
+
+### Do Not Wrap Store Selectors
+
+```typescript
+// Do not create hooks that just forward store selectors
+const useNodes = () => useFlowStore((state) => state.nodes)
+const useEdges = () => useFlowStore((state) => state.edges)
+
+// Instead, use selectors directly in the component
+const Component = () => {
+  const nodes = useFlowStore((state) => state.nodes)
+  const edges = useFlowStore((state) => state.edges)
+}
+```
+
+### Do Not Wrap Single API Calls
+
+```typescript
+// Do not create thin wrappers around UseRequestProcessor queries
+const useGetFlow = (flowId: string) => {
+  const { query } = UseRequestProcessor()
+  return query(["useGetFlow", flowId], () => api.get(`${getURL("FLOWS")}/${flowId}`))
+}
+
+// These already exist in controllers/API/queries/ - use them directly
+import { useGetFlow } from "@/controllers/API/queries/flows/use-get-flow"
+```
+
+### Do Extract Orchestration Hooks
+
+```typescript
+// Orchestrating multiple queries and derived state is a valid hook extraction
+const useFlowBuildState = (flowId: string) => {
+  const { data: flow } = useGetFlow({ id: flowId })
+  const { data: builds } = useGetBuilds({ flowId })
+  const isBuilding = useFlowStore((state) => state.isBuilding)
+
+  const lastBuild = useMemo(
+    () => builds?.sort((a, b) => b.timestamp.localeCompare(a.timestamp))[0],
+    [builds],
+  )
+
+  const buildProgress = useMemo(() => {
+    if (!isBuilding) return null
+    // ... compute progress from build state
+  }, [isBuilding, builds])
+
+  return { flow, lastBuild, isBuilding, buildProgress }
+}
+```

--- a/.agents/skills/e2e-testing/SKILL.md
+++ b/.agents/skills/e2e-testing/SKILL.md
@@ -1,0 +1,354 @@
+---
+name: e2e-testing
+description: Write and review Playwright E2E tests for Langflow. Trigger when the user asks to write, fix, or review E2E tests, spec files, Playwright tests, or integration tests that exercise the full UI. Also trigger when modifying data-testid attributes, test helpers in tests/utils/, or fixture configuration.
+---
+
+# Langflow E2E Testing (Playwright)
+
+## When to Apply
+
+- User asks to **write E2E tests** for a feature or flow
+- User asks to **fix a failing E2E test**
+- User asks to **review E2E test coverage**
+- User modifies `data-testid` attributes in components (may break existing tests)
+- User changes test utilities in `src/frontend/tests/utils/`
+
+**Do NOT apply** when:
+- User asks about unit tests (use `frontend-testing` skill for Jest)
+- User asks about backend tests (use `backend-code-review` skill for pytest)
+
+## Tech Stack
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Playwright | 1.57.0 | E2E test runner + browser automation |
+| Chromium | (bundled) | Default browser (Firefox/Safari disabled) |
+| Custom fixtures | `tests/fixtures.ts` | Auto-detects API errors and flow execution failures |
+
+## Key Commands
+
+```bash
+# Run all E2E tests
+npx playwright test
+
+# Run tests filtered by tag
+npx playwright test --grep "@release"
+npx playwright test --grep "@workspace"
+npx playwright test --grep "@starter-projects"
+
+# Run a specific test file
+npx playwright test tests/core/features/run-flow.spec.ts
+
+# Debug mode (headed browser + step through)
+npx playwright test --debug
+
+# Show HTML report after run
+npx playwright show-report
+
+# Update snapshots (if used)
+npx playwright test --update-snapshots
+```
+
+## Configuration
+
+**File**: `src/frontend/playwright.config.ts`
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `fullyParallel` | `true` | Tests run in parallel for speed |
+| `timeout` | 5 minutes | Flow builds can be slow; prevents false timeouts |
+| `retries` | 3 (local), 2 (CI) | Flaky network/rendering issues; retries catch them |
+| `workers` | 2 | Balances speed and resource usage |
+| `actionTimeout` | 20s | Individual action timeout (click, fill, etc.) |
+| `trace` | `on-first-retry` | Captures trace on failures for debugging |
+| `baseURL` | `http://localhost:3000` | Vite dev server |
+
+**WebServer**: Playwright auto-starts backend (uvicorn on 7860) + frontend (npm start on 3000).
+
+## Directory Structure
+
+```
+src/frontend/tests/
+├── fixtures.ts                     # Custom test fixture with error detection
+├── globalTeardown.ts               # Cleanup (removes temp DB after tests)
+├── core/
+│   ├── features/                   # Main feature tests (run-flow, playground, etc.)
+│   ├── integrations/               # Starter project / template tests
+│   ├── regression/                 # Bug regression tests
+│   └── unit/                       # Component-level Playwright tests
+├── extended/
+│   ├── features/                   # Extended features (MCP, auto-save, etc.)
+│   ├── integrations/               # Extended integrations
+│   └── regression/                 # Extended regressions
+└── utils/                          # 37+ shared helper functions
+```
+
+## File Naming
+
+- **kebab-case** with `.spec.ts` suffix: `run-flow.spec.ts`, `playground.spec.ts`, `flow-lock.spec.ts`
+- Template tests may use spaces: `Document QA.spec.ts`, `Social Media Agent.spec.ts`
+- Sharded tests for parallelization: `chatInputOutputUser-shard-0.spec.ts`
+
+> **Note**: E2E tests use `.spec.ts` (Playwright convention). Unit tests use `.test.tsx` (Jest convention). Do not mix them.
+
+## Test Anatomy
+
+### Basic Test
+
+```typescript
+import { expect, test } from "../../fixtures";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+
+test(
+  "user should be able to run a flow successfully",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page);
+
+    // Arrange: Create a flow
+    await page.getByTestId("blank-flow").click();
+
+    // Act: Add components and run
+    await page.getByTestId("sidebar-search-input").fill("Chat Output");
+    // ... setup ...
+
+    // Assert: Verify result
+    await expect(page.getByTestId("build-status-success")).toBeVisible({ timeout: 30000 });
+  },
+);
+```
+
+### With test.describe
+
+```typescript
+test.describe("Flow Lock Feature", () => {
+  test(
+    "should lock and unlock a flow",
+    { tag: ["@release", "@api"] },
+    async ({ page }) => {
+      // ...
+    },
+  );
+
+  test(
+    "should prevent editing when locked",
+    { tag: ["@release"] },
+    async ({ page }) => {
+      // ...
+    },
+  );
+});
+```
+
+### With Serial Mode (tests that depend on order)
+
+```typescript
+test.describe.configure({ mode: "serial" });
+
+test("step 1: create flow", async ({ page }) => { /* ... */ });
+test("step 2: edit flow", async ({ page }) => { /* ... */ });
+test("step 3: delete flow", async ({ page }) => { /* ... */ });
+```
+
+### With Event Delivery Modes (streaming/polling/direct)
+
+```typescript
+import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
+
+withEventDeliveryModes(
+  "Document Q&A should work",
+  { tag: ["@release", "@starter-projects"] },
+  async ({ page }) => {
+    // This test runs 3 times: streaming, polling, direct
+    // Each mode is configured automatically via route interception
+  },
+);
+```
+
+## Tags System
+
+Every test MUST have at least one tag. Tags enable filtering and CI pipeline configuration.
+
+| Tag | Purpose | When to Use |
+|-----|---------|-------------|
+| `@release` | Tests that must pass before release | Critical user flows |
+| `@workspace` | Workspace/flow management | Creating, editing, deleting flows |
+| `@api` | API-dependent features | Tests that call backend endpoints |
+| `@database` | Database operations | Tests involving persistence |
+| `@components` | Component-level tests | Individual component behavior |
+| `@starter-projects` | Template/starter project tests | Pre-built flow templates |
+| `@regression` | Bug regression tests | Tests for specific fixed bugs |
+
+```typescript
+// Right: tag your test
+test("my feature test", { tag: ["@release", "@workspace"] }, async ({ page }) => { ... });
+
+// Wrong: no tags — test can't be filtered
+test("my feature test", async ({ page }) => { ... });
+```
+
+## Custom Fixtures: Error Detection
+
+**Always import `test` and `expect` from `../../fixtures`, NOT from `@playwright/test`.**
+
+```typescript
+// Right
+import { expect, test } from "../../fixtures";
+
+// Wrong — bypasses error detection
+import { expect, test } from "@playwright/test";
+```
+
+Why: The custom fixture automatically monitors all `/api/` responses and fails the test if:
+- HTTP 400, 404, 422, or 500 errors occur
+- Flow execution returns `error: true` in event streams
+- Python exceptions appear in streamed responses
+
+To opt-in to expected errors (e.g., testing error handling):
+```typescript
+test("should show error on invalid input", { tag: ["@release"] }, async ({ page }) => {
+  page.allowFlowErrors();  // Allow flow errors for this test
+  // ... test that expects errors ...
+});
+```
+
+## Selector Strategy
+
+### Priority (in order of preference)
+
+1. **`getByTestId`** — Most stable, used 95% of the time in Langflow
+2. **`getByRole`** — For buttons, headings, and form elements
+3. **`getByText`** — For visible text content
+4. **`waitForSelector`** — For CSS selectors and dynamic elements
+5. **`locator`** — For complex selectors (CSS, XPath)
+
+### Common data-testid Patterns
+
+**Canvas & Navigation:**
+- `blank-flow` — New blank flow button
+- `sidebar-search-input` — Component search
+- `canvas_controls_dropdown` — Canvas controls menu
+- `fit_view`, `zoom_out`, `zoom_in` — Canvas controls
+- `react-flow-id` — ReactFlow canvas container
+
+**Component Fields:**
+- `popover-anchor-input-{fieldname}` — Input field for a component parameter
+- `input-chat-playground` — Playground chat input
+- `div-chat-message` — Chat message in playground
+
+**Actions:**
+- `add-component-button-{component}` — Add component to canvas
+- `button-send` — Send chat message
+- `button_run_{component}` — Run specific component
+- `publish-button`, `save-flow-button` — Flow actions
+- `edit-fields-button` — Toggle inspection panel field editor
+
+**Modals & Panels:**
+- `modal-title` — Modal heading
+- `icon-Globe` — Global variables
+- `icon-Lock` — Flow lock toggle
+- `session-selector` — Playground session switcher
+
+### Important: Global Variables and Badges
+
+When a component field has a global variable selected (`load_from_db: true` + `value: "OPENAI_API_KEY"`), the field renders a **badge** instead of an `<input>` element. This means `getByTestId("popover-anchor-input-api_key")` will NOT find the element — it doesn't exist in the DOM.
+
+Templates with global variables pre-selected: Market Research, Price Deal Finder, Research Agent.
+Templates without (input IS rendered): Instagram Copywriter.
+
+## Core Helper Functions
+
+Located in `src/frontend/tests/utils/`:
+
+| Function | What it Does | When to Use |
+|----------|-------------|-------------|
+| `awaitBootstrapTest(page)` | Waits for app to fully load | **Start of every test** |
+| `initialGPTsetup(page)` | Full setup: adjustView → updateComponents → selectModel → addKey → adjustView → unselectNodes | Tests that need OpenAI configured |
+| `adjustScreenView(page, opts?)` | Fit view + zoom out | After adding components to canvas |
+| `zoomOut(page, times)` | Zoom out N times | When components are too small |
+| `selectGptModel(page)` | Selects gpt-4o-mini for all Language Model nodes | GPT-dependent tests |
+| `addOpenAiInputKey(page)` | Fills OPENAI_API_KEY for all openai_api_key fields | Tests requiring API key |
+| `enableInspectPanel(page)` | Toggles inspection panel ON | **MUST call before `edit-fields-button`** |
+| `disableInspectPanel(page)` | Toggles inspection panel OFF | Cleanup after inspection |
+| `updateOldComponents(page)` | Clicks "Update all" if outdated components exist | After loading saved flows |
+| `unselectNodes(page)` | Clicks empty canvas area to deselect all nodes | After node operations |
+| `renameFlow(page, { flowName })` | Renames the current flow | Flow management tests |
+| `uploadFile(page, filename)` | Uploads a file from test assets | File upload tests |
+| `withEventDeliveryModes(...)` | Runs test 3x: streaming, polling, direct | Starter project tests |
+
+### initialGPTsetup Options
+
+```typescript
+await initialGPTsetup(page);  // All steps
+
+await initialGPTsetup(page, {
+  skipAdjustScreenView: true,
+  skipUpdateOldComponents: true,
+  skipSelectGptModel: true,
+});
+```
+
+### Inspection Panel Pattern (CRITICAL)
+
+```typescript
+// MUST enable inspection panel FIRST
+await enableInspectPanel(page);
+
+// Click a node to select it
+await page.getByTestId("title-OpenAI").click();
+
+// Open field editor
+await page.getByTestId("edit-fields-button").click();
+
+// Toggle field visibility
+await page.getByTestId("showmodel_name").click();
+
+// Close field editor
+await page.getByTestId("edit-fields-button").click();
+```
+
+**If you skip `enableInspectPanel(page)`, the `edit-fields-button` will NOT be visible.**
+
+## Skip Patterns
+
+```typescript
+// Skip test if env var missing
+test.skip(!process?.env?.OPENAI_API_KEY, "OPENAI_API_KEY required to run this test");
+
+// Skip test unconditionally with reason
+test.skip(true, "Feature not yet implemented with new designs");
+```
+
+## Writing Good E2E Tests
+
+### Do:
+- **Tag every test** with at least one tag
+- **Import from `../../fixtures`**, not `@playwright/test`
+- **Start with `awaitBootstrapTest(page)`** — always
+- **Use `getByTestId`** for stable selectors
+- **Set explicit timeouts** on `waitForSelector` and `expect(...).toBeVisible()` for async operations
+- **Test the complete user flow**: setup → action → verification
+- **Use `withEventDeliveryModes`** for tests that involve flow execution (chat, build)
+
+### Don't:
+- **Don't use `page.waitForTimeout()`** unless absolutely necessary — prefer `waitForSelector` or `expect().toBeVisible()`
+- **Don't hardcode API keys** — read from `process.env.OPENAI_API_KEY`
+- **Don't skip tests without a reason** — always provide the second argument to `test.skip()`
+- **Don't import from `@playwright/test`** — use the custom fixtures
+- **Don't forget `enableInspectPanel(page)`** before accessing `edit-fields-button`
+- **Don't assume input fields exist** when global variables are selected (badge renders instead)
+
+### Challenge Tests (Apply Here Too)
+
+E2E tests should also cover adversarial scenarios:
+- **Invalid input**: paste 10K characters, special characters (`<script>alert(1)</script>`), empty submissions
+- **Network interruption**: what happens if the user loses connection mid-build?
+- **Permission boundaries**: can a user access another user's flow via direct URL?
+- **Concurrent actions**: double-click delete, rapid chat messages
+- **Error recovery**: does the UI recover gracefully from a 500 error?
+
+## References
+
+- [Selector Patterns](references/selectors.md) — Complete data-testid catalog
+- [Helper Functions](references/helpers.md) — Detailed documentation of all 37+ utility functions
+- [Test Fixtures](references/fixtures.md) — Custom fixture error detection behavior

--- a/.agents/skills/e2e-testing/references/fixtures.md
+++ b/.agents/skills/e2e-testing/references/fixtures.md
@@ -1,0 +1,83 @@
+# Custom Test Fixtures
+
+## Overview
+
+Langflow extends Playwright's default `test` and `expect` with a custom fixture in `src/frontend/tests/fixtures.ts`. This fixture adds **automatic error detection** that fails tests when unexpected API errors or flow execution errors occur.
+
+## Why Custom Fixtures Exist
+
+Without the custom fixture, a test could pass even though:
+- The backend returned a 500 Internal Server Error (test only checked for UI text)
+- A flow build silently failed with a Python exception (test only checked button state)
+- An API call returned 404 because the resource was deleted (test didn't check the response)
+
+The custom fixture catches these silent failures by monitoring ALL `/api/` responses during the test.
+
+## Import Rule
+
+**Always import from `../../fixtures`, never from `@playwright/test`:**
+
+```typescript
+// Right — includes error detection
+import { expect, test } from "../../fixtures";
+
+// Wrong — NO error detection, silent failures possible
+import { expect, test } from "@playwright/test";
+```
+
+## What the Fixture Detects
+
+### HTTP Error Responses
+
+The fixture intercepts all responses from `/api/` endpoints and fails the test if:
+
+| Status Code | Meaning | Why it Fails |
+|-------------|---------|-------------|
+| 400 | Bad Request | Client sent invalid data — likely a bug in the frontend |
+| 404 | Not Found | Resource doesn't exist — likely a stale ID or missing setup |
+| 422 | Validation Error | Pydantic validation failed — likely a schema mismatch |
+| 500 | Internal Server Error | Backend crash — always a bug |
+
+### Flow Execution Errors
+
+For streaming responses (build, chat), the fixture parses the event stream and fails if:
+- JSON payload contains `"error": true`
+- Response body contains Python exception patterns (`Traceback`, `Error`, etc.)
+- The stream indicates a component build failure
+
+## Allowing Expected Errors
+
+Some tests intentionally trigger errors (testing error handling, validation feedback, etc.). Use `page.allowFlowErrors()` to prevent the fixture from failing on flow execution errors:
+
+```typescript
+test("should show error message on invalid component config", { tag: ["@release"] }, async ({ page }) => {
+  page.allowFlowErrors();  // Allow flow errors for THIS test only
+
+  await awaitBootstrapTest(page);
+  // ... test that triggers an error ...
+
+  await expect(page.getByText(/error/i)).toBeVisible();
+});
+```
+
+**Note**: `allowFlowErrors()` only suppresses flow execution errors. HTTP 500 errors will still fail the test — those indicate a backend crash, not expected behavior.
+
+## Error Reporting
+
+When the fixture detects an error, it adds it to an internal list. After the test function completes, the fixture checks the list and fails with a descriptive message:
+
+```
+Test failed due to unexpected API errors:
+  - POST /api/v1/build/abc123/flow → 500 Internal Server Error
+  - Flow execution error: Traceback (most recent call last)...
+```
+
+This makes it easy to identify the root cause without adding manual response checks to every test.
+
+## Timeout Behavior
+
+The fixture reads response bodies with a 2-second timeout. If the body can't be read within 2 seconds (e.g., streaming response still in progress), it skips body parsing for that response. This prevents the fixture from blocking indefinitely on long-running streams.
+
+## Global Teardown
+
+`src/frontend/tests/globalTeardown.ts` runs after all tests complete and removes the temporary test database. This ensures a clean state for the next test run.

--- a/.agents/skills/e2e-testing/references/helpers.md
+++ b/.agents/skills/e2e-testing/references/helpers.md
@@ -1,0 +1,180 @@
+# E2E Test Helper Functions
+
+All helpers are located in `src/frontend/tests/utils/`. Import them by name.
+
+## Bootstrap & Setup
+
+### `awaitBootstrapTest(page, options?)`
+
+**Call this at the start of EVERY test.** Waits for the app to fully load and optionally opens the new project modal.
+
+```typescript
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+
+// Default: waits for load + opens new project modal
+await awaitBootstrapTest(page);
+
+// Skip opening modal (for tests that start on an existing page)
+await awaitBootstrapTest(page, { skipModal: true });
+```
+
+Why: Without this, tests race against the app's initialization. Components may not be rendered, stores may not be hydrated, and API calls may not be complete. Every flaky "element not found" failure is likely a missing `awaitBootstrapTest`.
+
+### `initialGPTsetup(page, options?)`
+
+Full OpenAI setup pipeline. Calls 6 steps in order:
+1. `adjustScreenView` — fit view + zoom out
+2. `updateOldComponents` — update any outdated components
+3. `selectGptModel` — select gpt-4o-mini for all Language Model nodes
+4. `addOpenAiInputKey` — fill OPENAI_API_KEY in all openai_api_key fields
+5. `adjustScreenView` — fit again (components may have moved)
+6. `unselectNodes` — click empty canvas to deselect
+
+```typescript
+// All steps
+await initialGPTsetup(page);
+
+// Skip specific steps
+await initialGPTsetup(page, {
+  skipAdjustScreenView: true,
+  skipUpdateOldComponents: true,
+  skipSelectGptModel: true,
+});
+```
+
+Why: Many tests need a working OpenAI-connected flow. This helper standardizes the setup so test authors don't reinvent it. The order matters — updating components before selecting models prevents stale model dropdowns.
+
+## Canvas Controls
+
+### `adjustScreenView(page, options?)`
+
+Clicks "fit view" then zooms out. Ensures all nodes are visible and interactable.
+
+```typescript
+await adjustScreenView(page);                          // Default: fit + 1 zoom out
+await adjustScreenView(page, { numberOfZoomOut: 3 });  // Fit + 3 zoom outs
+```
+
+Why: After adding components, some may be off-screen or overlapping. Fit view centers them; zoom out ensures click targets are large enough for Playwright to hit reliably.
+
+### `zoomOut(page, times)`
+
+Zooms out the canvas a specific number of times.
+
+```typescript
+await zoomOut(page, 5);
+```
+
+### `unselectNodes(page)`
+
+Clicks the empty canvas area at position (0, 0) to deselect all nodes.
+
+```typescript
+await unselectNodes(page);
+```
+
+Why: Selected nodes show selection UI (toolbars, handles) that can overlay other elements. Deselecting before interacting with other elements prevents click interception.
+
+## Component Setup
+
+### `selectGptModel(page)`
+
+Finds all Language Model nodes and selects `gpt-4o-mini` in their model dropdown.
+
+Why: Tests that require LLM execution need a specific model. Using `gpt-4o-mini` keeps costs low and responses fast.
+
+### `addOpenAiInputKey(page)`
+
+Finds all fields with `data-testid="popover-anchor-input-openai_api_key"` and fills them with `process.env.OPENAI_API_KEY`.
+
+**Warning**: Only works when the field renders as an `<input>`. If a global variable is selected (badge mode), this helper won't find the field. Check the template's `load_from_db` setting.
+
+### `updateOldComponents(page)`
+
+If the canvas shows an "Update all" button (outdated components), clicks it and waits for update to complete.
+
+Why: Saved flows from older versions may have outdated component definitions. Updating them ensures the test runs against current component behavior, not stale cached versions.
+
+## Inspection Panel
+
+### `enableInspectPanel(page)`
+
+Opens the canvas controls dropdown and toggles the inspection panel ON.
+
+**MUST be called BEFORE any interaction with `edit-fields-button`.** Without it, the inspection panel is hidden and `edit-fields-button` does not exist in the DOM.
+
+```typescript
+await enableInspectPanel(page);
+await page.getByTestId("title-OpenAI").click();       // Select a node
+await page.getByTestId("edit-fields-button").click();  // Now visible
+```
+
+### `disableInspectPanel(page)`
+
+Toggles the inspection panel OFF. Use for cleanup or when testing canvas-only behavior.
+
+## Flow Management
+
+### `renameFlow(page, options)`
+
+Renames the current flow in the workspace.
+
+```typescript
+await renameFlow(page, { flowName: "My Test Flow" });
+```
+
+### `uploadFile(page, filename)`
+
+Uploads a file from the `tests/assets/` directory.
+
+```typescript
+await uploadFile(page, "test-document.pdf");
+```
+
+## Event Delivery Modes
+
+### `withEventDeliveryModes(title, config, testFn, options?)`
+
+Wraps a test function to run it 3 times: once for each event delivery mode (streaming, polling, direct). Each mode is configured by intercepting the `/api/v1/config` route.
+
+```typescript
+import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
+
+withEventDeliveryModes(
+  "Document Q&A should process and respond",
+  { tag: ["@release", "@starter-projects"] },
+  async ({ page }) => {
+    // Test body — runs 3 times with different delivery modes
+    await page.getByTestId("input-chat-playground").fill("What is this about?");
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("div-chat-message")).toBeVisible({ timeout: 60000 });
+  },
+  { timeout: 10000 },  // Optional delay between mode switches
+);
+```
+
+Why: Langflow supports 3 event delivery modes. A bug that only appears in polling mode would be missed if tests only run in streaming mode. This helper ensures all modes are covered without writing 3x the tests.
+
+## Advanced Patterns
+
+### `openAdvancedOptions(page)` (LEGACY)
+
+Opens the old edit modal for component configuration. **Deprecated** — use `enableInspectPanel` + `edit-fields-button` for new tests.
+
+### `closeAdvancedOptions(page)` (LEGACY)
+
+Closes the old edit modal. **Deprecated**.
+
+## Creating New Helpers
+
+When to create a new helper:
+- The same 5+ lines of setup appear in 3+ test files (DRY)
+- The pattern involves complex waits or retries that are easy to get wrong
+- The helper encapsulates Langflow-specific knowledge (e.g., global variable badge behavior)
+
+When NOT to create a helper:
+- For a single test's setup (keep it inline)
+- For generic Playwright operations (use Playwright API directly)
+- For assertions (assertions should be explicit in the test, not hidden in helpers)
+
+Place new helpers in `src/frontend/tests/utils/` with kebab-case naming: `my-new-helper.ts`.

--- a/.agents/skills/e2e-testing/references/selectors.md
+++ b/.agents/skills/e2e-testing/references/selectors.md
@@ -1,0 +1,111 @@
+# Langflow E2E Selector Catalog
+
+This is the canonical reference for `data-testid` selectors used in Langflow E2E tests. When adding new interactive elements, follow these naming conventions and add the element to this catalog.
+
+## Naming Convention
+
+All `data-testid` values use kebab-case with a prefix that indicates the element type:
+
+| Prefix | Element Type | Example |
+|--------|-------------|---------|
+| `input-` | Text inputs | `input-chat-playground`, `input-flow-name` |
+| `button-` / `button_` | Action buttons | `button-send`, `button_run_chat output` |
+| `icon-` | Icon buttons | `icon-Globe`, `icon-Lock`, `icon-ChevronLeft` |
+| `popover-anchor-input-` | Component parameter fields | `popover-anchor-input-openai_api_key` |
+| `add-component-button-` | Drag-to-add buttons | `add-component-button-chat-output` |
+| `card-` | Flow/component cards | `card-my-flow-name` |
+| `title-` | Node titles on canvas | `title-OpenAI`, `title-Chat Output` |
+| `handle-` | Connection handles | `handle-{component}-{shownode}-{field}-{direction}` |
+| `div-chat-message` | Chat messages | `div-chat-message` |
+| `show` | Field visibility toggles | `showmodel_name`, `showtemperature` |
+
+## Canvas & Navigation
+
+| Selector | Element | Notes |
+|----------|---------|-------|
+| `blank-flow` | "New Blank Flow" button | On project creation modal |
+| `sidebar-search-input` | Component search input | Sidebar search bar |
+| `sidebar-nav-add_note` | Sticky note button | Sidebar navigation |
+| `sidebar-add-sticky-note-button` | Add sticky note (new) | Updated button name |
+| `react-flow-id` | ReactFlow canvas container | Use for drag targets |
+| `canvas_controls_dropdown` | Canvas controls dropdown | Opens zoom/fit/inspector menu |
+| `fit_view` | Fit view button | Inside canvas controls |
+| `zoom_out` | Zoom out button | Inside canvas controls |
+| `zoom_in` | Zoom in button | Inside canvas controls |
+| `inspector-toggle` | Inspection panel toggle | Inside canvas controls dropdown |
+
+## Component Fields
+
+| Selector | Element | Notes |
+|----------|---------|-------|
+| `popover-anchor-input-{name}` | Component input field | `name` matches the field's `name` attribute |
+| `popover-anchor-input-openai_api_key` | OpenAI API key field | Only visible when no global variable selected |
+| `input_output{component}` | Output connection handle area | e.g., `input_outputChat Output` |
+
+**Important**: When `load_from_db: true` and a global variable is selected, the field renders as a **badge** (not an `<input>`). The `popover-anchor-input-{name}` selector will NOT exist in the DOM for those fields.
+
+## Actions & Buttons
+
+| Selector | Element | Notes |
+|----------|---------|-------|
+| `button-send` | Send message button | Playground chat |
+| `button_run_{component}` | Run component button | e.g., `button_run_chat output` |
+| `publish-button` | Publish/deploy flow | Top toolbar |
+| `save-flow-button` | Save flow | Top toolbar |
+| `edit-fields-button` | Toggle field editor | Inspection panel — requires `enableInspectPanel()` first |
+| `playground-btn-flow-io` | Playground button | Use `dispatchEvent("click")` to close (not `.click()`) |
+| `manage-model-providers` | Model providers button | Settings |
+
+## Modals & Panels
+
+| Selector | Element | Notes |
+|----------|---------|-------|
+| `modal-title` | Modal heading | Generic modal title |
+| `edit-button-modal` | Edit button (legacy) | Old modal pattern |
+| `edit-button-close` | Close edit modal | Old modal pattern |
+| `lock-flow-switch` | Flow lock toggle | Flow settings |
+| `input-flow-name` | Flow name input | Flow settings modal |
+| `input-flow-description` | Flow description input | Flow settings modal |
+| `session-selector` | Session selector | Playground session switcher |
+
+## Icons (as buttons)
+
+| Selector | Action |
+|----------|--------|
+| `icon-Globe` | Open global variables |
+| `icon-Lock` | Toggle flow lock |
+| `icon-ChevronLeft` | Navigate back |
+| `icon-Trash2` | Delete action |
+| `icon-Plus` | Add/create action |
+
+## Inspection Panel Field Toggles
+
+These selectors toggle field visibility in the inspection panel. The format is `show{fieldname}` (no separator):
+
+| Selector | Field |
+|----------|-------|
+| `showmodel_name` | Model name field |
+| `showtemperature` | Temperature field |
+| `showmax_tokens` | Max tokens field |
+| `showopenai_api_key` | OpenAI API key field |
+
+## When to Add New data-testid
+
+Add `data-testid` to an element when:
+1. E2E tests need to interact with it (click, fill, assert visibility)
+2. The element has no stable `role` or `text` alternative
+3. The element is dynamically rendered and needs a stable anchor
+
+Format: `{type}-{descriptive-name}` in kebab-case. Keep it descriptive enough that a test author understands the element without reading the component source.
+
+```tsx
+// Right — descriptive, kebab-case
+<button data-testid="save-flow-button">Save</button>
+<input data-testid="input-flow-name" />
+<div data-testid="card-flow-summary" />
+
+// Wrong — too generic
+<button data-testid="btn1">Save</button>
+<input data-testid="input" />
+<div data-testid="wrapper" />
+```

--- a/.agents/skills/frontend-code-review/SKILL.md
+++ b/.agents/skills/frontend-code-review/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: frontend-code-review
+description: "Review frontend code (.tsx, .ts, .js files) for quality, performance, and correctness against Langflow's frontend conventions. Supports pending-change reviews and file-targeted reviews."
+---
+
+# Frontend Code Review
+
+## When to use this skill
+
+Use this skill whenever the user asks to **review, analyze, or improve** frontend code (`.tsx`, `.ts`, `.js` files) under the `src/frontend/` directory. Supports the following review modes:
+
+1. **Pending-change review** -- inspect staged or working-tree files slated for commit and flag checklist violations before submission.
+2. **File-targeted review** -- review the specific file(s) the user names and report the relevant checklist findings.
+
+Do NOT use this skill when:
+
+- The request is about backend code (`.py` files under `src/backend/`).
+- The user is not asking for a review/analysis/improvement of frontend code.
+- The scope is outside `src/frontend/` (unless the user explicitly asks to review frontend-related changes elsewhere).
+
+## How to use this skill
+
+Follow these steps when using this skill:
+
+1. **Identify the review mode** (pending-change vs file-targeted) based on the user's input. Keep the scope tight: review only what the user provided or explicitly referenced.
+2. Follow the rules defined in the **Checklist** to perform the review. If no checklist rule matches, apply **General Review Rules** as a fallback.
+3. Compose the final output strictly following the **Required Output Format**.
+
+Notes when using this skill:
+
+- Always include actionable fixes or suggestions (including possible code snippets).
+- Use `File:Line` references when a file path and line numbers are available; otherwise, use the most specific identifier you can.
+- The Langflow frontend uses React 19, TypeScript 5.4, Vite 7 with SWC, Zustand for state management, TanStack React Query for server state, @xyflow/react v12 for graph visualization, Radix UI + shadcn-ui components, Tailwind CSS v3, and Biome for linting/formatting.
+
+## Checklist
+
+- **Code quality**: For any reviewed file, follow [references/code-quality.md](references/code-quality.md) to check styling conventions, TypeScript usage, Biome compliance, and component patterns.
+- **Performance**: If the review scope involves React components, hooks, Zustand stores, React Query usage, or @xyflow/react node rendering, follow [references/performance.md](references/performance.md) to check for re-render issues, memoization, and data flow patterns.
+- **Business logic**: If the review scope involves custom nodes (GenericNode), flow state, API calls, the component system, global variables, or the inspection panel, follow [references/business-logic.md](references/business-logic.md) to check for Langflow-specific correctness.
+
+## General Review Rules
+
+### 1. Security Review
+
+Check for:
+- XSS vulnerabilities (dangerouslySetInnerHTML, unescaped user input)
+- Sensitive data exposure in client-side code
+- Insecure direct object references in API calls
+- Hardcoded secrets, tokens, or API keys
+
+### 2. Accessibility Review
+
+Check for:
+- Missing aria labels on interactive elements
+- Keyboard navigation support
+- Proper use of semantic HTML elements
+- Color contrast issues in custom styling
+
+### 3. Code Quality Review
+
+Check for:
+- Code duplication (DRY violations — extract at 3+ identical usages)
+- Functions/components doing too much (SRP violations — if you need "and" to describe it, split it)
+- Deep nesting or complex conditionals (prefer early returns and guard clauses)
+- Magic numbers/strings without named constants
+- Poor naming: generic names (`data`, `result`, `temp`), missing verb prefixes on functions, missing `is`/`has`/`can`/`should` prefixes on booleans
+- Missing error handling or error boundaries
+- Incomplete TypeScript type coverage (no `any`, no `as any` casts)
+- Comments that explain WHAT instead of WHY
+- Commented-out code (use version control)
+- Boolean parameters that switch component behavior (use two components instead)
+- Mutable patterns where `const` or immutable alternatives exist
+- Production files exceeding ~500 lines (red flag at 600+)
+- `console.log` in production code (Biome flags this)
+
+### 4. Testing Impact Review
+
+Check for:
+- Changes to data-testid attributes that may break E2E tests
+- Modified component interfaces that require test updates
+- New interactive elements missing data-testid attributes
+
+### 5. Pre-Commit Verification
+
+For pending-change reviews, verify:
+- `npm run format` (Biome formatter) — zero diffs
+- `npm run lint` (Biome linter) — zero errors
+- `npm test` (Jest) — zero failures
+
+## Required Output Format
+
+When this skill is invoked, the response must exactly follow one of the two templates:
+
+### Template A (any findings)
+
+```markdown
+# Code Review
+
+Found <N> urgent issues that need to be fixed:
+
+## 1. <brief description of issue>
+
+FilePath: <path> line <line>
+<relevant code snippet or pointer>
+
+
+### Suggested fix
+
+<brief description of suggested fix with code example>
+
+---
+
+... (repeat for each urgent issue) ...
+
+Found <M> suggestions for improvement:
+
+## 1. <brief description of suggestion>
+
+FilePath: <path> line <line>
+<relevant code snippet or pointer>
+
+
+### Suggested fix
+
+<brief description of suggested fix with code example>
+
+---
+
+... (repeat for each suggestion) ...
+```
+
+- If there are no urgent issues, omit that section. If there are no suggestions, omit that section.
+- If the issue count exceeds 10, summarize as "10+ urgent issues" or "10+ suggestions" and output only the first 10 items.
+- Do not compress the blank lines between sections; keep them as-is for readability.
+- If Template A is used (there are issues to fix) and at least one issue requires code changes, append a brief follow-up question after the structured output asking whether the user wants the suggested fixes applied. For example: "Would you like me to apply the suggested fixes to address these issues?"
+
+### Template B (no issues)
+
+```markdown
+## Code Review
+
+No issues found.
+```

--- a/.agents/skills/frontend-code-review/references/business-logic.md
+++ b/.agents/skills/frontend-code-review/references/business-logic.md
@@ -1,0 +1,253 @@
+# Rule Catalog -- Business Logic
+
+Update this file when adding, editing, or removing Business Logic rules so the catalog remains accurate.
+
+## Custom node components must not import stores directly outside the provider tree
+
+IsUrgent: True
+Category: Business Logic
+
+### Description
+
+File path pattern of node components: `src/frontend/src/CustomNodes/GenericNode/` and sub-components.
+
+GenericNode and its child components render inside the @xyflow/react canvas, which has its own React context. These components may also render in contexts where certain store providers are not available (e.g., preview panels, template views). Directly importing and calling Zustand store hooks that depend on a specific provider context can cause blank screens or runtime errors when the component mounts outside that provider.
+
+### Suggested Fix
+
+Use the store hooks that are available globally (like `useFlowStore`, `useTypesStore`) or pass data as props from the parent that has provider access. If imperative store access is needed, use the store's `getState()` method which does not require a provider.
+
+```tsx
+// Wrong -- may fail outside provider tree
+import { useSpecialContext } from "@/contexts/specialContext";
+
+function NodeField() {
+  const { config } = useSpecialContext(); // crashes if provider missing
+  return <div>{config.label}</div>;
+}
+
+// Right -- use props or global store
+function NodeField({ config }: { config: FieldConfig }) {
+  return <div>{config.label}</div>;
+}
+```
+
+## Flow state management: use `flowStore` for current flow state
+
+IsUrgent: True
+Category: Business Logic
+
+### Description
+
+The current flow's state (nodes, edges, flow metadata) is managed through `useFlowStore` (located in `src/frontend/src/stores/flowStore.ts`). Always use this store for reading and modifying the active flow. Do not create parallel state tracking for flow data, and do not cache flow state in component-local state unless there is a specific performance reason (document it if so).
+
+### Suggested Fix
+
+```tsx
+// Wrong -- local state duplicating flow data
+const [nodes, setNodes] = useState(initialNodes);
+
+// Right -- use the flow store
+const nodes = useFlowStore((state) => state.nodes);
+const setNodes = useFlowStore((state) => state.setNodes);
+```
+
+## API interceptor patterns: do not duplicate auth/retry logic
+
+IsUrgent: True
+Category: Business Logic
+
+### Description
+
+The Axios HTTP client in `src/frontend/src/controllers/API/` is configured with interceptors that handle authentication headers, token refresh, retry logic, and error normalization. Do not duplicate any of this logic in individual API call sites or components. Use the configured Axios instance (via the API controller helpers) for all backend requests. Do not create new Axios instances or use raw `fetch()` for API calls to the Langflow backend.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- raw fetch with manual auth
+const response = await fetch("/api/v1/flows", {
+  headers: { Authorization: `Bearer ${token}` },
+});
+
+// Wrong -- new Axios instance bypassing interceptors
+const client = axios.create({ baseURL: "/api/v1" });
+const response = await client.get("/flows");
+
+// Right -- use the project's API utilities
+import { api } from "@/controllers/API/api";
+
+const response = await api.get("/flows");
+```
+
+## Component data-testid patterns
+
+IsUrgent: False
+Category: Business Logic
+
+### Description
+
+Interactive components must include `data-testid` attributes following the project's established naming conventions. This is critical for E2E test stability. The primary patterns are:
+
+- Input fields: `popover-anchor-input-{name}` (generated via `StrRenderComponent` -> `InputComponent` -> `CustomInputPopover`)
+- Buttons: descriptive kebab-case, e.g., `edit-fields-button`, `playground-btn-flow-io`
+- Sidebar items: `sidebar-nav-{item}`, `sidebar-add-sticky-note-button`
+- Node-related: `title-{display_name}`, `handle-{id}`
+
+When adding new interactive elements, follow the existing patterns. When modifying elements that have `data-testid`, preserve the attribute and its value to avoid breaking E2E tests.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- missing data-testid on interactive element
+<button onClick={handleSave}>Save</button>
+
+// Right -- includes data-testid
+<button data-testid="save-flow-button" onClick={handleSave}>Save</button>
+```
+
+## Global variables: understand `load_from_db` and `value` pattern
+
+IsUrgent: True
+Category: Business Logic
+
+### Description
+
+Template fields in starter projects use the `load_from_db` + `value` pattern to reference global variables. When `load_from_db: true` and `value` is set to a key like `"OPENAI_API_KEY"`, the field displays a badge (via `InputGlobalComponent`) instead of a text input. The actual input element (`<input>`) does not exist in the DOM when a global variable is selected.
+
+This has implications for:
+- **Component rendering**: Do not assume an input element exists when `load_from_db` is true and a global variable is set.
+- **E2E tests**: `getByTestId("popover-anchor-input-api_key")` will not find an element when a global variable badge is displayed.
+- **Templates affected**: Market Research, Price Deal Finder, Research Agent have `load_from_db: true` with global variable values.
+
+### Suggested Fix
+
+When writing components that interact with template fields, check the `load_from_db` state:
+
+```tsx
+// Wrong -- assumes input always exists
+const apiKeyInput = data.node.template.api_key;
+// Directly rendering an <input> without checking load_from_db
+
+// Right -- handle both states
+if (field.load_from_db && field.value) {
+  // Render global variable badge
+  return <GlobalVariableBadge name={field.value} />;
+}
+// Render normal input
+return <InputComponent value={field.value} onChange={handleChange} />;
+```
+
+## Inspection panel: use `enableInspectPanel` before accessing panel elements
+
+IsUrgent: True
+Category: Business Logic
+
+### Description
+
+The inspection panel (added in the panel migration from the old edit modal pattern) must be explicitly enabled before its elements are accessible. In E2E tests and in code that interacts with the panel programmatically:
+
+1. Call `enableInspectPanel(page)` before attempting to access `edit-fields-button` or other panel controls.
+2. Click a node to select it, then use `edit-fields-button` to toggle field editing.
+3. The old `openAdvancedOptions(page)` / `closeAdvancedOptions(page)` pattern is deprecated.
+4. The `editNode` flag is always `false`; `-edit` suffix testids no longer exist.
+
+This rule is especially important when writing or modifying E2E tests that interact with node configuration.
+
+## Node field visibility rules
+
+IsUrgent: False
+Category: Business Logic
+
+### Description
+
+Node fields have different visibility rules depending on where they are rendered. Understanding these rules is critical when modifying field display logic:
+
+- **Canvas view**: Shows non-advanced, non-hidden fields. Controlled by `isCanvasVisible()` in `src/frontend/src/CustomNodes/helpers/parameter-filtering.ts`.
+- **Inspection panel**: Shows only advanced fields. Controlled by `shouldRenderInspectionPanelField()` in the same file.
+- **`showNode` flag**: Defaults to `true`. When set to `false`, fields receive the `hidden` CSS class rather than being removed from the DOM.
+
+When adding new fields or modifying visibility logic, ensure both canvas and inspection panel rendering paths are considered.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- only checking one visibility context
+if (!field.advanced) {
+  return <FieldComponent />;
+}
+
+// Right -- check the appropriate visibility function for the context
+import { isCanvasVisible, shouldRenderInspectionPanelField } from "@/CustomNodes/helpers/parameter-filtering";
+
+// In canvas context
+if (isCanvasVisible(field)) {
+  return <FieldComponent />;
+}
+
+// In inspection panel context
+if (shouldRenderInspectionPanelField(field)) {
+  return <FieldComponent />;
+}
+```
+
+## Customization layer usage
+
+IsUrgent: False
+Category: Business Logic
+
+### Description
+
+Langflow has a customization layer in `src/frontend/src/customization/` that allows overriding default behaviors and components. When adding new features that may need to be customized (e.g., branding, feature flags, custom components), use the customization layer rather than hardcoding values. Check `src/frontend/src/customization/` for existing customization points before adding new ones.
+
+## React Hook Form + Zod for form validation
+
+IsUrgent: False
+Category: Business Logic
+
+### Description
+
+Forms that require validation should use React Hook Form with Zod schemas. Do not implement manual form state tracking or validation logic when React Hook Form can handle it. Define Zod schemas for form data types and use `zodResolver` to integrate them with React Hook Form.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- manual form state and validation
+const [name, setName] = useState("");
+const [error, setError] = useState("");
+
+const handleSubmit = () => {
+  if (!name) {
+    setError("Name is required");
+    return;
+  }
+  // submit
+};
+
+// Right -- React Hook Form + Zod
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+const schema = z.object({
+  name: z.string().min(1, "Name is required"),
+});
+
+type FormData = z.infer<typeof schema>;
+
+function MyForm() {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = (data: FormData) => {
+    // submit
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input {...register("name")} />
+      {errors.name && <span>{errors.name.message}</span>}
+    </form>
+  );
+}
+```

--- a/.agents/skills/frontend-code-review/references/code-quality.md
+++ b/.agents/skills/frontend-code-review/references/code-quality.md
@@ -1,0 +1,475 @@
+# Rule Catalog -- Code Quality
+
+Update this file when adding, editing, or removing Code Quality rules so the catalog remains accurate.
+
+## Use `cn()` for conditional class names
+
+IsUrgent: True
+Category: Code Quality
+
+### Description
+
+All conditional CSS class logic must use the `cn()` utility from `@/utils` instead of manual string concatenation, template literals, or ternary expressions that build class strings. The `cn()` function wraps `clsx` and `tailwind-merge`, ensuring proper deduplication and conflict resolution of Tailwind classes.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- manual concatenation
+<div className={`px-4 ${isActive ? "text-primary" : "text-muted-foreground"}`}>
+
+// Wrong -- ternary without cn()
+<div className={isActive ? "px-4 text-primary" : "px-4 text-muted-foreground"}>
+
+// Right
+import { cn } from "@/utils/utils";
+
+<div className={cn("px-4", isActive ? "text-primary" : "text-muted-foreground")}>
+```
+
+## Tailwind-first styling
+
+IsUrgent: True
+Category: Code Quality
+
+### Description
+
+Favor Tailwind CSS utility classes for all styling. Do not introduce new CSS modules or custom CSS files unless a Tailwind combination cannot achieve the required styling. Keeping styles in Tailwind improves consistency, reduces bundle size, and simplifies maintenance. The project uses Tailwind v3 with a custom theme configuration.
+
+Why this matters: Introducing custom CSS files creates a parallel styling system that falls out of sync with Tailwind tokens. When the design team changes a border color, they update the CSS variable in `index.css` — but your CSS module keeps the old hardcoded color. Custom CSS also bypasses Tailwind's purging, increasing bundle size. In Langflow, with 300+ components sharing a design system, inconsistent styling compounds fast.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- adding a CSS module for simple styling
+import styles from "./Button.module.css";
+<div className={styles.container}>
+
+// Right -- Tailwind utilities
+<div className="flex items-center gap-2 rounded-md border px-4 py-2">
+```
+
+## Use design tokens instead of raw Tailwind colors
+
+IsUrgent: True
+Category: Code Quality
+
+### Description
+
+**Never use raw Tailwind color classes** like `text-red-500`, `bg-blue-100`, `border-gray-300`, etc. The project defines a complete design token system via CSS custom properties in `src/frontend/src/style/index.css` and maps them to Tailwind classes in `tailwind.config.mjs`. These tokens support both light and dark mode automatically. Using raw colors bypasses the theme system, breaks dark mode, and creates visual inconsistency.
+
+### Available Design Token Classes
+
+**Core semantic colors** (use these for general UI):
+
+| Purpose | Text | Background | Border |
+|---------|------|------------|--------|
+| Primary text/bg | `text-foreground` | `bg-background` | `border-border` |
+| Primary action | `text-primary` | `bg-primary` | — |
+| Primary action text | `text-primary-foreground` | — | — |
+| Secondary | `text-secondary-foreground` | `bg-secondary` | — |
+| Muted/subtle | `text-muted-foreground` | `bg-muted` | — |
+| Destructive/danger | `text-destructive` | `bg-destructive` | — |
+| Accent | `text-accent-foreground` | `bg-accent` | — |
+| Cards | `text-card-foreground` | `bg-card` | — |
+| Popovers | `text-popover-foreground` | `bg-popover` | — |
+| Tooltips | `text-tooltip-foreground` | `bg-tooltip` | — |
+| Input fields | — | — | `border-input` |
+| Focus rings | — | — | `ring-ring` |
+| Placeholder | `text-placeholder-foreground` | — | — |
+
+**Status colors** (for build state, node status, alerts):
+
+| Status | Class |
+|--------|-------|
+| Success | `bg-success-background`, `text-success-foreground` |
+| Error | `bg-error-background`, `text-error-foreground`, `bg-error` |
+| Info | `bg-info-background`, `text-info-foreground` |
+| Warning | `bg-warning`, `text-warning-foreground` |
+| Status indicators | `bg-status-green`, `bg-status-red`, `bg-status-yellow`, `bg-status-blue`, `bg-status-gray` |
+
+**Accent colors** (for highlights, badges, categories):
+
+| Accent | Background | Foreground |
+|--------|------------|------------|
+| Emerald | `bg-accent-emerald` | `text-accent-emerald-foreground` |
+| Indigo | `bg-accent-indigo` | `text-accent-indigo-foreground` |
+| Blue | `bg-accent-blue` | `text-accent-blue-foreground` |
+| Pink | `bg-accent-pink` | `text-accent-pink-foreground` |
+| Amber | `bg-accent-amber` | `text-accent-amber-foreground` |
+
+**Data type colors** (for flow node field types):
+
+| Type | Background | Foreground |
+|------|------------|------------|
+| String | `bg-datatype-yellow` | `text-datatype-yellow-foreground` |
+| Number | `bg-datatype-blue` | `text-datatype-blue-foreground` |
+| Boolean | `bg-datatype-lime` | `text-datatype-lime-foreground` |
+| List | `bg-datatype-purple` | `text-datatype-purple-foreground` |
+| Dict | `bg-datatype-indigo` | `text-datatype-indigo-foreground` |
+| Object | `bg-datatype-gray` | `text-datatype-gray-foreground` |
+| Error | `bg-datatype-red` | `text-datatype-red-foreground` |
+| Message | `bg-datatype-emerald` | `text-datatype-emerald-foreground` |
+
+**Sticky note colors**:
+`bg-note-amber`, `bg-note-neutral`, `bg-note-rose`, `bg-note-blue`, `bg-note-lime`
+
+**Other tokens**:
+`bg-canvas` (flow canvas background), `text-node-ring` (node selection ring), `bg-code-background` / `text-code-foreground` (code blocks), `bg-hover` (hover state), `text-hard-zinc`, `bg-smooth-red`, `text-placeholder`
+
+### Suggested Fix
+
+```tsx
+// Wrong -- raw Tailwind colors (breaks dark mode, no theme consistency)
+<span className="text-red-500">Error</span>
+<div className="bg-gray-100 border-gray-300">
+<span className="text-blue-600">Link</span>
+<div className="bg-green-50 text-green-800">Success</div>
+
+// Right -- design tokens (automatic dark mode, theme-consistent)
+<span className="text-destructive">Error</span>
+<div className="bg-muted border-border">
+<span className="text-accent-blue-foreground">Link</span>
+<div className="bg-success-background text-success-foreground">Success</div>
+
+// Wrong -- hardcoded hex or rgb values
+<div style={{ color: "#ef4444" }}>
+<div className="text-[#2563eb]">
+
+// Right -- use CSS variable if no Tailwind class exists
+<div className="text-status-red">
+<div className="text-status-blue">
+```
+
+### When Raw Colors Are Acceptable
+
+Raw Tailwind colors are only acceptable when:
+1. Building a one-off demo or prototype (tag with `// TODO: replace with design token`)
+2. The color is truly static and theme-independent (extremely rare)
+3. An exact design spec requires a color with no matching token — in that case, **add a new CSS variable** to `src/frontend/src/style/index.css` (both `:root` and `.dark` variants) and register it in `tailwind.config.mjs` instead of using the raw color inline
+
+## Class name ordering for overridable components
+
+IsUrgent: False
+Category: Code Quality
+
+### Description
+
+When a component accepts a `className` prop, always place it last inside `cn()` so downstream consumers can override or extend the component's default styling. The component's own classes come first, then the incoming `className`.
+
+### Suggested Fix
+
+```tsx
+import { cn } from "@/utils/utils";
+
+const Card = ({ className }: { className?: string }) => {
+  return (
+    <div className={cn("rounded-lg border bg-background p-4 shadow-sm", className)}>
+      {/* content */}
+    </div>
+  );
+};
+```
+
+Why: If the component's own classes come after `className`, a consumer passing `className='bg-destructive'` gets silently overridden by the component's `bg-background`. The consumer's intent is lost. By placing `className` last in `cn()`, Tailwind Merge resolves conflicts in favor of the consumer.
+
+## Strong TypeScript typing -- no `any`
+
+IsUrgent: True
+Category: Code Quality
+
+### Description
+
+Never use `any` as a type annotation. Using `any` disables TypeScript's ability to catch type mismatches at compile time — bugs that would be caught by the compiler instead crash in production. In Langflow, flow data structures are deeply nested (`NodeDataType.node.template[fieldName].value`); an `any` at any level silently allows accessing non-existent properties, causing 'Cannot read properties of undefined' in the canvas. Use `unknown` with type guards for genuinely unknown data, or specific types/generics for everything else.
+
+### Suggested Fix
+
+```ts
+// Wrong
+function processData(data: any) { ... }
+
+// Right
+function processData(data: Record<string, unknown>) { ... }
+
+// Right -- with type guard
+function processData(data: unknown) {
+  if (isFlowData(data)) { ... }
+}
+```
+
+## Biome formatting conventions
+
+IsUrgent: False
+Category: Code Quality
+
+### Description
+
+The project uses Biome (not ESLint/Prettier) for linting and formatting. Follow Biome conventions: double quotes for strings, 2-space indentation, trailing commas in multi-line structures. Run `biome check` or `biome format` to verify compliance. Do not add ESLint or Prettier configuration files.
+
+### Suggested Fix
+
+```ts
+// Wrong -- single quotes, 4-space indent
+const name = 'flow'
+const config = {
+    key: 'value'
+}
+
+// Right -- double quotes, 2-space indent, trailing comma
+const name = "flow";
+const config = {
+  key: "value",
+};
+```
+
+## Prefer Radix UI primitives for accessible components
+
+IsUrgent: False
+Category: Code Quality
+
+### Description
+
+When building interactive UI elements (dialogs, dropdowns, tooltips, popovers, tabs, etc.), use Radix UI primitives via the shadcn-ui wrappers in `components/ui/`. Custom implementations of these patterns consistently miss: keyboard navigation (arrow keys in dropdowns), focus trapping (Tab stays inside dialogs), screen reader announcements (ARIA live regions), and Escape key handling. Rebuilding these from scratch introduces accessibility regressions that affect keyboard-only and screen reader users. Langflow is used by enterprise teams that may require WCAG compliance — every custom dropdown without proper focus management is a compliance risk.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- custom dropdown implementation
+const [open, setOpen] = useState(false);
+<div onBlur={() => setOpen(false)}>
+  <button onClick={() => setOpen(!open)}>Menu</button>
+  {open && <div className="absolute">{/* items */}</div>}
+</div>
+
+// Right -- use shadcn/Radix DropdownMenu
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+<DropdownMenu>
+  <DropdownMenuTrigger>Menu</DropdownMenuTrigger>
+  <DropdownMenuContent>
+    <DropdownMenuItem>Item 1</DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+## State management: Zustand for client, React Query for server
+
+IsUrgent: True
+Category: Code Quality
+
+### Description
+
+Use Zustand stores (in `src/frontend/src/stores/`) for client-side UI state and TanStack React Query (via hooks in `src/frontend/src/controllers/API/`) for server state (data fetching, caching, mutations). Do not store fetched server data in Zustand; let React Query manage it. Do not use React Query for purely client-side state.
+
+### Suggested Fix
+
+```ts
+// Wrong -- storing fetched data in Zustand
+const useFlowStore = create((set) => ({
+  flows: [],
+  fetchFlows: async () => {
+    const data = await api.getFlows();
+    set({ flows: data });
+  },
+}));
+
+// Right -- React Query for server state
+const useFlows = () => {
+  return useQueryFunctionType<FlowType[]>(["flows"], api.getFlows);
+};
+
+// Right -- Zustand for client UI state
+const useFlowStore = create((set) => ({
+  selectedNodeId: null,
+  setSelectedNodeId: (id: string | null) => set({ selectedNodeId: id }),
+}));
+```
+
+## No `console.log` in production code
+
+IsUrgent: True
+Category: Code Quality
+
+### Description
+
+Do not leave `console.log`, `console.warn`, or `console.error` statements in production code. Biome enforces this rule. Use proper error handling, error boundaries, or toast notifications for user-facing errors. If logging is truly needed for debugging, remove it before committing.
+
+Why: `console.log` in production code writes to the browser's developer console. In Langflow, component data often includes API keys stored in global variables — a `console.log(data)` accidentally leaks credentials to anyone who opens DevTools. Biome catches this at lint time; if Biome is not catching it, the linting step was skipped.
+
+## Prefer `const` and immutable patterns
+
+IsUrgent: False
+Category: Code Quality
+
+### Description
+
+Use `const` by default. Only use `let` when reassignment is genuinely needed. Never use `var`. Prefer immutable update patterns (spread operator, `map`, `filter`) over mutation when working with arrays and objects, especially in state updates.
+
+### Suggested Fix
+
+```ts
+// Wrong
+let items = getItems();
+items.push(newItem);
+setState({ items });
+
+// Right
+const items = getItems();
+setState({ items: [...items, newItem] });
+```
+
+Why: Mutation creates invisible dependencies between code paths. If function A mutates an array that function B reads, changing A's behavior silently breaks B with no compile error. React also relies on reference equality for re-renders — mutating an object in state doesn't trigger a re-render because `oldObj === newObj` is still `true`. Spread/map/filter create new references that React can detect.
+
+## Functional components with hooks only
+
+IsUrgent: True
+Category: Code Quality
+
+### Description
+
+All React components must be functional components using hooks. Do not use class components, `React.Component`, or lifecycle methods (`componentDidMount`, etc.). Use `useEffect`, `useState`, `useMemo`, `useCallback`, and custom hooks instead.
+
+Why: Class components have a larger API surface (lifecycle methods, `this` binding, constructor), making them harder to test and reason about. Hooks compose better — a custom hook can combine state, effects, and context without nesting HOCs. The entire Langflow codebase uses functional components; introducing a class component breaks consistency and forces other developers to context-switch between paradigms.
+
+## Early returns for guard clauses
+
+IsUrgent: False
+Category: Code Quality
+
+### Description
+
+Use early returns to handle edge cases and guard conditions at the top of functions and components. This reduces nesting, improves readability, and makes the main logic path clear.
+
+Deep nesting increases cognitive load: each additional level of indentation requires the reader to hold one more condition in working memory. Studies show that code with 3+ nesting levels has significantly higher defect rates. Guard clauses at the top make preconditions explicit and keep the main logic at the lowest indentation — the 'happy path' is visually clear.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- deeply nested
+function NodeComponent({ data }: NodeProps) {
+  if (data) {
+    if (data.node) {
+      if (data.node.template) {
+        return <div>{/* main content */}</div>;
+      }
+    }
+  }
+  return null;
+}
+
+// Right -- early returns
+function NodeComponent({ data }: NodeProps) {
+  if (!data?.node?.template) return null;
+
+  return <div>{/* main content */}</div>;
+}
+```
+
+## Use Lucide React for icons
+
+IsUrgent: False
+Category: Code Quality
+
+### Description
+
+The project standardizes on Lucide React for icons. Do not import icons from other libraries (heroicons, react-icons, font-awesome, etc.) unless Lucide does not have an equivalent. Check the Lucide icon set first at https://lucide.dev before introducing a new icon dependency.
+
+Why: Multiple icon libraries bloat the bundle (each library ships its own SVG set). Lucide is tree-shakeable — unused icons are removed at build time. Mixing libraries also creates visual inconsistency (different stroke widths, sizing conventions, visual weight). Langflow standardized on Lucide; check https://lucide.dev before adding a new dependency.
+
+### Suggested Fix
+
+```tsx
+// Wrong
+import { AiOutlineCheck } from "react-icons/ai";
+
+// Right
+import { Check } from "lucide-react";
+```
+
+## Follow the project's naming and folder conventions
+
+IsUrgent: True
+Category: Code Quality
+
+### Description
+
+All **new** frontend code must use **kebab-case** file names with descriptive names. The legacy codebase has mixed conventions (`index.tsx`, camelCase, PascalCase) — do NOT follow those patterns for new code.
+
+**The standard for NEW code:**
+
+- **All files**: kebab-case with a name that describes what the file does. **Never name a file `index.tsx`** — this is a legacy pattern that makes navigation and search harder.
+- **Folders**: kebab-case, named after the feature or component.
+- **Hooks**: kebab-case with `use-` prefix (`use-add-flow.ts`, `use-debounce.ts`).
+- **Stores**: camelCase with "Store" suffix (`flowStore.ts`, `alertStore.ts`) — existing convention, keep it.
+- **Types**: kebab-case folders with descriptive file names.
+
+| What | Convention | Example |
+|------|-----------|---------|
+| Component file | kebab-case, descriptive | `flow-settings-panel.tsx`, `node-input-field.tsx` |
+| Component folder | kebab-case | `flow-settings/`, `node-toolbar/` |
+| Hook file | kebab-case, `use-` prefix | `use-save-flow.ts`, `use-debounce.ts` |
+| Helper file | kebab-case, descriptive | `column-defs.ts`, `format-data.ts` |
+| Type file | kebab-case | `flow-types.ts`, `api-types.ts` |
+| Store file | camelCase + "Store" | `flowStore.ts` (existing convention) |
+| UI component (shadcn) | kebab-case | `dropdown-menu.tsx` (shadcn standard) |
+
+**Never `index.tsx`:**
+
+```
+// Wrong (legacy pattern — do NOT use for new code)
+my-component/
+├── index.tsx          ← ambiguous, hard to find in search/tabs
+
+// Right (new standard)
+my-component/
+├── my-component.tsx   ← clear, searchable, self-documenting
+├── components/
+│   ├── sub-part.tsx
+│   └── another-part.tsx
+├── helpers/
+│   ├── column-defs.ts
+│   └── format-data.ts
+├── hooks/
+│   └── use-local-state.ts
+└── types/
+    └── my-component-types.ts
+```
+
+**Key rule: helpers are LOCAL, not centralized.** Each component owns its own `helpers/` folder. Do not create shared helper files in unrelated directories.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- index.tsx (legacy pattern)
+// src/frontend/src/components/core/myComponent/index.tsx
+
+// Wrong -- centralized helper
+// src/frontend/src/helpers/flowHelpers.ts
+
+// Right -- kebab-case, descriptive name, local helpers
+// src/frontend/src/components/core/my-component/my-component.tsx
+// src/frontend/src/pages/FlowPage/components/flow-sidebar/helpers/format-flow.ts
+```
+
+## Use available shadcn components from `components/ui/`
+
+IsUrgent: False
+Category: Code Quality
+
+### Description
+
+Before building a custom interactive UI element, check if a shadcn/Radix component already exists in `src/frontend/src/components/ui/`. The project has 39+ base components available:
+
+**Layout & Containers:** `accordion`, `card`, `dialog`, `dialog-with-no-close`, `disclosure`, `popover`, `separator`, `sidebar`, `simple-sidebar`, `tabs`, `tabs-button`
+
+**Forms & Inputs:** `button`, `checkbox`, `input`, `label`, `radio-group`, `select`, `select-custom`, `switch`, `textarea`
+
+**Feedback & Overlay:** `alert`, `badge`, `command`, `context-menu`, `dropdown-menu`, `loading`, `skeleton`, `skeletonGroup`, `tooltip`
+
+**Visual:** `animated-close`, `background-gradient`, `checkmark`, `dot-background`, `refreshButton`, `table`, `text-loop`, `textAnimation`, `TextShimmer`, `xmark`
+
+Do not recreate these patterns manually. Import from `@/components/ui/` instead.

--- a/.agents/skills/frontend-code-review/references/performance.md
+++ b/.agents/skills/frontend-code-review/references/performance.md
@@ -1,0 +1,265 @@
+# Rule Catalog -- Performance
+
+Update this file when adding, editing, or removing Performance rules so the catalog remains accurate.
+
+## @xyflow/react data usage
+
+IsUrgent: True
+Category: Performance
+
+### Description
+
+When working with the flow graph powered by @xyflow/react v12, use `useNodes()` and `useEdges()` hooks for rendering UI that displays node/edge data. For callbacks that mutate or read node/edge state imperatively (e.g., inside event handlers), use `useReactFlow()` or `useStoreApi()` to access the store directly. Avoid pulling the full node/edge arrays in callbacks, as this creates unnecessary subscriptions and re-renders.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- subscribes to all node changes in a callback-only context
+function MyPanel() {
+  const nodes = useNodes();
+  const handleExport = () => {
+    const data = nodes.map((n) => n.data);
+    exportFlow(data);
+  };
+  return <button onClick={handleExport}>Export</button>;
+}
+
+// Right -- use store API for imperative access
+function MyPanel() {
+  const { getNodes } = useReactFlow();
+  const handleExport = () => {
+    const data = getNodes().map((n) => n.data);
+    exportFlow(data);
+  };
+  return <button onClick={handleExport}>Export</button>;
+}
+```
+
+## Complex prop memoization with `useMemo`
+
+IsUrgent: True
+Category: Performance
+
+### Description
+
+Wrap complex prop values (objects, arrays, computed structures) in `useMemo` before passing them to child components. Without memoization, a new reference is created on every render, causing children wrapped in `React.memo` to re-render unnecessarily. This is especially critical in the flow canvas where hundreds of nodes may be rendered simultaneously.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- new object on every render
+<GenericNode
+  config={{
+    template: data.node.template,
+    display_name: data.node.display_name,
+  }}
+/>
+
+// Right -- stable reference
+const config = useMemo(
+  () => ({
+    template: data.node.template,
+    display_name: data.node.display_name,
+  }),
+  [data.node.template, data.node.display_name],
+);
+
+<GenericNode config={config} />
+```
+
+## Avoid re-renders with `React.memo` and `useCallback`
+
+IsUrgent: True
+Category: Performance
+
+### Description
+
+Use `React.memo` for components that receive stable props and should not re-render when their parent re-renders. Use `useCallback` for callback functions passed as props to memoized children. This is critical for node components on the canvas: GenericNode and its sub-components should be memoized to avoid cascading re-renders when the flow state changes.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- inline callback causes child re-render
+function ParentNode({ id }: { id: string }) {
+  return (
+    <ChildComponent
+      onUpdate={(value: string) => updateNodeField(id, value)}
+    />
+  );
+}
+
+// Right -- stable callback reference
+function ParentNode({ id }: { id: string }) {
+  const handleUpdate = useCallback(
+    (value: string) => updateNodeField(id, value),
+    [id],
+  );
+  return <ChildComponent onUpdate={handleUpdate} />;
+}
+
+const ChildComponent = React.memo(({ onUpdate }: Props) => {
+  // ...
+});
+```
+
+## Lazy loading for heavy pages
+
+IsUrgent: False
+Category: Performance
+
+### Description
+
+Use `React.lazy()` with `<Suspense>` for route-level code splitting of heavy pages (flow editor, settings, store, etc.). This reduces the initial bundle size and improves first-load performance. Route definitions should use lazy imports rather than static imports for page components.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- static import of heavy page
+import FlowEditor from "@/pages/FlowEditor";
+
+// Right -- lazy loaded
+const FlowEditor = React.lazy(() => import("@/pages/FlowEditor"));
+
+<Suspense fallback={<LoadingSpinner />}>
+  <FlowEditor />
+</Suspense>
+```
+
+## No expensive operations in render functions
+
+IsUrgent: True
+Category: Performance
+
+### Description
+
+Do not perform expensive computations (deep object traversals, array sorting/filtering of large datasets, JSON parsing, regex on large strings) directly in the render body of a component. Move these into `useMemo` with appropriate dependencies, or into event handlers / effects if they produce side effects. The flow canvas may trigger frequent re-renders; keeping the render path lightweight is critical.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- sorts on every render
+function NodeList({ nodes }: { nodes: NodeType[] }) {
+  const sorted = nodes
+    .filter((n) => n.data.showNode)
+    .sort((a, b) => a.data.node.display_name.localeCompare(b.data.node.display_name));
+
+  return <>{sorted.map((n) => <NodeCard key={n.id} node={n} />)}</>;
+}
+
+// Right -- memoized computation
+function NodeList({ nodes }: { nodes: NodeType[] }) {
+  const sorted = useMemo(
+    () =>
+      nodes
+        .filter((n) => n.data.showNode)
+        .sort((a, b) =>
+          a.data.node.display_name.localeCompare(b.data.node.display_name),
+        ),
+    [nodes],
+  );
+
+  return <>{sorted.map((n) => <NodeCard key={n.id} node={n} />)}</>;
+}
+```
+
+## Zustand selector optimization
+
+IsUrgent: True
+Category: Performance
+
+### Description
+
+When reading from Zustand stores, always use selectors to subscribe to only the specific slices of state the component needs. Selecting the entire store object causes the component to re-render on every store update, even for unrelated state changes. Langflow has 15+ Zustand stores; careless subscriptions can create cascading performance problems.
+
+### Suggested Fix
+
+```ts
+// Wrong -- subscribes to entire store, re-renders on any change
+const store = useFlowStore();
+const nodes = store.nodes;
+
+// Wrong -- inline object selector creates new reference each render
+const { nodes, edges } = useFlowStore((state) => ({
+  nodes: state.nodes,
+  edges: state.edges,
+}));
+
+// Right -- individual selectors for each value
+const nodes = useFlowStore((state) => state.nodes);
+const edges = useFlowStore((state) => state.edges);
+
+// Right -- use useShallow for multiple values if needed
+import { useShallow } from "zustand/react/shallow";
+
+const { nodes, edges } = useFlowStore(
+  useShallow((state) => ({ nodes: state.nodes, edges: state.edges })),
+);
+```
+
+## React Query: proper staleTime and gcTime configuration
+
+IsUrgent: False
+Category: Performance
+
+### Description
+
+Configure `staleTime` and `gcTime` (formerly `cacheTime`) appropriately for each query based on how frequently the data changes. Avoid leaving defaults (0ms staleTime) for data that rarely changes (e.g., component type definitions, user settings), as this causes unnecessary refetches. Conversely, do not set excessively long stale times for data that changes frequently (e.g., flow execution status).
+
+### Suggested Fix
+
+```ts
+// Wrong -- default staleTime of 0, refetches on every mount
+const { data } = useQuery({
+  queryKey: ["componentTypes"],
+  queryFn: getComponentTypes,
+});
+
+// Right -- component types rarely change, cache for 5 minutes
+const { data } = useQuery({
+  queryKey: ["componentTypes"],
+  queryFn: getComponentTypes,
+  staleTime: 5 * 60 * 1000,
+});
+```
+
+## Avoid creating new objects/arrays inline in JSX
+
+IsUrgent: False
+Category: Performance
+
+### Description
+
+Do not create new object or array literals directly inside JSX props, especially for configuration objects, data arrays, or callback payloads. Each render creates a new reference, which defeats `React.memo` and `useMemo` optimizations in child components. Extract these to constants outside the component, or memoize them inside the component.
+
+**Note**: Since this project uses Tailwind CSS, inline `style={}` props should be extremely rare. Use Tailwind classes with design tokens instead (see code-quality.md). This rule applies primarily to non-style object props like `config`, `data`, `options`, `columns`, etc.
+
+### Suggested Fix
+
+```tsx
+// Wrong -- new config object every render, child re-renders even if data hasn't changed
+function FlowSettings({ flowId }: { flowId: string }) {
+  return (
+    <SettingsPanel
+      config={{ flowId, autoSave: true, showMinimap: false }}
+    />
+  );
+}
+
+// Right -- constant outside component for static values
+const DEFAULT_SETTINGS = { autoSave: true, showMinimap: false } as const;
+
+function FlowSettings({ flowId }: { flowId: string }) {
+  const config = useMemo(
+    () => ({ flowId, ...DEFAULT_SETTINGS }),
+    [flowId],
+  );
+  return <SettingsPanel config={config} />;
+}
+
+// Wrong -- new array every render
+<SelectComponent options={["option1", "option2", "option3"]} />
+
+// Right -- constant outside component
+const OPTIONS = ["option1", "option2", "option3"] as const;
+<SelectComponent options={OPTIONS} />
+```

--- a/.agents/skills/frontend-query-mutation/SKILL.md
+++ b/.agents/skills/frontend-query-mutation/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: frontend-query-mutation
+description: Guide for implementing Langflow frontend query and mutation patterns with Axios and TanStack React Query v5. Trigger when creating or updating API hooks in controllers/API/queries, consuming UseRequestProcessor in components, deciding whether to use useQuery or useMutation, handling conditional queries, cache invalidation, mutation error handling, or migrating legacy API calls to the query hook pattern.
+---
+
+# Frontend Query & Mutation
+
+## Intent
+
+- Keep API hooks in `controllers/API/queries/{domain}/` as the organized source of truth.
+- Use `UseRequestProcessor` for consistent retry, invalidation, and error handling.
+- Use Axios `api` instance for all HTTP calls (never raw `fetch` for REST).
+- Use `performStreamingRequest()` for streaming operations (build, chat).
+- Keep cache invalidation in mutation `onSettled` callbacks.
+
+## Architecture Overview
+
+Langflow uses **Axios + TanStack React Query v5** for data fetching. There is no oRPC or contract layer. The architecture is:
+
+```
+Component
+  -> API hook (controllers/API/queries/{domain}/use-{verb}-{resource}.ts)
+    -> UseRequestProcessor (controllers/API/services/request-processor.ts)
+      -> useQuery / useMutation (TanStack React Query)
+        -> queryFn / mutationFn
+          -> api.get/post/patch/delete (Axios instance from controllers/API/api.tsx)
+```
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `controllers/API/api.tsx` | Axios instance, `ApiInterceptor` component, `performStreamingRequest()` |
+| `controllers/API/services/request-processor.ts` | `UseRequestProcessor` hook wrapping `useQuery`/`useMutation` with retry defaults |
+| `controllers/API/helpers/constants.ts` | URL constants (`URLs`) and `getURL()` helper |
+| `controllers/API/queries/{domain}/` | Domain-organized query and mutation hooks |
+| `types/api/index.ts` | `useQueryFunctionType`, `useMutationFunctionType` type helpers |
+| `stores/` | Zustand stores for client-side state |
+
+## Workflow
+
+1. Identify the change surface.
+   - Read `references/query-patterns.md` for hook structure, naming, URL patterns, and query/mutation call-site shape.
+   - Read `references/runtime-rules.md` for conditional queries, invalidation, error handling, and streaming.
+   - Read both references when a task spans hook creation and runtime behavior.
+2. Implement the hook following existing patterns.
+   - Use `UseRequestProcessor` for `query()` and `mutate()` wrappers.
+   - Use the `api` Axios instance for all HTTP calls.
+   - Use `getURL()` for constructing API paths.
+   - Type the hook with `useQueryFunctionType` or `useMutationFunctionType`.
+3. Preserve Langflow conventions.
+   - Query keys are arrays with the hook name: `["useGetFlows"]`.
+   - Mutations invalidate related queries in `onSettled`.
+   - Zustand store updates happen in the query/mutation function, not in components.
+   - `UseRequestProcessor` provides default retry (5 for queries, 3 for mutations) with exponential backoff.
+
+## Files Commonly Touched
+
+- `controllers/API/queries/{domain}/use-get-*.ts` (query hooks)
+- `controllers/API/queries/{domain}/use-post-*.ts` (create mutations)
+- `controllers/API/queries/{domain}/use-patch-*.ts` (update mutations)
+- `controllers/API/queries/{domain}/use-delete-*.ts` (delete mutations)
+- `controllers/API/helpers/constants.ts` (URL constants)
+- `types/api/index.ts` (API type definitions)
+- `stores/` (Zustand store updates triggered by queries)
+
+## References
+
+- Use `references/query-patterns.md` for hook structure, naming conventions, directory layout, and anti-patterns.
+- Use `references/runtime-rules.md` for conditional queries, invalidation, `mutate` versus `mutateAsync`, error handling, and streaming requests.
+
+Treat this skill as the single query and mutation entry point for Langflow frontend work. Keep detailed rules in the reference files instead of duplicating them in project docs.

--- a/.agents/skills/frontend-query-mutation/references/query-patterns.md
+++ b/.agents/skills/frontend-query-mutation/references/query-patterns.md
@@ -1,0 +1,472 @@
+# Query and Mutation Patterns
+
+## Table of Contents
+
+- Intent
+- Directory structure
+- Query hook structure
+- Mutation hook structure
+- URL constants
+- Query keys
+- Type signatures
+- Anti-patterns
+
+## Intent
+
+- Keep API hooks in `controllers/API/queries/{domain}/` organized by domain.
+- Use `UseRequestProcessor` for consistent behavior across all hooks.
+- Use the shared `api` Axios instance for all REST calls.
+- Type hooks with `useQueryFunctionType` or `useMutationFunctionType` from `types/api/`.
+
+## Directory Structure
+
+```text
+controllers/API/
+  api.tsx                          # Axios instance, interceptors, streaming
+  helpers/
+    constants.ts                   # URL constants and getURL()
+  services/
+    request-processor.ts           # UseRequestProcessor hook
+  queries/
+    flows/
+      use-get-flow.ts
+      use-get-refresh-flows-query.ts
+      use-post-add-flow.ts
+      use-delete-delete-flows.ts
+      use-get-download-flows.ts
+      index.ts
+    folders/
+      use-get-folder.ts
+      use-get-folders.ts
+      use-post-folders.ts
+      use-patch-folders.ts
+      use-delete-folders.ts
+      index.ts
+    variables/
+      use-get-global-variables.ts
+      use-post-global-variables.ts
+      use-patch-global-variables.ts
+      index.ts
+    auth/
+      use-get-autologin.ts
+      use-post-login-user.ts
+      use-post-logout.ts
+      use-post-refresh-access.ts
+      index.ts
+    messages/
+      use-get-messages.ts
+      use-get-messages-polling.ts
+      use-delete-messages.ts
+      index.ts
+```
+
+### Naming Convention
+
+- **Queries**: `use-get-{resource}.ts` (e.g., `use-get-flow.ts`, `use-get-global-variables.ts`)
+- **Create mutations**: `use-post-{resource}.ts` (e.g., `use-post-add-flow.ts`)
+- **Update mutations**: `use-patch-{resource}.ts` (e.g., `use-patch-global-variables.ts`)
+- **Delete mutations**: `use-delete-{resource}.ts` (e.g., `use-delete-messages.ts`)
+- **Other mutations**: `use-{action}-{resource}.ts` (e.g., `use-rename-session.ts`)
+
+## Query Hook Structure
+
+Every query hook follows this structure:
+
+```typescript
+import type { UseQueryResult } from "@tanstack/react-query"
+import type { useQueryFunctionType } from "@/types/api"
+import { api } from "../../api"
+import { getURL } from "../../helpers/constants"
+import { UseRequestProcessor } from "../../services/request-processor"
+
+// 1. Define the response type (or import from types/)
+interface GlobalVariable {
+  id: string
+  name: string
+  value: string
+  type: string
+}
+
+// 2. Export the hook typed with useQueryFunctionType
+export const useGetGlobalVariables: useQueryFunctionType<
+  undefined,
+  GlobalVariable[]
+> = (options?) => {
+  // 3. Get query helper from UseRequestProcessor
+  const { query } = UseRequestProcessor()
+
+  // 4. Define the query function using the api Axios instance
+  const getGlobalVariablesFn = async (): Promise<GlobalVariable[]> => {
+    const res = await api.get(`${getURL("VARIABLES")}/`)
+    return res.data
+  }
+
+  // 5. Return the query result
+  const queryResult: UseQueryResult<GlobalVariable[], Error> = query(
+    ["useGetGlobalVariables"],
+    getGlobalVariablesFn,
+    {
+      refetchOnWindowFocus: false,
+      ...options,
+    },
+  )
+
+  return queryResult
+}
+```
+
+### Query Hook with Parameters
+
+When a query takes parameters, use the first type argument:
+
+```typescript
+export const useGetFolder: useQueryFunctionType<
+  { id: string },
+  FolderResponse
+> = (params, options?) => {
+  const { query } = UseRequestProcessor()
+
+  const getFolderFn = async (): Promise<FolderResponse> => {
+    const res = await api.get(`${getURL("FOLDERS")}/${params.id}`)
+    return res.data
+  }
+
+  return query(["useGetFolder", params.id], getFolderFn, {
+    ...options,
+  })
+}
+```
+
+### Important: Some "get" Hooks Use Mutation
+
+In the Langflow codebase, some hooks named `use-get-*` (e.g., `useGetFlow`) are actually **mutation hooks** typed with `useMutationFunctionType`. This happens when the "get" operation is triggered imperatively (on demand) rather than declaratively (on mount/re-render). Check the actual type signature before following the query pattern — if a hook uses `mutate` from `UseRequestProcessor`, follow the Mutation Hook Structure below instead.
+
+### Query Hook with Store Updates
+
+Many Langflow queries update Zustand stores as a side effect within the query function:
+
+```typescript
+export const useGetGlobalVariables: useQueryFunctionType<
+  undefined,
+  GlobalVariable[]
+> = (options?) => {
+  const { query } = UseRequestProcessor()
+
+  // Access store setters
+  const setGlobalVariablesEntries = useGlobalVariablesStore(
+    (state) => state.setGlobalVariablesEntries,
+  )
+
+  const getGlobalVariablesFn = async (): Promise<GlobalVariable[]> => {
+    const res = await api.get(`${getURL("VARIABLES")}/`)
+    // Update store as side effect of fetching
+    setGlobalVariablesEntries(res.data.map((entry) => entry.name))
+    return res.data
+  }
+
+  return query(["useGetGlobalVariables"], getGlobalVariablesFn, {
+    refetchOnWindowFocus: false,
+    ...options,
+  })
+}
+```
+
+## Mutation Hook Structure
+
+Every mutation hook follows this structure:
+
+```typescript
+import type { UseMutationResult } from "@tanstack/react-query"
+import type { useMutationFunctionType } from "@/types/api"
+import { api } from "../../api"
+import { getURL } from "../../helpers/constants"
+import { UseRequestProcessor } from "../../services/request-processor"
+
+// 1. Define the payload type
+interface PostAddFlowPayload {
+  name: string
+  data: ReactFlowJsonObject
+  description: string
+  folder_id: string
+}
+
+// 2. Export the hook typed with useMutationFunctionType
+export const usePostAddFlow: useMutationFunctionType<
+  undefined,       // Params (undefined if none)
+  PostAddFlowPayload  // Variables (mutation payload)
+> = (options?) => {
+  // 3. Get mutate helper and queryClient from UseRequestProcessor
+  const { mutate, queryClient } = UseRequestProcessor()
+
+  // 4. Define the mutation function using the api Axios instance
+  const postAddFlowFn = async (payload: PostAddFlowPayload): Promise<any> => {
+    const response = await api.post(`${getURL("FLOWS")}/`, {
+      name: payload.name,
+      data: payload.data,
+      description: payload.description,
+      folder_id: payload.folder_id || null,
+    })
+    return response.data
+  }
+
+  // 5. Return the mutation with cache invalidation in onSettled
+  // NOTE: Place hook-specific options (onSettled, retry) BEFORE ...options
+  // so consumers can override them if needed. This matches the codebase convention.
+  const mutation: UseMutationResult<any, any, PostAddFlowPayload> = mutate(
+    ["usePostAddFlow"],
+    postAddFlowFn,
+    {
+      onSettled: (response) => {
+        if (response) {
+          // Invalidate related queries so they refetch
+          queryClient.refetchQueries({
+            queryKey: ["useGetRefreshFlowsQuery", { get_all: true, header_flows: true }],
+          })
+          queryClient.refetchQueries({
+            queryKey: ["useGetFolder", response.folder_id],
+          })
+        }
+      },
+      ...options,  // Consumer options come LAST (can override onSettled, retry, etc.)
+    },
+  )
+
+  return mutation
+}
+```
+
+### Delete Mutation Example
+
+```typescript
+export const useDeleteMessages: useMutationFunctionType<undefined, string[]> = (
+  options?,
+) => {
+  const { mutate, queryClient } = UseRequestProcessor()
+
+  const deleteMessagesFn = async (messageIds: string[]): Promise<void> => {
+    await api.delete(`${getURL("MESSAGES")}/`, {
+      data: messageIds,
+    })
+  }
+
+  const mutation = mutate(["useDeleteMessages"], deleteMessagesFn, {
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["useGetMessages"] })
+    },
+    ...options,
+  })
+
+  return mutation
+}
+```
+
+### Patch Mutation Example
+
+```typescript
+export const usePatchGlobalVariables: useMutationFunctionType<
+  undefined,
+  { id: string; name: string; value: string; type: string }
+> = (options?) => {
+  const { mutate, queryClient } = UseRequestProcessor()
+
+  const patchGlobalVariablesFn = async (payload: {
+    id: string
+    name: string
+    value: string
+    type: string
+  }): Promise<GlobalVariable> => {
+    const response = await api.patch(
+      `${getURL("VARIABLES")}/${payload.id}`,
+      payload,
+    )
+    return response.data
+  }
+
+  const mutation = mutate(["usePatchGlobalVariables"], patchGlobalVariablesFn, {
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["useGetGlobalVariables"] })
+    },
+    retry: false,
+    ...options,
+  })
+
+  return mutation
+}
+```
+
+## URL Constants
+
+All API paths are defined in `controllers/API/helpers/constants.ts`:
+
+```typescript
+export const URLs = {
+  FLOWS: "flows",
+  FOLDERS: "projects",
+  VARIABLES: "variables",
+  MESSAGES: "monitor/messages",
+  BUILDS: "monitor/builds",
+  API_KEY: "api_key",
+  FILES: "files",
+  // ...
+} as const
+```
+
+Use `getURL()` to construct full API paths:
+
+```typescript
+import { getURL } from "../../helpers/constants"
+
+// Basic: /api/v1/flows
+const url = getURL("FLOWS")
+
+// With params: /api/v1/flows/{flowId}
+const url = `${getURL("FLOWS")}/${flowId}`
+
+// With v2 flag: /api/v2/flows
+const url = getURL("FLOWS", {}, true)
+```
+
+When adding new endpoints, add the constant to `URLs` first, then use `getURL()` in the hook.
+
+## Query Keys
+
+Query keys are arrays that uniquely identify cached data. Langflow conventions:
+
+```typescript
+// Hook name as key (no params)
+["useGetGlobalVariables"]
+
+// Hook name + params for cache isolation
+["useGetFlow", flowId]
+["useGetFolder", folderId]
+
+// Hook name + object params for complex queries
+["useGetRefreshFlowsQuery", { get_all: true, header_flows: true }]
+["useGetMessages", { flowId, sessionId, page }]
+```
+
+Rules:
+- The first element is always the hook name as a string.
+- Additional elements are parameters that differentiate cache entries.
+- Use objects for multi-parameter queries.
+- Keep keys consistent so invalidation works correctly.
+
+## Type Signatures
+
+### useQueryFunctionType
+
+Used for query hooks. Defined in `types/api/index.ts`:
+
+```typescript
+// Without params: useQueryFunctionType<undefined, ResponseType>
+// The hook signature becomes: (options?) => UseQueryResult<ResponseType>
+
+// With params: useQueryFunctionType<ParamsType, ResponseType>
+// The hook signature becomes: (params, options?) => UseQueryResult<ResponseType>
+```
+
+### useMutationFunctionType
+
+Used for mutation hooks:
+
+```typescript
+// Without params: useMutationFunctionType<undefined, VariablesType>
+// The hook signature becomes: (options?) => UseMutationResult<Data, Error, Variables>
+
+// With params: useMutationFunctionType<ParamsType, VariablesType>
+// The hook signature becomes: (params, options?) => UseMutationResult<Data, Error, Variables>
+```
+
+## Anti-Patterns
+
+### Do Not Bypass UseRequestProcessor
+
+```typescript
+// Do not call useQuery/useMutation directly
+const result = useQuery({
+  queryKey: ["flows"],
+  queryFn: () => api.get("/api/v1/flows"),
+})
+
+// Use UseRequestProcessor for consistent retry and error handling
+const { query } = UseRequestProcessor()
+const result = query(["useGetFlows"], () => api.get(getURL("FLOWS")))
+```
+
+### Do Not Bypass the api Instance
+
+```typescript
+// Do not use raw axios or fetch for REST calls
+const result = await axios.get("/api/v1/flows")
+const result = await fetch("/api/v1/flows")
+
+// Use the shared api instance (has interceptors for auth, headers, error handling)
+const result = await api.get(`${getURL("FLOWS")}/`)
+```
+
+### Do Not Hardcode URLs
+
+```typescript
+// Do not hardcode API paths
+const result = await api.get("/api/v1/variables/")
+
+// Use getURL() helper
+const result = await api.get(`${getURL("VARIABLES")}/`)
+```
+
+### Do Not Duplicate Query Keys
+
+```typescript
+// Do not use different key strings for the same query
+query(["getFlows"], fetchFn)       // in hook A
+query(["useGetFlows"], fetchFn)    // in hook B
+query(["flows-list"], fetchFn)     // in hook C
+
+// Use one canonical key matching the hook name
+query(["useGetFlows"], fetchFn)
+```
+
+### Do Not Invalidate from Components
+
+```typescript
+// Do not put invalidation logic in components
+const Component = () => {
+  const queryClient = useQueryClient()
+  const { mutate } = useDeleteFlow()
+
+  const handleDelete = () => {
+    mutate(flowId, {
+      onSuccess: () => {
+        // Avoid: invalidation knowledge leaks into component
+        queryClient.invalidateQueries({ queryKey: ["useGetFlows"] })
+        queryClient.invalidateQueries({ queryKey: ["useGetFolder"] })
+      },
+    })
+  }
+}
+
+// Put invalidation in the mutation hook's onSettled
+export const useDeleteFlow = (options?) => {
+  const { mutate, queryClient } = UseRequestProcessor()
+
+  return mutate(["useDeleteFlow"], deleteFlowFn, {
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["useGetFlows"] })
+      queryClient.invalidateQueries({ queryKey: ["useGetFolder"] })
+    },
+    ...options,  // Consumer options come LAST
+  })
+}
+```
+
+### Do Not Create Thin Wrapper Hooks
+
+```typescript
+// Do not create hooks that just re-export an existing query hook
+const useFlows = () => {
+  return useGetRefreshFlowsQuery({ get_all: true })
+}
+
+// Import the existing hook directly where needed
+import { useGetRefreshFlowsQuery } from "@/controllers/API/queries/flows"
+```

--- a/.agents/skills/frontend-query-mutation/references/runtime-rules.md
+++ b/.agents/skills/frontend-query-mutation/references/runtime-rules.md
@@ -1,0 +1,415 @@
+# Runtime Rules
+
+## Table of Contents
+
+- Conditional queries
+- Cache invalidation
+- Query key conventions
+- `mutate` vs `mutateAsync`
+- Error handling
+- Streaming requests
+- UseRequestProcessor defaults
+
+## Conditional Queries
+
+Use the `enabled` option to conditionally run queries. Langflow hooks pass through `options` to `UseRequestProcessor`, which passes them to `useQuery`.
+
+```typescript
+// Pattern: Disable query when not authenticated
+export const useGetGlobalVariables: useQueryFunctionType<
+  undefined,
+  GlobalVariable[]
+> = (options?) => {
+  const { query } = UseRequestProcessor()
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+
+  const getGlobalVariablesFn = async (): Promise<GlobalVariable[]> => {
+    if (!isAuthenticated) return []
+    const res = await api.get(`${getURL("VARIABLES")}/`)
+    return res.data
+  }
+
+  return query(["useGetGlobalVariables"], getGlobalVariablesFn, {
+    refetchOnWindowFocus: false,
+    enabled: isAuthenticated && (options?.enabled ?? true),
+    ...options,
+  })
+}
+```
+
+```typescript
+// Pattern: Disable query when required param is missing
+export const useGetFlow: useQueryFunctionType<{ id: string }, FlowResponse> = (
+  params,
+  options?,
+) => {
+  const { query } = UseRequestProcessor()
+
+  const getFlowFn = async (): Promise<FlowResponse> => {
+    const res = await api.get(`${getURL("FLOWS")}/${params.id}`)
+    return res.data
+  }
+
+  return query(["useGetFlow", params.id], getFlowFn, {
+    enabled: !!params.id && (options?.enabled ?? true),
+    ...options,
+  })
+}
+```
+
+```typescript
+// Pattern: Consumer disables query via options
+const { data: flow } = useGetFlow(
+  { id: flowId },
+  { enabled: showFlowDetails },
+)
+```
+
+Rules:
+- Always check `options?.enabled ?? true` when combining with other conditions, so consumers can also disable the query.
+- Guard early in the query function when auth or required data might be missing.
+- Do not use non-null assertions on params to work around missing data; use `enabled` instead.
+
+## Cache Invalidation
+
+Bind invalidation in the mutation hook definition. Components should only add UI feedback (toasts, navigation) in call-site callbacks, not decide which queries to invalidate.
+
+### Invalidation via onSettled
+
+The `UseRequestProcessor.mutate()` wrapper already calls `queryClient.invalidateQueries({ queryKey: mutationKey })` in its default `onSettled`. For additional invalidation, extend `onSettled`:
+
+```typescript
+export const usePostAddFlow: useMutationFunctionType<
+  undefined,
+  PostAddFlowPayload
+> = (options?) => {
+  const { mutate, queryClient } = UseRequestProcessor()
+  const myCollectionId = useFolderStore((state) => state.myCollectionId)
+
+  const postAddFlowFn = async (payload: PostAddFlowPayload): Promise<any> => {
+    const response = await api.post(`${getURL("FLOWS")}/`, payload)
+    return response.data
+  }
+
+  return mutate(["usePostAddFlow"], postAddFlowFn, {
+    onSettled: (response) => {
+      if (response) {
+        queryClient.refetchQueries({
+          queryKey: ["useGetRefreshFlowsQuery", { get_all: true, header_flows: true }],
+        })
+        queryClient.refetchQueries({
+          queryKey: ["useGetFolder", response.folder_id ?? myCollectionId],
+        })
+      }
+    },
+    ...options,  // Consumer options come LAST
+  })
+}
+```
+
+### Invalidation Patterns
+
+```typescript
+// Broad invalidation: all queries for a domain
+queryClient.invalidateQueries({ queryKey: ["useGetFlows"] })
+
+// Specific invalidation: single cache entry
+queryClient.invalidateQueries({ queryKey: ["useGetFlow", flowId] })
+
+// Refetch instead of invalidate when you need data immediately
+queryClient.refetchQueries({ queryKey: ["useGetFolder", folderId] })
+```
+
+### Component-side callbacks are for UI only
+
+```typescript
+// Component only adds UI behavior
+const { mutate: addFlow } = usePostAddFlow()
+
+const handleCreate = () => {
+  addFlow(flowData, {
+    onSuccess: (response) => {
+      // UI-only: navigate, show toast
+      navigate(`/flow/${response.id}`)
+      setSuccessData({ title: "Flow created successfully" })
+    },
+    onError: (error) => {
+      setErrorData({
+        title: "Failed to create flow",
+        list: [error.message],
+      })
+    },
+  })
+}
+```
+
+## Query Key Conventions
+
+```typescript
+// Base key: hook name
+["useGetGlobalVariables"]
+
+// Parameterized key: hook name + params
+["useGetFlow", flowId]
+["useGetFolder", folderId]
+
+// Complex key: hook name + param object
+["useGetRefreshFlowsQuery", { get_all: true, header_flows: true }]
+["useGetMessages", { flowId, sessionId }]
+["useGetBuilds", { flowId }]
+
+// Mutation key: hook name (used for automatic invalidation by UseRequestProcessor)
+["usePostAddFlow"]
+["useDeleteMessages"]
+```
+
+Rules:
+- First element is always the hook name as a string.
+- Keep mutation keys matching the hook name.
+- `UseRequestProcessor.mutate()` auto-invalidates the `mutationKey` on settled.
+- Additional invalidation targets must be explicitly added in `onSettled`.
+
+## `mutate` vs `mutateAsync`
+
+Prefer `mutate` by default. Use `mutateAsync` only when Promise semantics are truly required.
+
+Rules:
+- Event handlers should call `mutate(...)` with `onSuccess` or `onError`.
+- Every `await mutateAsync(...)` must be wrapped in `try/catch`.
+- Do not use `mutateAsync` when callbacks already express the flow clearly.
+
+```typescript
+// Default: use mutate with callbacks
+const { mutate: deleteFlow } = useDeleteFlow()
+
+const handleDelete = () => {
+  deleteFlow(flowId, {
+    onSuccess: () => {
+      navigate("/flows")
+      setSuccessData({ title: "Flow deleted" })
+    },
+    onError: (error) => {
+      setErrorData({ title: "Delete failed", list: [error.message] })
+    },
+  })
+}
+
+// Exception: Promise semantics needed for sequential operations
+const handleDuplicateAndOpen = async () => {
+  try {
+    const newFlow = await duplicateFlow.mutateAsync(flowData)
+    await renameFlow.mutateAsync({ id: newFlow.id, name: `${flowData.name} (copy)` })
+    navigate(`/flow/${newFlow.id}`)
+  } catch (error) {
+    setErrorData({
+      title: "Failed to duplicate flow",
+      list: [error instanceof Error ? error.message : "Unknown error"],
+    })
+  }
+}
+```
+
+## Error Handling
+
+### API Interceptor Handles Auth Errors
+
+The `ApiInterceptor` in `controllers/API/api.tsx` automatically handles:
+- **401 Unauthorized**: Attempts token refresh via `useRefreshAccessToken`, then retries the request.
+- **403 Forbidden**: Same auth error flow as 401.
+- **After 3+ auth errors**: Logs the user out automatically.
+- **500 errors**: Clears build vertex state in the flow store.
+
+You do not need to handle 401/403 errors in individual hooks or components.
+
+### Mutation Error Handling
+
+Handle errors at the call site for user-facing feedback:
+
+```typescript
+const { mutate: saveFlow } = useSaveFlow()
+
+const handleSave = () => {
+  saveFlow(flowData, {
+    onError: (error) => {
+      setErrorData({
+        title: "Failed to save flow",
+        list: [error.response?.data?.detail ?? error.message],
+      })
+    },
+  })
+}
+```
+
+### Query Error Handling
+
+For queries, React Query's retry logic (5 retries with exponential backoff via `UseRequestProcessor`) handles transient failures. For permanent errors, use `onError` in options or error boundaries:
+
+```typescript
+const { data, error, isError } = useGetFlow(
+  { id: flowId },
+  {
+    retry: false, // Override default retry for known-missing resources
+    onError: (error) => {
+      if (error.response?.status === 404) {
+        navigate("/flows")
+      }
+    },
+  },
+)
+```
+
+## Streaming Requests
+
+Langflow uses `performStreamingRequest()` from `controllers/API/api.tsx` for build and chat streaming. This uses the browser `fetch` API (not Axios) with Server-Sent Events (SSE) parsing.
+
+### Streaming Architecture
+
+```typescript
+import { performStreamingRequest } from "@/controllers/API/api"
+
+const buildController = new AbortController()
+
+await performStreamingRequest({
+  method: "POST",
+  url: `${baseURL}/api/v1/build/${flowId}/flow`,
+  body: { inputs, files },
+  buildController,
+  onData: async (event) => {
+    // Process individual SSE events
+    // Return true to continue, false to abort
+    return true
+  },
+  onDataBatch: async (events) => {
+    // Process batch of events from a single chunk (more efficient)
+    // Return true to continue, false to abort
+    return true
+  },
+  onError: (statusCode) => {
+    // Handle HTTP error status
+  },
+  onNetworkError: (error) => {
+    // Handle network-level errors
+  },
+})
+```
+
+### Streaming vs REST Decision
+
+| Operation | Method |
+|-----------|--------|
+| Build flow | `performStreamingRequest()` with SSE |
+| Chat interaction | `performStreamingRequest()` with SSE |
+| CRUD operations (flows, folders, variables) | Axios `api` instance via query/mutation hooks |
+| File upload/download | Axios `api` instance |
+| Auth operations | Axios `api` instance |
+
+### Aborting Streams
+
+Use `AbortController` to cancel streaming operations:
+
+```typescript
+const buildController = useRef(new AbortController())
+
+const handleStopBuild = () => {
+  buildController.current.abort()
+  buildController.current = new AbortController()
+}
+```
+
+## UseRequestProcessor Defaults
+
+The `UseRequestProcessor` hook in `controllers/API/services/request-processor.ts` provides:
+
+### Query Defaults
+
+```typescript
+{
+  retry: 5,
+  retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+  // 1s, 2s, 4s, 8s, 16s (capped at 30s)
+}
+```
+
+### Mutation Defaults
+
+The actual `mutate()` implementation in `request-processor.ts`:
+
+```typescript
+function mutate(mutationKey, mutationFn, options = {}) {
+  return useMutation({
+    mutationKey,
+    mutationFn,
+    onSettled: (data, error, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: mutationKey });
+      options.onSettled && options.onSettled(data, error, variables, context);
+    },
+    ...options,                              // Spreads AFTER the wrapper onSettled
+    retry: options.retry ?? 3,               // Comes AFTER the spread
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+  });
+}
+```
+
+**How onSettled actually works (important subtlety):**
+
+1. `UseRequestProcessor.mutate()` defines a wrapper `onSettled` that (a) auto-invalidates the `mutationKey`, then (b) calls the hook's `options.onSettled`.
+2. **However**, the `...options` spread comes AFTER the wrapper, so if the hook's `options` object contains its own `onSettled`, it **overrides** the wrapper. This means the auto-invalidation is effectively **skipped** when hooks provide their own `onSettled`.
+3. In practice, most hooks DO provide their own `onSettled` with specific refetch/invalidation logic, so the auto-invalidation of the mutation key rarely runs.
+4. This is fine because invalidating a mutation key is usually unnecessary — mutations don't have cached entries like queries do.
+
+**Hook convention: place custom `onSettled` BEFORE `...options`:**
+
+```typescript
+mutate(["usePostAddFlow"], fn, {
+  onSettled: () => { queryClient.refetchQueries(...) },  // Hook-specific invalidation
+  retry: false,     // Override default retry if needed
+  ...options,       // Consumer options come LAST (can override onSettled, retry, etc.)
+})
+```
+
+### When to Use `retry: false`
+
+Override the default `retry: 3` with `retry: false` for mutations where retrying would cause problems:
+
+- **Create operations** that are not idempotent (duplicate creation risk)
+- **Update operations** on global variables or settings (stale data risk)
+- **Delete operations** where the resource may already be gone
+
+```typescript
+// Example: POST that creates a resource (not safe to retry)
+const mutation = mutate(["usePostGlobalVariables"], postFn, {
+  onSettled: () => { queryClient.refetchQueries({ queryKey: ["useGetGlobalVariables"] }) },
+  retry: false,
+  ...options,
+})
+```
+
+## Polling Patterns
+
+For queries that need periodic refreshing (build status, messages):
+
+```typescript
+export const useGetMessagesPolling: useQueryFunctionType<
+  { flowId: string; sessionId: string },
+  Message[]
+> = (params, options?) => {
+  const { query } = UseRequestProcessor()
+
+  const getMessagesFn = async (): Promise<Message[]> => {
+    const res = await api.get(
+      `${getURL("MESSAGES")}/?flow_id=${params.flowId}&session_id=${params.sessionId}`,
+    )
+    return res.data
+  }
+
+  return query(
+    ["useGetMessagesPolling", params.flowId, params.sessionId],
+    getMessagesFn,
+    {
+      refetchInterval: 3000, // Poll every 3 seconds
+      refetchIntervalInBackground: false,
+      ...options,
+    },
+  )
+}
+```

--- a/.agents/skills/frontend-testing/SKILL.md
+++ b/.agents/skills/frontend-testing/SKILL.md
@@ -1,0 +1,296 @@
+# Frontend Testing Skill - Langflow
+
+## When to Apply
+
+Activate this skill when:
+- Writing new unit or integration tests for React components, hooks, utilities, or Zustand stores
+- Reviewing existing tests for correctness, coverage, or best practices
+- Improving test coverage for under-tested modules
+- Debugging flaky or failing tests
+- Refactoring test code for maintainability
+
+## Tech Stack
+
+| Technology | Version | Purpose |
+|---|---|---|
+| Jest | 30.x | Test runner and assertion framework |
+| ts-jest | 29.x | TypeScript transform for Jest |
+| React Testing Library | 16.x | Component rendering and DOM queries |
+| @testing-library/user-event | 14.x | Realistic user interaction simulation |
+| @testing-library/jest-dom | 6.x | Extended DOM matchers |
+| jsdom | (via jest-environment-jsdom 30.x) | Browser environment simulation |
+| React | 19.x | UI framework |
+| TypeScript | 5.4 | Type safety |
+| Zustand | 4.x | State management |
+| React Router DOM | 6.x | Client-side routing |
+| @tanstack/react-query | 5.x | Server state management |
+| Axios | 1.x | HTTP client |
+
+## Project Configuration
+
+- **Jest config**: `src/frontend/jest.config.js`
+- **Setup files**: `src/frontend/jest.setup.js` (globals/mocks) and `src/frontend/src/setupTests.ts` (DOM matchers, ResizeObserver, IntersectionObserver, matchMedia)
+- **Path alias**: `@/` maps to `<rootDir>/src/`
+- **Test match patterns**: `src/**/__tests__/**/*.{test,spec}.{ts,tsx}` and `src/**/*.{test,spec}.{ts,tsx}`
+- **Transform**: Custom `transform-import-meta.js` handles `import.meta` for Jest compatibility
+- **Global mocks** (in `jest.setup.js`): `@radix-ui/react-form`, `react-markdown`, `lucide-react/dynamicIconImports`, `@/components/common/genericIconComponent`, `@/icons/BotMessageSquare`, `@/stores/darkStore`, `localStorage`, `sessionStorage`, `crypto`
+
+## Key Commands
+
+```bash
+# Run all tests
+npm test
+
+# Run a specific test file
+npm test -- path/to/file.test.tsx
+
+# Run tests matching a pattern
+npm test -- --testPathPattern="alertStore"
+
+# Run tests in watch mode
+npm run test:watch
+
+# Run tests with coverage
+npm run test:coverage
+
+# Run a single test file with coverage
+npm test -- --coverage --collectCoverageFrom='src/path/to/source.ts' path/to/__tests__/source.test.ts
+```
+
+## File Naming and Location
+
+Test files follow one of two patterns:
+
+1. **Dedicated `__tests__` directory** (preferred for components and modules):
+   ```
+   src/components/core/my-component/
+   ├── my-component.tsx
+   └── __tests__/
+       └── my-component.test.tsx
+   ```
+
+2. **Co-located test file** (acceptable for utilities and simple modules):
+   ```
+   src/utils/
+   ├── myUtil.ts
+   └── myUtil.test.ts
+   ```
+
+Naming convention: `ComponentName.test.tsx` for components, `hook-name.test.ts` for hooks, `util-name.test.ts` for utilities.
+
+**Do NOT use `.spec.tsx`** -- while technically matched, the project convention is `.test.tsx`.
+
+## Test Structure Template
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MyComponent from "../MyComponent";
+
+// Mock dependencies (use jest.mock, NOT vi.mock)
+jest.mock("@/controllers/API/api", () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+}));
+
+describe("MyComponent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("should render the component with default props", () => {
+      // Arrange
+      render(<MyComponent />);
+
+      // Act - (none for render test)
+
+      // Assert
+      expect(screen.getByRole("button", { name: /submit/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("user interactions", () => {
+    it("should call onSubmit when the form is submitted", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const onSubmit = jest.fn();
+      render(<MyComponent onSubmit={onSubmit} />);
+
+      // Act
+      await user.click(screen.getByRole("button", { name: /submit/i }));
+
+      // Assert
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+```
+
+## Incremental Testing Workflow
+
+When testing a directory with multiple files, follow this order:
+
+1. **Identify all source files** in the target directory
+2. **Order by complexity** (simplest first):
+   - Pure utility functions (no React, no side effects)
+   - Constants and configuration objects
+   - Custom hooks (no UI rendering)
+   - Simple presentational components (no state, no side effects)
+   - Stateful components with local state
+   - Components using Zustand stores
+   - Components with API calls or complex async behavior
+   - Integration-level components that compose many children
+3. **For each file**:
+   a. Read the source file completely
+   b. Identify all exported functions, components, and types
+   c. Write tests covering all branches and edge cases
+   d. Run the tests and fix any failures
+   e. Check coverage and add tests for uncovered lines
+   f. Move to the next file
+4. **Run full directory coverage** at the end to verify
+
+## Complexity-Based Test Ordering
+
+Within a single test file, order test cases from simplest to most complex:
+
+1. Default rendering / initial state
+2. Props variations and conditional rendering
+3. User interactions (clicks, typing, form submission)
+4. Async operations (API calls, timers)
+5. Error states and edge cases
+6. Integration with stores or context
+7. Cleanup and unmount behavior
+
+## Core Principles
+
+### Arrange-Act-Assert (AAA)
+Every test should have a clear three-phase structure. Use blank lines to separate each phase for readability.
+
+### Black-Box Testing
+Test the component from the user's perspective. Query by role, label, text, or `data-testid` -- never by CSS class, internal state variable, or implementation detail.
+
+### Single Behavior Per Test
+Each `it()` block should verify exactly one behavior. If you need to write "and" in the test name, split it into two tests.
+
+### Semantic Test Names
+Use descriptive names that explain the expected behavior:
+- Good: `"should disable the submit button when the form is invalid"`
+- Bad: `"button test"` or `"test 1"`
+
+Format: `"should [expected behavior] when [condition]"`
+
+## Required Test Scenarios
+
+For every component, cover at minimum:
+
+### Rendering
+- Default render with no optional props
+- Render with all optional props provided
+- Conditional rendering branches (if/else in JSX)
+
+### Props and State
+- Each prop variation that changes rendered output
+- Default prop values
+- State transitions triggered by user actions
+
+### User Interactions
+- Click handlers
+- Form input and submission
+- Keyboard navigation (if applicable)
+- Hover/focus states (if applicable)
+
+### Challenge Tests (MANDATORY — not optional)
+
+**Happy path tests alone are NOT enough.** They only confirm the code works when everything is perfect. Real bugs hide in the cracks. You MUST write tests that actively TRY TO BREAK the code:
+
+**Unexpected inputs:**
+- `null`, `undefined`, `""`, `[]`, `{}`, `0`, `-1`, `NaN`, `Infinity`
+- What happens when a required prop is missing?
+- What happens when data from the API comes back with missing fields?
+
+**Boundary values:**
+- Max length strings (paste 10,000 chars in an input)
+- Exactly at the limit, one past the limit
+- Zero items, one item, maximum items
+- First page, last page, out-of-range page
+
+**Malformed data:**
+- API returns `{ data: null }` instead of `{ data: [] }`
+- JSON with extra unexpected fields
+- Dates in wrong format, numbers as strings
+
+**Error states:**
+- Network failure (API rejects with 500)
+- Authentication expired mid-action (401)
+- Resource not found (404)
+- Permission denied (403)
+- Timeout
+
+**What should NOT happen:**
+- Verify that deleting a flow does NOT delete flows from other users
+- Verify that a read-only user CANNOT trigger write mutations
+- Verify that XSS payloads in user input are sanitized
+
+**Rapid/concurrent actions:**
+- Double-click on submit button
+- Rapid repeated API calls
+- Unmount component while async operation is in flight
+
+**Write tests based on REQUIREMENTS, not on what the source code does.** This is how you catch bugs where the code diverges from expected behavior.
+
+**When a test fails:** first ask if the CODE is wrong, not the test. Do NOT silently change a failing assertion to match the current code without understanding WHY.
+
+### Async Behavior
+- Loading states
+- Success states
+- Error states
+- Timeout/retry behavior
+
+## Coverage Goals
+
+Per source file:
+- **Function coverage**: 100%
+- **Branch coverage**: > 95%
+- **Line coverage**: > 95%
+- **Statement coverage**: > 95%
+
+Run coverage for a specific file:
+```bash
+npm test -- --coverage --collectCoverageFrom='src/path/to/file.ts' src/path/to/__tests__/file.test.ts
+```
+
+## Important Rules
+
+1. **Never use Vitest APIs**: Use `jest.fn()`, `jest.mock()`, `jest.spyOn()`, `jest.mocked()` -- never `vi.*` equivalents.
+2. **Never mock base UI components** from `@/components/ui/` -- render them as-is.
+3. **Check `jest.setup.js` before mocking**: Many modules are already globally mocked (darkStore, genericIconComponent, react-markdown, radix-form, etc.). Do not re-mock them.
+4. **Use `@testing-library/user-event`** over `fireEvent` for user interactions.
+5. **Wrap state updates in `act()`** when testing Zustand stores or React state changes.
+6. **Clean up after each test**: Use `beforeEach(() => jest.clearAllMocks())` and `afterEach` for timers.
+7. **Always write both happy path AND adversarial tests** (null, undefined, empty values, boundary conditions, error states).
+8. **Minimum coverage: 75%** (target 80%). Below 75% the task is not complete.
+
+## Forbidden Test Anti-Patterns
+
+| Pattern | Problem | How to Detect |
+|---------|---------|---------------|
+| **The Liar** | Test passes but doesn't verify the behavior it claims to test | Assertions don't match the test name |
+| **The Mirror** | Test reads source code and asserts exactly what the code does — finds zero bugs | Test would never fail even if logic changes |
+| **The Giant** | 50+ lines of setup, multiple acts, dozens of assertions | Should be 5+ separate tests |
+| **The Mockery** | So many mocks that the test only tests the mock setup | Count mocks — if > 3 deep, rethink |
+| **The Inspector** | Coupled to implementation details, breaks on any refactor | Tests internal state instead of behavior |
+| **The Chain Gang** | Tests depend on execution order or share mutable state | Tests fail when run in isolation |
+| **The Flaky** | Sometimes passes, sometimes fails with no code changes | Non-deterministic assertions or timing issues |
+
+## References
+
+- [Incremental Testing Workflow](references/workflow.md) - Step-by-step process for testing directories
+- [Mocking Guide](references/mocking.md) - Patterns for mocking APIs, stores, routers, and context
+- [Async Testing](references/async-testing.md) - Patterns for async operations, timers, and waitFor
+- [Common Patterns](references/common-patterns.md) - Query priority, events, forms, modals, data-driven tests
+- [Test Checklist](references/checklist.md) - Pre-submission verification checklist
+- [Domain Components](references/domain-components.md) - Langflow-specific component testing patterns
+- [Component Template](assets/component-test.template.tsx) - Starter template for component tests
+- [Hook Template](assets/hook-test.template.ts) - Starter template for hook tests
+- [Utility Template](assets/utility-test.template.ts) - Starter template for utility tests

--- a/.agents/skills/frontend-testing/assets/component-test.template.tsx
+++ b/.agents/skills/frontend-testing/assets/component-test.template.tsx
@@ -1,0 +1,203 @@
+/**
+ * Test template for React components in Langflow.
+ *
+ * Usage:
+ * 1. Copy this file to `__tests__/ComponentName.test.tsx`
+ * 2. Replace all TEMPLATE_* placeholders with actual values
+ * 3. Remove unused sections
+ * 4. Run: npm test -- path/to/__tests__/ComponentName.test.tsx
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+// Replace with actual component import path
+import TEMPLATE_COMPONENT from "../TEMPLATE_COMPONENT";
+
+// ============================================================
+// Mocks
+// ============================================================
+
+// Mock API calls (if component fetches data)
+// jest.mock("@/controllers/API/api", () => ({
+//   __esModule: true,
+//   default: {
+//     get: jest.fn(),
+//     post: jest.fn(),
+//   },
+// }));
+
+// Mock Zustand stores (if component reads from stores)
+// jest.mock("@/stores/flowStore", () => ({
+//   __esModule: true,
+//   default: (selector?: (state: any) => any) =>
+//     selector ? selector({ nodes: [], edges: [] }) : {},
+// }));
+
+// Mock child components (only if they have complex dependencies)
+// jest.mock("../ChildComponent", () => ({
+//   __esModule: true,
+//   default: (props: any) => <div data-testid="mock-child">{props.label}</div>,
+// }));
+
+// ============================================================
+// Test Data
+// ============================================================
+
+const defaultProps = {
+  // Replace with actual default props for the component
+  // title: "Test Title",
+  // onClick: jest.fn(),
+};
+
+// ============================================================
+// Helper Functions
+// ============================================================
+
+function renderComponent(overrides = {}) {
+  const props = { ...defaultProps, ...overrides };
+  return render(<TEMPLATE_COMPONENT {...props} />);
+}
+
+// Use this if the component requires providers (router, query client, context)
+// function renderWithProviders(overrides = {}) {
+//   const props = { ...defaultProps, ...overrides };
+//   const queryClient = new QueryClient({
+//     defaultOptions: { queries: { retry: false } },
+//   });
+//   return render(
+//     <QueryClientProvider client={queryClient}>
+//       <MemoryRouter>
+//         <TEMPLATE_COMPONENT {...props} />
+//       </MemoryRouter>
+//     </QueryClientProvider>,
+//   );
+// }
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("TEMPLATE_COMPONENT", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ----------------------------------------------------------
+  // Rendering
+  // ----------------------------------------------------------
+
+  describe("rendering", () => {
+    it("should render with default props", () => {
+      renderComponent();
+
+      // Replace with actual assertions
+      // expect(screen.getByRole("button")).toBeInTheDocument();
+      // expect(screen.getByText("Test Title")).toBeInTheDocument();
+    });
+
+    it("should render with all optional props", () => {
+      renderComponent({
+        // Provide all optional props
+      });
+
+      // Assert all optional elements are rendered
+    });
+
+    it("should apply conditional rendering based on props", () => {
+      // Test each conditional branch in the JSX
+    });
+  });
+
+  // ----------------------------------------------------------
+  // User Interactions
+  // ----------------------------------------------------------
+
+  describe("user interactions", () => {
+    it("should handle click events", async () => {
+      const user = userEvent.setup();
+      const onClick = jest.fn();
+      renderComponent({ onClick });
+
+      await user.click(screen.getByRole("button"));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle text input", async () => {
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+      renderComponent({ onChange });
+
+      await user.type(screen.getByRole("textbox"), "test input");
+
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
+
+  // ----------------------------------------------------------
+  // Async Behavior
+  // ----------------------------------------------------------
+
+  // describe("async behavior", () => {
+  //   it("should show loading state initially", () => {
+  //     renderComponent();
+  //     expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+  //   });
+  //
+  //   it("should display data after loading", async () => {
+  //     jest.mocked(api.get).mockResolvedValueOnce({
+  //       data: { items: [{ id: "1", name: "Test" }] },
+  //     });
+  //
+  //     renderComponent();
+  //
+  //     await waitFor(() => {
+  //       expect(screen.getByText("Test")).toBeInTheDocument();
+  //     });
+  //   });
+  //
+  //   it("should handle API errors gracefully", async () => {
+  //     jest.mocked(api.get).mockRejectedValueOnce(new Error("Network error"));
+  //
+  //     renderComponent();
+  //
+  //     await waitFor(() => {
+  //       expect(screen.getByText(/error/i)).toBeInTheDocument();
+  //     });
+  //   });
+  // });
+
+  // ----------------------------------------------------------
+  // Edge Cases
+  // ----------------------------------------------------------
+
+  describe("edge cases", () => {
+    it("should handle empty data", () => {
+      renderComponent({
+        // Pass empty arrays, empty strings, etc.
+      });
+
+      // Assert empty state rendering
+    });
+
+    it("should handle undefined optional props", () => {
+      renderComponent({
+        // Explicitly pass undefined for optional props
+      });
+
+      // Assert fallback behavior
+    });
+  });
+
+  // ----------------------------------------------------------
+  // Cleanup
+  // ----------------------------------------------------------
+
+  // describe("cleanup", () => {
+  //   it("should clean up on unmount", () => {
+  //     const { unmount } = renderComponent();
+  //     unmount();
+  //     // Assert cleanup (e.g., clearInterval called, event listeners removed)
+  //   });
+  // });
+});

--- a/.agents/skills/frontend-testing/assets/hook-test.template.ts
+++ b/.agents/skills/frontend-testing/assets/hook-test.template.ts
@@ -1,0 +1,240 @@
+/**
+ * Test template for custom React hooks in Langflow.
+ *
+ * Usage:
+ * 1. Copy this file to `__tests__/use-hook-name.test.ts`
+ * 2. Replace all TEMPLATE_* placeholders with actual values
+ * 3. Remove unused sections
+ * 4. Run: npm test -- path/to/__tests__/use-hook-name.test.ts
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+// Replace with actual hook import path
+import { TEMPLATE_HOOK } from "../TEMPLATE_HOOK";
+
+// ============================================================
+// Mocks
+// ============================================================
+
+// Mock dependencies (if the hook calls APIs, reads stores, etc.)
+// jest.mock("@/controllers/API/api", () => ({
+//   __esModule: true,
+//   default: {
+//     get: jest.fn(),
+//     post: jest.fn(),
+//   },
+// }));
+
+// Mock Zustand store (if the hook reads from a store)
+// import useMyStore from "@/stores/myStore";
+// beforeEach(() => {
+//   useMyStore.setState({ items: [], loading: false });
+// });
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("TEMPLATE_HOOK", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ----------------------------------------------------------
+  // Initial State
+  // ----------------------------------------------------------
+
+  describe("initial state", () => {
+    it("should return the correct initial value", () => {
+      const { result } = renderHook(() => TEMPLATE_HOOK());
+
+      // Replace with actual initial state assertions
+      // expect(result.current.value).toBe(initialValue);
+      // expect(result.current.loading).toBe(false);
+      // expect(result.current.error).toBeNull();
+    });
+  });
+
+  // ----------------------------------------------------------
+  // State Updates
+  // ----------------------------------------------------------
+
+  describe("state updates", () => {
+    it("should update state when action is called", () => {
+      const { result } = renderHook(() => TEMPLATE_HOOK());
+
+      act(() => {
+        // Call the hook's update function
+        // result.current.setValue("new value");
+      });
+
+      // Assert the new state
+      // expect(result.current.value).toBe("new value");
+    });
+
+    it("should handle multiple sequential updates", () => {
+      const { result } = renderHook(() => TEMPLATE_HOOK());
+
+      act(() => {
+        // result.current.increment();
+        // result.current.increment();
+        // result.current.increment();
+      });
+
+      // expect(result.current.count).toBe(3);
+    });
+  });
+
+  // ----------------------------------------------------------
+  // Parameters
+  // ----------------------------------------------------------
+
+  describe("parameters", () => {
+    it("should accept and use initial parameters", () => {
+      const { result } = renderHook(() =>
+        TEMPLATE_HOOK(/* initial params */),
+      );
+
+      // Assert hook uses the provided parameters
+    });
+
+    it("should react to parameter changes on rerender", () => {
+      const { result, rerender } = renderHook(
+        ({ param }) => TEMPLATE_HOOK(param),
+        { initialProps: { param: "initial" } },
+      );
+
+      // Assert initial state
+      // expect(result.current.value).toBe("initial");
+
+      // Rerender with new parameter
+      rerender({ param: "updated" });
+
+      // Assert updated state
+      // expect(result.current.value).toBe("updated");
+    });
+  });
+
+  // ----------------------------------------------------------
+  // Async Behavior
+  // ----------------------------------------------------------
+
+  // describe("async behavior", () => {
+  //   it("should fetch data on mount", async () => {
+  //     jest.mocked(api.get).mockResolvedValueOnce({
+  //       data: { items: [{ id: "1" }] },
+  //     });
+  //
+  //     const { result } = renderHook(() => TEMPLATE_HOOK());
+  //
+  //     // Initially loading
+  //     expect(result.current.loading).toBe(true);
+  //
+  //     // Wait for data
+  //     await waitFor(() => {
+  //       expect(result.current.loading).toBe(false);
+  //     });
+  //
+  //     expect(result.current.data).toEqual([{ id: "1" }]);
+  //   });
+  //
+  //   it("should handle fetch errors", async () => {
+  //     jest.mocked(api.get).mockRejectedValueOnce(new Error("Failed"));
+  //
+  //     const { result } = renderHook(() => TEMPLATE_HOOK());
+  //
+  //     await waitFor(() => {
+  //       expect(result.current.error).toBeTruthy();
+  //     });
+  //   });
+  // });
+
+  // ----------------------------------------------------------
+  // Debounced/Throttled Behavior
+  // ----------------------------------------------------------
+
+  // describe("debounced behavior", () => {
+  //   beforeEach(() => {
+  //     jest.useFakeTimers();
+  //   });
+  //
+  //   afterEach(() => {
+  //     jest.runOnlyPendingTimers();
+  //     jest.useRealTimers();
+  //   });
+  //
+  //   it("should debounce the callback", () => {
+  //     const callback = jest.fn();
+  //     const { result } = renderHook(() => TEMPLATE_HOOK(callback, 500));
+  //
+  //     result.current("arg1");
+  //     result.current("arg2");
+  //     result.current("arg3");
+  //
+  //     expect(callback).not.toHaveBeenCalled();
+  //
+  //     jest.advanceTimersByTime(500);
+  //
+  //     expect(callback).toHaveBeenCalledTimes(1);
+  //     expect(callback).toHaveBeenCalledWith("arg3");
+  //   });
+  // });
+
+  // ----------------------------------------------------------
+  // Memoization
+  // ----------------------------------------------------------
+
+  describe("memoization", () => {
+    it("should return stable reference when dependencies do not change", () => {
+      const { result, rerender } = renderHook(() => TEMPLATE_HOOK());
+
+      const firstResult = result.current;
+      rerender();
+      const secondResult = result.current;
+
+      // For functions/objects that should be memoized:
+      // expect(firstResult.handler).toBe(secondResult.handler);
+    });
+  });
+
+  // ----------------------------------------------------------
+  // Edge Cases
+  // ----------------------------------------------------------
+
+  describe("edge cases", () => {
+    it("should handle empty input", () => {
+      const { result } = renderHook(() => TEMPLATE_HOOK(/* empty/null */));
+
+      // Assert graceful handling
+    });
+
+    it("should handle rapid calls", () => {
+      const { result } = renderHook(() => TEMPLATE_HOOK());
+
+      act(() => {
+        for (let i = 0; i < 100; i++) {
+          // result.current.action();
+        }
+      });
+
+      // Assert correct final state
+    });
+  });
+
+  // ----------------------------------------------------------
+  // Cleanup
+  // ----------------------------------------------------------
+
+  // describe("cleanup", () => {
+  //   it("should clean up resources on unmount", () => {
+  //     const removeListenerSpy = jest.fn();
+  //     jest.spyOn(window, "addEventListener").mockImplementation(() => {});
+  //     jest.spyOn(window, "removeEventListener").mockImplementation(removeListenerSpy);
+  //
+  //     const { unmount } = renderHook(() => TEMPLATE_HOOK());
+  //     unmount();
+  //
+  //     expect(removeListenerSpy).toHaveBeenCalled();
+  //   });
+  // });
+});

--- a/.agents/skills/frontend-testing/assets/utility-test.template.ts
+++ b/.agents/skills/frontend-testing/assets/utility-test.template.ts
@@ -1,0 +1,185 @@
+/**
+ * Test template for utility/helper functions in Langflow.
+ *
+ * Usage:
+ * 1. Copy this file to `__tests__/util-name.test.ts`
+ * 2. Replace all TEMPLATE_* placeholders with actual values
+ * 3. Remove unused sections
+ * 4. Run: npm test -- path/to/__tests__/util-name.test.ts
+ */
+
+// Replace with actual utility import path
+import {
+  TEMPLATE_FUNCTION_A,
+  TEMPLATE_FUNCTION_B,
+} from "../TEMPLATE_UTIL_FILE";
+
+// ============================================================
+// Mocks (only if the utility has side effects or external deps)
+// ============================================================
+
+// jest.mock("@/controllers/API/api", () => ({
+//   __esModule: true,
+//   default: { get: jest.fn(), post: jest.fn() },
+// }));
+
+// ============================================================
+// Test Data
+// ============================================================
+
+// Define reusable test fixtures
+// const VALID_INPUT = { id: "1", name: "Test" };
+// const EMPTY_INPUT = {};
+// const INVALID_INPUT = null;
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("TEMPLATE_FUNCTION_A", () => {
+  // ----------------------------------------------------------
+  // Normal Cases
+  // ----------------------------------------------------------
+
+  describe("normal cases", () => {
+    it("should return expected output for standard input", () => {
+      // const result = TEMPLATE_FUNCTION_A(VALID_INPUT);
+      // expect(result).toEqual(expectedOutput);
+    });
+
+    it("should handle multiple valid inputs", () => {
+      // Test with different valid inputs
+    });
+  });
+
+  // ----------------------------------------------------------
+  // Data-Driven Tests
+  // ----------------------------------------------------------
+
+  // Use it.each for functions with many input/output combinations
+  // it.each([
+  //   { input: "hello", expected: "HELLO", description: "lowercase string" },
+  //   { input: "Hello", expected: "HELLO", description: "mixed case string" },
+  //   { input: "", expected: "", description: "empty string" },
+  //   { input: "HELLO", expected: "HELLO", description: "already uppercase" },
+  // ])("should return $expected for $description", ({ input, expected }) => {
+  //   expect(TEMPLATE_FUNCTION_A(input)).toBe(expected);
+  // });
+
+  // Alternatively, use array format for simpler cases:
+  // it.each([
+  //   [0, "0s"],
+  //   [500, "0.5s"],
+  //   [1000, "1.0s"],
+  //   [60000, "1m 0s"],
+  // ])("should format %i ms as %s", (input, expected) => {
+  //   expect(TEMPLATE_FUNCTION_A(input)).toBe(expected);
+  // });
+
+  // ----------------------------------------------------------
+  // Edge Cases
+  // ----------------------------------------------------------
+
+  describe("edge cases", () => {
+    it("should handle empty input", () => {
+      // const result = TEMPLATE_FUNCTION_A("");
+      // expect(result).toBe(expectedDefault);
+    });
+
+    it("should handle null or undefined", () => {
+      // expect(TEMPLATE_FUNCTION_A(null)).toBe(fallbackValue);
+      // expect(TEMPLATE_FUNCTION_A(undefined)).toBe(fallbackValue);
+    });
+
+    it("should handle boundary values", () => {
+      // Test with minimum/maximum values
+      // expect(TEMPLATE_FUNCTION_A(0)).toBe(expectedForZero);
+      // expect(TEMPLATE_FUNCTION_A(Number.MAX_SAFE_INTEGER)).toBe(expectedForMax);
+    });
+
+    it("should handle special characters", () => {
+      // Test with unicode, emojis, special chars if applicable
+    });
+  });
+
+  // ----------------------------------------------------------
+  // Error Cases
+  // ----------------------------------------------------------
+
+  describe("error cases", () => {
+    it("should throw for invalid input", () => {
+      // expect(() => TEMPLATE_FUNCTION_A(invalidInput)).toThrow("Expected error message");
+    });
+
+    it("should return fallback for malformed data", () => {
+      // const result = TEMPLATE_FUNCTION_A(malformedData);
+      // expect(result).toBe(fallbackValue);
+    });
+  });
+
+  // ----------------------------------------------------------
+  // Type-Specific Tests
+  // ----------------------------------------------------------
+
+  // describe("with arrays", () => {
+  //   it("should handle empty array", () => {
+  //     expect(TEMPLATE_FUNCTION_A([])).toEqual([]);
+  //   });
+  //
+  //   it("should handle single element", () => {
+  //     expect(TEMPLATE_FUNCTION_A([1])).toEqual([expectedSingle]);
+  //   });
+  //
+  //   it("should preserve order", () => {
+  //     const input = [3, 1, 2];
+  //     const result = TEMPLATE_FUNCTION_A(input);
+  //     expect(result).toEqual([expectedOrdered]);
+  //   });
+  //
+  //   it("should not mutate the original array", () => {
+  //     const input = [1, 2, 3];
+  //     const inputCopy = [...input];
+  //     TEMPLATE_FUNCTION_A(input);
+  //     expect(input).toEqual(inputCopy);
+  //   });
+  // });
+
+  // describe("with objects", () => {
+  //   it("should handle nested objects", () => {
+  //     const input = { a: { b: { c: "deep" } } };
+  //     expect(TEMPLATE_FUNCTION_A(input)).toBe(expectedDeep);
+  //   });
+  //
+  //   it("should not mutate the original object", () => {
+  //     const input = { key: "value" };
+  //     const inputCopy = { ...input };
+  //     TEMPLATE_FUNCTION_A(input);
+  //     expect(input).toEqual(inputCopy);
+  //   });
+  // });
+});
+
+// ============================================================
+// Second Function (if the file exports multiple functions)
+// ============================================================
+
+describe("TEMPLATE_FUNCTION_B", () => {
+  it("should return expected output for standard input", () => {
+    // const result = TEMPLATE_FUNCTION_B(input);
+    // expect(result).toBe(expected);
+  });
+
+  // Add more tests following the same pattern as above
+});
+
+// ============================================================
+// Integration Tests (if functions work together)
+// ============================================================
+
+// describe("integration", () => {
+//   it("should compose TEMPLATE_FUNCTION_A and TEMPLATE_FUNCTION_B correctly", () => {
+//     const intermediate = TEMPLATE_FUNCTION_A(rawInput);
+//     const result = TEMPLATE_FUNCTION_B(intermediate);
+//     expect(result).toBe(expectedFinalOutput);
+//   });
+// });

--- a/.agents/skills/frontend-testing/references/async-testing.md
+++ b/.agents/skills/frontend-testing/references/async-testing.md
@@ -1,0 +1,347 @@
+# Async Testing Patterns
+
+Patterns for testing asynchronous behavior in Langflow with Jest and React Testing Library.
+
+## waitFor
+
+Use `waitFor` when you need to wait for an asynchronous operation to complete before making assertions.
+
+```typescript
+import { render, screen, waitFor } from "@testing-library/react";
+
+it("should load and display data", async () => {
+  jest.mocked(api.get).mockResolvedValueOnce({
+    data: { items: [{ id: "1", name: "Test Item" }] },
+  });
+
+  render(<ItemList />);
+
+  // Wait for the async data to appear
+  await waitFor(() => {
+    expect(screen.getByText("Test Item")).toBeInTheDocument();
+  });
+});
+```
+
+### waitFor Options
+
+```typescript
+await waitFor(
+  () => {
+    expect(screen.getByText("loaded")).toBeInTheDocument();
+  },
+  {
+    timeout: 3000,    // Max time to wait (default: 1000ms)
+    interval: 50,     // Polling interval (default: 50ms)
+  },
+);
+```
+
+### waitFor Best Practices
+
+- Put only ONE assertion inside `waitFor`. Multiple assertions can cause misleading failures.
+- Use `waitFor` for appearance, not disappearance. Use `waitForElementToBeRemoved` for that.
+- Do not use `waitFor` for synchronous operations -- it adds unnecessary delay.
+
+```typescript
+// GOOD: Single assertion in waitFor
+await waitFor(() => {
+  expect(screen.getByText("Data loaded")).toBeInTheDocument();
+});
+
+// BAD: Multiple assertions -- if second fails, first may have been true
+await waitFor(() => {
+  expect(screen.getByText("Data loaded")).toBeInTheDocument();
+  expect(screen.getByText("5 items")).toBeInTheDocument(); // unreliable
+});
+
+// GOOD: Chain waitFor calls
+await waitFor(() => {
+  expect(screen.getByText("Data loaded")).toBeInTheDocument();
+});
+expect(screen.getByText("5 items")).toBeInTheDocument();
+```
+
+## waitForElementToBeRemoved
+
+```typescript
+it("should hide loading spinner after data loads", async () => {
+  jest.mocked(api.get).mockResolvedValueOnce({ data: [] });
+
+  render(<ItemList />);
+
+  // Spinner appears immediately
+  expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+
+  // Wait for it to disappear
+  await waitForElementToBeRemoved(() =>
+    screen.queryByTestId("loading-spinner"),
+  );
+
+  // Now assert the loaded state
+  expect(screen.getByText("No items found")).toBeInTheDocument();
+});
+```
+
+## findBy Queries
+
+`findBy*` queries return a promise that resolves when the element appears. They are shorthand for `waitFor` + `getBy*`.
+
+```typescript
+it("should display async content", async () => {
+  jest.mocked(api.get).mockResolvedValueOnce({ data: { name: "Test" } });
+
+  render(<AsyncComponent />);
+
+  // findByText = waitFor(() => getByText(...))
+  const element = await screen.findByText("Test");
+  expect(element).toBeInTheDocument();
+});
+```
+
+### findBy with Custom Timeout
+
+```typescript
+const element = await screen.findByText("Slow content", {}, { timeout: 5000 });
+```
+
+## Fake Timers
+
+Use fake timers for components that use `setTimeout`, `setInterval`, or `Date.now`.
+
+```typescript
+describe("TimerComponent", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("should update after interval", () => {
+    render(<TimerComponent interval={1000} />);
+
+    expect(screen.getByText("0 seconds")).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(screen.getByText("3 seconds")).toBeInTheDocument();
+  });
+
+  it("should clean up interval on unmount", () => {
+    const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+
+    const { unmount } = render(<TimerComponent interval={1000} />);
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+});
+```
+
+### Combining Fake Timers with Async Operations
+
+When a component uses both timers and async operations (API calls), you need special handling:
+
+```typescript
+it("should poll for updates", async () => {
+  jest.useFakeTimers();
+
+  const mockGet = jest.mocked(api.get);
+  mockGet
+    .mockResolvedValueOnce({ data: { status: "pending" } })
+    .mockResolvedValueOnce({ data: { status: "complete" } });
+
+  render(<PollingComponent />);
+
+  // First fetch happens immediately
+  await waitFor(() => {
+    expect(screen.getByText("pending")).toBeInTheDocument();
+  });
+
+  // Advance past the polling interval
+  act(() => {
+    jest.advanceTimersByTime(5000);
+  });
+
+  // Second fetch resolves
+  await waitFor(() => {
+    expect(screen.getByText("complete")).toBeInTheDocument();
+  });
+
+  jest.useRealTimers();
+});
+```
+
+### Mocking Date.now
+
+For components that use `Date.now()` for elapsed time:
+
+```typescript
+it("should track elapsed time", async () => {
+  const realDateNow = Date.now;
+  let mockTime = 1000000;
+  Date.now = jest.fn(() => mockTime);
+
+  jest.useFakeTimers();
+
+  render(<ElapsedTimer />);
+
+  // Advance mock time by 2 seconds
+  mockTime += 2000;
+  act(() => {
+    jest.advanceTimersByTime(100); // Trigger interval callback
+  });
+
+  await waitFor(() => {
+    expect(screen.getByText("2.0s")).toBeInTheDocument();
+  });
+
+  Date.now = realDateNow;
+  jest.useRealTimers();
+});
+```
+
+## Testing Promise Rejection
+
+```typescript
+it("should display error message on API failure", async () => {
+  jest.mocked(api.get).mockRejectedValueOnce(new Error("Server error"));
+
+  render(<DataComponent />);
+
+  await waitFor(() => {
+    expect(screen.getByText(/server error/i)).toBeInTheDocument();
+  });
+});
+```
+
+## Testing Debounced Functions
+
+```typescript
+it("should debounce search input", async () => {
+  jest.useFakeTimers();
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(<SearchInput onSearch={mockSearch} debounceMs={300} />);
+
+  const input = screen.getByRole("textbox");
+  await user.type(input, "hello");
+
+  // Should not have called search yet
+  expect(mockSearch).not.toHaveBeenCalled();
+
+  // Advance past debounce delay
+  act(() => {
+    jest.advanceTimersByTime(300);
+  });
+
+  expect(mockSearch).toHaveBeenCalledWith("hello");
+
+  jest.useRealTimers();
+});
+```
+
+**Important**: When using `userEvent` with fake timers, pass `advanceTimers: jest.advanceTimersByTime` to the setup options. This allows userEvent to advance fake timers during its internal delays.
+
+## Testing Event Streams / WebSockets
+
+For components that consume SSE or WebSocket events:
+
+```typescript
+it("should handle streaming messages", async () => {
+  const mockEventSource = {
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    close: jest.fn(),
+  };
+
+  jest.spyOn(global, "EventSource" as any).mockImplementation(
+    () => mockEventSource,
+  );
+
+  render(<StreamingChat />);
+
+  // Simulate incoming message
+  const onMessage = mockEventSource.addEventListener.mock.calls.find(
+    ([event]: [string]) => event === "message",
+  )?.[1];
+
+  act(() => {
+    onMessage?.({ data: JSON.stringify({ text: "Hello from stream" }) });
+  });
+
+  expect(screen.getByText("Hello from stream")).toBeInTheDocument();
+});
+```
+
+## Testing React Query Mutations
+
+```typescript
+it("should save and show success", async () => {
+  const user = userEvent.setup();
+  jest.mocked(api.post).mockResolvedValueOnce({ data: { id: "new-1" } });
+
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <CreateForm />
+    </QueryClientProvider>,
+  );
+
+  await user.type(screen.getByLabelText("Name"), "New Item");
+  await user.click(screen.getByRole("button", { name: /save/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/saved successfully/i)).toBeInTheDocument();
+  });
+
+  expect(api.post).toHaveBeenCalledWith("/api/v1/items", {
+    name: "New Item",
+  });
+});
+```
+
+## Testing Loading States
+
+```typescript
+it("should show loading then content", async () => {
+  let resolvePromise: (value: any) => void;
+  const promise = new Promise((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  jest.mocked(api.get).mockReturnValueOnce(promise as any);
+
+  render(<DataDisplay />);
+
+  // Loading state
+  expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+  expect(screen.queryByText("Data content")).not.toBeInTheDocument();
+
+  // Resolve the promise
+  await act(async () => {
+    resolvePromise!({ data: { content: "Data content" } });
+  });
+
+  // Loaded state
+  expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+  expect(screen.getByText("Data content")).toBeInTheDocument();
+});
+```
+
+## Common Pitfalls
+
+1. **Forgetting `act()` with timers**: Always wrap `jest.advanceTimersByTime()` in `act()` when it triggers React state updates.
+
+2. **Not cleaning up timers**: Always call `jest.runOnlyPendingTimers()` then `jest.useRealTimers()` in `afterEach` to prevent timer leaks between tests.
+
+3. **Using `waitFor` for sync assertions**: If the element is already in the DOM after render, use `getBy*` directly. `waitFor` adds unnecessary polling.
+
+4. **Missing `await` on async operations**: Forgetting `await` on `waitFor`, `findBy*`, or `userEvent` methods causes tests to pass vacuously.
+
+5. **Fake timers breaking promises**: If promises are not resolving with fake timers, try `jest.advanceTimersByTime()` inside `act(async () => { ... })`.

--- a/.agents/skills/frontend-testing/references/checklist.md
+++ b/.agents/skills/frontend-testing/references/checklist.md
@@ -1,0 +1,98 @@
+# Test Generation Checklist
+
+Verify each item before submitting test code for Langflow frontend.
+
+## Pre-Writing
+
+- [ ] Read the source file completely before writing any tests
+- [ ] Identify all exported functions, components, hooks, and types
+- [ ] Identify all conditional branches (if/else, ternary, switch, early returns, `&&`/`||` short-circuits)
+- [ ] Identify all dependencies that need mocking
+- [ ] Check `jest.setup.js` for pre-existing global mocks to avoid duplication
+- [ ] Check if there is an existing test file to extend (rather than creating a new one)
+
+## File Structure
+
+- [ ] File is in `__tests__/` directory or co-located with source
+- [ ] File name follows `ComponentName.test.tsx` or `util-name.test.ts` convention
+- [ ] Imports use `@/` path alias consistently
+- [ ] `jest.mock()` calls are at the top of the file, after imports
+- [ ] `beforeEach` includes `jest.clearAllMocks()`
+- [ ] `beforeEach` resets Zustand store state (if using stores)
+- [ ] `afterEach` cleans up fake timers (if used)
+
+## Test Quality
+
+- [ ] Each `it()` block tests exactly ONE behavior
+- [ ] Test names follow `"should [behavior] when [condition]"` format
+- [ ] Tests are ordered from simplest to most complex
+- [ ] Tests use Arrange-Act-Assert (AAA) pattern with blank line separation
+- [ ] No implementation details tested (no internal state, no CSS classes, no private functions)
+- [ ] No test depends on another test's side effects (test isolation)
+
+## Queries and Assertions
+
+- [ ] Queries follow RTL priority: `getByRole` > `getByLabelText` > `getByText` > `getByTestId`
+- [ ] `queryBy*` used for asserting absence (`expect(queryByText("x")).not.toBeInTheDocument()`)
+- [ ] `findBy*` or `waitFor` used for async elements
+- [ ] `screen` object used for all queries (not destructured from `render`)
+- [ ] Assertions use `jest-dom` matchers: `toBeInTheDocument()`, `toHaveValue()`, `toBeDisabled()`, etc.
+- [ ] No use of `.innerHTML`, `.className`, or `.style` for assertions
+
+## User Interactions
+
+- [ ] `userEvent.setup()` used (not `fireEvent`)
+- [ ] All `userEvent` calls are `await`ed
+- [ ] `userEvent.setup({ advanceTimers: jest.advanceTimersByTime })` used when combining with fake timers
+
+## Mocking
+
+- [ ] Uses `jest.fn()`, `jest.mock()`, `jest.spyOn()` (NEVER `vi.*`)
+- [ ] Only mocks what is necessary (prefer real implementations)
+- [ ] Does NOT mock base UI components from `@/components/ui/`
+- [ ] Does NOT re-mock modules already mocked in `jest.setup.js`
+- [ ] Mock return values match the actual API shape (type-safe)
+- [ ] `jest.mocked()` used for type-safe mock assertions
+
+## Async
+
+- [ ] All `waitFor` calls contain a single assertion
+- [ ] All promises are properly `await`ed
+- [ ] `act()` wraps state-updating operations (store updates, timer advances)
+- [ ] Fake timers cleaned up in `afterEach`: `jest.runOnlyPendingTimers()` then `jest.useRealTimers()`
+- [ ] No unhandled promise rejections
+
+## Challenge Tests (MANDATORY — not just happy paths)
+
+- [ ] Happy path tests exist (baseline — code works under normal conditions)
+- [ ] **Unexpected inputs tested**: `null`, `undefined`, `""`, `[]`, `{}`, `0`, `-1`
+- [ ] **Boundary values tested**: max length, exactly at limit, one past limit, zero items, max items
+- [ ] **Malformed data tested**: missing fields, extra fields, wrong types
+- [ ] **Error states tested**: API 500, 404, 401, network failure, timeout
+- [ ] **What should NOT happen tested**: forbidden actions are rejected, wrong user can't access resources
+- [ ] **Error messages verified**: not just that it fails, but HOW it fails (correct message, correct type)
+- [ ] Tests written based on **requirements/spec**, not copied from source code logic
+
+## Coverage
+
+- [ ] All exported functions/components are tested
+- [ ] All conditional branches are covered (both sides of if/else, all catch blocks)
+- [ ] Function coverage: 100%
+- [ ] Branch coverage: > 95%
+- [ ] Line coverage: > 95%
+
+## Execution
+
+- [ ] Test file runs without errors: `npm test -- path/to/file.test.tsx`
+- [ ] No console warnings or errors in test output (or they are intentionally suppressed)
+- [ ] Tests pass in isolation (can run the file alone)
+- [ ] Tests pass with the full suite (no cross-file contamination)
+- [ ] Coverage verified: `npm test -- --coverage --collectCoverageFrom='src/path/to/source.ts' path/to/test.test.ts`
+
+## Final Review
+
+- [ ] No `console.log` left in test code
+- [ ] No `.only` or `.skip` left on tests
+- [ ] No hardcoded timeouts longer than 5000ms
+- [ ] No `any` type assertions that could be properly typed
+- [ ] Test file is not in `testPathIgnorePatterns` (not named `test-utils.tsx`)

--- a/.agents/skills/frontend-testing/references/common-patterns.md
+++ b/.agents/skills/frontend-testing/references/common-patterns.md
@@ -1,0 +1,411 @@
+# Common Testing Patterns
+
+Frequently used patterns for testing Langflow React components with Jest and React Testing Library.
+
+## Query Priority
+
+Use queries in this priority order (most to least preferred):
+
+| Priority | Query | When to Use |
+|---|---|---|
+| 1 | `getByRole` | Buttons, inputs, headings, links, checkboxes |
+| 2 | `getByLabelText` | Form inputs associated with labels |
+| 3 | `getByPlaceholderText` | Inputs with placeholder text |
+| 4 | `getByText` | Non-interactive content, paragraphs, spans |
+| 5 | `getByDisplayValue` | Filled input/textarea/select values |
+| 6 | `getByAltText` | Images |
+| 7 | `getByTitle` | Elements with title attribute |
+| 8 | `getByTestId` | Last resort -- when no semantic query works |
+
+### Query Variants
+
+| Variant | Throws if not found | Returns | Use When |
+|---|---|---|---|
+| `getBy*` | Yes | Element | Element should exist |
+| `queryBy*` | No | Element or null | Asserting element does NOT exist |
+| `findBy*` | Yes (after timeout) | Promise<Element> | Element appears asynchronously |
+| `getAllBy*` | Yes | Element[] | Multiple elements expected |
+| `queryAllBy*` | No | Element[] (may be empty) | Counting or absence of multiple |
+| `findAllBy*` | Yes (after timeout) | Promise<Element[]> | Multiple elements appear async |
+
+### Examples
+
+```typescript
+// Preferred: query by role
+screen.getByRole("button", { name: /save/i });
+screen.getByRole("textbox", { name: /search/i });
+screen.getByRole("heading", { level: 2 });
+screen.getByRole("checkbox", { name: /agree/i });
+screen.getByRole("combobox");
+
+// Assert absence
+expect(screen.queryByText("Error")).not.toBeInTheDocument();
+
+// Async appearance
+const element = await screen.findByText("Loaded");
+```
+
+## User Events
+
+Always use `@testing-library/user-event` over `fireEvent`:
+
+```typescript
+import userEvent from "@testing-library/user-event";
+
+describe("UserInteractions", () => {
+  it("should handle click", async () => {
+    const user = userEvent.setup();
+    const onClick = jest.fn();
+
+    render(<button onClick={onClick}>Click me</button>);
+    await user.click(screen.getByRole("button"));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle typing", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(<input onChange={onChange} />);
+    await user.type(screen.getByRole("textbox"), "hello");
+
+    expect(onChange).toHaveBeenCalledTimes(5); // One per character
+  });
+
+  it("should handle clearing and typing", async () => {
+    const user = userEvent.setup();
+
+    render(<input defaultValue="old value" />);
+    const input = screen.getByRole("textbox");
+
+    await user.clear(input);
+    await user.type(input, "new value");
+
+    expect(input).toHaveValue("new value");
+  });
+
+  it("should handle keyboard navigation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <input data-testid="input-1" />
+        <input data-testid="input-2" />
+      </div>,
+    );
+
+    await user.tab();
+    expect(screen.getByTestId("input-1")).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByTestId("input-2")).toHaveFocus();
+  });
+
+  it("should handle select/dropdown", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <select>
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+      </select>,
+    );
+
+    await user.selectOptions(screen.getByRole("combobox"), "b");
+    expect(screen.getByRole("combobox")).toHaveValue("b");
+  });
+
+  it("should handle hover", async () => {
+    const user = userEvent.setup();
+    const onMouseEnter = jest.fn();
+
+    render(<div onMouseEnter={onMouseEnter}>Hover me</div>);
+    await user.hover(screen.getByText("Hover me"));
+
+    expect(onMouseEnter).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+## Form Testing
+
+```typescript
+describe("LoginForm", () => {
+  it("should submit form with valid data", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+
+    render(<LoginForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/username/i), "testuser");
+    await user.type(screen.getByLabelText(/password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      username: "testuser",
+      password: "password123",
+    });
+  });
+
+  it("should show validation errors for empty fields", async () => {
+    const user = userEvent.setup();
+
+    render(<LoginForm onSubmit={jest.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(screen.getByText(/username is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/password is required/i)).toBeInTheDocument();
+  });
+
+  it("should disable submit button while submitting", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn(() => new Promise(() => {})); // Never resolves
+
+    render(<LoginForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/username/i), "testuser");
+    await user.type(screen.getByLabelText(/password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeDisabled();
+  });
+});
+```
+
+## Modal/Dialog Testing
+
+Langflow uses Radix UI dialogs:
+
+```typescript
+describe("ConfirmDialog", () => {
+  it("should open and close the dialog", async () => {
+    const user = userEvent.setup();
+
+    render(<ConfirmDialog trigger={<button>Open</button>} />);
+
+    // Dialog should not be visible initially
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    // Open dialog
+    await user.click(screen.getByRole("button", { name: /open/i }));
+
+    // Dialog should be visible
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+
+    // Close dialog by clicking cancel
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    // Dialog should be hidden
+    await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
+  });
+
+  it("should call onConfirm when confirmed", async () => {
+    const user = userEvent.setup();
+    const onConfirm = jest.fn();
+
+    render(
+      <ConfirmDialog trigger={<button>Open</button>} onConfirm={onConfirm} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+## Data-Driven Tests (Parameterized)
+
+Use `it.each` for testing multiple inputs with the same logic:
+
+```typescript
+describe("formatDuration", () => {
+  it.each([
+    [0, "0s"],
+    [500, "0.5s"],
+    [1000, "1.0s"],
+    [1500, "1.5s"],
+    [60000, "1m 0s"],
+    [90000, "1m 30s"],
+    [3600000, "1h 0m"],
+  ])("should format %i ms as %s", (input, expected) => {
+    expect(formatDuration(input)).toBe(expected);
+  });
+});
+```
+
+### Named Parameters with Objects
+
+```typescript
+it.each([
+  { input: "", expected: false, description: "empty string" },
+  { input: "valid@email.com", expected: true, description: "valid email" },
+  { input: "no-at-sign", expected: false, description: "missing @" },
+  { input: "@no-local", expected: false, description: "missing local part" },
+])("should return $expected for $description", ({ input, expected }) => {
+  expect(isValidEmail(input)).toBe(expected);
+});
+```
+
+## Snapshot Testing
+
+Use sparingly -- only for stable, presentational components:
+
+```typescript
+it("should match snapshot", () => {
+  const { container } = render(<Badge variant="success" label="Active" />);
+  expect(container.firstChild).toMatchSnapshot();
+});
+```
+
+Prefer explicit assertions over snapshots. Snapshots are fragile and do not communicate test intent.
+
+## Testing Conditional Rendering
+
+```typescript
+describe("StatusBadge", () => {
+  it("should render success variant", () => {
+    render(<StatusBadge status="success" />);
+    expect(screen.getByText("Success")).toBeInTheDocument();
+  });
+
+  it("should render error variant", () => {
+    render(<StatusBadge status="error" />);
+    expect(screen.getByText("Error")).toBeInTheDocument();
+  });
+
+  it("should render nothing for unknown status", () => {
+    const { container } = render(<StatusBadge status="unknown" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+```
+
+## Testing Lists and Tables
+
+```typescript
+describe("ItemList", () => {
+  it("should render all items", () => {
+    const items = [
+      { id: "1", name: "Item 1" },
+      { id: "2", name: "Item 2" },
+      { id: "3", name: "Item 3" },
+    ];
+
+    render(<ItemList items={items} />);
+
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(3);
+    expect(listItems[0]).toHaveTextContent("Item 1");
+    expect(listItems[1]).toHaveTextContent("Item 2");
+    expect(listItems[2]).toHaveTextContent("Item 3");
+  });
+
+  it("should show empty state when no items", () => {
+    render(<ItemList items={[]} />);
+
+    expect(screen.getByText(/no items/i)).toBeInTheDocument();
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+  });
+});
+```
+
+## Testing Tooltips
+
+Langflow uses Radix tooltips which require hover:
+
+```typescript
+it("should show tooltip on hover", async () => {
+  const user = userEvent.setup();
+
+  render(<TooltipButton label="Delete" tooltip="Delete this item" />);
+
+  await user.hover(screen.getByRole("button", { name: /delete/i }));
+
+  await waitFor(() => {
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Delete this item");
+  });
+});
+```
+
+## Testing Error Boundaries
+
+```typescript
+describe("ErrorBoundary", () => {
+  // Suppress console.error for expected errors
+  const originalError = console.error;
+  beforeAll(() => {
+    console.error = jest.fn();
+  });
+  afterAll(() => {
+    console.error = originalError;
+  });
+
+  it("should catch errors and show fallback UI", () => {
+    const ThrowError = () => {
+      throw new Error("Test error");
+    };
+
+    render(
+      <ErrorBoundary fallback={<div>Something went wrong</div>}>
+        <ThrowError />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+});
+```
+
+## Testing Custom data-testid Attributes
+
+Langflow components frequently use `data-testid` for testing. Common patterns:
+
+```typescript
+// Input components
+screen.getByTestId("popover-anchor-input-api_key");
+
+// Buttons
+screen.getByTestId("sidebar-nav-add_note");
+
+// Modal elements
+screen.getByTestId("modal-title");
+
+// Flow elements
+screen.getByTestId("handle-source-bottom");
+```
+
+## Testing with Zustand Store Updates
+
+```typescript
+it("should react to store changes", async () => {
+  render(<NotificationBanner />);
+
+  // Initially no notification
+  expect(screen.queryByText("Error occurred")).not.toBeInTheDocument();
+
+  // Update store
+  act(() => {
+    useAlertStore.setState({
+      errorData: { title: "Error occurred", list: [] },
+    });
+  });
+
+  // Notification should appear
+  expect(screen.getByText("Error occurred")).toBeInTheDocument();
+});
+```
+
+## Cleanup
+
+React Testing Library automatically cleans up after each test (unmounts rendered components). You do not need to call `cleanup()` manually.
+
+However, you DO need to clean up:
+- Fake timers: `jest.useRealTimers()` in `afterEach`
+- Spies: `spy.mockRestore()` or `jest.restoreAllMocks()` in `afterEach`
+- Store state: Reset via `store.setState()` in `beforeEach`
+- Global overrides: Restore original values in `afterEach`

--- a/.agents/skills/frontend-testing/references/domain-components.md
+++ b/.agents/skills/frontend-testing/references/domain-components.md
@@ -1,0 +1,598 @@
+# Domain-Specific Component Testing for Langflow
+
+Patterns for testing Langflow-specific components that have unique architectural concerns.
+
+## Flow/Graph Components
+
+Langflow's flow editor is built on `@xyflow/react` (React Flow). These components require specific mocking strategies.
+
+### GenericNode
+
+`GenericNode` is the main node component rendered in the flow canvas. Located at `src/frontend/src/CustomNodes/GenericNode/`.
+
+```typescript
+import { render, screen } from "@testing-library/react";
+import GenericNode from "@/CustomNodes/GenericNode";
+
+// Mock @xyflow/react
+jest.mock("@xyflow/react", () => ({
+  Handle: ({ type, position, id }: any) => (
+    <div data-testid={`handle-${type}-${id}`} data-position={position} />
+  ),
+  Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
+  useUpdateNodeInternals: () => jest.fn(),
+  useReactFlow: () => ({
+    getNodes: jest.fn().mockReturnValue([]),
+    getEdges: jest.fn().mockReturnValue([]),
+    setNodes: jest.fn(),
+    setEdges: jest.fn(),
+  }),
+}));
+
+// Mock the flow store
+jest.mock("@/stores/flowStore", () => ({
+  __esModule: true,
+  default: (selector?: (state: any) => any) =>
+    selector
+      ? selector({
+          nodes: [],
+          edges: [],
+          setNodes: jest.fn(),
+          onNodesChange: jest.fn(),
+        })
+      : {},
+}));
+
+const mockNodeData = {
+  id: "node-1",
+  type: "genericNode",
+  data: {
+    node: {
+      display_name: "OpenAI",
+      description: "OpenAI language model",
+      template: {
+        api_key: {
+          type: "str",
+          required: true,
+          show: true,
+          name: "api_key",
+          display_name: "API Key",
+          password: true,
+          value: "",
+          advanced: false,
+        },
+        model_name: {
+          type: "str",
+          required: false,
+          show: true,
+          name: "model_name",
+          display_name: "Model Name",
+          options: ["gpt-4", "gpt-3.5-turbo"],
+          value: "gpt-4",
+          advanced: false,
+        },
+      },
+      output_types: ["Message"],
+      input_types: ["Text"],
+    },
+    showNode: true,
+  },
+  position: { x: 100, y: 200 },
+};
+
+describe("GenericNode", () => {
+  it("should render the node with display name", () => {
+    render(<GenericNode data={mockNodeData.data} id="node-1" />);
+    expect(screen.getByText("OpenAI")).toBeInTheDocument();
+  });
+
+  it("should render input handles for each visible input field", () => {
+    render(<GenericNode data={mockNodeData.data} id="node-1" />);
+    // Verify handles are rendered based on template fields
+    expect(screen.getByTestId("handle-target-api_key")).toBeInTheDocument();
+  });
+});
+```
+
+### Edge Components
+
+Test edge rendering and connection validation:
+
+```typescript
+describe("CustomEdge", () => {
+  it("should render a connection between compatible types", () => {
+    render(
+      <CustomEdge
+        id="edge-1"
+        source="node-1"
+        target="node-2"
+        sourceHandle="output-Message"
+        targetHandle="input-Text"
+      />,
+    );
+
+    expect(screen.getByTestId("edge-edge-1")).toBeInTheDocument();
+  });
+});
+```
+
+### Connection Validation
+
+Test type compatibility logic (typically a pure function):
+
+```typescript
+import { isValidConnection } from "@/CustomNodes/helpers/connection-validation";
+
+describe("isValidConnection", () => {
+  it("should allow connection between compatible types", () => {
+    expect(
+      isValidConnection({
+        sourceType: "Message",
+        targetType: "Text",
+        compatibleTypes: { Text: ["Message", "Text"] },
+      }),
+    ).toBe(true);
+  });
+
+  it("should reject connection between incompatible types", () => {
+    expect(
+      isValidConnection({
+        sourceType: "DataFrame",
+        targetType: "Text",
+        compatibleTypes: { Text: ["Message", "Text"] },
+      }),
+    ).toBe(false);
+  });
+});
+```
+
+### Handle Rendering
+
+Test the handle display logic for minimized/expanded nodes:
+
+```typescript
+import { computeDisplayHandle } from "@/CustomNodes/GenericNode/components/RenderInputParameters/helpers";
+
+describe("computeDisplayHandle", () => {
+  it("should show handles for non-advanced visible fields", () => {
+    const result = computeDisplayHandle({
+      showNode: true,
+      isAdvanced: false,
+      isHidden: false,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("should hide handles when node is minimized", () => {
+    const result = computeDisplayHandle({
+      showNode: false,
+      isAdvanced: false,
+      isHidden: false,
+    });
+    expect(result).toBe(false);
+  });
+});
+```
+
+## Component Configuration Panels
+
+Components for editing node parameters in the inspection panel or modal.
+
+### Parameter Render Components
+
+Located at `src/frontend/src/components/core/parameterRenderComponent/`:
+
+```typescript
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import InputComponent from "@/components/core/parameterRenderComponent/components/inputComponent";
+
+describe("InputComponent", () => {
+  const defaultProps = {
+    value: "",
+    onChange: jest.fn(),
+    name: "api_key",
+    id: "input-api_key",
+    password: false,
+    placeholder: "Enter API key",
+  };
+
+  it("should render input with placeholder", () => {
+    render(<InputComponent {...defaultProps} />);
+    expect(screen.getByPlaceholderText("Enter API key")).toBeInTheDocument();
+  });
+
+  it("should call onChange when user types", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<InputComponent {...defaultProps} onChange={onChange} />);
+
+    await user.type(screen.getByRole("textbox"), "sk-123");
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("should mask input when password is true", () => {
+    render(<InputComponent {...defaultProps} password={true} />);
+    expect(screen.getByTestId("popover-anchor-input-api_key")).toHaveAttribute(
+      "type",
+      "password",
+    );
+  });
+});
+```
+
+### Dropdown/Select Components
+
+```typescript
+describe("DropdownComponent", () => {
+  it("should render options and allow selection", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(
+      <DropdownComponent
+        value="gpt-4"
+        options={["gpt-4", "gpt-3.5-turbo", "gpt-4-turbo"]}
+        onChange={onChange}
+      />,
+    );
+
+    // Open dropdown
+    await user.click(screen.getByRole("combobox"));
+
+    // Select an option
+    await user.click(screen.getByText("gpt-3.5-turbo"));
+
+    expect(onChange).toHaveBeenCalledWith("gpt-3.5-turbo");
+  });
+});
+```
+
+## Chat Components
+
+Located at `src/frontend/src/components/core/chatComponents/` and `src/frontend/src/modals/IOModal/components/chatView/`.
+
+### Message Display
+
+```typescript
+import { render, screen } from "@testing-library/react";
+import ChatMessage from "@/components/core/chatComponents/ChatMessage";
+
+describe("ChatMessage", () => {
+  it("should render user message", () => {
+    render(
+      <ChatMessage
+        message={{ text: "Hello!", sender: "User", sender_name: "User" }}
+      />,
+    );
+
+    expect(screen.getByText("Hello!")).toBeInTheDocument();
+  });
+
+  it("should render bot message with different styling", () => {
+    render(
+      <ChatMessage
+        message={{ text: "Hi there!", sender: "Machine", sender_name: "AI" }}
+      />,
+    );
+
+    expect(screen.getByText("Hi there!")).toBeInTheDocument();
+  });
+
+  it("should render markdown content", () => {
+    render(
+      <ChatMessage
+        message={{
+          text: "Here is **bold** text",
+          sender: "Machine",
+          sender_name: "AI",
+        }}
+      />,
+    );
+
+    // react-markdown is mocked globally, so test the text content
+    expect(screen.getByText(/bold/)).toBeInTheDocument();
+  });
+});
+```
+
+### Message Sorting
+
+Test the message sorting utility (pure function):
+
+```typescript
+import { sortMessages } from "@/modals/IOModal/components/chatView/helpers";
+
+describe("sortMessages", () => {
+  it("should sort messages by timestamp ascending", () => {
+    const messages = [
+      { id: "3", timestamp: "2024-01-03T00:00:00Z" },
+      { id: "1", timestamp: "2024-01-01T00:00:00Z" },
+      { id: "2", timestamp: "2024-01-02T00:00:00Z" },
+    ];
+
+    const sorted = sortMessages(messages);
+
+    expect(sorted.map((m) => m.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("should handle empty array", () => {
+    expect(sortMessages([])).toEqual([]);
+  });
+});
+```
+
+### Chat Input
+
+```typescript
+describe("ChatInput", () => {
+  it("should send message on Enter key", async () => {
+    const user = userEvent.setup();
+    const onSend = jest.fn();
+
+    render(<ChatInput onSend={onSend} />);
+
+    const textarea = screen.getByRole("textbox");
+    await user.type(textarea, "Hello{Enter}");
+
+    expect(onSend).toHaveBeenCalledWith("Hello");
+  });
+
+  it("should not send empty message", async () => {
+    const user = userEvent.setup();
+    const onSend = jest.fn();
+
+    render(<ChatInput onSend={onSend} />);
+
+    const textarea = screen.getByRole("textbox");
+    await user.type(textarea, "{Enter}");
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("should disable input while message is being sent", () => {
+    render(<ChatInput onSend={jest.fn()} isLoading={true} />);
+
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+});
+```
+
+## Global Variable Components
+
+Located at `src/frontend/src/components/core/GlobalVariableModal/` and `src/frontend/src/pages/SettingsPage/pages/GlobalVariablesPage/`.
+
+### Global Variable Modal
+
+```typescript
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GlobalVariableModal from "@/components/core/GlobalVariableModal";
+
+// Mock the API
+jest.mock("@/controllers/API/api", () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+describe("GlobalVariableModal", () => {
+  it("should render the form fields", () => {
+    render(
+      <GlobalVariableModal
+        open={true}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/variable name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/value/i)).toBeInTheDocument();
+  });
+
+  it("should validate required fields", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <GlobalVariableModal
+        open={true}
+        onClose={jest.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/name is required/i)).toBeInTheDocument();
+    });
+  });
+});
+```
+
+### Global Variable in Node Fields
+
+When a global variable is selected for a node field, the input renders as a badge instead of a text input. This is important for testing:
+
+```typescript
+describe("InputGlobalComponent", () => {
+  it("should show badge when global variable is selected", () => {
+    render(
+      <InputGlobalComponent
+        name="api_key"
+        value="OPENAI_API_KEY"
+        load_from_db={true}
+      />,
+    );
+
+    // Badge is rendered instead of input
+    expect(screen.queryByTestId("popover-anchor-input-api_key")).not.toBeInTheDocument();
+    // Look for the global variable badge instead
+    expect(screen.getByText("OPENAI_API_KEY")).toBeInTheDocument();
+  });
+
+  it("should show input when no global variable is selected", () => {
+    render(
+      <InputGlobalComponent
+        name="api_key"
+        value=""
+        load_from_db={false}
+      />,
+    );
+
+    expect(screen.getByTestId("popover-anchor-input-api_key")).toBeInTheDocument();
+  });
+});
+```
+
+## Playground Components
+
+Located at `src/frontend/src/components/core/playgroundComponent/`.
+
+### Playground View
+
+```typescript
+// Mock stores needed by playground
+jest.mock("@/stores/flowStore", () => ({
+  __esModule: true,
+  default: (selector?: (state: any) => any) =>
+    selector
+      ? selector({
+          nodes: [],
+          edges: [],
+          inputs: [{ id: "input-1", type: "ChatInput" }],
+          outputs: [{ id: "output-1", type: "ChatOutput" }],
+        })
+      : {},
+}));
+
+jest.mock("@/stores/playgroundStore", () => ({
+  __esModule: true,
+  default: (selector?: (state: any) => any) =>
+    selector
+      ? selector({
+          isPlaygroundOpen: true,
+          setIsPlaygroundOpen: jest.fn(),
+        })
+      : {},
+}));
+
+describe("PlaygroundComponent", () => {
+  it("should render chat interface when flow has chat I/O", () => {
+    render(<PlaygroundComponent />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+});
+```
+
+### Duration Display
+
+The `DurationDisplay` component shows elapsed time during message processing. It uses `Date.now()` and `setInterval`:
+
+```typescript
+// See DurationDisplay.test.tsx in the codebase for a comprehensive example
+// Key patterns:
+// 1. Mock Date.now for deterministic time
+// 2. Use jest.useFakeTimers() for interval control
+// 3. Use act() when advancing timers
+// 4. Test remount behavior (playground open/close)
+```
+
+## Sidebar Components
+
+Located at `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/`.
+
+### Sidebar Search and Filtering
+
+```typescript
+describe("SidebarSearch", () => {
+  it("should filter components by search term", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <FlowSidebar
+        components={[
+          { name: "OpenAI", category: "LLMs" },
+          { name: "Pinecone", category: "Vector Stores" },
+          { name: "ChatInput", category: "Inputs" },
+        ]}
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText(/search/i), "open");
+
+    expect(screen.getByText("OpenAI")).toBeInTheDocument();
+    expect(screen.queryByText("Pinecone")).not.toBeInTheDocument();
+    expect(screen.queryByText("ChatInput")).not.toBeInTheDocument();
+  });
+});
+```
+
+### Draggable Components
+
+```typescript
+describe("SidebarDraggableComponent", () => {
+  it("should have draggable attributes", () => {
+    render(
+      <SidebarDraggableComponent
+        name="OpenAI"
+        type="llm"
+        draggable={true}
+      />,
+    );
+
+    const draggable = screen.getByTestId("sidebar-draggable-openai");
+    expect(draggable).toHaveAttribute("draggable", "true");
+  });
+});
+```
+
+## API Code Generation (Modals)
+
+Located at `src/frontend/src/modals/apiModal/utils/`.
+
+These are pure functions that generate code snippets -- ideal for data-driven tests:
+
+```typescript
+import { getPythonApiCode } from "@/modals/apiModal/utils/get-python-api-code";
+
+describe("getPythonApiCode", () => {
+  it("should generate valid Python code for a flow", () => {
+    const code = getPythonApiCode({
+      flowId: "flow-123",
+      tweaks: { "node-1": { model_name: "gpt-4" } },
+      isAuth: true,
+    });
+
+    expect(code).toContain("flow-123");
+    expect(code).toContain("gpt-4");
+    expect(code).toContain("Authorization");
+  });
+
+  it("should omit auth header when isAuth is false", () => {
+    const code = getPythonApiCode({
+      flowId: "flow-123",
+      tweaks: {},
+      isAuth: false,
+    });
+
+    expect(code).not.toContain("Authorization");
+  });
+});
+```
+
+## Testing Tips for Langflow Components
+
+1. **Node template data**: Create reusable mock node data objects. The template structure is deeply nested and used across many components.
+
+2. **Store interdependencies**: Many components read from multiple stores (flowStore, typesStore, alertStore). Mock or initialize all relevant stores.
+
+3. **data-testid conventions**: Langflow uses `data-testid` extensively. Common patterns:
+   - `popover-anchor-input-{name}` for input fields
+   - `handle-{type}-{position}` for flow handles
+   - `sidebar-nav-{action}` for sidebar buttons
+   - `edit-fields-button` for inspection panel
+
+4. **Global variable awareness**: When testing components that render node fields, be aware that fields with `load_from_db: true` and a global variable value render as badges, not inputs. The input element will not exist in the DOM.
+
+5. **Inspection panel vs. canvas**: Fields render differently depending on context. Canvas shows non-advanced fields; the inspection panel shows advanced fields. Use `shouldRenderInspectionPanelField()` and `isCanvasVisible()` from `src/frontend/src/CustomNodes/helpers/parameter-filtering.ts`.

--- a/.agents/skills/frontend-testing/references/mocking.md
+++ b/.agents/skills/frontend-testing/references/mocking.md
@@ -1,0 +1,458 @@
+# Mocking Guide for Langflow Tests
+
+All mocking in Langflow uses Jest APIs. Never use Vitest (`vi.*`) APIs.
+
+## Quick Reference
+
+| Vitest (DO NOT USE) | Jest (USE THIS) |
+|---|---|
+| `vi.fn()` | `jest.fn()` |
+| `vi.mock()` | `jest.mock()` |
+| `vi.spyOn()` | `jest.spyOn()` |
+| `vi.mocked()` | `jest.mocked()` |
+| `vi.clearAllMocks()` | `jest.clearAllMocks()` |
+| `vi.useFakeTimers()` | `jest.useFakeTimers()` |
+| `vi.useRealTimers()` | `jest.useRealTimers()` |
+| `vi.advanceTimersByTime()` | `jest.advanceTimersByTime()` |
+
+## Pre-Existing Global Mocks
+
+These modules are already mocked in `jest.setup.js`. Do NOT re-mock them unless you need different behavior:
+
+- `@radix-ui/react-form` (all exports render children)
+- `react-markdown` (renders null)
+- `lucide-react/dynamicIconImports` (empty object)
+- `@/components/common/genericIconComponent` (renders null)
+- `@/icons/BotMessageSquare` (renders null)
+- `@/stores/darkStore` (returns default state)
+- `localStorage` and `sessionStorage` (jest.fn() stubs)
+
+To use the real implementation instead:
+```typescript
+jest.unmock("@/stores/darkStore");
+```
+
+## API Mocking
+
+### Mocking Axios Calls
+
+Langflow uses Axios via a configured API instance. Mock the API module:
+
+```typescript
+import api from "@/controllers/API/api";
+
+jest.mock("@/controllers/API/api", () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+describe("MyComponent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should fetch data on mount", async () => {
+    jest.mocked(api.get).mockResolvedValueOnce({
+      data: { items: [{ id: "1", name: "Test" }] },
+    });
+
+    render(<MyComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Test")).toBeInTheDocument();
+    });
+
+    expect(api.get).toHaveBeenCalledWith("/api/v1/items");
+  });
+
+  it("should handle API errors", async () => {
+    jest.mocked(api.get).mockRejectedValueOnce(new Error("Network error"));
+
+    render(<MyComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/error/i)).toBeInTheDocument();
+    });
+  });
+});
+```
+
+### Mocking Specific API Query Hooks
+
+For components using React Query hooks from `@/controllers/API/queries/`:
+
+```typescript
+jest.mock("@/controllers/API/queries/flows", () => ({
+  useGetFlowsQuery: jest.fn().mockReturnValue({
+    data: [{ id: "flow-1", name: "My Flow" }],
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+  }),
+}));
+```
+
+### Mocking Individual API Functions
+
+```typescript
+jest.mock("@/controllers/API", () => ({
+  getFlows: jest.fn().mockResolvedValue([]),
+  saveFlow: jest.fn().mockResolvedValue({ id: "new-flow" }),
+  deleteFlow: jest.fn().mockResolvedValue(undefined),
+}));
+```
+
+## Zustand Store Mocking
+
+Langflow does NOT have a global Zustand auto-mock. You have two options:
+
+### Option 1: Use Real Stores with `setState()` (Preferred)
+
+```typescript
+import useAlertStore from "@/stores/alertStore";
+
+describe("Alert-dependent component", () => {
+  beforeEach(() => {
+    // Reset store to known state before each test
+    useAlertStore.setState({
+      errorData: { title: "", list: [] },
+      noticeData: { title: "", link: "" },
+      successData: { title: "" },
+      notificationCenter: false,
+      notificationList: [],
+      tempNotificationList: [],
+    });
+  });
+
+  it("should display error notification", () => {
+    // Pre-set store state
+    useAlertStore.setState({
+      errorData: { title: "Something went wrong", list: ["Detail"] },
+    });
+
+    render(<NotificationBanner />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+});
+```
+
+### Option 2: Mock the Store Module
+
+Use when the real store has complex initialization or `import.meta` dependencies:
+
+```typescript
+const mockFlowStore = {
+  nodes: [],
+  edges: [],
+  setNodes: jest.fn(),
+  setEdges: jest.fn(),
+  onNodesChange: jest.fn(),
+  onEdgesChange: jest.fn(),
+  onConnect: jest.fn(),
+};
+
+jest.mock("@/stores/flowStore", () => ({
+  __esModule: true,
+  default: (selector?: (state: any) => any) =>
+    selector ? selector(mockFlowStore) : mockFlowStore,
+}));
+
+describe("FlowCanvas", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFlowStore.nodes = [];
+    mockFlowStore.edges = [];
+  });
+
+  it("should render nodes from the store", () => {
+    mockFlowStore.nodes = [
+      { id: "node-1", type: "genericNode", data: { node: { display_name: "OpenAI" } }, position: { x: 0, y: 0 } },
+    ];
+
+    render(<FlowCanvas />);
+
+    expect(screen.getByText("OpenAI")).toBeInTheDocument();
+  });
+});
+```
+
+### Option 3: Use `renderHook` for Store Tests
+
+For testing the store itself:
+
+```typescript
+import { act, renderHook } from "@testing-library/react";
+import useMyStore from "../myStore";
+
+describe("useMyStore", () => {
+  beforeEach(() => {
+    useMyStore.setState({ count: 0 });
+  });
+
+  it("should increment count", () => {
+    const { result } = renderHook(() => useMyStore());
+
+    act(() => {
+      result.current.increment();
+    });
+
+    expect(result.current.count).toBe(1);
+  });
+});
+```
+
+## React Router Mocking
+
+Langflow uses `react-router-dom` v6 (NOT Next.js routing).
+
+### Wrapping with MemoryRouter
+
+```typescript
+import { MemoryRouter } from "react-router-dom";
+
+it("should render the page", () => {
+  render(
+    <MemoryRouter initialEntries={["/flows/flow-123"]}>
+      <FlowPage />
+    </MemoryRouter>,
+  );
+});
+```
+
+### Mocking useNavigate
+
+```typescript
+const mockNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+it("should navigate to flow page on click", async () => {
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <FlowCard flow={mockFlow} />
+    </MemoryRouter>,
+  );
+
+  await user.click(screen.getByText("Open Flow"));
+  expect(mockNavigate).toHaveBeenCalledWith("/flow/flow-123");
+});
+```
+
+### Mocking useParams
+
+```typescript
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: () => ({ flowId: "flow-123" }),
+}));
+```
+
+### Mocking useSearchParams
+
+```typescript
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useSearchParams: () => [new URLSearchParams("tab=settings"), jest.fn()],
+}));
+```
+
+## React Query Mocking
+
+### Creating a Test QueryClient
+
+```typescript
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+```
+
+### Mocking useMutation
+
+```typescript
+jest.mock("@tanstack/react-query", () => ({
+  ...jest.requireActual("@tanstack/react-query"),
+  useMutation: jest.fn().mockReturnValue({
+    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    data: undefined,
+  }),
+}));
+```
+
+## Context Provider Mocking
+
+### Wrapping with Providers
+
+For components that depend on React context:
+
+```typescript
+import { AuthContext } from "@/contexts/authContext";
+
+const mockAuthContext = {
+  isAuthenticated: true,
+  userData: { id: "user-1", username: "testuser" },
+  login: jest.fn(),
+  logout: jest.fn(),
+  getAuthentication: jest.fn(),
+  autoLogin: false,
+};
+
+it("should show user name when authenticated", () => {
+  render(
+    <AuthContext.Provider value={mockAuthContext}>
+      <UserMenu />
+    </AuthContext.Provider>,
+  );
+
+  expect(screen.getByText("testuser")).toBeInTheDocument();
+});
+```
+
+### Mocking useContext Directly
+
+```typescript
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useContext: jest.fn().mockReturnValue({
+    isAuthenticated: true,
+    userData: { username: "testuser" },
+  }),
+}));
+```
+
+## Component Mocking
+
+### Mocking Child Components
+
+When a child component is complex or has side effects:
+
+```typescript
+jest.mock("@/components/core/chatView/ChatView", () => ({
+  __esModule: true,
+  default: ({ onSend }: any) => (
+    <div data-testid="mock-chat-view">
+      <button onClick={() => onSend("test message")}>Send</button>
+    </div>
+  ),
+}));
+```
+
+### DO NOT Mock Base UI Components
+
+Never mock components from `@/components/ui/`:
+- `Button`, `Input`, `Select`, `Dialog`, `Popover`, etc.
+- These are simple Radix/shadcn wrappers and should be rendered as-is
+- Mocking them hides real rendering issues
+
+### Mocking Third-Party Components
+
+```typescript
+// Mock @xyflow/react for flow-related tests
+jest.mock("@xyflow/react", () => ({
+  ReactFlow: ({ children }: any) => <div data-testid="react-flow">{children}</div>,
+  useReactFlow: () => ({
+    getNodes: jest.fn().mockReturnValue([]),
+    getEdges: jest.fn().mockReturnValue([]),
+    setNodes: jest.fn(),
+    setEdges: jest.fn(),
+    fitView: jest.fn(),
+    zoomIn: jest.fn(),
+    zoomOut: jest.fn(),
+  }),
+  useNodesState: jest.fn().mockReturnValue([[], jest.fn(), jest.fn()]),
+  useEdgesState: jest.fn().mockReturnValue([[], jest.fn(), jest.fn()]),
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+  Handle: ({ type, position }: any) => (
+    <div data-testid={`handle-${type}-${position}`} />
+  ),
+  Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
+  MarkerType: { ArrowClosed: "arrowclosed" },
+}));
+```
+
+## Window and DOM Mocking
+
+### Already Mocked in Setup Files
+
+These are globally mocked in `setupTests.ts` -- do not re-mock:
+- `ResizeObserver`
+- `IntersectionObserver`
+- `window.matchMedia`
+
+### Mocking window.location
+
+```typescript
+const originalLocation = window.location;
+
+beforeEach(() => {
+  Object.defineProperty(window, "location", {
+    value: { ...originalLocation, href: "http://localhost:3000", assign: jest.fn() },
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    value: originalLocation,
+    writable: true,
+  });
+});
+```
+
+### Mocking Clipboard
+
+```typescript
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn().mockResolvedValue(undefined),
+    readText: jest.fn().mockResolvedValue("clipboard content"),
+  },
+});
+```
+
+## Common Pitfalls
+
+1. **Mocking before imports**: `jest.mock()` calls are hoisted automatically by Jest. You do not need to place them before import statements (but it is conventional to do so for readability).
+
+2. **Forgetting `__esModule: true`**: When mocking a module with default exports, include `__esModule: true` in the mock factory.
+
+3. **Over-mocking**: Only mock what is necessary. If the real module works in jsdom, prefer using it.
+
+4. **Not resetting mocks**: Always use `jest.clearAllMocks()` in `beforeEach` to prevent test contamination.
+
+5. **Mocking globally-mocked modules**: Check `jest.setup.js` first. Duplicating a mock may cause unexpected behavior.

--- a/.agents/skills/frontend-testing/references/workflow.md
+++ b/.agents/skills/frontend-testing/references/workflow.md
@@ -1,0 +1,197 @@
+# Incremental Testing Workflow
+
+Step-by-step process for systematically testing a directory of source files in Langflow.
+
+## Phase 1: Discovery
+
+### 1.1 Identify Source Files
+
+List all `.ts` and `.tsx` files in the target directory (excluding existing test files):
+
+```bash
+find src/frontend/src/path/to/directory -name '*.ts' -o -name '*.tsx' | grep -v '__tests__' | grep -v '.test.' | grep -v '.spec.' | sort
+```
+
+### 1.2 Categorize by Complexity
+
+Sort files into tiers:
+
+| Tier | Description | Examples |
+|---|---|---|
+| 1 | Pure functions, constants, types | `utils.ts`, `constants.ts`, `types.ts` |
+| 2 | Custom hooks (no UI) | `useDebounce.ts`, `useLocalStorage.ts` |
+| 3 | Simple presentational components | `Badge.tsx`, `EmptyState.tsx` |
+| 4 | Stateful components | `SearchInput.tsx`, `FilterPanel.tsx` |
+| 5 | Store-connected components | `NodeToolbar.tsx`, `SidebarHeader.tsx` |
+| 6 | Async/API components | `FlowList.tsx`, `GlobalVariablesPage.tsx` |
+| 7 | Integration components | `FlowPage.tsx`, `ChatView.tsx` |
+
+### 1.3 Check Existing Coverage
+
+```bash
+npm test -- --coverage --collectCoverageFrom='src/path/to/directory/**/*.{ts,tsx}' src/path/to/directory/__tests__/
+```
+
+## Phase 2: Write Tests (Per File)
+
+For each source file, starting from Tier 1:
+
+### 2.1 Read the Source
+
+Read the entire source file. Identify:
+- All exported functions, components, hooks, and types
+- All conditional branches (if/else, ternary, switch, early returns)
+- All side effects (API calls, store mutations, DOM manipulation)
+- All dependencies that need mocking
+
+### 2.2 Create the Test File
+
+Create `__tests__/SourceFileName.test.tsx` (or `.test.ts` for non-JSX files).
+
+### 2.3 Write Tests in Order
+
+1. **Imports and mocks** at the top
+2. **describe block** named after the exported entity
+3. **beforeEach** with `jest.clearAllMocks()` and any store resets
+4. **Rendering tests** first
+5. **Props/state variation tests** next
+6. **Interaction tests** next
+7. **Async/error tests** last
+
+### 2.4 Run and Verify
+
+```bash
+# Run the single test file
+npm test -- src/path/to/__tests__/SourceFileName.test.tsx
+
+# Check coverage for the source file
+npm test -- --coverage --collectCoverageFrom='src/path/to/SourceFileName.tsx' src/path/to/__tests__/SourceFileName.test.tsx
+```
+
+### 2.5 Fix Failures
+
+Common issues:
+- **Missing mock**: Add `jest.mock()` for the dependency
+- **Act warning**: Wrap state updates in `act()` or use `await waitFor()`
+- **Element not found**: Check query strategy -- use `screen.debug()` to inspect DOM
+- **Globally mocked module**: Check `jest.setup.js` -- the module may already be mocked
+
+### 2.6 Reach Coverage Targets
+
+If coverage is below targets (100% function, >95% branch/line):
+1. Identify uncovered lines in the coverage report
+2. Write additional test cases targeting those branches
+3. Re-run coverage to confirm improvement
+
+## Phase 3: Directory-Level Verification
+
+After all files in the directory have tests:
+
+### 3.1 Run All Tests Together
+
+```bash
+npm test -- --testPathPattern="src/path/to/directory"
+```
+
+### 3.2 Check Combined Coverage
+
+```bash
+npm test -- --coverage --collectCoverageFrom='src/path/to/directory/**/*.{ts,tsx}' --testPathPattern="src/path/to/directory"
+```
+
+### 3.3 Review Test Quality
+
+For each test file, verify:
+- [ ] No implementation details tested (no internal state inspection)
+- [ ] No redundant tests (each test adds unique coverage)
+- [ ] All async operations properly awaited
+- [ ] Cleanup performed (timers, spies, store resets)
+- [ ] Test names are descriptive and follow the `"should ... when ..."` pattern
+
+## Phase 4: Cleanup
+
+### 4.1 Remove Unnecessary Mocks
+
+If a mock is not actually needed (the real implementation works in jsdom), remove it. Fewer mocks means more realistic tests.
+
+### 4.2 Extract Shared Test Utilities
+
+If multiple test files use the same setup patterns, extract them into a `test-utils.tsx` file in the `__tests__` directory:
+
+```tsx
+// __tests__/test-utils.tsx
+import { render, type RenderOptions } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+export function renderWithProviders(
+  ui: React.ReactElement,
+  options?: RenderOptions & { route?: string },
+) {
+  const queryClient = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[options?.route ?? "/"]}>
+        {ui}
+      </MemoryRouter>
+    </QueryClientProvider>,
+    options,
+  );
+}
+```
+
+Note: The Jest config ignores files named `test-utils.tsx` via `testPathIgnorePatterns`.
+
+### 4.3 Final Verification
+
+```bash
+# Run full test suite to ensure nothing is broken
+npm test
+
+# Run with coverage for a summary report
+npm run test:coverage
+```
+
+## Troubleshooting
+
+### "Cannot find module" Errors
+
+The `@/` alias maps to `src/frontend/src/`. If a module is not resolved, check `jest.config.js` `moduleNameMapper`.
+
+### "import.meta" Errors
+
+The project uses `transform-import-meta.js` to handle Vite's `import.meta.env`. If you encounter issues, check that the transform is applied in `jest.config.js`.
+
+### Global Mocks Conflicting
+
+Modules mocked in `jest.setup.js` are mocked globally. If you need the real implementation in a specific test:
+
+```typescript
+// At the top of your test file, before other imports
+jest.unmock("@/stores/darkStore");
+```
+
+### Zustand Store State Leaking Between Tests
+
+Always reset store state in `beforeEach`:
+
+```typescript
+import useMyStore from "@/stores/myStore";
+
+beforeEach(() => {
+  useMyStore.setState({
+    // Reset to initial state
+    items: [],
+    loading: false,
+  });
+});
+```


### PR DESCRIPTION
Objective
Add comprehensive AI agent skill definitions that enforce Langflow's coding standards, architecture patterns, and testing practices across frontend and backend.

Changes
  - Add backend-code-review skill with rules for SQLModel, async sessions, architecture layering, PII, and Google-style docstrings
  - Add frontend-code-review skill with rules for design tokens, kebab-case naming, Tailwind-first styling, Radix UI, and TypeScript strictness
  - Add frontend-testing skill with Jest/RTL patterns, challenge test requirements, mocking guide, and test templates
  - Add e2e-testing skill with Playwright patterns, custom fixtures, selector catalog, helper documentation, and tag system
  - Add component-refactoring skill with complexity patterns, hook extraction, and component splitting strategies
  - Add frontend-query-mutation skill with Axios + React Query patterns, UseRequestProcessor conventions, and cache invalidation rules

Notes
  - All skills are adapted to Langflow's actual codebase patterns (verified against real source files)
  - Skills follow AGENTS-example.md best practices (SOLID, DRY, KISS, YAGNI, Clean Code)
  - Every rule includes WHY explanation and consequences of violations
  - 6 skills, 30 files, ~9,000 lines of documentation