### PR TITLE
fix: replace deprecated Google embedding models with gemini-embedding-001

### DIFF
--- a/docs/docs/Components/bundles-google.mdx
+++ b/docs/docs/Components/bundles-google.mdx
@@ -121,7 +121,7 @@ For more information about using embedding model components in flows, see [Embed
 | Name | Display Name | Info |
 |------|--------------|------|
 | api_key | API Key | Input parameter. The secret API key for accessing Google's generative AI service. Required. |
-| model_name | Model Name | Input parameter. The name of the embedding model to use. Default: "models/text-embedding-004". |
+| model_name | Model Name | Input parameter. The name of the embedding model to use. Default: "models/gemini-embedding-001". |
 | embeddings | Embeddings | Output parameter. The built GoogleGenerativeAIEmbeddings object. |
 
 ## Google Search API

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -62,10 +62,9 @@ from langflow.services.deps import (
 
 def update_projects_components_with_latest_component_versions(project_data, all_types_dict):
     # Flatten the all_types_dict for easy access
-    all_types_dict_flat = {}
-    for category in all_types_dict.values():
-        for key, component in category.items():
-            all_types_dict_flat[key] = component
+    all_types_dict_flat = {
+        key: component for category in all_types_dict.values() for key, component in category.items()
+    }
 
     node_changes_log = defaultdict(list)
     project_data_copy = deepcopy(project_data)

--- a/src/backend/tests/unit/components/files_and_knowledge/test_retrieval.py
+++ b/src/backend/tests/unit/components/files_and_knowledge/test_retrieval.py
@@ -278,7 +278,7 @@ class TestKnowledgeBaseComponent(ComponentTestBaseWithClient):
 
         metadata = {
             "embedding_provider": "Google Generative AI",
-            "embedding_model": "models/embedding-001",
+            "embedding_model": "models/gemini-embedding-001",
             "chunk_size": 1000,
         }
 
@@ -288,7 +288,7 @@ class TestKnowledgeBaseComponent(ComponentTestBaseWithClient):
         result = component._build_embeddings(metadata, api_key="test-google-key")
 
         mock_google_embeddings.assert_called_once_with(
-            model="models/embedding-001",
+            model="models/gemini-embedding-001",
             google_api_key="test-google-key",  # pragma:allowlist secret
         )
         assert result == mock_embeddings
@@ -299,7 +299,7 @@ class TestKnowledgeBaseComponent(ComponentTestBaseWithClient):
 
         metadata = {
             "embedding_provider": "Google Generative AI",
-            "embedding_model": "models/embedding-001",
+            "embedding_model": "models/gemini-embedding-001",
             "chunk_size": 1000,
         }
 

--- a/src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py
+++ b/src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py
@@ -160,7 +160,7 @@ class TestEmbeddingModelComponent(ComponentTestBaseWithoutClient):
         component = component_class(
             model=[
                 {
-                    "name": "models/text-embedding-004",
+                    "name": "models/gemini-embedding-001",
                     "provider": "Google Generative AI",
                     "metadata": {
                         "embedding_class": "GoogleGenerativeAIEmbeddings",
@@ -192,7 +192,7 @@ class TestEmbeddingModelComponent(ComponentTestBaseWithoutClient):
 
         # Verify the GoogleGenerativeAIEmbeddings was called with the correct parameters
         mock_google_class.assert_called_once_with(
-            model="models/text-embedding-004",
+            model="models/gemini-embedding-001",
             google_api_key="test-google-key",
         )
 

--- a/src/lfx/src/lfx/base/models/google_generative_ai_constants.py
+++ b/src/lfx/src/lfx/base/models/google_generative_ai_constants.py
@@ -100,8 +100,7 @@ GOOGLE_GENERATIVE_AI_MODELS = [metadata["name"] for metadata in GOOGLE_GENERATIV
 
 # Google Generative AI Embedding Models
 GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS = [
-    "models/text-embedding-004",
-    "models/embedding-001",
+    "models/gemini-embedding-001",
 ]
 
 # Embedding models as detailed metadata

--- a/src/lfx/src/lfx/components/google/google_generative_ai_embeddings.py
+++ b/src/lfx/src/lfx/components/google/google_generative_ai_embeddings.py
@@ -11,9 +11,9 @@ from lfx.io import MessageTextInput, Output, SecretStrInput
 
 MIN_DIMENSION_ERROR = "Output dimensionality must be at least 1"
 MAX_DIMENSION_ERROR = (
-    "Output dimensionality cannot exceed 768. Google's embedding models only support dimensions up to 768."
+    "Output dimensionality cannot exceed 3072. Google's embedding models only support dimensions up to 3072."
 )
-MAX_DIMENSION = 768
+MAX_DIMENSION = 3072
 MIN_DIMENSION = 1
 
 
@@ -29,7 +29,7 @@ class GoogleGenerativeAIEmbeddingsComponent(Component):
 
     inputs = [
         SecretStrInput(name="api_key", display_name="Google Generative AI API Key", required=True),
-        MessageTextInput(name="model_name", display_name="Model Name", value="models/text-embedding-004"),
+        MessageTextInput(name="model_name", display_name="Model Name", value="models/gemini-embedding-001"),
     ]
 
     outputs = [

--- a/src/lfx/src/lfx/components/google/google_generative_ai_embeddings.py
+++ b/src/lfx/src/lfx/components/google/google_generative_ai_embeddings.py
@@ -11,7 +11,7 @@ from lfx.io import MessageTextInput, Output, SecretStrInput
 
 MIN_DIMENSION_ERROR = "Output dimensionality must be at least 1"
 MAX_DIMENSION_ERROR = (
-    "Output dimensionality cannot exceed 3072. Google's embedding models only support dimensions up to 3072."
+    "Output dimensionality {} cannot exceed 3072. Google's embedding models only support dimensions up to 3072."
 )
 MAX_DIMENSION = 3072
 MIN_DIMENSION = 1

--- a/src/lfx/tests/unit/test_flow_requirements.py
+++ b/src/lfx/tests/unit/test_flow_requirements.py
@@ -307,7 +307,7 @@ class TestDetectProviders:
                 "value": [{"provider": "OpenAI", "name": "gpt-4o"}],
             },
             "embeddings_model": {
-                "value": [{"provider": "Google Generative AI", "name": "embedding-001"}],
+                "value": [{"provider": "Google Generative AI", "name": "gemini-embedding-001"}],
             },
         }
         result = _detect_providers_from_template(template)
@@ -561,7 +561,7 @@ class TestGenerateRequirementsFromFlow:
             "Embeddings",
             "",
             template_extra={
-                "embeddings_model": {"value": [{"provider": "Google Generative AI", "name": "embedding-001"}]},
+                "embeddings_model": {"value": [{"provider": "Google Generative AI", "name": "gemini-embedding-001"}]},
             },
         )
         flow = _make_flow(node1, node2)


### PR DESCRIPTION
Fixes #12277

## Summary

The Google embedding models `text-embedding-004` and `embedding-001` have been deprecated and return 404 errors, breaking knowledge base ingestion in langflow. This PR replaces them with `gemini-embedding-001`, Google's current embedding model.

### Changes

- **google_generative_ai_constants.py**: Updated `GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS` list — replaced `models/text-embedding-004` and `models/embedding-001` with `models/gemini-embedding-001`
- **google_generative_ai_embeddings.py**: Updated default `model_name` to `models/gemini-embedding-001` and `MAX_DIMENSION` from 768 to 3072 (gemini-embedding-001 supports higher dimensions)
- **test_embedding_model_component.py**: Updated test fixture model name
- **test_retrieval.py**: Updated test fixture model name
- **bundles-google.mdx**: Updated documentation default model name
- **component_index.json**: Regenerated to reflect new defaults

## Test Plan

- [x] `uv run pytest src/backend/tests/unit/components/models_and_agents/test_embedding_model_component.py -v -k test_build_embeddings_google` — passes
- [x] `uv run pytest src/backend/tests/unit/components/files_and_knowledge/test_retrieval.py -v` — passes (44 passed, 4 skipped)
- [x] `uv run ruff check` on changed Python files — all checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Google Generative AI Embeddings component to use a new default embedding model (`gemini-embedding-001`)
  * Expanded maximum embedding dimensionality support from 768 to 3072 dimensions
  * Updated component documentation to reflect new defaults

* **Documentation**
  * Updated Google Generative AI Embeddings documentation

* **Refactor**
  * Simplified internal data structure processing logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->