### PR TITLE
 fix: Add ephemeral file upload and credential env fallback                                                                                  

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -88,12 +88,11 @@ RUN ARCH=$(dpkg --print-architecture) \
        elif [ "$ARCH" = "arm64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
-                    | grep -oP "node-v\K[0-9]+\.[0-9]+\.[0-9]+(?=-linux-${NODE_ARCH}\.tar\.xz)" \
+                    | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
                     | head -1) \
+    && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
-    | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest \
-    && npm cache clean --force
+    | tar -xJ -C /usr/local --strip-components=1
 RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -63,12 +63,11 @@ RUN ARCH=$(dpkg --print-architecture) \
        elif [ "$ARCH" = "arm64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
-                    | grep -oP "node-v\K[0-9]+\.[0-9]+\.[0-9]+(?=-linux-${NODE_ARCH}\.tar\.xz)" \
+                    | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
                     | head -1) \
+    && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
-    | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest \
-    && npm cache clean --force
+    | tar -xJ -C /usr/local --strip-components=1
 
 # Create non-root user
 RUN useradd --uid 1000 --gid 0 --no-create-home --home-dir /app/data user

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -89,12 +89,11 @@ RUN ARCH=$(dpkg --print-architecture) \
        elif [ "$ARCH" = "arm64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
-                    | grep -oP "node-v\K[0-9]+\.[0-9]+\.[0-9]+(?=-linux-${NODE_ARCH}\.tar\.xz)" \
+                    | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
                     | head -1) \
+    && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
-    | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest \
-    && npm cache clean --force
+    | tar -xJ -C /usr/local --strip-components=1
 RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -84,12 +84,11 @@ RUN ARCH=$(dpkg --print-architecture) \
        elif [ "$ARCH" = "arm64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
-                    | grep -oP "node-v\K[0-9]+\.[0-9]+\.[0-9]+(?=-linux-${NODE_ARCH}\.tar\.xz)" \
+                    | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
                     | head -1) \
+    && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
-    | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest \
-    && npm cache clean --force
+    | tar -xJ -C /usr/local --strip-components=1
 RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -85,12 +85,11 @@ RUN ARCH=$(dpkg --print-architecture) \
        elif [ "$ARCH" = "arm64" ]; then NODE_ARCH="arm64"; \
        else NODE_ARCH="$ARCH"; fi \
     && NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/latest-v22.x/ \
-                    | grep -oP "node-v\K[0-9]+\.[0-9]+\.[0-9]+(?=-linux-${NODE_ARCH}\.tar\.xz)" \
+                    | sed -nE "s/.*node-v([0-9]+\.[0-9]+\.[0-9]+)-linux-${NODE_ARCH}\.tar\.xz.*/\1/p" \
                     | head -1) \
+    && if [ -z "$NODE_VERSION" ]; then echo "ERROR: Could not determine Node.js version" && exit 1; fi \
     && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
-    | tar -xJ -C /usr/local --strip-components=1 \
-    && npm install -g npm@latest \
-    && npm cache clean --force
+    | tar -xJ -C /usr/local --strip-components=1
 RUN useradd user -u 1000 -g 0 --no-create-home --home-dir /app/data
 
 COPY --from=builder --chown=1000 /app/.venv /app/.venv

--- a/src/backend/base/langflow/api/v2/files.py
+++ b/src/backend/base/langflow/api/v2/files.py
@@ -137,6 +137,7 @@ async def upload_user_file(
     settings_service: Annotated[SettingsService, Depends(get_settings_service)],
     *,
     append: bool = False,
+    ephemeral: bool = False,
 ) -> UploadFileResponse:
     """Upload a file for the current user and track it in the database."""
     # Get the max allowed file size from settings (in MB)
