### PR TITLE
fix(ui): guard credential clear effect against empty globalVariables

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
@@ -54,15 +54,23 @@ export default function InputGlobalComponent({
     handleOnNewValue,
   );
 
-  // Clean up when selected variable no longer exists
+  // Clean up when selected variable no longer exists.
+  // Guard against empty globalVariables (still loading) to avoid clearing
+  // the value before variables have been fetched — same guard used in useInitialLoad.
   useEffect(() => {
-    if (loadFromDb && currentValue && !valueExists && !isDisabled) {
+    if (
+      loadFromDb &&
+      currentValue &&
+      !valueExists &&
+      !isDisabled &&
+      typedGlobalVariables.length > 0
+    ) {
       handleOnNewValue(
         { value: "", load_from_db: false },
         { skipSnapshot: true },
       );
     }
-  }, [loadFromDb, currentValue, valueExists, isDisabled, handleOnNewValue]);
+  }, [loadFromDb, currentValue, valueExists, isDisabled, handleOnNewValue, typedGlobalVariables.length]);
 
   // Create handlers object for better organization
   const handlers: GlobalVariableHandlers = {

--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
@@ -70,7 +70,14 @@ export default function InputGlobalComponent({
         { skipSnapshot: true },
       );
     }
-  }, [loadFromDb, currentValue, valueExists, isDisabled, handleOnNewValue, typedGlobalVariables.length]);
+  }, [
+    loadFromDb,
+    currentValue,
+    valueExists,
+    isDisabled,
+    handleOnNewValue,
+    typedGlobalVariables.length,
+  ]);
 
   // Create handlers object for better organization
   const handlers: GlobalVariableHandlers = {


### PR DESCRIPTION
## Summary

- When navigating to a flow (not hard refresh), credential/global variable fields appear blank
- The cleanup effect in `InputGlobalComponent` fires before `globalVariables` has been fetched from the API
- React Query returns `[]` while loading, so `valueExists` is `false` even when the variable exists — causing the effect to wipe the value
- On hard refresh the bug doesn't appear because React Query returns cached data immediately, so `valueExists` is already `true` when the component mounts

**Root cause** (`inputGlobalComponent/index.tsx`):
```ts
// fires while globalVariables is still [] (loading)
useEffect(() => {
  if (loadFromDb && currentValue && !valueExists && !isDisabled) {
    handleOnNewValue({ value: "", load_from_db: false }, ...);
  }
}, [...]);
```

**Fix:** add `typedGlobalVariables.length > 0` guard — the same guard already used in `useInitialLoad` in `hooks.ts` — so the cleanup only runs once variables are known to be loaded.

## Test plan

- [ ] Open a flow that has a credential/global variable set on a component (e.g. an API key field with `load_from_db: true`)
- [ ] Navigate to that flow from the flows list (do not hard refresh)
- [ ] Verify the credential field shows the selected variable name, not blank
- [ ] Delete a global variable that is referenced by a flow component, navigate to that flow — verify the field correctly clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where input field values would reset unexpectedly while global variables were loading, ensuring user input is preserved during the loading phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->