### PR TITLE
fix: Update Google embedding models to latest versions

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -63,9 +63,7 @@ from langflow.services.deps import (
 def update_projects_components_with_latest_component_versions(project_data, all_types_dict):
     # Flatten the all_types_dict for easy access
     all_types_dict_flat = {
-        key: component
-        for category in all_types_dict.values()
-        for key, component in category.items()
+        key: component for category in all_types_dict.values() for key, component in category.items()
     }
 
     node_changes_log = defaultdict(list)

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -62,10 +62,11 @@ from langflow.services.deps import (
 
 def update_projects_components_with_latest_component_versions(project_data, all_types_dict):
     # Flatten the all_types_dict for easy access
-    all_types_dict_flat = {}
-    for category in all_types_dict.values():
-        for key, component in category.items():
-            all_types_dict_flat[key] = component
+    all_types_dict_flat = {
+        key: component
+        for category in all_types_dict.values()
+        for key, component in category.items()
+    }
 
     node_changes_log = defaultdict(list)
     project_data_copy = deepcopy(project_data)

--- a/src/backend/base/langflow/services/cache/factory.py
+++ b/src/backend/base/langflow/services/cache/factory.py
@@ -37,8 +37,9 @@ class CacheServiceFactory(ServiceFactory):
         if settings_service.settings.cache_type == "async":
             return AsyncInMemoryCache(expiration_time=settings_service.settings.cache_expire)
         if settings_service.settings.cache_type == "disk":
+            cache_dir = settings_service.settings.cache_dir or settings_service.settings.config_dir
             return AsyncDiskCache(
-                cache_dir=settings_service.settings.config_dir,
+                cache_dir=cache_dir,
                 expiration_time=settings_service.settings.cache_expire,
             )
         return None

--- a/src/lfx/src/lfx/base/models/google_generative_ai_constants.py
+++ b/src/lfx/src/lfx/base/models/google_generative_ai_constants.py
@@ -100,8 +100,8 @@ GOOGLE_GENERATIVE_AI_MODELS = [metadata["name"] for metadata in GOOGLE_GENERATIV
 
 # Google Generative AI Embedding Models
 GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS = [
-    "models/text-embedding-004",
-    "models/embedding-001",
+    "models/gemini-embedding-001",
+    "models/gemini-embedding-2-preview",
 ]
 
 # Embedding models as detailed metadata

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -151,6 +151,8 @@ class Settings(BaseSettings):
     """The cache type can be 'async' or 'redis'."""
     cache_expire: int = 3600
     """The cache expire in seconds."""
+    cache_dir: str | None = None
+    """The directory to store disk cache. Defaults to config_dir if not set."""
     variable_store: str = "db"
     """The store can be 'db' or 'kubernetes'."""
 

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -509,6 +509,26 @@ class Settings(BaseSettings):
 
         return str(value)
 
+    @field_validator("cache_dir", mode="before")
+    @classmethod
+    def validate_cache_dir(cls, value):
+        """Validate and normalize cache_dir path.
+
+        If not set, returns None and the factory will fall back to config_dir.
+        If set, resolves to an absolute path and creates the directory if needed.
+        """
+        if not value:
+            return None
+
+        if isinstance(value, str):
+            value = Path(value)
+        # Resolve to absolute path to handle relative paths correctly
+        value = value.resolve()
+        if not value.exists():
+            value.mkdir(parents=True, exist_ok=True)
+
+        return str(value)
+
     @field_validator("database_url", mode="before")
     @classmethod
     def set_database_url(cls, value, info):


### PR DESCRIPTION
Fixes #12277

Replace deprecated text-embedding-004 and embedding-001 with:
- gemini-embedding-001 (text-only)
- gemini-embedding-2-preview (multimodal)

Verified from Google official docs: https://ai.google.dev/gemini-api/docs/embeddings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable cache directory setting for disk cache storage

* **Updates**
  * Google Generative AI embedding models updated to latest versions
  * Improved disk cache directory resolution with fallback logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->