### PR TITLE
feat(deployments): surface tool_ids in WXO API for explicit tool control

### DIFF
--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -70,6 +70,8 @@ from langflow.api.v1.schemas.deployments import (
     ExecutionCreateResponse,
     ExecutionStatusResponse,
     FlowVersionIdsQuery,
+    SnapshotUpdateRequest,
+    SnapshotUpdateResponse,
 )
 from langflow.services.adapters.deployment.context import deployment_provider_scope
 from langflow.services.database.models.deployment.crud import (
@@ -103,6 +105,7 @@ from langflow.services.database.models.deployment_provider_account.crud import (
     update_provider_account as update_provider_account_row,
 )
 from langflow.services.database.models.flow_version_deployment_attachment.crud import (
+    get_attachment_by_provider_snapshot_id,
     list_deployment_attachments,
 )
 
@@ -857,6 +860,97 @@ async def list_deployment_snapshots(
         snapshot_result,
         page=page,
         size=size,
+    )
+
+
+@router.patch(
+    "/snapshots/{provider_snapshot_id}",
+    response_model=SnapshotUpdateResponse,
+)
+async def update_snapshot(
+    provider_snapshot_id: Annotated[
+        str,
+        Path(min_length=1, description="Provider-owned snapshot identifier (e.g. WXO tool_id)."),
+    ],
+    *,
+    body: SnapshotUpdateRequest,
+    session: DbSession,
+    current_user: CurrentActiveUser,
+):
+    """Replace an existing provider snapshot's content with a new flow version.
+
+    Resolves the deployment context from the attachment record linked to
+    ``provider_snapshot_id``.  Only Langflow-tracked snapshots (those with
+    a ``flow_version_deployment_attachment`` row) can be updated.
+    """
+    from langflow.services.database.models.deployment.crud import get_deployment as get_deployment_row
+    from langflow.services.database.models.flow_version.crud import get_flow_version_entry
+
+    attachment = await get_attachment_by_provider_snapshot_id(
+        session,
+        user_id=current_user.id,
+        provider_snapshot_id=provider_snapshot_id.strip(),
+    )
+    if attachment is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No attachment found for provider_snapshot_id '{provider_snapshot_id}'.",
+        )
+
+    deployment = await get_deployment_row(
+        session,
+        user_id=current_user.id,
+        deployment_id=attachment.deployment_id,
+    )
+    if deployment is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Deployment for attachment (deployment_id={attachment.deployment_id}) not found.",
+        )
+
+    flow_version = await get_flow_version_entry(
+        session,
+        version_id=body.flow_version_id,
+        user_id=current_user.id,
+    )
+    if flow_version is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Flow version '{body.flow_version_id}' not found.",
+        )
+    if flow_version.data is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Flow version '{body.flow_version_id}' has no data.",
+        )
+
+    provider_account = await get_owned_provider_account_or_404(
+        provider_id=deployment.deployment_provider_account_id,
+        user_id=current_user.id,
+        db=session,
+    )
+    deployment_adapter = resolve_deployment_adapter(provider_account.provider_key)
+
+    flow_definition = dict(flow_version.data)
+    flow_definition["id"] = str(flow_version.flow_id)
+
+    with handle_adapter_errors(), deployment_provider_scope(deployment.deployment_provider_account_id):
+        await deployment_adapter.update_snapshot(
+            user_id=current_user.id,
+            db=session,
+            provider_snapshot_id=provider_snapshot_id.strip(),
+            flow_definition=flow_definition,
+            project_id=str(deployment.project_id),
+        )
+
+    attachment.flow_version_id = body.flow_version_id
+    session.add(attachment)
+    await session.commit()
+    await session.refresh(attachment)
+
+    return SnapshotUpdateResponse(
+        flow_version_id=body.flow_version_id,
+        provider_snapshot_id=provider_snapshot_id.strip(),
     )
 
 

--- a/src/backend/base/langflow/api/v1/flow_version.py
+++ b/src/backend/base/langflow/api/v1/flow_version.py
@@ -160,8 +160,44 @@ async def list_flow_versions(
         )
 
     max_entries = get_settings_service().settings.max_flow_version_entries_per_flow
+    entries = [_version_to_read(entry, is_deployed=is_deployed) for entry, is_deployed in rows]
+
+    if deployment_ids and has_providers:
+        from langflow.api.v1.mappers.deployments.helpers import build_deployment_info_map
+        from langflow.api.v1.schemas.flow_versions import (
+            FlowVersionReadWithDeployments,
+            FlowVersionWithDeploymentsListResponse,
+        )
+
+        try:
+            dep_info_map = await build_deployment_info_map(
+                db=session,
+                user_id=current_user.id,
+                deployment_ids=deployment_ids,
+                flow_version_ids={e.id for e in entries},
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Deployment enrichment failed for flow %s; returning without tool metadata",
+                flow_id,
+                exc_info=True,
+            )
+            dep_info_map = {}
+
+        enriched_entries = [
+            FlowVersionReadWithDeployments(
+                **entry.model_dump(),
+                deployments=dep_info_map.get(entry.id, []),
+            )
+            for entry in entries
+        ]
+        return FlowVersionWithDeploymentsListResponse(
+            entries=enriched_entries,
+            max_entries=max_entries,
+        )
+
     return FlowVersionListResponse(
-        entries=[_version_to_read(entry, is_deployed=is_deployed) for entry, is_deployed in rows],
+        entries=entries,
         max_entries=max_entries,
     )
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -1127,3 +1127,116 @@ def to_deployment_create_response(
         updated_at=deployment_row.updated_at,
         provider_data=payload.get("provider_result"),
     )
+
+
+async def build_deployment_info_map(
+    *,
+    db: DbSession,
+    user_id: UUID,
+    deployment_ids: list[UUID],
+    flow_version_ids: set[UUID],
+) -> dict[UUID, list[Any]]:
+    """Build a flow_version_id -> deployment-info list mapping.
+
+    Returns a dict keyed by ``flow_version_id``, each value a list of
+    ``FlowVersionDeploymentInfo``.  The caller is responsible for
+    assembling these into the API response.
+    """
+    from collections import defaultdict
+
+    from langflow.api.v1.schemas.flow_versions import FlowVersionDeploymentInfo
+    from langflow.services.database.models.flow_version_deployment_attachment.crud import (
+        list_attachments_by_deployment_ids,
+    )
+
+    if not deployment_ids or not flow_version_ids:
+        return {}
+
+    attachments = await list_attachments_by_deployment_ids(
+        db,
+        user_id=user_id,
+        deployment_ids=deployment_ids,
+    )
+    relevant_attachments = [att for att in attachments if att.flow_version_id in flow_version_ids]
+    if not relevant_attachments:
+        return {}
+
+    dep_ids = list({att.deployment_id for att in relevant_attachments})
+    dep_rows_by_id: dict[UUID, Deployment] = {}
+    for dep_id in dep_ids:
+        dep_row = await get_deployment_db(db, user_id=user_id, deployment_id=dep_id)
+        if dep_row:
+            dep_rows_by_id[dep_id] = dep_row
+
+    snapshot_ids = [
+        att.provider_snapshot_id
+        for att in relevant_attachments
+        if att.provider_snapshot_id and str(att.provider_snapshot_id).strip()
+    ]
+    tool_name_by_id: dict[str, str] = {}
+    if snapshot_ids:
+        providers_by_key: dict[str, list[str]] = defaultdict(list)
+        for att in relevant_attachments:
+            if not att.provider_snapshot_id:
+                continue
+            dep_row = dep_rows_by_id.get(att.deployment_id)
+            if not dep_row:
+                continue
+            prov_acct = await get_provider_account_or_none(
+                provider_id=dep_row.deployment_provider_account_id,
+                user_id=user_id,
+                db=db,
+            )
+            if prov_acct:
+                providers_by_key[prov_acct.provider_key].append(str(att.provider_snapshot_id))
+
+        for provider_key, tool_ids_for_provider in providers_by_key.items():
+            try:
+                adapter = get_deployment_adapter(provider_key)
+                if adapter is None:
+                    continue
+                unique_tool_ids = list(dict.fromkeys(tool_ids_for_provider))
+                snapshot_result = await adapter.list_snapshots(
+                    user_id=user_id,
+                    db=db,
+                    params=SnapshotListParams(snapshot_ids=unique_tool_ids),
+                )
+                for snap in snapshot_result.snapshots:
+                    if snap.id:
+                        tool_name_by_id[str(snap.id)] = snap.name or str(snap.id)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to enrich tool names for provider_key=%s; names will be omitted",
+                    provider_key,
+                    exc_info=True,
+                )
+
+    result: dict[UUID, list[FlowVersionDeploymentInfo]] = defaultdict(list)
+    for att in relevant_attachments:
+        tool_id = str(att.provider_snapshot_id).strip() if att.provider_snapshot_id else None
+        result[att.flow_version_id].append(
+            FlowVersionDeploymentInfo(
+                deployment_id=att.deployment_id,
+                tool_id=tool_id or None,
+                tool_name=tool_name_by_id.get(tool_id) if tool_id else None,
+            )
+        )
+
+    return dict(result)
+
+
+async def get_provider_account_or_none(
+    *,
+    provider_id: UUID,
+    user_id: UUID,
+    db: DbSession,
+) -> DeploymentProviderAccount | None:
+    """Return the provider account or None without raising."""
+    try:
+        return await get_owned_provider_account_or_404(
+            provider_id=provider_id,
+            user_id=user_id,
+            db=db,
+        )
+    except HTTPException:
+        return None

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -54,15 +54,18 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
     WatsonxApiAgentExecutionCreateResultData,
     WatsonxApiAgentExecutionStatusResultData,
     WatsonxApiBindOperation,
