### PR TITLE
feat(deployments): add paginated deployment flow-version listing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2491,17 +2491,9 @@
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/api/v1/test_deployment_schemas.py",
-        "hashed_secret": "99091d046a81493ef2545d8c3cd8e881e8702893",
-        "is_verified": false,
-        "line_number": 49,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/api/v1/test_deployment_schemas.py",
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_verified": false,
-        "line_number": 71,
+        "line_number": 67,
         "is_secret": false
       }
     ],
@@ -5650,5 +5642,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-31T16:15:19Z"
+  "generated_at": "2026-04-01T22:21:13Z"
 }

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -29,6 +29,7 @@ from langflow.api.v1.mappers.deployments.helpers import (
     get_deployment_row_or_404,
     get_owned_provider_account_or_404,
     handle_adapter_errors,
+    list_deployment_flow_versions_synced,
     list_deployments_synced,
     normalize_flow_version_query_ids,
     page_offset,
@@ -54,6 +55,7 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentCreateRequest,
     DeploymentCreateResponse,
     DeploymentDuplicateResponse,
+    DeploymentFlowVersionListResponse,
     DeploymentGetResponse,
     DeploymentListResponse,
     DeploymentLlmListResponse,
@@ -1309,6 +1311,42 @@ async def get_deployment_status(
         created_at=deployment_row.created_at,
         updated_at=deployment_row.updated_at,
         provider_data=health_result.provider_data,
+    )
+
+
+@router.get(
+    "/{deployment_id}/flows",
+    response_model=DeploymentFlowVersionListResponse,
+)
+async def list_deployment_flow_versions(
+    deployment_id: DeploymentIdPath,
+    session: DbSession,
+    current_user: CurrentActiveUser,
+    page: Annotated[int, Query(ge=1)] = 1,
+    size: Annotated[int, Query(ge=1, le=50)] = 20,
+):
+    deployment_row, deployment_adapter, deployment_mapper = await resolve_adapter_mapper_from_deployment(
+        deployment_id=deployment_id,
+        user_id=current_user.id,
+        db=session,
+    )
+    with handle_adapter_errors(), deployment_provider_scope(deployment_row.deployment_provider_account_id):
+        rows, total, snapshot_result = await list_deployment_flow_versions_synced(
+            deployment_adapter=deployment_adapter,
+            deployment_mapper=deployment_mapper,
+            user_id=current_user.id,
+            provider_id=deployment_row.deployment_provider_account_id,
+            deployment_id=deployment_row.id,
+            db=session,
+            page=page,
+            size=size,
+        )
+    return deployment_mapper.shape_flow_version_list_result(
+        rows=rows,
+        snapshot_result=snapshot_result,
+        page=page,
+        size=size,
+        total=total,
     )
 
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -307,7 +307,7 @@ class BaseDeploymentMapper:
     def shape_flow_version_list_result(
         self,
         *,
-        rows: list[tuple[FlowVersionDeploymentAttachment, FlowVersion]],
+        rows: list[tuple[FlowVersionDeploymentAttachment, FlowVersion, str | None]],
         snapshot_result: SnapshotListResult | None,
         page: int,
         size: int,
@@ -318,12 +318,13 @@ class BaseDeploymentMapper:
             DeploymentFlowVersionListItem(
                 id=flow_version.id,
                 flow_id=flow_version.flow_id,
+                flow_name=flow_name,
                 version_number=flow_version.version_number,
                 attached_at=attachment.created_at,
                 provider_snapshot_id=(attachment.provider_snapshot_id or "").strip() or None,
                 provider_data=None,
             )
-            for attachment, flow_version in rows
+            for attachment, flow_version, flow_name in rows
         ]
         return DeploymentFlowVersionListResponse(
             flow_versions=flow_versions,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -62,6 +62,8 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentConfigListItem,
     DeploymentConfigListResponse,
     DeploymentCreateRequest,
+    DeploymentFlowVersionListItem,
+    DeploymentFlowVersionListResponse,
     DeploymentListItem,
     DeploymentListResponse,
     DeploymentLlmListResponse,
@@ -91,6 +93,10 @@ if TYPE_CHECKING:
 
     from langflow.services.database.models.deployment.model import Deployment
     from langflow.services.database.models.deployment_provider_account.model import DeploymentProviderAccount
+    from langflow.services.database.models.flow_version.model import FlowVersion
+    from langflow.services.database.models.flow_version_deployment_attachment.model import (
+        FlowVersionDeploymentAttachment,
+    )
 
 
 @dataclass(frozen=True)
@@ -297,6 +303,34 @@ class BaseDeploymentMapper:
             )
             for row, attached_count, matched_flow_versions in rows_with_counts
         ]
