### PR TITLE
fix: add ON DELETE CASCADE to span.trace_id foreign key

### DIFF
--- a/src/backend/base/langflow/alembic/versions/83cd04b12a34_add_ondelete_cascade_to_span_trace_id_fk.py
+++ b/src/backend/base/langflow/alembic/versions/83cd04b12a34_add_ondelete_cascade_to_span_trace_id_fk.py
@@ -1,0 +1,89 @@
+"""Add ondelete CASCADE to span.trace_id FK
+
+Revision ID: 83cd04b12a34
+Revises: 0e6138e7a0c2
+Create Date: 2026-03-29 12:00:00.000000
+
+Phase: EXPAND
+
+The original migration (3478f0bd6ccb) created the span.trace_id foreign key
+without ondelete="CASCADE". This causes a ForeignKeyViolation when deleting
+flows that have associated traces, because the cascade chain
+flow -> trace -> span is broken at the trace -> span link.
+
+See: https://github.com/langflow-ai/langflow/issues/12346
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+
+# revision identifiers, used by Alembic.
+revision: str = "83cd04b12a34"  # pragma: allowlist secret
+down_revision: str | None = "0e6138e7a0c2"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_fk_constraint_name(conn, table_name: str, column_name: str) -> str | None:
+    """Find the foreign key constraint name for a given column."""
+    inspector = sa.inspect(conn)
+    for fk in inspector.get_foreign_keys(table_name):
+        if column_name in fk["constrained_columns"]:
+            return fk["name"]
+    return None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if not migration.table_exists("span", conn):
+        return
+
+    fk_name = _get_fk_constraint_name(conn, "span", "trace_id")
+
+    if fk_name is None:
+        # No FK exists, create one with CASCADE
+        with op.batch_alter_table("span", schema=None) as batch_op:
+            batch_op.create_foreign_key(
+                "fk_span_trace_id_trace",
+                "trace",
+                ["trace_id"],
+                ["id"],
+                ondelete="CASCADE",
+            )
+    else:
+        # FK exists, recreate it with CASCADE
+        with op.batch_alter_table("span", schema=None) as batch_op:
+            batch_op.drop_constraint(fk_name, type_="foreignkey")
+            batch_op.create_foreign_key(
+                "fk_span_trace_id_trace",
+                "trace",
+                ["trace_id"],
+                ["id"],
+                ondelete="CASCADE",
+            )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    if not migration.table_exists("span", conn):
+        return
+
+    fk_name = _get_fk_constraint_name(conn, "span", "trace_id")
+
+    if fk_name is None:
+        return
+
+    # Revert to FK without CASCADE
+    with op.batch_alter_table("span", schema=None) as batch_op:
+        batch_op.drop_constraint(fk_name, type_="foreignkey")
+        batch_op.create_foreign_key(
+            None,  # Let database auto-generate name
+            "trace",
+            ["trace_id"],
+            ["id"],
+        )

--- a/src/backend/base/langflow/api/utils/core.py
+++ b/src/backend/base/langflow/api/utils/core.py
@@ -354,7 +354,7 @@ async def cascade_delete_flow(session: AsyncSession, flow_id: uuid.UUID) -> None
         # Delete spans before traces (span.trace_id → trace.id FK dependency order).
         await session.exec(
             delete(SpanTable).where(
-                SpanTable.trace_id.in_(  # type: ignore[union-attr]
+                SpanTable.trace_id.in_(  # type: ignore[attr-defined]
                     select(TraceTable.id).where(TraceTable.flow_id == flow_id)
                 )
             )

--- a/src/backend/base/langflow/api/utils/core.py
+++ b/src/backend/base/langflow/api/utils/core.py
@@ -352,9 +352,13 @@ async def cascade_delete_flow(session: AsyncSession, flow_id: uuid.UUID) -> None
         # the existing pattern of explicitly deleting all child records.
         await session.exec(delete(FlowVersion).where(FlowVersion.flow_id == flow_id))
         # Delete spans before traces (span.trace_id → trace.id FK dependency order).
-        await session.exec(delete(SpanTable).where(SpanTable.trace_id.in_(  # type: ignore[union-attr]
-            select(TraceTable.id).where(TraceTable.flow_id == flow_id)
-        )))
+        await session.exec(
+            delete(SpanTable).where(
+                SpanTable.trace_id.in_(  # type: ignore[union-attr]
+                    select(TraceTable.id).where(TraceTable.flow_id == flow_id)
+                )
+            )
+        )
         await session.exec(delete(TraceTable).where(TraceTable.flow_id == flow_id))
         await session.exec(delete(Flow).where(Flow.id == flow_id))
     except Exception as e:

--- a/src/backend/base/langflow/api/utils/core.py
+++ b/src/backend/base/langflow/api/utils/core.py
@@ -12,13 +12,14 @@ from lfx.graph.graph.base import Graph
 from lfx.log.logger import logger
 from lfx.services.deps import injectable_session_scope, injectable_session_scope_readonly, session_scope
 from lfx.utils.validate_cloud import raise_error_if_astra_cloud_disable_component
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from langflow.services.auth.utils import get_current_active_user, get_current_active_user_mcp
 from langflow.services.database.models.flow.model import Flow
 from langflow.services.database.models.flow_version.model import FlowVersion
 from langflow.services.database.models.message.model import MessageTable
+from langflow.services.database.models.traces.model import SpanTable, TraceTable
 from langflow.services.database.models.transactions.model import TransactionTable
 from langflow.services.database.models.user.model import User
 from langflow.services.database.models.vertex_builds.model import VertexBuildTable
@@ -350,6 +351,11 @@ async def cascade_delete_flow(session: AsyncSession, flow_id: uuid.UUID) -> None
         # by default (requires PRAGMA foreign_keys = ON), and this function follows
         # the existing pattern of explicitly deleting all child records.
         await session.exec(delete(FlowVersion).where(FlowVersion.flow_id == flow_id))
+        # Delete spans before traces (span.trace_id → trace.id FK dependency order).
+        await session.exec(delete(SpanTable).where(SpanTable.trace_id.in_(  # type: ignore[union-attr]
+            select(TraceTable.id).where(TraceTable.flow_id == flow_id)
+        )))
+        await session.exec(delete(TraceTable).where(TraceTable.flow_id == flow_id))
         await session.exec(delete(Flow).where(Flow.id == flow_id))
     except Exception as e:
         msg = f"Unable to cascade delete flow: {flow_id}"

--- a/src/backend/base/langflow/services/database/models/traces/model.py
+++ b/src/backend/base/langflow/services/database/models/traces/model.py
@@ -251,7 +251,7 @@ class SpanTable(SpanBase, table=True):  # type: ignore[call-arg]
     __tablename__ = "span"
 
     id: UUID = Field(default_factory=uuid4, primary_key=True)
-    trace_id: UUID = Field(foreign_key="trace.id", index=True, description="Parent trace ID")
+    trace_id: UUID = Field(foreign_key="trace.id", ondelete="CASCADE", index=True, description="Parent trace ID")
     parent_span_id: UUID | None = Field(
         default=None,
         foreign_key="span.id",


### PR DESCRIPTION
## Summary

- Adds Alembic migration to drop and re-create the `span.trace_id` FK with `ON DELETE CASCADE`, completing the cascade chain `flow → trace → span` at the database level
- Updates `SpanTable` model to include `ondelete="CASCADE"` on `trace_id` field so new deployments get the correct schema
- Adds explicit `DELETE` for `SpanTable` and `TraceTable` in `cascade_delete_flow()` for defence in depth, matching the existing pattern for `MessageTable`, `TransactionTable`, `VertexBuildTable`, and `FlowVersion`

Fixes #12346

## Details

The original migration `3478f0bd6ccb` created the `span.trace_id` FK without `ondelete="CASCADE"`. When PostgreSQL cascades a flow deletion through `flow → trace` (which correctly has CASCADE), it then tries to delete `trace` rows but fails because `span` rows still reference them without a cascade rule.

### Changes

| File | Change |
|------|--------|
| `alembic/versions/83cd04b12a34_add_ondelete_cascade_to_span_trace_id_fk.py` | New migration: drops existing FK, re-creates with `ON DELETE CASCADE` |
| `services/database/models/traces/model.py` | Added `ondelete="CASCADE"` to `SpanTable.trace_id` Field |
| `api/utils/core.py` | Added explicit span/trace deletion in `cascade_delete_flow()` |

### Migration safety

- Uses `batch_alter_table` for SQLite compatibility
- Guards with `table_exists` check
- Introspects actual FK constraint name (handles both auto-generated and named constraints)
- Fully reversible `downgrade()` function
- Follows the exact same pattern as existing cascade migrations (`0e6138e7a0c2`, `59a272d6669a`)

## Test plan

- [ ] Run migration against PostgreSQL: `alembic upgrade head`
- [ ] Run migration against SQLite: `alembic upgrade head`
- [ ] Create a flow, execute it to generate traces/spans, then delete the flow — should succeed without `ForeignKeyViolation`
- [ ] Run `alembic downgrade -1` to verify reversibility
- [ ] Verify existing flows without traces can still be deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency by implementing cascade deletion for trace and span records to ensure proper cleanup and prevent orphaned data when flows are deleted.

* **Chores**
  * Updated package dependencies for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->