### PR TITLE
feat: flow scheduling with concurrency control, retry and observability

### DIFF
--- a/src/backend/base/langflow/alembic/versions/a1b2c3d4e5f6_add_flow_schedule_table.py
+++ b/src/backend/base/langflow/alembic/versions/a1b2c3d4e5f6_add_flow_schedule_table.py
@@ -1,0 +1,62 @@
+"""add flow schedule table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 0e6138e7a0c2, d37bc4322900, 1cb603706752
+Create Date: 2026-03-22 10:00:00.000000
+
+Phase: EXPAND
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = ("0e6138e7a0c2", "d37bc4322900", "1cb603706752")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "flowschedule" not in existing_tables:
+        op.create_table(
+            "flowschedule",
+            sa.Column("id", sa.Uuid(), nullable=False),
+            sa.Column("flow_id", sa.Uuid(), nullable=False),
+            sa.Column("user_id", sa.Uuid(), nullable=False),
+            sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+            sa.Column("schedule_type", sa.String(), nullable=False, server_default=sa.text("'cron'")),
+            sa.Column("minute", sa.String(), nullable=False, server_default=sa.text("'0'")),
+            sa.Column("hour", sa.String(), nullable=False, server_default=sa.text("'*'")),
+            sa.Column("day_of_week", sa.String(), nullable=False, server_default=sa.text("'*'")),
+            sa.Column("day_of_month", sa.String(), nullable=False, server_default=sa.text("'*'")),
+            sa.Column("month", sa.String(), nullable=False, server_default=sa.text("'*'")),
+            sa.Column("timezone", sa.String(), nullable=False, server_default=sa.text("'UTC'")),
+            sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_run_status", sa.String(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["flow_id"], ["flow.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("flow_id", name="unique_flow_schedule"),
+        )
+        op.create_index(op.f("ix_flowschedule_flow_id"), "flowschedule", ["flow_id"], unique=False)
+        op.create_index(op.f("ix_flowschedule_user_id"), "flowschedule", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "flowschedule" in existing_tables:
+        op.drop_index(op.f("ix_flowschedule_user_id"), table_name="flowschedule")
+        op.drop_index(op.f("ix_flowschedule_flow_id"), table_name="flowschedule")
+        op.drop_table("flowschedule")

--- a/src/backend/base/langflow/alembic/versions/b2c3d4e5f6a7_add_start_at_to_flowschedule.py
+++ b/src/backend/base/langflow/alembic/versions/b2c3d4e5f6a7_add_start_at_to_flowschedule.py
@@ -1,0 +1,44 @@
+"""add start_at to flowschedule
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-03-23 12:00:00.000000
+
+Phase: EXPAND
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"
+down_revision: str | Sequence[str] | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "flowschedule" in existing_tables:
+        columns = [col["name"] for col in inspector.get_columns("flowschedule")]
+        if "start_at" not in columns:
+            op.add_column(
+                "flowschedule",
+                sa.Column("start_at", sa.DateTime(timezone=True), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "flowschedule" in existing_tables:
+        columns = [col["name"] for col in inspector.get_columns("flowschedule")]
+        if "start_at" in columns:
+            op.drop_column("flowschedule", "start_at")

--- a/src/backend/base/langflow/alembic/versions/c3d4e5f6a7b8_add_retry_fields_to_flowschedule.py
+++ b/src/backend/base/langflow/alembic/versions/c3d4e5f6a7b8_add_retry_fields_to_flowschedule.py
@@ -1,0 +1,51 @@
+"""add retry fields to flowschedule
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-03-23 16:00:00.000000
+
+Phase: EXPAND
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: str | Sequence[str] | None = "b2c3d4e5f6a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "flowschedule" in existing_tables:
+        columns = [col["name"] for col in inspector.get_columns("flowschedule")]
+        if "retry_count" not in columns:
+            op.add_column(
+                "flowschedule",
+                sa.Column("retry_count", sa.Integer(), nullable=False, server_default="0"),
+            )
+        if "max_retries" not in columns:
+            op.add_column(
+                "flowschedule",
+                sa.Column("max_retries", sa.Integer(), nullable=False, server_default="3"),
+            )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "flowschedule" in existing_tables:
+        columns = [col["name"] for col in inspector.get_columns("flowschedule")]
+        if "max_retries" in columns:
+            op.drop_column("flowschedule", "max_retries")
+        if "retry_count" in columns:
+            op.drop_column("flowschedule", "retry_count")

--- a/src/backend/base/langflow/api/router.py
+++ b/src/backend/base/langflow/api/router.py
@@ -19,6 +19,7 @@ from langflow.api.v1 import (
     monitor_router,
     openai_responses_router,
     projects_router,
+    schedules_router,
     starter_projects_router,
     store_router,
     traces_router,
@@ -64,6 +65,7 @@ router_v1.include_router(openai_responses_router)
 router_v1.include_router(models_router)
 router_v1.include_router(model_options_router)
 router_v1.include_router(deployment_router)
+router_v1.include_router(schedules_router)
 
 
 # Agentic flow execution - lazy import to avoid circular dependency

--- a/src/backend/base/langflow/api/v1/__init__.py
+++ b/src/backend/base/langflow/api/v1/__init__.py
@@ -15,6 +15,7 @@ from langflow.api.v1.models import router as models_router
 from langflow.api.v1.monitor import router as monitor_router
 from langflow.api.v1.openai_responses import router as openai_responses_router
 from langflow.api.v1.projects import router as projects_router
+from langflow.api.v1.schedules import router as schedules_router
 from langflow.api.v1.starter_projects import router as starter_projects_router
 from langflow.api.v1.store import router as store_router
 from langflow.api.v1.traces import router as traces_router
@@ -41,6 +42,7 @@ __all__ = [
     "monitor_router",
     "openai_responses_router",
     "projects_router",
+    "schedules_router",
     "starter_projects_router",
     "store_router",
     "traces_router",

--- a/src/backend/base/langflow/api/v1/schedules.py
+++ b/src/backend/base/langflow/api/v1/schedules.py
@@ -1,0 +1,182 @@
+"""API router for flow schedule management."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, status
+from lfx.log.logger import logger
+
+from langflow.api.utils import CurrentActiveUser, DbSession
+from langflow.services.database.models.flow.model import Flow
+from langflow.services.database.models.schedule.crud import (
+    create_schedule,
+    delete_schedule,
+    get_schedule_by_flow_id,
+    get_schedule_by_id,
+    toggle_schedule,
+    update_schedule,
+)
+from langflow.services.database.models.schedule.model import (
+    FlowSchedule,
+    FlowScheduleCreate,
+    FlowScheduleRead,
+    FlowScheduleUpdate,
+)
+from langflow.services.deps import get_scheduler_service
+
+router = APIRouter(prefix="/schedules", tags=["Schedules"])
+
+
+async def _verify_flow_ownership(session, flow_id: UUID, user_id: UUID) -> Flow:
+    """Verify that the flow exists and belongs to the user.
+
+    Allows access when flow.user_id is None (no ownership set, e.g. single-user mode)
+    or when it matches the current user.
+    """
+    from sqlmodel import select
+
+    statement = select(Flow).where(Flow.id == flow_id)
+    result = await session.exec(statement)
+    flow = result.first()
+    if flow is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Flow not found")
+    if flow.user_id is not None and flow.user_id != user_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this flow")
+    return flow
+
+
+@router.get("/{flow_id}", response_model=FlowScheduleRead)
+async def get_flow_schedule(
+    flow_id: UUID,
+    session: DbSession,
+    current_user: CurrentActiveUser,
+):
+    """Get the schedule for a specific flow."""
+    await _verify_flow_ownership(session, flow_id, current_user.id)
+    schedule = await get_schedule_by_flow_id(session, flow_id)
+    if schedule is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found for this flow")
+    return schedule
+
+
+@router.post("", response_model=FlowScheduleRead, status_code=status.HTTP_201_CREATED)
+async def create_flow_schedule(
+    schedule_data: FlowScheduleCreate,
+    session: DbSession,
+    current_user: CurrentActiveUser,
+):
+    """Create a schedule for a flow."""
+    await _verify_flow_ownership(session, schedule_data.flow_id, current_user.id)
+
+    # Check if schedule already exists
+    existing = await get_schedule_by_flow_id(session, schedule_data.flow_id)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Schedule already exists for this flow. Use PATCH to update.",
+        )
+
+    schedule = FlowSchedule(
+        **schedule_data.model_dump(),
+        user_id=current_user.id,
+    )
+    schedule = await create_schedule(session, schedule)
+
+    # If active, register with scheduler
+    if schedule.is_active:
+        try:
+            scheduler_service = get_scheduler_service()
+            scheduler_service.add_schedule(schedule)
+        except Exception:
+            await logger.aexception("Failed to register schedule with APScheduler")
+
+    return schedule
+
+
+@router.patch("/{schedule_id}", response_model=FlowScheduleRead)
+async def update_flow_schedule(
+    schedule_id: UUID,
+    schedule_data: FlowScheduleUpdate,
+    session: DbSession,
+    current_user: CurrentActiveUser,
+):
+    """Update an existing schedule."""
+    schedule = await get_schedule_by_id(session, schedule_id)
+    if schedule is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found")
+
+    await _verify_flow_ownership(session, schedule.flow_id, current_user.id)
+
+    update_dict = schedule_data.model_dump(exclude_none=True)
+    if not update_dict:
+        return schedule
+
+    updated = await update_schedule(session, schedule_id, update_dict)
+    if updated is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found")
+
+    # Update APScheduler
+    try:
+        scheduler_service = get_scheduler_service()
+        if updated.is_active:
+            scheduler_service.add_schedule(updated)
+        else:
+            scheduler_service.remove_schedule(updated.flow_id)
+    except Exception:
+        await logger.aexception("Failed to update schedule in APScheduler")
+
+    return updated
+
+
+@router.delete("/{schedule_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_flow_schedule(
+    schedule_id: UUID,
+    session: DbSession,
+    current_user: CurrentActiveUser,
+):
+    """Delete a schedule."""
+    schedule = await get_schedule_by_id(session, schedule_id)
+    if schedule is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found")
+
+    await _verify_flow_ownership(session, schedule.flow_id, current_user.id)
+
+    # Remove from APScheduler
+    try:
+        scheduler_service = get_scheduler_service()
+        scheduler_service.remove_schedule(schedule.flow_id)
+    except Exception:
+        await logger.aexception("Failed to remove schedule from APScheduler")
+
+    await delete_schedule(session, schedule_id)
+
+
+@router.patch("/{schedule_id}/toggle", response_model=FlowScheduleRead)
+async def toggle_flow_schedule(
+    schedule_id: UUID,
+    session: DbSession,
+    current_user: CurrentActiveUser,
+):
+    """Toggle the active state of a schedule."""
+    schedule = await get_schedule_by_id(session, schedule_id)
+    if schedule is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found")
+
+    await _verify_flow_ownership(session, schedule.flow_id, current_user.id)
+
+    toggled = await toggle_schedule(session, schedule_id)
+    if toggled is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found")
+
+    # Update APScheduler
+    try:
+        scheduler_service = get_scheduler_service()
+        if toggled.is_active:
+            scheduler_service.add_schedule(toggled)
+        else:
+            scheduler_service.remove_schedule(toggled.flow_id)
+    except Exception:
+        await logger.aexception("Failed to toggle schedule in APScheduler")
+
+    return toggled

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -281,6 +281,15 @@ def get_lifespan(*, fix_migration=False, version=None):
                 queue_service.start()
             await logger.adebug(f"Flows loaded in {asyncio.get_event_loop().time() - current_time:.2f}s")
 
+            # Start scheduler service for automatic flow execution
+            current_time = asyncio.get_event_loop().time()
+            await logger.adebug("Starting scheduler service")
+            from langflow.services.deps import get_scheduler_service
+
+            scheduler_service = get_scheduler_service()
+            await scheduler_service.start()
+            await logger.adebug(f"Scheduler service started in {asyncio.get_event_loop().time() - current_time:.2f}s")
+
             total_time = asyncio.get_event_loop().time() - start_time
             await logger.adebug(f"Total initialization time: {total_time:.2f}s")
 

--- a/src/backend/base/langflow/services/database/models/jobs/model.py
+++ b/src/backend/base/langflow/services/database/models/jobs/model.py
@@ -29,6 +29,7 @@ class JobType(str, Enum):
     WORKFLOW = "workflow"
     INGESTION = "ingestion"
     EVALUATION = "evaluation"
+    SCHEDULED = "scheduled"
 
 
 class JobBase(SQLModel):

--- a/src/backend/base/langflow/services/database/models/schedule/__init__.py
+++ b/src/backend/base/langflow/services/database/models/schedule/__init__.py
@@ -1,0 +1,13 @@
+from langflow.services.database.models.schedule.model import (
+    FlowSchedule,
+    FlowScheduleCreate,
+    FlowScheduleRead,
+    FlowScheduleUpdate,
+)
+
+__all__ = [
+    "FlowSchedule",
+    "FlowScheduleCreate",
+    "FlowScheduleRead",
+    "FlowScheduleUpdate",
+]

--- a/src/backend/base/langflow/services/database/models/schedule/crud.py
+++ b/src/backend/base/langflow/services/database/models/schedule/crud.py
@@ -1,0 +1,126 @@
+"""CRUD operations for FlowSchedule model."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+from sqlmodel import select
+
+from langflow.services.database.models.schedule.model import FlowSchedule
+
+
+async def create_schedule(db: AsyncSession, schedule: FlowSchedule) -> FlowSchedule:
+    """Create a new flow schedule."""
+    db.add(schedule)
+    await db.flush()
+    await db.refresh(schedule)
+    return schedule
+
+
+async def get_schedule_by_flow_id(db: AsyncSession, flow_id: UUID) -> FlowSchedule | None:
+    """Get schedule for a specific flow."""
+    statement = select(FlowSchedule).where(FlowSchedule.flow_id == flow_id)
+    result = await db.exec(statement)
+    return result.first()
+
+
+async def get_schedule_by_id(db: AsyncSession, schedule_id: UUID) -> FlowSchedule | None:
+    """Get schedule by its ID."""
+    statement = select(FlowSchedule).where(FlowSchedule.id == schedule_id)
+    result = await db.exec(statement)
+    return result.first()
+
+
+async def get_all_active_schedules(db: AsyncSession) -> list[FlowSchedule]:
+    """Get all active schedules."""
+    statement = select(FlowSchedule).where(FlowSchedule.is_active == True)  # noqa: E712
+    result = await db.exec(statement)
+    return list(result.all())
+
+
+async def update_schedule(
+    db: AsyncSession,
+    schedule_id: UUID,
+    data: dict,
+) -> FlowSchedule | None:
+    """Update a flow schedule."""
+    schedule = await get_schedule_by_id(db, schedule_id)
+    if schedule is None:
+        return None
+    for key, value in data.items():
+        if value is not None:
+            setattr(schedule, key, value)
+    schedule.updated_at = datetime.now(timezone.utc)
+    db.add(schedule)
+    await db.flush()
+    await db.refresh(schedule)
+    return schedule
+
+
+async def delete_schedule(db: AsyncSession, schedule_id: UUID) -> bool:
+    """Delete a flow schedule. Returns True if deleted."""
+    schedule = await get_schedule_by_id(db, schedule_id)
+    if schedule is None:
+        return False
+    await db.delete(schedule)
+    await db.flush()
+    return True
+
+
+async def toggle_schedule(db: AsyncSession, schedule_id: UUID) -> FlowSchedule | None:
+    """Toggle the is_active state of a schedule."""
+    schedule = await get_schedule_by_id(db, schedule_id)
+    if schedule is None:
+        return None
+    schedule.is_active = not schedule.is_active
+    schedule.updated_at = datetime.now(timezone.utc)
+    db.add(schedule)
+    await db.flush()
+    await db.refresh(schedule)
+    return schedule
+
+
+async def reset_retry_count(db: AsyncSession, schedule_id: UUID) -> FlowSchedule | None:
+    """Reset the retry count to zero (called on successful execution or new cron trigger)."""
+    schedule = await get_schedule_by_id(db, schedule_id)
+    if schedule is None:
+        return None
+    schedule.retry_count = 0
+    db.add(schedule)
+    await db.flush()
+    return schedule
+
+
+async def increment_retry_count(db: AsyncSession, schedule_id: UUID) -> FlowSchedule | None:
+    """Increment the retry count by 1. Returns the updated schedule."""
+    schedule = await get_schedule_by_id(db, schedule_id)
+    if schedule is None:
+        return None
+    schedule.retry_count += 1
+    schedule.updated_at = datetime.now(timezone.utc)
+    db.add(schedule)
+    await db.flush()
+    await db.refresh(schedule)
+    return schedule
+
+
+async def update_last_run(
+    db: AsyncSession,
+    schedule_id: UUID,
+    status: str,
+) -> FlowSchedule | None:
+    """Update the last run timestamp and status."""
+    schedule = await get_schedule_by_id(db, schedule_id)
+    if schedule is None:
+        return None
+    schedule.last_run_at = datetime.now(timezone.utc)
+    schedule.last_run_status = status
+    db.add(schedule)
+    await db.flush()
+    return schedule

--- a/src/backend/base/langflow/services/database/models/schedule/model.py
+++ b/src/backend/base/langflow/services/database/models/schedule/model.py
@@ -1,0 +1,97 @@
+"""FlowSchedule model for scheduling automatic flow executions."""
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from sqlalchemy import Column, DateTime, Text, UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+
+class FlowScheduleBase(SQLModel):
+    """Base model for flow schedules."""
+
+    flow_id: UUID = Field(index=True, foreign_key="flow.id")
+    is_active: bool = Field(default=False, nullable=False)
+    schedule_type: str = Field(
+        default="cron",
+        nullable=False,
+        description="Type of schedule: 'cron', 'interval'",
+    )
+    # Cron expression fields
+    minute: str = Field(default="0", nullable=False, description="Cron minute field (0-59, */N, etc.)")
+    hour: str = Field(default="*", nullable=False, description="Cron hour field (0-23, */N, etc.)")
+    day_of_week: str = Field(default="*", nullable=False, description="Cron day of week (0-6, mon-sun, etc.)")
+    day_of_month: str = Field(default="*", nullable=False, description="Cron day of month (1-31, */N, etc.)")
+    month: str = Field(default="*", nullable=False, description="Cron month field (1-12, */N, etc.)")
+    timezone: str = Field(default="UTC", nullable=False, description="Timezone for the schedule (IANA format)")
+    start_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+        description="When the schedule becomes effective. None means immediately.",
+    )
+    # Metadata
+    last_run_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    last_run_status: str | None = Field(default=None, nullable=True, description="Status of the last run")
+    # Retry fields
+    retry_count: int = Field(default=0, nullable=False, description="Current consecutive failure count, reset on success")
+    max_retries: int = Field(default=3, nullable=False, description="Max retry attempts before marking as permanently failed")
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class FlowSchedule(FlowScheduleBase, table=True):  # type: ignore[call-arg]
+    """Database table for flow schedules."""
+
+    __tablename__ = "flowschedule"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, unique=True)
+    user_id: UUID = Field(index=True, foreign_key="user.id", nullable=False)
+
+    __table_args__ = (UniqueConstraint("flow_id", name="unique_flow_schedule"),)
+
+
+class FlowScheduleCreate(SQLModel):
+    """Schema for creating a flow schedule."""
+
+    flow_id: UUID
+    is_active: bool = False
+    schedule_type: str = "cron"
+    minute: str = "0"
+    hour: str = "*"
+    day_of_week: str = "*"
+    day_of_month: str = "*"
+    month: str = "*"
+    timezone: str = "UTC"
+    start_at: datetime | None = None
+    max_retries: int = 3
+
+
+class FlowScheduleRead(FlowScheduleBase):
+    """Schema for reading a flow schedule."""
+
+    id: UUID
+    user_id: UUID
+
+
+class FlowScheduleUpdate(SQLModel):
+    """Schema for updating a flow schedule."""
+
+    is_active: bool | None = None
+    schedule_type: str | None = None
+    minute: str | None = None
+    hour: str | None = None
+    day_of_week: str | None = None
+    day_of_month: str | None = None
+    month: str | None = None
+    timezone: str | None = None
+    start_at: datetime | None = None
+    max_retries: int | None = None

--- a/src/backend/base/langflow/services/database/models/schedule/model.py
+++ b/src/backend/base/langflow/services/database/models/schedule/model.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
-from sqlalchemy import Column, DateTime, Text, UniqueConstraint
+from sqlalchemy import Column, DateTime, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
 
@@ -36,8 +36,12 @@ class FlowScheduleBase(SQLModel):
     )
     last_run_status: str | None = Field(default=None, nullable=True, description="Status of the last run")
     # Retry fields
-    retry_count: int = Field(default=0, nullable=False, description="Current consecutive failure count, reset on success")
-    max_retries: int = Field(default=3, nullable=False, description="Max retry attempts before marking as permanently failed")
+    retry_count: int = Field(
+        default=0, nullable=False, description="Current consecutive failure count, reset on success"
+    )
+    max_retries: int = Field(
+        default=3, nullable=False, description="Max retry attempts before marking as permanently failed"
+    )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         sa_column=Column(DateTime(timezone=True), nullable=False),

--- a/src/backend/base/langflow/services/deps.py
+++ b/src/backend/base/langflow/services/deps.py
@@ -254,6 +254,17 @@ def get_auth_service() -> BaseAuthService:
     return get_service(ServiceType.AUTH_SERVICE, AuthServiceFactory())
 
 
+def get_scheduler_service():
+    """Retrieves the SchedulerService instance from the service manager.
+
+    Returns:
+        SchedulerService: The SchedulerService instance.
+    """
+    from langflow.services.scheduler.factory import SchedulerServiceFactory
+
+    return get_service(ServiceType.SCHEDULER_SERVICE, SchedulerServiceFactory())
+
+
 def get_job_service():
     """Retrieves the JobService instance from the service manager.
 

--- a/src/backend/base/langflow/services/scheduler/__init__.py
+++ b/src/backend/base/langflow/services/scheduler/__init__.py
@@ -1,0 +1,3 @@
+from langflow.services.scheduler.service import SchedulerService
+
+__all__ = ["SchedulerService"]

--- a/src/backend/base/langflow/services/scheduler/factory.py
+++ b/src/backend/base/langflow/services/scheduler/factory.py
@@ -1,0 +1,18 @@
+"""Factory for creating SchedulerService instances."""
+
+from langflow.services.factory import ServiceFactory
+from langflow.services.scheduler.service import SchedulerService
+
+
+class SchedulerServiceFactory(ServiceFactory):
+    """Factory for creating SchedulerService instances."""
+
+    def __init__(self):
+        super().__init__(SchedulerService)
+        self._instance = None
+
+    def create(self):
+        """Create a SchedulerService instance."""
+        if self._instance is None:
+            self._instance = SchedulerService()
+        return self._instance

--- a/src/backend/base/langflow/services/scheduler/service.py
+++ b/src/backend/base/langflow/services/scheduler/service.py
@@ -1,0 +1,363 @@
+"""Scheduler service for automatic flow execution using APScheduler.
+
+Includes concurrency control (semaphore), jitter (anti-thundering herd),
+retry with exponential backoff, and structured observability logging.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+import time
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+from lfx.log.logger import logger
+
+from langflow.services.base import Service
+from langflow.services.database.models.schedule.crud import (
+    get_all_active_schedules,
+    get_schedule_by_id,
+    increment_retry_count,
+    reset_retry_count,
+    update_last_run,
+)
+from langflow.services.deps import session_scope
+
+if TYPE_CHECKING:
+    from langflow.services.database.models.schedule.model import FlowSchedule
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read an integer from an environment variable with a fallback default."""
+    try:
+        return int(os.environ.get(name, default))
+    except (ValueError, TypeError):
+        return default
+
+
+class SchedulerService(Service):
+    """Service for managing scheduled flow executions via APScheduler.
+
+    Configuration via environment variables:
+        LANGFLOW_SCHEDULER_MAX_CONCURRENCY     – max parallel flow executions (default 5)
+        LANGFLOW_SCHEDULER_MAX_JITTER_SECONDS  – random delay window in seconds (default 30, 0 to disable)
+        LANGFLOW_SCHEDULER_RETRY_BASE_DELAY    – initial retry delay in seconds (default 30)
+        LANGFLOW_SCHEDULER_RETRY_MAX_DELAY     – cap for retry delay in seconds (default 300)
+        LANGFLOW_SCHEDULER_DEFAULT_MAX_RETRIES – default max retries per schedule (default 3)
+    """
+
+    name = "scheduler_service"
+
+    def __init__(self):
+        self.scheduler = AsyncIOScheduler()
+
+        # ── Configuration ──────────────────────────────────────────────
+        self._max_concurrency: int = _env_int("LANGFLOW_SCHEDULER_MAX_CONCURRENCY", 5)
+        self._max_jitter: int = _env_int("LANGFLOW_SCHEDULER_MAX_JITTER_SECONDS", 30)
+        self._retry_base_delay: int = _env_int("LANGFLOW_SCHEDULER_RETRY_BASE_DELAY", 30)
+        self._retry_max_delay: int = _env_int("LANGFLOW_SCHEDULER_RETRY_MAX_DELAY", 300)
+        self._default_max_retries: int = _env_int("LANGFLOW_SCHEDULER_DEFAULT_MAX_RETRIES", 3)
+
+        # ── Observability counters ─────────────────────────────────────
+        self._active_count: int = 0
+        self._total_executions: int = 0
+        self._total_failures: int = 0
+
+        # Semaphore is created lazily in start() to ensure the event loop exists.
+        self._semaphore: asyncio.Semaphore | None = None
+
+        self.set_ready()
+
+    # ── Lifecycle ──────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Start the scheduler and load active schedules from DB."""
+        await logger.ainfo("Starting SchedulerService...")
+
+        # Create the semaphore inside the running event loop.
+        self._semaphore = asyncio.Semaphore(self._max_concurrency)
+
+        await logger.ainfo(
+            "SchedulerService configuration",
+            extra={
+                "max_concurrency": self._max_concurrency,
+                "max_jitter_seconds": self._max_jitter,
+                "retry_base_delay": self._retry_base_delay,
+                "retry_max_delay": self._retry_max_delay,
+                "default_max_retries": self._default_max_retries,
+            },
+        )
+
+        self.scheduler.start()
+        await self._load_schedules_from_db()
+        await logger.ainfo("SchedulerService started successfully")
+
+    async def teardown(self) -> None:
+        """Shutdown the scheduler."""
+        await logger.ainfo("Shutting down SchedulerService...")
+        if self.scheduler.running:
+            self.scheduler.shutdown(wait=False)
+        await logger.ainfo(
+            "SchedulerService shut down",
+            extra={
+                "total_executions": self._total_executions,
+                "total_failures": self._total_failures,
+            },
+        )
+
+    # ── Schedule management ────────────────────────────────────────────
+
+    async def _load_schedules_from_db(self) -> None:
+        """Load all active schedules from the database and register them."""
+        try:
+            async with session_scope() as session:
+                schedules = await get_all_active_schedules(session)
+                count = 0
+                for schedule in schedules:
+                    self.add_schedule(schedule)
+                    count += 1
+                await logger.ainfo(f"Loaded {count} active schedules from database")
+        except Exception:
+            await logger.aexception("Failed to load schedules from database")
+
+    def add_schedule(self, schedule: FlowSchedule) -> None:
+        """Add or replace a schedule in APScheduler."""
+        job_id = f"schedule_{schedule.flow_id}"
+
+        # Remove existing job if present
+        existing = self.scheduler.get_job(job_id)
+        if existing:
+            self.scheduler.remove_job(job_id)
+
+        trigger = CronTrigger(
+            minute=schedule.minute,
+            hour=schedule.hour,
+            day_of_week=schedule.day_of_week,
+            day=schedule.day_of_month,
+            month=schedule.month,
+            timezone=schedule.timezone,
+            start_date=schedule.start_at,
+        )
+
+        self.scheduler.add_job(
+            self._execute_flow,
+            trigger=trigger,
+            id=job_id,
+            args=[schedule.flow_id, schedule.user_id, schedule.id],
+            replace_existing=True,
+            misfire_grace_time=60,
+        )
+        logger.debug(f"Added schedule job {job_id} for flow {schedule.flow_id}")
+
+    def remove_schedule(self, flow_id: UUID) -> None:
+        """Remove a schedule from APScheduler."""
+        job_id = f"schedule_{flow_id}"
+        existing = self.scheduler.get_job(job_id)
+        if existing:
+            self.scheduler.remove_job(job_id)
+            logger.debug(f"Removed schedule job {job_id}")
+
+    # ── Flow execution ─────────────────────────────────────────────────
+
+    async def _execute_flow(
+        self,
+        flow_id: UUID,
+        user_id: UUID,
+        schedule_id: UUID,
+        *,
+        is_retry: bool = False,
+    ) -> None:
+        """Execute a flow as a scheduled job with concurrency control and retry."""
+        from lfx.graph.graph.base import Graph
+
+        from langflow.processing.process import run_graph_internal
+        from langflow.services.database.models.flow.model import Flow
+        from langflow.services.database.models.jobs.model import Job, JobStatus, JobType
+        from langflow.services.jobs.service import JobService
+
+        # ── 1. Jitter: spread arrivals to avoid thundering herd ────────
+        if self._max_jitter > 0:
+            jitter = random.uniform(0, self._max_jitter)  # noqa: S311
+            await logger.adebug(
+                f"Applying {jitter:.1f}s jitter for flow {flow_id}",
+            )
+            await asyncio.sleep(jitter)
+
+        # ── 2. Queue: wait for semaphore slot ──────────────────────────
+        t_queued = time.monotonic()
+        self._total_executions += 1
+
+        await logger.ainfo(
+            "Scheduled flow queued for execution",
+            extra={
+                "flow_id": str(flow_id),
+                "schedule_id": str(schedule_id),
+                "active_count": self._active_count,
+                "is_retry": is_retry,
+            },
+        )
+
+        assert self._semaphore is not None  # noqa: S101 - guaranteed after start()
+        async with self._semaphore:
+            t_started = time.monotonic()
+            wait_seconds = t_started - t_queued
+            self._active_count += 1
+            status = "failed"
+
+            try:
+                # ── 3. Reset retry count on regular (non-retry) trigger ─
+                if not is_retry:
+                    try:
+                        async with session_scope() as session:
+                            await reset_retry_count(session, schedule_id)
+                    except Exception:
+                        await logger.aexception("Failed to reset retry count")
+
+                # ── 4. Load flow from DB ───────────────────────────────
+                async with session_scope() as session:
+                    from sqlmodel import select
+
+                    statement = select(Flow).where(Flow.id == flow_id)
+                    result = await session.exec(statement)
+                    flow = result.first()
+
+                    if flow is None:
+                        await logger.aerror(f"Scheduled flow {flow_id} not found, skipping execution")
+                        return
+
+                    if flow.data is None:
+                        await logger.aerror(f"Scheduled flow {flow_id} has no data, skipping execution")
+                        return
+
+                    flow_data = flow.data
+
+                # ── 5. Build graph ─────────────────────────────────────
+                graph = Graph.from_payload(
+                    flow_data,
+                    flow_id=str(flow_id),
+                    user_id=str(user_id),
+                )
+
+                # ── 6. Create job and execute ──────────────────────────
+                job_id = uuid4()
+                job_service = JobService()
+
+                async with session_scope() as session:
+                    job = Job(
+                        job_id=job_id,
+                        flow_id=flow_id,
+                        status=JobStatus.QUEUED,
+                        type=JobType.SCHEDULED,
+                        user_id=user_id,
+                    )
+                    session.add(job)
+                    await session.flush()
+
+                await job_service.execute_with_status(
+                    job_id,
+                    run_graph_internal,
+                    graph,
+                    str(flow_id),
+                )
+
+                # ── 7. Success ─────────────────────────────────────────
+                async with session_scope() as session:
+                    await update_last_run(session, schedule_id, "completed")
+                    await reset_retry_count(session, schedule_id)
+
+                status = "completed"
+
+            except Exception:
+                self._total_failures += 1
+                await logger.aexception(f"Scheduled execution failed for flow {flow_id}")
+
+                # Update last run and attempt retry
+                await self._handle_retry(flow_id, user_id, schedule_id)
+
+            finally:
+                self._active_count -= 1
+                duration = time.monotonic() - t_started
+
+                await logger.ainfo(
+                    "Scheduled flow execution finished",
+                    extra={
+                        "flow_id": str(flow_id),
+                        "schedule_id": str(schedule_id),
+                        "status": status,
+                        "duration_seconds": round(duration, 2),
+                        "wait_seconds": round(wait_seconds, 2),
+                        "active_count": self._active_count,
+                        "is_retry": is_retry,
+                        "total_executions": self._total_executions,
+                        "total_failures": self._total_failures,
+                    },
+                )
+
+    # ── Retry logic ────────────────────────────────────────────────────
+
+    async def _handle_retry(
+        self,
+        flow_id: UUID,
+        user_id: UUID,
+        schedule_id: UUID,
+    ) -> None:
+        """Handle retry logic after a failed execution.
+
+        Increments retry_count, and if below max_retries, schedules a one-shot
+        retry with exponential backoff via APScheduler DateTrigger.
+        """
+        try:
+            async with session_scope() as session:
+                await update_last_run(session, schedule_id, "failed")
+                schedule = await increment_retry_count(session, schedule_id)
+
+                if schedule is None:
+                    return
+
+                max_retries = schedule.max_retries or self._default_max_retries
+
+                if schedule.retry_count <= max_retries:
+                    delay = min(
+                        self._retry_base_delay * (2 ** (schedule.retry_count - 1)),
+                        self._retry_max_delay,
+                    )
+                    run_at = datetime.now(timezone.utc) + timedelta(seconds=delay)
+                    retry_job_id = f"schedule_{flow_id}_retry_{schedule.retry_count}"
+
+                    self.scheduler.add_job(
+                        self._execute_flow,
+                        trigger=DateTrigger(run_date=run_at),
+                        id=retry_job_id,
+                        args=[flow_id, user_id, schedule_id],
+                        kwargs={"is_retry": True},
+                        replace_existing=True,
+                        misfire_grace_time=60,
+                    )
+                    await logger.ainfo(
+                        f"Scheduled retry {schedule.retry_count}/{max_retries} "
+                        f"for flow {flow_id} in {delay}s",
+                        extra={
+                            "flow_id": str(flow_id),
+                            "retry_attempt": schedule.retry_count,
+                            "max_retries": max_retries,
+                            "retry_delay_seconds": delay,
+                        },
+                    )
+                else:
+                    await update_last_run(session, schedule_id, "failed_permanent")
+                    await logger.aerror(
+                        f"Flow {flow_id} exhausted all {max_retries} retries",
+                        extra={
+                            "flow_id": str(flow_id),
+                            "schedule_id": str(schedule_id),
+                            "retry_count": schedule.retry_count,
+                        },
+                    )
+        except Exception:
+            await logger.aexception("Failed to handle retry logic")

--- a/src/backend/base/langflow/services/scheduler/service.py
+++ b/src/backend/base/langflow/services/scheduler/service.py
@@ -22,7 +22,6 @@ from lfx.log.logger import logger
 from langflow.services.base import Service
 from langflow.services.database.models.schedule.crud import (
     get_all_active_schedules,
-    get_schedule_by_id,
     increment_retry_count,
     reset_retry_count,
     update_last_run,
@@ -340,8 +339,7 @@ class SchedulerService(Service):
                         misfire_grace_time=60,
                     )
                     await logger.ainfo(
-                        f"Scheduled retry {schedule.retry_count}/{max_retries} "
-                        f"for flow {flow_id} in {delay}s",
+                        f"Scheduled retry {schedule.retry_count}/{max_retries} for flow {flow_id} in {delay}s",
                         extra={
                             "flow_id": str(flow_id),
                             "retry_attempt": schedule.retry_count,

--- a/src/backend/base/langflow/services/schema.py
+++ b/src/backend/base/langflow/services/schema.py
@@ -21,3 +21,4 @@ class ServiceType(str, Enum):
     JOB_QUEUE_SERVICE = "job_queue_service"
     MCP_COMPOSER_SERVICE = "mcp_composer_service"
     JOB_SERVICE = "jobs_service"
+    SCHEDULER_SERVICE = "scheduler_service"

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -86,6 +86,7 @@ dependencies = [
     "aiosqlite>=0.20.0,<1.0.0",
     "greenlet>=3.1.1,<4.0.0",
     "jsonquerylang>=1.1.1,<2.0.0",
+    "apscheduler>=3.10,<4.0.0",
     "sqlalchemy[aiosqlite]>=2.0.38,<3.0.0",
     'elevenlabs==1.58.1; python_version == "3.12"',
     'elevenlabs>=1.52.0,<2.0.0; python_version != "3.12"',

--- a/src/frontend/src/components/core/flowToolbarComponent/components/flow-toolbar-options.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/flow-toolbar-options.tsx
@@ -1,6 +1,7 @@
 import useFlowStore from "@/stores/flowStore";
 import PublishDropdown from "./deploy-dropdown";
 import PlaygroundButton from "./playground-button";
+import ScheduleButton from "./schedule-button";
 
 type FlowToolbarOptionsProps = {
   openApiModal: boolean;
@@ -15,6 +16,7 @@ const FlowToolbarOptions = ({
   return (
     <div className="flex items-center gap-1">
       <PlaygroundButton hasIO={hasIO} />
+      <ScheduleButton />
       <PublishDropdown
         openApiModal={openApiModal}
         setOpenApiModal={setOpenApiModal}

--- a/src/frontend/src/components/core/flowToolbarComponent/components/schedule-button.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/schedule-button.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import IconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import ScheduleModal from "@/modals/scheduleModal";
+import useFlowsManagerStore from "@/stores/flowsManagerStore";
+
+const ScheduleButton = () => {
+  const [openScheduleModal, setOpenScheduleModal] = useState(false);
+  const currentFlow = useFlowsManagerStore((state) => state.currentFlow);
+  const flowId = currentFlow?.id;
+
+  if (!flowId) return null;
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="md"
+        className="!px-2.5 font-normal"
+        onClick={() => setOpenScheduleModal(true)}
+        data-testid="schedule-button"
+      >
+        <IconComponent name="Clock" className="!h-4 !w-4 mr-1.5" />
+        Schedule
+      </Button>
+      <ScheduleModal
+        open={openScheduleModal}
+        setOpen={setOpenScheduleModal}
+        flowId={flowId}
+      />
+    </>
+  );
+};
+
+export default ScheduleButton;

--- a/src/frontend/src/controllers/API/helpers/constants.ts
+++ b/src/frontend/src/controllers/API/helpers/constants.ts
@@ -38,6 +38,7 @@ export const URLs = {
   RUN: `run`,
   RUN_SESSION: `run/session`,
   REGISTRATION: `registration`,
+  SCHEDULES: `schedules`,
 } as const;
 
 // IMPORTANT: FOLDERS endpoint now points to 'projects' for backward compatibility

--- a/src/frontend/src/controllers/API/queries/schedules/use-create-schedule.ts
+++ b/src/frontend/src/controllers/API/queries/schedules/use-create-schedule.ts
@@ -1,0 +1,43 @@
+import type { UseMutationResult } from "@tanstack/react-query";
+import type { useMutationFunctionType } from "@/types/api";
+import type {
+  FlowScheduleCreateType,
+  FlowScheduleType,
+} from "@/types/schedule";
+import { api } from "../../api";
+import { getURL } from "../../helpers/constants";
+import { UseRequestProcessor } from "../../services/request-processor";
+
+export const useCreateSchedule: useMutationFunctionType<
+  undefined,
+  FlowScheduleCreateType
+> = (options?) => {
+  const { mutate, queryClient } = UseRequestProcessor();
+
+  const createScheduleFn = async (
+    payload: FlowScheduleCreateType,
+  ): Promise<FlowScheduleType> => {
+    const response = await api.post<FlowScheduleType>(
+      getURL("SCHEDULES"),
+      payload,
+    );
+    return response.data;
+  };
+
+  const mutation: UseMutationResult<
+    FlowScheduleType,
+    any,
+    FlowScheduleCreateType
+  > = mutate(["useCreateSchedule"], createScheduleFn, {
+    onSettled: (res) => {
+      if (res) {
+        queryClient.invalidateQueries({
+          queryKey: ["useGetSchedule", res.flow_id],
+        });
+      }
+    },
+    ...options,
+  });
+
+  return mutation;
+};

--- a/src/frontend/src/controllers/API/queries/schedules/use-delete-schedule.ts
+++ b/src/frontend/src/controllers/API/queries/schedules/use-delete-schedule.ts
@@ -1,0 +1,41 @@
+import type { UseMutationResult } from "@tanstack/react-query";
+import type { useMutationFunctionType } from "@/types/api";
+import { api } from "../../api";
+import { getURL } from "../../helpers/constants";
+import { UseRequestProcessor } from "../../services/request-processor";
+
+interface IDeleteSchedule {
+  id: string;
+  flow_id: string;
+}
+
+export const useDeleteSchedule: useMutationFunctionType<
+  undefined,
+  IDeleteSchedule
+> = (options?) => {
+  const { mutate, queryClient } = UseRequestProcessor();
+
+  const deleteScheduleFn = async ({
+    id,
+    flow_id,
+  }: IDeleteSchedule): Promise<void> => {
+    await api.delete(`${getURL("SCHEDULES")}/${id}`);
+  };
+
+  const mutation: UseMutationResult<void, any, IDeleteSchedule> = mutate(
+    ["useDeleteSchedule"],
+    deleteScheduleFn,
+    {
+      onSettled: (_res, _err, variables) => {
+        if (variables) {
+          queryClient.invalidateQueries({
+            queryKey: ["useGetSchedule", variables.flow_id],
+          });
+        }
+      },
+      ...options,
+    },
+  );
+
+  return mutation;
+};

--- a/src/frontend/src/controllers/API/queries/schedules/use-get-schedule.ts
+++ b/src/frontend/src/controllers/API/queries/schedules/use-get-schedule.ts
@@ -1,0 +1,31 @@
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { FlowScheduleType } from "@/types/schedule";
+import { api } from "../../api";
+import { getURL } from "../../helpers/constants";
+import { UseRequestProcessor } from "../../services/request-processor";
+
+export const useGetSchedule = (
+  flowId: string,
+  enabled: boolean = true,
+): UseQueryResult<FlowScheduleType | null> => {
+  const { query } = UseRequestProcessor();
+
+  const getScheduleFn = async (): Promise<FlowScheduleType | null> => {
+    try {
+      const response = await api.get<FlowScheduleType>(
+        `${getURL("SCHEDULES")}/${flowId}`,
+      );
+      return response.data;
+    } catch (error: any) {
+      if (error?.response?.status === 404) {
+        return null;
+      }
+      throw error;
+    }
+  };
+
+  return query(["useGetSchedule", flowId], getScheduleFn, {
+    enabled: enabled && !!flowId,
+    refetchOnWindowFocus: false,
+  });
+};

--- a/src/frontend/src/controllers/API/queries/schedules/use-toggle-schedule.ts
+++ b/src/frontend/src/controllers/API/queries/schedules/use-toggle-schedule.ts
@@ -1,0 +1,41 @@
+import type { UseMutationResult } from "@tanstack/react-query";
+import type { useMutationFunctionType } from "@/types/api";
+import type { FlowScheduleType } from "@/types/schedule";
+import { api } from "../../api";
+import { getURL } from "../../helpers/constants";
+import { UseRequestProcessor } from "../../services/request-processor";
+
+interface IToggleSchedule {
+  id: string;
+  flow_id: string;
+}
+
+export const useToggleSchedule: useMutationFunctionType<
+  undefined,
+  IToggleSchedule
+> = (options?) => {
+  const { mutate, queryClient } = UseRequestProcessor();
+
+  const toggleScheduleFn = async ({
+    id,
+  }: IToggleSchedule): Promise<FlowScheduleType> => {
+    const response = await api.patch<FlowScheduleType>(
+      `${getURL("SCHEDULES")}/${id}/toggle`,
+    );
+    return response.data;
+  };
+
+  const mutation: UseMutationResult<FlowScheduleType, any, IToggleSchedule> =
+    mutate(["useToggleSchedule"], toggleScheduleFn, {
+      onSettled: (res, _err, variables) => {
+        if (variables) {
+          queryClient.invalidateQueries({
+            queryKey: ["useGetSchedule", variables.flow_id],
+          });
+        }
+      },
+      ...options,
+    });
+
+  return mutation;
+};

--- a/src/frontend/src/controllers/API/queries/schedules/use-update-schedule.ts
+++ b/src/frontend/src/controllers/API/queries/schedules/use-update-schedule.ts
@@ -1,6 +1,9 @@
 import type { UseMutationResult } from "@tanstack/react-query";
 import type { useMutationFunctionType } from "@/types/api";
-import type { FlowScheduleType, FlowScheduleUpdateType } from "@/types/schedule";
+import type {
+  FlowScheduleType,
+  FlowScheduleUpdateType,
+} from "@/types/schedule";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";

--- a/src/frontend/src/controllers/API/queries/schedules/use-update-schedule.ts
+++ b/src/frontend/src/controllers/API/queries/schedules/use-update-schedule.ts
@@ -1,0 +1,42 @@
+import type { UseMutationResult } from "@tanstack/react-query";
+import type { useMutationFunctionType } from "@/types/api";
+import type { FlowScheduleType, FlowScheduleUpdateType } from "@/types/schedule";
+import { api } from "../../api";
+import { getURL } from "../../helpers/constants";
+import { UseRequestProcessor } from "../../services/request-processor";
+
+interface IUpdateSchedule extends FlowScheduleUpdateType {
+  id: string;
+}
+
+export const useUpdateSchedule: useMutationFunctionType<
+  undefined,
+  IUpdateSchedule
+> = (options?) => {
+  const { mutate, queryClient } = UseRequestProcessor();
+
+  const updateScheduleFn = async ({
+    id,
+    ...payload
+  }: IUpdateSchedule): Promise<FlowScheduleType> => {
+    const response = await api.patch<FlowScheduleType>(
+      `${getURL("SCHEDULES")}/${id}`,
+      payload,
+    );
+    return response.data;
+  };
+
+  const mutation: UseMutationResult<FlowScheduleType, any, IUpdateSchedule> =
+    mutate(["useUpdateSchedule"], updateScheduleFn, {
+      onSettled: (res) => {
+        if (res) {
+          queryClient.invalidateQueries({
+            queryKey: ["useGetSchedule", res.flow_id],
+          });
+        }
+      },
+      ...options,
+    });
+
+  return mutation;
+};

--- a/src/frontend/src/modals/scheduleModal/index.tsx
+++ b/src/frontend/src/modals/scheduleModal/index.tsx
@@ -68,20 +68,62 @@ function frequencyToCron(
   minute: string,
   selectedDays: string[],
   dayOfMonth: string,
-): { minute: string; hour: string; day_of_week: string; day_of_month: string; month: string } {
+): {
+  minute: string;
+  hour: string;
+  day_of_week: string;
+  day_of_month: string;
+  month: string;
+} {
   switch (frequency) {
     case "every_minute":
-      return { minute: "*", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+      return {
+        minute: "*",
+        hour: "*",
+        day_of_week: "*",
+        day_of_month: "*",
+        month: "*",
+      };
     case "every_5_minutes":
-      return { minute: "*/5", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+      return {
+        minute: "*/5",
+        hour: "*",
+        day_of_week: "*",
+        day_of_month: "*",
+        month: "*",
+      };
     case "every_15_minutes":
-      return { minute: "*/15", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+      return {
+        minute: "*/15",
+        hour: "*",
+        day_of_week: "*",
+        day_of_month: "*",
+        month: "*",
+      };
     case "every_30_minutes":
-      return { minute: "*/30", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+      return {
+        minute: "*/30",
+        hour: "*",
+        day_of_week: "*",
+        day_of_month: "*",
+        month: "*",
+      };
     case "hourly":
-      return { minute: minute || "0", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+      return {
+        minute: minute || "0",
+        hour: "*",
+        day_of_week: "*",
+        day_of_month: "*",
+        month: "*",
+      };
     case "daily":
-      return { minute: minute || "0", hour: hour || "9", day_of_week: "*", day_of_month: "*", month: "*" };
+      return {
+        minute: minute || "0",
+        hour: hour || "9",
+        day_of_week: "*",
+        day_of_month: "*",
+        month: "*",
+      };
     case "weekly":
       return {
         minute: minute || "0",
@@ -99,7 +141,13 @@ function frequencyToCron(
         month: "*",
       };
     default:
-      return { minute: "0", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+      return {
+        minute: "0",
+        hour: "*",
+        day_of_week: "*",
+        day_of_month: "*",
+        month: "*",
+      };
   }
 }
 
@@ -108,36 +156,101 @@ function cronToFrequency(
   hr: string,
   dow: string,
   dom: string,
-): { frequency: string; hour: string; minute: string; selectedDays: string[]; dayOfMonth: string } {
+): {
+  frequency: string;
+  hour: string;
+  minute: string;
+  selectedDays: string[];
+  dayOfMonth: string;
+} {
   if (min === "*" && hr === "*" && dow === "*" && dom === "*") {
-    return { frequency: "every_minute", hour: "0", minute: "0", selectedDays: [], dayOfMonth: "1" };
+    return {
+      frequency: "every_minute",
+      hour: "0",
+      minute: "0",
+      selectedDays: [],
+      dayOfMonth: "1",
+    };
   }
   if (min === "*/5" && hr === "*") {
-    return { frequency: "every_5_minutes", hour: "0", minute: "0", selectedDays: [], dayOfMonth: "1" };
+    return {
+      frequency: "every_5_minutes",
+      hour: "0",
+      minute: "0",
+      selectedDays: [],
+      dayOfMonth: "1",
+    };
   }
   if (min === "*/15" && hr === "*") {
-    return { frequency: "every_15_minutes", hour: "0", minute: "0", selectedDays: [], dayOfMonth: "1" };
+    return {
+      frequency: "every_15_minutes",
+      hour: "0",
+      minute: "0",
+      selectedDays: [],
+      dayOfMonth: "1",
+    };
   }
   if (min === "*/30" && hr === "*") {
-    return { frequency: "every_30_minutes", hour: "0", minute: "0", selectedDays: [], dayOfMonth: "1" };
+    return {
+      frequency: "every_30_minutes",
+      hour: "0",
+      minute: "0",
+      selectedDays: [],
+      dayOfMonth: "1",
+    };
   }
   if (hr === "*" && dow === "*" && dom === "*") {
-    return { frequency: "hourly", hour: "0", minute: min, selectedDays: [], dayOfMonth: "1" };
+    return {
+      frequency: "hourly",
+      hour: "0",
+      minute: min,
+      selectedDays: [],
+      dayOfMonth: "1",
+    };
   }
   if (dow === "*" && dom === "*") {
-    return { frequency: "daily", hour: hr, minute: min, selectedDays: [], dayOfMonth: "1" };
+    return {
+      frequency: "daily",
+      hour: hr,
+      minute: min,
+      selectedDays: [],
+      dayOfMonth: "1",
+    };
   }
   if (dom === "*" && dow !== "*") {
-    return { frequency: "weekly", hour: hr, minute: min, selectedDays: dow.split(","), dayOfMonth: "1" };
+    return {
+      frequency: "weekly",
+      hour: hr,
+      minute: min,
+      selectedDays: dow.split(","),
+      dayOfMonth: "1",
+    };
   }
   if (dow === "*" && dom !== "*") {
-    return { frequency: "monthly", hour: hr, minute: min, selectedDays: [], dayOfMonth: dom };
+    return {
+      frequency: "monthly",
+      hour: hr,
+      minute: min,
+      selectedDays: [],
+      dayOfMonth: dom,
+    };
   }
-  return { frequency: "custom", hour: hr, minute: min, selectedDays: [], dayOfMonth: dom };
+  return {
+    frequency: "custom",
+    hour: hr,
+    minute: min,
+    selectedDays: [],
+    dayOfMonth: dom,
+  };
 }
 
 /** Frequencies that require the user to pick a specific time (and thus a timezone). */
-const FREQUENCIES_WITH_TIMEZONE = new Set(["daily", "weekly", "monthly", "custom"]);
+const FREQUENCIES_WITH_TIMEZONE = new Set([
+  "daily",
+  "weekly",
+  "monthly",
+  "custom",
+]);
 
 function needsTimezone(frequency: string): boolean {
   return FREQUENCIES_WITH_TIMEZONE.has(frequency);
@@ -164,16 +277,26 @@ function describeSchedule(
   const time = `${hour.padStart(2, "0")}:${minute.padStart(2, "0")}`;
   const tzSuffix = needsTimezone(frequency) ? ` (${tz})` : "";
   switch (frequency) {
-    case "every_minute": return "Every minute";
-    case "every_5_minutes": return "Every 5 minutes";
-    case "every_15_minutes": return "Every 15 minutes";
-    case "every_30_minutes": return "Every 30 minutes";
-    case "hourly": return `Every hour at minute ${minute}`;
-    case "daily": return `Daily at ${time}${tzSuffix}`;
-    case "weekly": return `Weekly on ${selectedDays.join(", ")} at ${time}${tzSuffix}`;
-    case "monthly": return `Monthly on day ${dayOfMonth} at ${time}${tzSuffix}`;
-    case "custom": return `Custom cron schedule${tzSuffix}`;
-    default: return "";
+    case "every_minute":
+      return "Every minute";
+    case "every_5_minutes":
+      return "Every 5 minutes";
+    case "every_15_minutes":
+      return "Every 15 minutes";
+    case "every_30_minutes":
+      return "Every 30 minutes";
+    case "hourly":
+      return `Every hour at minute ${minute}`;
+    case "daily":
+      return `Daily at ${time}${tzSuffix}`;
+    case "weekly":
+      return `Weekly on ${selectedDays.join(", ")} at ${time}${tzSuffix}`;
+    case "monthly":
+      return `Monthly on day ${dayOfMonth} at ${time}${tzSuffix}`;
+    case "custom":
+      return `Custom cron schedule${tzSuffix}`;
+    default:
+      return "";
   }
 }
 
@@ -242,7 +365,13 @@ export default function ScheduleModal({
           month: customMonth,
         };
       } else {
-        cronFields = frequencyToCron(frequency, hour, minute, selectedDays, dayOfMonth);
+        cronFields = frequencyToCron(
+          frequency,
+          hour,
+          minute,
+          selectedDays,
+          dayOfMonth,
+        );
       }
 
       const effectiveTimezone = showTimezone ? timezone : "UTC";
@@ -299,7 +428,12 @@ export default function ScheduleModal({
   if (!open) return null;
 
   return (
-    <BaseModal open={open} setOpen={setOpen} size="small-update" className="p-4">
+    <BaseModal
+      open={open}
+      setOpen={setOpen}
+      size="small-update"
+      className="p-4"
+    >
       <BaseModal.Header>
         <div className="flex items-center gap-2">
           <IconComponent name="Clock" className="h-5 w-5" />
@@ -390,7 +524,9 @@ export default function ScheduleModal({
                     <Button
                       key={day.value}
                       type="button"
-                      variant={selectedDays.includes(day.value) ? "default" : "outline"}
+                      variant={
+                        selectedDays.includes(day.value) ? "default" : "outline"
+                      }
                       size="sm"
                       onClick={() => toggleDay(day.value)}
                       data-testid={`schedule-day-${day.value}`}
@@ -423,24 +559,45 @@ export default function ScheduleModal({
                 <Label className="text-sm font-medium">Cron Expression</Label>
                 <div className="grid grid-cols-5 gap-2">
                   <div className="flex flex-col gap-1">
-                    <span className="text-xs text-muted-foreground">Minute</span>
-                    <Input value={customMinute} onChange={(e) => setCustomMinute(e.target.value)} />
+                    <span className="text-xs text-muted-foreground">
+                      Minute
+                    </span>
+                    <Input
+                      value={customMinute}
+                      onChange={(e) => setCustomMinute(e.target.value)}
+                    />
                   </div>
                   <div className="flex flex-col gap-1">
                     <span className="text-xs text-muted-foreground">Hour</span>
-                    <Input value={customHour} onChange={(e) => setCustomHour(e.target.value)} />
+                    <Input
+                      value={customHour}
+                      onChange={(e) => setCustomHour(e.target.value)}
+                    />
                   </div>
                   <div className="flex flex-col gap-1">
-                    <span className="text-xs text-muted-foreground">Day/Month</span>
-                    <Input value={customDom} onChange={(e) => setCustomDom(e.target.value)} />
+                    <span className="text-xs text-muted-foreground">
+                      Day/Month
+                    </span>
+                    <Input
+                      value={customDom}
+                      onChange={(e) => setCustomDom(e.target.value)}
+                    />
                   </div>
                   <div className="flex flex-col gap-1">
                     <span className="text-xs text-muted-foreground">Month</span>
-                    <Input value={customMonth} onChange={(e) => setCustomMonth(e.target.value)} />
+                    <Input
+                      value={customMonth}
+                      onChange={(e) => setCustomMonth(e.target.value)}
+                    />
                   </div>
                   <div className="flex flex-col gap-1">
-                    <span className="text-xs text-muted-foreground">Day/Week</span>
-                    <Input value={customDow} onChange={(e) => setCustomDow(e.target.value)} />
+                    <span className="text-xs text-muted-foreground">
+                      Day/Week
+                    </span>
+                    <Input
+                      value={customDow}
+                      onChange={(e) => setCustomDow(e.target.value)}
+                    />
                   </div>
                 </div>
               </div>
@@ -488,7 +645,9 @@ export default function ScheduleModal({
                 )}
               </div>
               <span className="text-xs text-muted-foreground">
-                {startAt ? `Starts at ${formatStartAt(startAt)}` : "Starts immediately"}
+                {startAt
+                  ? `Starts at ${formatStartAt(startAt)}`
+                  : "Starts immediately"}
               </span>
             </div>
 
@@ -497,14 +656,22 @@ export default function ScheduleModal({
               <span className="text-sm text-muted-foreground">
                 {frequency === "custom"
                   ? `Cron: ${customMinute} ${customHour} ${customDom} ${customMonth} ${customDow} (${timezone})`
-                  : describeSchedule(frequency, hour, minute, selectedDays, dayOfMonth, timezone)}
+                  : describeSchedule(
+                      frequency,
+                      hour,
+                      minute,
+                      selectedDays,
+                      dayOfMonth,
+                      timezone,
+                    )}
               </span>
             </div>
 
             {/* Last run info */}
             {existingSchedule?.last_run_at && (
               <div className="text-xs text-muted-foreground">
-                Last run: {new Date(existingSchedule.last_run_at).toLocaleString()} —{" "}
+                Last run:{" "}
+                {new Date(existingSchedule.last_run_at).toLocaleString()} —{" "}
                 {existingSchedule.last_run_status}
               </div>
             )}

--- a/src/frontend/src/modals/scheduleModal/index.tsx
+++ b/src/frontend/src/modals/scheduleModal/index.tsx
@@ -1,0 +1,539 @@
+import { useEffect, useMemo, useState } from "react";
+import IconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { useCreateSchedule } from "@/controllers/API/queries/schedules/use-create-schedule";
+import { useDeleteSchedule } from "@/controllers/API/queries/schedules/use-delete-schedule";
+import { useGetSchedule } from "@/controllers/API/queries/schedules/use-get-schedule";
+import { useUpdateSchedule } from "@/controllers/API/queries/schedules/use-update-schedule";
+import useAlertStore from "@/stores/alertStore";
+import BaseModal from "../baseModal";
+
+type ScheduleModalProps = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  flowId: string;
+};
+
+const FREQUENCY_OPTIONS = [
+  { value: "every_minute", label: "Every minute" },
+  { value: "every_5_minutes", label: "Every 5 minutes" },
+  { value: "every_15_minutes", label: "Every 15 minutes" },
+  { value: "every_30_minutes", label: "Every 30 minutes" },
+  { value: "hourly", label: "Hourly" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+  { value: "custom", label: "Custom (Cron)" },
+];
+
+const DAYS_OF_WEEK = [
+  { value: "mon", label: "Mon" },
+  { value: "tue", label: "Tue" },
+  { value: "wed", label: "Wed" },
+  { value: "thu", label: "Thu" },
+  { value: "fri", label: "Fri" },
+  { value: "sat", label: "Sat" },
+  { value: "sun", label: "Sun" },
+];
+
+const TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Sao_Paulo",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "Asia/Tokyo",
+  "Asia/Shanghai",
+  "Asia/Kolkata",
+  "Australia/Sydney",
+];
+
+function frequencyToCron(
+  frequency: string,
+  hour: string,
+  minute: string,
+  selectedDays: string[],
+  dayOfMonth: string,
+): { minute: string; hour: string; day_of_week: string; day_of_month: string; month: string } {
+  switch (frequency) {
+    case "every_minute":
+      return { minute: "*", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+    case "every_5_minutes":
+      return { minute: "*/5", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+    case "every_15_minutes":
+      return { minute: "*/15", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+    case "every_30_minutes":
+      return { minute: "*/30", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+    case "hourly":
+      return { minute: minute || "0", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+    case "daily":
+      return { minute: minute || "0", hour: hour || "9", day_of_week: "*", day_of_month: "*", month: "*" };
+    case "weekly":
+      return {
+        minute: minute || "0",
+        hour: hour || "9",
+        day_of_week: selectedDays.length > 0 ? selectedDays.join(",") : "mon",
+        day_of_month: "*",
+        month: "*",
+      };
+    case "monthly":
+      return {
+        minute: minute || "0",
+        hour: hour || "9",
+        day_of_week: "*",
+        day_of_month: dayOfMonth || "1",
+        month: "*",
+      };
+    default:
+      return { minute: "0", hour: "*", day_of_week: "*", day_of_month: "*", month: "*" };
+  }
+}
+
+function cronToFrequency(
+  min: string,
+  hr: string,
+  dow: string,
+  dom: string,
+): { frequency: string; hour: string; minute: string; selectedDays: string[]; dayOfMonth: string } {
+  if (min === "*" && hr === "*" && dow === "*" && dom === "*") {
+    return { frequency: "every_minute", hour: "0", minute: "0", selectedDays: [], dayOfMonth: "1" };
+  }
+  if (min === "*/5" && hr === "*") {
+    return { frequency: "every_5_minutes", hour: "0", minute: "0", selectedDays: [], dayOfMonth: "1" };
+  }
+  if (min === "*/15" && hr === "*") {
+    return { frequency: "every_15_minutes", hour: "0", minute: "0", selectedDays: [], dayOfMonth: "1" };
+  }
+  if (min === "*/30" && hr === "*") {
+    return { frequency: "every_30_minutes", hour: "0", minute: "0", selectedDays: [], dayOfMonth: "1" };
+  }
+  if (hr === "*" && dow === "*" && dom === "*") {
+    return { frequency: "hourly", hour: "0", minute: min, selectedDays: [], dayOfMonth: "1" };
+  }
+  if (dow === "*" && dom === "*") {
+    return { frequency: "daily", hour: hr, minute: min, selectedDays: [], dayOfMonth: "1" };
+  }
+  if (dom === "*" && dow !== "*") {
+    return { frequency: "weekly", hour: hr, minute: min, selectedDays: dow.split(","), dayOfMonth: "1" };
+  }
+  if (dow === "*" && dom !== "*") {
+    return { frequency: "monthly", hour: hr, minute: min, selectedDays: [], dayOfMonth: dom };
+  }
+  return { frequency: "custom", hour: hr, minute: min, selectedDays: [], dayOfMonth: dom };
+}
+
+/** Frequencies that require the user to pick a specific time (and thus a timezone). */
+const FREQUENCIES_WITH_TIMEZONE = new Set(["daily", "weekly", "monthly", "custom"]);
+
+function needsTimezone(frequency: string): boolean {
+  return FREQUENCIES_WITH_TIMEZONE.has(frequency);
+}
+
+/** Format a local datetime string for display. */
+function formatStartAt(value: string | null): string {
+  if (!value) return "Now";
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+function describeSchedule(
+  frequency: string,
+  hour: string,
+  minute: string,
+  selectedDays: string[],
+  dayOfMonth: string,
+  tz: string,
+): string {
+  const time = `${hour.padStart(2, "0")}:${minute.padStart(2, "0")}`;
+  const tzSuffix = needsTimezone(frequency) ? ` (${tz})` : "";
+  switch (frequency) {
+    case "every_minute": return "Every minute";
+    case "every_5_minutes": return "Every 5 minutes";
+    case "every_15_minutes": return "Every 15 minutes";
+    case "every_30_minutes": return "Every 30 minutes";
+    case "hourly": return `Every hour at minute ${minute}`;
+    case "daily": return `Daily at ${time}${tzSuffix}`;
+    case "weekly": return `Weekly on ${selectedDays.join(", ")} at ${time}${tzSuffix}`;
+    case "monthly": return `Monthly on day ${dayOfMonth} at ${time}${tzSuffix}`;
+    case "custom": return `Custom cron schedule${tzSuffix}`;
+    default: return "";
+  }
+}
+
+export default function ScheduleModal({
+  open,
+  setOpen,
+  flowId,
+}: ScheduleModalProps) {
+  const { data: existingSchedule, isLoading } = useGetSchedule(flowId, open);
+  const { mutateAsync: createSchedule } = useCreateSchedule();
+  const { mutateAsync: updateSchedule } = useUpdateSchedule();
+  const { mutateAsync: deleteSchedule } = useDeleteSchedule();
+  const setSuccessData = useAlertStore((state) => state.setSuccessData);
+  const setErrorData = useAlertStore((state) => state.setErrorData);
+
+  const [isActive, setIsActive] = useState(false);
+  const [frequency, setFrequency] = useState("daily");
+  const [hour, setHour] = useState("9");
+  const [minute, setMinute] = useState("0");
+  const [selectedDays, setSelectedDays] = useState<string[]>(["mon"]);
+  const [dayOfMonth, setDayOfMonth] = useState("1");
+  const [timezone, setTimezone] = useState("UTC");
+  const [customMinute, setCustomMinute] = useState("0");
+  const [customHour, setCustomHour] = useState("*");
+  const [customDow, setCustomDow] = useState("*");
+  const [customDom, setCustomDom] = useState("*");
+  const [customMonth, setCustomMonth] = useState("*");
+  const [startAt, setStartAt] = useState<string | null>(null); // null = now
+
+  const showTimezone = useMemo(() => needsTimezone(frequency), [frequency]);
+
+  useEffect(() => {
+    if (existingSchedule) {
+      setIsActive(existingSchedule.is_active);
+      setTimezone(existingSchedule.timezone);
+      const parsed = cronToFrequency(
+        existingSchedule.minute,
+        existingSchedule.hour,
+        existingSchedule.day_of_week,
+        existingSchedule.day_of_month,
+      );
+      setFrequency(parsed.frequency);
+      setHour(parsed.hour);
+      setMinute(parsed.minute);
+      setSelectedDays(parsed.selectedDays);
+      setDayOfMonth(parsed.dayOfMonth);
+      // Set custom fields
+      setCustomMinute(existingSchedule.minute);
+      setCustomHour(existingSchedule.hour);
+      setCustomDow(existingSchedule.day_of_week);
+      setCustomDom(existingSchedule.day_of_month);
+      setCustomMonth(existingSchedule.month);
+      setStartAt(existingSchedule.start_at ?? null);
+    }
+  }, [existingSchedule]);
+
+  const handleSave = async () => {
+    try {
+      let cronFields;
+      if (frequency === "custom") {
+        cronFields = {
+          minute: customMinute,
+          hour: customHour,
+          day_of_week: customDow,
+          day_of_month: customDom,
+          month: customMonth,
+        };
+      } else {
+        cronFields = frequencyToCron(frequency, hour, minute, selectedDays, dayOfMonth);
+      }
+
+      const effectiveTimezone = showTimezone ? timezone : "UTC";
+      const effectiveStartAt = startAt || undefined;
+
+      if (existingSchedule) {
+        await updateSchedule({
+          id: existingSchedule.id,
+          is_active: isActive,
+          ...cronFields,
+          timezone: effectiveTimezone,
+          start_at: effectiveStartAt,
+        });
+        setSuccessData({ title: "Schedule updated successfully" });
+      } else {
+        await createSchedule({
+          flow_id: flowId,
+          is_active: isActive,
+          ...cronFields,
+          timezone: effectiveTimezone,
+          start_at: effectiveStartAt,
+        });
+        setSuccessData({ title: "Schedule created successfully" });
+      }
+      setOpen(false);
+    } catch (error: any) {
+      setErrorData({
+        title: "Failed to save schedule",
+        list: [error?.message || "Unknown error"],
+      });
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!existingSchedule) return;
+    try {
+      await deleteSchedule({ id: existingSchedule.id, flow_id: flowId });
+      setSuccessData({ title: "Schedule deleted successfully" });
+      setOpen(false);
+    } catch (error: any) {
+      setErrorData({
+        title: "Failed to delete schedule",
+        list: [error?.message || "Unknown error"],
+      });
+    }
+  };
+
+  const toggleDay = (day: string) => {
+    setSelectedDays((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day],
+    );
+  };
+
+  if (!open) return null;
+
+  return (
+    <BaseModal open={open} setOpen={setOpen} size="small-update" className="p-4">
+      <BaseModal.Header>
+        <div className="flex items-center gap-2">
+          <IconComponent name="Clock" className="h-5 w-5" />
+          <span className="text-base font-semibold">Schedule Flow</span>
+        </div>
+      </BaseModal.Header>
+      <BaseModal.Content>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <span className="text-muted-foreground">Loading...</span>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4 py-2">
+            {/* Active Toggle */}
+            <div className="flex items-center justify-between">
+              <Label className="text-sm font-medium">Enable Schedule</Label>
+              <Switch
+                checked={isActive}
+                onCheckedChange={setIsActive}
+                data-testid="schedule-active-toggle"
+              />
+            </div>
+
+            {/* Frequency */}
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-sm font-medium">Frequency</Label>
+              <Select value={frequency} onValueChange={setFrequency}>
+                <SelectTrigger data-testid="schedule-frequency-select">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {FREQUENCY_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Time picker for daily/weekly/monthly/hourly */}
+            {["daily", "weekly", "monthly"].includes(frequency) && (
+              <div className="flex gap-3">
+                <div className="flex flex-1 flex-col gap-1.5">
+                  <Label className="text-sm font-medium">Hour</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={23}
+                    value={hour}
+                    onChange={(e) => setHour(e.target.value)}
+                    data-testid="schedule-hour-input"
+                  />
+                </div>
+                <div className="flex flex-1 flex-col gap-1.5">
+                  <Label className="text-sm font-medium">Minute</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={59}
+                    value={minute}
+                    onChange={(e) => setMinute(e.target.value)}
+                    data-testid="schedule-minute-input"
+                  />
+                </div>
+              </div>
+            )}
+
+            {frequency === "hourly" && (
+              <div className="flex flex-col gap-1.5">
+                <Label className="text-sm font-medium">At minute</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={59}
+                  value={minute}
+                  onChange={(e) => setMinute(e.target.value)}
+                />
+              </div>
+            )}
+
+            {/* Day of week selector for weekly */}
+            {frequency === "weekly" && (
+              <div className="flex flex-col gap-1.5">
+                <Label className="text-sm font-medium">Days of Week</Label>
+                <div className="flex flex-wrap gap-1.5">
+                  {DAYS_OF_WEEK.map((day) => (
+                    <Button
+                      key={day.value}
+                      type="button"
+                      variant={selectedDays.includes(day.value) ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => toggleDay(day.value)}
+                      data-testid={`schedule-day-${day.value}`}
+                    >
+                      {day.label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Day of month for monthly */}
+            {frequency === "monthly" && (
+              <div className="flex flex-col gap-1.5">
+                <Label className="text-sm font-medium">Day of Month</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  max={31}
+                  value={dayOfMonth}
+                  onChange={(e) => setDayOfMonth(e.target.value)}
+                  data-testid="schedule-dom-input"
+                />
+              </div>
+            )}
+
+            {/* Custom cron fields */}
+            {frequency === "custom" && (
+              <div className="flex flex-col gap-2">
+                <Label className="text-sm font-medium">Cron Expression</Label>
+                <div className="grid grid-cols-5 gap-2">
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs text-muted-foreground">Minute</span>
+                    <Input value={customMinute} onChange={(e) => setCustomMinute(e.target.value)} />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs text-muted-foreground">Hour</span>
+                    <Input value={customHour} onChange={(e) => setCustomHour(e.target.value)} />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs text-muted-foreground">Day/Month</span>
+                    <Input value={customDom} onChange={(e) => setCustomDom(e.target.value)} />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs text-muted-foreground">Month</span>
+                    <Input value={customMonth} onChange={(e) => setCustomMonth(e.target.value)} />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs text-muted-foreground">Day/Week</span>
+                    <Input value={customDow} onChange={(e) => setCustomDow(e.target.value)} />
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Timezone — only for frequencies that reference a specific time */}
+            {showTimezone && (
+              <div className="flex flex-col gap-1.5">
+                <Label className="text-sm font-medium">Timezone</Label>
+                <Select value={timezone} onValueChange={setTimezone}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TIMEZONES.map((tz) => (
+                      <SelectItem key={tz} value={tz}>
+                        {tz}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {/* Start at */}
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-sm font-medium">Start at</Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  type="datetime-local"
+                  value={startAt ?? ""}
+                  onChange={(e) => setStartAt(e.target.value || null)}
+                  data-testid="schedule-start-at-input"
+                  className="flex-1 dark:[&::-webkit-calendar-picker-indicator]:invert"
+                />
+                {startAt && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setStartAt(null)}
+                  >
+                    Now
+                  </Button>
+                )}
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {startAt ? `Starts at ${formatStartAt(startAt)}` : "Starts immediately"}
+              </span>
+            </div>
+
+            {/* Schedule description preview */}
+            <div className="mt-2 rounded-md border border-border bg-muted p-3">
+              <span className="text-sm text-muted-foreground">
+                {frequency === "custom"
+                  ? `Cron: ${customMinute} ${customHour} ${customDom} ${customMonth} ${customDow} (${timezone})`
+                  : describeSchedule(frequency, hour, minute, selectedDays, dayOfMonth, timezone)}
+              </span>
+            </div>
+
+            {/* Last run info */}
+            {existingSchedule?.last_run_at && (
+              <div className="text-xs text-muted-foreground">
+                Last run: {new Date(existingSchedule.last_run_at).toLocaleString()} —{" "}
+                {existingSchedule.last_run_status}
+              </div>
+            )}
+          </div>
+        )}
+      </BaseModal.Content>
+      <BaseModal.Footer>
+        <div className="flex w-full items-center justify-between">
+          <div>
+            {existingSchedule && (
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                data-testid="schedule-delete-button"
+              >
+                Delete
+              </Button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} data-testid="schedule-save-button">
+              {existingSchedule ? "Update" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </BaseModal.Footer>
+    </BaseModal>
+  );
+}

--- a/src/frontend/src/pages/MainPage/components/list/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/list/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import ShadTooltip from "@/components/common/shadTooltipComponent";
 import useDragStart from "@/components/core/cardComponent/hooks/use-on-drag-start";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -10,6 +11,9 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Switch } from "@/components/ui/switch";
+import { useGetSchedule } from "@/controllers/API/queries/schedules/use-get-schedule";
+import { useToggleSchedule } from "@/controllers/API/queries/schedules/use-toggle-schedule";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import useDeleteFlow from "@/hooks/flows/use-delete-flow";
 import DeleteConfirmationModal from "@/modals/deleteConfirmationModal";
@@ -24,6 +28,55 @@ import useDescriptionModal from "../../hooks/use-description-modal";
 import { useGetTemplateStyle } from "../../utils/get-template-style";
 import { timeElapsed } from "../../utils/time-elapse";
 import DropdownComponent from "../dropdown";
+
+const ScheduleToggle = ({ flowId }: { flowId: string }) => {
+  const { data: schedule } = useGetSchedule(flowId);
+  const { mutateAsync: toggleSchedule } = useToggleSchedule();
+  const setErrorData = useAlertStore((state) => state.setErrorData);
+
+  if (!schedule) return null;
+
+  const handleToggle = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await toggleSchedule({ id: schedule.id, flow_id: flowId });
+    } catch (error: any) {
+      setErrorData({
+        title: "Failed to toggle schedule",
+        list: [error?.message || "Unknown error"],
+      });
+    }
+  };
+
+  return (
+    <ShadTooltip
+      content={
+        schedule.is_active
+          ? "Schedule is active. Click to disable."
+          : "Schedule is inactive. Click to enable."
+      }
+    >
+      <div
+        className="flex items-center gap-1.5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <ForwardedIconComponent
+          name="Clock"
+          className={cn(
+            "h-4 w-4",
+            schedule.is_active ? "text-primary" : "text-muted-foreground",
+          )}
+        />
+        <Switch
+          checked={schedule.is_active}
+          onClick={handleToggle}
+          className="scale-[75%]"
+          data-testid={`schedule-toggle-${flowId}`}
+        />
+      </div>
+    </ShadTooltip>
+  );
+};
 
 const ListComponent = ({
   flowData,
@@ -178,6 +231,7 @@ const ListComponent = ({
         </div>
 
         <div className="ml-5 flex items-center gap-2">
+          {!isComponent && <ScheduleToggle flowId={flowData.id} />}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button

--- a/src/frontend/src/types/schedule/index.ts
+++ b/src/frontend/src/types/schedule/index.ts
@@ -1,0 +1,43 @@
+export type FlowScheduleType = {
+  id: string;
+  flow_id: string;
+  user_id: string;
+  is_active: boolean;
+  schedule_type: string;
+  minute: string;
+  hour: string;
+  day_of_week: string;
+  day_of_month: string;
+  month: string;
+  timezone: string;
+  start_at?: string | null;
+  last_run_at?: string;
+  last_run_status?: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type FlowScheduleCreateType = {
+  flow_id: string;
+  is_active?: boolean;
+  schedule_type?: string;
+  minute?: string;
+  hour?: string;
+  day_of_week?: string;
+  day_of_month?: string;
+  month?: string;
+  timezone?: string;
+  start_at?: string;
+};
+
+export type FlowScheduleUpdateType = {
+  is_active?: boolean;
+  schedule_type?: string;
+  minute?: string;
+  hour?: string;
+  day_of_week?: string;
+  day_of_month?: string;
+  month?: string;
+  timezone?: string;
+  start_at?: string;
+};

--- a/uv.lock
+++ b/uv.lock
@@ -426,6 +426,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2438,26 +2450,22 @@ name = "easyocr"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ninja" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "opencv-python-headless", version = "4.11.0.86", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "opencv-python-headless", version = "4.13.0.92", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pillow" },
-    { name = "pyclipper" },
-    { name = "python-bidi" },
-    { name = "pyyaml" },
-    { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "shapely" },
-    { name = "torch", version = "2.2.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.2.2+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "ninja", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.12' and platform_machine != 'x86_64') or (python_full_version < '3.12' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and platform_machine != 'x86_64') or (python_full_version >= '3.12' and sys_platform != 'darwin')" },
+    { name = "opencv-python-headless", version = "4.11.0.86", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.12' and platform_machine != 'x86_64') or (python_full_version < '3.12' and sys_platform != 'darwin')" },
+    { name = "opencv-python-headless", version = "4.13.0.92", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and platform_machine != 'x86_64') or (python_full_version >= '3.12' and sys_platform != 'darwin')" },
+    { name = "pillow", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "pyclipper", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "python-bidi", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "pyyaml", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "shapely", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
     { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.17.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.17.2+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "torchvision", version = "0.25.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
     { name = "torchvision", version = "0.25.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
@@ -3262,10 +3270,10 @@ name = "gassist"
 version = "0.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama" },
-    { name = "flask" },
-    { name = "flask-cors" },
-    { name = "tqdm" },
+    { name = "colorama", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'linux') or sys_platform == 'win32'" },
+    { name = "flask", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'linux') or sys_platform == 'win32'" },
+    { name = "flask-cors", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'linux') or sys_platform == 'win32'" },
+    { name = "tqdm", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'linux') or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/2e/f79632d7300874f7f0e60b61a6ab22455a245e1556116a1729542a77b0da/gassist-0.0.1-py3-none-any.whl", hash = "sha256:bb0fac74b453153a6c74b2db40a14fdde7879cbc10ec692ed170e576c8e2b6aa", size = 23819, upload-time = "2025-05-09T18:22:23.609Z" },
@@ -4429,9 +4437,9 @@ name = "imageio"
 version = "2.37.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pillow" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.12' and platform_machine != 'x86_64') or (python_full_version < '3.12' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and platform_machine != 'x86_64') or (python_full_version >= '3.12' and sys_platform != 'darwin')" },
+    { name = "pillow", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
 wheels = [
@@ -5750,6 +5758,7 @@ dependencies = [
     { name = "aiofiles" },
     { name = "aiosqlite" },
     { name = "alembic" },
+    { name = "apscheduler" },
     { name = "assemblyai" },
     { name = "asyncer" },
     { name = "bcrypt" },
@@ -6435,6 +6444,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0,<1.0.0" },
     { name = "alembic", specifier = ">=1.13.0,<2.0.0" },
     { name = "apify-client", marker = "extra == 'apify'", specifier = ">=1.8.1" },
+    { name = "apscheduler", specifier = ">=3.10,<4.0.0" },
     { name = "arize-phoenix-otel", marker = "extra == 'arize'", specifier = ">=0.6.1" },
     { name = "assemblyai", specifier = ">=0.33.0,<1.0.0" },
     { name = "assemblyai", marker = "extra == 'assemblyai'", specifier = "==0.35.1" },
@@ -6912,7 +6922,7 @@ name = "lazy-loader"
 version = "0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
 wheels = [
@@ -7724,7 +7734,7 @@ name = "mlx"
 version = "0.31.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mlx-metal", marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
+    { name = "mlx-metal", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/f9/f1663dafd45af02467f4f41777c13ec34b9104b2b0450d870c3f906285cd/mlx-0.31.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:bc46c911cc060d2eaf21b9e24a1712dc56763b660b53631b9057a32ab1c0271a", size = 574137, upload-time = "2026-03-12T02:15:54.996Z" },
@@ -7746,13 +7756,13 @@ name = "mlx-lm"
 version = "0.29.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "mlx", marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "protobuf", marker = "python_full_version >= '3.12'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
-    { name = "sentencepiece", marker = "python_full_version >= '3.12'" },
-    { name = "transformers", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "mlx", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "protobuf", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "sentencepiece", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "transformers", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/62/f46e1355256a114808517947f8e83ad6be310c7288c551db0fa678f47923/mlx_lm-0.29.1.tar.gz", hash = "sha256:b99180d8f33d33a077b814e550bfb2d8a59ae003d668fd1f4b3fff62a381d34b", size = 232302, upload-time = "2025-12-16T16:58:27.959Z" }
 wheels = [
@@ -7774,19 +7784,19 @@ name = "mlx-vlm"
 version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datasets", marker = "python_full_version >= '3.12'" },
-    { name = "fastapi", marker = "python_full_version >= '3.12'" },
-    { name = "mlx", marker = "python_full_version >= '3.12'" },
-    { name = "mlx-lm", marker = "python_full_version >= '3.12'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "opencv-python", version = "4.13.0.92", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pillow", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "soundfile", marker = "python_full_version >= '3.12'" },
-    { name = "tqdm", marker = "python_full_version >= '3.12'" },
-    { name = "transformers", marker = "python_full_version >= '3.12'" },
-    { name = "uvicorn", marker = "python_full_version >= '3.12'" },
+    { name = "datasets", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "fastapi", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "mlx", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "mlx-lm", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "opencv-python", version = "4.13.0.92", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pillow", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "requests", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "soundfile", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "transformers", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ff/9f/de419334820da334203de28eaf861b57ae0d06b0882770e5e5d0671dc5dd/mlx_vlm-0.3.3.tar.gz", hash = "sha256:5a08c802d1bf32cc47bd6aebe348d3554ce21bfce417a585bba83f9d213a6e66", size = 231935, upload-time = "2025-08-20T14:52:51.323Z" }
 wheels = [
@@ -8471,9 +8481,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "pyobjc-framework-vision" },
+    { name = "click", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -8642,7 +8652,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.12' and platform_machine != 'x86_64') or (python_full_version < '3.12' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz", hash = "sha256:996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798", size = 95177929, upload-time = "2025-01-16T13:53:40.22Z" }
 wheels = [
@@ -8666,7 +8676,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and platform_machine != 'x86_64') or (python_full_version >= '3.12' and sys_platform != 'darwin')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209", size = 46247192, upload-time = "2026-02-05T07:01:35.187Z" },
@@ -9879,7 +9889,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -11139,7 +11149,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -11155,8 +11165,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -11172,8 +11182,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -11189,10 +11199,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreml" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [
@@ -12641,14 +12651,14 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "imageio", marker = "python_full_version < '3.11'" },
-    { name = "lazy-loader", marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "imageio", marker = "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "lazy-loader", marker = "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "packaging", marker = "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "pillow", marker = "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
+    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/a8/3c0f256012b93dd2cb6fda9245e9f4bff7dc0486880b248005f15ea2255e/scikit_image-0.25.2.tar.gz", hash = "sha256:e5a37e6cd4d0c018a7a55b9d601357e3382826d3888c10d0213fc63bff977dde", size = 22693594, upload-time = "2025-02-18T18:05:24.538Z" }
 wheels = [
@@ -12690,15 +12700,15 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "imageio", marker = "python_full_version >= '3.11'" },
-    { name = "lazy-loader", marker = "python_full_version >= '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "imageio", marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "lazy-loader", marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and platform_machine != 'x86_64') or (python_full_version >= '3.12' and sys_platform != 'darwin')" },
+    { name = "packaging", marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "pillow", marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
 wheels = [
@@ -13270,8 +13280,8 @@ name = "soundfile"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "python_full_version >= '3.12'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "cffi", marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/41/9b873a8c055582859b239be17902a85339bec6a30ad162f98c9b0288a2cc/soundfile-0.13.1.tar.gz", hash = "sha256:b2c68dab1e30297317080a5b43df57e302584c49e2942defdde0acccc53f0e5b", size = 46156, upload-time = "2025-01-25T09:17:04.831Z" }
 wheels = [
@@ -13599,7 +13609,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine != 'x86_64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
 wheels = [
@@ -13621,8 +13631,8 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and platform_machine != 'x86_64') or (python_full_version >= '3.12' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -13909,9 +13919,9 @@ dependencies = [
     { name = "torch", version = "2.2.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.17.2-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:1f2910fe3c21ad6875b2720d46fad835b2e4b336e9553d31ca364d24c90b1d4f" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.17.2-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:9b83e55ee7d0a1704f52b9c0ac87388e7a6d1d98a6bde7b0b35f9ab54d7bda54" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14fd1d4a033c325bdba2d03a69c3450cab6d3a625f85cc375781d9237ca5d04d" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.17.2-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:1f2910fe3c21ad6875b2720d46fad835b2e4b336e9553d31ca364d24c90b1d4f" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.17.2-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:9b83e55ee7d0a1704f52b9c0ac87388e7a6d1d98a6bde7b0b35f9ab54d7bda54" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14fd1d4a033c325bdba2d03a69c3450cab6d3a625f85cc375781d9237ca5d04d" },
 ]
 
 [[package]]
@@ -13944,11 +13954,11 @@ dependencies = [
     { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7810841916a2a870cbfb581f4084b59479908fb9db6edfdf78139931392d8677" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a76ce7b8d4fce291a25721ee2f921c783acc6dbd4fc32dc741ed2a1d5a8dde2f" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:724f212a58a0d0d758649ce288601056b5f46a01de545702f42bccc5b25cb0cc" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6c444119c6af8fa48b79c59f1529fc15a45a2bbf823cf85f851e7203d84f727f" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:80895a40faa5783ce19ed5a692a54062c7888a385490e866324355f8d59b2eb3" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7810841916a2a870cbfb581f4084b59479908fb9db6edfdf78139931392d8677" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a76ce7b8d4fce291a25721ee2f921c783acc6dbd4fc32dc741ed2a1d5a8dde2f" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:724f212a58a0d0d758649ce288601056b5f46a01de545702f42bccc5b25cb0cc" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6c444119c6af8fa48b79c59f1529fc15a45a2bbf823cf85f851e7203d84f727f" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:80895a40faa5783ce19ed5a692a54062c7888a385490e866324355f8d59b2eb3" },
 ]
 
 [[package]]
@@ -13971,21 +13981,21 @@ dependencies = [
     { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:73ce04dea64914ff1110008311204c366107d651d3b04faa0dbee77efb7133b7" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:7f851245a2687743742157988ed9c42c6e312b95bbe6cfcac9e7d0d0c28ae62f" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:3e2ae9981e32a5b9db685659d5c7af0f04b159ff20394650a90124baf6ada51a" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:59be99d1c470ef470b134468aa6afa6f968081a503acb4ee883d70332f822e35" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:aa016ab73e06a886f72edc8929ed2ed4c85aaaa6e10500ecdef921b03129b19e" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:c7eb5f219fdfaf1f65e68c00eb81172ab4fa08a9874dae9dad2bca360da34d0f" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:727334e9a721cfc1ac296ce0bf9e69d9486821bfa5b1e75a8feb6f78041db481" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c1be164e93c68b2dbf460fd58975377c892dbcf3358fb72941709c3857351bba" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:2d444009c0956669ada149f61ed78f257c1cc96d259efa6acf3929ca96ceb3f0" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:fe54cbd5942cd0b26a90f1748f0d4421caf67be35c281c6c3b8573733a03d630" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:90eec299e1f82cfaf080ccb789df3838cb9a54b57e2ebe33852cd392c692de5c" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:783c8fc580bbfc159bff52f4f72cdd538e42b32956e70dffa42b940db114e151" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e985e12a9a232618e5a43476de5689e4b14989f5da6b93909c57afa57ec27012" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:813f0106eb3e268f3783da67b882458e544c6fb72f946e6ca64b5ed4e62c6a77" },
-    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:9212210f417888e6261c040495180f053084812cf873dedba9fc51ff4b24b2d3" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:73ce04dea64914ff1110008311204c366107d651d3b04faa0dbee77efb7133b7" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:7f851245a2687743742157988ed9c42c6e312b95bbe6cfcac9e7d0d0c28ae62f" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:3e2ae9981e32a5b9db685659d5c7af0f04b159ff20394650a90124baf6ada51a" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:59be99d1c470ef470b134468aa6afa6f968081a503acb4ee883d70332f822e35" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:aa016ab73e06a886f72edc8929ed2ed4c85aaaa6e10500ecdef921b03129b19e" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:c7eb5f219fdfaf1f65e68c00eb81172ab4fa08a9874dae9dad2bca360da34d0f" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:727334e9a721cfc1ac296ce0bf9e69d9486821bfa5b1e75a8feb6f78041db481" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c1be164e93c68b2dbf460fd58975377c892dbcf3358fb72941709c3857351bba" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:2d444009c0956669ada149f61ed78f257c1cc96d259efa6acf3929ca96ceb3f0" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:fe54cbd5942cd0b26a90f1748f0d4421caf67be35c281c6c3b8573733a03d630" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:90eec299e1f82cfaf080ccb789df3838cb9a54b57e2ebe33852cd392c692de5c" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:783c8fc580bbfc159bff52f4f72cdd538e42b32956e70dffa42b940db114e151" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e985e12a9a232618e5a43476de5689e4b14989f5da6b93909c57afa57ec27012" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:813f0106eb3e268f3783da67b882458e544c6fb72f946e6ca64b5ed4e62c6a77" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.25.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:9212210f417888e6261c040495180f053084812cf873dedba9fc51ff4b24b2d3" },
 ]
 
 [[package]]
@@ -14497,6 +14507,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds a complete flow scheduling system using APScheduler with cron expressions
- Concurrency semaphore limits parallel executions (default 5) to prevent DB pool exhaustion and event loop starvation
- Random jitter (0-30s) prevents thundering herd when many flows share the same cron schedule
- Retry with exponential backoff (30s-300s, max 3 attempts) for failed scheduled executions
- Structured logging with execution duration, queue wait time, and active count metrics
- Frontend modal for schedule management with frequency presets, timezone support, and dark mode fixes

## Details

### Backend
- `SchedulerService` with `asyncio.Semaphore` for concurrency control
- Jitter applied **before** semaphore acquisition to spread DB connection demand
- `_handle_retry()` schedules one-shot retry jobs via APScheduler `DateTrigger`
- `FlowSchedule` model with cron fields, `retry_count`, `max_retries`, `start_at`
- All configuration via environment variables (`LANGFLOW_SCHEDULER_*`)
- 3 Alembic migrations (table creation, start_at, retry fields)

### Frontend
- Schedule modal with frequency selector (every minute → custom cron)
- Dark mode calendar icon fix (`dark:[&::-webkit-calendar-picker-indicator]:invert`)
- Removed overlapping `placeholder="Now"` on datetime-local input
- React Query hooks for all schedule CRUD operations

### Configuration (env vars)
| Variable | Default | Description |
|---|---|---|
| `LANGFLOW_SCHEDULER_MAX_CONCURRENCY` | `5` | Max parallel flow executions |
| `LANGFLOW_SCHEDULER_MAX_JITTER_SECONDS` | `30` | Random delay window (0 to disable) |
| `LANGFLOW_SCHEDULER_RETRY_BASE_DELAY` | `30` | Initial retry delay (seconds) |
| `LANGFLOW_SCHEDULER_RETRY_MAX_DELAY` | `300` | Max retry delay cap (seconds) |
| `LANGFLOW_SCHEDULER_DEFAULT_MAX_RETRIES` | `3` | Default retries per schedule |

## Test plan
- [ ] Create 10+ schedules with `* * * * *`, verify max 5 run simultaneously via logs
- [ ] Verify jitter spreads execution start times across 0-30s window
- [ ] Create a flow that fails, confirm retries are scheduled with increasing delays (30s, 60s, 120s)
- [ ] Confirm retries stop after `max_retries` with `failed_permanent` status
- [ ] Verify `alembic upgrade head` works on SQLite and PostgreSQL
- [ ] Test schedule CRUD via API and frontend modal
- [ ] Verify dark mode calendar icon visibility
- [ ] Verify no placeholder overlap on datetime-local input

🤖 Generated with [Claude Code](https://claude.com/claude-code)