### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![YouTube Channel](https://img.shields.io/youtube/channel/subscribers/UCn2bInQrjdDYKEEmbpwblLQ?label=Subscribe)](https://www.youtube.com/@Langflow)
 [![Discord Server](https://img.shields.io/discord/1116803230643527710?logo=discord&style=social&label=Join)](https://discord.gg/EqksyE2EX9)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langflow-ai/langflow)
+[![gitcgr](https://gitcgr.com/badge/langflow-ai/langflow.svg)](https://gitcgr.com/langflow-ai/langflow)
 
 [Langflow](https://langflow.org) is a powerful platform for building and deploying AI-powered agents and workflows. It provides developers with both a visual authoring experience and built-in API and MCP servers that turn every workflow into a tool that can be integrated into applications built on any framework or stack. Langflow comes with batteries included and supports all major LLMs, vector databases and a growing library of AI tools.
 


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/langflow-ai/langflow.svg)](https://gitcgr.com/langflow-ai/langflow)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a status badge to the repository for improved project visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->