### PR TITLE
ci: upgrade runtime to python:3.14.3-slim-trixie

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -73,7 +73,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.12-slim-trixie AS runtime
+FROM python:3.14.3-slim-trixie AS runtime
 
 
 RUN apt-get update \

--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -73,7 +73,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.14.3-slim-trixie AS runtime
+FROM python:3.12.13-slim-trixie AS runtime
 
 
 RUN apt-get update \

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ################################
 # RUNTIME
 ################################
-FROM python:3.12.12-slim-trixie AS runtime
+FROM python:3.14.3-slim-trixie AS runtime
 
 # Install minimal runtime dependencies
 RUN apt-get update \

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ################################
 # RUNTIME
 ################################
-FROM python:3.14.3-slim-trixie AS runtime
+FROM python:3.12.13-slim-trixie AS runtime
 
 # Install minimal runtime dependencies
 RUN apt-get update \

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -74,7 +74,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.12-slim-trixie AS runtime
+FROM python:3.14.3-slim-trixie AS runtime
 
 
 RUN apt-get update \

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -74,7 +74,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.14.3-slim-trixie AS runtime
+FROM python:3.12.13-slim-trixie AS runtime
 
 
 RUN apt-get update \

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.14.3-slim-trixie AS runtime
+FROM python:3.12.13-slim-trixie AS runtime
 
 RUN apt-get update \
     && apt-get upgrade -y \

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.12-slim-trixie AS runtime
+FROM python:3.14.3-slim-trixie AS runtime
 
 RUN apt-get update \
     && apt-get upgrade -y \

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.14.3-slim-trixie AS runtime
+FROM python:3.12.13-slim-trixie AS runtime
 
 
 RUN apt-get update \

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.12-slim-trixie AS runtime
+FROM python:3.14.3-slim-trixie AS runtime
 
 
 RUN apt-get update \


### PR DESCRIPTION
upgrade our dockerfiles to use LTS runner version python:3.14.3-slim-trixie
needed due to security vulnerability scans