### PR TITLE
fix(mcp): Stop sending API key as Bearer token in MCP client 

### DIFF
--- a/src/lfx/src/lfx/mcp/client.py
+++ b/src/lfx/src/lfx/mcp/client.py
@@ -56,9 +56,8 @@ class LangflowClient:
 
     def _headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}
-        token = self.access_token or self.api_key
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
+        if self.access_token:
+            headers["Authorization"] = f"Bearer {self.access_token}"
         if self.api_key:
             headers["x-api-key"] = self.api_key
         return headers


### PR DESCRIPTION
Objective                                                                                                                                                  
Fix MCP client authentication failing with 401 when using LANGFLOW_API_KEY environment variable.

Changes
  - Remove API key from Authorization: Bearer header in LangflowClient._headers()                                                                            
  - Send API key only via x-api-key header; reserve Authorization: Bearer for JWT access tokens
                                                                                                                                                             
Notes                                                                       
When both Authorization: Bearer <api_key> and x-api-key: <api_key> headers were sent, the backend validated the Bearer token first as a JWT, failed with "Invalid token", and returned 401 before ever checking the x-api-key header. This made LANGFLOW_API_KEY env var auth unusable for the MCP server. The fix ensures each header is used only for its intended auth mechanism: x-api-key for API keys, Authorization: Bearer for JWT tokens from login.