+
+    def shape_flow_version_list_result(
+        self,
+        *,
+        rows: list[tuple[FlowVersionDeploymentAttachment, FlowVersion]],
+        snapshot_result: SnapshotListResult | None,
+        page: int,
+        size: int,
+        total: int,
+    ) -> DeploymentFlowVersionListResponse:
+        _ = snapshot_result
+        flow_versions = [
+            DeploymentFlowVersionListItem(
+                id=flow_version.id,
+                flow_id=flow_version.flow_id,
+                version_number=flow_version.version_number,
+                attached_at=attachment.created_at,
+                provider_snapshot_id=(attachment.provider_snapshot_id or "").strip() or None,
+                provider_data=None,
+            )
+            for attachment, flow_version in rows
+        ]
+        return DeploymentFlowVersionListResponse(
+            flow_versions=flow_versions,
+            page=page,
+            size=size,
+            total=total,
+        )
 
     def shape_deployment_create_result(self, provider_result: dict[str, Any] | None) -> dict[str, Any] | None:
         return provider_result

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -21,6 +21,7 @@ from lfx.services.adapters.deployment.schema import (
     DeploymentType,
     DeploymentUpdateResult,
     SnapshotListParams,
+    SnapshotListResult,
 )
 from lfx.services.adapters.deployment.schema import (
     DeploymentCreateResult as AdapterDeploymentCreateResult,
@@ -54,10 +55,13 @@ from langflow.services.database.models.deployment_provider_account.model import 
 from langflow.services.database.models.flow.model import Flow
 from langflow.services.database.models.flow_version.model import FlowVersion
 from langflow.services.database.models.flow_version_deployment_attachment.crud import (
+    count_deployment_attachments,
     create_deployment_attachment,
     delete_deployment_attachment,
     get_deployment_attachment,
     list_attachments_by_deployment_ids,
+    list_deployment_attachments,
+    list_deployment_attachments_with_versions,
     update_deployment_attachment_provider_snapshot_id,
 )
 from langflow.services.database.models.flow_version_deployment_attachment.model import (
@@ -1014,6 +1018,73 @@ async def list_deployments_synced(
         flow_version_ids=flow_version_ids,
     )
     return accepted, total
+
+
+async def list_deployment_flow_versions_synced(
+    *,
+    deployment_adapter: DeploymentServiceProtocol,
+    deployment_mapper: BaseDeploymentMapper,
+    user_id: UUID,
+    provider_id: UUID,
+    deployment_id: UUID,
+    db: DbSession,
+    page: int,
+    size: int,
+) -> tuple[list[tuple[FlowVersionDeploymentAttachment, FlowVersion]], int, SnapshotListResult | None]:
+    """Return a paginated deployment attachment view synced against provider snapshots.
+
+    Uses attachment-tracked ``provider_snapshot_id`` values to verify provider
+    snapshot existence in one batched adapter call. Stale attachments are
+    deleted before pagination is applied.
+    """
+    attachments = await list_deployment_attachments(
+        db,
+        user_id=user_id,
+        deployment_id=deployment_id,
+    )
+    snapshot_result: SnapshotListResult | None = None
+    snapshot_ids = list(dict.fromkeys(deployment_mapper.util_snapshot_ids_to_verify(attachments)))
+    if snapshot_ids:
+        try:
+            snapshot_result = await deployment_adapter.list_snapshots(
+                user_id=user_id,
+                db=db,
+                params=SnapshotListParams(snapshot_ids=snapshot_ids),
+            )
+            known_snapshot_ids = {str(item.id) for item in snapshot_result.snapshots if item.id}
+
+            async with db.begin_nested():
+                await sync_attachment_snapshot_ids(
+                    user_id=user_id,
+                    deployment_ids=[deployment_id],
+                    attachments=attachments,
+                    known_snapshot_ids=known_snapshot_ids,
+                    db=db,
+                )
+        except Exception:  # noqa: BLE001
+            snapshot_result = None
+            logger.warning(
+                "Snapshot-level sync failed while listing deployment flow versions for deployment %s "
+                "(provider %s); "
+                "returning DB rows without provider enrichment",
+                deployment_id,
+                provider_id,
+                exc_info=True,
+            )
+
+    rows = await list_deployment_attachments_with_versions(
+        db,
+        user_id=user_id,
+        deployment_id=deployment_id,
+        offset=page_offset(page, size),
+        limit=size,
+    )
+    total = await count_deployment_attachments(
+        db,
+        user_id=user_id,
+        deployment_id=deployment_id,
+    )
+    return rows, total, snapshot_result
 
 
 async def attach_flow_versions(

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -1030,7 +1030,7 @@ async def list_deployment_flow_versions_synced(
     db: DbSession,
     page: int,
     size: int,
-) -> tuple[list[tuple[FlowVersionDeploymentAttachment, FlowVersion]], int, SnapshotListResult | None]:
+) -> tuple[list[tuple[FlowVersionDeploymentAttachment, FlowVersion, str | None]], int, SnapshotListResult | None]:
     """Return a paginated deployment attachment view synced against provider snapshots.
 
     Uses attachment-tracked ``provider_snapshot_id`` values to verify provider

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -110,6 +110,7 @@ if TYPE_CHECKING:
 class _NormalizedAttachmentRow:
     attachment: FlowVersionDeploymentAttachment
     flow_version: FlowVersion
+    flow_name: str | None
     snapshot_id: str
 
 
@@ -896,7 +897,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
     def shape_flow_version_list_result(
         self,
         *,
-        rows: list[tuple[FlowVersionDeploymentAttachment, FlowVersion]],
+        rows: list[tuple[FlowVersionDeploymentAttachment, FlowVersion, str | None]],
         snapshot_result: SnapshotListResult | None,
         page: int,
         size: int,
@@ -911,6 +912,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             DeploymentFlowVersionListItem(
                 id=row.flow_version.id,
                 flow_id=row.flow_version.flow_id,
+                flow_name=row.flow_name,
                 version_number=row.flow_version.version_number,
                 attached_at=row.attachment.created_at,
                 provider_snapshot_id=row.snapshot_id,
@@ -928,10 +930,10 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
 
     def _normalize_flow_version_attachment_rows(
         self,
-        rows: list[tuple[FlowVersionDeploymentAttachment, FlowVersion]],
+        rows: list[tuple[FlowVersionDeploymentAttachment, FlowVersion, str | None]],
     ) -> list[_NormalizedAttachmentRow]:
         normalized_rows: list[_NormalizedAttachmentRow] = []
-        for attachment, flow_version in rows:
+        for attachment, flow_version, flow_name in rows:
             snapshot_id = (attachment.provider_snapshot_id or "").strip()
             if not snapshot_id:
                 msg = "Flow version attachment has an invalid provider_snapshot_id."
@@ -940,6 +942,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 _NormalizedAttachmentRow(
                     attachment=attachment,
                     flow_version=flow_version,
+                    flow_name=flow_name,
                     snapshot_id=snapshot_id,
                 )
             )

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -57,6 +58,7 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
     WatsonxApiBindOperation,
     WatsonxApiBindToolOperation,
     WatsonxApiDeploymentCreatePayload,
+    WatsonxApiDeploymentFlowVersionItemData,
     WatsonxApiDeploymentListProviderData,
     WatsonxApiDeploymentLlmListResultData,
     WatsonxApiDeploymentUpdatePayload,
@@ -104,6 +106,13 @@ if TYPE_CHECKING:
     )
 
 
+@dataclass(frozen=True)
+class _NormalizedAttachmentRow:
+    attachment: FlowVersionDeploymentAttachment
+    flow_version: FlowVersion
+    snapshot_id: str
+
+
 @register_mapper(AdapterType.DEPLOYMENT, WATSONX_ORCHESTRATE_DEPLOYMENT_ADAPTER_KEY)
 class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
     """Deployment mapper for Watsonx Orchestrate provider."""
@@ -123,6 +132,10 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         ),
         deployment_list_result=PayloadSlot(
             adapter_model=WatsonxApiDeploymentListProviderData,
+            policy=PayloadSlotPolicy.VALIDATE_ONLY,
+        ),
+        deployment_item_data=PayloadSlot(
+            adapter_model=WatsonxApiDeploymentFlowVersionItemData,
             policy=PayloadSlotPolicy.VALIDATE_ONLY,
         ),
         execution_create_result=PayloadSlot(
@@ -889,27 +902,22 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         size: int,
         total: int,
     ) -> DeploymentFlowVersionListResponse:
-        snapshot_data_by_id = {
-            snapshot_id: (snapshot.provider_data if isinstance(snapshot.provider_data, dict) else None)
-            for snapshot in (snapshot_result.snapshots if snapshot_result else [])
-            if (snapshot_id := str(snapshot.id or "").strip())
-        }
+        normalized_rows = self._normalize_flow_version_attachment_rows(rows)
+        snapshot_data_by_id = self._resolve_snapshot_data_by_id(
+            snapshot_result=snapshot_result,
+        )
 
-        flow_versions: list[DeploymentFlowVersionListItem] = []
-        for attachment, flow_version in rows:
-            snapshot_id = (attachment.provider_snapshot_id or "").strip() or None
-            flow_versions.append(
-                DeploymentFlowVersionListItem(
-                    id=flow_version.id,
-                    flow_id=flow_version.flow_id,
-                    version_number=flow_version.version_number,
-                    attached_at=attachment.created_at,
-                    provider_snapshot_id=snapshot_id,
-                    provider_data=self.shape_deployment_flow_version_item_data(
-                        snapshot_data_by_id.get(snapshot_id) if snapshot_id else None
-                    ),
-                )
+        flow_versions = [
+            DeploymentFlowVersionListItem(
+                id=row.flow_version.id,
+                flow_id=row.flow_version.flow_id,
+                version_number=row.flow_version.version_number,
+                attached_at=row.attachment.created_at,
+                provider_snapshot_id=row.snapshot_id,
+                provider_data=self.shape_deployment_flow_version_item_data(snapshot_data_by_id.get(row.snapshot_id)),
             )
+            for row in normalized_rows
+        ]
 
         return DeploymentFlowVersionListResponse(
             flow_versions=flow_versions,
@@ -917,6 +925,45 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             size=size,
             total=total,
         )
+
+    def _normalize_flow_version_attachment_rows(
+        self,
+        rows: list[tuple[FlowVersionDeploymentAttachment, FlowVersion]],
+    ) -> list[_NormalizedAttachmentRow]:
+        normalized_rows: list[_NormalizedAttachmentRow] = []
+        for attachment, flow_version in rows:
+            snapshot_id = (attachment.provider_snapshot_id or "").strip()
+            if not snapshot_id:
+                msg = "Flow version attachment has an invalid provider_snapshot_id."
+                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
+            normalized_rows.append(
+                _NormalizedAttachmentRow(
+                    attachment=attachment,
+                    flow_version=flow_version,
+                    snapshot_id=snapshot_id,
+                )
+            )
+        return normalized_rows
+
+    def _resolve_snapshot_data_by_id(
+        self,
+        *,
+        snapshot_result: SnapshotListResult | None,
+    ) -> dict[str, dict[str, Any] | None]:
+        if snapshot_result is None:
+            return {}
+        if not snapshot_result.snapshots:
+            return {}
+
+        snapshot_data_by_id: dict[str, dict[str, Any] | None] = {}
+        for snapshot in snapshot_result.snapshots:
+            snapshot_id = str(snapshot.id).strip()
+            if not snapshot_id:
+                continue
+            provider_data = snapshot.provider_data
+            snapshot_data_by_id[snapshot_id] = provider_data if isinstance(provider_data, dict) else None
+
+        return snapshot_data_by_id
 
     def shape_deployment_flow_version_item_data(
         self,
@@ -927,7 +974,17 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         raw_connections = snapshot_data.get("connections", {})
         if not isinstance(raw_connections, dict) or not raw_connections:
             return None
-        return {"connection_app_ids": list(raw_connections.keys())}
+        try:
+            return self._validate_slot(
+                self.api_payloads.deployment_item_data,
+                {"app_ids": list(raw_connections.keys())},
+            )
+        except AdapterPayloadValidationError as exc:
+            detail = exc.format_first_error()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Invalid flow-version provider_data payload: {detail}",
+            ) from exc
 
     def _shape_provider_deployment_list_entry(self, item: Any) -> dict[str, Any]:
         item_provider_data = item.provider_data

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -15,6 +15,7 @@ from lfx.services.adapters.deployment.schema import (
     DeploymentUpdateResult,
     ExecutionCreateResult,
     ExecutionStatusResult,
+    SnapshotListResult,
     VerifyCredentials,
 )
 from lfx.services.adapters.deployment.schema import (
@@ -69,6 +70,8 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
 )
 from langflow.api.v1.schemas.deployments import (
     DeploymentCreateRequest,
+    DeploymentFlowVersionListItem,
+    DeploymentFlowVersionListResponse,
     DeploymentListResponse,
     DeploymentLlmListResponse,
     DeploymentProviderAccountCreateRequest,
@@ -95,6 +98,10 @@ if TYPE_CHECKING:
 
     from langflow.services.database.models.deployment.model import Deployment
     from langflow.services.database.models.deployment_provider_account.model import DeploymentProviderAccount
+    from langflow.services.database.models.flow_version.model import FlowVersion
+    from langflow.services.database.models.flow_version_deployment_attachment.model import (
+        FlowVersionDeploymentAttachment,
+    )
 
 
 @register_mapper(AdapterType.DEPLOYMENT, WATSONX_ORCHESTRATE_DEPLOYMENT_ADAPTER_KEY)
@@ -872,6 +879,55 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             total=total,
             provider_data=validated_payload,
         )
+
+    def shape_flow_version_list_result(
+        self,
+        *,
+        rows: list[tuple[FlowVersionDeploymentAttachment, FlowVersion]],
+        snapshot_result: SnapshotListResult | None,
+        page: int,
+        size: int,
+        total: int,
+    ) -> DeploymentFlowVersionListResponse:
+        snapshot_data_by_id = {
+            snapshot_id: (snapshot.provider_data if isinstance(snapshot.provider_data, dict) else None)
+            for snapshot in (snapshot_result.snapshots if snapshot_result else [])
+            if (snapshot_id := str(snapshot.id or "").strip())
+        }
+
+        flow_versions: list[DeploymentFlowVersionListItem] = []
+        for attachment, flow_version in rows:
+            snapshot_id = (attachment.provider_snapshot_id or "").strip() or None
+            flow_versions.append(
+                DeploymentFlowVersionListItem(
+                    id=flow_version.id,
+                    flow_id=flow_version.flow_id,
+                    version_number=flow_version.version_number,
+                    attached_at=attachment.created_at,
+                    provider_snapshot_id=snapshot_id,
+                    provider_data=self.shape_deployment_flow_version_item_data(
+                        snapshot_data_by_id.get(snapshot_id) if snapshot_id else None
+                    ),
+                )
+            )
+
+        return DeploymentFlowVersionListResponse(
+            flow_versions=flow_versions,
+            page=page,
+            size=size,
+            total=total,
+        )
+
+    def shape_deployment_flow_version_item_data(
+        self,
+        snapshot_data: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        if not snapshot_data:
+            return None
+        raw_connections = snapshot_data.get("connections", {})
+        if not isinstance(raw_connections, dict) or not raw_connections:
+            return None
+        return {"connection_app_ids": list(raw_connections.keys())}
 
     def _shape_provider_deployment_list_entry(self, item: Any) -> dict[str, Any]:
         item_provider_data = item.provider_data

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -974,8 +974,8 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
     ) -> dict[str, Any] | None:
         if not snapshot_data:
             return None
-        raw_connections = snapshot_data.get("connections", {})
-        if not isinstance(raw_connections, dict) or not raw_connections:
+        raw_connections = snapshot_data.get("connections")
+        if raw_connections is None or not isinstance(raw_connections, dict):
             return None
         try:
             return self._validate_slot(

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -458,7 +458,7 @@ class WatsonxApiDeploymentFlowVersionItemData(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    app_ids: list[str] = Field(min_length=1)
+    app_ids: list[str] = Field(default_factory=list)
 
     @field_validator("app_ids", mode="before")
     @classmethod

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -453,6 +453,21 @@ class WatsonxApiDeploymentListProviderData(BaseModel):
     entries: list[WatsonxApiProviderDeploymentListItem] = Field(default_factory=list)
 
 
+class WatsonxApiDeploymentFlowVersionItemData(BaseModel):
+    """API-facing provider_data contract for deployment flow-version list items."""
+
+    model_config = {"extra": "forbid"}
+
+    app_ids: list[str] = Field(min_length=1)
+
+    @field_validator("app_ids", mode="before")
+    @classmethod
+    def normalize_app_ids(cls, value: Any) -> list[str]:
+        if value is None:
+            return []
+        return [str(app_id).strip() for app_id in value if str(app_id).strip()]
+
+
 class _WatsonxApiAgentExecutionResultBase(BaseModel):
     """Shared fields for API-facing agent execution result payloads.
 

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -349,6 +349,10 @@ class DeploymentFlowVersionListItem(BaseModel):
 
     id: UUID = Field(description="Langflow flow version UUID (`flow_version.id`).")
     flow_id: UUID = Field(description="Langflow flow UUID (`flow.id`) for this version.")
+    flow_name: str | None = Field(
+        default=None,
+        description="Name of the flow owning this version (`flow.name`).",
+    )
     version_number: int = Field(ge=1, description="Flow version number.")
     attached_at: datetime | None = Field(
         default=None,

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -344,6 +344,30 @@ class DeploymentSnapshotListResponse(_PaginatedResponse):
     snapshots: list[DeploymentSnapshotListItem]
 
 
+class DeploymentFlowVersionListItem(BaseModel):
+    """Flow version metadata attached to a deployment."""
+
+    id: UUID = Field(description="Langflow flow version UUID (`flow_version.id`).")
+    flow_id: UUID = Field(description="Langflow flow UUID (`flow.id`) for this version.")
+    version_number: int = Field(ge=1, description="Flow version number.")
+    attached_at: datetime | None = Field(
+        default=None,
+        description="Timestamp when this flow version was attached to the deployment.",
+    )
+    provider_snapshot_id: str | None = Field(
+        default=None,
+        description="Provider-owned snapshot/tool identifier linked by the attachment.",
+    )
+    provider_data: dict[str, Any] | None = Field(
+        default=None,
+        description="Provider-owned opaque payload for this attached flow version.",
+    )
+
+
+class DeploymentFlowVersionListResponse(_PaginatedResponse):
+    flow_versions: list[DeploymentFlowVersionListItem]
+
+
 class DeploymentCreateResponse(_DeploymentResponseBase):
     """API response for deployment creation."""
 

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
@@ -521,11 +521,28 @@ async def verify_tools_by_ids(
         if not isinstance(tool, dict) or not tool.get("id"):
             continue
         connections = extract_langflow_connections_binding(tool)
+        normalized_connections: dict[str, str] = {
+            key: value
+            for raw_key, raw_value in connections.items()
+            if isinstance(raw_key, str)
+            and isinstance(raw_value, str)
+            and (key := raw_key.strip())
+            and (value := raw_value.strip())
+        }
+
+        if len(normalized_connections) < len(connections):
+            logger.warning(
+                "Tool %s returned malformed langflow connection bindings; defaulting to empty mapping",
+                tool["id"],
+            )
+            provider_data: dict[str, dict[str, str]] = {"connections": {}}
+        else:
+            provider_data = {"connections": normalized_connections}
         snapshots.append(
             SnapshotItem(
                 id=tool["id"],
                 name=tool.get("name") or tool["id"],
-                provider_data={"connections": connections} if connections else None,
+                provider_data=provider_data,
             )
         )
     return SnapshotListResult(snapshots=snapshots)

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
@@ -104,6 +104,22 @@ def ensure_langflow_connections_binding(tool_payload: dict[str, Any]) -> dict[st
     return _ensure_dict(langflow, "connections")
 
 
+def extract_langflow_connections_binding(tool_payload: dict[str, Any]) -> dict[str, str]:
+    """Extract ``binding.langflow.connections`` from a provider tool payload.
+
+    Read-path helper: returns ``{}`` for missing or malformed nested shapes
+    without mutating the input payload.
+    """
+    binding = tool_payload.get("binding")
+    if not isinstance(binding, dict):
+        return {}
+    langflow = binding.get("langflow")
+    if not isinstance(langflow, dict):
+        return {}
+    connections = langflow.get("connections")
+    return connections if isinstance(connections, dict) else {}
+
+
 async def update_existing_tool_connection_bindings(
     *,
     clients: WxOClient,
@@ -500,13 +516,16 @@ async def verify_tools_by_ids(
             log_msg="Unexpected error while verifying wxO tool snapshots by ID",
         )
 
-    return SnapshotListResult(
-        snapshots=[
+    snapshots: list[SnapshotItem] = []
+    for tool in tools or []:
+        if not isinstance(tool, dict) or not tool.get("id"):
+            continue
+        connections = extract_langflow_connections_binding(tool)
+        snapshots.append(
             SnapshotItem(
                 id=tool["id"],
                 name=tool.get("name") or tool["id"],
+                provider_data={"connections": connections} if connections else None,
             )
-            for tool in (tools or [])
-            if isinstance(tool, dict) and tool.get("id")
-        ],
-    )
+        )
+    return SnapshotListResult(snapshots=snapshots)

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
@@ -672,6 +672,14 @@ class WatsonxDeploymentLlmListResultData(BaseModel):
     models: list[WatsonxModelOut] = Field(default_factory=list)
 
 
+class WatsonxSnapshotConnectionsProviderData(BaseModel):
+    """Provider data contract for snapshot list items in snapshot-ids mode."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    connections: dict[NormalizedId, NormalizedId] = Field(default_factory=dict)
+
+
 class WatsonxProviderUpdateApplyResult(BaseModel):
     """Public adapter contract for update helper apply results.
 
@@ -718,6 +726,7 @@ class WatsonxVerifyCredentialsPayload(BaseModel):
 PAYLOAD_SCHEMAS = DeploymentPayloadSchemas(
     deployment_create=PayloadSlot(WatsonxDeploymentCreatePayload),
     flow_artifact=PayloadSlot(WatsonxFlowArtifactProviderData),
+    snapshot_item_data=PayloadSlot(WatsonxSnapshotConnectionsProviderData),
     deployment_create_result=PayloadSlot(WatsonxDeploymentCreateResultData),
     deployment_update=PayloadSlot(WatsonxDeploymentUpdatePayload),
     deployment_update_result=PayloadSlot(WatsonxDeploymentUpdateResultData),

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -82,6 +82,7 @@ from langflow.services.adapters.deployment.watsonx_orchestrate.core.status impor
 )
 from langflow.services.adapters.deployment.watsonx_orchestrate.core.tools import (
     build_langflow_artifact_bytes,
+    extract_langflow_connections_binding,
     upload_tool_artifact_bytes,
     verify_tools_by_ids,
 )
@@ -739,7 +740,7 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
         for tool in tools or []:
             if not isinstance(tool, dict):
                 continue
-            connections: dict = tool.get("binding", {}).get("langflow", {}).get("connections", {})
+            connections = extract_langflow_connections_binding(tool)
             if not connections:
                 continue
             app_ids.update(connections.keys())

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -163,6 +163,19 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             msg = exc.format_first_error() if isinstance(exc, AdapterPayloadValidationError) else str(exc)
             raise InvalidContentError(message=msg) from None
 
+    def _validate_snapshot_item_provider_data(self, raw: dict[str, object]) -> dict[str, object]:
+        """Validate per-item snapshot provider_data via configured slot."""
+        snapshot_item_slot = self.payload_schemas.snapshot_item_data
+        if snapshot_item_slot is None:
+            msg = f"{ErrorPrefix.LIST.value} Required slot 'snapshot_item_data' is not configured."
+            raise DeploymentError(message=msg, error_code="deployment_error")
+
+        try:
+            return snapshot_item_slot.apply(raw)
+        except (AdapterPayloadMissingError, AdapterPayloadValidationError) as exc:
+            detail = exc.format_first_error() if isinstance(exc, AdapterPayloadValidationError) else str(exc)
+            raise InvalidContentError(message=detail) from None
+
     async def create(
         self,
         *,
@@ -794,7 +807,9 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                 SnapshotItem(
                     id=tool["id"],
                     name=tool.get("name") or tool["id"],
-                    provider_data=tool,
+                    provider_data=self._validate_snapshot_item_provider_data(
+                        {"connections": extract_langflow_connections_binding(tool)}
+                    ),
                 )
                 for tool in (raw_tools or [])
                 if isinstance(tool, dict) and tool.get("id")
@@ -835,12 +850,22 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             SnapshotItem(
                 id=tool["id"],
                 name=tool.get("name") or tool["id"],
+                provider_data=self._validate_snapshot_item_provider_data(
+                    {"connections": extract_langflow_connections_binding(tool)}
+                ),
             )
             for tool in (tools or [])
-            if tool.get("id")
+            if isinstance(tool, dict) and tool.get("id")
         ]
         if not snapshots and requested_tool_ids:
-            snapshots = [SnapshotItem(id=tool_id, name=tool_id) for tool_id in requested_tool_ids]
+            snapshots = [
+                SnapshotItem(
+                    id=tool_id,
+                    name=tool_id,
+                    provider_data=self._validate_snapshot_item_provider_data({"connections": {}}),
+                )
+                for tool_id in requested_tool_ids
+            ]
 
         return SnapshotListResult(
             snapshots=snapshots,
@@ -867,7 +892,7 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                 error_prefix=ErrorPrefix.LIST,
                 log_msg="Unexpected error while verifying wxO tool snapshots by ID",
             )
-        return SnapshotListResult(snapshots=snapshots)
+        return snapshots
 
     async def verify_credentials(
         self,

--- a/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
+++ b/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 
     from sqlmodel.ext.asyncio.session import AsyncSession
 
+    from langflow.services.database.models.flow_version.model import FlowVersion
+
 
 async def create_deployment_attachment(
     db: AsyncSession,
@@ -77,6 +79,37 @@ async def list_deployment_attachments(
             FlowVersionDeploymentAttachment.deployment_id == deployment_id,
         )
         .order_by(FlowVersionDeploymentAttachment.created_at)
+    )
+    return list((await db.exec(stmt)).all())
+
+
+async def list_deployment_attachments_with_versions(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    deployment_id: UUID,
+    offset: int,
+    limit: int,
+) -> list[tuple[FlowVersionDeploymentAttachment, FlowVersion]]:
+    """Return paginated attachment rows joined with their flow version metadata."""
+    from langflow.services.database.models.flow_version.model import FlowVersion
+
+    if limit <= 0:
+        return []
+
+    stmt = (
+        select(FlowVersionDeploymentAttachment, FlowVersion)
+        .join(FlowVersion, FlowVersion.id == FlowVersionDeploymentAttachment.flow_version_id)
+        .where(
+            FlowVersionDeploymentAttachment.user_id == user_id,
+            FlowVersionDeploymentAttachment.deployment_id == deployment_id,
+        )
+        .order_by(
+            col(FlowVersionDeploymentAttachment.created_at).desc(),
+            col(FlowVersionDeploymentAttachment.updated_at).desc(),
+        )
+        .offset(offset)
+        .limit(limit)
     )
     return list((await db.exec(stmt)).all())
 
@@ -240,3 +273,17 @@ async def count_attachments_by_deployment_ids(
     )
     rows = (await db.exec(stmt)).all()
     return {deployment_id: int(count) for deployment_id, count in rows}
+
+
+async def count_deployment_attachments(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    deployment_id: UUID,
+) -> int:
+    stmt = select(func.count()).where(
+        FlowVersionDeploymentAttachment.user_id == user_id,
+        FlowVersionDeploymentAttachment.deployment_id == deployment_id,
+    )
+    total = (await db.exec(stmt)).one()
+    return int(total or 0)

--- a/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
+++ b/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
@@ -90,16 +90,18 @@ async def list_deployment_attachments_with_versions(
     deployment_id: UUID,
     offset: int,
     limit: int,
-) -> list[tuple[FlowVersionDeploymentAttachment, FlowVersion]]:
-    """Return paginated attachment rows joined with their flow version metadata."""
+) -> list[tuple[FlowVersionDeploymentAttachment, FlowVersion, str | None]]:
+    """Return paginated attachment rows joined with version metadata and flow name."""
+    from langflow.services.database.models.flow.model import Flow
     from langflow.services.database.models.flow_version.model import FlowVersion
 
     if limit <= 0:
         return []
 
     stmt = (
-        select(FlowVersionDeploymentAttachment, FlowVersion)
+        select(FlowVersionDeploymentAttachment, FlowVersion, Flow.name.label("flow_name"))
         .join(FlowVersion, FlowVersion.id == FlowVersionDeploymentAttachment.flow_version_id)
+        .join(Flow, Flow.id == FlowVersion.flow_id)
         .where(
             FlowVersionDeploymentAttachment.user_id == user_id,
             FlowVersionDeploymentAttachment.deployment_id == deployment_id,

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
@@ -410,6 +410,7 @@ def test_base_mapper_shapes_flow_version_list_result() -> None:
         (
             SimpleNamespace(provider_snapshot_id=" tool-1 ", created_at=attached_at),
             SimpleNamespace(id=flow_version_id, flow_id=flow_id, version_number=4),
+            "Flow A",
         )
     ]
     snapshot_result = SnapshotListResult(
@@ -436,6 +437,7 @@ def test_base_mapper_shapes_flow_version_list_result() -> None:
     assert len(shaped.flow_versions) == 1
     assert shaped.flow_versions[0].id == flow_version_id
     assert shaped.flow_versions[0].flow_id == flow_id
+    assert shaped.flow_versions[0].flow_name == "Flow A"
     assert shaped.flow_versions[0].version_number == 4
     assert shaped.flow_versions[0].attached_at == attached_at
     assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
@@ -448,6 +450,7 @@ def test_base_mapper_flow_version_item_data_defaults_to_none() -> None:
         (
             SimpleNamespace(provider_snapshot_id=None, created_at=None),
             SimpleNamespace(id=uuid4(), flow_id=uuid4(), version_number=1),
+            None,
         )
     ]
 
@@ -460,6 +463,7 @@ def test_base_mapper_flow_version_item_data_defaults_to_none() -> None:
     )
 
     assert len(shaped.flow_versions) == 1
+    assert shaped.flow_versions[0].flow_name is None
     assert shaped.flow_versions[0].provider_snapshot_id is None
     assert shaped.flow_versions[0].provider_data is None
 

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
@@ -27,6 +27,8 @@ from lfx.services.adapters.deployment.schema import (
     ExecutionCreateResult,
     ExecutionStatusResult,
     ItemResult,
+    SnapshotItem,
+    SnapshotListResult,
 )
 from lfx.services.adapters.payload import AdapterPayloadValidationError, PayloadSlot, PayloadSlotPolicy
 from lfx.services.adapters.schema import AdapterType
@@ -397,6 +399,69 @@ def test_base_mapper_shapes_deployment_list_result() -> None:
             }
         ]
     }
+
+
+def test_base_mapper_shapes_flow_version_list_result() -> None:
+    mapper = BaseDeploymentMapper()
+    attached_at = datetime.now(tz=timezone.utc)
+    flow_version_id = uuid4()
+    flow_id = uuid4()
+    rows = [
+        (
+            SimpleNamespace(provider_snapshot_id=" tool-1 ", created_at=attached_at),
+            SimpleNamespace(id=flow_version_id, flow_id=flow_id, version_number=4),
+        )
+    ]
+    snapshot_result = SnapshotListResult(
+        snapshots=[
+            SnapshotItem(
+                id="tool-1",
+                name="Tool 1",
+                provider_data={"connections": {"cfg-1": "conn-1"}},
+            )
+        ]
+    )
+
+    shaped = mapper.shape_flow_version_list_result(
+        rows=rows,
+        snapshot_result=snapshot_result,
+        page=2,
+        size=5,
+        total=7,
+    )
+
+    assert shaped.page == 2
+    assert shaped.size == 5
+    assert shaped.total == 7
+    assert len(shaped.flow_versions) == 1
+    assert shaped.flow_versions[0].id == flow_version_id
+    assert shaped.flow_versions[0].flow_id == flow_id
+    assert shaped.flow_versions[0].version_number == 4
+    assert shaped.flow_versions[0].attached_at == attached_at
+    assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
+    assert shaped.flow_versions[0].provider_data is None
+
+
+def test_base_mapper_flow_version_item_data_defaults_to_none() -> None:
+    mapper = BaseDeploymentMapper()
+    rows = [
+        (
+            SimpleNamespace(provider_snapshot_id=None, created_at=None),
+            SimpleNamespace(id=uuid4(), flow_id=uuid4(), version_number=1),
+        )
+    ]
+
+    shaped = mapper.shape_flow_version_list_result(
+        rows=rows,
+        snapshot_result=None,
+        page=1,
+        size=20,
+        total=1,
+    )
+
+    assert len(shaped.flow_versions) == 1
+    assert shaped.flow_versions[0].provider_snapshot_id is None
+    assert shaped.flow_versions[0].provider_data is None
 
 
 def test_base_mapper_execution_provider_data_shapers_passthrough() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -107,13 +107,13 @@ def test_watsonx_mapper_shapes_flow_version_item_data_from_connections() -> None
     assert shaped == {"app_ids": ["cfg-1", "cfg-2"]}
 
 
-def test_watsonx_mapper_flow_version_item_data_returns_none_for_missing_or_invalid_connections() -> None:
+def test_watsonx_mapper_flow_version_item_data_handles_missing_invalid_and_empty_connections() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
 
     assert mapper.shape_deployment_flow_version_item_data(None) is None
     assert mapper.shape_deployment_flow_version_item_data({}) is None
     assert mapper.shape_deployment_flow_version_item_data({"connections": []}) is None
-    assert mapper.shape_deployment_flow_version_item_data({"connections": {}}) is None
+    assert mapper.shape_deployment_flow_version_item_data({"connections": {}}) == {"app_ids": []}
 
 
 def test_watsonx_mapper_shapes_flow_version_list_result_with_enrichment() -> None:
@@ -156,6 +156,39 @@ def test_watsonx_mapper_shapes_flow_version_list_result_with_enrichment() -> Non
     assert shaped.flow_versions[0].attached_at == attached_at
     assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
     assert shaped.flow_versions[0].provider_data == {"app_ids": ["cfg-1"]}
+
+
+def test_watsonx_mapper_flow_version_list_result_returns_empty_app_ids_when_snapshot_has_no_connections() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    rows = [
+        (
+            SimpleNamespace(provider_snapshot_id="tool-1", created_at=datetime.now(tz=timezone.utc)),
+            SimpleNamespace(id=uuid4(), flow_id=uuid4(), version_number=1),
+            "Flow A",
+        )
+    ]
+    snapshot_result = SnapshotListResult(
+        snapshots=[
+            SnapshotItem(
+                id="tool-1",
+                name="Tool 1",
+                provider_data={"connections": {}},
+            )
+        ]
+    )
+
+    shaped = mapper.shape_flow_version_list_result(
+        rows=rows,
+        snapshot_result=snapshot_result,
+        page=1,
+        size=20,
+        total=1,
+    )
+
+    assert shaped.total == 1
+    assert len(shaped.flow_versions) == 1
+    assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
+    assert shaped.flow_versions[0].provider_data == {"app_ids": []}
 
 
 def test_watsonx_mapper_flow_version_list_result_degrades_when_snapshot_result_missing() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -104,7 +104,7 @@ def test_watsonx_mapper_shapes_flow_version_item_data_from_connections() -> None
 
     shaped = mapper.shape_deployment_flow_version_item_data({"connections": {"cfg-1": "conn-1", "cfg-2": "conn-2"}})
 
-    assert shaped == {"connection_app_ids": ["cfg-1", "cfg-2"]}
+    assert shaped == {"app_ids": ["cfg-1", "cfg-2"]}
 
 
 def test_watsonx_mapper_flow_version_item_data_returns_none_for_missing_or_invalid_connections() -> None:
@@ -153,7 +153,87 @@ def test_watsonx_mapper_shapes_flow_version_list_result_with_enrichment() -> Non
     assert shaped.flow_versions[0].version_number == 3
     assert shaped.flow_versions[0].attached_at == attached_at
     assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
-    assert shaped.flow_versions[0].provider_data == {"connection_app_ids": ["cfg-1"]}
+    assert shaped.flow_versions[0].provider_data == {"app_ids": ["cfg-1"]}
+
+
+def test_watsonx_mapper_flow_version_list_result_degrades_when_snapshot_result_missing() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    rows = [
+        (
+            SimpleNamespace(provider_snapshot_id="tool-1", created_at=datetime.now(tz=timezone.utc)),
+            SimpleNamespace(id=uuid4(), flow_id=uuid4(), version_number=1),
+        )
+    ]
+
+    shaped = mapper.shape_flow_version_list_result(
+        rows=rows,
+        snapshot_result=None,
+        page=1,
+        size=20,
+        total=1,
+    )
+
+    assert shaped.total == 1
+    assert len(shaped.flow_versions) == 1
+    assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
+    assert shaped.flow_versions[0].provider_data is None
+
+
+def test_watsonx_mapper_flow_version_list_result_degrades_when_required_snapshot_missing() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    rows = [
+        (
+            SimpleNamespace(provider_snapshot_id="tool-1", created_at=datetime.now(tz=timezone.utc)),
+            SimpleNamespace(id=uuid4(), flow_id=uuid4(), version_number=1),
+        )
+    ]
+    snapshot_result = SnapshotListResult(
+        snapshots=[
+            SnapshotItem(
+                id="tool-2",
+                name="Tool 2",
+                provider_data={"connections": {"cfg-2": "conn-2"}},
+            )
+        ]
+    )
+
+    shaped = mapper.shape_flow_version_list_result(
+        rows=rows,
+        snapshot_result=snapshot_result,
+        page=1,
+        size=20,
+        total=1,
+    )
+
+    assert shaped.total == 1
+    assert len(shaped.flow_versions) == 1
+    assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
+    assert shaped.flow_versions[0].provider_data is None
+
+
+@pytest.mark.parametrize("provider_snapshot_id", [None, "   "])
+def test_watsonx_mapper_flow_version_list_result_fails_fast_on_invalid_attachment_snapshot_id(
+    provider_snapshot_id: str | None,
+) -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    rows = [
+        (
+            SimpleNamespace(provider_snapshot_id=provider_snapshot_id, created_at=datetime.now(tz=timezone.utc)),
+            SimpleNamespace(id=uuid4(), flow_id=uuid4(), version_number=1),
+        )
+    ]
+
+    with pytest.raises(HTTPException) as exc_info:
+        mapper.shape_flow_version_list_result(
+            rows=rows,
+            snapshot_result=SnapshotListResult(snapshots=[]),
+            page=1,
+            size=20,
+            total=1,
+        )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Flow version attachment has an invalid provider_snapshot_id."
 
 
 def test_watsonx_api_payload_accepts_flow_version_create_bind_contract() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -25,6 +25,8 @@ from lfx.services.adapters.deployment.schema import (
     DeploymentListLlmsResult,
     DeploymentType,
     DeploymentUpdateResult,
+    SnapshotItem,
+    SnapshotListResult,
 )
 from lfx.services.adapters.payload import AdapterPayloadValidationError, PayloadSlot
 from lfx.services.adapters.schema import AdapterType
@@ -95,6 +97,63 @@ def test_watsonx_mapper_provider_list_entry_rejects_non_dict_provider_data() -> 
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == "Invalid deployment list item provider_data payload: expected object or null."
+
+
+def test_watsonx_mapper_shapes_flow_version_item_data_from_connections() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+
+    shaped = mapper.shape_deployment_flow_version_item_data({"connections": {"cfg-1": "conn-1", "cfg-2": "conn-2"}})
+
+    assert shaped == {"connection_app_ids": ["cfg-1", "cfg-2"]}
+
+
+def test_watsonx_mapper_flow_version_item_data_returns_none_for_missing_or_invalid_connections() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+
+    assert mapper.shape_deployment_flow_version_item_data(None) is None
+    assert mapper.shape_deployment_flow_version_item_data({}) is None
+    assert mapper.shape_deployment_flow_version_item_data({"connections": []}) is None
+    assert mapper.shape_deployment_flow_version_item_data({"connections": {}}) is None
+
+
+def test_watsonx_mapper_shapes_flow_version_list_result_with_enrichment() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    attached_at = datetime.now(tz=timezone.utc)
+    flow_version_id = uuid4()
+    flow_id = uuid4()
+
+    rows = [
+        (
+            SimpleNamespace(provider_snapshot_id="tool-1", created_at=attached_at),
+            SimpleNamespace(id=flow_version_id, flow_id=flow_id, version_number=3),
+        )
+    ]
+    snapshot_result = SnapshotListResult(
+        snapshots=[
+            SnapshotItem(
+                id="tool-1",
+                name="Tool 1",
+                provider_data={"connections": {"cfg-1": "conn-1"}},
+            )
+        ]
+    )
+
+    shaped = mapper.shape_flow_version_list_result(
+        rows=rows,
+        snapshot_result=snapshot_result,
+        page=1,
+        size=20,
+        total=1,
+    )
+
+    assert shaped.total == 1
+    assert len(shaped.flow_versions) == 1
+    assert shaped.flow_versions[0].id == flow_version_id
+    assert shaped.flow_versions[0].flow_id == flow_id
+    assert shaped.flow_versions[0].version_number == 3
+    assert shaped.flow_versions[0].attached_at == attached_at
+    assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
+    assert shaped.flow_versions[0].provider_data == {"connection_app_ids": ["cfg-1"]}
 
 
 def test_watsonx_api_payload_accepts_flow_version_create_bind_contract() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -126,6 +126,7 @@ def test_watsonx_mapper_shapes_flow_version_list_result_with_enrichment() -> Non
         (
             SimpleNamespace(provider_snapshot_id="tool-1", created_at=attached_at),
             SimpleNamespace(id=flow_version_id, flow_id=flow_id, version_number=3),
+            "Flow A",
         )
     ]
     snapshot_result = SnapshotListResult(
@@ -150,6 +151,7 @@ def test_watsonx_mapper_shapes_flow_version_list_result_with_enrichment() -> Non
     assert len(shaped.flow_versions) == 1
     assert shaped.flow_versions[0].id == flow_version_id
     assert shaped.flow_versions[0].flow_id == flow_id
+    assert shaped.flow_versions[0].flow_name == "Flow A"
     assert shaped.flow_versions[0].version_number == 3
     assert shaped.flow_versions[0].attached_at == attached_at
     assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
@@ -162,6 +164,7 @@ def test_watsonx_mapper_flow_version_list_result_degrades_when_snapshot_result_m
         (
             SimpleNamespace(provider_snapshot_id="tool-1", created_at=datetime.now(tz=timezone.utc)),
             SimpleNamespace(id=uuid4(), flow_id=uuid4(), version_number=1),
+            "Flow A",
         )
     ]
 
@@ -185,6 +188,7 @@ def test_watsonx_mapper_flow_version_list_result_degrades_when_required_snapshot
         (
             SimpleNamespace(provider_snapshot_id="tool-1", created_at=datetime.now(tz=timezone.utc)),
             SimpleNamespace(id=uuid4(), flow_id=uuid4(), version_number=1),
+            "Flow A",
         )
     ]
     snapshot_result = SnapshotListResult(
@@ -220,6 +224,7 @@ def test_watsonx_mapper_flow_version_list_result_fails_fast_on_invalid_attachmen
         (
             SimpleNamespace(provider_snapshot_id=provider_snapshot_id, created_at=datetime.now(tz=timezone.utc)),
             SimpleNamespace(id=uuid4(), flow_id=uuid4(), version_number=1),
+            "Flow A",
         )
     ]
 
@@ -1493,7 +1498,10 @@ def test_wxo_mapper_resolve_verify_credentials_rejects_extra_fields() -> None:
 
 @pytest.mark.asyncio
 async def test_watsonx_mapper_create_preserves_env_var_source_in_connection_payloads() -> None:
-    """Connections with environment_variables should preserve source (raw vs variable) through to the adapter payload."""
+    """Connections with environment_variables should preserve source.
+
+    Preserve raw-vs-variable semantics all the way to the adapter payload.
+    """
     mapper = WatsonxOrchestrateDeploymentMapper()
     flow_version_id = uuid4()
     flow_id = uuid4()

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -694,6 +694,79 @@ class TestConfigAndSnapshotListRoutes:
 
 
 # ---------------------------------------------------------------------------
+# list_deployment_flow_versions
+# ---------------------------------------------------------------------------
+
+
+class TestListDeploymentFlowVersionsRoute:
+    @pytest.mark.asyncio
+    @patch(f"{ROUTES_MODULE}.list_deployment_flow_versions_synced", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.resolve_adapter_mapper_from_deployment", new_callable=AsyncMock)
+    async def test_returns_paginated_flow_versions(
+        self,
+        mock_resolve,
+        mock_list_flow_versions_synced,
+    ):
+        from langflow.api.v1.deployments import list_deployment_flow_versions
+
+        deployment_row = _fake_deployment_row()
+        adapter = AsyncMock()
+        mapper = MagicMock()
+        rows = [(SimpleNamespace(provider_snapshot_id="tool-1", created_at=None), SimpleNamespace())]
+        snapshot_result = SnapshotListResult(
+            snapshots=[
+                SnapshotItem(
+                    id="tool-1",
+                    name="Tool 1",
+                    provider_data={"connections": {"cfg-1": "conn-1"}},
+                )
+            ]
+        )
+        mock_resolve.return_value = (deployment_row, adapter, mapper)
+        mock_list_flow_versions_synced.return_value = (rows, 7, snapshot_result)
+        mapper.shape_flow_version_list_result.return_value = SimpleNamespace(
+            page=2,
+            size=5,
+            total=7,
+            flow_versions=[
+                SimpleNamespace(
+                    provider_snapshot_id="tool-1",
+                    provider_data={"connection_app_ids": ["cfg-1"]},
+                )
+            ],
+        )
+
+        response = await list_deployment_flow_versions(
+            deployment_id=deployment_row.id,
+            session=AsyncMock(),
+            current_user=_fake_user(),
+            page=2,
+            size=5,
+        )
+
+        assert response.page == 2
+        assert response.size == 5
+        assert response.total == 7
+        assert len(response.flow_versions) == 1
+        assert response.flow_versions[0].provider_snapshot_id == "tool-1"
+        assert response.flow_versions[0].provider_data == {"connection_app_ids": ["cfg-1"]}
+
+        mock_list_flow_versions_synced.assert_awaited_once()
+        helper_kwargs = mock_list_flow_versions_synced.call_args.kwargs
+        assert helper_kwargs["provider_id"] == deployment_row.deployment_provider_account_id
+        assert helper_kwargs["deployment_id"] == deployment_row.id
+        assert helper_kwargs["page"] == 2
+        assert helper_kwargs["size"] == 5
+        mapper.shape_flow_version_list_result.assert_called_once_with(
+            rows=rows,
+            snapshot_result=snapshot_result,
+            page=2,
+            size=5,
+            total=7,
+        )
+
+
+# ---------------------------------------------------------------------------
 # provider account routes
 # ---------------------------------------------------------------------------
 

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -731,7 +731,7 @@ class TestListDeploymentFlowVersionsRoute:
             flow_versions=[
                 SimpleNamespace(
                     provider_snapshot_id="tool-1",
-                    provider_data={"connection_app_ids": ["cfg-1"]},
+                    provider_data={"app_ids": ["cfg-1"]},
                 )
             ],
         )
@@ -749,7 +749,7 @@ class TestListDeploymentFlowVersionsRoute:
         assert response.total == 7
         assert len(response.flow_versions) == 1
         assert response.flow_versions[0].provider_snapshot_id == "tool-1"
-        assert response.flow_versions[0].provider_data == {"connection_app_ids": ["cfg-1"]}
+        assert response.flow_versions[0].provider_data == {"app_ids": ["cfg-1"]}
 
         mock_list_flow_versions_synced.assert_awaited_once()
         helper_kwargs = mock_list_flow_versions_synced.call_args.kwargs

--- a/src/backend/tests/unit/api/v1/test_deployment_schemas.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_schemas.py
@@ -432,11 +432,11 @@ class TestDeploymentFlowVersionListSchemas:
             version_number=3,
             attached_at=now,
             provider_snapshot_id="tool-1",
-            provider_data={"connection_app_ids": ["cfg-1"]},
+            provider_data={"app_ids": ["cfg-1"]},
         )
         assert item.attached_at == now
         assert item.provider_snapshot_id == "tool-1"