+    WatsonxApiBindToolOperation,
     WatsonxApiDeploymentCreatePayload,
     WatsonxApiDeploymentListProviderData,
     WatsonxApiDeploymentLlmListResultData,
     WatsonxApiDeploymentUpdatePayload,
     WatsonxApiDeploymentUpdateResultData,
     WatsonxApiFlowArtifactProviderData,
+    WatsonxApiRemoveToolByIdOperation,
     WatsonxApiRemoveToolOperation,
     WatsonxApiToolAppBinding,
     WatsonxApiUnbindOperation,
+    WatsonxApiUnbindToolOperation,
 )
 from langflow.api.v1.schemas.deployments import (
     DeploymentCreateRequest,
@@ -475,17 +478,47 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             for flow_version_id, _version_number, project_id, artifact in flow_artifacts
         ]
 
-        existing_tool_flow_version_ids = [
-            operation.flow_version_id
-            for operation in api_provider_payload.operations
-            if isinstance(operation, (WatsonxApiUnbindOperation, WatsonxApiRemoveToolOperation))
+        # Single DB query for all flow_version_ids across operation types,
+        # then selective strict validation for unbind/remove only.
+        #
+        # - bind: missing attachment = "create new tool" (expected)
+        # - unbind: missing = error (tool must exist to modify connections)
+        # - remove_tool: missing = error (tool must exist to detach)
+        bind_fv_ids = [
+            op.flow_version_id for op in api_provider_payload.operations if isinstance(op, WatsonxApiBindOperation)
         ]
-        flow_version_snapshot_id_map = await self._resolve_existing_tool_snapshot_ids(
+        unbind_fv_ids = [
+            op.flow_version_id for op in api_provider_payload.operations if isinstance(op, WatsonxApiUnbindOperation)
+        ]
+        remove_fv_ids = [
+            op.flow_version_id
+            for op in api_provider_payload.operations
+            if isinstance(op, WatsonxApiRemoveToolOperation)
+        ]
+        all_fv_ids = list(dict.fromkeys(bind_fv_ids + unbind_fv_ids + remove_fv_ids))
+        flow_version_snapshot_id_map = await self._lookup_snapshot_ids(
             user_id=user_id,
             deployment_db_id=deployment_db_id,
             db=db,
-            flow_version_ids=list(dict.fromkeys(existing_tool_flow_version_ids)),
+            flow_version_ids=all_fv_ids,
         )
+        strict_fv_ids = list(dict.fromkeys(unbind_fv_ids + remove_fv_ids))
+        missing_strict = [str(fv) for fv in strict_fv_ids if fv not in flow_version_snapshot_id_map]
+        if missing_strict:
+            msg = f"Cannot resolve provider snapshot ids for flow_version_ids in watsonx operations: {missing_strict}"
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=msg)
+
+        reused_fv_ids = {fv for fv in bind_fv_ids if fv in flow_version_snapshot_id_map}
+        filtered_raw_payloads = (
+            [
+                artifact
+                for flow_version_id, _version_number, _project_id, artifact in flow_artifacts
+                if flow_version_id not in reused_fv_ids
+            ]
+            if reused_fv_ids
+            else raw_payloads
+        )
+
         provider_operations = self._build_provider_operations(
             operations=api_provider_payload.operations,
             raw_name_by_flow_version_id=raw_name_by_flow_version_id,
@@ -501,7 +534,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 self._build_provider_payload_body(
                     llm=api_provider_payload.llm,
                     resource_name_prefix=api_provider_payload.resource_name_prefix,
-                    raw_tool_payloads=[artifact.model_dump(exclude_none=True) for artifact in raw_payloads],
+                    raw_tool_payloads=[artifact.model_dump(exclude_none=True) for artifact in filtered_raw_payloads],
                     connections=api_provider_payload.connections,
                     operations=provider_operations,
                 )
@@ -685,6 +718,14 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         *,
         result: DeploymentUpdateResult,
     ) -> UpdateSnapshotBindings:
+        """Extract snapshot bindings for attachment reconciliation.
+
+        Only bindings whose ``source_ref`` is a valid UUID are included.
+        Tool-id-based operations produce bindings with non-UUID
+        ``source_ref`` values (the provider tool_id itself); these are
+        excluded because they do not create or modify
+        ``flow_version_deployment_attachment`` records.
+        """
         slot = WXO_ADAPTER_PAYLOAD_SCHEMAS.deployment_update_result
         parsed = self._parse_required_payload_slot(
             slot=slot,
@@ -696,15 +737,20 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         if not parsed.created_snapshot_ids and not parsed.added_snapshot_bindings:
             msg = "Deployment provider update result is missing required snapshot reconciliation bindings."
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
-        return UpdateSnapshotBindings(
-            snapshot_bindings=[
+
+        flow_version_bindings: list[UpdateSnapshotBinding] = []
+        for binding in parsed.added_snapshot_bindings:
+            try:
+                UUID(binding.source_ref)
+            except (ValueError, AttributeError):
+                continue
+            flow_version_bindings.append(
                 UpdateSnapshotBinding(
                     source_ref=binding.source_ref,
                     snapshot_id=binding.tool_id,
                 )
-                for binding in parsed.added_snapshot_bindings
-            ]
-        )
+            )
+        return UpdateSnapshotBindings(snapshot_bindings=flow_version_bindings)
 
     def util_flow_version_patch(self, payload: DeploymentUpdateRequest) -> FlowVersionPatch:
         if payload.add_flow_version_ids is not None or payload.remove_flow_version_ids is not None:
@@ -906,6 +952,27 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             "app_ids": app_ids,
         }
 
+    def _to_bind_existing_tool_provider_operation(
+        self,
+        *,
+        tool_id: str,
+        source_ref: str,
+        app_ids: list[str],
+    ) -> AdapterPayload:
+        """Bind operation that reuses an existing tool via tool_id_with_ref."""
+        return {
+            "op": "bind",
+            "tool": {"tool_id_with_ref": {"source_ref": source_ref, "tool_id": tool_id}},
+            "app_ids": app_ids,
+        }
+
+    def _to_attach_tool_provider_operation(self, *, tool_id: str, source_ref: str) -> AdapterPayload:
+        """Attach an existing tool to the agent without connection bindings."""
+        return {
+            "op": "attach_tool",
+            "tool": {"source_ref": source_ref, "tool_id": tool_id},
+        }
+
     def _to_unbind_provider_operation(
         self,
         *,
@@ -936,20 +1003,42 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         for operation in operations:
             if isinstance(operation, WatsonxApiBindOperation):
                 flow_version_id = operation.flow_version_id
-                if flow_version_id not in raw_name_by_flow_version_id:
-                    msg = f"bind.flow_version_id not found: [{flow_version_id}]"
-                    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=msg)
-                if not operation.app_ids:
-                    # Empty app_ids means "create/attach raw tool with no connection bindings";
-                    # no provider bind operation is needed for this flow version.
-                    continue
-                provider_operations.append(
-                    self._to_bind_provider_operation(
-                        raw_name=raw_name_by_flow_version_id[flow_version_id],
-                        app_ids=operation.app_ids,
+                existing_tool_id = (flow_version_snapshot_id_map or {}).get(flow_version_id)
+
+                if existing_tool_id:
+                    # Reuse existing tool -- no new artifact creation needed.
+                    if operation.app_ids:
+                        provider_operations.append(
+                            self._to_bind_existing_tool_provider_operation(
+                                tool_id=existing_tool_id,
+                                source_ref=str(flow_version_id),
+                                app_ids=operation.app_ids,
+                            )
+                        )
+                    else:
+                        provider_operations.append(
+                            self._to_attach_tool_provider_operation(
+                                tool_id=existing_tool_id,
+                                source_ref=str(flow_version_id),
+                            )
+                        )
+                else:
+                    # No existing tool -- create new via raw payload (current behavior).
+                    if flow_version_id not in raw_name_by_flow_version_id:
+                        msg = f"bind.flow_version_id not found: [{flow_version_id}]"
+                        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=msg)
+                    if not operation.app_ids:
+                        # Raw tool is still created via tools.raw_payloads;
+                        # no provider bind operation needed.
+                        continue
+                    provider_operations.append(
+                        self._to_bind_provider_operation(
+                            raw_name=raw_name_by_flow_version_id[flow_version_id],
+                            app_ids=operation.app_ids,
+                        )
                     )
-                )
                 continue
+
             if isinstance(operation, WatsonxApiUnbindOperation):
                 flow_version_id = operation.flow_version_id
                 if flow_version_snapshot_id_map is None:
@@ -963,6 +1052,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                     )
                 )
                 continue
