### PR TITLE
fix: Add platform markers to cuga extra for macOS x86_64

### DIFF
--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -339,7 +339,10 @@ fastparquet = ["fastparquet>=2024.11.0,<2025.0.0"]
 
 # Vision / ML
 vlmrun = ["vlmrun[all]>=0.2.0"]
-cuga = ["cuga>=0.2.10"]
+cuga = [
+    "cuga>=0.2.10; sys_platform != 'darwin'",
+    "cuga>=0.2.10; sys_platform == 'darwin' and platform_machine == 'arm64'",
+]
 mlx = [
     "mlx>=0.29.0; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version >= '3.12'",
     "mlx-vlm~=0.3.9; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version >= '3.12'",


### PR DESCRIPTION
OBJECTIVE: Fix CI dependency resolution failure caused by torch having no compatible wheels for macOS x86_64 with Python 3.13.           
  
CHANGES:                                                                                                                                 
  - Add environment markers to cuga optional dependency to exclude macOS x86_64
  - Split cuga extra into two entries: one for non-darwin platforms and one for darwin ARM64 only