-        assert item.provider_data == {"connection_app_ids": ["cfg-1"]}
+        assert item.provider_data == {"app_ids": ["cfg-1"]}
 
     def test_flow_version_list_item_does_not_expose_description_or_created_at(self):
         assert "description" not in DeploymentFlowVersionListItem.model_fields

--- a/src/backend/tests/unit/api/v1/test_deployment_schemas.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_schemas.py
@@ -12,6 +12,8 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentConfigListItem,
     DeploymentConfigListResponse,
     DeploymentCreateRequest,
+    DeploymentFlowVersionListItem,
+    DeploymentFlowVersionListResponse,
     DeploymentProviderAccountCreateRequest,
     DeploymentProviderAccountGetResponse,
     DeploymentProviderAccountUpdateRequest,
@@ -417,3 +419,46 @@ class TestDeploymentConfigListResponse:
         assert response.page == 1
         assert response.size == 20
         assert response.total == 0
+
+
+class TestDeploymentFlowVersionListSchemas:
+    def test_flow_version_list_item_uses_attached_at(self):
+        from datetime import datetime, timezone
+
+        now = datetime.now(tz=timezone.utc)
+        item = DeploymentFlowVersionListItem(
+            id=uuid4(),
+            flow_id=uuid4(),
+            version_number=3,
+            attached_at=now,
+            provider_snapshot_id="tool-1",
+            provider_data={"connection_app_ids": ["cfg-1"]},
+        )
+        assert item.attached_at == now
+        assert item.provider_snapshot_id == "tool-1"
+        assert item.provider_data == {"connection_app_ids": ["cfg-1"]}
+
+    def test_flow_version_list_item_does_not_expose_description_or_created_at(self):
+        assert "description" not in DeploymentFlowVersionListItem.model_fields
+        assert "created_at" not in DeploymentFlowVersionListItem.model_fields
+
+    def test_flow_version_list_response_wraps_items_with_pagination(self):
+        response = DeploymentFlowVersionListResponse(
+            flow_versions=[
+                DeploymentFlowVersionListItem(
+                    id=uuid4(),
+                    flow_id=uuid4(),
+                    version_number=1,
+                    attached_at=None,
+                    provider_snapshot_id=None,
+                    provider_data=None,
+                )
+            ],
+            page=2,
+            size=5,
+            total=9,
+        )
+        assert len(response.flow_versions) == 1
+        assert response.page == 2
+        assert response.size == 5
+        assert response.total == 9