@@ -231,6 +232,12 @@ async def upload_user_file(
         except Exception as e:
             # General error saving file or getting file size
             raise HTTPException(status_code=500, detail=f"Error accessing file: {e}") from e
+
+        if ephemeral:
+            # Ephemeral uploads: file is saved to storage (servable for chat history)
+            # but no UserFile record is created (won't appear in "My Files")
+            file_path = f"{current_user.id}/{stored_file_name}"
+            return UploadFileResponse(id=file_id, name=root_filename, path=file_path, size=file_size)
 
         if append and existing_file:
             existing_file.size = file_size

--- a/src/backend/tests/unit/api/v2/test_files.py
+++ b/src/backend/tests/unit/api/v2/test_files.py
@@ -149,6 +149,77 @@ async def test_upload_file(files_client, files_created_api_key):
     assert "id" in response_json
 
 
+async def test_should_not_persist_in_my_files_when_upload_is_ephemeral(files_client, files_created_api_key):
+    """Ephemeral uploads save the file to storage but do NOT create a UserFile DB record.
+
+    This is the expected behavior for chat playground uploads in Desktop,
+    where the file must be servable (for chat history) but should not
+    appear in the user's 'My Files' list.
+    """
+    headers = {"x-api-key": files_created_api_key.api_key}
+
+    # Upload with ephemeral=true
+    response = await files_client.post(
+        "api/v2/files",
+        files={"file": ("playground_image.png", b"fake image content")},
+        params={"ephemeral": "true"},
+        headers=headers,
+    )
+    assert response.status_code == 201, f"Expected 201, got {response.status_code}: {response.text}"
+
+    upload_response = response.json()
+    assert "path" in upload_response
+
+    # The file must NOT appear in the user's file list
+    list_response = await files_client.get("api/v2/files", headers=headers)
+    assert list_response.status_code == 200
+    file_names = [f["name"] for f in list_response.json()]
+    assert "playground_image" not in file_names, (
+        f"Ephemeral file should not appear in My Files, but found: {file_names}"
+    )
+
+    # The file is saved in storage and the response includes a valid path
+    file_path = upload_response["path"]
+    assert file_path, "Ephemeral upload should return a non-empty path"
+    # Path format: {user_id}/{stored_file_name}
+    parts = file_path.split("/")
+    assert len(parts) == 2, f"Expected path format 'user_id/filename', got: {file_path}"
+
+
+async def test_should_return_path_with_forward_slashes_when_uploading_file(files_client, files_created_api_key):
+    """Upload response path must use forward slashes on all platforms.
+
+    On Windows, pathlib.Path serializes with backslashes, but the GET list
+    endpoint returns the raw DB string with forward slashes. If the POST
+    response uses backslashes, the frontend cannot match them with
+    selectedFiles.includes(file.path), leaving checkboxes unchecked.
+    """
+    headers = {"x-api-key": files_created_api_key.api_key}
+
+    response = await files_client.post(
+        "api/v2/files",
+        files={"file": ("test_path.txt", b"path test content")},
+        headers=headers,
+    )
+    assert response.status_code == 201
+
+    upload_path = response.json()["path"]
+    assert "\\" not in upload_path, (
+        f"Upload response path contains backslashes: '{upload_path}'. "
+        "Path must use forward slashes on all platforms for frontend compatibility."
+    )
+
+    # Verify the upload path matches what GET /files returns
+    list_response = await files_client.get("api/v2/files", headers=headers)
+    assert list_response.status_code == 200
+
+    listed_paths = [f["path"] for f in list_response.json()]
+    assert upload_path in listed_paths, (
+        f"Upload path '{upload_path}' not found in listed paths {listed_paths}. "
+        "POST and GET must return identical path strings."
+    )
+
+
 async def test_download_file(files_client, files_created_api_key):
     headers = {"x-api-key": files_created_api_key.api_key}
 

--- a/src/backend/tests/unit/test_credential_resolution.py
+++ b/src/backend/tests/unit/test_credential_resolution.py
@@ -1,0 +1,102 @@
+"""Tests for credential resolution in the unified models system.
+
+Bug: Desktop Global Variable OPENAI_API_KEY not injected at runtime.
+When api_key parameter is None (Agent component default), get_api_key_for_provider
+only attempts DB lookup but has no os.getenv() fallback and no error handling
+for ValueError from get_variable(). This causes failures in Desktop where the
+env var is not set and the DB lookup is the only path.
+"""
+
+from unittest.mock import patch
+from uuid import uuid4
+
+
+class TestGetApiKeyForProviderDbFallback:
+    """Tests for get_api_key_for_provider when api_key param is None (second path)."""
+
+    @patch("lfx.base.models.unified_models.get_model_provider_variable_mapping")
+    @patch("lfx.base.models.unified_models.run_until_complete")
+    def test_should_fallback_to_env_when_db_lookup_raises_value_error(self, mock_run, mock_mapping, monkeypatch):
+        """When variable_service.get_variable raises ValueError (variable not found in DB).
+
+        get_api_key_for_provider should fall back to os.getenv() instead of returning None.
+        """
+        from lfx.base.models.unified_models import get_api_key_for_provider
+
+        user_id = str(uuid4())
+        mock_mapping.return_value = {"OpenAI": "OPENAI_API_KEY"}
+        mock_run.side_effect = ValueError("OPENAI_API_KEY variable not found.")
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-env-key")
+
+        result = get_api_key_for_provider(user_id, "OpenAI", None)
+
+        assert result == "sk-test-env-key"
+
+    @patch("lfx.base.models.unified_models.get_model_provider_variable_mapping")
+    @patch("lfx.base.models.unified_models.run_until_complete")
+    def test_should_fallback_to_env_when_db_lookup_returns_empty_string(self, mock_run, mock_mapping, monkeypatch):
+        """When decryption fails, get_variable returns empty string.
+
+        get_api_key_for_provider should fall back to os.getenv().
+        """
+        from lfx.base.models.unified_models import get_api_key_for_provider
+
+        user_id = str(uuid4())
+        mock_mapping.return_value = {"OpenAI": "OPENAI_API_KEY"}
+        mock_run.return_value = ""
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-env-key")
+
+        result = get_api_key_for_provider(user_id, "OpenAI", None)
+
+        assert result == "sk-test-env-key"
+
+    @patch("lfx.base.models.unified_models.get_model_provider_variable_mapping")
+    @patch("lfx.base.models.unified_models.run_until_complete")
+    def test_should_fallback_to_env_when_variable_service_is_none(self, mock_run, mock_mapping, monkeypatch):
+        """When variable_service is None (service not available in thread context).
+
+        get_api_key_for_provider should fall back to os.getenv().
+        """
+        from lfx.base.models.unified_models import get_api_key_for_provider
+
+        user_id = str(uuid4())
+        mock_mapping.return_value = {"OpenAI": "OPENAI_API_KEY"}
+        mock_run.return_value = None
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-env-key")
+
+        result = get_api_key_for_provider(user_id, "OpenAI", None)
+
+        assert result == "sk-test-env-key"
+
+    @patch("lfx.base.models.unified_models.get_model_provider_variable_mapping")
+    @patch("lfx.base.models.unified_models.run_until_complete")
+    def test_should_return_none_when_both_db_and_env_unavailable(self, mock_run, mock_mapping, monkeypatch):
+        """When both DB lookup and env var are unavailable, should return None."""
+        from lfx.base.models.unified_models import get_api_key_for_provider
+
+        user_id = str(uuid4())
+        mock_mapping.return_value = {"OpenAI": "OPENAI_API_KEY"}
+        mock_run.return_value = None
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        result = get_api_key_for_provider(user_id, "OpenAI", None)
+
+        assert result is None
+
+    @patch("lfx.base.models.unified_models.get_model_provider_variable_mapping")
+    @patch("lfx.base.models.unified_models.run_until_complete")
+    def test_should_return_db_value_when_db_lookup_succeeds(self, mock_run, mock_mapping):
+        """When DB lookup succeeds, should return the DB value (no env fallback needed)."""
+        from lfx.base.models.unified_models import get_api_key_for_provider
+
+        user_id = str(uuid4())
+        mock_mapping.return_value = {"OpenAI": "OPENAI_API_KEY"}
+        mock_run.return_value = "sk-from-database"
+
+        result = get_api_key_for_provider(user_id, "OpenAI", None)
+
+        assert result == "sk-from-database"

--- a/src/lfx/src/lfx/_assets/stable_hash_history.json
+++ b/src/lfx/src/lfx/_assets/stable_hash_history.json
@@ -2,925 +2,1079 @@
   "FAISS": {
     "versions": {
       "0.3.0": "2bd7a064d724",
-      "0.3.1": "2bd7a064d724"
+      "0.3.1": "2bd7a064d724",
+      "0.3.2": "2bd7a064d724"
     }
   },
   "AddContentToPage": {
     "versions": {
       "0.3.0": "ffcd44201c09",
-      "0.3.1": "ffcd44201c09"
+      "0.3.1": "ffcd44201c09",
+      "0.3.2": "ffcd44201c09"
     }
   },
   "NotionPageCreator": {
     "versions": {
       "0.3.0": "640438ed3d7b",
-      "0.3.1": "640438ed3d7b"
+      "0.3.1": "640438ed3d7b",
+      "0.3.2": "640438ed3d7b"
     }
   },
   "NotionDatabaseProperties": {
     "versions": {
       "0.3.0": "adce99660f9e",
-      "0.3.1": "adce99660f9e"
+      "0.3.1": "adce99660f9e",
+      "0.3.2": "adce99660f9e"
     }
   },
   "NotionListPages": {
     "versions": {
       "0.3.0": "373f9ad32937",
-      "0.3.1": "373f9ad32937"
+      "0.3.1": "373f9ad32937",
+      "0.3.2": "373f9ad32937"
     }
   },
   "NotionUserList": {
     "versions": {
       "0.3.0": "8966397da1d5",
-      "0.3.1": "8966397da1d5"
+      "0.3.1": "8966397da1d5",
+      "0.3.2": "8966397da1d5"
     }
   },
   "NotionPageContent": {
     "versions": {
       "0.3.0": "ba15d6a01d04",
-      "0.3.1": "ba15d6a01d04"
+      "0.3.1": "ba15d6a01d04",
+      "0.3.2": "ba15d6a01d04"
     }
   },
   "NotionSearch": {
     "versions": {
       "0.3.0": "793b8818a3b4",
-      "0.3.1": "793b8818a3b4"
+      "0.3.1": "793b8818a3b4",
+      "0.3.2": "793b8818a3b4"
     }
   },
   "NotionPageUpdate": {
     "versions": {
       "0.3.0": "32ccdf34df73",
-      "0.3.1": "32ccdf34df73"
+      "0.3.1": "32ccdf34df73",
+      "0.3.2": "32ccdf34df73"
     }
   },
   "AgentQL": {
     "versions": {
       "0.3.0": "37de3210aed9",
-      "0.3.1": "37de3210aed9"
+      "0.3.1": "37de3210aed9",
+      "0.3.2": "37de3210aed9"
     }
   },
   "AIMLModel": {
     "versions": {
       "0.3.0": "db72277a0d5a",
-      "0.3.1": "db72277a0d5a"
+      "0.3.1": "db72277a0d5a",
+      "0.3.2": "db72277a0d5a"
     }
   },
   "AIMLEmbeddings": {
     "versions": {
       "0.3.0": "dae370391ba3",
-      "0.3.1": "dae370391ba3"
+      "0.3.1": "dae370391ba3",
+      "0.3.2": "dae370391ba3"
     }
   },
   "ALTK Agent": {
     "versions": {
       "0.3.0": "d1caf0d1db88",
-      "0.3.1": "d1caf0d1db88"
+      "0.3.1": "d1caf0d1db88",
+      "0.3.2": "d1caf0d1db88"
     }
   },
   "AmazonBedrockConverseModel": {
     "versions": {
       "0.3.0": "54c335f8699f",
-      "0.3.1": "54c335f8699f"
+      "0.3.1": "54c335f8699f",
+      "0.3.2": "54c335f8699f"
     }
   },
   "AmazonBedrockEmbeddings": {
     "versions": {
       "0.3.0": "70d039ff79f0",
-      "0.3.1": "70d039ff79f0"
+      "0.3.1": "70d039ff79f0",
+      "0.3.2": "70d039ff79f0"
     }
   },
   "AmazonBedrockModel": {
     "versions": {
       "0.3.0": "922093a831b6",
-      "0.3.1": "922093a831b6"
+      "0.3.1": "922093a831b6",
+      "0.3.2": "922093a831b6"
     }
   },
   "s3bucketuploader": {
     "versions": {
       "0.3.0": "6e4ba2dafc3c",
-      "0.3.1": "6e4ba2dafc3c"
+      "0.3.1": "6e4ba2dafc3c",
+      "0.3.2": "6e4ba2dafc3c"
     }
   },
   "AnthropicModel": {
     "versions": {
       "0.3.0": "7c894c5a66ba",
-      "0.3.1": "7c894c5a66ba"
+      "0.3.1": "7c894c5a66ba",
+      "0.3.2": "7c894c5a66ba"
     }
   },
   "ApifyActors": {
     "versions": {
       "0.3.0": "e84290d462c2",
-      "0.3.1": "e84290d462c2"
+      "0.3.1": "e84290d462c2",
+      "0.3.2": "e84290d462c2"
     }
   },
   "ArXivComponent": {
     "versions": {
       "0.3.0": "219239ee2b48",
-      "0.3.1": "219239ee2b48"
+      "0.3.1": "219239ee2b48",
+      "0.3.2": "219239ee2b48"
     }
   },
   "AssemblyAIGetSubtitles": {
     "versions": {
       "0.3.0": "533d1fcf7c7a",
-      "0.3.1": "533d1fcf7c7a"
+      "0.3.1": "533d1fcf7c7a",
+      "0.3.2": "533d1fcf7c7a"
     }
   },
   "AssemblyAILeMUR": {
     "versions": {
       "0.3.0": "8c96738ab967",
-      "0.3.1": "8c96738ab967"
+      "0.3.1": "8c96738ab967",
+      "0.3.2": "8c96738ab967"
     }
   },
   "AssemblyAIListTranscripts": {
     "versions": {
       "0.3.0": "267dcda48ad4",
-      "0.3.1": "267dcda48ad4"
+      "0.3.1": "267dcda48ad4",
+      "0.3.2": "267dcda48ad4"
     }
   },
   "AssemblyAITranscriptionJobPoller": {
     "versions": {
       "0.3.0": "935c9296b149",
-      "0.3.1": "935c9296b149"
+      "0.3.1": "935c9296b149",
+      "0.3.2": "935c9296b149"
     }
   },
   "AssemblyAITranscriptionJobCreator": {
     "versions": {
       "0.3.0": "7ff7b3f90298",
-      "0.3.1": "7ff7b3f90298"
+      "0.3.1": "7ff7b3f90298",
+      "0.3.2": "7ff7b3f90298"
     }
   },
   "AzureOpenAIModel": {
     "versions": {
       "0.3.0": "2ba26202203e",
-      "0.3.1": "2ba26202203e"
+      "0.3.1": "2ba26202203e",
+      "0.3.2": "2ba26202203e"
     }
   },
   "AzureOpenAIEmbeddings": {
     "versions": {
       "0.3.0": "6b54f3243a6a",
-      "0.3.1": "6b54f3243a6a"
+      "0.3.1": "6b54f3243a6a",
+      "0.3.2": "6b54f3243a6a"
     }
   },
   "BaiduQianfanChatModel": {
     "versions": {
       "0.3.0": "a5fdfdb5757f",
-      "0.3.1": "a5fdfdb5757f"
+      "0.3.1": "a5fdfdb5757f",
+      "0.3.2": "a5fdfdb5757f"
     }
   },
   "BingSearchAPI": {
     "versions": {
       "0.3.0": "84334607b325",
-      "0.3.1": "84334607b325"
+      "0.3.1": "84334607b325",
+      "0.3.2": "84334607b325"
     }
   },
   "Cassandra": {
     "versions": {
       "0.3.0": "833f277daab7",
-      "0.3.1": "833f277daab7"
+      "0.3.1": "833f277daab7",
+      "0.3.2": "833f277daab7"
     }
   },
   "CassandraChatMemory": {
     "versions": {
       "0.3.0": "f6497182984e",
-      "0.3.1": "f6497182984e"
+      "0.3.1": "f6497182984e",
+      "0.3.2": "f6497182984e"
     }
   },
   "CassandraGraph": {
     "versions": {
       "0.3.0": "26c63f80745e",
-      "0.3.1": "26c63f80745e"
+      "0.3.1": "26c63f80745e",
+      "0.3.2": "26c63f80745e"
     }
   },
   "Chroma": {
     "versions": {
       "0.3.0": "82d38624f19a",
-      "0.3.1": "82d38624f19a"
+      "0.3.1": "82d38624f19a",
+      "0.3.2": "82d38624f19a"
     }
   },
   "CleanlabEvaluator": {
     "versions": {
       "0.3.0": "06963c804ffe",
-      "0.3.1": "06963c804ffe"
+      "0.3.1": "06963c804ffe",
+      "0.3.2": "06963c804ffe"
     }
   },
   "CleanlabRAGEvaluator": {
     "versions": {
       "0.3.0": "f48b57ff7ca3",
-      "0.3.1": "f48b57ff7ca3"
+      "0.3.1": "f48b57ff7ca3",
+      "0.3.2": "f48b57ff7ca3"
     }
   },
   "CleanlabRemediator": {
     "versions": {
       "0.3.0": "a5b19d338991",
-      "0.3.1": "a5b19d338991"
+      "0.3.1": "a5b19d338991",
+      "0.3.2": "a5b19d338991"
     }
   },
   "Clickhouse": {
     "versions": {
       "0.3.0": "ab991e83da44",
-      "0.3.1": "ab991e83da44"
+      "0.3.1": "ab991e83da44",
+      "0.3.2": "ab991e83da44"
     }
   },
   "CloudflareWorkersAIEmbeddings": {
     "versions": {
       "0.3.0": "1ea6e4857c14",
-      "0.3.1": "1ea6e4857c14"
+      "0.3.1": "1ea6e4857c14",
+      "0.3.2": "1ea6e4857c14"
     }
   },
   "CohereEmbeddings": {
     "versions": {
       "0.3.0": "9c0f413a2c64",
-      "0.3.1": "9c0f413a2c64"
+      "0.3.1": "9c0f413a2c64",
+      "0.3.2": "9c0f413a2c64"
     }
   },
   "CohereModel": {
     "versions": {
       "0.3.0": "594852e1d706",
-      "0.3.1": "594852e1d706"
+      "0.3.1": "594852e1d706",
+      "0.3.2": "594852e1d706"
     }
   },
   "CohereRerank": {
     "versions": {
       "0.3.0": "a94a0d11eeac",
-      "0.3.1": "a94a0d11eeac"
+      "0.3.1": "a94a0d11eeac",
+      "0.3.2": "a94a0d11eeac"
     }
   },
   "CometAPIModel": {
     "versions": {
       "0.3.0": "4ec4a8852e9c",
-      "0.3.1": "4ec4a8852e9c"
+      "0.3.1": "4ec4a8852e9c",
+      "0.3.2": "4ec4a8852e9c"
     }
   },
   "ComposioAgentQLAPIComponent": {
     "versions": {
       "0.3.0": "cca708a10ab6",
-      "0.3.1": "cca708a10ab6"
+      "0.3.1": "cca708a10ab6",
+      "0.3.2": "cca708a10ab6"
     }
   },
   "ComposioAgiledAPIComponent": {
     "versions": {
       "0.3.0": "3294a951a1a8",
-      "0.3.1": "3294a951a1a8"
+      "0.3.1": "3294a951a1a8",
+      "0.3.2": "3294a951a1a8"
     }
   },
   "ComposioAirtableAPIComponent": {
     "versions": {
       "0.3.0": "e47ad011c33c",
-      "0.3.1": "e47ad011c33c"
+      "0.3.1": "e47ad011c33c",
+      "0.3.2": "e47ad011c33c"
     }
   },
   "ComposioApolloAPIComponent": {
     "versions": {
       "0.3.0": "3af16f5d6ceb",
-      "0.3.1": "3af16f5d6ceb"
+      "0.3.1": "3af16f5d6ceb",
+      "0.3.2": "3af16f5d6ceb"
     }
   },
   "ComposioAsanaAPIComponent": {
     "versions": {
       "0.3.0": "290d6d61d049",
-      "0.3.1": "290d6d61d049"
+      "0.3.1": "290d6d61d049",
+      "0.3.2": "290d6d61d049"
     }
   },
   "ComposioAttioAPIComponent": {
     "versions": {
       "0.3.0": "de43b3cf5671",
-      "0.3.1": "de43b3cf5671"
+      "0.3.1": "de43b3cf5671",
+      "0.3.2": "de43b3cf5671"
     }
   },
   "ComposioBitbucketAPIComponent": {
     "versions": {
       "0.3.0": "7528a8928646",
-      "0.3.1": "7528a8928646"
+      "0.3.1": "7528a8928646",
+      "0.3.2": "7528a8928646"
     }
   },
   "ComposioBolnaAPIComponent": {
     "versions": {
       "0.3.0": "dde7d2ee80a2",
-      "0.3.1": "dde7d2ee80a2"
+      "0.3.1": "dde7d2ee80a2",
+      "0.3.2": "dde7d2ee80a2"
     }
   },
   "ComposioBrightdataAPIComponent": {
     "versions": {
       "0.3.0": "49a04c5a23cb",
-      "0.3.1": "49a04c5a23cb"
+      "0.3.1": "49a04c5a23cb",
+      "0.3.2": "49a04c5a23cb"
     }
   },
   "ComposioCalendlyAPIComponent": {
     "versions": {
       "0.3.0": "4a282e413d55",
-      "0.3.1": "4a282e413d55"
+      "0.3.1": "4a282e413d55",
+      "0.3.2": "4a282e413d55"
     }
   },
   "ComposioCanvaAPIComponent": {
     "versions": {
       "0.3.0": "d149aa178e80",
-      "0.3.1": "d149aa178e80"
+      "0.3.1": "d149aa178e80",
+      "0.3.2": "d149aa178e80"
     }
   },
   "ComposioCanvasAPIComponent": {
     "versions": {
       "0.3.0": "6510d212a720",
-      "0.3.1": "6510d212a720"
+      "0.3.1": "6510d212a720",
+      "0.3.2": "6510d212a720"
     }
   },
   "ComposioCodaAPIComponent": {
     "versions": {
       "0.3.0": "f7693920313f",
-      "0.3.1": "f7693920313f"
+      "0.3.1": "f7693920313f",
+      "0.3.2": "f7693920313f"
     }
   },
   "ComposioAPI": {
     "versions": {
       "0.3.0": "764255821307",
-      "0.3.1": "764255821307"
+      "0.3.1": "764255821307",
+      "0.3.2": "764255821307"
     }
   },
   "ComposioContentfulAPIComponent": {
     "versions": {
       "0.3.0": "36befb1ec8fc",
-      "0.3.1": "36befb1ec8fc"
+      "0.3.1": "36befb1ec8fc",
+      "0.3.2": "36befb1ec8fc"
     }
   },
   "ComposioDigicertAPIComponent": {
     "versions": {
       "0.3.0": "0fcbc1b899f8",
-      "0.3.1": "0fcbc1b899f8"
+      "0.3.1": "0fcbc1b899f8",
+      "0.3.2": "0fcbc1b899f8"
     }
   },
   "ComposioDiscordAPIComponent": {
     "versions": {
       "0.3.0": "2ec988f25784",
-      "0.3.1": "2ec988f25784"
+      "0.3.1": "2ec988f25784",
+      "0.3.2": "2ec988f25784"
     }
   },
   "ComposioDropboxAPIComponent": {
     "versions": {
       "0.3.0": "d05825599def",
-      "0.3.1": "d05825599def"
+      "0.3.1": "d05825599def",
+      "0.3.2": "d05825599def"
     }
   },
   "ComposioElevenLabsAPIComponent": {
     "versions": {
       "0.3.0": "e0c91533558b",
-      "0.3.1": "e0c91533558b"
+      "0.3.1": "e0c91533558b",
+      "0.3.2": "e0c91533558b"
     }
   },
   "ComposioExaAPIComponent": {
     "versions": {
       "0.3.0": "3b5cecdefab8",
-      "0.3.1": "3b5cecdefab8"
+      "0.3.1": "3b5cecdefab8",
+      "0.3.2": "3b5cecdefab8"
     }
   },
   "ComposioFigmaAPIComponent": {
     "versions": {
       "0.3.0": "7443d213546b",
-      "0.3.1": "7443d213546b"
+      "0.3.1": "7443d213546b",
+      "0.3.2": "7443d213546b"
     }
   },
   "ComposioFinageAPIComponent": {
     "versions": {
       "0.3.0": "50a2bdee4cd1",
-      "0.3.1": "50a2bdee4cd1"
+      "0.3.1": "50a2bdee4cd1",
+      "0.3.2": "50a2bdee4cd1"
     }
   },
   "ComposioFirecrawlAPIComponent": {
     "versions": {
       "0.3.0": "2ab1c4b00071",
-      "0.3.1": "2ab1c4b00071"
+      "0.3.1": "2ab1c4b00071",
+      "0.3.2": "2ab1c4b00071"
     }
   },
   "ComposioFirefliesAPIComponent": {
     "versions": {
       "0.3.0": "233cd91dbdad",
-      "0.3.1": "233cd91dbdad"
+      "0.3.1": "233cd91dbdad",
+      "0.3.2": "233cd91dbdad"
     }
   },
   "ComposioFixerAPIComponent": {
     "versions": {
       "0.3.0": "9e4c00f9dcd8",
-      "0.3.1": "9e4c00f9dcd8"
+      "0.3.1": "9e4c00f9dcd8",
+      "0.3.2": "9e4c00f9dcd8"
     }
   },
   "ComposioFlexisignAPIComponent": {
     "versions": {
       "0.3.0": "c69bbee0005d",
-      "0.3.1": "c69bbee0005d"
+      "0.3.1": "c69bbee0005d",
+      "0.3.2": "c69bbee0005d"
     }
   },
   "ComposioFreshdeskAPIComponent": {
     "versions": {
       "0.3.0": "1dde03d615ca",
-      "0.3.1": "1dde03d615ca"
+      "0.3.1": "1dde03d615ca",
+      "0.3.2": "1dde03d615ca"
     }
   },
   "ComposioGitHubAPIComponent": {
     "versions": {
       "0.3.0": "ee201105d924",
-      "0.3.1": "ee201105d924"
+      "0.3.1": "ee201105d924",
+      "0.3.2": "ee201105d924"
     }
   },
   "ComposioGmailAPIComponent": {
     "versions": {
       "0.3.0": "d4b13ac8a3a1",
-      "0.3.1": "d4b13ac8a3a1"
+      "0.3.1": "d4b13ac8a3a1",
+      "0.3.2": "d4b13ac8a3a1"
     }
   },
   "ComposioGoogleBigQueryAPIComponent": {
     "versions": {
       "0.3.0": "f7d84aaae78f",
-      "0.3.1": "f7d84aaae78f"
+      "0.3.1": "f7d84aaae78f",
+      "0.3.2": "f7d84aaae78f"
     }
   },
   "ComposioGoogleCalendarAPIComponent": {
     "versions": {
       "0.3.0": "28adb6fff093",
-      "0.3.1": "28adb6fff093"
+      "0.3.1": "28adb6fff093",
+      "0.3.2": "28adb6fff093"
     }
   },
   "ComposioGoogleclassroomAPIComponent": {
     "versions": {
       "0.3.0": "85a5c37c13f6",
-      "0.3.1": "85a5c37c13f6"
+      "0.3.1": "85a5c37c13f6",
+      "0.3.2": "85a5c37c13f6"
     }
   },
   "ComposioGoogleDocsAPIComponent": {
     "versions": {
       "0.3.0": "ac2e88b6f706",
-      "0.3.1": "ac2e88b6f706"
+      "0.3.1": "ac2e88b6f706",
+      "0.3.2": "ac2e88b6f706"
     }
   },
   "ComposioGooglemeetAPIComponent": {
     "versions": {
       "0.3.0": "cdbf16c4b42f",
-      "0.3.1": "cdbf16c4b42f"
+      "0.3.1": "cdbf16c4b42f",
+      "0.3.2": "cdbf16c4b42f"
     }
   },
   "ComposioGoogleSheetsAPIComponent": {
     "versions": {
       "0.3.0": "b0db7a3abe1f",
-      "0.3.1": "b0db7a3abe1f"
+      "0.3.1": "b0db7a3abe1f",
+      "0.3.2": "b0db7a3abe1f"
     }
   },
   "ComposioGoogleTasksAPIComponent": {
     "versions": {
       "0.3.0": "2ba9c1661f41",
-      "0.3.1": "2ba9c1661f41"
+      "0.3.1": "2ba9c1661f41",
+      "0.3.2": "2ba9c1661f41"
     }
   },
   "ComposioHeygenAPIComponent": {
     "versions": {
       "0.3.0": "c72fd5d0350f",
-      "0.3.1": "c72fd5d0350f"
+      "0.3.1": "c72fd5d0350f",
+      "0.3.2": "c72fd5d0350f"
     }
   },
   "ComposioInstagramAPIComponent": {
     "versions": {
       "0.3.0": "a6691c905833",
-      "0.3.1": "a6691c905833"
+      "0.3.1": "a6691c905833",
+      "0.3.2": "a6691c905833"
     }
   },
   "ComposioJiraAPIComponent": {
     "versions": {
       "0.3.0": "3e62396f3868",
-      "0.3.1": "3e62396f3868"
+      "0.3.1": "3e62396f3868",
+      "0.3.2": "3e62396f3868"
     }
   },
   "ComposioJotformAPIComponent": {
     "versions": {
       "0.3.0": "7c1c6a676814",
-      "0.3.1": "7c1c6a676814"
+      "0.3.1": "7c1c6a676814",
+      "0.3.2": "7c1c6a676814"
     }
   },
   "ComposioKlaviyoAPIComponent": {
     "versions": {
       "0.3.0": "3be7e8a5e3fe",
-      "0.3.1": "3be7e8a5e3fe"
+      "0.3.1": "3be7e8a5e3fe",
+      "0.3.2": "3be7e8a5e3fe"
     }
   },
   "ComposioLinearAPIComponent": {
     "versions": {
       "0.3.0": "be2b2ebbeea7",
-      "0.3.1": "be2b2ebbeea7"
+      "0.3.1": "be2b2ebbeea7",
+      "0.3.2": "be2b2ebbeea7"
     }
   },
   "ComposioListennotesAPIComponent": {
     "versions": {
       "0.3.0": "b85f2fe51906",
-      "0.3.1": "b85f2fe51906"
+      "0.3.1": "b85f2fe51906",
+      "0.3.2": "b85f2fe51906"
     }
   },
   "ComposioMem0APIComponent": {
     "versions": {
       "0.3.0": "68871a483786",
-      "0.3.1": "68871a483786"
+      "0.3.1": "68871a483786",
+      "0.3.2": "68871a483786"
     }
   },
   "ComposioMiroAPIComponent": {
     "versions": {
       "0.3.0": "1e9c421e1ac4",
-      "0.3.1": "1e9c421e1ac4"
+      "0.3.1": "1e9c421e1ac4",
+      "0.3.2": "1e9c421e1ac4"
     }
   },
   "ComposioMissiveAPIComponent": {
     "versions": {
       "0.3.0": "6def944a7739",
-      "0.3.1": "6def944a7739"
+      "0.3.1": "6def944a7739",
+      "0.3.2": "6def944a7739"
     }
   },
   "ComposioNotionAPIComponent": {
     "versions": {
       "0.3.0": "590aa6ff30d1",
-      "0.3.1": "590aa6ff30d1"
+      "0.3.1": "590aa6ff30d1",
+      "0.3.2": "590aa6ff30d1"
     }
   },
   "ComposioOneDriveAPIComponent": {
     "versions": {
       "0.3.0": "497cc4625121",
-      "0.3.1": "497cc4625121"
+      "0.3.1": "497cc4625121",
+      "0.3.2": "497cc4625121"
     }
   },
   "ComposioOutlookAPIComponent": {
     "versions": {
       "0.3.0": "bf6998d60b63",
-      "0.3.1": "bf6998d60b63"
+      "0.3.1": "bf6998d60b63",
+      "0.3.2": "bf6998d60b63"
     }
   },
   "ComposioPandadocAPIComponent": {
     "versions": {
       "0.3.0": "21d92aabc1bf",
-      "0.3.1": "21d92aabc1bf"
+      "0.3.1": "21d92aabc1bf",
+      "0.3.2": "21d92aabc1bf"
     }
   },
   "ComposioPeopleDataLabsAPIComponent": {
     "versions": {
       "0.3.0": "bd05ce58f55c",
-      "0.3.1": "bd05ce58f55c"
+      "0.3.1": "bd05ce58f55c",
+      "0.3.2": "bd05ce58f55c"
     }
   },
   "ComposioPerplexityAIAPIComponent": {
     "versions": {
       "0.3.0": "e40b0651344f",
-      "0.3.1": "e40b0651344f"
+      "0.3.1": "e40b0651344f",
+      "0.3.2": "e40b0651344f"
     }
   },
   "ComposioRedditAPIComponent": {
     "versions": {
       "0.3.0": "a86794073c22",
-      "0.3.1": "a86794073c22"
+      "0.3.1": "a86794073c22",
+      "0.3.2": "a86794073c22"
     }
   },
   "ComposioSerpAPIComponent": {
     "versions": {
       "0.3.0": "74b0a07ee54b",
-      "0.3.1": "74b0a07ee54b"
+      "0.3.1": "74b0a07ee54b",
+      "0.3.2": "74b0a07ee54b"
     }
   },
   "ComposioSlackAPIComponent": {
     "versions": {
       "0.3.0": "fa340cae1330",
-      "0.3.1": "fa340cae1330"
+      "0.3.1": "fa340cae1330",
+      "0.3.2": "fa340cae1330"
     }
   },
   "ComposioSlackbotAPIComponent": {
     "versions": {
       "0.3.0": "ddeb26bc04e6",
-      "0.3.1": "ddeb26bc04e6"
+      "0.3.1": "ddeb26bc04e6",
+      "0.3.2": "ddeb26bc04e6"
     }
   },
   "ComposioSnowflakeAPIComponent": {
     "versions": {
       "0.3.0": "d0d1af5686d2",
-      "0.3.1": "d0d1af5686d2"
+      "0.3.1": "d0d1af5686d2",
+      "0.3.2": "d0d1af5686d2"
     }
   },
   "ComposioSupabaseAPIComponent": {
     "versions": {
       "0.3.0": "7ad58ce34cc0",
-      "0.3.1": "7ad58ce34cc0"
+      "0.3.1": "7ad58ce34cc0",
+      "0.3.2": "7ad58ce34cc0"
     }
   },
   "ComposioTavilyAPIComponent": {
     "versions": {
       "0.3.0": "97af05e37911",
-      "0.3.1": "97af05e37911"
+      "0.3.1": "97af05e37911",
+      "0.3.2": "97af05e37911"
     }
   },
   "ComposioTimelinesAIAPIComponent": {
     "versions": {
       "0.3.0": "76e70e2de4d3",
-      "0.3.1": "76e70e2de4d3"
+      "0.3.1": "76e70e2de4d3",
+      "0.3.2": "76e70e2de4d3"
     }
   },
   "ComposioTodoistAPIComponent": {
     "versions": {
       "0.3.0": "4dd9852f2058",
-      "0.3.1": "4dd9852f2058"
+      "0.3.1": "4dd9852f2058",
+      "0.3.2": "4dd9852f2058"
     }
   },
   "ComposioWrikeAPIComponent": {
     "versions": {
       "0.3.0": "a5f2cf00ca08",
-      "0.3.1": "a5f2cf00ca08"
+      "0.3.1": "a5f2cf00ca08",
+      "0.3.2": "a5f2cf00ca08"
     }
   },
   "ComposioYoutubeAPIComponent": {
     "versions": {
       "0.3.0": "d1af2ea00e8b",
-      "0.3.1": "d1af2ea00e8b"
+      "0.3.1": "d1af2ea00e8b",
+      "0.3.2": "d1af2ea00e8b"
     }
   },
   "Confluence": {
     "versions": {
       "0.3.0": "8a7ef34b66e4",
-      "0.3.1": "8a7ef34b66e4"
+      "0.3.1": "8a7ef34b66e4",
+      "0.3.2": "8a7ef34b66e4"
     }
   },
   "Couchbase": {
     "versions": {
       "0.3.0": "70ed475a6f48",
-      "0.3.1": "70ed475a6f48"
+      "0.3.1": "70ed475a6f48",
+      "0.3.2": "70ed475a6f48"
     }
   },
   "CrewAIAgentComponent": {
     "versions": {
       "0.3.0": "a23f0923049d",
-      "0.3.1": "a23f0923049d"
+      "0.3.1": "a23f0923049d",
+      "0.3.2": "a23f0923049d"
     }
   },
   "HierarchicalCrewComponent": {
     "versions": {
       "0.3.0": "144be482cfb0",
-      "0.3.1": "144be482cfb0"
+      "0.3.1": "144be482cfb0",
+      "0.3.2": "144be482cfb0"
     }
   },
   "HierarchicalTaskComponent": {
     "versions": {
       "0.3.0": "25071652dc20",
-      "0.3.1": "25071652dc20"
+      "0.3.1": "25071652dc20",
+      "0.3.2": "25071652dc20"
     }
   },
   "SequentialCrewComponent": {
     "versions": {
       "0.3.0": "42e59f6d6572",
-      "0.3.1": "42e59f6d6572"
+      "0.3.1": "42e59f6d6572",
+      "0.3.2": "42e59f6d6572"
     }
   },
   "SequentialTaskComponent": {
     "versions": {
       "0.3.0": "b1f17b8fcc5c",
-      "0.3.1": "b1f17b8fcc5c"
+      "0.3.1": "b1f17b8fcc5c",
+      "0.3.2": "b1f17b8fcc5c"
     }
   },
   "SequentialTaskAgentComponent": {
     "versions": {
       "0.3.0": "0a5483ef82c3",
-      "0.3.1": "0a5483ef82c3"
+      "0.3.1": "0a5483ef82c3",
+      "0.3.2": "0a5483ef82c3"
     }
   },
   "Cuga": {
     "versions": {
       "0.3.0": "35e838f89d13",
-      "0.3.1": "35e838f89d13"
+      "0.3.1": "35e838f89d13",
+      "0.3.2": "35e838f89d13"
     }
   },
   "CustomComponent": {
     "versions": {
       "0.3.0": "d50a68a6fa57",
-      "0.3.1": "d50a68a6fa57"
+      "0.3.1": "d50a68a6fa57",
+      "0.3.2": "d50a68a6fa57"
     }
   },
   "APIRequest": {
     "versions": {
       "0.3.0": "f102aadfb328",
-      "0.3.1": "f102aadfb328"
+      "0.3.1": "f102aadfb328",
+      "0.3.2": "f102aadfb328"
     }
   },
   "CSVtoData": {
     "versions": {
       "0.3.0": "85c7d6df7473",
-      "0.3.1": "85c7d6df7473"
+      "0.3.1": "85c7d6df7473",
+      "0.3.2": "85c7d6df7473"
     }
   },
   "JSONtoData": {
     "versions": {
       "0.3.0": "0d9d78d496a2",
-      "0.3.1": "0d9d78d496a2"
+      "0.3.1": "0d9d78d496a2",
+      "0.3.2": "0d9d78d496a2"
     }
   },
   "MockDataGenerator": {
     "versions": {
       "0.3.0": "d21dce7b329b",
-      "0.3.1": "d21dce7b329b"
+      "0.3.1": "d21dce7b329b",
+      "0.3.2": "d21dce7b329b"
     }
   },
   "NewsSearch": {
     "versions": {
       "0.3.0": "b8cb11f78518",
-      "0.3.1": "b8cb11f78518"
+      "0.3.1": "b8cb11f78518",
+      "0.3.2": "b8cb11f78518"
     }
   },
   "RSSReaderSimple": {
     "versions": {
       "0.3.0": "6eb8fb48c9b5",
-      "0.3.1": "6eb8fb48c9b5"
+      "0.3.1": "6eb8fb48c9b5",
+      "0.3.2": "6eb8fb48c9b5"
     }
   },
   "SQLComponent": {
     "versions": {
       "0.3.0": "a8dd79af50b8",
-      "0.3.1": "a8dd79af50b8"
+      "0.3.1": "a8dd79af50b8",
+      "0.3.2": "a8dd79af50b8"
     }
   },
   "URLComponent": {
     "versions": {
       "0.3.0": "f773f55e3820",
-      "0.3.1": "f773f55e3820"
+      "0.3.1": "f773f55e3820",
+      "0.3.2": "f773f55e3820"
     }
   },
   "UnifiedWebSearch": {
     "versions": {
       "0.3.0": "cbeeaef8889a",
-      "0.3.1": "cbeeaef8889a"
+      "0.3.1": "cbeeaef8889a",
+      "0.3.2": "cbeeaef8889a"
     }
   },
   "Astra Assistant Agent": {
     "versions": {
       "0.3.0": "4716d3b7c350",
-      "0.3.1": "4716d3b7c350"
+      "0.3.1": "4716d3b7c350",
+      "0.3.2": "4716d3b7c350"
     }
   },
   "AstraDBChatMemory": {
     "versions": {
       "0.3.0": "bafc81f78c76",
-      "0.3.1": "bafc81f78c76"
+      "0.3.1": "bafc81f78c76",
+      "0.3.2": "bafc81f78c76"
     }
   },
   "AstraDBCQLToolComponent": {
     "versions": {
       "0.3.0": "70c4523f841d",
-      "0.3.1": "70c4523f841d"
+      "0.3.1": "70c4523f841d",
+      "0.3.2": "70c4523f841d"
     }
   },
   "AstraDBGraph": {
     "versions": {
       "0.3.0": "9f5d576b30ca",
-      "0.3.1": "9f5d576b30ca"
+      "0.3.1": "9f5d576b30ca",
+      "0.3.2": "9f5d576b30ca"
     }
   },
   "AstraDBTool": {
     "versions": {
       "0.3.0": "44719b6ed1a3",
-      "0.3.1": "44719b6ed1a3"
+      "0.3.1": "44719b6ed1a3",
+      "0.3.2": "44719b6ed1a3"
     }
   },
   "AstraVectorize": {
     "versions": {
       "0.3.0": "3d976690c262",
-      "0.3.1": "3d976690c262"
+      "0.3.1": "3d976690c262",
+      "0.3.2": "3d976690c262"
     }
   },
   "AstraDB": {
     "versions": {
       "0.3.0": "d52094e54e96",
-      "0.3.1": "d52094e54e96"
+      "0.3.1": "d52094e54e96",
+      "0.3.2": "d52094e54e96"
     }
   },
   "AssistantsCreateAssistant": {
     "versions": {
       "0.3.0": "8d9869d9a89d",
-      "0.3.1": "8d9869d9a89d"
+      "0.3.1": "8d9869d9a89d",
+      "0.3.2": "8d9869d9a89d"
     }
   },
   "AssistantsCreateThread": {
     "versions": {
       "0.3.0": "5d40a73accfd",
-      "0.3.1": "5d40a73accfd"
+      "0.3.1": "5d40a73accfd",
+      "0.3.2": "5d40a73accfd"
     }
   },
   "Dotenv": {
     "versions": {
       "0.3.0": "343ea9aaca1b",
-      "0.3.1": "343ea9aaca1b"
+      "0.3.1": "343ea9aaca1b",
+      "0.3.2": "343ea9aaca1b"
     }
   },
   "AssistantsGetAssistantName": {
     "versions": {
       "0.3.0": "1f60da161fd3",
-      "0.3.1": "1f60da161fd3"
+      "0.3.1": "1f60da161fd3",
+      "0.3.2": "1f60da161fd3"
     }
   },
   "GetEnvVar": {
     "versions": {
       "0.3.0": "083f0a94f380",
-      "0.3.1": "083f0a94f380"
+      "0.3.1": "083f0a94f380",
+      "0.3.2": "083f0a94f380"
     }
   },
   "GraphRAG": {
     "versions": {
       "0.3.0": "4d83709a5f5f",
-      "0.3.1": "4d83709a5f5f"
+      "0.3.1": "4d83709a5f5f",
+      "0.3.2": "4d83709a5f5f"
     }
   },
   "HCD": {
     "versions": {
       "0.3.0": "25f009b9e171",
-      "0.3.1": "25f009b9e171"
+      "0.3.1": "25f009b9e171",
+      "0.3.2": "25f009b9e171"
     }
   },
   "AssistantsListAssistants": {
     "versions": {
       "0.3.0": "17e9c5c78a6e",
-      "0.3.1": "17e9c5c78a6e"
+      "0.3.1": "17e9c5c78a6e",
+      "0.3.2": "17e9c5c78a6e"
     }
   },
   "AssistantsRun": {
     "versions": {
       "0.3.0": "5e219cd290d3",
-      "0.3.1": "5e219cd290d3"
+      "0.3.1": "5e219cd290d3",
+      "0.3.2": "5e219cd290d3"
     }
   },
   "DeepSeekModelComponent": {
     "versions": {
       "0.3.0": "c8dac7a258d7",
-      "0.3.1": "c8dac7a258d7"
+      "0.3.1": "c8dac7a258d7",
+      "0.3.2": "c8dac7a258d7"
     }
   },
   "ChunkDoclingDocument": {
     "versions": {
       "0.3.0": "49d762d97039",
-      "0.3.1": "49d762d97039"
+      "0.3.1": "49d762d97039",
+      "0.3.2": "49d762d97039"
     }
   },
   "DoclingInline": {
     "versions": {
       "0.3.0": "519d12bd6451",
-      "0.3.1": "519d12bd6451"
+      "0.3.1": "519d12bd6451",
+      "0.3.2": "519d12bd6451"
     }
   },
   "DoclingRemote": {
     "versions": {
       "0.3.0": "409d771a961e",
-      "0.3.1": "409d771a961e"
+      "0.3.1": "409d771a961e",
+      "0.3.2": "409d771a961e"
     }
   },
   "ExportDoclingDocument": {
     "versions": {
       "0.3.0": "32577a7e396b",
-      "0.3.1": "32577a7e396b"
+      "0.3.1": "32577a7e396b",
+      "0.3.2": "32577a7e396b"
     }
   },
   "DuckDuckGoSearchComponent": {
     "versions": {
       "0.3.0": "2e522a5a4389",
-      "0.3.1": "2e522a5a4389"
+      "0.3.1": "2e522a5a4389",
+      "0.3.2": "2e522a5a4389"
     }
   },
   "Elasticsearch": {
     "versions": {
       "0.3.0": "23ea4383039e",
-      "0.3.1": "23ea4383039e"
+      "0.3.1": "23ea4383039e",
+      "0.3.2": "23ea4383039e"
     }
   },
   "OpenSearchVectorStoreComponent": {
     "versions": {
       "0.3.0": "4968b4d34fad",
-      "0.3.1": "4968b4d34fad"
+      "0.3.1": "4968b4d34fad",
+      "0.3.2": "4968b4d34fad"
     }
   },
   "OpenSearchVectorStoreComponentMultimodalMultiEmbedding": {
     "versions": {
       "0.3.0": "6a3df45b55c5",
-      "0.3.1": "6a3df45b55c5"
+      "0.3.1": "6a3df45b55c5",
+      "0.3.2": "6a3df45b55c5"
     }
   },
   "EmbeddingSimilarityComponent": {
     "versions": {
       "0.3.0": "d94c7d791f69",
-      "0.3.1": "d94c7d791f69"
+      "0.3.1": "d94c7d791f69",
+      "0.3.2": "d94c7d791f69"
     }
   },
   "TextEmbedderComponent": {
     "versions": {
       "0.3.0": "541a2fb78066",
-      "0.3.1": "541a2fb78066"
+      "0.3.1": "541a2fb78066",
+      "0.3.2": "541a2fb78066"
     }
   },
   "ExaSearch": {
     "versions": {
       "0.3.0": "26039e2a8b78",
-      "0.3.1": "26039e2a8b78"
+      "0.3.1": "26039e2a8b78",
+      "0.3.2": "26039e2a8b78"
     }
   },
   "Directory": {
     "versions": {
       "0.3.0": "328e6f996926",
-      "0.3.1": "328e6f996926"
+      "0.3.1": "328e6f996926",
+      "0.3.2": "328e6f996926"
     }
   },
   "File": {
     "versions": {
       "0.3.0": "12a5841f1a03",
-      "0.3.1": "12a5841f1a03"
+      "0.3.1": "12a5841f1a03",
+      "0.3.2": "12a5841f1a03"
     }
   },
   "KnowledgeIngestion": {
@@ -936,1231 +1090,1436 @@
   "SaveToFile": {
     "versions": {
       "0.3.0": "6d0e4842271e",
-      "0.3.1": "6d0e4842271e"
+      "0.3.1": "6d0e4842271e",
+      "0.3.2": "6d0e4842271e"
     }
   },
   "FirecrawlCrawlApi": {
     "versions": {
       "0.3.0": "22fd75efce27",
-      "0.3.1": "22fd75efce27"
+      "0.3.1": "22fd75efce27",
+      "0.3.2": "22fd75efce27"
     }
   },
   "FirecrawlExtractApi": {
     "versions": {
       "0.3.0": "8083782c2c28",
-      "0.3.1": "8083782c2c28"
+      "0.3.1": "8083782c2c28",
+      "0.3.2": "8083782c2c28"
     }
   },
   "FirecrawlMapApi": {
     "versions": {
       "0.3.0": "e326e840049b",
-      "0.3.1": "e326e840049b"
+      "0.3.1": "e326e840049b",
+      "0.3.2": "e326e840049b"
     }
   },
   "FirecrawlScrapeApi": {
     "versions": {
       "0.3.0": "857b7da04207",
-      "0.3.1": "857b7da04207"
+      "0.3.1": "857b7da04207",
+      "0.3.2": "857b7da04207"
     }
   },
   "ConditionalRouter": {
     "versions": {
       "0.3.0": "e92b1b243e5f",
-      "0.3.1": "e92b1b243e5f"
+      "0.3.1": "e92b1b243e5f",
+      "0.3.2": "e92b1b243e5f"
     }
   },
   "DataConditionalRouter": {
     "versions": {
       "0.3.0": "6fa1bf4166a3",
-      "0.3.1": "6fa1bf4166a3"
+      "0.3.1": "6fa1bf4166a3",
+      "0.3.2": "6fa1bf4166a3"
     }
   },
   "FlowTool": {
     "versions": {
       "0.3.0": "9348d79d19f4",
-      "0.3.1": "9348d79d19f4"
+      "0.3.1": "9348d79d19f4",
+      "0.3.2": "9348d79d19f4"
     }
   },
   "Listen": {
     "versions": {
       "0.3.0": "93fc11377c96",
-      "0.3.1": "93fc11377c96"
+      "0.3.1": "93fc11377c96",
+      "0.3.2": "93fc11377c96"
     }
   },
   "LoopComponent": {
     "versions": {
       "0.3.0": "e516ea99611c",
-      "0.3.1": "e516ea99611c"
+      "0.3.1": "e516ea99611c",
+      "0.3.2": "e516ea99611c"
     }
   },
   "Notify": {
     "versions": {
       "0.3.0": "03d68ba28530",
-      "0.3.1": "03d68ba28530"
+      "0.3.1": "03d68ba28530",
+      "0.3.2": "03d68ba28530"
     }
   },
   "Pass": {
     "versions": {
       "0.3.0": "04d3e1ed3390",
-      "0.3.1": "04d3e1ed3390"
+      "0.3.1": "04d3e1ed3390",
+      "0.3.2": "04d3e1ed3390"
     }
   },
   "RunFlow": {
     "versions": {
       "0.3.0": "9e5eefa14766",
-      "0.3.1": "9e5eefa14766"
+      "0.3.1": "9e5eefa14766",
+      "0.3.2": "9e5eefa14766"
     }
   },
   "SubFlow": {
     "versions": {
       "0.3.0": "8ba6fbc5ca3a",
-      "0.3.1": "8ba6fbc5ca3a"
+      "0.3.1": "8ba6fbc5ca3a",
+      "0.3.2": "8ba6fbc5ca3a"
     }
   },
   "GitLoaderComponent": {
     "versions": {
       "0.3.0": "ac5de0564a4f",
-      "0.3.1": "ac5de0564a4f"
+      "0.3.1": "ac5de0564a4f",
+      "0.3.2": "ac5de0564a4f"
     }
   },
   "GitExtractorComponent": {
     "versions": {
       "0.3.0": "79f338765b69",
-      "0.3.1": "79f338765b69"
+      "0.3.1": "79f338765b69",
+      "0.3.2": "79f338765b69"
     }
   },
   "GleanSearchAPIComponent": {
     "versions": {
       "0.3.0": "493ca281d420",
-      "0.3.1": "493ca281d420"
+      "0.3.1": "493ca281d420",
+      "0.3.2": "493ca281d420"
     }
   },
   "GmailLoaderComponent": {
     "versions": {
       "0.3.0": "b973c5a1987b",
-      "0.3.1": "b973c5a1987b"
+      "0.3.1": "b973c5a1987b",
+      "0.3.2": "b973c5a1987b"
     }
   },
   "BigQueryExecutor": {
     "versions": {
       "0.3.0": "7f61159743ec",
-      "0.3.1": "7f61159743ec"
+      "0.3.1": "7f61159743ec",
+      "0.3.2": "7f61159743ec"
     }
   },
   "GoogleDriveComponent": {
     "versions": {
       "0.3.0": "1727f517e814",
-      "0.3.1": "1727f517e814"
+      "0.3.1": "1727f517e814",
+      "0.3.2": "1727f517e814"
     }
   },
   "GoogleDriveSearchComponent": {
     "versions": {
       "0.3.0": "8f8dbdf04aaf",
-      "0.3.1": "8f8dbdf04aaf"
+      "0.3.1": "8f8dbdf04aaf",
+      "0.3.2": "8f8dbdf04aaf"
     }
   },
   "GoogleGenerativeAIModel": {
     "versions": {
       "0.3.0": "049f38001189",
-      "0.3.1": "049f38001189"
+      "0.3.1": "049f38001189",
+      "0.3.2": "049f38001189"
     }
   },
   "Google Generative AI Embeddings": {
     "versions": {
       "0.3.0": "7756ad70a221",
-      "0.3.1": "7756ad70a221"
+      "0.3.1": "7756ad70a221",
+      "0.3.2": "7756ad70a221"
     }
   },
   "GoogleOAuthToken": {
     "versions": {
       "0.3.0": "151778572099",
-      "0.3.1": "151778572099"
+      "0.3.1": "151778572099",
+      "0.3.2": "151778572099"
     }
   },
   "GoogleSearchAPICore": {
     "versions": {
       "0.3.0": "853c193aa41c",
-      "0.3.1": "853c193aa41c"
+      "0.3.1": "853c193aa41c",
+      "0.3.2": "853c193aa41c"
     }
   },
   "GoogleSerperAPICore": {
     "versions": {
       "0.3.0": "527183dcb201",
-      "0.3.1": "527183dcb201"
+      "0.3.1": "527183dcb201",
+      "0.3.2": "527183dcb201"
     }
   },
   "GroqModel": {
     "versions": {
       "0.3.0": "2aee7de6ee88",
-      "0.3.1": "2aee7de6ee88"
+      "0.3.1": "2aee7de6ee88",
+      "0.3.2": "2aee7de6ee88"
     }
   },
   "HomeAssistantControl": {
     "versions": {
       "0.3.0": "32b34baf3c7d",
-      "0.3.1": "32b34baf3c7d"
+      "0.3.1": "32b34baf3c7d",
+      "0.3.2": "32b34baf3c7d"
     }
   },
   "ListHomeAssistantStates": {
     "versions": {
       "0.3.0": "c7bb91632474",
-      "0.3.1": "c7bb91632474"
+      "0.3.1": "c7bb91632474",
+      "0.3.2": "c7bb91632474"
     }
   },
   "HuggingFaceModel": {
     "versions": {
       "0.3.0": "ba9d7c28859d",
-      "0.3.1": "ba9d7c28859d"
+      "0.3.1": "ba9d7c28859d",
+      "0.3.2": "ba9d7c28859d"
     }
   },
   "HuggingFaceInferenceAPIEmbeddings": {
     "versions": {
       "0.3.0": "af0546658974",
-      "0.3.1": "af0546658974"
+      "0.3.1": "af0546658974",
+      "0.3.2": "af0546658974"
     }
   },
   "IBMwatsonxModel": {
     "versions": {
       "0.3.0": "689a87ecc73a",
-      "0.3.1": "689a87ecc73a"
+      "0.3.1": "689a87ecc73a",
+      "0.3.2": "689a87ecc73a"
     }
   },
   "WatsonxEmbeddingsComponent": {
     "versions": {
       "0.3.0": "011bcac795de",
-      "0.3.1": "011bcac795de"
+      "0.3.1": "011bcac795de",
+      "0.3.2": "011bcac795de"
     }
   },
   "Combinatorial Reasoner": {
     "versions": {
       "0.3.0": "48557047ff23",
-      "0.3.1": "48557047ff23"
+      "0.3.1": "48557047ff23",
+      "0.3.2": "48557047ff23"
     }
   },
   "ChatInput": {
     "versions": {
       "0.3.0": "7a26c54d89ed",
-      "0.3.1": "7a26c54d89ed"
+      "0.3.1": "7a26c54d89ed",
+      "0.3.2": "7a26c54d89ed"
     }
   },
   "ChatOutput": {
     "versions": {
       "0.3.0": "8c87e536cca4",
-      "0.3.1": "8c87e536cca4"
+      "0.3.1": "8c87e536cca4",
+      "0.3.2": "8c87e536cca4"
     }
   },
   "TextInput": {
     "versions": {
       "0.3.0": "518f16485886",
-      "0.3.1": "518f16485886"
+      "0.3.1": "518f16485886",
+      "0.3.2": "518f16485886"
     }
   },
   "TextOutput": {
     "versions": {
       "0.3.0": "6aba888f4632",
-      "0.3.1": "6aba888f4632"
+      "0.3.1": "6aba888f4632",
+      "0.3.2": "6aba888f4632"
     }
   },
   "Webhook": {
     "versions": {
       "0.3.0": "eb561ef21f3d",
-      "0.3.1": "eb561ef21f3d"
+      "0.3.1": "eb561ef21f3d",
+      "0.3.2": "eb561ef21f3d"
     }
   },
   "JigsawStackAIScraper": {
     "versions": {
       "0.3.0": "08a0063e2564",
-      "0.3.1": "08a0063e2564"
+      "0.3.1": "08a0063e2564",
+      "0.3.2": "08a0063e2564"
     }
   },
   "JigsawStackAISearch": {
     "versions": {
       "0.3.0": "5e821ee44040",
-      "0.3.1": "5e821ee44040"
+      "0.3.1": "5e821ee44040",
+      "0.3.2": "5e821ee44040"
     }
   },
   "JigsawStackFileRead": {
     "versions": {
       "0.3.0": "84d122f46fb1",
-      "0.3.1": "84d122f46fb1"
+      "0.3.1": "84d122f46fb1",
+      "0.3.2": "84d122f46fb1"
     }
   },
   "JigsawStackFileUpload": {
     "versions": {
       "0.3.0": "8261dc72a655",
-      "0.3.1": "8261dc72a655"
+      "0.3.1": "8261dc72a655",
+      "0.3.2": "8261dc72a655"
     }
   },
   "JigsawStackImageGeneration": {
     "versions": {
       "0.3.0": "463f8efbaa18",
-      "0.3.1": "463f8efbaa18"
+      "0.3.1": "463f8efbaa18",
+      "0.3.2": "463f8efbaa18"
     }
   },
   "JigsawStackNSFW": {
     "versions": {
       "0.3.0": "88b5eee38906",
-      "0.3.1": "88b5eee38906"
+      "0.3.1": "88b5eee38906",
+      "0.3.2": "88b5eee38906"
     }
   },
   "JigsawStackObjectDetection": {
     "versions": {
       "0.3.0": "fceaf0286f20",
-      "0.3.1": "fceaf0286f20"
+      "0.3.1": "fceaf0286f20",
+      "0.3.2": "fceaf0286f20"
     }
   },
   "JigsawStackSentiment": {
     "versions": {
       "0.3.0": "00d0377e5c2e",
-      "0.3.1": "00d0377e5c2e"
+      "0.3.1": "00d0377e5c2e",
+      "0.3.2": "00d0377e5c2e"
     }
   },
   "JigsawStackTextToSQL": {
     "versions": {
       "0.3.0": "30aa0cc15fb8",
-      "0.3.1": "30aa0cc15fb8"
+      "0.3.1": "30aa0cc15fb8",
+      "0.3.2": "30aa0cc15fb8"
     }
   },
   "JigsawStackTextTranslate": {
     "versions": {
       "0.3.0": "46233e19961f",
-      "0.3.1": "46233e19961f"
+      "0.3.1": "46233e19961f",
+      "0.3.2": "46233e19961f"
     }
   },
   "JigsawStackVOCR": {
     "versions": {
       "0.3.0": "a44491947ba7",
-      "0.3.1": "a44491947ba7"
+      "0.3.1": "a44491947ba7",
+      "0.3.2": "a44491947ba7"
     }
   },
   "CharacterTextSplitter": {
     "versions": {
       "0.3.0": "995b35c5296c",
-      "0.3.1": "995b35c5296c"
+      "0.3.1": "995b35c5296c",
+      "0.3.2": "995b35c5296c"
     }
   },
   "ConversationChain": {
     "versions": {
       "0.3.0": "b0e4044d3f08",
-      "0.3.1": "b0e4044d3f08"
+      "0.3.1": "b0e4044d3f08",
+      "0.3.2": "b0e4044d3f08"
     }
   },
   "CSVAgent": {
     "versions": {
       "0.3.0": "1888a727f9dd",
-      "0.3.1": "1888a727f9dd"
+      "0.3.1": "1888a727f9dd",
+      "0.3.2": "1888a727f9dd"
     }
   },
   "LangChainFakeEmbeddings": {
     "versions": {
       "0.3.0": "faaa1be642a1",
-      "0.3.1": "faaa1be642a1"
+      "0.3.1": "faaa1be642a1",
+      "0.3.2": "faaa1be642a1"
     }
   },
   "HtmlLinkExtractor": {
     "versions": {
       "0.3.0": "13cc6457f84c",
-      "0.3.1": "13cc6457f84c"
+      "0.3.1": "13cc6457f84c",
+      "0.3.2": "13cc6457f84c"
     }
   },
   "JsonAgent": {
     "versions": {
       "0.3.0": "117a41e142c6",
-      "0.3.1": "117a41e142c6"
+      "0.3.1": "117a41e142c6",
+      "0.3.2": "117a41e142c6"
     }
   },
   "LangChain Hub Prompt": {
     "versions": {
       "0.3.0": "9f59bf236231",
-      "0.3.1": "9f59bf236231"
+      "0.3.1": "9f59bf236231",
+      "0.3.2": "9f59bf236231"
     }
   },
   "LanguageRecursiveTextSplitter": {
     "versions": {
       "0.3.0": "207a88b20a7e",
-      "0.3.1": "207a88b20a7e"
+      "0.3.1": "207a88b20a7e",
+      "0.3.2": "207a88b20a7e"
     }
   },
   "SemanticTextSplitter": {
     "versions": {
       "0.3.0": "e9178757dea0",
-      "0.3.1": "e9178757dea0"
+      "0.3.1": "e9178757dea0",
+      "0.3.2": "e9178757dea0"
     }
   },
   "LLMCheckerChain": {
     "versions": {
       "0.3.0": "81aa2c9910db",
-      "0.3.1": "81aa2c9910db"
+      "0.3.1": "81aa2c9910db",
+      "0.3.2": "81aa2c9910db"
     }
   },
   "LLMMathChain": {
     "versions": {
       "0.3.0": "422d8e0d4614",
-      "0.3.1": "422d8e0d4614"
+      "0.3.1": "422d8e0d4614",
+      "0.3.2": "422d8e0d4614"
     }
   },
   "NaturalLanguageTextSplitter": {
     "versions": {
       "0.3.0": "aed1e0bb411e",
-      "0.3.1": "aed1e0bb411e"
+      "0.3.1": "aed1e0bb411e",
+      "0.3.2": "aed1e0bb411e"
     }
   },
   "OpenAIToolsAgent": {
     "versions": {
       "0.3.0": "21bfd16796e5",
-      "0.3.1": "21bfd16796e5"
+      "0.3.1": "21bfd16796e5",
+      "0.3.2": "21bfd16796e5"
     }
   },
   "OpenAPIAgent": {
     "versions": {
       "0.3.0": "a4a7564100da",
-      "0.3.1": "a4a7564100da"
+      "0.3.1": "a4a7564100da",
+      "0.3.2": "a4a7564100da"
     }
   },
   "RecursiveCharacterTextSplitter": {
     "versions": {
       "0.3.0": "9ed58a212804",
-      "0.3.1": "9ed58a212804"
+      "0.3.1": "9ed58a212804",
+      "0.3.2": "9ed58a212804"
     }
   },
   "RetrievalQA": {
     "versions": {
       "0.3.0": "16c80b234abf",
-      "0.3.1": "16c80b234abf"
+      "0.3.1": "16c80b234abf",
+      "0.3.2": "16c80b234abf"
     }
   },
   "RunnableExecutor": {
     "versions": {
       "0.3.0": "32135f41efe5",
-      "0.3.1": "32135f41efe5"
+      "0.3.1": "32135f41efe5",
+      "0.3.2": "32135f41efe5"
     }
   },
   "SelfQueryRetriever": {
     "versions": {
       "0.3.0": "a18169f36371",
-      "0.3.1": "a18169f36371"
+      "0.3.1": "a18169f36371",
+      "0.3.2": "a18169f36371"
     }
   },
   "SpiderTool": {
     "versions": {
       "0.3.0": "08c823a20237",
-      "0.3.1": "08c823a20237"
+      "0.3.1": "08c823a20237",
+      "0.3.2": "08c823a20237"
     }
   },
   "SQLAgent": {
     "versions": {
       "0.3.0": "550c16461236",
-      "0.3.1": "550c16461236"
+      "0.3.1": "550c16461236",
+      "0.3.2": "550c16461236"
     }
   },
   "SQLDatabase": {
     "versions": {
       "0.3.0": "7d07b7faa341",
-      "0.3.1": "7d07b7faa341"
+      "0.3.1": "7d07b7faa341",
+      "0.3.2": "7d07b7faa341"
     }
   },
   "SQLGenerator": {
     "versions": {
       "0.3.0": "971a82407ec6",
-      "0.3.1": "971a82407ec6"
+      "0.3.1": "971a82407ec6",
+      "0.3.2": "971a82407ec6"
     }
   },
   "ToolCallingAgent": {
     "versions": {
       "0.3.0": "cdeb13ac7430",
-      "0.3.1": "cdeb13ac7430"
+      "0.3.1": "cdeb13ac7430",
+      "0.3.2": "cdeb13ac7430"
     }
   },
   "VectorStoreInfo": {
     "versions": {
       "0.3.0": "62f06efeec2c",
-      "0.3.1": "62f06efeec2c"
+      "0.3.1": "62f06efeec2c",
+      "0.3.2": "62f06efeec2c"
     }
   },
   "VectorStoreRouterAgent": {
     "versions": {
       "0.3.0": "b16515f6e722",
-      "0.3.1": "b16515f6e722"
+      "0.3.1": "b16515f6e722",
+      "0.3.2": "b16515f6e722"
     }
   },
   "XMLAgent": {
     "versions": {
       "0.3.0": "17a0cb4c48a8",
-      "0.3.1": "17a0cb4c48a8"
+      "0.3.1": "17a0cb4c48a8",
+      "0.3.2": "17a0cb4c48a8"
     }
   },
   "LangWatchEvaluator": {
     "versions": {
       "0.3.0": "6db3bccd5945",
-      "0.3.1": "6db3bccd5945"
+      "0.3.1": "6db3bccd5945",
+      "0.3.2": "6db3bccd5945"
     }
   },
   "BatchRunComponent": {
     "versions": {
       "0.3.0": "8b1ec3b03475",
-      "0.3.1": "8b1ec3b03475"
+      "0.3.1": "8b1ec3b03475",
+      "0.3.2": "8b1ec3b03475"
     }
   },
   "Smart Transform": {
     "versions": {
       "0.3.0": "0d3667d6d687",
-      "0.3.1": "0d3667d6d687"
+      "0.3.1": "0d3667d6d687",
+      "0.3.2": "0d3667d6d687"
     }
   },
   "SmartRouter": {
     "versions": {
       "0.3.0": "86404d4beb95",
-      "0.3.1": "86404d4beb95"
+      "0.3.1": "86404d4beb95",
+      "0.3.2": "86404d4beb95"
     }
   },
   "LLMSelectorComponent": {
     "versions": {
       "0.3.0": "59de3f4015ff",
-      "0.3.1": "59de3f4015ff"
+      "0.3.1": "59de3f4015ff",
+      "0.3.2": "59de3f4015ff"
     }
   },
   "StructuredOutput": {
     "versions": {
       "0.3.0": "058ca1f51e9f",
-      "0.3.1": "058ca1f51e9f"
+      "0.3.1": "058ca1f51e9f",
+      "0.3.2": "058ca1f51e9f"
     }
   },
   "LMStudioEmbeddingsComponent": {
     "versions": {
       "0.3.0": "ecd584b7a486",
-      "0.3.1": "ecd584b7a486"
+      "0.3.1": "ecd584b7a486",
+      "0.3.2": "ecd584b7a486"
     }
   },
   "LMStudioModel": {
     "versions": {
       "0.3.0": "da4b3b155dc4",
-      "0.3.1": "da4b3b155dc4"
+      "0.3.1": "da4b3b155dc4",
+      "0.3.2": "da4b3b155dc4"
     }
   },
   "Maritalk": {
     "versions": {
       "0.3.0": "25c5da31181e",
-      "0.3.1": "25c5da31181e"
+      "0.3.1": "25c5da31181e",
+      "0.3.2": "25c5da31181e"
     }
   },
   "mem0_chat_memory": {
     "versions": {
       "0.3.0": "b6addbcccf9a",
-      "0.3.1": "b6addbcccf9a"
+      "0.3.1": "b6addbcccf9a",
+      "0.3.2": "b6addbcccf9a"
     }
   },
   "Milvus": {
     "versions": {
       "0.3.0": "2b5efe313b31",
-      "0.3.1": "2b5efe313b31"
+      "0.3.1": "2b5efe313b31",
+      "0.3.2": "2b5efe313b31"
     }
   },
   "MistralModel": {
     "versions": {
       "0.3.0": "e21780948144",
-      "0.3.1": "e21780948144"
+      "0.3.1": "e21780948144",
+      "0.3.2": "e21780948144"
     }
   },
   "MistalAIEmbeddings": {
     "versions": {
       "0.3.0": "42ea92fd2df2",
-      "0.3.1": "42ea92fd2df2"
+      "0.3.1": "42ea92fd2df2",
+      "0.3.2": "42ea92fd2df2"
     }
   },
   "Agent": {
     "versions": {
       "0.3.0": "40d1976f4718",
-      "0.3.1": "40d1976f4718"
+      "0.3.1": "40d1976f4718",
+      "0.3.2": "40d1976f4718"
     }
   },
   "EmbeddingModel": {
     "versions": {
       "0.3.0": "b5cf1a06bba8",
-      "0.3.1": "b5cf1a06bba8"
+      "0.3.1": "b5cf1a06bba8",
+      "0.3.2": "b5cf1a06bba8"
     }
   },
   "LanguageModelComponent": {
     "versions": {
       "0.3.0": "e9233312b063",
-      "0.3.1": "e9233312b063"
+      "0.3.1": "e9233312b063",
+      "0.3.2": "e9233312b063"
     }
   },
   "MCPTools": {
     "versions": {
       "0.3.0": "a3700ab467a1",
-      "0.3.1": "a3700ab467a1"
+      "0.3.1": "a3700ab467a1",
+      "0.3.2": "a3700ab467a1"
     }
   },
   "Memory": {
     "versions": {
       "0.3.0": "efd064ef48ff",
-      "0.3.1": "efd064ef48ff"
+      "0.3.1": "efd064ef48ff",
+      "0.3.2": "efd064ef48ff"
     }
   },
   "Prompt Template": {
     "versions": {
       "0.3.0": "5b3e6730923e",
-      "0.3.1": "5b3e6730923e"
+      "0.3.1": "5b3e6730923e",
+      "0.3.2": "5b3e6730923e"
     }
   },
   "MongoDBAtlasVector": {
     "versions": {
       "0.3.0": "3a502cb4d313",
-      "0.3.1": "3a502cb4d313"
+      "0.3.1": "3a502cb4d313",
+      "0.3.2": "3a502cb4d313"
     }
   },
   "needle": {
     "versions": {
       "0.3.0": "5f6cedaa0217",
-      "0.3.1": "5f6cedaa0217"
+      "0.3.1": "5f6cedaa0217",
+      "0.3.2": "5f6cedaa0217"
     }
   },
   "NotDiamond": {
     "versions": {
       "0.3.0": "a26ebf501f67",
-      "0.3.1": "a26ebf501f67"
+      "0.3.1": "a26ebf501f67",
+      "0.3.2": "a26ebf501f67"
     }
   },
   "NovitaModel": {
     "versions": {
       "0.3.0": "2142c4dd2b64",
-      "0.3.1": "2142c4dd2b64"
+      "0.3.1": "2142c4dd2b64",
+      "0.3.2": "2142c4dd2b64"
     }
   },
   "NVIDIAModelComponent": {
     "versions": {
       "0.3.0": "fd6cae31c2a0",
-      "0.3.1": "fd6cae31c2a0"
+      "0.3.1": "fd6cae31c2a0",
+      "0.3.2": "fd6cae31c2a0"
     }
   },
   "NVIDIAEmbeddingsComponent": {
     "versions": {
       "0.3.0": "0fded038082d",
-      "0.3.1": "0fded038082d"
+      "0.3.1": "0fded038082d",
+      "0.3.2": "0fded038082d"
     }
   },
   "NvidiaIngestComponent": {
     "versions": {
       "0.3.0": "ff0c6660d991",
-      "0.3.1": "ff0c6660d991"
+      "0.3.1": "ff0c6660d991",
+      "0.3.2": "ff0c6660d991"
     }
   },
   "NvidiaRerankComponent": {
     "versions": {
       "0.3.0": "cf3976b241f1",
-      "0.3.1": "cf3976b241f1"
+      "0.3.1": "cf3976b241f1",
+      "0.3.2": "cf3976b241f1"
     }
   },
   "NvidiaSystemAssistComponent": {
     "versions": {
       "0.3.0": "1affc5dcebe1",
-      "0.3.1": "1affc5dcebe1"
+      "0.3.1": "1affc5dcebe1",
+      "0.3.2": "1affc5dcebe1"
     }
   },
   "OlivyaComponent": {
     "versions": {
       "0.3.0": "b5a5c201c4e0",
-      "0.3.1": "b5a5c201c4e0"
+      "0.3.1": "b5a5c201c4e0",
+      "0.3.2": "b5a5c201c4e0"
     }
   },
   "OllamaModel": {
     "versions": {
       "0.3.0": "cd3dc38272a7",
-      "0.3.1": "cd3dc38272a7"
+      "0.3.1": "cd3dc38272a7",
+      "0.3.2": "cd3dc38272a7"
     }
   },
   "OllamaEmbeddings": {
     "versions": {
       "0.3.0": "a8c56d0835de",
-      "0.3.1": "a8c56d0835de"
+      "0.3.1": "a8c56d0835de",
+      "0.3.2": "a8c56d0835de"
     }
   },
   "OpenAIEmbeddings": {
     "versions": {
       "0.3.0": "8a658ed6d4c9",
-      "0.3.1": "8a658ed6d4c9"
+      "0.3.1": "8a658ed6d4c9",
+      "0.3.2": "8a658ed6d4c9"
     }
   },
   "OpenAIModel": {
     "versions": {
       "0.3.0": "128d8ef661d4",
-      "0.3.1": "128d8ef661d4"
+      "0.3.1": "128d8ef661d4",
+      "0.3.2": "128d8ef661d4"
     }
   },
   "OpenRouterComponent": {
     "versions": {
       "0.3.0": "83c3c312a7a2",
-      "0.3.1": "83c3c312a7a2"
+      "0.3.1": "83c3c312a7a2",
+      "0.3.2": "83c3c312a7a2"
     }
   },
   "PerplexityModel": {
     "versions": {
       "0.3.0": "b970844e376e",
-      "0.3.1": "b970844e376e"
+      "0.3.1": "b970844e376e",
+      "0.3.2": "b970844e376e"
     }
   },
   "pgvector": {
     "versions": {
       "0.3.0": "50117607bf5e",
-      "0.3.1": "50117607bf5e"
+      "0.3.1": "50117607bf5e",
+      "0.3.2": "50117607bf5e"
     }
   },
   "Pinecone": {
     "versions": {
       "0.3.0": "564ca0a0e9ab",
-      "0.3.1": "564ca0a0e9ab"
+      "0.3.1": "564ca0a0e9ab",
+      "0.3.2": "564ca0a0e9ab"
     }
   },
   "AlterMetadata": {
     "versions": {
       "0.3.0": "0b2fe62eaec4",
-      "0.3.1": "0b2fe62eaec4"
+      "0.3.1": "0b2fe62eaec4",
+      "0.3.2": "0b2fe62eaec4"
     }
   },
   "CombineText": {
     "versions": {
       "0.3.0": "10ffb6543dd9",
-      "0.3.1": "10ffb6543dd9"
+      "0.3.1": "10ffb6543dd9",
+      "0.3.2": "10ffb6543dd9"
     }
   },
   "TypeConverterComponent": {
     "versions": {
       "0.3.0": "be7797f8df1c",
-      "0.3.1": "be7797f8df1c"
+      "0.3.1": "be7797f8df1c",
+      "0.3.2": "be7797f8df1c"
     }
   },
   "CreateData": {
     "versions": {
       "0.3.0": "3e313525090d",
-      "0.3.1": "3e313525090d"
+      "0.3.1": "3e313525090d",
+      "0.3.2": "3e313525090d"
     }
   },
   "CreateList": {
     "versions": {
       "0.3.0": "9ec770d03310",
-      "0.3.1": "9ec770d03310"
+      "0.3.1": "9ec770d03310",
+      "0.3.2": "9ec770d03310"
     }
   },
   "DataOperations": {
     "versions": {
       "0.3.0": "1e5bfda1706b",
-      "0.3.1": "1e5bfda1706b"
+      "0.3.1": "1e5bfda1706b",
+      "0.3.2": "1e5bfda1706b"
     }
   },
   "DataToDataFrame": {
     "versions": {
       "0.3.0": "57b9f79028e9",
-      "0.3.1": "57b9f79028e9"
+      "0.3.1": "57b9f79028e9",
+      "0.3.2": "57b9f79028e9"
     }
   },
   "DataFrameOperations": {
     "versions": {
       "0.3.0": "904f4eaebccd",
-      "0.3.1": "904f4eaebccd"
+      "0.3.1": "904f4eaebccd",
+      "0.3.2": "904f4eaebccd"
     }
   },
   "DynamicCreateData": {
     "versions": {
       "0.3.0": "0457c4acdf45",
-      "0.3.1": "0457c4acdf45"
+      "0.3.1": "0457c4acdf45",
+      "0.3.2": "0457c4acdf45"
     }
   },
   "ExtractaKey": {
     "versions": {
       "0.3.0": "eded3f4e1533",
-      "0.3.1": "eded3f4e1533"
+      "0.3.1": "eded3f4e1533",
+      "0.3.2": "eded3f4e1533"
     }
   },
   "FilterData": {
     "versions": {
       "0.3.0": "04c50937216d",
-      "0.3.1": "04c50937216d"
+      "0.3.1": "04c50937216d",
+      "0.3.2": "04c50937216d"
     }
   },
   "FilterDataValues": {
     "versions": {
       "0.3.0": "847522549c67",
-      "0.3.1": "847522549c67"
+      "0.3.1": "847522549c67",
+      "0.3.2": "847522549c67"
     }
   },
   "JSONCleaner": {
     "versions": {
       "0.3.0": "5c150997aec4",
-      "0.3.1": "5c150997aec4"
+      "0.3.1": "5c150997aec4",
+      "0.3.2": "5c150997aec4"
     }
   },
   "MergeDataComponent": {
     "versions": {
       "0.3.0": "a2ecb813aac5",
-      "0.3.1": "a2ecb813aac5"
+      "0.3.1": "a2ecb813aac5",
+      "0.3.2": "a2ecb813aac5"
     }
   },
   "MessagetoData": {
     "versions": {
       "0.3.0": "d0af1222aeaf",
-      "0.3.1": "d0af1222aeaf"
+      "0.3.1": "d0af1222aeaf",
+      "0.3.2": "d0af1222aeaf"
     }
   },
   "OutputParser": {
     "versions": {
       "0.3.0": "9beb62a3e8fb",
-      "0.3.1": "9beb62a3e8fb"
+      "0.3.1": "9beb62a3e8fb",
+      "0.3.2": "9beb62a3e8fb"
     }
   },
   "ParseData": {
     "versions": {
       "0.3.0": "3fac44a9bb37",
-      "0.3.1": "3fac44a9bb37"
+      "0.3.1": "3fac44a9bb37",
+      "0.3.2": "3fac44a9bb37"
     }
   },
   "ParseDataFrame": {
     "versions": {
       "0.3.0": "9d4b05cf1564",
-      "0.3.1": "9d4b05cf1564"
+      "0.3.1": "9d4b05cf1564",
+      "0.3.2": "9d4b05cf1564"
     }
   },
   "ParseJSONData": {
     "versions": {
       "0.3.0": "5268ca4c42d6",
-      "0.3.1": "5268ca4c42d6"
+      "0.3.1": "5268ca4c42d6",
+      "0.3.2": "5268ca4c42d6"
     }
   },
   "ParserComponent": {
     "versions": {
       "0.3.0": "3cda25c3f7b5",
-      "0.3.1": "3cda25c3f7b5"
+      "0.3.1": "3cda25c3f7b5",
+      "0.3.2": "3cda25c3f7b5"
     }
   },
   "RegexExtractorComponent": {
     "versions": {
       "0.3.0": "f67d7bd7f65e",
-      "0.3.1": "f67d7bd7f65e"
+      "0.3.1": "f67d7bd7f65e",
+      "0.3.2": "f67d7bd7f65e"
     }
   },
   "SelectData": {
     "versions": {
       "0.3.0": "0512bd98ce4d",
-      "0.3.1": "0512bd98ce4d"
+      "0.3.1": "0512bd98ce4d",
+      "0.3.2": "0512bd98ce4d"
     }
   },
   "SplitText": {
     "versions": {
       "0.3.0": "29ae597d2d86",
-      "0.3.1": "29ae597d2d86"
+      "0.3.1": "29ae597d2d86",
+      "0.3.2": "29ae597d2d86"
     }
   },
   "StoreMessage": {
     "versions": {
       "0.3.0": "9ad1aa08b597",
-      "0.3.1": "9ad1aa08b597"
+      "0.3.1": "9ad1aa08b597",
+      "0.3.2": "9ad1aa08b597"
     }
   },
   "TextOperations": {
     "versions": {
       "0.3.0": "2c2991ef0a37",
-      "0.3.1": "2c2991ef0a37"
+      "0.3.1": "2c2991ef0a37",
+      "0.3.2": "2c2991ef0a37"
     }
   },
   "UpdateData": {
     "versions": {
       "0.3.0": "d0790af3ac9b",
-      "0.3.1": "d0790af3ac9b"
+      "0.3.1": "d0790af3ac9b",
+      "0.3.2": "d0790af3ac9b"
     }
   },
   "PythonFunction": {
     "versions": {
       "0.3.0": "7da7d856a545",
-      "0.3.1": "7da7d856a545"
+      "0.3.1": "7da7d856a545",
+      "0.3.2": "7da7d856a545"
     }
   },
   "QdrantVectorStoreComponent": {
     "versions": {
       "0.3.0": "bcfc1728e7b1",
-      "0.3.1": "bcfc1728e7b1"
+      "0.3.1": "bcfc1728e7b1",
+      "0.3.2": "bcfc1728e7b1"
     }
   },
   "Redis": {
     "versions": {
       "0.3.0": "fec4041f4017",
-      "0.3.1": "fec4041f4017"
+      "0.3.1": "fec4041f4017",
+      "0.3.2": "fec4041f4017"
     }
   },
   "RedisChatMemory": {
     "versions": {
       "0.3.0": "01ec6e1e34a8",
-      "0.3.1": "01ec6e1e34a8"
+      "0.3.1": "01ec6e1e34a8",
+      "0.3.2": "01ec6e1e34a8"
     }
   },
   "SambaNovaModel": {
     "versions": {
       "0.3.0": "f12728900b8d",
-      "0.3.1": "f12728900b8d"
+      "0.3.1": "f12728900b8d",
+      "0.3.2": "f12728900b8d"
     }
   },
   "ScrapeGraphMarkdownifyApi": {
     "versions": {
       "0.3.0": "0f5f12091af6",
-      "0.3.1": "0f5f12091af6"
+      "0.3.1": "0f5f12091af6",
+      "0.3.2": "0f5f12091af6"
     }
   },
   "ScrapeGraphSearchApi": {
     "versions": {
       "0.3.0": "002d2af653ef",
-      "0.3.1": "002d2af653ef"
+      "0.3.1": "002d2af653ef",
+      "0.3.2": "002d2af653ef"
     }
   },
   "ScrapeGraphSmartScraperApi": {
     "versions": {
       "0.3.0": "cb419bec02ed",
-      "0.3.1": "cb419bec02ed"
+      "0.3.1": "cb419bec02ed",
+      "0.3.2": "cb419bec02ed"
     }
   },
   "SearchComponent": {
     "versions": {
       "0.3.0": "625d1f5b3290",
-      "0.3.1": "625d1f5b3290"
+      "0.3.1": "625d1f5b3290",
+      "0.3.2": "625d1f5b3290"
     }
   },
   "Serp": {
     "versions": {
       "0.3.0": "dcc2ecb44ff6",
-      "0.3.1": "dcc2ecb44ff6"
+      "0.3.1": "dcc2ecb44ff6",
+      "0.3.2": "dcc2ecb44ff6"
     }
   },
   "SupabaseVectorStore": {
     "versions": {
       "0.3.0": "5045b81c340b",
-      "0.3.1": "5045b81c340b"
+      "0.3.1": "5045b81c340b",
+      "0.3.2": "5045b81c340b"
     }
   },
   "TavilyExtractComponent": {
     "versions": {
       "0.3.0": "fec95e2181d8",
-      "0.3.1": "fec95e2181d8"
+      "0.3.1": "fec95e2181d8",
+      "0.3.2": "fec95e2181d8"
     }
   },
   "TavilySearchComponent": {
     "versions": {
       "0.3.0": "e602eaec8316",
-      "0.3.1": "e602eaec8316"
+      "0.3.1": "e602eaec8316",
+      "0.3.2": "e602eaec8316"
     }
   },
   "CalculatorTool": {
     "versions": {
       "0.3.0": "30008a17eb27",
-      "0.3.1": "30008a17eb27"
+      "0.3.1": "30008a17eb27",
+      "0.3.2": "30008a17eb27"
     }
   },
   "GoogleSearchAPI": {
     "versions": {
       "0.3.0": "5f47bcd2163c",
-      "0.3.1": "5f47bcd2163c"
+      "0.3.1": "5f47bcd2163c",
+      "0.3.2": "5f47bcd2163c"
     }
   },
   "GoogleSerperAPI": {
     "versions": {
       "0.3.0": "f51b15d26440",
-      "0.3.1": "f51b15d26440"
+      "0.3.1": "f51b15d26440",
+      "0.3.2": "f51b15d26440"
     }
   },
   "PythonCodeStructuredTool": {
     "versions": {
       "0.3.0": "99f294af525b",
-      "0.3.1": "99f294af525b"
+      "0.3.1": "99f294af525b",
+      "0.3.2": "99f294af525b"
     }
   },
   "PythonREPLTool": {
     "versions": {
       "0.3.0": "695ab612478d",
-      "0.3.1": "695ab612478d"
+      "0.3.1": "695ab612478d",
+      "0.3.2": "695ab612478d"
     }
   },
   "SearchAPI": {
     "versions": {
       "0.3.0": "4a9c8b914b68",
-      "0.3.1": "4a9c8b914b68"
+      "0.3.1": "4a9c8b914b68",
+      "0.3.2": "4a9c8b914b68"
     }
   },
   "SearXNGTool": {
     "versions": {
       "0.3.0": "154e292dad2b",
-      "0.3.1": "154e292dad2b"
+      "0.3.1": "154e292dad2b",
+      "0.3.2": "154e292dad2b"
     }
   },
   "SerpAPI": {
     "versions": {
       "0.3.0": "882d7b35a9d7",
-      "0.3.1": "882d7b35a9d7"
+      "0.3.1": "882d7b35a9d7",
+      "0.3.2": "882d7b35a9d7"
     }
   },
   "TavilyAISearch": {
     "versions": {
       "0.3.0": "70b5611e8fd6",
-      "0.3.1": "70b5611e8fd6"
+      "0.3.1": "70b5611e8fd6",
+      "0.3.2": "70b5611e8fd6"
     }
   },
   "WikidataAPI": {
     "versions": {
       "0.3.0": "4752066f8971",
-      "0.3.1": "4752066f8971"
+      "0.3.1": "4752066f8971",
+      "0.3.2": "4752066f8971"
     }
   },
   "WikipediaAPI": {
     "versions": {
       "0.3.0": "d7ae953444c9",
-      "0.3.1": "d7ae953444c9"
+      "0.3.1": "d7ae953444c9",
+      "0.3.2": "d7ae953444c9"
     }
   },
   "YahooFinanceTool": {
     "versions": {
       "0.3.0": "fda358f6395e",
-      "0.3.1": "fda358f6395e"
+      "0.3.1": "fda358f6395e",
+      "0.3.2": "fda358f6395e"
     }
   },
   "ConvertAstraToTwelveLabs": {
     "versions": {
       "0.3.0": "90ad7b9b59eb",
-      "0.3.1": "90ad7b9b59eb"
+      "0.3.1": "90ad7b9b59eb",
+      "0.3.2": "90ad7b9b59eb"
     }
   },
   "TwelveLabsPegasusIndexVideo": {
     "versions": {
       "0.3.0": "a2c0865be096",
-      "0.3.1": "a2c0865be096"
+      "0.3.1": "a2c0865be096",
+      "0.3.2": "a2c0865be096"
     }
   },
   "SplitVideo": {
     "versions": {
       "0.3.0": "4d3a4a724aa5",
-      "0.3.1": "4d3a4a724aa5"
+      "0.3.1": "4d3a4a724aa5",
+      "0.3.2": "4d3a4a724aa5"
     }
   },
   "TwelveLabsTextEmbeddings": {
     "versions": {
       "0.3.0": "5c7501f5088c",
-      "0.3.1": "5c7501f5088c"
+      "0.3.1": "5c7501f5088c",
+      "0.3.2": "5c7501f5088c"
     }
   },
   "TwelveLabsPegasus": {
     "versions": {
       "0.3.0": "92cc032822a6",
-      "0.3.1": "92cc032822a6"
+      "0.3.1": "92cc032822a6",
+      "0.3.2": "92cc032822a6"
     }
   },
   "TwelveLabsVideoEmbeddings": {
     "versions": {
       "0.3.0": "294e3539629c",
-      "0.3.1": "294e3539629c"
+      "0.3.1": "294e3539629c",
+      "0.3.2": "294e3539629c"
     }
   },
   "VideoFile": {
     "versions": {
       "0.3.0": "8dc827e42377",
-      "0.3.1": "8dc827e42377"
+      "0.3.1": "8dc827e42377",
+      "0.3.2": "8dc827e42377"
     }
   },
   "Unstructured": {
     "versions": {
       "0.3.0": "bbb4e71aee8e",
-      "0.3.1": "bbb4e71aee8e"
+      "0.3.1": "bbb4e71aee8e",
+      "0.3.2": "bbb4e71aee8e"
     }
   },
   "Upstash": {
     "versions": {
       "0.3.0": "b5b2d78e8c44",
-      "0.3.1": "b5b2d78e8c44"
+      "0.3.1": "b5b2d78e8c44",
+      "0.3.2": "b5b2d78e8c44"
     }
   },
   "CalculatorComponent": {
     "versions": {
       "0.3.0": "acbe2603b034",
-      "0.3.1": "acbe2603b034"
+      "0.3.1": "acbe2603b034",
+      "0.3.2": "acbe2603b034"
     }
   },
   "CurrentDate": {
     "versions": {
       "0.3.0": "4a93d7b489e6",
-      "0.3.1": "4a93d7b489e6"
+      "0.3.1": "4a93d7b489e6",
+      "0.3.2": "4a93d7b489e6"
     }
   },
   "IDGenerator": {
     "versions": {
       "0.3.0": "cddb8b4edbc3",
-      "0.3.1": "cddb8b4edbc3"
+      "0.3.1": "cddb8b4edbc3",
+      "0.3.2": "cddb8b4edbc3"
     }
   },
   "PythonREPLComponent": {
     "versions": {
       "0.3.0": "80eeaf032b83",
-      "0.3.1": "80eeaf032b83"
+      "0.3.1": "80eeaf032b83",
+      "0.3.2": "80eeaf032b83"
     }
   },
   "Vectara": {
     "versions": {
       "0.3.0": "a2309e046c06",
-      "0.3.1": "a2309e046c06"
+      "0.3.1": "a2309e046c06",
+      "0.3.2": "a2309e046c06"
     }
   },
   "VectaraRAG": {
     "versions": {
       "0.3.0": "123c9eef9191",
-      "0.3.1": "123c9eef9191"
+      "0.3.1": "123c9eef9191",
+      "0.3.2": "123c9eef9191"
     }
   },
   "LocalDB": {
     "versions": {
       "0.3.0": "767988a11f4a",
-      "0.3.1": "767988a11f4a"
+      "0.3.1": "767988a11f4a",
+      "0.3.2": "767988a11f4a"
     }
   },
   "VertexAiModel": {
     "versions": {
       "0.3.0": "d9f75281d3fa",
-      "0.3.1": "d9f75281d3fa"
+      "0.3.1": "d9f75281d3fa",
+      "0.3.2": "d9f75281d3fa"
     }
   },
   "VertexAIEmbeddings": {
     "versions": {
       "0.3.0": "3abd5c15264a",
-      "0.3.1": "3abd5c15264a"
+      "0.3.1": "3abd5c15264a",
+      "0.3.2": "3abd5c15264a"
     }
   },
   "vLLMModel": {
     "versions": {
       "0.3.0": "ed6c1aa73200",
-      "0.3.1": "ed6c1aa73200"
+      "0.3.1": "ed6c1aa73200",
+      "0.3.2": "ed6c1aa73200"
     }
   },
   "vLLMEmbeddings": {
     "versions": {
       "0.3.0": "079b6a2dd397",
-      "0.3.1": "079b6a2dd397"
+      "0.3.1": "079b6a2dd397",
+      "0.3.2": "079b6a2dd397"
     }
   },
   "VLMRunTranscription": {
     "versions": {
       "0.3.0": "c91e2349a3df",
-      "0.3.1": "c91e2349a3df"
+      "0.3.1": "c91e2349a3df",
+      "0.3.2": "c91e2349a3df"
     }
   },
   "Weaviate": {
     "versions": {
       "0.3.0": "ccc9f1e0149d",
-      "0.3.1": "ccc9f1e0149d"
+      "0.3.1": "ccc9f1e0149d",
+      "0.3.2": "ccc9f1e0149d"
     }
   },
   "WikidataComponent": {
     "versions": {
       "0.3.0": "59df9d399440",
-      "0.3.1": "59df9d399440"
+      "0.3.1": "59df9d399440",
+      "0.3.2": "59df9d399440"
     }
   },
   "WikipediaComponent": {
     "versions": {
       "0.3.0": "cc13e26c79c4",
-      "0.3.1": "cc13e26c79c4"
+      "0.3.1": "cc13e26c79c4",
+      "0.3.2": "cc13e26c79c4"
     }
   },
   "WolframAlphaAPI": {
     "versions": {
       "0.3.0": "86caf22224ad",
-      "0.3.1": "86caf22224ad"
+      "0.3.1": "86caf22224ad",
+      "0.3.2": "86caf22224ad"
     }
   },
   "xAIModel": {
     "versions": {
       "0.3.0": "ef0eb1cfadeb",
-      "0.3.1": "ef0eb1cfadeb"
+      "0.3.1": "ef0eb1cfadeb",
+      "0.3.2": "ef0eb1cfadeb"
     }
   },
   "YfinanceComponent": {
     "versions": {
       "0.3.0": "d6bf628ab821",
-      "0.3.1": "d6bf628ab821"
+      "0.3.1": "d6bf628ab821",
+      "0.3.2": "d6bf628ab821"
     }
   },
   "YouTubeChannelComponent": {
     "versions": {
       "0.3.0": "c889afb883fa",
-      "0.3.1": "c889afb883fa"
+      "0.3.1": "c889afb883fa",
+      "0.3.2": "c889afb883fa"
     }
   },
   "YouTubeCommentsComponent": {
     "versions": {
       "0.3.0": "20398e0d18df",
-      "0.3.1": "20398e0d18df"
+      "0.3.1": "20398e0d18df",
+      "0.3.2": "20398e0d18df"
     }
   },
   "YouTubePlaylistComponent": {
     "versions": {
       "0.3.0": "2d6ac9665d53",
-      "0.3.1": "2d6ac9665d53"
+      "0.3.1": "2d6ac9665d53",
+      "0.3.2": "2d6ac9665d53"
     }
   },
   "YouTubeSearchComponent": {
     "versions": {
       "0.3.0": "1c4a94a094e2",
-      "0.3.1": "1c4a94a094e2"
+      "0.3.1": "1c4a94a094e2",
+      "0.3.2": "1c4a94a094e2"
     }
   },
   "YouTubeTrendingComponent": {
     "versions": {
       "0.3.0": "1450a5529486",
-      "0.3.1": "1450a5529486"
+      "0.3.1": "1450a5529486",
+      "0.3.2": "1450a5529486"
     }
   },
   "YouTubeVideoDetailsComponent": {
     "versions": {
       "0.3.0": "6c2be0d5450b",
-      "0.3.1": "6c2be0d5450b"
+      "0.3.1": "6c2be0d5450b",
+      "0.3.2": "6c2be0d5450b"
     }
   },
   "YouTubeTranscripts": {
     "versions": {
       "0.3.0": "0ed75539d58d",
-      "0.3.1": "0ed75539d58d"
+      "0.3.1": "0ed75539d58d",
+      "0.3.2": "0ed75539d58d"
     }
   },
   "ZepChatMemory": {
     "versions": {
       "0.3.0": "ec825c33caf6",
-      "0.3.1": "ec825c33caf6"
+      "0.3.1": "ec825c33caf6",
+      "0.3.2": "ec825c33caf6"
     }
   },
   "GuardrailValidator": {
     "versions": {
       "0.3.0": "70918cbb8522",
-      "0.3.1": "70918cbb8522"
+      "0.3.1": "70918cbb8522",
+      "0.3.2": "70918cbb8522"
     }
   },
   "LiteLLMProxyModel": {
     "versions": {
       "0.3.0": "386ae52865b5",
-      "0.3.1": "386ae52865b5"
+      "0.3.1": "386ae52865b5",
+      "0.3.2": "386ae52865b5"
     }
   },
   "SemanticAggregator": {
     "versions": {
       "0.3.0": "4e631c501d33",
-      "0.3.1": "4e631c501d33"
+      "0.3.1": "4e631c501d33",
+      "0.3.2": "4e631c501d33"
     }
   },
   "SemanticMap": {
     "versions": {
       "0.3.0": "9fe34c926467",
-      "0.3.1": "9fe34c926467"
+      "0.3.1": "9fe34c926467",
+      "0.3.2": "9fe34c926467"
     }
   },
   "SyntheticDataGenerator": {
     "versions": {
       "0.3.0": "efd180878996",
-      "0.3.1": "efd180878996"
+      "0.3.1": "efd180878996",
+      "0.3.2": "efd180878996"
     }
   },
   "KnowledgeBase": {
     "versions": {
       "0.3.0": "8b5ca1f38f6e",
-      "0.3.1": "8b5ca1f38f6e"
+      "0.3.1": "8b5ca1f38f6e",
+      "0.3.2": "8b5ca1f38f6e"
     }
   }
 }

--- a/src/lfx/src/lfx/base/models/unified_models.py
+++ b/src/lfx/src/lfx/base/models/unified_models.py
@@ -458,20 +458,31 @@ def get_api_key_for_provider(user_id: UUID | str | None, provider: str, api_key:
     if not variable_name:
         return None
 
-    # Try to get from global variables
+    # Try to get from global variables, fall back to environment
     async def _get_variable():
         async with session_scope() as session:
             variable_service = get_variable_service()
             if variable_service is None:
                 return None
-            return await variable_service.get_variable(
-                user_id=UUID(user_id) if isinstance(user_id, str) else user_id,
-                name=variable_name,
-                field="",
-                session=session,
-            )
+            try:
+                return await variable_service.get_variable(
+                    user_id=UUID(user_id) if isinstance(user_id, str) else user_id,
+                    name=variable_name,
+                    field="",
+                    session=session,
+                )
+            except ValueError:
+                return None
 
-    return run_until_complete(_get_variable())
+    try:
+        api_key = run_until_complete(_get_variable())
+    except (ValueError, Exception):  # noqa: BLE001
+        api_key = None
+
+    if api_key:
+        return api_key
+
+    return os.getenv(variable_name)
 
 
 def get_all_variables_for_provider(user_id: UUID | str | None, provider: str) -> dict[str, str]:


### PR DESCRIPTION
Objective                                                                                                                                                   
Backport ephemeral file upload support for Desktop playground and fix credential resolution fallback to environment variables when DB lookup fails.

Changes
  - Add ephemeral query parameter to file upload endpoint, skipping UserFile DB record creation while keeping the file servable                               
  - Add try/except and os.getenv() fallback in get_api_key_for_provider when DB variable lookup raises ValueError or returns empty
  - Add unit tests for ephemeral upload behavior and credential resolution fallback scenarios