### PR TITLE
fix: Close popup when navigating to MCP settings

### DIFF
--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -314,7 +314,11 @@ export default function AddMcpServerModal({
               ) : (
                 <>
                   Add and save MCP servers. Manage servers in{" "}
-                  <CustomLink className="underline" to={MCP_SETTINGS_PAGE}>
+                  <CustomLink
+                    className="underline"
+                    to={MCP_SETTINGS_PAGE}
+                    onClick={() => setOpen(false)}
+                  >
                     settings
                   </CustomLink>
                   .


### PR DESCRIPTION
This pull request introduces a small usability improvement to the MCP server modal. Now, when a user clicks the "settings" link, the modal will automatically close, providing a smoother user experience.

* When the "settings" link (`CustomLink`) is clicked in the `AddMcpServerModal`, the modal is closed by calling `setOpen(false)`.