### PR TITLE
fix(deps): pin tar-fs to >=2.1.4 to fix symlink following vulnerabili…

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -7,6 +7,7 @@
   },
   "overrides": {
     "tar": "^7.5.7",
+    "tar-fs": ">=2.1.4",
     "glob": "^11.1.0",
     "test-exclude": "^7.0.0"
   },


### PR DESCRIPTION
…ty (#12078)

Adds override for tar-fs in package.json to ensure versions prior to 2.1.4 are never resolved. Addresses CVE in tar-fs <2.1.4 (PVR0686558) where symlink validation bypass was possible with a crafted tarball.