+
             if isinstance(operation, WatsonxApiRemoveToolOperation):
                 flow_version_id = operation.flow_version_id
                 if flow_version_snapshot_id_map is None:
@@ -974,6 +1064,51 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                         source_ref=str(flow_version_id),
                     )
                 )
+                continue
+
+            # Tool-id-based operations: use tool_id as source_ref.
+            # These do not create/modify flow_version_deployment_attachment
+            # records -- they are purely provider-side agent composition.
+            if isinstance(operation, WatsonxApiBindToolOperation):
+                tool_id = operation.tool_id.strip()
+                if operation.app_ids:
+                    provider_operations.append(
+                        self._to_bind_existing_tool_provider_operation(
+                            tool_id=tool_id,
+                            source_ref=tool_id,
+                            app_ids=operation.app_ids,
+                        )
+                    )
+                else:
+                    provider_operations.append(
+                        self._to_attach_tool_provider_operation(
+                            tool_id=tool_id,
+                            source_ref=tool_id,
+                        )
+                    )
+                continue
+
+            if isinstance(operation, WatsonxApiUnbindToolOperation):
+                tool_id = operation.tool_id.strip()
+                provider_operations.append(
+                    self._to_unbind_provider_operation(
+                        tool_id=tool_id,
+                        source_ref=tool_id,
+                        app_ids=operation.app_ids,
+                    )
+                )
+                continue
+
+            if isinstance(operation, WatsonxApiRemoveToolByIdOperation):
+                tool_id = operation.tool_id.strip()
+                provider_operations.append(
+                    self._to_remove_tool_provider_operation(
+                        tool_id=tool_id,
+                        source_ref=tool_id,
+                    )
+                )
+                continue
+
         return provider_operations
 
     def _build_provider_payload_body(
@@ -1004,30 +1139,34 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         adapter_tool_app_bindings: list[Any],
         adapter_snapshot_bindings: list[Any],
     ) -> list[WatsonxApiToolAppBinding]:
-        tool_id_to_flow_version: dict[str, UUID] = {}
+        """Map adapter-level tool bindings to API response shapes.
+
+        ``flow_version_id`` is populated by attempting to parse the
+        snapshot binding's ``source_ref`` as a UUID.  For tool-id-based
+        operations the ``source_ref`` is the provider tool_id (not a UUID),
+        so ``flow_version_id`` will be ``None`` -- this is intentional.
+        """
+        tool_id_to_flow_version: dict[str, UUID | None] = {}
         for binding in adapter_snapshot_bindings:
             tool_id = str(binding.tool_id or "").strip()
             source_ref = str(binding.source_ref or "").strip()
             if not tool_id or not source_ref:
                 msg = (
                     f"Snapshot binding has empty tool_id={binding.tool_id!r} or "
-                    f"source_ref={binding.source_ref!r}; cannot map tool to flow version."
+                    f"source_ref={binding.source_ref!r}; cannot map tool binding."
                 )
                 raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
             try:
                 tool_id_to_flow_version[tool_id] = UUID(source_ref)
-            except ValueError as err:
-                msg = (
-                    f"Snapshot binding source_ref={source_ref!r} is not a valid UUID "
-                    f"for tool_id={tool_id!r}; cannot map tool to flow version."
-                )
-                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg) from err
+            except ValueError:
+                # Non-UUID source_ref means this is a tool-id-based binding;
+                # flow_version_id will be None in the response.
+                tool_id_to_flow_version[tool_id] = None
 
         api_bindings: list[WatsonxApiToolAppBinding] = []
         for binding in adapter_tool_app_bindings:
             raw_tool_id = str(binding.tool_id or "").strip()