--- a/src/backend/tests/unit/api/v1/test_deployment_sync.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_sync.py
@@ -21,7 +21,12 @@ from langflow.api.v1.mappers.deployments.contracts import (
     UpdateSnapshotBindings,
 )
 from langflow.api.v1.schemas.deployments import DeploymentUpdateRequest
-from lfx.services.adapters.deployment.schema import DeploymentCreateResult, DeploymentUpdateResult
+from lfx.services.adapters.deployment.schema import (
+    DeploymentCreateResult,
+    DeploymentUpdateResult,
+    SnapshotItem,
+    SnapshotListResult,
+)
 
 try:
     from langflow.api.v1.mappers.deployments.watsonx_orchestrate import WatsonxOrchestrateDeploymentMapper
@@ -1408,3 +1413,303 @@ class TestListDeploymentsSyncedSnapshotPhase:
         assert len(accepted) == 1
         assert accepted[0][1] == 3
         db.begin_nested.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# list_deployment_flow_versions_synced
+# ---------------------------------------------------------------------------
+
+
+class TestListDeploymentFlowVersionsSynced:
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployment_attachments", new_callable=AsyncMock, return_value=2)
+    @patch(f"{MODULE}.list_deployment_attachments_with_versions", new_callable=AsyncMock)
+    @patch(f"{MODULE}.sync_attachment_snapshot_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.list_deployment_attachments", new_callable=AsyncMock)
+    async def test_syncs_snapshots_with_snapshot_ids_and_returns_enrichment(
+        self,
+        mock_list_attachments,
+        mock_sync_snapshot_ids,
+        mock_list_with_versions,
+        mock_count_attachments,
+    ):
+        deployment_id = uuid4()
+        attachments = [
+            _mock_attachment(provider_snapshot_id="snap-1", deployment_id=deployment_id),
+            _mock_attachment(provider_snapshot_id="snap-stale", deployment_id=deployment_id),
+            _mock_attachment(provider_snapshot_id=None, deployment_id=deployment_id),
+        ]
+        mock_list_attachments.return_value = attachments
+        rows = [(SimpleNamespace(provider_snapshot_id="snap-1"), SimpleNamespace())]
+        mock_list_with_versions.return_value = rows
+
+        adapter = AsyncMock()
+        adapter.list_snapshots.return_value = SnapshotListResult(
+            snapshots=[
+                SnapshotItem(
+                    id="snap-1",
+                    name="tool-1",
+                    provider_data={"connections": {"cfg-1": "conn-1"}},
+                )
+            ]
+        )
+        mapper = WatsonxOrchestrateDeploymentMapper()
+        db = MagicMock()
+        db.begin_nested.return_value = _AsyncNoopSavepoint()
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployment_flow_versions_synced
+
+        out_rows, total, snapshot_result = await list_deployment_flow_versions_synced(
+            deployment_adapter=adapter,
+            deployment_mapper=mapper,
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            deployment_id=deployment_id,
+            db=db,
+            page=2,
+            size=3,
+        )
+
+        assert out_rows == rows
+        assert total == 2
+        assert isinstance(snapshot_result, SnapshotListResult)
+        assert [snapshot.id for snapshot in snapshot_result.snapshots] == ["snap-1"]
+        adapter.list_snapshots.assert_awaited_once()
+        adapter_params = adapter.list_snapshots.call_args.kwargs["params"]
+        assert adapter_params.snapshot_ids == ["snap-1", "snap-stale"]
+        mock_sync_snapshot_ids.assert_awaited_once()
+        assert mock_sync_snapshot_ids.call_args.kwargs["known_snapshot_ids"] == {"snap-1"}
+        assert mock_list_with_versions.call_args.kwargs["offset"] == 3
+        assert mock_list_with_versions.call_args.kwargs["limit"] == 3
+        mock_count_attachments.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployment_attachments", new_callable=AsyncMock, return_value=1)
+    @patch(f"{MODULE}.list_deployment_attachments_with_versions", new_callable=AsyncMock)
+    @patch(f"{MODULE}.sync_attachment_snapshot_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.list_deployment_attachments", new_callable=AsyncMock)
+    async def test_skips_adapter_call_when_no_provider_snapshot_ids(
+        self,
+        mock_list_attachments,
+        mock_sync_snapshot_ids,
+        mock_list_with_versions,
+        mock_count_attachments,
+    ):
+        deployment_id = uuid4()
+        attachments = [
+            _mock_attachment(provider_snapshot_id=None, deployment_id=deployment_id),
+            _mock_attachment(provider_snapshot_id="", deployment_id=deployment_id),
+        ]
+        mock_list_attachments.return_value = attachments
+        rows = [(SimpleNamespace(provider_snapshot_id=None), SimpleNamespace())]
+        mock_list_with_versions.return_value = rows
+
+        adapter = AsyncMock()
+        mapper = WatsonxOrchestrateDeploymentMapper()
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployment_flow_versions_synced
+
+        out_rows, total, snapshot_result = await list_deployment_flow_versions_synced(
+            deployment_adapter=adapter,
+            deployment_mapper=mapper,
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            deployment_id=deployment_id,
+            db=AsyncMock(),
+            page=1,
+            size=10,
+        )
+
+        assert out_rows == rows
+        assert total == 1
+        assert snapshot_result is None
+        adapter.list_snapshots.assert_not_awaited()
+        mock_sync_snapshot_ids.assert_not_awaited()
+        mock_count_attachments.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployment_attachments", new_callable=AsyncMock, return_value=1)
+    @patch(f"{MODULE}.list_deployment_attachments_with_versions", new_callable=AsyncMock)
+    @patch(f"{MODULE}.sync_attachment_snapshot_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.list_deployment_attachments", new_callable=AsyncMock)
+    async def test_snapshot_sync_savepoint_failure_clears_enrichment_payload(
+        self,
+        mock_list_attachments,
+        mock_sync_snapshot_ids,
+        mock_list_with_versions,
+        mock_count_attachments,
+    ):
+        deployment_id = uuid4()
+        mock_list_attachments.return_value = [
+            _mock_attachment(provider_snapshot_id="snap-1", deployment_id=deployment_id)
+        ]
+        rows = [(SimpleNamespace(provider_snapshot_id="snap-1"), SimpleNamespace())]
+        mock_list_with_versions.return_value = rows
+
+        adapter = AsyncMock()
+        adapter.list_snapshots.return_value = SnapshotListResult(
+            snapshots=[
+                SnapshotItem(
+                    id="snap-1",
+                    name="tool-1",
+                    provider_data={"connections": {"cfg-1": "conn-1"}},
+                )
+            ]
+        )
+        mock_sync_snapshot_ids.side_effect = RuntimeError("savepoint failed")
+        mapper = WatsonxOrchestrateDeploymentMapper()
+        db = MagicMock()
+        db.begin_nested.return_value = _AsyncNoopSavepoint()
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployment_flow_versions_synced
+
+        out_rows, total, snapshot_result = await list_deployment_flow_versions_synced(
+            deployment_adapter=adapter,
+            deployment_mapper=mapper,
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            deployment_id=deployment_id,
+            db=db,
+            page=1,
+            size=20,
+        )
+
+        assert out_rows == rows
+        assert total == 1
+        assert snapshot_result is None
+        adapter.list_snapshots.assert_awaited_once()
+        mock_sync_snapshot_ids.assert_awaited_once()
+        mock_count_attachments.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployment_attachments", new_callable=AsyncMock, return_value=1)
+    @patch(f"{MODULE}.list_deployment_attachments_with_versions", new_callable=AsyncMock)
+    @patch(f"{MODULE}.sync_attachment_snapshot_ids", new_callable=AsyncMock)
+    @patch(f"{MODULE}.list_deployment_attachments", new_callable=AsyncMock)
+    async def test_snapshot_sync_errors_fall_back_to_db_rows_without_enrichment(
+        self,
+        mock_list_attachments,
+        mock_sync_snapshot_ids,
+        mock_list_with_versions,
+        mock_count_attachments,
+    ):
+        deployment_id = uuid4()
+        mock_list_attachments.return_value = [
+            _mock_attachment(provider_snapshot_id="snap-1", deployment_id=deployment_id)
+        ]
+        rows = [(SimpleNamespace(provider_snapshot_id="snap-1"), SimpleNamespace())]
+        mock_list_with_versions.return_value = rows
+
+        adapter = AsyncMock()
+        adapter.list_snapshots.side_effect = RuntimeError("provider down")
+        mapper = WatsonxOrchestrateDeploymentMapper()
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployment_flow_versions_synced
+
+        out_rows, total, snapshot_result = await list_deployment_flow_versions_synced(
+            deployment_adapter=adapter,
+            deployment_mapper=mapper,
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            deployment_id=deployment_id,
+            db=AsyncMock(),
+            page=1,
+            size=20,
+        )
+
+        assert out_rows == rows
+        assert total == 1
+        assert snapshot_result is None
+        mock_sync_snapshot_ids.assert_not_awaited()
+        mock_count_attachments.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# flow_version_deployment_attachment CRUD helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeAllResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeOneResult:
+    def __init__(self, value):
+        self._value = value
+
+    def one(self):
+        return self._value
+
+
+class _CaptureDb:
+    def __init__(self, result):
+        self._result = result
+        self.statements = []
+
+    async def exec(self, statement):
+        self.statements.append(statement)
+        return self._result
+
+
+class TestFlowVersionDeploymentAttachmentCrud:
+    @pytest.mark.asyncio
+    async def test_list_deployment_attachments_with_versions_orders_by_attachment_timestamps(self):
+        from langflow.services.database.models.flow_version_deployment_attachment.crud import (
+            list_deployment_attachments_with_versions,
+        )
+
+        rows = [(SimpleNamespace(), SimpleNamespace())]
+        db = _CaptureDb(_FakeAllResult(rows))
+
+        result = await list_deployment_attachments_with_versions(
+            db,
+            user_id=uuid4(),
+            deployment_id=uuid4(),
+            offset=5,
+            limit=10,
+        )
+
+        assert result == rows
+        statement_text = str(db.statements[0]).lower()
+        assert "order by" in statement_text
+        assert "created_at desc" in statement_text
+        assert "updated_at desc" in statement_text
+
+    @pytest.mark.asyncio
+    async def test_list_deployment_attachments_with_versions_skips_query_when_limit_non_positive(self):
+        from langflow.services.database.models.flow_version_deployment_attachment.crud import (
+            list_deployment_attachments_with_versions,
+        )
+
+        db = _CaptureDb(_FakeAllResult([]))
+        result = await list_deployment_attachments_with_versions(
+            db,
+            user_id=uuid4(),
+            deployment_id=uuid4(),
+            offset=0,
+            limit=0,
+        )
+
+        assert result == []
+        assert db.statements == []
+
+    @pytest.mark.asyncio
+    async def test_count_deployment_attachments_returns_scalar_count(self):
+        from langflow.services.database.models.flow_version_deployment_attachment.crud import (
+            count_deployment_attachments,
+        )
+
+        db = _CaptureDb(_FakeOneResult(4))
+
+        total = await count_deployment_attachments(
+            db,
+            user_id=uuid4(),
+            deployment_id=uuid4(),
+        )
+
+        assert total == 4
+        assert len(db.statements) == 1

