### PR TITLE
deps: add official wxo client package to langflow-base complete

### DIFF
--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
@@ -261,7 +261,14 @@ def create_wxo_flow_tool(
     tool: LangflowTool = create_langflow_tool(
         tool_definition=flow_definition,
         connections=connections,
-        show_details=False,
+        show_details=True,
+        # TODO: show_details is only set to true because the adk
+        # has a bug where it fails to create requirements
+        # when it is set to False.
+        # Reset to False when the bug is fixed in the adk.
+        # Even better, for us, remove this parameter entirely
+        # and just default to False internally and not expose
+        # it to the caller.
     )
 
     tool_payload = tool.__tool_spec__.model_dump(

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -363,7 +363,6 @@ ibm-watsonx = [
     "ibm-watsonx-orchestrate-clients~=2.7.0; python_version >= '3.11'",
 ]
 
-# Complete installation (excluding ibm-watsonx for now)
 complete = [
     "langflow-base[couchbase]",
     "langflow-base[cassandra]",

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -360,6 +360,7 @@ gassist = ["gassist>=0.0.1; sys_platform == 'win32'"]
 # SDKs for IBM watsonx Orchestrate deployment adapter.
 ibm-watsonx-clients = [
     "ibm-cloud-sdk-core~=3.24.4",
+    "ibm-watsonx-orchestrate-core~=2.7.0; python_version >= '3.11'",
     "ibm-watsonx-orchestrate-clients~=2.7.0; python_version >= '3.11'",
 ]
 

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -358,7 +358,7 @@ astrapy = ["astrapy>=2.1.0,<3.0.0"]
 gassist = ["gassist>=0.0.1; sys_platform == 'win32'"]
 
 # SDKs for IBM watsonx Orchestrate deployment adapter.
-ibm-watsonx = [
+ibm-watsonx-clients = [
     "ibm-cloud-sdk-core~=3.24.4",
     "ibm-watsonx-orchestrate-clients~=2.7.0; python_version >= '3.11'",
 ]
@@ -476,8 +476,7 @@ complete = [
     # Windows-specific
     "langflow-base[gassist]",
     # wxO deployment adapter,
-    # will add to complete once the feature flag is dropped
-    # "langflow-base[ibm-watsonx]"
+    "langflow-base[ibm-watsonx-clients]"
 ]
 
 all = [

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -475,8 +475,9 @@ complete = [
     "langflow-base[astrapy]",
     # Windows-specific
     "langflow-base[gassist]",
-    # wxO deployment adapter
-    "langflow-base[ibm-watsonx]"
+    # wxO deployment adapter,
+    # will add to complete once the feature flag is dropped
+    # "langflow-base[ibm-watsonx]"
 ]
 
 all = [

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -166,17 +166,6 @@ ignore_missing_imports = true
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-# TODO(WXO): Remove testpypi index and uv.sources once the ibm-watsonx-orchestrate
-# packages publish their official release to PyPI (expected late March 2026).
-[[tool.uv.index]]
-name = "testpypi"
-url = "https://test.pypi.org/simple"
-explicit = true
-
-[tool.uv.sources]
-ibm-watsonx-orchestrate-core = [{ index = "testpypi" }]
-ibm-watsonx-orchestrate-clients = [{ index = "testpypi" }]
-
 [project.urls]
 Repository = "https://github.com/langflow-ai/langflow"
 Documentation = "https://docs.langflow.org"
@@ -369,13 +358,9 @@ astrapy = ["astrapy>=2.1.0,<3.0.0"]
 gassist = ["gassist>=0.0.1; sys_platform == 'win32'"]
 
 # SDKs for IBM watsonx Orchestrate deployment adapter.
-# TODO(WXO): Pin to stable versions once official PyPI releases land (late March 2026).
 ibm-watsonx = [
     "ibm-cloud-sdk-core~=3.24.4",
-    "ibm-watsonx-orchestrate-clients==2.3.2.dev5117; python_version >= '3.11'",
-    "ibm-watsonx-orchestrate-core==2.3.2.dev5117; python_version >= '3.11'",
-    "rich",
-    "PyYAML"
+    "ibm-watsonx-orchestrate-clients~=2.7.0; python_version >= '3.11'",
 ]
 
 # Complete installation (excluding ibm-watsonx for now)
@@ -491,9 +476,8 @@ complete = [
     "langflow-base[astrapy]",
     # Windows-specific
     "langflow-base[gassist]",
-    # wxO deployment adapter intentionally excluded from `complete` for now:
-    # its dependencies are currently distributed outside stable public indexes.
-    # Install explicitly with `langflow-base[ibm-watsonx]` when available.
+    # wxO deployment adapter
+    "langflow-base[ibm-watsonx]"
 ]
 
 all = [

--- a/uv.lock
+++ b/uv.lock
@@ -6246,6 +6246,7 @@ all = [
     { name = "huggingface-hub", extra = ["inference"] },
     { name = "ibm-cloud-sdk-core" },
     { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11'" },
+    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11'" },
     { name = "jigsawstack" },
     { name = "json-repair" },
     { name = "kubernetes" },
@@ -6416,6 +6417,7 @@ complete = [
     { name = "huggingface-hub", extra = ["inference"] },
     { name = "ibm-cloud-sdk-core" },
     { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11'" },
+    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11'" },
     { name = "jigsawstack" },
     { name = "json-repair" },
     { name = "kubernetes" },
@@ -6573,6 +6575,7 @@ huggingface = [
 ibm-watsonx-clients = [
     { name = "ibm-cloud-sdk-core" },
     { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11'" },
+    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11'" },
 ]
 jigsawstack = [
     { name = "jigsawstack" },
@@ -6880,6 +6883,7 @@ requires-dist = [
     { name = "ibm-cloud-sdk-core", marker = "extra == 'ibm-watsonx-clients'", specifier = "~=3.24.4" },
     { name = "ibm-watsonx-ai", specifier = ">=1.3.1,<2.0.0" },
     { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11' and extra == 'ibm-watsonx-clients'", specifier = "~=2.7.0" },
+    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11' and extra == 'ibm-watsonx-clients'", specifier = "~=2.7.0" },
     { name = "jaraco-context", specifier = ">=6.1.0" },
     { name = "jigsawstack", marker = "extra == 'jigsawstack'", specifier = "==0.2.7" },
     { name = "jq", marker = "sys_platform != 'win32'", specifier = ">=1.7.0,<2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -6570,7 +6570,7 @@ groq = [
 huggingface = [
     { name = "huggingface-hub", extra = ["inference"] },
 ]
-ibm-watsonx = [
+ibm-watsonx-clients = [
     { name = "ibm-cloud-sdk-core" },
     { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11'" },
 ]
@@ -6877,9 +6877,9 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=22.0.0,<23.0.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27,<1.0.0" },
     { name = "huggingface-hub", extras = ["inference"], marker = "extra == 'huggingface'", specifier = ">=0.23.2,<1.0.0" },
-    { name = "ibm-cloud-sdk-core", marker = "extra == 'ibm-watsonx'", specifier = "~=3.24.4" },
+    { name = "ibm-cloud-sdk-core", marker = "extra == 'ibm-watsonx-clients'", specifier = "~=3.24.4" },
     { name = "ibm-watsonx-ai", specifier = ">=1.3.1,<2.0.0" },
-    { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11' and extra == 'ibm-watsonx'", specifier = "~=2.7.0" },
+    { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11' and extra == 'ibm-watsonx-clients'", specifier = "~=2.7.0" },
     { name = "jaraco-context", specifier = ">=6.1.0" },
     { name = "jigsawstack", marker = "extra == 'jigsawstack'", specifier = "==0.2.7" },
     { name = "jq", marker = "sys_platform != 'win32'", specifier = ">=1.7.0,<2.0.0" },
@@ -6958,7 +6958,7 @@ requires-dist = [
     { name = "langflow-base", extras = ["graph-retriever"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["groq"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["huggingface"], marker = "extra == 'complete'", editable = "src/backend/base" },
-    { name = "langflow-base", extras = ["ibm-watsonx"], marker = "extra == 'complete'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["ibm-watsonx-clients"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["jigsawstack"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["json-repair"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["kubernetes"], marker = "extra == 'complete'", editable = "src/backend/base" },
@@ -7116,7 +7116,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = ">=1.0.0,<2.0.0" },
     { name = "zep-python", marker = "extra == 'zep'", specifier = "==2.0.2" },
 ]
-provides-extras = ["audio", "postgresql", "local", "couchbase", "cassandra", "clickhouse", "mongodb", "supabase", "redis", "elasticsearch", "faiss", "qdrant", "weaviate", "chroma", "upstash", "pinecone", "milvus", "mongodb-vectors", "astradb", "openai", "anthropic", "cohere", "google", "ollama", "nvidia", "mistral", "sambanova", "groq", "llama-cpp", "sentence-transformers", "ctransformers", "langfuse", "langwatch", "langsmith", "arize", "pypdf", "docx", "pytube", "dspy", "smolagents", "beautifulsoup", "serpapi", "google-api", "wikipedia", "fake-useragent", "duckduckgo", "yfinance", "wolframalpha", "pyarrow", "fastavro", "gitpython", "nltk", "lark", "huggingface", "metaphor", "metal", "markup", "aws", "numexpr", "qianfan", "pgvector", "litellm", "zep", "youtube", "markdown", "kubernetes", "json-repair", "astra", "composio", "ragstack", "opensearch", "atlassian", "mem0", "needle", "sseclient", "openinference", "mcp", "ag2", "scrapegraph", "pydantic-ai", "apify", "spider", "altk", "langchain-huggingface", "langchain-unstructured", "graph-retriever", "langchain-mcp-adapters", "opik", "traceloop", "openlayer", "docling", "easyocr", "cleanlab", "twelvelabs", "jigsawstack", "assemblyai", "datasets", "fastparquet", "vlmrun", "cuga", "mlx", "fastmcp", "aioboto3", "astrapy", "gassist", "ibm-watsonx", "complete", "all"]
+provides-extras = ["audio", "postgresql", "local", "couchbase", "cassandra", "clickhouse", "mongodb", "supabase", "redis", "elasticsearch", "faiss", "qdrant", "weaviate", "chroma", "upstash", "pinecone", "milvus", "mongodb-vectors", "astradb", "openai", "anthropic", "cohere", "google", "ollama", "nvidia", "mistral", "sambanova", "groq", "llama-cpp", "sentence-transformers", "ctransformers", "langfuse", "langwatch", "langsmith", "arize", "pypdf", "docx", "pytube", "dspy", "smolagents", "beautifulsoup", "serpapi", "google-api", "wikipedia", "fake-useragent", "duckduckgo", "yfinance", "wolframalpha", "pyarrow", "fastavro", "gitpython", "nltk", "lark", "huggingface", "metaphor", "metal", "markup", "aws", "numexpr", "qianfan", "pgvector", "litellm", "zep", "youtube", "markdown", "kubernetes", "json-repair", "astra", "composio", "ragstack", "opensearch", "atlassian", "mem0", "needle", "sseclient", "openinference", "mcp", "ag2", "scrapegraph", "pydantic-ai", "apify", "spider", "altk", "langchain-huggingface", "langchain-unstructured", "graph-retriever", "langchain-mcp-adapters", "opik", "traceloop", "openlayer", "docling", "easyocr", "cleanlab", "twelvelabs", "jigsawstack", "assemblyai", "datasets", "fastparquet", "vlmrun", "cuga", "mlx", "fastmcp", "aioboto3", "astrapy", "gassist", "ibm-watsonx-clients", "complete", "all"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -4578,27 +4578,29 @@ wheels = [
 
 [[package]]
 name = "ibm-watsonx-orchestrate-clients"
-version = "2.3.2.dev5117"
-source = { registry = "https://test.pypi.org/simple" }
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ibm-cloud-sdk-core", marker = "python_full_version >= '3.11'" },
     { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11'" },
+    { name = "websocket-client", marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/77/95/f202c3578199261afa69d525c7c8212fa2d328fe8ef189deac426685c6a4/ibm_watsonx_orchestrate_clients-2.3.2.dev5117.tar.gz", hash = "sha256:c0d1ce2831dc54ad578afd8fd6f586b160fc5ee9e6bfdfc0b7938c8a1ec0aa16", size = 1255, upload-time = "2026-02-11T13:47:57.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/b4/de4617db62ec12bc846fe671ef95c469b4429658c7d07cbf9a191ef6fddc/ibm_watsonx_orchestrate_clients-2.7.0.tar.gz", hash = "sha256:9c664eb87b16cfaf1e94dc8c36b14d126bdb1af9b4017f05176fd3b656a68528", size = 1880, upload-time = "2026-03-27T23:14:47.305Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/33/11/278075261cdaee932d4844a7ab0a422cdccb055c205b6a9043830d17c43c/ibm_watsonx_orchestrate_clients-2.3.2.dev5117-py3-none-any.whl", hash = "sha256:1248b6f0118043e4021fc9b759adc23a376e8ad806cc0f13f6aecb51b312914b", size = 22247, upload-time = "2026-02-11T13:47:52.677Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/cd/d80c16678aebd90c72000c72393bdf523a2027f86d12dc7815e7594a5dad/ibm_watsonx_orchestrate_clients-2.7.0-py3-none-any.whl", hash = "sha256:d671ebc066e9706dc73f4ee7b0dc87cb23395dde619fb763f04a8614f0447193", size = 52424, upload-time = "2026-03-27T23:14:41.612Z" },
 ]
 
 [[package]]
 name = "ibm-watsonx-orchestrate-core"
-version = "2.3.2.dev5117"
-source = { registry = "https://test.pypi.org/simple" }
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/f0/93/37d2a3b8374e0a8c9550c7b22574659ed6f871ebd9db1719c6952894ffac/ibm_watsonx_orchestrate_core-2.3.2.dev5117.tar.gz", hash = "sha256:4a2cdce1fc762839ce3502bbae2e3236b80bf53341622056b307b8137a5da4b9", size = 1195, upload-time = "2026-02-11T13:47:58.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/5c/7ac8c059044a0e02c46c310d68b8fdf73c644bbdc499eadc3644f9a659f2/ibm_watsonx_orchestrate_core-2.7.0.tar.gz", hash = "sha256:c14e7a1f578e27d57b266bd4baeee82c849186d502083efd71e2c69552177cdd", size = 1216, upload-time = "2026-03-27T23:14:47.843Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/79/9e/e6cea9daf819637807d722f3c00513dd34d31efe50481669928615298167/ibm_watsonx_orchestrate_core-2.3.2.dev5117-py3-none-any.whl", hash = "sha256:5bd64699ae3dad05683bffe2438e38dcffd2b58d2270893d5a4ac3f177b58339", size = 25175, upload-time = "2026-02-11T13:47:53.72Z" },
+    { url = "https://files.pythonhosted.org/packages/55/cd/9799eca2e276cab69a4368f3bbb0d46de7de104f4791444ec3fbd4f726ed/ibm_watsonx_orchestrate_core-2.7.0-py3-none-any.whl", hash = "sha256:d263e3a2588fa09323e06aa2df84dd4b06f2c4f1d03102d9022e7dc9587359cc", size = 39985, upload-time = "2026-03-27T23:14:43.032Z" },
 ]
 
 [[package]]
@@ -6242,6 +6244,8 @@ all = [
     { name = "google-search-results" },
     { name = "graph-retriever" },
     { name = "huggingface-hub", extra = ["inference"] },
+    { name = "ibm-cloud-sdk-core" },
+    { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11'" },
     { name = "jigsawstack" },
     { name = "json-repair" },
     { name = "kubernetes" },
@@ -6410,6 +6414,8 @@ complete = [
     { name = "google-search-results" },
     { name = "graph-retriever" },
     { name = "huggingface-hub", extra = ["inference"] },
+    { name = "ibm-cloud-sdk-core" },
+    { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11'" },
     { name = "jigsawstack" },
     { name = "json-repair" },
     { name = "kubernetes" },
@@ -6567,9 +6573,6 @@ huggingface = [
 ibm-watsonx = [
     { name = "ibm-cloud-sdk-core" },
     { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11'" },
-    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml" },
-    { name = "rich" },
 ]
 jigsawstack = [
     { name = "jigsawstack" },
@@ -6876,8 +6879,7 @@ requires-dist = [
     { name = "huggingface-hub", extras = ["inference"], marker = "extra == 'huggingface'", specifier = ">=0.23.2,<1.0.0" },
     { name = "ibm-cloud-sdk-core", marker = "extra == 'ibm-watsonx'", specifier = "~=3.24.4" },
     { name = "ibm-watsonx-ai", specifier = ">=1.3.1,<2.0.0" },
-    { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11' and extra == 'ibm-watsonx'", specifier = "==2.3.2.dev5117", index = "https://test.pypi.org/simple" },
-    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11' and extra == 'ibm-watsonx'", specifier = "==2.3.2.dev5117", index = "https://test.pypi.org/simple" },
+    { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11' and extra == 'ibm-watsonx'", specifier = "~=2.7.0" },
     { name = "jaraco-context", specifier = ">=6.1.0" },
     { name = "jigsawstack", marker = "extra == 'jigsawstack'", specifier = "==0.2.7" },
     { name = "jq", marker = "sys_platform != 'win32'", specifier = ">=1.7.0,<2.0.0" },
@@ -6956,6 +6958,7 @@ requires-dist = [
     { name = "langflow-base", extras = ["graph-retriever"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["groq"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["huggingface"], marker = "extra == 'complete'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["ibm-watsonx"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["jigsawstack"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["json-repair"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["kubernetes"], marker = "extra == 'complete'", editable = "src/backend/base" },
@@ -7074,13 +7077,11 @@ requires-dist = [
     { name = "python-docx", marker = "extra == 'docx'", specifier = ">=1.1.0" },
     { name = "python-multipart", specifier = ">=0.0.12,<1.0.0" },
     { name = "pytube", marker = "extra == 'pytube'", specifier = "==15.0.0" },
-    { name = "pyyaml", marker = "extra == 'ibm-watsonx'" },
     { name = "qdrant-client", marker = "extra == 'qdrant'", specifier = "==1.9.2" },
     { name = "qianfan", marker = "extra == 'qianfan'", specifier = "==0.3.5" },
     { name = "ragstack-ai-knowledge-store", marker = "extra == 'ragstack'", specifier = "==0.2.1" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.2.1,<6.0.0" },
     { name = "rich", specifier = ">=13.7.0,<14.0.0" },
-    { name = "rich", marker = "extra == 'ibm-watsonx'" },
     { name = "scipy", specifier = ">=1.15.2,<2.0.0" },
     { name = "scrapegraph-py", marker = "extra == 'scrapegraph'", specifier = ">=1.12.0" },
     { name = "sentence-transformers", marker = "extra == 'local'", specifier = ">=2.0.0" },


### PR DESCRIPTION
adds the official `ibm-watsonx-orchestrate-clients` package to the `langflow-base` `complete` installation via optional project dependency `ibm-watsonx-clients`, replacing the existing dev build from Test PyPI, and removing Test PyPI altogether