### PR TITLE
fix: prevent success toast on file upload cancel

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/filesPage/components/FilesTab.tsx
+++ b/src/frontend/src/pages/MainPage/pages/filesPage/components/FilesTab.tsx
@@ -75,9 +75,11 @@ const FilesTab = ({
       const filesIds = await uploadFile({
         files: files,
       });
-      setSuccessData({
-        title: `File${filesIds.length > 1 ? "s" : ""} uploaded successfully`,
-      });
+      if (filesIds.length > 0) {
+        setSuccessData({
+          title: `File${filesIds.length > 1 ? "s" : ""} uploaded successfully`,
+        });
+      }
     } catch (error: any) {
       setErrorData({
         title: "Error uploading file",


### PR DESCRIPTION
## Summary
- Check if filesIds.length > 0 before showing success toast
- Fixes #12318

## Problem
When user clicks "Upload Files" button and then cancels the file dialog, a success toast "File uploaded successfully" was incorrectly shown.

## Root Cause
The `handleUpload` function in `FilesTab.tsx` was showing success toast unconditionally, without checking if any files were actually uploaded.

## Solution
Add `if (filesIds.length > 0)` check before showing success toast, matching the pattern used in `DragFilesComponent`.

## Test Plan
1. Go to Files page
2. Click "Upload Files" button
3. Click "Cancel" in file dialog
4. Verify no success toast appears
5. Upload a file normally
6. Verify success toast appears correctly