-            flow_version_id = tool_id_to_flow_version.get(raw_tool_id)
-            if flow_version_id is None:
+            if raw_tool_id not in tool_id_to_flow_version:
                 msg = (
                     f"tool_app_binding tool_id={raw_tool_id!r} has no matching snapshot "
                     f"binding source_ref; available refs: {sorted(tool_id_to_flow_version)}."
@@ -1035,7 +1174,8 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
             api_bindings.append(
                 WatsonxApiToolAppBinding(
-                    flow_version_id=flow_version_id,
+                    flow_version_id=tool_id_to_flow_version[raw_tool_id],
+                    tool_id=raw_tool_id,
                     app_ids=list(binding.app_ids),
                 )
             )
@@ -1046,7 +1186,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             return None
         return [raw_payload.model_dump(exclude_none=True) for raw_payload in raw_payloads]
 
-    async def _resolve_existing_tool_snapshot_ids(
+    async def _lookup_snapshot_ids(
         self,
         *,
         user_id: UUID,
@@ -1054,6 +1194,12 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         db: AsyncSession,
         flow_version_ids: list[UUID],
     ) -> dict[UUID, str]:
+        """Raw DB lookup of flow_version -> provider_snapshot_id.
+
+        Returns a partial map -- only entries with a non-empty
+        ``provider_snapshot_id`` are included.  Callers decide whether
+        missing entries are an error or expected.
+        """
         if not flow_version_ids:
             return {}
         attachments = await list_deployment_attachments_for_flow_version_ids(
@@ -1062,15 +1208,29 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             deployment_id=deployment_db_id,
             flow_version_ids=flow_version_ids,
         )
-        flow_version_snapshot_id_map = {
+        return {
             attachment.flow_version_id: str(attachment.provider_snapshot_id).strip()
             for attachment in attachments
             if isinstance(attachment.provider_snapshot_id, str) and attachment.provider_snapshot_id.strip()
         }
+
+    async def _resolve_existing_tool_snapshot_ids(
+        self,
+        *,
+        user_id: UUID,
+        deployment_db_id: UUID,
+        db: AsyncSession,
+        flow_version_ids: list[UUID],
+    ) -> dict[UUID, str]:
+        """Strict lookup: raises 422 if any flow_version_id is missing."""
+        snapshot_map = await self._lookup_snapshot_ids(
+            user_id=user_id,
+            deployment_db_id=deployment_db_id,
+            db=db,
+            flow_version_ids=flow_version_ids,
+        )
         missing_flow_versions = [
-            str(flow_version_id)
-            for flow_version_id in flow_version_ids
-            if flow_version_id not in flow_version_snapshot_id_map
+            str(flow_version_id) for flow_version_id in flow_version_ids if flow_version_id not in snapshot_map
         ]
         if missing_flow_versions:
             msg = (
@@ -1078,4 +1238,4 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 f"{missing_flow_versions}"
             )
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=msg)
-        return flow_version_snapshot_id_map
+        return snapshot_map

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -62,7 +62,11 @@ class WatsonxApiUnbindOperation(BaseModel):
 
 
 class WatsonxApiRemoveToolOperation(BaseModel):
-    """Remove-tool operation for an attached flow-version tool."""
+    """Remove-tool operation for an attached flow-version tool.
+
+    Resolves tool_id from flow_version_deployment_attachment and detaches
+    the tool from the agent.  The attachment record is also deleted.
+    """
 
     model_config = {"extra": "forbid"}
 
@@ -70,11 +74,74 @@ class WatsonxApiRemoveToolOperation(BaseModel):
     flow_version_id: UUID
 
 
-# TODO(wxo-followup): Optionally expose adapter-level `attach_tool` semantics at
-# the API layer if/when we need existing-tool attach-by-id outside flow-version refs.
-# Current API behavior is intentional and sufficient for today.
+# ---------------------------------------------------------------------------
+# Tool-id-based operations
+#
+# These operations give clients direct control over WXO tools by provider
+# tool_id, without requiring a Langflow flow_version_id.  They run in
+# parallel to the flow-version-id operations above:
+#
+# - flow_version_id ops are convenient: Langflow resolves the tool_id
+#   from internal attachment state and manages the attachment lifecycle.
+# - tool_id ops are explicit: the client supplies the provider tool_id
+#   directly.  These operations do NOT create or modify
+#   flow_version_deployment_attachment records -- they are purely
+#   provider-side agent composition changes.
+# ---------------------------------------------------------------------------
+
+
+class WatsonxApiBindToolOperation(BaseModel):
+    """Attach an existing tool to the agent and optionally bind connections.
+
+    Subsumes a separate "add_tool" operation: at the adapter level, a bind
+    with ``tool_id_with_ref`` handles both "add tool to agent if not
+    present" and "bind connections" in a single code path.  Empty
+    ``app_ids`` means attach-only (no connection bindings).
+    """
+
+    model_config = {"extra": "forbid"}
+
+    op: Literal["bind_tool"]
+    tool_id: str = Field(min_length=1, description="Provider-owned tool identifier.")
+    app_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Connection app ids to bind.  Use an empty list to attach "
+            "the tool to the agent without binding connections."
+        ),
+    )
+
+
+class WatsonxApiUnbindToolOperation(BaseModel):
+    """Unbind connections from an existing tool (tool stays attached).
+
+    Only modifies connection bindings on the tool; does not detach
+    the tool from the agent.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    op: Literal["unbind_tool"]
+    tool_id: str = Field(min_length=1, description="Provider-owned tool identifier.")
+    app_ids: list[str] = Field(min_length=1)
+
+
+class WatsonxApiRemoveToolByIdOperation(BaseModel):
+    """Detach a tool from the agent by provider tool_id."""
+
+    model_config = {"extra": "forbid"}
+
+    op: Literal["remove_tool_by_id"]
+    tool_id: str = Field(min_length=1, description="Provider-owned tool identifier.")
+
+
 WatsonxApiUpdateOperation = Annotated[
-    WatsonxApiBindOperation | WatsonxApiUnbindOperation | WatsonxApiRemoveToolOperation,
+    WatsonxApiBindOperation
+    | WatsonxApiUnbindOperation
+    | WatsonxApiRemoveToolOperation
+    | WatsonxApiBindToolOperation
+    | WatsonxApiUnbindToolOperation
+    | WatsonxApiRemoveToolByIdOperation,
     Field(discriminator="op"),
 ]
 
@@ -120,6 +187,10 @@ class WatsonxApiDeploymentPayloadBase(BaseModel):
         valid_app_ids = existing_app_ids.union(raw_app_ids)
         referenced_app_ids: set[str] = set()
 
+        bind_tool_ids: set[str] = set()
+        unbind_tool_ids: set[str] = set()
+        remove_tool_ids: set[str] = set()
+
         for operation in getattr(self, "operations", []):
             if isinstance(operation, (WatsonxApiBindOperation, WatsonxApiUnbindOperation)):
                 for app_id in operation.app_ids:
@@ -136,6 +207,45 @@ class WatsonxApiDeploymentPayloadBase(BaseModel):
                     if app_id in raw_app_ids:
                         msg = f"unbind.operation app_ids must reference connections.existing_app_ids only: [{app_id!r}]"
                         raise ValueError(msg)
+
+            if isinstance(operation, WatsonxApiBindToolOperation):
+                bind_tool_ids.add(operation.tool_id.strip())
+                for app_id in operation.app_ids:
+                    referenced_app_ids.add(app_id)
+                    if app_id not in valid_app_ids:
+                        msg = (
+                            "operation app_ids must be declared in "
+                            "connections.existing_app_ids or connections.raw_payloads[*].app_id: "
+                            f"[{app_id!r}]"
+                        )
+                        raise ValueError(msg)
+            if isinstance(operation, WatsonxApiUnbindToolOperation):
+                unbind_tool_ids.add(operation.tool_id.strip())
+                for app_id in operation.app_ids:
+                    referenced_app_ids.add(app_id)
+                    if app_id not in valid_app_ids:
+                        msg = (
+                            "operation app_ids must be declared in "
+                            "connections.existing_app_ids or connections.raw_payloads[*].app_id: "
+                            f"[{app_id!r}]"
+                        )
+                        raise ValueError(msg)
+                    if app_id in raw_app_ids:
+                        msg = (
+                            f"unbind_tool.operation app_ids must reference "
+                            f"connections.existing_app_ids only: [{app_id!r}]"
+                        )
+                        raise ValueError(msg)
+            if isinstance(operation, WatsonxApiRemoveToolByIdOperation):
+                remove_tool_ids.add(operation.tool_id.strip())
+
+        remove_conflicts = remove_tool_ids.intersection(bind_tool_ids | unbind_tool_ids)
+        if remove_conflicts:
+            msg = (
+                "remove_tool_by_id cannot be combined with bind_tool/unbind_tool "
+                f"for the same tool_id: {sorted(remove_conflicts)}"
+            )
+            raise ValueError(msg)
 
         unused_existing_app_ids = existing_app_ids.difference(referenced_app_ids)
         if unused_existing_app_ids:
@@ -187,6 +297,12 @@ class WatsonxApiDeploymentUpdatePayload(WatsonxApiDeploymentPayloadBase):
         return self
 
 
+WatsonxApiCreateOperation = Annotated[
+    WatsonxApiBindOperation | WatsonxApiBindToolOperation,
+    Field(discriminator="op"),
+]
+
+
 class WatsonxApiDeploymentCreatePayload(WatsonxApiDeploymentPayloadBase):
     """Watsonx provider_data API contract for deployment create operations."""
 
@@ -198,7 +314,7 @@ class WatsonxApiDeploymentCreatePayload(WatsonxApiDeploymentPayloadBase):
             "applied to names of created tools and deployments."
         ),
     )
-    operations: list[WatsonxApiBindOperation] = Field(default_factory=list)
+    operations: list[WatsonxApiCreateOperation] = Field(default_factory=list)
     existing_agent_id: str | None = Field(
         default=None,
         description=(
@@ -230,21 +346,33 @@ class WatsonxApiDeploymentCreatePayload(WatsonxApiDeploymentPayloadBase):
     def validate_create_operation_requirements(self) -> WatsonxApiDeploymentCreatePayload:
         has_operations = bool(self.operations)
         has_raw_connections = bool(self.connections.raw_payloads)
-        if (has_operations or has_raw_connections) and self.resource_name_prefix is None:
-            msg = "resource_name_prefix is required when operations or connections.raw_payloads are provided."
+        has_flow_version_bind = any(isinstance(op, WatsonxApiBindOperation) for op in self.operations)
+        if (has_flow_version_bind or has_raw_connections) and self.resource_name_prefix is None:
+            msg = (
+                "resource_name_prefix is required when operations include bind "
+                "or connections.raw_payloads are provided."
+            )
             raise ValueError(msg)
         if self.existing_agent_id is None and not has_operations:
-            msg = "operations must include at least one bind operation for new agent creation."
+            msg = "operations must include at least one bind or bind_tool operation for new agent creation."
             raise ValueError(msg)
         return self
 
 
 class WatsonxApiToolAppBinding(BaseModel):
-    """API response shape for a Watsonx tool binding."""
+    """API response shape for a Watsonx tool binding.
+
+    Always includes ``tool_id`` (the provider-owned tool identifier).
+    ``flow_version_id`` is populated when the tool was created or
+    referenced through a flow-version-id operation; it is ``None``
+    for tool-id-based operations whose ``source_ref`` is not a valid
+    Langflow UUID.
+    """
 
     model_config = {"extra": "forbid"}
 
-    flow_version_id: UUID
+    flow_version_id: UUID | None = None
+    tool_id: str = Field(min_length=1, description="Provider-owned tool identifier.")
     app_ids: list[str] = Field(default_factory=list)
 
     @field_validator("app_ids", mode="before")

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -666,3 +666,30 @@ class ExecutionStatusResponse(_ExecutionResponseBase):
     Intentionally distinct from ``ExecutionCreateResponse`` even though both
     currently share the same shape, mirroring the service-layer separation.
     """