--- a/src/backend/tests/unit/api/v1/test_deployments_routes.py
+++ b/src/backend/tests/unit/api/v1/test_deployments_routes.py
@@ -69,6 +69,17 @@ def test_deployment_status_path_matches_status_endpoint(deployment_routes: list[
     )
 
 
+def test_deployment_flows_path_matches_flow_versions_endpoint(deployment_routes: list[APIRoute]) -> None:
+    deployment_id = uuid4()
+    assert (
+        _resolve_endpoint_name(
+            deployment_routes,
+            path=f"/deployments/{deployment_id}/flows",
+        )
+        == "list_deployment_flow_versions"
+    )
+
+
 def test_include_deployment_router_skips_routes_when_feature_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(api_router_module.FEATURE_FLAGS, "wxo_deployments", False)
 

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -36,7 +36,9 @@ from lfx.services.adapters.deployment.schema import (
     ExecutionCreate,
     ExecutionCreateResult,
     ExecutionStatusResult,
+    SnapshotItem,
     SnapshotListParams,
+    SnapshotListResult,
 )
 from pydantic import ValidationError
 
@@ -2004,7 +2006,7 @@ async def test_update_provider_data_maps_raw_connection_conflict_to_deployment_c
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
     monkeypatch.setattr(shared_core_module, "create_config", mock_create_config)
 
-    with pytest.raises(DeploymentConflictError, match="error details"):
+    with pytest.raises(DeploymentConflictError, match="already exists in the provider"):
         await service.update(
             user_id="user-1",
             deployment_id="dep-1",
@@ -2068,7 +2070,7 @@ async def test_create_provider_data_maps_raw_connection_conflict_to_deployment_c
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
     monkeypatch.setattr(shared_core_module, "create_config", mock_create_config)
 
-    with pytest.raises(DeploymentConflictError, match="error details"):
+    with pytest.raises(DeploymentConflictError, match="already exists in the provider"):
         await service.create(
             user_id="user-1",
             payload=DeploymentCreate(
@@ -3116,6 +3118,40 @@ async def test_list_snapshots_single_deployment_scope(monkeypatch):
     )
 
     assert [snapshot.id for snapshot in result.snapshots] == ["tool-1", "tool-2"]
+    assert result.snapshots[0].provider_data == {"connections": {}}
+    assert result.snapshots[1].provider_data == {"connections": {}}
+
+
+@pytest.mark.anyio
+async def test_list_snapshots_single_deployment_scope_extracts_connections(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]}),
+        tool=FakeToolClient(
+            [
+                {
+                    "id": "tool-1",
+                    "name": "Tool One",
+                    "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}},
+                }
+            ]
+        ),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_snapshots(
+        user_id="user-1",
+        db=object(),
+        params=SnapshotListParams(deployment_ids=["dep-1"]),
+    )
+
+    assert [snapshot.id for snapshot in result.snapshots] == ["tool-1"]
+    assert result.snapshots[0].provider_data == {"connections": {"cfg-1": "conn-1"}}
 
 
 @pytest.mark.anyio
@@ -3148,7 +3184,7 @@ async def test_list_snapshots_without_deployment_id_lists_tenant_scope(monkeypat
     fake_base = FakeBaseClient(
         get_payloads={
             "/tools": [
-                {"id": "tool-1", "name": "Tool One"},
+                {"id": "tool-1", "name": "Tool One", "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}}},
                 {"id": "tool-2"},
             ]
         }
@@ -3169,7 +3205,80 @@ async def test_list_snapshots_without_deployment_id_lists_tenant_scope(monkeypat
 
     result = await service.list_snapshots(user_id="user-1", db=object(), params=None)
     assert [snapshot.id for snapshot in result.snapshots] == ["tool-1", "tool-2"]
+    assert result.snapshots[0].provider_data == {"connections": {"cfg-1": "conn-1"}}
+    assert result.snapshots[1].provider_data == {"connections": {}}
     assert result.provider_result == {"scope": "tenant"}
+
+
+@pytest.mark.anyio
+async def test_list_snapshots_snapshot_ids_returns_verified_provider_data(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": []}),
+        tool=FakeToolClient([]),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    async def mock_verify_tools_by_ids(clients, snapshot_ids):  # noqa: ARG001
+        return SnapshotListResult(
+            snapshots=[
+                SnapshotItem(
+                    id="tool-1",
+                    name="Tool One",
+                    provider_data={"connections": {"cfg-1": "conn-1"}},
+                )
+            ]
+        )
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+    monkeypatch.setattr(service_module, "verify_tools_by_ids", mock_verify_tools_by_ids)
+
+    result = await service.list_snapshots(
+        user_id="user-1",
+        db=object(),
+        params=SnapshotListParams(snapshot_ids=["tool-1"]),
+    )
+
+    assert [snapshot.id for snapshot in result.snapshots] == ["tool-1"]
+    assert result.snapshots[0].provider_data == {"connections": {"cfg-1": "conn-1"}}
+
+
+@pytest.mark.anyio
+async def test_list_snapshots_snapshot_ids_trusts_verified_results_without_revalidation(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": []}),
+        tool=FakeToolClient([]),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    async def mock_verify_tools_by_ids(clients, snapshot_ids):  # noqa: ARG001
+        return SnapshotListResult(
+            snapshots=[
+                SnapshotItem(
+                    id="tool-1",
+                    name="Tool One",
+                    provider_data={"unexpected": "value"},
+                )
+            ]
+        )
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+    monkeypatch.setattr(service_module, "verify_tools_by_ids", mock_verify_tools_by_ids)
+
+    result = await service.list_snapshots(
+        user_id="user-1",
+        db=object(),
+        params=SnapshotListParams(snapshot_ids=["tool-1"]),
+    )
+
+    assert result.snapshots[0].provider_data == {"unexpected": "value"}
 
 
 @pytest.mark.anyio
@@ -3197,7 +3306,7 @@ async def test_verify_tools_by_ids_returns_only_connections_provider_data():
 
     assert [snapshot.id for snapshot in result.snapshots] == ["tool-1", "tool-2"]
     assert result.snapshots[0].provider_data == {"connections": {"cfg-1": "conn-1"}}
-    assert result.snapshots[1].provider_data is None
+    assert result.snapshots[1].provider_data == {"connections": {}}
 
 
 @pytest.mark.anyio
@@ -3218,7 +3327,58 @@ async def test_verify_tools_by_ids_tolerates_malformed_connections_payload():
 
     assert len(result.snapshots) == 1
     assert result.snapshots[0].id == "tool-1"
-    assert result.snapshots[0].provider_data is None
+    assert result.snapshots[0].provider_data == {"connections": {}}
+
+
+@pytest.mark.anyio
+async def test_verify_tools_by_ids_tolerates_malformed_connection_values():
+    fake_clients = SimpleNamespace(
+        tool=FakeToolClient(
+            [
+                {
+                    "id": "tool-1",
+                    "name": "Tool One",
+                    "binding": {"langflow": {"connections": {"cfg-1": "   "}}},
+                }
+            ]
+        )
+    )
+
+    result = await tools_module.verify_tools_by_ids(fake_clients, ["tool-1"])
+
+    assert len(result.snapshots) == 1
+    assert result.snapshots[0].id == "tool-1"
+    assert result.snapshots[0].provider_data == {"connections": {}}
+
+
+@pytest.mark.anyio
+async def test_verify_tools_by_ids_rejects_mixed_connections_payload():
+    fake_clients = SimpleNamespace(
+        tool=FakeToolClient(
+            [
+                {
+                    "id": "tool-1",
+                    "name": "Tool One",
+                    "binding": {
+                        "langflow": {
+                            "connections": {
+                                "cfg-1": "conn-1",
+                                "cfg-2": "   ",
+                                "   ": "conn-3",
+                                "cfg-4": 123,
+                            }
+                        }
+                    },
+                }
+            ]
+        )
+    )
+
+    result = await tools_module.verify_tools_by_ids(fake_clients, ["tool-1"])
+
+    assert len(result.snapshots) == 1
+    assert result.snapshots[0].id == "tool-1"
+    assert result.snapshots[0].provider_data == {"connections": {}}
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -3172,6 +3172,55 @@ async def test_list_snapshots_without_deployment_id_lists_tenant_scope(monkeypat
     assert result.provider_result == {"scope": "tenant"}
 
 
+@pytest.mark.anyio
+async def test_verify_tools_by_ids_returns_only_connections_provider_data():
+    fake_clients = SimpleNamespace(
+        tool=FakeToolClient(
+            [
+                {
+                    "id": "tool-1",
+                    "name": "Tool One",
+                    "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}},
+                    "extra": "ignored",
+                },
+                {
+                    "id": "tool-2",
+                    "name": "Tool Two",
+                    "binding": {"langflow": {"connections": {}}},
+                    "extra": "ignored",
+                },
+            ]
+        )
+    )
+
+    result = await tools_module.verify_tools_by_ids(fake_clients, ["tool-1", "tool-2"])
+
+    assert [snapshot.id for snapshot in result.snapshots] == ["tool-1", "tool-2"]
+    assert result.snapshots[0].provider_data == {"connections": {"cfg-1": "conn-1"}}
+    assert result.snapshots[1].provider_data is None
+
+
+@pytest.mark.anyio
+async def test_verify_tools_by_ids_tolerates_malformed_connections_payload():
+    fake_clients = SimpleNamespace(
+        tool=FakeToolClient(
+            [
+                {
+                    "id": "tool-1",
+                    "name": "Tool One",
+                    "binding": {"langflow": {"connections": ["not-a-dict"]}},
+                }
+            ]
+        )
+    )
+
+    result = await tools_module.verify_tools_by_ids(fake_clients, ["tool-1"])
+
+    assert len(result.snapshots) == 1
+    assert result.snapshots[0].id == "tool-1"
+    assert result.snapshots[0].provider_data is None
+
+
 # ---------------------------------------------------------------------------
 # Retry / backoff tests
 # ---------------------------------------------------------------------------

--- a/src/lfx/src/lfx/services/adapters/deployment/payloads.py
+++ b/src/lfx/src/lfx/services/adapters/deployment/payloads.py
@@ -50,6 +50,8 @@ T_VerifyCredentialsResultModel = TypeVar("T_VerifyCredentialsResultModel", bound
 # Flow artifact provider_data pair
 T_FlowProviderData = TypeVar("T_FlowProviderData", default=AdapterPayload)
 T_FlowProviderDataModel = TypeVar("T_FlowProviderDataModel", bound=BaseModel, default=BaseModel)
+T_SnapshotItemData = TypeVar("T_SnapshotItemData", default=AdapterPayload)
+T_SnapshotItemDataModel = TypeVar("T_SnapshotItemDataModel", bound=BaseModel, default=BaseModel)
 
 # Outbound payload pairs
 T_DeploymentCreateResult = TypeVar("T_DeploymentCreateResult", default=AdapterPayload)
@@ -128,6 +130,7 @@ class DeploymentPayloadFields(ProviderPayloadSchemas):
     deployment_llm_list_result: PayloadSlot[T_DeploymentLlmListResultModel] | None = None
     config_list_result: PayloadSlot[T_ConfigListResultModel] | None = None
     snapshot_list_result: PayloadSlot[T_SnapshotListResultModel] | None = None
+    snapshot_item_data: PayloadSlot[T_SnapshotItemDataModel] | None = None
     execution_create_result: PayloadSlot[T_ExecutionCreateResultModel] | None = None
     execution_status_result: PayloadSlot[T_ExecutionStatusResultModel] | None = None
     deployment_item_data: PayloadSlot[T_DeploymentItemDataModel] | None = None

--- a/src/lfx/src/lfx/services/adapters/deployment/schema.py
+++ b/src/lfx/src/lfx/services/adapters/deployment/schema.py
@@ -30,6 +30,7 @@ from lfx.services.adapters.deployment.payloads import (
     T_ListParamsPayload,
     T_ProviderData,
     T_ProviderResult,
+    T_SnapshotItemData,
     T_SnapshotListParams,
     T_SnapshotListResult,
     T_VerifyCredentials,
@@ -105,12 +106,15 @@ class BaseFlowArtifact(BaseModel, Generic[T_FlowProviderData]):
 SnapshotList = Annotated[list[BaseFlowArtifact[AdapterPayload]], Field(min_length=1)]
 
 
-class SnapshotItem(BaseModel):
+class SnapshotItem(BaseModel, Generic[T_SnapshotItemData]):
     """Model representing a result for a snapshot item."""
 
     id: IdLike = Field(description="The id of the snapshot item")
     name: str = Field(description="The name of the snapshot item")
-    provider_data: dict | None = Field(None, description="The data of the snapshot item from the provider")
+    provider_data: T_SnapshotItemData | None = Field(
+        None,
+        description="The data of the snapshot item from the provider",
+    )
 
 
 class SnapshotItems(BaseModel, Generic[T_FlowProviderData]):
@@ -405,10 +409,13 @@ class ConfigListResult(ProviderResultModel[T_ConfigListResult]):
     configs: list[ConfigListItem] = Field(description="The list of configs")
 
 
-class SnapshotListResult(ProviderResultModel[T_SnapshotListResult]):
+class SnapshotListResult(
+    ProviderResultModel[T_SnapshotListResult],
+    Generic[T_SnapshotListResult, T_SnapshotItemData],
+):
     """Model representing a result for a snapshot list operation."""
 
-    snapshots: list[SnapshotItem] = Field(description="The list of snapshots")
+    snapshots: list[SnapshotItem[T_SnapshotItemData]] = Field(description="The list of snapshots")
 
 
 class _BaseListParams(BaseModel, Generic[T_ListParamsPayload]):

--- a/src/lfx/tests/unit/services/deployment/test_payload_formalization.py
+++ b/src/lfx/tests/unit/services/deployment/test_payload_formalization.py
@@ -270,7 +270,7 @@ def test_generic_parametrization_applies_to_result_and_list_models() -> None:
         configs=[],
         provider_result={"external_url": "https://dep.example"},
     )
-    typed_snapshot_list = SnapshotListResult[_ResultModel](
+    typed_snapshot_list = SnapshotListResult[_ResultModel, _StatusModel](
         snapshots=[],
         provider_result={"external_url": "https://dep.example"},
     )


### PR DESCRIPTION
Add a new read path for listing flow versions attached to a deployment:
- introduces GET /deployments/{deployment_id}/flows with page/size pagination
- returns attachment-scoped metadata (flow_version id, flow_id, version_number, attached_at, provider_snapshot_id)
- keeps provider-owned fields under provider_data on each item
Implement snapshot-aware synchronization behavior for this list endpoint:
- loads deployment attachments from DB, extracts provider_snapshot_id values, and verifies them via adapter list_snapshots(snapshot_ids=...)
- removes stale attachment rows when snapshot IDs no longer exist on the provider
- falls back to DB-only response without enrichment on any sync failure (including partial failures after list_snapshots)
Refactor mapper boundaries to follow shape_* contract conventions:
- helper now passes through SnapshotListResult | None instead of pre-building enrichment maps
- route delegates full response shaping to mapper.shape_flow_version_list_result(...)
- base mapper performs direct DB->API mapping for flow-version list items
- WXO mapper overrides list shaping to enrich provider_data with connection_app_ids from snapshot binding.langflow.connections
Normalize WXO connection extraction into a shared read-path helper:
- add extract_langflow_connections_binding(...) in core/tools.py
- reuse it in verify_tools_by_ids and service config listing to avoid duplicated nested payload parsing
Add/adjust persistence and tests:
- add CRUD helpers for paginated attachment+flow_version join and attachment counting
- extend schema and route tests for new response models/endpoint behavior
- add mapper tests for base direct mapping and WXO-specific enrichment
- add sync tests for snapshot-id verification, stale-row cleanup, and fallback semantics