### PR TITLE
feat(mcp): make MCP tool call timeout configurable

### DIFF
--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -65,6 +65,11 @@ def get_session_cleanup_interval() -> int:
     return _get_mcp_setting("mcp_session_cleanup_interval")
 
 
+def get_tool_timeout() -> int:
+    """Get per-tool call timeout in seconds."""
+    return _get_mcp_setting("mcp_tool_timeout")
+
+
 # RFC 7230 compliant header name pattern: token = 1*tchar
 # tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
 #         "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
@@ -1166,7 +1171,7 @@ class MCPStdioClient:
 
                 result = await asyncio.wait_for(
                     session.call_tool(tool_name, arguments=arguments),
-                    timeout=30.0,  # 30 second timeout
+                    timeout=get_tool_timeout(),
                 )
             except Exception as e:
                 current_error_type = type(e).__name__
@@ -1438,7 +1443,7 @@ class MCPStreamableHttpClient:
 
                 result = await asyncio.wait_for(
                     session.call_tool(tool_name, arguments=arguments),
-                    timeout=30.0,  # 30 second timeout
+                    timeout=get_tool_timeout(),
                 )
             except Exception as e:
                 current_error_type = type(e).__name__

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -112,6 +112,10 @@ class Settings(BaseSettings):
     """Frequency (in seconds) at which the background cleanup task wakes up to
     reap idle sessions."""
 
+    mcp_tool_timeout: int = 30  # seconds
+    """How long (in seconds) to wait for a single MCP tool call to complete before
+    raising a TimeoutError. Increase for long-running tools like page generators."""
+
     # sqlite configuration
     sqlite_pragmas: dict | None = {"synchronous": "NORMAL", "journal_mode": "WAL", "busy_timeout": 30000}
     """SQLite pragmas to use when connecting to the database."""


### PR DESCRIPTION
## Summary

- The 30-second timeout on MCP tool calls was hard-coded in both `MCPStdioClient.run_tool` and `MCPStreamableHttpClient.run_tool` with no way to override it
- Long-running tools (e.g. page generators, heavy AI tasks) consistently hit the limit and fail after two attempts with `TimeoutError`
- Adds `mcp_tool_timeout: int = 30` to `Settings` — default preserves existing behaviour
- Replaces both hard-coded `timeout=30.0` values with `get_tool_timeout()`, following the same lazy-loaded settings pattern already used for `mcp_session_idle_timeout` and `mcp_session_cleanup_interval`
- Override via `LANGFLOW_MCP_TOOL_TIMEOUT` env var

## Test plan

- [ ] Run an MCP tool that completes within 30s — behaviour unchanged
- [ ] Set `LANGFLOW_MCP_TOOL_TIMEOUT=120` and run a tool that takes >30s — should complete instead of timing out
- [ ] Confirm both stdio and streamable HTTP transports respect the setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout setting for MCP tool execution (default: 30 seconds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->