### PR TITLE
docs: contribute to next release candidate branch and not main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,10 @@ Thank you for your interest in contributing!
 
 1. Fork the [Langflow GitHub repository](https://github.com/langflow-ai/langflow).
 2. Create a new branch for your changes.
-3. Submit a pull request to the `main` branch with a clear title and description.
+3. Open a GitHub pull request against the active `release-X.Y.Z` release candidate branch.
+Do not target `main`.
+For example, if the latest released version is `1.8.0`, your pull request should target the `release-1.9.0` branch.
+Include a clear title and description.
 Reference any issues fixed, for example `Fixes #1234`.
 Ensure your PR title follows [semantic commit conventions](https://www.conventionalcommits.org/).
 4. A maintainer will review your PR and may request changes.

--- a/docs/docs/Contributing/contributing-how-to-contribute.mdx
+++ b/docs/docs/Contributing/contributing-how-to-contribute.mdx
@@ -288,7 +288,11 @@ This can help you find broken links before creating a PR.
 
 To submit a pull request, do the following:
 
-1. Open a new GitHub pull request with your patch against the `main` branch.
+1. Open a GitHub pull request against the active `release-X.Y.Z` release candidate branch.
+Do not target `main`.
+For example, if the latest released version is `1.8.0`, your pull request should target the `release-1.9.0` branch.
+Include a clear title and description.
+
 2. Ensure the PR title follows semantic commit conventions. For example, features are `feat: add new feature` and fixes are `fix: correct issue with X`.
 
 Some additional guidance on pull request titles:


### PR DESCRIPTION
Release strategy has changed, and `main` should remain frozen.
Update docs to indicate that contributions should target the current release candidate branch.
(This PR is pointed at `main` on purpose, but we can move it to 1.9.0).