### PR TITLE
fix: Avoid foreign key violation on span table with topological sort

### DIFF
--- a/src/backend/base/langflow/services/tracing/native.py
+++ b/src/backend/base/langflow/services/tracing/native.py
@@ -20,6 +20,11 @@ from typing_extensions import override
 from langflow.serialization.serialization import serialize
 from langflow.services.database.models.traces.model import SpanStatus, SpanType
 from langflow.services.tracing.base import BaseTracer
+from langflow.services.tracing.span_sorting import (
+    LANGFLOW_SPAN_NAMESPACE,
+    resolve_span_uuids,
+    topological_sort_spans,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -28,8 +33,6 @@ if TYPE_CHECKING:
     from lfx.graph.vertex.base import Vertex
 
     from langflow.services.tracing.schema import Log
-
-LANGFLOW_SPAN_NAMESPACE = UUID("a3e1c2d4-5b6f-7890-abcd-ef1234567890")
 
 TYPE_MAP = {
     "chain": SpanType.CHAIN,
@@ -268,14 +271,12 @@ class NativeTracer(BaseTracer):
     async def _flush_to_database(self, error: Exception | None = None) -> None:
         """Persist the completed trace and all its spans in a single DB session to minimise round-trips."""
         try:
-            from uuid import UUID as UUID_
-
             from lfx.services.deps import session_scope
 
             from langflow.services.database.models.traces.model import SpanTable, TraceTable
 
             try:
-                flow_uuid = UUID_(self.flow_id)
+                flow_uuid = UUID(self.flow_id)
             except (ValueError, TypeError):
                 # Deterministic fallback so malformed flow_ids don't silently discard trace data.
                 flow_uuid = uuid5(LANGFLOW_SPAN_NAMESPACE, f"invalid-flow-id:{self.flow_id}")
@@ -323,8 +324,8 @@ class NativeTracer(BaseTracer):
                 # Pre-compute UUIDs and topologically sort so parents are inserted
                 # before children — required by PostgreSQL's immediate FK enforcement
                 # on span.parent_span_id → span.id.
-                resolved = self._resolve_span_uuids(self.completed_spans)
-                resolved = self._topological_sort_spans(resolved)
+                resolved = resolve_span_uuids(self.completed_spans, self.trace_id)
+                resolved = topological_sort_spans(resolved)
 
                 for span_data, span_uuid, parent_uuid in resolved:
                     span = SpanTable(
@@ -540,92 +541,6 @@ class NativeTracer(BaseTracer):
         if parent_span_id is not None:
             span["parent_span_id"] = parent_span_id
         return span
-
-    def _resolve_span_uuids(
-        self,
-        completed_spans: list[dict[str, Any]],
-    ) -> list[tuple[dict[str, Any], UUID, UUID | None]]:
-        """Pre-compute DB UUIDs for each span and its parent.
-
-        Returns a list of (span_data, span_uuid, parent_uuid) tuples that can
-        be topologically sorted before insertion.
-        """
-        from uuid import UUID as UUID_
-
-        resolved: list[tuple[dict[str, Any], UUID, UUID | None]] = []
-        for span_data in completed_spans:
-            try:
-                span_uuid = UUID_(span_data["id"])
-            except (ValueError, TypeError):
-                span_uuid = uuid5(LANGFLOW_SPAN_NAMESPACE, f"{self.trace_id}-{span_data['id']}")
-
-            parent_uuid: UUID | None = None
-            if span_data.get("parent_span_id"):
-                parent_id = span_data["parent_span_id"]
-                if isinstance(parent_id, UUID_):
-                    parent_uuid = parent_id
-                else:
-                    try:
-                        parent_uuid = UUID_(str(parent_id))
-                    except (ValueError, TypeError):
-                        parent_uuid = uuid5(LANGFLOW_SPAN_NAMESPACE, f"{self.trace_id}-{parent_id}")
-
-            resolved.append((span_data, span_uuid, parent_uuid))
-        return resolved
-
-    @staticmethod
-    def _topological_sort_spans(
-        resolved: list[tuple[dict[str, Any], UUID, UUID | None]],
-    ) -> list[tuple[dict[str, Any], UUID, UUID | None]]:
-        """Sort spans so parents appear before children.
-
-        PostgreSQL enforces foreign-key constraints at INSERT time, so a child
-        span referencing ``parent_span_id`` will fail if the parent row hasn't
-        been written yet.  This performs a Kahn's-algorithm-style topological
-        sort over the batch so that every parent is inserted first.
-
-        Spans whose ``parent_span_id`` points outside the current batch are
-        treated as roots (the parent already exists in the DB from a prior
-        flush).
-        """
-        batch_ids = {span_uuid for _, span_uuid, _ in resolved}
-
-        sorted_spans: list[tuple[dict[str, Any], UUID, UUID | None]] = []
-        inserted: set[UUID] = set()
-        remaining = list(resolved)
-
-        while remaining:
-            next_round: list[tuple[dict[str, Any], UUID, UUID | None]] = []
-            progress = False
-            for item in remaining:
-                _, span_uuid, parent_uuid = item
-                # Insert if: no parent, parent outside batch, or parent already inserted
-                if parent_uuid is None or parent_uuid not in batch_ids or parent_uuid in inserted:
-                    sorted_spans.append(item)
-                    inserted.add(span_uuid)
-                    progress = True
-                else:
-                    next_round.append(item)
-
-            if not progress:
-                # Cycle or unresolvable dependency detected.
-                # To avoid reintroducing foreign-key violations, break the cycle by
-                # nulling out parent_span_id for the remaining spans before inserting.
-                if next_round:
-                    logger.warning(
-                        "Detected cycle or unresolvable span dependencies in tracing batch; "
-                        "breaking parent relationships for %d spans to preserve DB integrity.",
-                        len(next_round),
-                    )
-                for span_data, span_uuid, _parent_uuid in next_round:
-                    # Ensure the payload reflects the broken parent relationship.
-                    if isinstance(span_data, dict):
-                        span_data["parent_span_id"] = None
-                    sorted_spans.append((span_data, span_uuid, None))
-                break
-            remaining = next_round
-
-        return sorted_spans
 
     @staticmethod
     def _map_trace_type(trace_type: str) -> SpanType:

--- a/src/backend/base/langflow/services/tracing/span_sorting.py
+++ b/src/backend/base/langflow/services/tracing/span_sorting.py
@@ -1,0 +1,105 @@
+"""Span pre-insertion utilities for the native tracer.
+
+Provides UUID resolution and topological sorting so that parent spans are
+always inserted before their children — a requirement for PostgreSQL's
+immediate foreign-key enforcement on ``span.parent_span_id → span.id``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID, uuid5
+
+from lfx.log.logger import logger
+
+# Deterministic namespace for generating span UUIDs from non-UUID string IDs.
+LANGFLOW_SPAN_NAMESPACE = UUID("a3e1c2d4-5b6f-7890-abcd-ef1234567890")
+
+
+def resolve_span_uuids(
+    completed_spans: list[dict[str, Any]],
+    trace_id: UUID,
+) -> list[tuple[dict[str, Any], UUID, UUID | None]]:
+    """Pre-compute DB UUIDs for each span and its parent.
+
+    Returns a list of (span_data, span_uuid, parent_uuid) tuples that can
+    be topologically sorted before insertion.
+
+    Args:
+        completed_spans: List of completed span dicts.
+        trace_id: The trace UUID used as part of the deterministic namespace
+            when generating UUIDs from non-UUID string IDs.
+    """
+    resolved: list[tuple[dict[str, Any], UUID, UUID | None]] = []
+    for span_data in completed_spans:
+        try:
+            span_uuid = UUID(span_data["id"])
+        except (ValueError, TypeError):
+            span_uuid = uuid5(LANGFLOW_SPAN_NAMESPACE, f"{trace_id}-{span_data['id']}")
+
+        parent_uuid: UUID | None = None
+        if span_data.get("parent_span_id"):
+            parent_id = span_data["parent_span_id"]
+            if isinstance(parent_id, UUID):
+                parent_uuid = parent_id
+            else:
+                try:
+                    parent_uuid = UUID(str(parent_id))
+                except (ValueError, TypeError):
+                    parent_uuid = uuid5(LANGFLOW_SPAN_NAMESPACE, f"{trace_id}-{parent_id}")
+
+        resolved.append((span_data, span_uuid, parent_uuid))
+    return resolved
+
+
+def topological_sort_spans(
+    resolved: list[tuple[dict[str, Any], UUID, UUID | None]],
+) -> list[tuple[dict[str, Any], UUID, UUID | None]]:
+    """Sort spans so parents appear before children.
+
+    PostgreSQL enforces foreign-key constraints at INSERT time, so a child
+    span referencing ``parent_span_id`` will fail if the parent row hasn't
+    been written yet.  This performs a Kahn's-algorithm-style topological
+    sort over the batch so that every parent is inserted first.
+
+    Spans whose ``parent_span_id`` points outside the current batch are
+    treated as roots (the parent already exists in the DB from a prior
+    flush).
+    """
+    batch_ids = {span_uuid for _, span_uuid, _ in resolved}
+
+    sorted_spans: list[tuple[dict[str, Any], UUID, UUID | None]] = []
+    inserted: set[UUID] = set()
+    remaining = list(resolved)
+
+    while remaining:
+        next_round: list[tuple[dict[str, Any], UUID, UUID | None]] = []
+        progress = False
+        for item in remaining:
+            _, span_uuid, parent_uuid = item
+            # Insert if: no parent, parent outside batch, or parent already inserted
+            if parent_uuid is None or parent_uuid not in batch_ids or parent_uuid in inserted:
+                sorted_spans.append(item)
+                inserted.add(span_uuid)
+                progress = True
+            else:
+                next_round.append(item)
+
+        if not progress:
+            # Cycle or unresolvable dependency detected.
+            # To avoid reintroducing foreign-key violations, break the cycle by
+            # nulling out parent_span_id for the remaining spans before inserting.
+            if next_round:
+                logger.warning(
+                    "Detected cycle or unresolvable span dependencies in tracing batch; "
+                    "breaking parent relationships for %d spans to preserve DB integrity.",
+                    len(next_round),
+                )
+            for span_data, span_uuid, _parent_uuid in next_round:
+                # Append with a nulled parent — do NOT mutate the original span_data
+                # dict because callers may still reference it after the sort.
+                sorted_spans.append((span_data, span_uuid, None))
+            break
+        remaining = next_round
+
+    return sorted_spans

--- a/src/backend/tests/unit/services/tracing/test_native_tracer.py
+++ b/src/backend/tests/unit/services/tracing/test_native_tracer.py
@@ -11,6 +11,7 @@ from uuid import UUID, uuid4
 import pytest
 from langflow.services.database.models.traces.model import SpanStatus, SpanType
 from langflow.services.tracing.native import NativeTracer
+from langflow.services.tracing.span_sorting import resolve_span_uuids, topological_sort_spans
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -626,7 +627,7 @@ class TestTopologicalSortSpans:
     def test_no_parents(self):
         a, b, c = uuid4(), uuid4(), uuid4()
         items = [self._make_span(a), self._make_span(b), self._make_span(c)]
-        result = NativeTracer._topological_sort_spans(items)
+        result = topological_sort_spans(items)
         assert [r[1] for r in result] == [a, b, c]
 
     def test_child_after_parent(self):
@@ -634,7 +635,7 @@ class TestTopologicalSortSpans:
         child_id = uuid4()
         # Child comes first in the input list
         items = [self._make_span(child_id, parent_id), self._make_span(parent_id)]
-        result = NativeTracer._topological_sort_spans(items)
+        result = topological_sort_spans(items)
         uuids = [r[1] for r in result]
         assert uuids.index(parent_id) < uuids.index(child_id)
 
@@ -648,7 +649,7 @@ class TestTopologicalSortSpans:
             self._make_span(mid, root),
             self._make_span(root),
         ]
-        result = NativeTracer._topological_sort_spans(items)
+        result = topological_sort_spans(items)
         uuids = [r[1] for r in result]
         assert uuids.index(root) < uuids.index(mid) < uuids.index(leaf)
 
@@ -657,7 +658,7 @@ class TestTopologicalSortSpans:
         external_parent = uuid4()
         child_id = uuid4()
         items = [self._make_span(child_id, external_parent)]
-        result = NativeTracer._topological_sort_spans(items)
+        result = topological_sort_spans(items)
         assert len(result) == 1
         assert result[0][1] == child_id
 
@@ -670,7 +671,7 @@ class TestTopologicalSortSpans:
             self._make_span(root_b),
             self._make_span(root_a),
         ]
-        result = NativeTracer._topological_sort_spans(items)
+        result = topological_sort_spans(items)
         uuids = [r[1] for r in result]
         assert uuids.index(root_a) < uuids.index(child_a)
 
@@ -682,7 +683,7 @@ class TestTopologicalSortSpans:
             self._make_span(a, b),
             self._make_span(b, a),
         ]
-        result = NativeTracer._topological_sort_spans(items)
+        result = topological_sort_spans(items)
         # Ensure all spans are present and no infinite loop / exception occurs.
         uuids = [r[1] for r in result]
         assert len(uuids) == 2
@@ -694,13 +695,93 @@ class TestTopologicalSortSpans:
         items = [
             self._make_span(span_id, span_id),
         ]
-        result = NativeTracer._topological_sort_spans(items)
+        result = topological_sort_spans(items)
         uuids = [r[1] for r in result]
         assert len(uuids) == 1
         assert uuids[0] == span_id
 
     def test_empty_input(self):
-        result = NativeTracer._topological_sort_spans([])
+        result = topological_sort_spans([])
+        assert result == []
+
+    def test_cycle_does_not_mutate_original_span_data(self):
+        """Verify cycle resolution doesn't mutate the original span dicts."""
+        a = uuid4()
+        b = uuid4()
+        span_a = {"id": str(a), "name": "span-a", "parent_span_id": b}
+        span_b = {"id": str(b), "name": "span-b", "parent_span_id": a}
+        items = [(span_a, a, b), (span_b, b, a)]
+        topological_sort_spans(items)
+        # Original dicts should retain their parent_span_id values
+        assert span_a["parent_span_id"] == b
+        assert span_b["parent_span_id"] == a
+
+
+# ---------------------------------------------------------------------------
+# resolve_span_uuids
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSpanUuids:
+    """Verify UUID resolution for span IDs and parent IDs."""
+
+    def test_valid_uuid_string_id(self):
+        trace_id = uuid4()
+        span_id = uuid4()
+        spans = [{"id": str(span_id), "name": "span"}]
+        result = resolve_span_uuids(spans, trace_id)
+        assert len(result) == 1
+        assert result[0][1] == span_id
+        assert result[0][2] is None
+
+    def test_non_uuid_string_id_uses_uuid5(self):
+        from uuid import uuid5 as _uuid5
+
+        from langflow.services.tracing.span_sorting import LANGFLOW_SPAN_NAMESPACE
+
+        trace_id = uuid4()
+        spans = [{"id": "not-a-uuid", "name": "span"}]
+        result = resolve_span_uuids(spans, trace_id)
+        expected = _uuid5(LANGFLOW_SPAN_NAMESPACE, f"{trace_id}-not-a-uuid")
+        assert result[0][1] == expected
+
+    def test_parent_as_uuid_instance(self):
+        trace_id = uuid4()
+        span_id = uuid4()
+        parent_id = uuid4()
+        spans = [{"id": str(span_id), "name": "span", "parent_span_id": parent_id}]
+        result = resolve_span_uuids(spans, trace_id)
+        assert result[0][2] == parent_id
+
+    def test_parent_as_valid_uuid_string(self):
+        trace_id = uuid4()
+        span_id = uuid4()
+        parent_id = uuid4()
+        spans = [{"id": str(span_id), "name": "span", "parent_span_id": str(parent_id)}]
+        result = resolve_span_uuids(spans, trace_id)
+        assert result[0][2] == parent_id
+
+    def test_parent_as_non_uuid_string(self):
+        from uuid import uuid5 as _uuid5
+
+        from langflow.services.tracing.span_sorting import LANGFLOW_SPAN_NAMESPACE
+
+        trace_id = uuid4()
+        span_id = uuid4()
+        spans = [{"id": str(span_id), "name": "span", "parent_span_id": "invalid-parent"}]
+        result = resolve_span_uuids(spans, trace_id)
+        expected_parent = _uuid5(LANGFLOW_SPAN_NAMESPACE, f"{trace_id}-invalid-parent")
+        assert result[0][2] == expected_parent
+
+    def test_no_parent_span_id_key(self):
+        trace_id = uuid4()
+        span_id = uuid4()
+        spans = [{"id": str(span_id), "name": "span"}]
+        result = resolve_span_uuids(spans, trace_id)
+        assert result[0][2] is None
+
+    def test_empty_input(self):
+        result = resolve_span_uuids([], uuid4())
         assert result == []
 
 


### PR DESCRIPTION
This pull request improves the reliability and correctness of span insertion into the database by ensuring parent spans are always inserted before their children, which is necessary for PostgreSQL's foreign key enforcement. It introduces new helper methods for resolving and sorting spans, and adds comprehensive tests to validate this behavior and handle edge cases like cycles.

**Core improvements to span insertion order:**

* Refactored `_flush_to_database` in `native.py` to pre-compute UUIDs for spans and perform a topological sort, ensuring that parent spans are inserted before their children, preventing foreign key violations in PostgreSQL.
* Added `_resolve_span_uuids` and `_topological_sort_spans` helper methods to encapsulate UUID resolution and topological sorting logic for spans, including cycle detection and safe handling of unresolvable dependencies.

**Testing and validation:**

* Added the `TestTopologicalSortSpans` test class to verify correct sorting of spans in various scenarios, including no parents, nested spans, cycles, and self-parenting.
* Added the `TestFlushParentChildOrder` test class to ensure that the database merge order respects parent-before-child insertion, even when spans are provided out of order.