### PR TITLE
fix(traces): sort spans topologically before DB insert to avoid FK violations

### DIFF
--- a/src/backend/base/langflow/services/tracing/native.py
+++ b/src/backend/base/langflow/services/tracing/native.py
@@ -320,7 +320,36 @@ class NativeTracer(BaseTracer):
                 )
                 await session.merge(trace)
 
-                for span_data in self.completed_spans:
+                # Sort spans so parents are always inserted before their children,
+                # avoiding FK violations when a child span references a parent that
+                # hasn't been persisted yet.
+                def _resolve_uuid(sid: Any) -> str:
+                    if isinstance(sid, UUID_):
+                        return str(sid)
+                    try:
+                        return str(UUID_(sid))
+                    except (ValueError, TypeError):
+                        return str(uuid5(LANGFLOW_SPAN_NAMESPACE, f"{self.trace_id}-{sid}"))
+
+                span_id_set = {_resolve_uuid(s["id"]) for s in self.completed_spans}
+                ordered: list[Any] = []
+                remaining = list(self.completed_spans)
+                max_passes = len(remaining) + 1
+                while remaining and max_passes > 0:
+                    max_passes -= 1
+                    deferred = []
+                    for s in remaining:
+                        pid = s.get("parent_span_id")
+                        if not pid or _resolve_uuid(pid) not in span_id_set or any(
+                            _resolve_uuid(o["id"]) == _resolve_uuid(pid) for o in ordered
+                        ):
+                            ordered.append(s)
+                        else:
+                            deferred.append(s)
+                    remaining = deferred
+                ordered.extend(remaining)  # append any unresolvable cycles rather than dropping them
+
+                for span_data in ordered:
                     try:
                         span_uuid = UUID_(span_data["id"])
                     except (ValueError, TypeError):

--- a/src/backend/base/langflow/services/tracing/native.py
+++ b/src/backend/base/langflow/services/tracing/native.py
@@ -340,8 +340,10 @@ class NativeTracer(BaseTracer):
                     deferred = []
                     for s in remaining:
                         pid = s.get("parent_span_id")
-                        if not pid or _resolve_uuid(pid) not in span_id_set or any(
-                            _resolve_uuid(o["id"]) == _resolve_uuid(pid) for o in ordered
+                        if (
+                            not pid
+                            or _resolve_uuid(pid) not in span_id_set
+                            or any(_resolve_uuid(o["id"]) == _resolve_uuid(pid) for o in ordered)
                         ):
                             ordered.append(s)
                         else:


### PR DESCRIPTION
## Problem

When `_flush_to_database` iterates over `completed_spans` and a child span happens to appear before its parent in the list, the `INSERT INTO span` fails with:

```
psycopg.errors.ForeignKeyViolation: insert or update on table "span" violates
foreign key constraint "fk_span_parent_span_id_span"
DETAIL: Key (parent_span_id)=(...) is not present in table "span".
```

This is a non-deterministic ordering issue — whether it triggers depends on the order spans were completed and appended to `completed_spans`.

## Solution

Before inserting spans, sort them topologically so every parent span is inserted before any of its children. The algorithm:

1. Normalises all span IDs to UUID strings (handling both native `UUID` objects and LangChain string IDs that get `uuid5`-derived).
2. Iterates in passes, moving spans whose parent is already in the `ordered` list (or has no parent, or has a parent outside this trace) to the output.
3. Any spans that remain after `max_passes` (e.g. genuine cycles) are appended rather than silently dropped.

## Related

Companion to #12194 / #12209 (enum constraint violations in the same flush path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace span ordering to correctly handle parent-child relationships when persisting trace data.

* **Chores**
  * Updated google dependency version from 2.30.0 to 2.8.0 across multiple components.
  * Updated component index configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->