### PR TITLE
fix: Use plain axios for external GitHub and Discord API calls 

### DIFF
--- a/src/frontend/src/controllers/API/index.ts
+++ b/src/frontend/src/controllers/API/index.ts
@@ -1,5 +1,5 @@
 import type { Edge, Node, ReactFlowJsonObject } from "@xyflow/react";
-import type { AxiosRequestConfig, AxiosResponse } from "axios";
+import axios, { type AxiosRequestConfig, type AxiosResponse } from "axios";
 import {
   customGetAppVersions,
   customGetLatestVersion,
@@ -19,7 +19,9 @@ const DISCORD_API_URL =
 
 export async function getRepoStars(owner: string, repo: string) {
   try {
-    const response = await api.get(`${GITHUB_API_URL}/repos/${owner}/${repo}`);
+    const response = await axios.get(
+      `${GITHUB_API_URL}/repos/${owner}/${repo}`,
+    );
     return response?.data.stargazers_count;
   } catch (error) {
     console.error("Error fetching repository data:", error);
@@ -29,7 +31,7 @@ export async function getRepoStars(owner: string, repo: string) {
 
 export async function getDiscordCount() {
   try {
-    const response = await api.get(DISCORD_API_URL);
+    const response = await axios.get(DISCORD_API_URL);
     return response?.data.approximate_member_count;
   } catch (error) {
     console.error("Error fetching repository data:", error);


### PR DESCRIPTION
Objective                                                       
Fix CORS failures on GitHub Stars and Discord member count API calls.                                                          
                                                                
Changes                                                         
  - Replace api.get() with axios.get() in getRepoStars() and getDiscordCount()
  - Add axios default import alongside existing type imports      
                                                                  
Notes
  - The api instance has withCredentials=true, which is incompatible with external APIs that return Access-Control-Allow-Origin: * (CORS spec forbids credentials with wildcard origin)                                         
  - Plain axios.get() does not send credentials, avoiding the CORS conflict