### PR TITLE
[backend] fix: add cache_dir setting to avoid multi-instance conflicts

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -63,9 +63,7 @@ from langflow.services.deps import (
 def update_projects_components_with_latest_component_versions(project_data, all_types_dict):
     # Flatten the all_types_dict for easy access
     all_types_dict_flat = {
-        key: component
-        for category in all_types_dict.values()
-        for key, component in category.items()
+        key: component for category in all_types_dict.values() for key, component in category.items()
     }
 
     node_changes_log = defaultdict(list)

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -62,10 +62,11 @@ from langflow.services.deps import (
 
 def update_projects_components_with_latest_component_versions(project_data, all_types_dict):
     # Flatten the all_types_dict for easy access
-    all_types_dict_flat = {}
-    for category in all_types_dict.values():
-        for key, component in category.items():
-            all_types_dict_flat[key] = component
+    all_types_dict_flat = {
+        key: component
+        for category in all_types_dict.values()
+        for key, component in category.items()
+    }
 
     node_changes_log = defaultdict(list)
     project_data_copy = deepcopy(project_data)

--- a/src/backend/base/langflow/services/cache/factory.py
+++ b/src/backend/base/langflow/services/cache/factory.py
@@ -37,8 +37,9 @@ class CacheServiceFactory(ServiceFactory):
         if settings_service.settings.cache_type == "async":
             return AsyncInMemoryCache(expiration_time=settings_service.settings.cache_expire)
         if settings_service.settings.cache_type == "disk":
+            cache_dir = settings_service.settings.cache_dir or settings_service.settings.config_dir
             return AsyncDiskCache(
-                cache_dir=settings_service.settings.config_dir,
+                cache_dir=cache_dir,
                 expiration_time=settings_service.settings.cache_expire,
             )
         return None

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -151,6 +151,8 @@ class Settings(BaseSettings):
     """The cache type can be 'async' or 'redis'."""
     cache_expire: int = 3600
     """The cache expire in seconds."""
+    cache_dir: str | None = None
+    """The directory to store disk cache. Defaults to config_dir if not set."""
     variable_store: str = "db"
     """The store can be 'db' or 'kubernetes'."""
 

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -509,6 +509,26 @@ class Settings(BaseSettings):
 
         return str(value)
 
+    @field_validator("cache_dir", mode="before")
+    @classmethod
+    def validate_cache_dir(cls, value):
+        """Validate and normalize cache_dir path.
+
+        If not set, returns None and the factory will fall back to config_dir.
+        If set, resolves to an absolute path and creates the directory if needed.
+        """
+        if not value:
+            return None
+
+        if isinstance(value, str):
+            value = Path(value)
+        # Resolve to absolute path to handle relative paths correctly
+        value = value.resolve()
+        if not value.exists():
+            value.mkdir(parents=True, exist_ok=True)
+
+        return str(value)
+
     @field_validator("database_url", mode="before")
     @classmethod
     def set_database_url(cls, value, info):


### PR DESCRIPTION
Fixes #12299

## Problem

Multi-instance deployments using disk cache type encountered `sqlite3.DatabaseError: database disk image is malformed` because:
- Cache factory always used `config_dir` for disk cache location
- Multiple instances shared the same cache directory (e.g., on NFS)
- Concurrent SQLite access caused corruption

## Solution

1. **Added `cache_dir` setting** in `lfx/services/settings/base.py`
   - Optional field, defaults to `None`
   - When `None`, uses `config_dir` (backward compatible)

2. **Updated cache factory** in `langflow/services/cache/factory.py`
   - Uses `cache_dir` if set
   - Falls back to `config_dir` if not set

## Configuration

Set via environment variable:
```bash
LANGFLOW_CACHE_DIR=/instance/specific/cache/path
LANGFLOW_CACHE_TYPE=disk
```

Or in settings file:
```yaml
cache_dir: /instance/specific/cache/path
cache_type: disk
```

## Impact

- ✅ Multi-instance deployments can use separate cache directories
- ✅ Prevents concurrent SQLite access issues on shared storage
- ✅ Backward compatible: existing deployments unaffected
- ✅ No database changes required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option that allows users to specify a custom directory for storing disk cache, independent from the main configuration directory. When not set, the system defaults to using the configuration directory, ensuring backward compatibility with existing setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->