### PR TITLE
feat: add frontend support for new content block types

### DIFF
--- a/src/frontend/src/components/core/chatComponents/ContentBlockDisplay.tsx
+++ b/src/frontend/src/components/core/chatComponents/ContentBlockDisplay.tsx
@@ -8,7 +8,7 @@ import {
   formatTime,
   formatToolTitle,
 } from "@/components/core/playgroundComponent/chat-view/chat-messages/utils/format";
-import type { ContentBlock } from "@/types/chat";
+import type { ContentBlock, ContentBlockItem, ContentType } from "@/types/chat";
 import { cn } from "@/utils/utils";
 import ForwardedIconComponent from "../../common/genericIconComponent";
 import {
@@ -20,8 +20,13 @@ import {
 import ContentDisplay from "./ContentDisplay";
 import DurationDisplay from "./DurationDisplay";
 
+/** Type guard: returns true for grouped ContentBlock items (with title + contents). */
+function isGroupedBlock(item: ContentBlockItem): item is ContentBlock {
+  return "contents" in item && "title" in item;
+}
+
 interface ContentBlockDisplayProps {
-  contentBlocks: ContentBlock[];
+  contentBlocks: ContentBlockItem[];
   isLoading?: boolean;
   state?: string;
   chatId: string;
@@ -39,13 +44,19 @@ export function ContentBlockDisplay({
 }: ContentBlockDisplayProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // Use shared hook for tool duration tracking
+  // Separate flat content items from grouped blocks
+  const groupedBlocks = contentBlocks.filter(isGroupedBlock);
+  const flatItems = contentBlocks.filter(
+    (item): item is ContentType => !isGroupedBlock(item),
+  );
+
+  // Use shared hook for tool duration tracking (only grouped blocks)
   const { toolElapsedTimes, toolItems } = useToolDurations(
-    contentBlocks,
+    groupedBlocks.length > 0 ? groupedBlocks : undefined,
     isLoading ?? false,
   );
 
-  if (!toolItems.length) {
+  if (!toolItems.length && !flatItems.length) {
     return null;
   }
 
@@ -65,121 +76,141 @@ export function ContentBlockDisplay({
 
   return (
     <div className="relative py-3">
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{
-          duration: 0.15,
-          ease: "easeOut",
-        }}
-        className={cn("relative rounded-lg bg-transparent", "overflow-hidden")}
-      >
-        {isLoading && (
-          <BorderTrail
-            size={100}
-            transition={{
-              repeat: Infinity,
-              duration: 10,
-              ease: "linear",
-            }}
-          />
-        )}
-        {!hideHeader && (
-          <div className="flex items-center justify-between p-4">
-            <div className="flex items-center gap-2 align-baseline">
-              {headerIcon && (
-                <span data-testid="header-icon">
-                  <ForwardedIconComponent
-                    name={headerIcon}
-                    className={cn(
-                      "h-4 w-4",
-                      state !== "partial" && "text-accent-emerald-foreground",
-                    )}
-                    strokeWidth={1.5}
-                  />
-                </span>
-              )}
-              <p className="m-0 flex items-center gap-2 text-sm font-semibold text-primary">
-                {headerTitle}
-              </p>
+      {/* Render flat content items directly (no accordion wrapping) */}
+      {flatItems.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {flatItems.map((item, idx) => (
+            <ContentDisplay
+              key={`flat-${idx}`}
+              content={item}
+              chatId={`${chatId}-flat-${idx}`}
+              playgroundPage={playgroundPage}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Render grouped blocks with accordion UI */}
+      {toolItems.length > 0 && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{
+            duration: 0.15,
+            ease: "easeOut",
+          }}
+          className={cn(
+            "relative rounded-lg bg-transparent",
+            "overflow-hidden",
+          )}
+        >
+          {isLoading && (
+            <BorderTrail
+              size={100}
+              transition={{
+                repeat: Infinity,
+                duration: 10,
+                ease: "linear",
+              }}
+            />
+          )}
+          {!hideHeader && (
+            <div className="flex items-center justify-between p-4">
+              <div className="flex items-center gap-2 align-baseline">
+                {headerIcon && (
+                  <span data-testid="header-icon">
+                    <ForwardedIconComponent
+                      name={headerIcon}
+                      className={cn(
+                        "h-4 w-4",
+                        state !== "partial" && "text-accent-emerald-foreground",
+                      )}
+                      strokeWidth={1.5}
+                    />
+                  </span>
+                )}
+                <p className="m-0 flex items-center gap-2 text-sm font-semibold text-primary">
+                  {headerTitle}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                {!playgroundPage && (
+                  <DurationDisplay duration={totalDuration} chatId={chatId} />
+                )}
+                <motion.div
+                  animate={{ rotate: isExpanded ? 180 : 0 }}
+                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                  onClick={() => setIsExpanded((prev) => !prev)}
+                  className="cursor-pointer"
+                >
+                  <ChevronDown className="h-5 w-5" />
+                </motion.div>
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              {!playgroundPage && (
-                <DurationDisplay duration={totalDuration} chatId={chatId} />
-              )}
-              <motion.div
-                animate={{ rotate: isExpanded ? 180 : 0 }}
-                transition={{ duration: 0.2, ease: "easeInOut" }}
-                onClick={() => setIsExpanded((prev) => !prev)}
-                className="cursor-pointer"
+          )}
+
+          {(hideHeader || isExpanded) && (
+            <div className="flex flex-col gap-2">
+              <Accordion
+                type="multiple"
+                className="w-full bg-transparent flex flex-col gap-2"
               >
-                <ChevronDown className="h-5 w-5" />
-              </motion.div>
+                {toolItems.map(
+                  ({ content, toolKey, blockIndex, contentIndex }, flatIdx) => {
+                    const rawTitle =
+                      content.header?.title ||
+                      content.name ||
+                      `Tool ${flatIdx + 1}`;
+                    const toolTitle =
+                      typeof rawTitle === "string"
+                        ? formatToolTitle(rawTitle)
+                        : rawTitle;
+                    const toolDuration =
+                      toolElapsedTimes[toolKey] ?? content.duration ?? 0;
+
+                    return (
+                      <AccordionItem
+                        key={toolKey}
+                        value={toolKey}
+                        className="border border-border rounded-lg overflow-hidden bg-background"
+                      >
+                        <AccordionTrigger className="hover:bg-muted hover:no-underline px-3 py-2.5">
+                          <div className="flex items-center justify-between w-full pr-2">
+                            <div className="flex items-center gap-1 text-sm font-normal min-w-0 flex-1 overflow-hidden">
+                              <div className="text-muted-foreground whitespace-nowrap flex-shrink-0">
+                                Called tool{" "}
+                              </div>
+                              <div className="truncate flex-1 muted-foreground bg-muted py-1 px-1.5 rounded-sm text-xs max-w-fit">
+                                <p className="truncate font-normal font-mono">
+                                  {toolTitle}
+                                </p>
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <span className="text-xs text-accent-emerald-foreground">
+                                {formatTime(toolDuration, true)}
+                              </span>
+                            </div>
+                          </div>
+                        </AccordionTrigger>
+                        <AccordionContent className="pt-0">
+                          <div className="text-sm text-muted-foreground px-4 pb-4 max-h-96 overflow-auto">
+                            <ContentDisplay
+                              playgroundPage={playgroundPage}
+                              content={content}
+                              chatId={`${chatId}-${blockIndex}-${contentIndex}`}
+                            />
+                          </div>
+                        </AccordionContent>
+                      </AccordionItem>
+                    );
+                  },
+                )}
+              </Accordion>
             </div>
-          </div>
-        )}
-
-        {(hideHeader || isExpanded) && (
-          <div className="flex flex-col gap-2">
-            <Accordion
-              type="multiple"
-              className="w-full bg-transparent flex flex-col gap-2"
-            >
-              {toolItems.map(
-                ({ content, toolKey, blockIndex, contentIndex }, flatIdx) => {
-                  const rawTitle =
-                    content.header?.title ||
-                    content.name ||
-                    `Tool ${flatIdx + 1}`;
-                  const toolTitle =
-                    typeof rawTitle === "string"
-                      ? formatToolTitle(rawTitle)
-                      : rawTitle;
-                  const toolDuration =
-                    toolElapsedTimes[toolKey] ?? content.duration ?? 0;
-
-                  return (
-                    <AccordionItem
-                      key={toolKey}
-                      value={toolKey}
-                      className="border border-border rounded-lg overflow-hidden bg-background"
-                    >
-                      <AccordionTrigger className="hover:bg-muted hover:no-underline px-3 py-2.5">
-                        <div className="flex items-center justify-between w-full pr-2">
-                          <div className="flex items-center gap-1 text-sm font-normal min-w-0 flex-1 overflow-hidden">
-                            <div className="text-muted-foreground whitespace-nowrap flex-shrink-0">
-                              Called tool{" "}
-                            </div>
-                            <div className="truncate flex-1 muted-foreground bg-muted py-1 px-1.5 rounded-sm text-xs max-w-fit">
-                              <p className="truncate font-normal font-mono">
-                                {toolTitle}
-                              </p>
-                            </div>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <span className="text-xs text-accent-emerald-foreground">
-                              {formatTime(toolDuration, true)}
-                            </span>
-                          </div>
-                        </div>
-                      </AccordionTrigger>
-                      <AccordionContent className="pt-0">
-                        <div className="text-sm text-muted-foreground px-4 pb-4 max-h-96 overflow-auto">
-                          <ContentDisplay
-                            playgroundPage={playgroundPage}
-                            content={content}
-                            chatId={`${chatId}-${blockIndex}-${contentIndex}`}
-                          />
-                        </div>
-                      </AccordionContent>
-                    </AccordionItem>
-                  );
-                },
-              )}
-            </Accordion>
-          </div>
-        )}
-      </motion.div>
+          )}
+        </motion.div>
+      )}
     </div>
   );
 }

--- a/src/frontend/src/components/core/chatComponents/ContentDisplay.tsx
+++ b/src/frontend/src/components/core/chatComponents/ContentDisplay.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+import { type ReactNode, useState } from "react";
 import Markdown from "react-markdown";
 import rehypeMathjax from "rehype-mathjax/browser";
 import remarkGfm from "remark-gfm";
@@ -242,12 +243,183 @@ export default function ContentDisplay({
         </div>
       );
       break;
+
+    case "image":
+      contentData = (
+        <div className="flex flex-col gap-2">
+          {content.urls?.map((url, index) => (
+            <img
+              key={index}
+              src={url}
+              alt={content.caption || `Image ${index + 1}`}
+              className="max-w-full rounded"
+            />
+          ))}
+          {content.base64 && (
+            <img
+              src={`data:${content.mime_type || "image/png"};base64,${content.base64}`}
+              alt={content.caption || "Image"}
+              className="max-w-full rounded"
+            />
+          )}
+          {content.caption && (
+            <p className="text-xs text-muted-foreground">{content.caption}</p>
+          )}
+        </div>
+      );
+      break;
+
+    case "audio":
+      contentData = (
+        <div className="flex flex-col gap-2">
+          {content.urls?.map((url, index) => (
+            <audio key={index} controls className="w-full">
+              <source src={url} type={content.mime_type} />
+            </audio>
+          ))}
+          {content.base64 && (
+            <audio controls className="w-full">
+              <source
+                src={`data:${content.mime_type || "audio/mpeg"};base64,${content.base64}`}
+                type={content.mime_type || "audio/mpeg"}
+              />
+            </audio>
+          )}
+          {content.transcript && (
+            <p className="text-xs text-muted-foreground italic">
+              {content.transcript}
+            </p>
+          )}
+        </div>
+      );
+      break;
+
+    case "video":
+      contentData = (
+        <div className="flex flex-col gap-2">
+          {content.urls?.map((url, index) => (
+            <video key={index} controls className="max-w-full rounded">
+              <source src={url} type={content.mime_type} />
+            </video>
+          ))}
+          {content.base64 && (
+            <video controls className="max-w-full rounded">
+              <source
+                src={`data:${content.mime_type || "video/mp4"};base64,${content.base64}`}
+                type={content.mime_type || "video/mp4"}
+              />
+            </video>
+          )}
+        </div>
+      );
+      break;
+
+    case "file":
+      contentData = (
+        <div className="flex items-center gap-2">
+          <ForwardedIconComponent
+            name="File"
+            className="h-4 w-4 text-muted-foreground"
+          />
+          {content.urls?.map((url, index) => (
+            <a
+              key={index}
+              href={url}
+              download={content.filename}
+              className="text-sm underline text-primary hover:text-primary/80"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {content.filename || `Download file ${index + 1}`}
+            </a>
+          ))}
+        </div>
+      );
+      break;
+
+    case "reasoning":
+      contentData = <ReasoningDisplay text={content.text} />;
+      break;
+
+    case "usage":
+      contentData = (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {content.model && (
+            <span className="font-medium">{content.model}</span>
+          )}
+          <span>
+            Tokens:{" "}
+            {content.input_tokens !== undefined
+              ? `${content.input_tokens} in`
+              : ""}
+            {content.input_tokens !== undefined &&
+            content.output_tokens !== undefined
+              ? " / "
+              : ""}
+            {content.output_tokens !== undefined
+              ? `${content.output_tokens} out`
+              : ""}
+          </span>
+        </div>
+      );
+      break;
+
+    case "citation":
+      contentData = (
+        <div className="flex flex-col gap-1 text-sm">
+          {content.url ? (
+            <a
+              href={content.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline text-primary hover:text-primary/80"
+            >
+              {content.title || content.url}
+            </a>
+          ) : (
+            content.title && (
+              <span className="font-medium">{content.title}</span>
+            )
+          )}
+          {content.cited_text && (
+            <blockquote className="border-l-2 border-muted-foreground/30 pl-3 text-xs text-muted-foreground italic">
+              {content.cited_text}
+            </blockquote>
+          )}
+        </div>
+      );
+      break;
   }
 
   return (
     <div className="relative p-[16px]">
       {renderDuration}
       {contentData}
+    </div>
+  );
+}
+
+/** Collapsible "Thinking" section for reasoning content. */
+function ReasoningDisplay({ text }: { text: string }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <ChevronDown
+          className={`h-3 w-3 transition-transform ${isOpen ? "rotate-180" : ""}`}
+        />
+        Thinking
+      </button>
+      {isOpen && (
+        <div className="pl-4 text-xs text-muted-foreground whitespace-pre-wrap border-l-2 border-muted-foreground/20">
+          {text}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/chat-message.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/chat-message.tsx
@@ -1,9 +1,15 @@
 import { useEffect, useState } from "react";
 import useFlowStore from "@/stores/flowStore";
+import type { ContentBlock, ContentBlockItem } from "@/types/chat";
 import type { chatMessagePropsType } from "@/types/components";
 import { BotMessage } from "./bot-message";
 import { ErrorView } from "./error-message";
 import { UserMessage } from "./user-message";
+
+/** Type guard: returns true for grouped ContentBlock items (with title + contents). */
+function isGroupedBlock(item: ContentBlockItem): item is ContentBlock {
+  return "contents" in item && "title" in item;
+}
 
 export default function ChatMessage({
   chat,
@@ -27,7 +33,7 @@ export default function ChatMessage({
 
   // Error messages
   if (chat.category === "error") {
-    const blocks = chat.content_blocks ?? [];
+    const blocks = (chat.content_blocks ?? []).filter(isGroupedBlock);
     return (
       <ErrorView
         blocks={blocks}

--- a/src/frontend/src/types/chat/index.ts
+++ b/src/frontend/src/types/chat/index.ts
@@ -25,7 +25,7 @@ export type ChatMessageType = {
   icon?: string;
   category?: string;
   properties?: PropertiesType;
-  content_blocks?: ContentBlock[];
+  content_blocks?: ContentBlockItem[];
 };
 
 export type SourceType = {
@@ -126,6 +126,59 @@ export interface ToolContent extends BaseContent {
   error?: JSONValue | string;
 }
 
+export interface ImageContent extends BaseContent {
+  type: "image";
+  urls?: string[];
+  base64?: string;
+  mime_type?: string;
+  caption?: string;
+}
+
+export interface AudioContent extends BaseContent {
+  type: "audio";
+  urls?: string[];
+  base64?: string;
+  mime_type?: string;
+  duration?: number;
+  transcript?: string;
+}
+
+export interface VideoContent extends BaseContent {
+  type: "video";
+  urls?: string[];
+  base64?: string;
+  mime_type?: string;
+  duration?: number;
+}
+
+export interface FileContent extends BaseContent {
+  type: "file";
+  urls?: string[];
+  mime_type?: string;
+  filename?: string;
+}
+
+export interface ReasoningContent extends BaseContent {
+  type: "reasoning";
+  text: string;
+}
+
+export interface UsageContent extends BaseContent {
+  type: "usage";
+  input_tokens?: number;
+  output_tokens?: number;
+  model?: string;
+}
+
+export interface CitationContent extends BaseContent {
+  type: "citation";
+  url?: string;
+  title?: string;
+  cited_text?: string;
+  start_index?: number;
+  end_index?: number;
+}
+
 // Union type for all content types
 export type ContentType =
   | ErrorContent
@@ -133,7 +186,14 @@ export type ContentType =
   | MediaContent
   | JSONContent
   | CodeContent
-  | ToolContent;
+  | ToolContent
+  | ImageContent
+  | AudioContent
+  | VideoContent
+  | FileContent
+  | ReasoningContent
+  | UsageContent
+  | CitationContent;
 
 // Updated ContentBlock interface
 export interface ContentBlock {
@@ -144,6 +204,9 @@ export interface ContentBlock {
   component: string;
 }
 
+// A content block item can be either a grouped ContentBlock or a flat ContentType
+export type ContentBlockItem = ContentType | ContentBlock;
+
 export interface PlaygroundEvent {
   event_type: "message" | "error" | "warning" | "info" | "token";
   background_color?: string;
@@ -151,7 +214,7 @@ export interface PlaygroundEvent {
   allow_markdown?: boolean;
   icon?: string | null;
   sender_name: string;
-  content_blocks?: ContentBlock[] | null;
+  content_blocks?: ContentBlockItem[] | null;
   files?: string[];
   text?: string;
   timestamp?: string;

--- a/src/frontend/src/types/messages/index.ts
+++ b/src/frontend/src/types/messages/index.ts
@@ -1,4 +1,4 @@
-import type { ContentBlock } from "../chat";
+import type { ContentBlockItem } from "../chat";
 
 type Message = {
   flow_id: string;
@@ -30,7 +30,7 @@ type Message = {
     build_duration?: number | null;
     [key: string]: unknown;
   };
-  content_blocks?: ContentBlock[];
+  content_blocks?: ContentBlockItem[];
 };
 
 export type { Message };


### PR DESCRIPTION
## Summary

Adds TypeScript types and renderers for the 7 new content types introduced in #12367.

- New content type interfaces: ImageContent, AudioContent, VideoContent, FileContent, ReasoningContent, UsageContent, CitationContent
- ContentBlockItem union type for mixed flat/grouped content
- ContentBlockDisplay handles both flat ContentType items and grouped ContentBlock items
- ContentDisplay renders all new types (image, audio, video, file, reasoning, usage, citation)
- ErrorView filtering for grouped blocks in chat-message component

Depends on #12367 (backend).