### PR TITLE
feat(deployments): add environment variable overrides for IBM IAM URLs (wxO)

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
@@ -661,7 +661,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
@@ -622,7 +622,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -538,7 +538,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1037,7 +1037,7 @@
                 "dependencies": [
                   {
                     "name": "requests",
-                    "version": "2.32.5"
+                    "version": "2.33.0"
                   },
                   {
                     "name": "bs4",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
@@ -2273,7 +2273,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -416,7 +416,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1319,7 +1319,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
@@ -130,7 +130,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -674,7 +674,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1755,7 +1755,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
@@ -456,7 +456,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -1124,7 +1124,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -2084,7 +2084,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -342,7 +342,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1192,7 +1192,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
@@ -259,7 +259,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -545,7 +545,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "43.0.3"
+                    "version": "46.0.6"
                   },
                   {
                     "name": "langchain_chroma",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -452,7 +452,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1204,7 +1204,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
@@ -685,7 +685,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -965,7 +965,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1245,7 +1245,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
@@ -425,7 +425,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -886,7 +886,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1186,7 +1186,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3
@@ -1757,7 +1757,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "pandas",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -512,7 +512,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -812,7 +812,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3
@@ -2338,7 +2338,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -396,7 +396,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1251,7 +1251,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -328,7 +328,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -928,7 +928,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -420,7 +420,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -1768,7 +1768,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -2823,7 +2823,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
@@ -372,7 +372,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
@@ -628,7 +628,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -405,7 +405,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -905,7 +905,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -571,7 +571,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -952,7 +952,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3
@@ -958,7 +958,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3
@@ -2403,7 +2403,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3
@@ -2976,7 +2976,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   },
                   {
                     "name": "pydantic",
@@ -3791,7 +3791,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -652,7 +652,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -951,7 +951,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3
@@ -1840,7 +1840,7 @@
                 "dependencies": [
                   {
                     "name": "requests",
-                    "version": "2.32.5"
+                    "version": "2.33.0"
                   },
                   {
                     "name": "bs4",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   },
                   {
                     "name": "pydantic",
@@ -976,7 +976,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1301,7 +1301,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -826,7 +826,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1108,7 +1108,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -3581,7 +3581,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -503,7 +503,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1679,7 +1679,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3
@@ -2262,7 +2262,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3
@@ -2845,7 +2845,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
@@ -706,7 +706,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -1042,7 +1042,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",
@@ -1588,7 +1588,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   },
                   {
                     "name": "pydantic",
@@ -2659,7 +2659,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   },
                   {
                     "name": "lfx",
@@ -3570,7 +3570,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.20"
+                    "version": "1.2.22"
                   }
                 ],
                 "total_dependencies": 3
@@ -1454,7 +1454,7 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.10.15"
+                    "version": "3.11.7"
                   },
                   {
                     "name": "fastapi",

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/constants.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/constants.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from enum import Enum
 
@@ -25,10 +26,29 @@ WXO_TRANSLATE = str.maketrans({" ": "_", "-": "_"})
 ERROR_PREFIX = "An error occurred while"
 ERROR_SUFFIX_IN = "in Watsonx Orchestrate."
 
+IBM_IAM_MCSP_PRODUCTION_URL = "https://iam.platform.saas.ibm.com"
+IBM_IAM_PRODUCTION_URL = "https://iam.cloud.ibm.com"
+
 
 class WxOAuthURL(str, Enum):
-    MCSP = "https://iam.platform.saas.ibm.com"
-    IBM_IAM = "https://iam.cloud.ibm.com"
+    """IAM token endpoint URLs used to authenticate against Watsonx Orchestrate.
+
+    Non-production wxO environments consume from a different IAM endpoint than
+    production environments. These cannot be exposed in plain text so
+    environment variables are surfaced instead.
+    Set ``IBM_IAM_MCSP_DEV_URL_OVERRIDE`` for AWS wxO environments,
+    ``IBM_IAM_DEV_URL_OVERRIDE`` for IBM Cloud.
+    When unset, the production URLs are used
+    ("https://iam.platform.saas.ibm.com" and "https://iam.cloud.ibm.com" respectively).
+
+    Please note: The IAM endpoints cannot be changed during runtime,
+    Langflow does not dynamically resolve the IAM endpoint based on
+    the wxO environment of a given tenant.
+    The environment variables are solely for internal testing and development.
+    """
+
+    MCSP = os.getenv("IBM_IAM_MCSP_DEV_URL_OVERRIDE", "").strip() or IBM_IAM_MCSP_PRODUCTION_URL
+    IBM_IAM = os.getenv("IBM_IAM_DEV_URL_OVERRIDE", "").strip() or IBM_IAM_PRODUCTION_URL
 
 
 class ErrorPrefix(str, Enum):

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/constants.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/constants.py
@@ -28,14 +28,14 @@ ERROR_SUFFIX_IN = "in Watsonx Orchestrate."
 
 # The IAM endpoints below generate
 # authentication tokens for production
-# wxO environments and are documented publically:
+# wxO environments and are documented publicly:
 # Documentation: https://www.ibm.com/docs/en/watsonx/watson-orchestrate/base?topic=api-generating-jwt-aws
 IBM_IAM_MCSP_PRODUCTION_URL = "https://iam.platform.saas.ibm.com"
 # Documentation: https://www.ibm.com/docs/en/watsonx/watson-orchestrate/base?topic=api-generating-access-token-cloud
 IBM_IAM_PRODUCTION_URL = "https://iam.cloud.ibm.com"
 # Non-production wxO environments use different
-# IAM URLs, which are not documented publically
-# and must not be used publically in plain text.
+# IAM URLs, which are not documented publicly
+# and must not be used publicly in plain text.
 
 
 class WxOAuthURL(str, Enum):

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/constants.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/constants.py
@@ -33,7 +33,7 @@ ERROR_SUFFIX_IN = "in Watsonx Orchestrate."
 IBM_IAM_MCSP_PRODUCTION_URL = "https://iam.platform.saas.ibm.com"
 # Documentation: https://www.ibm.com/docs/en/watsonx/watson-orchestrate/base?topic=api-generating-access-token-cloud
 IBM_IAM_PRODUCTION_URL = "https://iam.cloud.ibm.com"
-# Non-production wxO environments consume from different
+# Non-production wxO environments use different
 # IAM URLs, which are not documented publically
 # and must not be used publically in plain text.
 
@@ -41,7 +41,7 @@ IBM_IAM_PRODUCTION_URL = "https://iam.cloud.ibm.com"
 class WxOAuthURL(str, Enum):
     """IAM token endpoint URLs used to authenticate against Watsonx Orchestrate.
 
-    Non-production wxO environments consume from a different IAM URL than
+    Non-production wxO environments use a different IAM URL than
     production environments. These cannot be exposed in plain text so
     environment variables are surfaced instead.
     Set ``IBM_IAM_MCSP_DEV_URL_OVERRIDE`` for AWS wxO environments,

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/constants.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/constants.py
@@ -26,14 +26,22 @@ WXO_TRANSLATE = str.maketrans({" ": "_", "-": "_"})
 ERROR_PREFIX = "An error occurred while"
 ERROR_SUFFIX_IN = "in Watsonx Orchestrate."
 
+# The IAM endpoints below generate
+# authentication tokens for production
+# wxO environments and are documented publically:
+# Documentation: https://www.ibm.com/docs/en/watsonx/watson-orchestrate/base?topic=api-generating-jwt-aws
 IBM_IAM_MCSP_PRODUCTION_URL = "https://iam.platform.saas.ibm.com"
+# Documentation: https://www.ibm.com/docs/en/watsonx/watson-orchestrate/base?topic=api-generating-access-token-cloud
 IBM_IAM_PRODUCTION_URL = "https://iam.cloud.ibm.com"
+# Non-production wxO environments consume from different
+# IAM URLs, which are not documented publically
+# and must not be used publically in plain text.
 
 
 class WxOAuthURL(str, Enum):
     """IAM token endpoint URLs used to authenticate against Watsonx Orchestrate.
 
-    Non-production wxO environments consume from a different IAM endpoint than
+    Non-production wxO environments consume from a different IAM URL than
     production environments. These cannot be exposed in plain text so
     environment variables are surfaced instead.
     Set ``IBM_IAM_MCSP_DEV_URL_OVERRIDE`` for AWS wxO environments,
@@ -41,10 +49,16 @@ class WxOAuthURL(str, Enum):
     When unset, the production URLs are used
     ("https://iam.platform.saas.ibm.com" and "https://iam.cloud.ibm.com" respectively).
 
-    Please note: The IAM endpoints cannot be changed during runtime,
-    Langflow does not dynamically resolve the IAM endpoint based on
-    the wxO environment of a given tenant.
-    The environment variables are solely for internal testing and development.
+    Please note:
+    - The stated environment variables are solely for
+    internal testing and development purposes,
+    and must be left unset when shipping Langflow
+    for general availability.
+    - The IAM URLs cannot be changed during runtime,
+    and Langflow does not dynamically resolve the IAM URL based on
+    the environment of a given wxO tenant. It simply uses the
+    default production IAM URLs, or the environment variable
+    overrides if set.
     """
 
     MCSP = os.getenv("IBM_IAM_MCSP_DEV_URL_OVERRIDE", "").strip() or IBM_IAM_MCSP_PRODUCTION_URL

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -13,6 +13,7 @@ from lfx.services.adapters.deployment.base import BaseDeploymentService
 from lfx.services.adapters.deployment.exceptions import (
     AuthenticationError,
     AuthorizationError,
+    AuthSchemeError,
     DeploymentConflictError,
     DeploymentError,
     DeploymentNotFoundError,
@@ -776,27 +777,35 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             raise DeploymentError(message=msg, error_code="deployment_error")
 
         provider_creds = verify_slot.parse(payload.provider_data)
-        authenticator = get_authenticator(
-            instance_url=payload.base_url,
-            api_key=provider_creds.api_key,
+
+        malformed_credentials_msg = (
+            "Provider credentials are malformed. Please ensure the URL and API key are correctly formatted."
         )
-        # AuthSchemeError bubbles up from get_authenticator for unrecognised URLs
 
         try:
-            authenticator.validate()
+            authenticator = get_authenticator(
+                instance_url=payload.base_url,
+                api_key=provider_creds.api_key,
+            )
         except ValueError as exc:
             raise InvalidContentError(
-                message=(
-                    "Provider credentials are malformed. Please ensure the URL and API key are correctly formatted."
-                ),
+                message=malformed_credentials_msg,
+                cause=exc,
+            ) from exc
+        except AuthSchemeError:
+            raise
+        except Exception as exc:
+            raise DeploymentError(
+                message="Credential verification failed unexpectedly.",
+                error_code="deployment_error",
                 cause=exc,
             ) from exc
 
         try:
             await asyncio.to_thread(authenticator.token_manager.get_token)
         except ApiException as exc:
-            # Log the raw provider detail for diagnostics but do not
-            # propagate it — the response body could echo secrets.
+            # Log only the status code for diagnostics and avoid exposing
+            # provider response details that could include sensitive values.
             logger.error(  # noqa: TRY400
                 "Credential verification failed (status=%s)",
                 exc.status_code,

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -65,6 +65,12 @@ WxOCredentials = importlib.import_module(
 ).WxOCredentials
 
 
+def _reload_wxo_auth_modules():
+    constants_module = importlib.import_module("langflow.services.adapters.deployment.watsonx_orchestrate.constants")
+    importlib.reload(constants_module)
+    return importlib.reload(client_module)
+
+
 def _tool_refs(*tool_ids: str) -> list[dict[str, str]]:
     """Build WatsonxToolRefBinding dicts for test data."""
     return [{"source_ref": f"fv-{tid}", "tool_id": tid} for tid in tool_ids]
@@ -3155,6 +3161,58 @@ def test_get_authenticator_unknown_url():
         get_authenticator("https://example.com", "test-key")
 
 
+def test_get_authenticator_uses_default_iam_urls_when_unset(monkeypatch):
+    try:
+        with monkeypatch.context() as context:
+            context.delenv("IBM_IAM_MCSP_DEV_URL_OVERRIDE", raising=False)
+            context.delenv("IBM_IAM_DEV_URL_OVERRIDE", raising=False)
+            reloaded_client_module = _reload_wxo_auth_modules()
+
+            iam_auth = reloaded_client_module.get_authenticator("https://api.region-foobar.cloud.ibm.com", "test-key")
+            mcsp_auth = reloaded_client_module.get_authenticator("https://api.wxo.ibm.com", "test-key")
+
+            assert iam_auth.token_manager.url == "https://iam.cloud.ibm.com"
+            assert mcsp_auth.token_manager.url == "https://iam.platform.saas.ibm.com"
+    finally:
+        _reload_wxo_auth_modules()
+
+
+@pytest.mark.parametrize("env_value", ["", "   "])
+def test_get_authenticator_empty_or_whitespace_env_var_falls_through_to_default(monkeypatch, env_value):
+    try:
+        with monkeypatch.context() as context:
+            context.setenv("IBM_IAM_MCSP_DEV_URL_OVERRIDE", env_value)
+            context.setenv("IBM_IAM_DEV_URL_OVERRIDE", env_value)
+            reloaded_client_module = _reload_wxo_auth_modules()
+
+            iam_auth = reloaded_client_module.get_authenticator("https://api.region-foobar.cloud.ibm.com", "test-key")
+            mcsp_auth = reloaded_client_module.get_authenticator("https://api.wxo.ibm.com", "test-key")
+
+            assert iam_auth.token_manager.url == "https://iam.cloud.ibm.com"
+            assert mcsp_auth.token_manager.url == "https://iam.platform.saas.ibm.com"
+    finally:
+        _reload_wxo_auth_modules()
+
+
+def test_get_authenticator_uses_override_iam_urls(monkeypatch):
+    custom_mcsp_url = "  https://iam.platform.saas.ibm.com/custom-mcsp  "
+    custom_iam_url = "  https://iam.cloud.ibm.com/custom-iam  "
+
+    try:
+        with monkeypatch.context() as context:
+            context.setenv("IBM_IAM_MCSP_DEV_URL_OVERRIDE", custom_mcsp_url)
+            context.setenv("IBM_IAM_DEV_URL_OVERRIDE", custom_iam_url)
+            reloaded_client_module = _reload_wxo_auth_modules()
+
+            iam_auth = reloaded_client_module.get_authenticator("https://api.region-foobar.cloud.ibm.com", "test-key")
+            mcsp_auth = reloaded_client_module.get_authenticator("https://api.wxo.ibm.com", "test-key")
+
+            assert iam_auth.token_manager.url == custom_iam_url.strip()
+            assert mcsp_auth.token_manager.url == custom_mcsp_url.strip()
+    finally:
+        _reload_wxo_auth_modules()
+
+
 @pytest.mark.anyio
 async def test_get_provider_clients_uses_request_scoped_context_memoization(monkeypatch):
     resolve_calls = 0
@@ -4744,9 +4802,6 @@ async def test_verify_credentials_success(monkeypatch):
     class FakeAuthenticator:
         token_manager = FakeTokenManager()
 
-        def validate(self):
-            pass
-
     monkeypatch.setattr(
         service_module,
         "get_authenticator",
@@ -4776,9 +4831,6 @@ async def test_verify_credentials_invalid_key_raises(monkeypatch):
     class FailingAuthenticator:
         token_manager = FakeTokenManager()
 
-        def validate(self):
-            pass
-
     monkeypatch.setattr(
         service_module,
         "get_authenticator",
@@ -4795,27 +4847,17 @@ async def test_verify_credentials_invalid_key_raises(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_verify_credentials_malformed_key_raises(monkeypatch):
-    """verify_credentials raises InvalidContentError when local validation fails."""
+async def test_verify_credentials_malformed_key_from_authenticator_constructor_raises():
+    """verify_credentials raises InvalidContentError when authenticator creation fails validation."""
     from lfx.services.adapters.deployment.exceptions import InvalidContentError
     from lfx.services.adapters.deployment.schema import VerifyCredentials
-
-    class MalformedAuthenticator:
-        def validate(self):
-            msg = "api key contains bad characters"
-            raise ValueError(msg)
-
-    monkeypatch.setattr(
-        service_module,
-        "get_authenticator",
-        lambda **_kwargs: MalformedAuthenticator(),
-    )
 
     svc = WatsonxOrchestrateDeploymentService(settings_service=DummySettingsService())
     payload = VerifyCredentials(
         base_url="https://api.us-south.wxo.cloud.ibm.com",
-        provider_data={"api_key": "bad\x00key"},  # pragma: allowlist secret
+        provider_data={"api_key": "{bad-key}"},  # pragma: allowlist secret
     )
+
     with pytest.raises(InvalidContentError, match="malformed"):
         await svc.verify_credentials(user_id="u1", payload=payload)
 
@@ -4851,6 +4893,60 @@ async def test_verify_credentials_bad_auth_scheme_raises():
 
 
 @pytest.mark.anyio
+async def test_verify_credentials_authenticator_construction_unexpected_error(monkeypatch):
+    """verify_credentials raises DeploymentError when get_authenticator() throws unexpectedly."""
+    from lfx.services.adapters.deployment.exceptions import DeploymentError
+    from lfx.services.adapters.deployment.schema import VerifyCredentials
+
+    def _exploding_authenticator(**_kwargs):
+        msg = "something unexpected"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(
+        service_module,
+        "get_authenticator",
+        _exploding_authenticator,
+    )
+
+    svc = WatsonxOrchestrateDeploymentService(settings_service=DummySettingsService())
+    payload = VerifyCredentials(
+        base_url="https://api.us-south.wxo.cloud.ibm.com",
+        provider_data={"api_key": "some-key"},  # pragma: allowlist secret
+    )
+    with pytest.raises(DeploymentError, match="failed unexpectedly"):
+        await svc.verify_credentials(user_id="u1", payload=payload)
+
+
+@pytest.mark.anyio
+async def test_verify_credentials_forbidden_key_raises(monkeypatch):
+    """verify_credentials raises AuthorizationError when provider returns 403."""
+    from ibm_cloud_sdk_core import ApiException
+    from lfx.services.adapters.deployment.exceptions import AuthorizationError
+    from lfx.services.adapters.deployment.schema import VerifyCredentials
+
+    class FakeTokenManager:
+        def get_token(self):
+            raise ApiException(403, message="forbidden")
+
+    class ForbiddenAuthenticator:
+        token_manager = FakeTokenManager()
+
+    monkeypatch.setattr(
+        service_module,
+        "get_authenticator",
+        lambda **_kwargs: ForbiddenAuthenticator(),
+    )
+
+    svc = WatsonxOrchestrateDeploymentService(settings_service=DummySettingsService())
+    payload = VerifyCredentials(
+        base_url="https://api.us-south.wxo.cloud.ibm.com",
+        provider_data={"api_key": "some-key"},  # pragma: allowlist secret
+    )
+    with pytest.raises(AuthorizationError, match="Credential verification"):
+        await svc.verify_credentials(user_id="u1", payload=payload)
+
+
+@pytest.mark.anyio
 async def test_verify_credentials_provider_unreachable(monkeypatch):
     """verify_credentials raises DeploymentError on network failure."""
     from lfx.services.adapters.deployment.exceptions import DeploymentError
@@ -4863,9 +4959,6 @@ async def test_verify_credentials_provider_unreachable(monkeypatch):
 
     class UnreachableAuthenticator:
         token_manager = FakeTokenManager()
-
-        def validate(self):
-            pass
 
     monkeypatch.setattr(
         service_module,


### PR DESCRIPTION
Adds environment variable overrides for IBM IAM URLs.

In the wxO deployment adapter, the IAM URL resolution only works for production wxO environments. Non-production environments use a different IAM URL. These cannot be exposed in plain text, so environment variables are surfaced instead. Set ``IBM_IAM_MCSP_DEV_URL_OVERRIDE`` for AWS wxO environments, ``IBM_IAM_DEV_URL_OVERRIDE`` for IBM Cloud.