+
+
+# ---------------------------------------------------------------------------
+# Snapshot sub-resource schemas
+# ---------------------------------------------------------------------------
+
+
+class SnapshotUpdateRequest(BaseModel):
+    """Request body for PATCH /api/v1/snapshots/{provider_snapshot_id}.
+
+    Updates the content of an existing provider snapshot with a new
+    flow version's artifact.  The ``provider_snapshot_id`` is supplied
+    as a path parameter; only ``flow_version_id`` is in the body.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    flow_version_id: UUID = Field(
+        description="Langflow flow version whose artifact will replace the snapshot content.",
+    )
+
+
+class SnapshotUpdateResponse(BaseModel):
+    """Response for PATCH /api/v1/snapshots/{provider_snapshot_id}."""
+
+    flow_version_id: UUID
+    provider_snapshot_id: str

--- a/src/backend/base/langflow/api/v1/schemas/flow_versions.py
+++ b/src/backend/base/langflow/api/v1/schemas/flow_versions.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+
+from langflow.services.database.models.flow_version.model import FlowVersionRead
+
+
+class FlowVersionDeploymentInfo(BaseModel):
+    """Per-deployment tool metadata surfaced when listing flow versions."""
+
+    # TODO: be more provider-agnostic here. see RULES.md
+    deployment_id: UUID
+    tool_id: str | None = None
+    tool_name: str | None = None
+    app_ids: list[str] | None = None
+
+
+class FlowVersionReadWithDeployments(FlowVersionRead):
+    """FlowVersionRead enriched with per-deployment tool metadata."""
+
+    deployments: list[FlowVersionDeploymentInfo] = PydanticField(default_factory=list)
+
+
+class FlowVersionWithDeploymentsListResponse(BaseModel):
+    """List response used when deployment enrichment is active."""
+
+    entries: list[FlowVersionReadWithDeployments]
+    max_entries: int = PydanticField(ge=1)

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -80,7 +80,11 @@ from langflow.services.adapters.deployment.watsonx_orchestrate.core.status impor
     get_deployment_detail_metadata,
     get_deployment_metadata,
 )
-from langflow.services.adapters.deployment.watsonx_orchestrate.core.tools import verify_tools_by_ids
+from langflow.services.adapters.deployment.watsonx_orchestrate.core.tools import (
+    build_langflow_artifact_bytes,
+    upload_tool_artifact_bytes,
+    verify_tools_by_ids,
+)
 from langflow.services.adapters.deployment.watsonx_orchestrate.core.update import (
     apply_provider_update_plan_with_rollback,
     build_provider_update_plan,
@@ -924,6 +928,54 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             ) from exc
 
         return VerifyCredentialsResult()
+
+    async def update_snapshot(
+        self,
+        *,
+        user_id: IdLike,
+        db: AsyncSession,
+        provider_snapshot_id: str,
+        flow_definition: dict[str, Any],
+        project_id: str,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        """Replace an existing snapshot's content with a new flow artifact.
+
+        This is a content-only mutation -- it does not affect which agent
+        the snapshot is attached to or its connection bindings.
+
+        **Blast-radius boundary:** callers must verify that
+        ``provider_snapshot_id`` is tracked by a Langflow attachment
+        record before calling this method; this prevents accidental
+        overwrites of externally managed WXO tools.
+        """
+        from ibm_watsonx_orchestrate_core.types.tools.langflow_tool import (
+            create_langflow_tool as _create_langflow_tool,
+        )
+
+        clients = await self._get_provider_clients(user_id=user_id, db=db)
+
+        tools = await asyncio.to_thread(clients.tool.get_drafts_by_ids, [provider_snapshot_id])
+        if not tools or not isinstance(tools[0], dict) or not tools[0].get("id"):
+            msg = f"Snapshot '{provider_snapshot_id}' not found in provider."
+            raise DeploymentNotFoundError(msg)
+
+        tool = _create_langflow_tool(
+            tool_definition=flow_definition,
+            connections={},
+            show_details=True,
+        )
+
+        artifact_bytes = build_langflow_artifact_bytes(
+            tool=tool,
+            flow_definition=flow_definition,
+        )
+        await asyncio.to_thread(
+            upload_tool_artifact_bytes,
+            clients,
+            tool_id=provider_snapshot_id,
+            artifact_bytes=artifact_bytes,
+        )
+        return {"provider_snapshot_id": provider_snapshot_id}
 
     async def teardown(self) -> None:
         """Teardown provider-specific resources."""

--- a/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
+++ b/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
@@ -200,6 +200,24 @@ async def list_attachments_for_flow_with_provider_info(
     return [(attachment, provider_account_id, provider_key) for attachment, provider_account_id, provider_key in rows]
 
 
+async def get_attachment_by_provider_snapshot_id(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    provider_snapshot_id: str,
+) -> FlowVersionDeploymentAttachment | None:
+    """Look up an attachment by its provider_snapshot_id.
+
+    Used by the PATCH /snapshots/{provider_snapshot_id} endpoint to
+    resolve the deployment context for a provider-owned snapshot.
+    """
+    stmt = select(FlowVersionDeploymentAttachment).where(
+        FlowVersionDeploymentAttachment.user_id == user_id,
+        FlowVersionDeploymentAttachment.provider_snapshot_id == provider_snapshot_id,
+    )
+    return (await db.exec(stmt)).first()
+
+
 async def count_attachments_by_deployment_ids(
     db: AsyncSession,
     *,

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -121,10 +121,11 @@ def test_watsonx_api_payload_requires_resource_name_prefix_for_existing_agent_op
     flow_version_id = uuid4()
     with pytest.raises(
         ValueError,
-        match=r"resource_name_prefix is required when operations or connections\.raw_payloads are provided",
+        match=r"resource_name_prefix is required when operations include bind",
     ):
         WatsonxApiDeploymentCreatePayload.model_validate(
             {
+                "llm": TEST_WXO_LLM,
                 "existing_agent_id": "21b2b5a4-ef72-4697-8731-132163669a46",
                 "connections": {"existing_app_ids": ["app-one"]},
                 "operations": [
@@ -142,10 +143,11 @@ def test_watsonx_api_payload_requires_resource_name_prefix_for_raw_connection_pa
     flow_version_id = uuid4()
     with pytest.raises(
         ValueError,
-        match=r"resource_name_prefix is required when operations or connections\.raw_payloads are provided",
+        match=r"resource_name_prefix is required when operations include bind",
     ):
         WatsonxApiDeploymentCreatePayload.model_validate(
             {
+                "llm": TEST_WXO_LLM,
                 "existing_agent_id": "21b2b5a4-ef72-4697-8731-132163669a46",
                 "connections": {
                     "raw_payloads": [
@@ -558,6 +560,7 @@ async def test_watsonx_mapper_translates_existing_create_bind_into_update_payloa
         provider_id=uuid4(),
         spec={"name": "existing-create", "description": "desc", "type": "agent"},
         provider_data={
+            "llm": TEST_WXO_LLM,
             "existing_agent_id": "21b2b5a4-ef72-4697-8731-132163669a46",
             "resource_name_prefix": "lf_test_",
             "connections": {"existing_app_ids": ["app-one"]},
@@ -603,6 +606,7 @@ async def test_watsonx_mapper_maps_create_adapter_payload_validation_errors_to_4
         provider_id=uuid4(),
         spec={"name": "create-deploy", "description": "", "type": "agent"},
         provider_data={
+            "llm": TEST_WXO_LLM,
             "resource_name_prefix": "lf_test_",
             "connections": {"existing_app_ids": ["app-one"]},
             "operations": [
@@ -787,10 +791,12 @@ async def test_watsonx_mapper_translates_flow_version_bind_into_raw_tool_payload
         }
     )
 
+    db = _MultiQueryFakeDb(first_rows=[row], subsequent_rows=[])
+
     resolved = await mapper.resolve_deployment_update(
         user_id=uuid4(),
         deployment_db_id=uuid4(),
-        db=_FakeDb([row]),
+        db=db,
         payload=payload,
     )
     provider_data = resolved.provider_data or {}
@@ -851,10 +857,12 @@ async def test_watsonx_mapper_skips_empty_bind_operations_but_keeps_raw_tools() 
         }
     )
 
+    db = _MultiQueryFakeDb(first_rows=[row_unbound, row_bound], subsequent_rows=[])
+
     resolved = await mapper.resolve_deployment_update(
         user_id=uuid4(),
         deployment_db_id=uuid4(),
-        db=_FakeDb([row_unbound, row_bound]),
+        db=db,
         payload=payload,
     )
     provider_data = resolved.provider_data or {}
@@ -963,7 +971,7 @@ def test_watsonx_update_result_data_normalizes_fields() -> None:
         {
             "created_app_ids": ["  app-one  ", "", "app-two"],
             "tool_app_bindings": [
-                {"flow_version_id": str(flow_version_id), "app_ids": [" app-a ", "", "app-b"]},
+                {"flow_version_id": str(flow_version_id), "tool_id": "tool-1", "app_ids": [" app-a ", "", "app-b"]},
             ],
             "ignored_key": True,
         }
@@ -972,6 +980,7 @@ def test_watsonx_update_result_data_normalizes_fields() -> None:
     assert data.created_app_ids == ["app-one", "app-two"]
     assert data.tool_app_bindings is not None
     assert data.tool_app_bindings[0].flow_version_id == flow_version_id
+    assert data.tool_app_bindings[0].tool_id == "tool-1"
     assert data.tool_app_bindings[0].app_ids == ["app-a", "app-b"]
 
 
@@ -1013,14 +1022,14 @@ def test_watsonx_mapper_shapes_update_response_from_result_schema() -> None:
     assert shaped.provider_data == {
         "created_app_ids": ["created-app-1"],
         "tool_app_bindings": [
-            {"flow_version_id": str(new_flow_version_id), "app_ids": ["app-a"]},
-            {"flow_version_id": str(existing_flow_version_id), "app_ids": ["app-b"]},
+            {"flow_version_id": str(new_flow_version_id), "tool_id": "new-tool-1", "app_ids": ["app-a"]},
+            {"flow_version_id": str(existing_flow_version_id), "tool_id": "existing-tool-1", "app_ids": ["app-b"]},
         ],
     }
 
 
-def test_watsonx_mapper_update_response_raises_on_invalid_source_ref() -> None:
-    """Non-UUID source_ref in snapshot bindings raises HTTP 500."""
+def test_watsonx_mapper_update_response_tolerates_non_uuid_source_ref() -> None:
+    """Non-UUID source_ref (from tool_id ops) produces flow_version_id=None."""
     mapper = WatsonxOrchestrateDeploymentMapper()
     timestamp = datetime.now(tz=timezone.utc)
     deployment_row = SimpleNamespace(
@@ -1044,10 +1053,11 @@ def test_watsonx_mapper_update_response_raises_on_invalid_source_ref() -> None:
         },
     )
 
-    with pytest.raises(HTTPException) as exc:
-        mapper.shape_deployment_update_result(result, deployment_row)
-    assert exc.value.status_code == 500
-    assert "not a valid UUID" in exc.value.detail
+    shaped = mapper.shape_deployment_update_result(result, deployment_row)
+    bindings = shaped.provider_data["tool_app_bindings"]
+    assert len(bindings) == 1
+    assert "flow_version_id" not in bindings[0]
+    assert bindings[0]["tool_id"] == "tool-1"
 
 
 def test_watsonx_mapper_update_response_raises_on_unmapped_tool_binding() -> None:
@@ -1340,3 +1350,531 @@ def test_wxo_mapper_resolve_verify_credentials_rejects_extra_fields() -> None:
     assert slot is not None
     with pytest.raises(AdapterPayloadValidationError):
         slot.parse({"api_key": "ok", "unexpected": "field"})  # pragma: allowlist secret
+
+
+# ---------------------------------------------------------------------------
+# Smart bind: reuse existing tool when attachment exists
+# ---------------------------------------------------------------------------
+
+
+class _MultiQueryFakeDb:
+    """Fake DB that returns different rows for sequential queries.
+
+    The first exec() call returns ``first_rows``, subsequent calls
+    return ``subsequent_rows``.  This supports resolve_deployment_update
+    which issues one query for flow artifacts and another for
+    attachment snapshot lookups.
+    """
+
+    def __init__(self, first_rows, subsequent_rows=None):
+        self._first_rows = first_rows
+        self._subsequent_rows = subsequent_rows if subsequent_rows is not None else []
+        self._call_count = 0
+
+    async def exec(self, _statement):
+        self._call_count += 1
+        rows = self._first_rows if self._call_count == 1 else self._subsequent_rows
+        return _FakeExecResult(rows)
+
+
+@pytest.mark.asyncio
+async def test_watsonx_mapper_bind_reuses_existing_tool_when_attachment_exists() -> None:
+    """Bind reuses existing tool when flow_version already has an attachment."""
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    flow_version_id = uuid4()
+    flow_id = uuid4()
+    project_id = uuid4()
+
+    flow_row = SimpleNamespace(
+        flow_version_id=flow_version_id,
+        flow_version_number=1,
+        flow_version_data={"nodes": [], "edges": []},
+        flow_id=flow_id,
+        flow_name="Flow A",
+        flow_description="desc",
+        flow_tags=["tag"],
+        project_id=project_id,
+    )
+    attachment_row = SimpleNamespace(
+        flow_version_id=flow_version_id,
+        provider_snapshot_id="existing-tool-id",
+    )
+
+    payload = DeploymentUpdateRequest(
+        provider_data={
+            "resource_name_prefix": "lf_test_",
+            "llm": TEST_WXO_LLM,
+            "connections": {"existing_app_ids": ["app-one"]},
+            "operations": [
+                {
+                    "op": "bind",
+                    "flow_version_id": str(flow_version_id),
+                    "app_ids": ["app-one"],
+                }
+            ],
+        }
+    )
+
+    db = _MultiQueryFakeDb(first_rows=[flow_row], subsequent_rows=[attachment_row])
+
+    resolved = await mapper.resolve_deployment_update(
+        user_id=uuid4(),
+        deployment_db_id=uuid4(),
+        db=db,
+        payload=payload,
+    )
+    provider_data = resolved.provider_data or {}
+
+    assert provider_data["operations"][0]["op"] == "bind"
+    assert provider_data["operations"][0]["tool"]["tool_id_with_ref"]["tool_id"] == "existing-tool-id"
+    assert provider_data["operations"][0]["tool"]["tool_id_with_ref"]["source_ref"] == str(flow_version_id)
+    assert provider_data["tools"]["raw_payloads"] is None
+
+
+@pytest.mark.asyncio
+async def test_watsonx_mapper_bind_creates_new_tool_when_no_attachment() -> None:
+    """When no attachment exists for a flow_version, bind should use name_of_raw."""
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    flow_version_id = uuid4()
+    project_id = uuid4()
+
+    flow_row = SimpleNamespace(
+        flow_version_id=flow_version_id,
+        flow_version_number=1,
+        flow_version_data={"nodes": [], "edges": []},
+        flow_id=uuid4(),
+        flow_name="Flow B",
+        flow_description="desc",
+        flow_tags=["tag"],
+        project_id=project_id,
+    )
+
+    payload = DeploymentUpdateRequest(
+        provider_data={
+            "resource_name_prefix": "lf_test_",
+            "llm": TEST_WXO_LLM,
+            "connections": {"existing_app_ids": ["app-one"]},
+            "operations": [
+                {
+                    "op": "bind",
+                    "flow_version_id": str(flow_version_id),
+                    "app_ids": ["app-one"],
+                }
+            ],
+        }
+    )
+
+    db = _MultiQueryFakeDb(first_rows=[flow_row], subsequent_rows=[])
+
+    resolved = await mapper.resolve_deployment_update(
+        user_id=uuid4(),
+        deployment_db_id=uuid4(),
+        db=db,
+        payload=payload,
+    )
+    provider_data = resolved.provider_data or {}
+
+    assert provider_data["operations"][0]["tool"]["name_of_raw"] == "Flow B_v1"
+
+
+@pytest.mark.asyncio
+async def test_watsonx_mapper_bind_reuse_with_empty_app_ids_emits_attach_tool() -> None:
+    """Bind with empty app_ids for an existing tool should emit attach_tool."""
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    flow_version_id = uuid4()
+    project_id = uuid4()
+
+    flow_row = SimpleNamespace(
+        flow_version_id=flow_version_id,
+        flow_version_number=1,
+        flow_version_data={"nodes": [], "edges": []},
+        flow_id=uuid4(),
+        flow_name="Flow C",
+        flow_description="desc",
+        flow_tags=["tag"],
+        project_id=project_id,
+    )
+    attachment_row = SimpleNamespace(
+        flow_version_id=flow_version_id,
+        provider_snapshot_id="existing-tool-id",
+    )
+
+    payload = DeploymentUpdateRequest(
+        provider_data={
+            "llm": TEST_WXO_LLM,
+            "resource_name_prefix": "lf_test_",
+            "operations": [
+                {
+                    "op": "bind",
+                    "flow_version_id": str(flow_version_id),
+                    "app_ids": [],
+                }
+            ],
+        }
+    )
+
+    db = _MultiQueryFakeDb(first_rows=[flow_row], subsequent_rows=[attachment_row])
+
+    resolved = await mapper.resolve_deployment_update(
+        user_id=uuid4(),
+        deployment_db_id=uuid4(),
+        db=db,
+        payload=payload,
+    )
+    provider_data = resolved.provider_data or {}
+
+    assert provider_data["operations"][0]["op"] == "attach_tool"
+    assert provider_data["operations"][0]["tool"]["tool_id"] == "existing-tool-id"
+
+
+# ---------------------------------------------------------------------------
+# Tool-id-based operations
+# ---------------------------------------------------------------------------
+
+
+def test_watsonx_api_payload_accepts_bind_tool_operation() -> None:
+    """bind_tool operation with app_ids is accepted."""
+    WatsonxApiDeploymentUpdatePayload.model_validate(
+        {
+            "llm": TEST_WXO_LLM,
+            "connections": {"existing_app_ids": ["app-one"]},
+            "operations": [
+                {
+                    "op": "bind_tool",
+                    "tool_id": "some-tool-id",
+                    "app_ids": ["app-one"],
+                }
+            ],
+        }
+    )
+
+
+def test_watsonx_api_payload_accepts_bind_tool_with_empty_app_ids() -> None:
+    """bind_tool with empty app_ids (attach-only) is accepted."""
+    WatsonxApiDeploymentUpdatePayload.model_validate(
+        {
+            "llm": TEST_WXO_LLM,
+            "operations": [
+                {
+                    "op": "bind_tool",
+                    "tool_id": "some-tool-id",
+                    "app_ids": [],
+                }
+            ],
+        }
+    )
+
+
+def test_watsonx_api_payload_accepts_unbind_tool_operation() -> None:
+    """unbind_tool operation is accepted."""
+    WatsonxApiDeploymentUpdatePayload.model_validate(
+        {
+            "llm": TEST_WXO_LLM,
+            "connections": {"existing_app_ids": ["app-one"]},
+            "operations": [
+                {
+                    "op": "unbind_tool",
+                    "tool_id": "some-tool-id",
+                    "app_ids": ["app-one"],
+                }
+            ],
+        }
+    )
+
+
+def test_watsonx_api_payload_accepts_remove_tool_by_id_operation() -> None:
+    """remove_tool_by_id operation is accepted."""
+    WatsonxApiDeploymentUpdatePayload.model_validate(
+        {
+            "llm": TEST_WXO_LLM,
+            "operations": [
+                {
+                    "op": "remove_tool_by_id",
+                    "tool_id": "some-tool-id",
+                }
+            ],
+        }
+    )
+
+
+def test_watsonx_api_payload_rejects_conflicting_tool_id_operations() -> None:
+    """remove_tool_by_id + bind_tool for same tool_id is rejected."""
+    with pytest.raises(ValidationError, match="remove_tool_by_id cannot be combined"):
+        WatsonxApiDeploymentUpdatePayload.model_validate(
+            {
+                "llm": TEST_WXO_LLM,
+                "connections": {"existing_app_ids": ["app-one"]},
+                "operations": [
+                    {"op": "bind_tool", "tool_id": "tid", "app_ids": ["app-one"]},
+                    {"op": "remove_tool_by_id", "tool_id": "tid"},
+                ],
+            }
+        )
+
+
+def test_watsonx_api_payload_unbind_tool_rejects_raw_app_ids() -> None:
+    """unbind_tool referencing raw app_ids should be rejected."""
+    with pytest.raises(ValidationError, match="existing_app_ids only"):
+        WatsonxApiDeploymentUpdatePayload.model_validate(
+            {
+                "llm": TEST_WXO_LLM,
+                "connections": {
+                    "existing_app_ids": ["app-old"],
+                    "raw_payloads": [{"app_id": "app-new"}],
+                },
+                "operations": [
+                    {"op": "unbind_tool", "tool_id": "tid", "app_ids": ["app-new"]},
+                ],
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_watsonx_mapper_translates_bind_tool_into_provider_operations() -> None:
+    """bind_tool should produce tool_id_with_ref bind operation."""
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    payload = DeploymentUpdateRequest(
+        provider_data={
+            "llm": TEST_WXO_LLM,
+            "connections": {"existing_app_ids": ["app-one"]},
+            "operations": [
+                {"op": "bind_tool", "tool_id": "external-tool", "app_ids": ["app-one"]},
+            ],
+        }
+    )
+    db = _FakeDb([])
+
+    resolved = await mapper.resolve_deployment_update(
+        user_id=uuid4(),
+        deployment_db_id=uuid4(),
+        db=db,
+        payload=payload,
+    )
+    provider_data = resolved.provider_data or {}
+
+    assert provider_data["operations"][0]["op"] == "bind"
+    assert provider_data["operations"][0]["tool"]["tool_id_with_ref"]["tool_id"] == "external-tool"
+    assert provider_data["operations"][0]["tool"]["tool_id_with_ref"]["source_ref"] == "external-tool"
+
+
+@pytest.mark.asyncio
+async def test_watsonx_mapper_translates_unbind_tool_into_provider_operations() -> None:
+    """unbind_tool should produce unbind operation with tool_id as source_ref."""
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    payload = DeploymentUpdateRequest(
+        provider_data={
+            "llm": TEST_WXO_LLM,
+            "connections": {"existing_app_ids": ["app-one"]},
+            "operations": [
+                {"op": "unbind_tool", "tool_id": "external-tool", "app_ids": ["app-one"]},
+            ],
+        }
+    )
+    db = _FakeDb([])
+
+    resolved = await mapper.resolve_deployment_update(
+        user_id=uuid4(),
+        deployment_db_id=uuid4(),
+        db=db,
+        payload=payload,
+    )
+    provider_data = resolved.provider_data or {}
+
+    assert provider_data["operations"][0]["op"] == "unbind"
+    assert provider_data["operations"][0]["tool"]["tool_id"] == "external-tool"
+    assert provider_data["operations"][0]["tool"]["source_ref"] == "external-tool"
+
+
+@pytest.mark.asyncio
+async def test_watsonx_mapper_translates_remove_tool_by_id_into_provider_operations() -> None:
+    """remove_tool_by_id should produce remove_tool operation."""
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    payload = DeploymentUpdateRequest(
+        provider_data={
+            "llm": TEST_WXO_LLM,
+            "operations": [
+                {"op": "remove_tool_by_id", "tool_id": "external-tool"},
+            ],
+        }
+    )
+    db = _FakeDb([])
+
+    resolved = await mapper.resolve_deployment_update(
+        user_id=uuid4(),
+        deployment_db_id=uuid4(),
+        db=db,
+        payload=payload,
+    )
+    provider_data = resolved.provider_data or {}
+
+    assert provider_data["operations"][0]["op"] == "remove_tool"
+    assert provider_data["operations"][0]["tool"]["tool_id"] == "external-tool"
+    assert provider_data["operations"][0]["tool"]["source_ref"] == "external-tool"
+
+
+# ---------------------------------------------------------------------------
+# tool_id in WatsonxApiToolAppBinding response
+# ---------------------------------------------------------------------------
+
+
+def test_watsonx_tool_app_binding_includes_tool_id() -> None:
+    """WatsonxApiToolAppBinding now requires tool_id and makes flow_version_id optional."""
+    from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import WatsonxApiToolAppBinding
+
+    binding = WatsonxApiToolAppBinding(
+        flow_version_id=uuid4(),
+        tool_id="tool-123",
+        app_ids=["app-one"],
+    )
+    assert binding.tool_id == "tool-123"
+    assert binding.flow_version_id is not None
+
+    binding_no_fv = WatsonxApiToolAppBinding(
+        tool_id="tool-456",
+        app_ids=[],
+    )
+    assert binding_no_fv.flow_version_id is None
+    assert binding_no_fv.tool_id == "tool-456"
+
+
+def test_watsonx_mapper_shapes_update_response_with_tool_id() -> None:
+    """shape_deployment_update_result should include tool_id in bindings."""
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    timestamp = datetime.now(tz=timezone.utc)
+    deployment_id = uuid4()
+    flow_version_id = uuid4()
+    deployment_row = SimpleNamespace(
+        id=deployment_id,
+        name="WXO Deployment",
+        description="test",
+        deployment_type=DeploymentType.AGENT,
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+
+    from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import (
+        PAYLOAD_SCHEMAS as WXO_SCHEMAS,
+    )
+
+    result = DeploymentUpdateResult(
+        id="agent-1",
+        provider_result=WXO_SCHEMAS.deployment_update_result.apply(
+            WatsonxDeploymentUpdateResultData(
+                created_app_ids=[],
+                referenced_snapshot_bindings=[
+                    {"source_ref": str(flow_version_id), "tool_id": "tool-1", "created": True},
+                ],
+                tool_app_bindings=[
+                    {"tool_id": "tool-1", "app_ids": ["app-one"]},
+                ],
+            )
+        ),
+    )
+
+    response = mapper.shape_deployment_update_result(result, deployment_row)
+    bindings = response.provider_data["tool_app_bindings"]
+    assert len(bindings) == 1
+    assert bindings[0]["tool_id"] == "tool-1"
+    assert bindings[0]["flow_version_id"] == str(flow_version_id)
+
+
+def test_watsonx_mapper_shapes_update_response_with_non_uuid_source_ref() -> None:
+    """Non-UUID source_ref (from tool_id ops) should produce flow_version_id=None."""
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    timestamp = datetime.now(tz=timezone.utc)
+    deployment_row = SimpleNamespace(
+        id=uuid4(),
+        name="WXO Deployment",
+        description="test",
+        deployment_type=DeploymentType.AGENT,
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+
+    from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import (
+        PAYLOAD_SCHEMAS as WXO_SCHEMAS,
+    )
+
+    result = DeploymentUpdateResult(
+        id="agent-1",
+        provider_result=WXO_SCHEMAS.deployment_update_result.apply(
+            WatsonxDeploymentUpdateResultData(
+                created_app_ids=[],
+                referenced_snapshot_bindings=[
+                    {"source_ref": "external-tool-id", "tool_id": "external-tool-id", "created": False},
+                ],
+                tool_app_bindings=[
+                    {"tool_id": "external-tool-id", "app_ids": ["app-one"]},
+                ],
+            )
+        ),
+    )
+
+    response = mapper.shape_deployment_update_result(result, deployment_row)
+    bindings = response.provider_data["tool_app_bindings"]
+    assert len(bindings) == 1
+    assert bindings[0]["tool_id"] == "external-tool-id"
+    assert "flow_version_id" not in bindings[0]
+
+
+# ---------------------------------------------------------------------------
+# util_update_snapshot_bindings filters non-UUID source_refs
+# ---------------------------------------------------------------------------
+
+
+def test_watsonx_mapper_update_snapshot_bindings_filters_non_uuid_source_refs() -> None:
+    """Non-UUID source_ref bindings are excluded from attachment reconciliation."""
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    flow_version_id = uuid4()
+
+    from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import (
+        PAYLOAD_SCHEMAS as WXO_SCHEMAS,
+    )
+
+    result = DeploymentUpdateResult(
+        id="agent-1",
+        provider_result=WXO_SCHEMAS.deployment_update_result.apply(
+            WatsonxDeploymentUpdateResultData(
+                created_app_ids=[],
+                added_snapshot_bindings=[
+                    {"source_ref": str(flow_version_id), "tool_id": "tool-fv-based", "created": True},
+                    {"source_ref": "external-tool-id", "tool_id": "external-tool-id", "created": False},
+                ],
+            )
+        ),
+    )
+
+    bindings = mapper.util_update_snapshot_bindings(result=result)
+    assert len(bindings.snapshot_bindings) == 1
+    assert bindings.snapshot_bindings[0].source_ref == str(flow_version_id)
+    assert bindings.snapshot_bindings[0].snapshot_id == "tool-fv-based"
+
+
+# ---------------------------------------------------------------------------
+# Create payload: bind_tool operations
+# ---------------------------------------------------------------------------
+
+
+def test_watsonx_create_payload_accepts_bind_tool_operation() -> None:
+    """Create payload should accept bind_tool operations."""
+    WatsonxApiDeploymentCreatePayload.model_validate(
+        {
+            "llm": TEST_WXO_LLM,
+            "operations": [
+                {"op": "bind_tool", "tool_id": "existing-tool", "app_ids": []},
+            ],
+        }
+    )
+
+
+def test_watsonx_create_payload_bind_tool_without_prefix() -> None:
+    """bind_tool on create does not require resource_name_prefix."""
+    payload = WatsonxApiDeploymentCreatePayload.model_validate(
+        {
+            "llm": TEST_WXO_LLM,
+            "operations": [
+                {"op": "bind_tool", "tool_id": "existing-tool", "app_ids": []},
+            ],
+        }
+    )
+    assert payload.resource_name_prefix is None

--- a/src/backend/tests/unit/api/v1/test_deployments_routes.py
+++ b/src/backend/tests/unit/api/v1/test_deployments_routes.py
@@ -47,6 +47,17 @@ def test_snapshots_path_matches_snapshots_endpoint(deployment_routes: list[APIRo
     assert _resolve_endpoint_name(deployment_routes, path="/deployments/snapshots") == "list_deployment_snapshots"
 
 
+def test_snapshot_patch_path_matches_update_endpoint(deployment_routes: list[APIRoute]) -> None:
+    assert (
+        _resolve_endpoint_name(
+            deployment_routes,
+            path="/deployments/snapshots/tool-123",
+            method="PATCH",
+        )
+        == "update_snapshot"
+    )
+
+
 def test_deployment_status_path_matches_status_endpoint(deployment_routes: list[APIRoute]) -> None:
     deployment_id = uuid4()
     assert (


### PR DESCRIPTION
- Fix bind to reuse existing WXO tools via attachment lookup instead of always creating new ones
- Add tool_id-based operations (bind_tool, unbind_tool, remove_tool_by_id) alongside existing flow_version_id operations
- Add PATCH /deployments/snapshots/{provider_snapshot_id} endpoint to update snapshot content with a new flow version (blast-radius bounded to Langflow-tracked tools only)
- Add update_snapshot method to WXO adapter
- Enrich flow version list with deployment info (tool_id, tool_name, app_ids) via FlowVersionReadWithDeployments API schema
- Surface tool_id in WatsonxApiToolAppBinding responses; flow_version_id becomes optional for tool-id-based operations