### PR TITLE
refactor(deployments): Revise v1 deployments API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2493,7 +2493,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_deployment_schemas.py",
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_verified": false,
-        "line_number": 65,
+        "line_number": 66,
         "is_secret": false
       }
     ],
@@ -5642,5 +5642,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-03T01:46:24Z"
+  "generated_at": "2026-04-05T00:04:04Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2493,7 +2493,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_deployment_schemas.py",
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_verified": false,
-        "line_number": 70,
+        "line_number": 66,
         "is_secret": false
       }
     ],
@@ -5642,5 +5642,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-02T04:49:55Z"
+  "generated_at": "2026-04-02T23:57:46Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2493,7 +2493,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_deployment_schemas.py",
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 68,
         "is_secret": false
       }
     ],
@@ -5642,5 +5642,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-05T00:04:04Z"
+  "generated_at": "2026-04-06T16:25:47Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2493,7 +2493,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_deployment_schemas.py",
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 65,
         "is_secret": false
       }
     ],
@@ -5642,5 +5642,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-02T23:57:46Z"
+  "generated_at": "2026-04-03T01:46:24Z"
 }

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -257,7 +257,7 @@ async def create_provider_account(
     deployment_mapper = get_deployment_mapper(payload.provider_key)
     deployment_adapter = resolve_deployment_adapter(payload.provider_key)
 
-    with handle_adapter_errors():
+    with handle_adapter_errors(mapper=deployment_mapper):
         verify_input = deployment_mapper.resolve_verify_credentials(payload=payload)
         await deployment_adapter.verify_credentials(
             user_id=current_user.id,
@@ -390,7 +390,7 @@ async def update_provider_account(
                 detail="This operation is not supported by the deployment provider.",
             ) from exc
         if verify_input is not None:
-            with handle_adapter_errors():
+            with handle_adapter_errors(mapper=deployment_mapper):
                 await deployment_adapter.verify_credentials(
                     user_id=current_user.id,
                     payload=verify_input,
@@ -474,7 +474,7 @@ async def create_deployment(
             db=session,
             payload=payload,
         )
-        with handle_adapter_errors(), deployment_provider_scope(provider_id):
+        with handle_adapter_errors(mapper=deployment_mapper), deployment_provider_scope(provider_id):
             provider_create_result = await deployment_adapter.create(
                 user_id=current_user.id,
                 payload=adapter_payload,
@@ -491,7 +491,7 @@ async def create_deployment(
                 db=session,
                 payload=payload,
             )
-            with handle_adapter_errors(), deployment_provider_scope(provider_id):
+            with handle_adapter_errors(mapper=deployment_mapper), deployment_provider_scope(provider_id):
                 provider_update_result: DeploymentUpdateResult = await deployment_adapter.update(
                     deployment_id=existing_resource_key,
                     payload=adapter_payload,
@@ -634,7 +634,7 @@ async def list_deployments(
     deployment_adapter = resolve_deployment_adapter(provider_account.provider_key)
     deployment_mapper = get_deployment_mapper(provider_account.provider_key)
     if load_from_provider:
-        with handle_adapter_errors(), deployment_provider_scope(provider_id):
+        with handle_adapter_errors(mapper=deployment_mapper), deployment_provider_scope(provider_id):
             provider_view = await deployment_adapter.list(
                 user_id=current_user.id,
                 db=session,
@@ -642,7 +642,7 @@ async def list_deployments(
             )
         return deployment_mapper.shape_deployment_list_result(provider_view)
 
-    with handle_adapter_errors(), deployment_provider_scope(provider_id):
+    with handle_adapter_errors(mapper=deployment_mapper), deployment_provider_scope(provider_id):
         rows_with_counts, total = await list_deployments_synced(
             deployment_adapter=deployment_adapter,
             deployment_mapper=deployment_mapper,
@@ -699,7 +699,7 @@ async def list_deployment_llms(
     )
     deployment_adapter = resolve_deployment_adapter(provider_account.provider_key)
     deployment_mapper = get_deployment_mapper(provider_account.provider_key)
-    with handle_adapter_errors(), deployment_provider_scope(provider_id):
+    with handle_adapter_errors(mapper=deployment_mapper), deployment_provider_scope(provider_id):
         llm_list_result = await deployment_adapter.list_llms(
             user_id=current_user.id,
             db=session,
@@ -728,7 +728,10 @@ async def create_deployment_execution(
         db=session,
         payload=payload,
     )
-    with handle_adapter_errors(), deployment_provider_scope(deployment_row.deployment_provider_account_id):
+    with (
+        handle_adapter_errors(mapper=deployment_mapper),
+        deployment_provider_scope(deployment_row.deployment_provider_account_id),
+    ):
         execution_result = await deployment_adapter.create_execution(
             payload=adapter_execution_payload,
             user_id=current_user.id,
@@ -754,7 +757,10 @@ async def get_deployment_execution(
         db=session,
     )
     execution_lookup_id = execution_id.strip()
-    with handle_adapter_errors(), deployment_provider_scope(deployment_row.deployment_provider_account_id):
+    with (
+        handle_adapter_errors(mapper=deployment_mapper),
+        deployment_provider_scope(deployment_row.deployment_provider_account_id),
+    ):
         execution_result = await deployment_adapter.get_execution(
             execution_id=execution_lookup_id,
             user_id=current_user.id,
@@ -829,7 +835,7 @@ async def list_deployment_configs(
         provider_params=None,
         db=session,
     )
-    with handle_adapter_errors(), deployment_provider_scope(provider_account.id):
+    with handle_adapter_errors(mapper=deployment_mapper), deployment_provider_scope(provider_account.id):
         config_result = await deployment_adapter.list_configs(
             user_id=current_user.id,
             params=adapter_params,
@@ -875,7 +881,7 @@ async def list_deployment_snapshots(
         provider_params=None,
         db=session,
     )
-    with handle_adapter_errors(), deployment_provider_scope(provider_account.id):
+    with handle_adapter_errors(mapper=deployment_mapper), deployment_provider_scope(provider_account.id):
         snapshot_result = await deployment_adapter.list_snapshots(
             user_id=current_user.id,
             params=adapter_params,
@@ -969,7 +975,10 @@ async def update_snapshot(
         deployment=deployment,
     )
 
-    with handle_adapter_errors(), deployment_provider_scope(deployment.deployment_provider_account_id):
+    with (
+        handle_adapter_errors(mapper=deployment_mapper),
+        deployment_provider_scope(deployment.deployment_provider_account_id),
+    ):
         await deployment_adapter.update_snapshot(
             user_id=current_user.id,
             db=session,
@@ -1173,7 +1182,7 @@ async def update_deployment(
         project_id=deployment_row.project_id,
         db=session,
     )
-    with handle_adapter_errors(), deployment_provider_scope(deployment_provider_account_id):
+    with handle_adapter_errors(mapper=deployment_mapper), deployment_provider_scope(deployment_provider_account_id):
         update_result: DeploymentUpdateResult = await deployment_adapter.update(
             deployment_id=deployment_resource_key,
             payload=adapter_payload,
@@ -1332,7 +1341,10 @@ async def list_deployment_flow_versions(
         user_id=current_user.id,
         db=session,
     )
-    with handle_adapter_errors(), deployment_provider_scope(deployment_row.deployment_provider_account_id):
+    with (
+        handle_adapter_errors(mapper=deployment_mapper),
+        deployment_provider_scope(deployment_row.deployment_provider_account_id),
+    ):
         rows, total, snapshot_result = await list_deployment_flow_versions_synced(
             deployment_adapter=deployment_adapter,
             deployment_mapper=deployment_mapper,

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -268,7 +268,7 @@ async def create_provider_account(
         resolved_provider_tenant_id = resolve_provider_tenant_id(
             deployment_mapper=deployment_mapper,
             provider_url=payload.url,
-            tenant_id=payload.tenant_id,
+            provider_data=payload.provider_data,
         )
         credential_kwargs = deployment_mapper.resolve_credential_fields(provider_data=payload.provider_data)
         provider_account = await create_provider_account_row(

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -781,7 +781,7 @@ async def get_deployment_execution(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/configs", response_model=DeploymentConfigListResponse)
+@router.get("/configs", response_model=DeploymentConfigListResponse, response_model_exclude_none=True)
 async def list_deployment_configs(
     session: DbSessionReadOnly,
     current_user: CurrentActiveUser,
@@ -851,7 +851,7 @@ async def list_deployment_configs(
     )
 
 
-@router.get("/snapshots", response_model=DeploymentSnapshotListResponse)
+@router.get("/snapshots", response_model=DeploymentSnapshotListResponse, response_model_exclude_none=True)
 async def list_deployment_snapshots(
     provider_id: DeploymentProviderAccountIdQuery,
     session: DbSessionReadOnly,

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -425,11 +425,11 @@ async def create_deployment(
         session,
         user_id=current_user.id,
         deployment_provider_account_id=provider_id,
-        name=payload.spec.name,
+        name=payload.name,
     ):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"A deployment named '{payload.spec.name}' already exists. "
+            detail=f"A deployment named '{payload.name}' already exists. "
             "Please choose a different name or delete the existing deployment first.",
         )
 
@@ -507,9 +507,9 @@ async def create_deployment(
             project_id=project_id,
             deployment_provider_account_id=provider_id,
             resource_key=str(provider_create_result.id),
-            name=payload.spec.name,
-            deployment_type=payload.spec.type,
-            description=payload.spec.description or None,
+            name=payload.name,
+            deployment_type=payload.type,
+            description=payload.description or None,
         )
 
         snapshot_id_by_flow_version_id: dict[UUID, str] = {}
@@ -560,7 +560,15 @@ async def create_deployment(
     )
 
 
-@router.get("", response_model=DeploymentListResponse)
+# exclude none as its associated with
+# irrelevant fields. If in the future
+# we want to include nulls, we can always
+# transisiton to that.
+@router.get(
+    "",
+    response_model=DeploymentListResponse,
+    response_model_exclude_none=True,
+)
 async def list_deployments(
     provider_id: DeploymentProviderAccountIdQuery,
     session: DbSession,
@@ -703,7 +711,7 @@ async def list_deployment_llms(
 
 
 @router.post(
-    "/deployments/{deployment_id}/executions",
+    "/{deployment_id}/executions",
     response_model=ExecutionCreateResponse,
     status_code=status.HTTP_201_CREATED,
 )
@@ -739,7 +747,7 @@ async def create_deployment_execution(
     )
 
 
-@router.get("/deployments/{deployment_id}/executions/{execution_id}", response_model=ExecutionStatusResponse)
+@router.get("/{deployment_id}/executions/{execution_id}", response_model=ExecutionStatusResponse)
 async def get_deployment_execution(
     deployment_id: DeploymentIdPath,
     execution_id: Annotated[str, Path(min_length=1, description="Provider-owned opaque execution identifier.")],
@@ -1034,7 +1042,12 @@ async def update_snapshot(
     )
 
 
-@router.get("/{deployment_id}", response_model=DeploymentGetResponse)
+# Internal note: keep exclude-none for lean responses; use explicit nulls only for intentional tri-state fields.
+@router.get(
+    "/{deployment_id}",
+    response_model=DeploymentGetResponse,
+    response_model_exclude_none=True,
+)
 async def get_deployment(
     deployment_id: DeploymentIdPath,
     session: DbSession,
@@ -1126,7 +1139,8 @@ async def get_deployment(
                 attached_count = 0
 
     payload = deployment.model_dump(exclude_unset=True)
-    provider_data = payload.get("provider_data") if isinstance(payload.get("provider_data"), dict) else {}
+    raw_provider_data = payload.get("provider_data")
+    provider_data = raw_provider_data if isinstance(raw_provider_data, dict) and raw_provider_data else None
     return DeploymentGetResponse(
         id=deployment_row.id,
         provider_id=deployment_row.deployment_provider_account_id,
@@ -1206,21 +1220,20 @@ async def update_deployment(
             db=session,
         )
 
-        if payload.spec is not None:
-            update_kwargs: dict = {}
-            if payload.spec.name is not None and payload.spec.name != deployment_row.name:
-                update_kwargs["name"] = payload.spec.name
-            if _field_was_explicitly_set(payload.spec, "description"):
-                if payload.spec.description != deployment_row.description:
-                    update_kwargs["description"] = payload.spec.description
-            elif payload.spec.description is not None and payload.spec.description != deployment_row.description:
-                update_kwargs["description"] = payload.spec.description
-            if update_kwargs:
-                deployment_row = await update_deployment_db(
-                    session,
-                    deployment=deployment_row,
-                    **update_kwargs,
-                )
+        update_kwargs: dict = {}
+        if payload.name is not None and payload.name != deployment_row.name:
+            update_kwargs["name"] = payload.name
+        if _field_was_explicitly_set(payload, "description"):
+            if payload.description != deployment_row.description:
+                update_kwargs["description"] = payload.description
+        elif payload.description is not None and payload.description != deployment_row.description:
+            update_kwargs["description"] = payload.description
+        if update_kwargs:
+            deployment_row = await update_deployment_db(
+                session,
+                deployment=deployment_row,
+                **update_kwargs,
+            )
 
         await session.commit()
     except Exception:

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -1343,7 +1343,18 @@ async def list_deployment_flow_versions(
     current_user: CurrentActiveUser,
     page: Annotated[int, Query(ge=1)] = 1,
     size: Annotated[int, Query(ge=1, le=50)] = 20,
+    flow_ids: Annotated[
+        FlowIdsQuery,
+        Query(
+            description=(
+                "Optional flow ids (pass as repeated query params, "
+                "e.g. ?flow_ids=id1). Currently limited to 1 value. "
+                "When provided, only attached flow versions belonging to the specified flow(s) are returned."
+            )
+        ),
+    ] = None,
 ):
+    normalized_flow_ids = normalize_flow_ids_query(flow_ids)
     deployment_row, deployment_adapter, deployment_mapper, _provider_key = await resolve_adapter_mapper_from_deployment(
         deployment_id=deployment_id,
         user_id=current_user.id,
@@ -1362,6 +1373,7 @@ async def list_deployment_flow_versions(
             db=session,
             page=page,
             size=size,
+            flow_ids=normalized_flow_ids or None,
         )
     return deployment_mapper.shape_flow_version_list_result(
         rows=rows,

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -54,7 +54,6 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentConfigListResponse,
     DeploymentCreateRequest,
     DeploymentCreateResponse,
-    DeploymentDuplicateResponse,
     DeploymentFlowVersionListResponse,
     DeploymentGetResponse,
     DeploymentListResponse,
@@ -63,7 +62,6 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentProviderAccountGetResponse,
     DeploymentProviderAccountListResponse,
     DeploymentProviderAccountUpdateRequest,
-    DeploymentRedeployResponse,
     DeploymentSnapshotListResponse,
     DeploymentStatusResponse,
     DeploymentTypeListResponse,
@@ -159,7 +157,10 @@ def _field_was_explicitly_set(model: object, field_name: str) -> bool:
 def _raise_http_for_provider_account_value_error(exc: ValueError) -> None:
     message = str(exc).lower()
     if "already exists" in message or "conflicts with an existing record" in message:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Provider account is already tracked by user.",
+        ) from exc
     raise_http_for_value_error(exc)
 
 
@@ -638,10 +639,7 @@ async def list_deployments(
                 db=session,
                 params=None if deployment_type is None else DeploymentListParams(deployment_types=[deployment_type]),
             )
-        return deployment_mapper.shape_deployment_list_result(
-            provider_view,
-            deployment_type=deployment_type,
-        )
+        return deployment_mapper.shape_deployment_list_result(provider_view)
 
     with handle_adapter_errors(), deployment_provider_scope(provider_id):
         rows_with_counts, total = await list_deployments_synced(
@@ -661,7 +659,6 @@ async def list_deployments(
     )
     return DeploymentListResponse(
         deployments=deployments,
-        deployment_type=deployment_type,
         page=params.page,
         size=params.size,
         total=total,
@@ -1364,32 +1361,3 @@ async def list_deployment_flow_versions(
         size=size,
         total=total,
     )
-
-
-@router.post(
-    "/{deployment_id}/redeploy",
-    response_model=DeploymentRedeployResponse,
-)
-async def redeploy_deployment(
-    deployment_id: DeploymentIdPath,
-    session: DbSessionReadOnly,
-    current_user: CurrentActiveUser,
-):
-    """Redeploy a deployment."""
-    _ = (deployment_id, session, current_user)
-    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Not implemented.")
-
-
-@router.post(
-    "/{deployment_id}/duplicate",
-    response_model=DeploymentDuplicateResponse,
-    status_code=status.HTTP_201_CREATED,
-)
-async def duplicate_deployment(
-    deployment_id: DeploymentIdPath,
-    session: DbSessionReadOnly,
-    current_user: CurrentActiveUser,
-):
-    """Duplicate a deployment."""
-    _ = (deployment_id, session, current_user)
-    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Not implemented.")

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -1139,14 +1139,14 @@ async def get_deployment(
 
     payload = deployment.model_dump(exclude_unset=True)
     provider_data = payload.get("provider_data") if isinstance(payload.get("provider_data"), dict) else {}
-    provider_data = {**provider_data, "resource_key": deployment_row.resource_key}
     return DeploymentGetResponse(
         id=deployment_row.id,
-        name=deployment.name,
-        description=getattr(deployment, "description", None),
-        type=deployment.type,
-        created_at=deployment.created_at,
-        updated_at=deployment.updated_at,
+        name=deployment_row.name,
+        description=deployment_row.description,
+        type=deployment_row.deployment_type,
+        # Timestamps are local DB audit fields, not provider payload fields.
+        created_at=deployment_row.created_at,
+        updated_at=deployment_row.updated_at,
         provider_data=provider_data,
         resource_key=deployment_row.resource_key,
         attached_count=attached_count,

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -267,8 +267,8 @@ async def create_provider_account(
     try:
         resolved_provider_tenant_id = resolve_provider_tenant_id(
             deployment_mapper=deployment_mapper,
-            provider_url=payload.provider_url,
-            provider_tenant_id=payload.provider_tenant_id,
+            provider_url=payload.url,
+            tenant_id=payload.tenant_id,
         )
         credential_kwargs = deployment_mapper.resolve_credential_fields(provider_data=payload.provider_data)
         provider_account = await create_provider_account_row(
@@ -277,7 +277,7 @@ async def create_provider_account(
             name=payload.name,
             provider_tenant_id=resolved_provider_tenant_id,
             provider_key=payload.provider_key,
-            provider_url=payload.provider_url,
+            provider_url=payload.url,
             **credential_kwargs,
         )
     except ValueError as exc:
@@ -368,14 +368,9 @@ async def update_provider_account(
         db=session,
     )
 
-    try:
-        payload.validate_provider_url_allowed(provider_account.provider_key)
-    except ValueError as exc:
-        _raise_http_for_provider_account_value_error(exc)
-
     deployment_mapper = get_deployment_mapper(provider_account.provider_key)
     verify_input = None
-    if _field_was_explicitly_set(payload, "provider_url") or _field_was_explicitly_set(payload, "provider_data"):
+    if _field_was_explicitly_set(payload, "provider_data"):
         deployment_adapter = resolve_deployment_adapter(provider_account.provider_key)
         try:
             verify_input = deployment_mapper.resolve_verify_credentials_for_update(

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -37,7 +37,6 @@ from langflow.api.v1.mappers.deployments.helpers import (
     raise_http_for_value_error,
     resolve_adapter_from_deployment,
     resolve_adapter_mapper_from_deployment,
-    resolve_adapter_mapper_from_provider_id,
     resolve_added_snapshot_bindings_for_update,
     resolve_deployment_adapter,
     resolve_flow_version_patch_for_update,
@@ -561,7 +560,9 @@ async def create_deployment(
                 db=session,
             )
         raise
-    return deployment_mapper.shape_deployment_create_result(provider_create_result, deployment_row)
+    return deployment_mapper.shape_deployment_create_result(
+        provider_create_result, deployment_row, provider_key=provider_account.provider_key
+    )
 
 
 @router.get("", response_model=DeploymentListResponse)
@@ -656,6 +657,7 @@ async def list_deployments(
     deployments = deployment_mapper.shape_deployment_list_items(
         rows_with_counts=rows_with_counts,
         has_flow_filter=bool(normalized_flow_version_ids),
+        provider_key=provider_account.provider_key,
     )
     return DeploymentListResponse(
         deployments=deployments,
@@ -705,22 +707,19 @@ async def list_deployment_llms(
     return deployment_mapper.shape_llm_list_result(llm_list_result)
 
 
-@router.post("/executions", response_model=ExecutionCreateResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/deployments/{deployment_id}/executions",
+    response_model=ExecutionCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_deployment_execution(
+    deployment_id: DeploymentIdPath,
     session: DbSession,
     payload: ExecutionCreateRequest,
     current_user: CurrentActiveUser,
 ):
-    deployment_row = await get_deployment_row_or_404(
-        deployment_id=payload.deployment_id,
-        user_id=current_user.id,
-        db=session,
-    )
-    if deployment_row.deployment_provider_account_id != payload.provider_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deployment not found for provider.")
-
-    deployment_adapter, deployment_mapper = await resolve_adapter_mapper_from_provider_id(
-        payload.provider_id,
+    deployment_row, deployment_adapter, deployment_mapper, _provider_key = await resolve_adapter_mapper_from_deployment(
+        deployment_id=deployment_id,
         user_id=current_user.id,
         db=session,
     )
@@ -729,7 +728,7 @@ async def create_deployment_execution(
         db=session,
         payload=payload,
     )
-    with handle_adapter_errors(), deployment_provider_scope(payload.provider_id):
+    with handle_adapter_errors(), deployment_provider_scope(deployment_row.deployment_provider_account_id):
         execution_result = await deployment_adapter.create_execution(
             payload=adapter_execution_payload,
             user_id=current_user.id,
@@ -742,40 +741,25 @@ async def create_deployment_execution(
     )
 
 
-@router.get("/executions/{execution_id}", response_model=ExecutionStatusResponse)
+@router.get("/deployments/{deployment_id}/executions/{execution_id}", response_model=ExecutionStatusResponse)
 async def get_deployment_execution(
+    deployment_id: DeploymentIdPath,
     execution_id: Annotated[str, Path(min_length=1, description="Provider-owned opaque execution identifier.")],
-    provider_id: DeploymentProviderAccountIdQuery,
     session: DbSessionReadOnly,
     current_user: CurrentActiveUser,
 ):
-    deployment_adapter, deployment_mapper = await resolve_adapter_mapper_from_provider_id(
-        provider_id,
+    deployment_row, deployment_adapter, deployment_mapper, _provider_key = await resolve_adapter_mapper_from_deployment(
+        deployment_id=deployment_id,
         user_id=current_user.id,
         db=session,
     )
     execution_lookup_id = execution_id.strip()
-    with handle_adapter_errors(), deployment_provider_scope(provider_id):
+    with handle_adapter_errors(), deployment_provider_scope(deployment_row.deployment_provider_account_id):
         execution_result = await deployment_adapter.get_execution(
             execution_id=execution_lookup_id,
             user_id=current_user.id,
             db=session,
         )
-
-    provider_deployment_id = deployment_mapper.util_resource_key_from_execution(execution_result)
-    if not provider_deployment_id:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Deployment provider execution result did not include a deployment identifier.",
-        )
-    deployment_row = await get_deployment_by_resource_key(
-        session,
-        user_id=current_user.id,
-        deployment_provider_account_id=provider_id,
-        resource_key=provider_deployment_id,
-    )
-    if deployment_row is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deployment not found for provider.")
 
     return deployment_mapper.shape_execution_status_result(
         execution_result,
@@ -1052,7 +1036,7 @@ async def get_deployment(
     session: DbSession,
     current_user: CurrentActiveUser,
 ):
-    deployment_row, deployment_adapter, deployment_mapper = await resolve_adapter_mapper_from_deployment(
+    deployment_row, deployment_adapter, deployment_mapper, provider_key = await resolve_adapter_mapper_from_deployment(
         deployment_id=deployment_id,
         user_id=current_user.id,
         db=session,
@@ -1141,6 +1125,8 @@ async def get_deployment(
     provider_data = payload.get("provider_data") if isinstance(payload.get("provider_data"), dict) else {}
     return DeploymentGetResponse(
         id=deployment_row.id,
+        provider_id=deployment_row.deployment_provider_account_id,
+        provider_key=provider_key,
         name=deployment_row.name,
         description=deployment_row.description,
         type=deployment_row.deployment_type,
@@ -1163,7 +1149,7 @@ async def update_deployment(
     payload: DeploymentUpdateRequest,
     current_user: CurrentActiveUser,
 ):
-    deployment_row, deployment_adapter, deployment_mapper = await resolve_adapter_mapper_from_deployment(
+    deployment_row, deployment_adapter, deployment_mapper, provider_key = await resolve_adapter_mapper_from_deployment(
         deployment_id=deployment_id,
         user_id=current_user.id,
         db=session,
@@ -1254,6 +1240,7 @@ async def update_deployment(
     return deployment_mapper.shape_deployment_update_result(
         update_result,
         deployment_row,
+        provider_key=provider_key,
     )
 
 
@@ -1265,7 +1252,7 @@ async def delete_deployment(
     *,
     include_provider: IncludeProviderDeleteQuery = True,
 ):
-    deployment_row, deployment_adapter = await resolve_adapter_from_deployment(
+    deployment_row, deployment_adapter, _provider_key = await resolve_adapter_from_deployment(
         deployment_id=deployment_id,
         user_id=current_user.id,
         db=session,
@@ -1305,7 +1292,7 @@ async def get_deployment_status(
     session: DbSessionReadOnly,
     current_user: CurrentActiveUser,
 ):
-    deployment_row, deployment_adapter = await resolve_adapter_from_deployment(
+    deployment_row, deployment_adapter, provider_key = await resolve_adapter_from_deployment(
         deployment_id=deployment_id,
         user_id=current_user.id,
         db=session,
@@ -1318,6 +1305,8 @@ async def get_deployment_status(
         )
     return DeploymentStatusResponse(
         id=deployment_row.id,
+        provider_id=deployment_row.deployment_provider_account_id,
+        provider_key=provider_key,
         name=deployment_row.name,
         description=deployment_row.description,
         type=deployment_row.deployment_type,
@@ -1338,7 +1327,7 @@ async def list_deployment_flow_versions(
     page: Annotated[int, Query(ge=1)] = 1,
     size: Annotated[int, Query(ge=1, le=50)] = 20,
 ):
-    deployment_row, deployment_adapter, deployment_mapper = await resolve_adapter_mapper_from_deployment(
+    deployment_row, deployment_adapter, deployment_mapper, _provider_key = await resolve_adapter_mapper_from_deployment(
         deployment_id=deployment_id,
         user_id=current_user.id,
         db=session,

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -296,7 +296,7 @@ async def list_provider_accounts(
     provider_accounts = await list_provider_account_rows(session, user_id=current_user.id, offset=offset, limit=size)
     total = await count_provider_account_rows(session, user_id=current_user.id)
     return DeploymentProviderAccountListResponse(
-        providers=[to_provider_account_response(item) for item in provider_accounts],
+        provider_accounts=[to_provider_account_response(item) for item in provider_accounts],
         page=page,
         size=size,
         total=total,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/RULES.md
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/RULES.md
@@ -300,12 +300,13 @@ The mapper is the **single** component that understands a provider's credential 
 
 - The mapper's `resolve_provider_account_update(payload=..., existing_account=...)` assembles the complete update kwargs dict. Only fields present in `payload.model_fields_set` are included so the CRUD layer receives a minimal diff.
 - Provider mappers override this method to add provider-specific update logic. Provider-account updates currently allow changing display name and credentials only; URL/tenant identifiers must remain immutable after create.
-- The base mapper provides a concrete default that handles name, URL, credentials, and tenant independently. Provider overrides call `super()` for the common fields and only add their own cross-field rules.
+- The base mapper provides a concrete default that handles common mutable fields (display name + credentials). Provider overrides call `super()` for the common fields and only add their own cross-field rules.
 
 **Defense-in-depth (DB model validator):**
 
 - The `DeploymentProviderAccount` model has a `model_validator` that calls `validate_tenant_url_consistency()`. This catches inconsistent tenant/URL pairs regardless of entry point — even if a future code path bypasses the mapper.
 - The validation logic lives in `deployment_provider_account/utils.py` as the single source of truth. Both the model validator and the WXO mapper's `resolve_provider_tenant_id` delegate to the same `extract_tenant_from_url()` function.
+- Provider metadata such as tenant/account identifiers should arrive via `provider_data`; mappers extract and normalize them before persistence.
 
 ---
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/RULES.md
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/RULES.md
@@ -299,7 +299,7 @@ The mapper is the **single** component that understands a provider's credential 
 **Update assembly (API → DB):**
 
 - The mapper's `resolve_provider_account_update(payload=..., existing_account=...)` assembles the complete update kwargs dict. Only fields present in `payload.model_fields_set` are included so the CRUD layer receives a minimal diff.
-- Provider mappers override this method to add cross-field logic. For example, WXO's override re-derives `provider_tenant_id` whenever `provider_url` changes, because the tenant is embedded in the URL path and the two must stay consistent.
+- Provider mappers override this method to add provider-specific update logic. Provider-account updates currently allow changing display name and credentials only; URL/tenant identifiers must remain immutable after create.
 - The base mapper provides a concrete default that handles name, URL, credentials, and tenant independently. Provider overrides call `super()` for the common fields and only add their own cross-field rules.
 
 **Defense-in-depth (DB model validator):**

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -407,6 +407,14 @@ class BaseDeploymentMapper:
         _ = provider_url
         return provider_tenant_id
 
+    def format_conflict_detail(self, raw_message: str) -> str:
+        """Format provider conflict errors for API responses.
+
+        Provider-specific mappers may override this to map provider-native
+        conflict wording to clearer end-user guidance.
+        """
+        return f"A resource with this name already exists in the provider. {raw_message}"
+
     def resolve_credential_fields(
         self,
         *,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -370,6 +370,7 @@ class BaseDeploymentMapper:
             type=deployment_row.deployment_type,
             created_at=deployment_row.created_at,
             updated_at=deployment_row.updated_at,
+            resource_key=deployment_row.resource_key,
             provider_data=provider_data,
         )
 
@@ -390,6 +391,7 @@ class BaseDeploymentMapper:
             type=deployment_row.deployment_type,
             created_at=deployment_row.created_at,
             updated_at=deployment_row.updated_at,
+            resource_key=deployment_row.resource_key,
             provider_data=provider_data,
         )
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -63,7 +63,6 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentFlowVersionListItem,
     DeploymentFlowVersionListResponse,
     DeploymentListItem,
-    DeploymentListItemAttachment,
     DeploymentListResponse,
     DeploymentLlmListResponse,
     DeploymentProviderAccountCreateRequest,
@@ -320,15 +319,7 @@ class BaseDeploymentMapper:
                 attached_count=attached_count,
                 created_at=row.created_at,
                 updated_at=row.updated_at,
-                matched_attachments=[
-                    DeploymentListItemAttachment(
-                        flow_version_id=fv_id,
-                        provider_snapshot_id=snap_id,
-                    )
-                    for fv_id, snap_id in matched_attachments
-                ]
-                if has_flow_filter
-                else None,
+                flow_version_ids=[fv_id for fv_id, _ in matched_attachments] if has_flow_filter else None,
             )
             for row, attached_count, matched_attachments in rows_with_counts
         ]
@@ -653,21 +644,26 @@ class BaseDeploymentMapper:
         self,
         result: DeploymentListResult,
     ) -> DeploymentListResponse:
-        entries = [
-            {
-                "resource_key": str(item.id),
-                "name": item.name,
-                "type": item.type,
-                "description": getattr(item, "description", None),
-                "created_at": item.created_at,
-                "updated_at": item.updated_at,
-                "provider_data": self.shape_deployment_item_data(
-                    item.provider_data if isinstance(item.provider_data, dict) else None
-                ),
-            }
-            for item in result.deployments
-            if str(item.id).strip()
-        ]
+        entries = []
+        for item in result.deployments:
+            item_id = str(item.id).strip()
+            if not item_id:
+                continue
+            item_provider_data = (
+                self.shape_deployment_item_data(item.provider_data if isinstance(item.provider_data, dict) else None)
+                or {}
+            )
+            entries.append(
+                {
+                    "id": item_id,
+                    "name": item.name,
+                    "type": item.type,
+                    "description": getattr(item, "description", None),
+                    "created_at": item.created_at,
+                    "updated_at": item.updated_at,
+                    **item_provider_data,
+                }
+            )
         return DeploymentListResponse(
             deployments=[],
             page=1,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -57,7 +57,6 @@ from lfx.services.adapters.deployment.schema import (
 from lfx.services.adapters.payload import PayloadSlot
 
 from langflow.api.v1.schemas.deployments import (
-    DeploymentConfigListItem,
     DeploymentConfigListResponse,
     DeploymentCreateRequest,
     DeploymentCreateResponse,
@@ -70,7 +69,6 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentProviderAccountCreateRequest,
     DeploymentProviderAccountGetResponse,
     DeploymentProviderAccountUpdateRequest,
-    DeploymentSnapshotListItem,
     DeploymentSnapshotListResponse,
     DeploymentUpdateRequest,
     DeploymentUpdateResponse,
@@ -680,20 +678,16 @@ class BaseDeploymentMapper:
             self.api_payloads.config_list_result,
             result.provider_result if isinstance(result.provider_result, dict) else None,
         )
-        configs_all = [
-            DeploymentConfigListItem(
-                id=str(item.id),
-                name=item.name,
-                created_at=item.created_at,
-                updated_at=item.updated_at,
-                provider_data=item.provider_data if isinstance(item.provider_data, dict) else None,
-            )
-            for item in result.configs
-        ]
-        total = len(configs_all)
+        items_all = [item.model_dump(mode="json", exclude_none=True) for item in result.configs]
+        total = len(items_all)
         offset = page_offset(page, size)
+        provider_result = result.provider_result if isinstance(result.provider_result, dict) else {}
+        provider_data: dict[str, Any] = {
+            **provider_result,
+            "configs": items_all[offset : offset + size],
+        }
         return DeploymentConfigListResponse(
-            configs=configs_all[offset : offset + size],
+            provider_data=provider_data or None,
             page=page,
             size=size,
             total=total,
@@ -710,20 +704,16 @@ class BaseDeploymentMapper:
             self.api_payloads.snapshot_list_result,
             result.provider_result if isinstance(result.provider_result, dict) else None,
         )
-        snapshots_all = [
-            DeploymentSnapshotListItem(
-                id=str(item.id),
-                name=item.name,
-                created_at=item.created_at,
-                updated_at=item.updated_at,
-                provider_data=item.provider_data if isinstance(item.provider_data, dict) else None,
-            )
-            for item in result.snapshots
-        ]
-        total = len(snapshots_all)
+        items_all = [item.model_dump(mode="json", exclude_none=True) for item in result.snapshots]
+        total = len(items_all)
         offset = page_offset(page, size)
+        provider_result = result.provider_result if isinstance(result.provider_result, dict) else {}
+        provider_data: dict[str, Any] = {
+            **provider_result,
+            "snapshots": items_all[offset : offset + size],
+        }
         return DeploymentSnapshotListResponse(
-            snapshots=snapshots_all[offset : offset + size],
+            provider_data=provider_data or None,
             page=page,
             size=size,
             total=total,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -395,10 +395,26 @@ class BaseDeploymentMapper:
             provider_data=provider_data,
         )
 
-    def resolve_provider_tenant_id(self, *, provider_url: str, tenant_id: str | None) -> str | None:
+    def resolve_provider_tenant_id(
+        self,
+        *,
+        provider_url: str,
+        provider_data: dict[str, Any],
+    ) -> str | None:
         """Resolve provider tenant id for provider-account create/update."""
         _ = provider_url
-        return tenant_id
+        return self.resolve_provider_tenant_id_from_data(provider_data=provider_data)
+
+    def resolve_provider_tenant_id_from_data(self, *, provider_data: dict[str, Any]) -> str | None:
+        """Extract optional tenant/account identifier from provider_data."""
+        raw_tenant_id = provider_data.get("tenant_id")
+        if raw_tenant_id is None:
+            return None
+        if not isinstance(raw_tenant_id, str):
+            msg = "provider_data.tenant_id must be a string when provided."
+            raise ValueError(msg)  # noqa: TRY004 - route layer maps ValueError to HTTP 4xx
+        tenant_id = raw_tenant_id.strip()
+        return tenant_id or None
 
     def format_conflict_detail(self, raw_message: str) -> str:
         """Format provider conflict errors for API responses.
@@ -486,12 +502,25 @@ class BaseDeploymentMapper:
         return DeploymentProviderAccountGetResponse(
             id=provider_account.id,
             name=provider_account.name,
-            tenant_id=provider_account.provider_tenant_id,
             provider_key=provider_account.provider_key,
             url=provider_account.provider_url,
+            provider_data=self.shape_provider_account_provider_data(provider_account),
             created_at=provider_account.created_at,
             updated_at=provider_account.updated_at,
         )
+
+    def shape_provider_account_provider_data(
+        self,
+        provider_account: DeploymentProviderAccount,
+    ) -> dict[str, Any] | None:
+        """Return non-sensitive provider metadata for provider-account responses."""
+        raw_tenant_id = provider_account.provider_tenant_id
+        if raw_tenant_id is None:
+            return None
+        tenant_id = str(raw_tenant_id).strip()
+        if not tenant_id:
+            return None
+        return {"tenant_id": tenant_id}
 
     def util_create_flow_artifact_provider_data(
         self,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -402,10 +402,10 @@ class BaseDeploymentMapper:
             provider_data=provider_data,
         )
 
-    def resolve_provider_tenant_id(self, *, provider_url: str, provider_tenant_id: str | None) -> str | None:
+    def resolve_provider_tenant_id(self, *, provider_url: str, tenant_id: str | None) -> str | None:
         """Resolve provider tenant id for provider-account create/update."""
         _ = provider_url
-        return provider_tenant_id
+        return tenant_id
 
     def format_conflict_detail(self, raw_message: str) -> str:
         """Format provider conflict errors for API responses.
@@ -438,24 +438,19 @@ class BaseDeploymentMapper:
         """Assemble DB column-value kwargs for a provider-account update.
 
         Only fields present in ``payload.model_fields_set`` are included so
-        the CRUD layer receives a minimal diff.  Provider mappers may override
-        to add cross-field logic (e.g. re-deriving tenant from URL).
+        the CRUD layer receives a minimal diff. Provider-account update fields
+        are intentionally limited to mutable values (display name and
+        credentials).
         """
+        _ = existing_account
         update_kwargs: dict[str, Any] = {}
         if "name" in payload.model_fields_set:
             update_kwargs["name"] = payload.name
-        if "provider_url" in payload.model_fields_set:
-            update_kwargs["provider_url"] = payload.provider_url
         if "provider_data" in payload.model_fields_set:
             if payload.provider_data is None:
                 msg = "'provider_data' cannot be null when provided."
                 raise ValueError(msg)
             update_kwargs.update(self.resolve_credential_fields(provider_data=payload.provider_data))
-        if "provider_tenant_id" in payload.model_fields_set:
-            update_kwargs["provider_tenant_id"] = self.resolve_provider_tenant_id(
-                provider_url=payload.provider_url or existing_account.provider_url,
-                provider_tenant_id=payload.provider_tenant_id,
-            )
         return update_kwargs
 
     def resolve_verify_credentials(
@@ -470,7 +465,7 @@ class BaseDeploymentMapper:
         provider mapper overrides.
         """
         return VerifyCredentials(
-            base_url=payload.provider_url,
+            base_url=payload.url,
         )
 
     def resolve_verify_credentials_for_update(
@@ -481,12 +476,12 @@ class BaseDeploymentMapper:
     ) -> VerifyCredentials | None:
         """Build adapter verify-credentials input for provider-account updates.
 
-        Returns ``None`` when the update does not touch credentials or URL.
+        Returns ``None`` when the update does not touch credentials.
         Provider-specific mappers must override this when update-time
         verification is supported.
         """
         _ = existing_account
-        if "provider_url" not in payload.model_fields_set and "provider_data" not in payload.model_fields_set:
+        if "provider_data" not in payload.model_fields_set:
             return None
         msg = "Credential verification for provider account updates is not implemented for this provider."
         raise NotImplementedError(msg)
@@ -498,9 +493,9 @@ class BaseDeploymentMapper:
         return DeploymentProviderAccountGetResponse(
             id=provider_account.id,
             name=provider_account.name,
-            provider_tenant_id=provider_account.provider_tenant_id,
+            tenant_id=provider_account.provider_tenant_id,
             provider_key=provider_account.provider_key,
-            provider_url=provider_account.provider_url,
+            url=provider_account.provider_url,
             created_at=provider_account.created_at,
             updated_at=provider_account.updated_at,
         )

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -153,9 +153,9 @@ class BaseDeploymentMapper:
         provider_data = self._validate_slot(self.api_payloads.deployment_create, payload.provider_data)
         return AdapterDeploymentCreate(
             spec=BaseDeploymentData(
-                name=payload.spec.name,
-                description=payload.spec.description,
-                type=payload.spec.type,
+                name=payload.name,
+                description=payload.description,
+                type=payload.type,
             ),
             provider_data=provider_data,
         )
@@ -177,8 +177,8 @@ class BaseDeploymentMapper:
         )
         return AdapterDeploymentUpdate(
             spec=BaseDeploymentDataUpdate(
-                name=payload.spec.name,
-                description=payload.spec.description,
+                name=payload.name,
+                description=payload.description,
             ),
             provider_data=create_payload.provider_data,
         )
@@ -194,10 +194,10 @@ class BaseDeploymentMapper:
         _ = (user_id, deployment_db_id)
         adapter_spec = (
             BaseDeploymentDataUpdate(
-                name=payload.spec.name,
-                description=payload.spec.description,
+                name=payload.name,
+                description=payload.description,
             )
-            if payload.spec is not None
+            if payload.name is not None or payload.description is not None
             else None
         )
         provider_data = self._validate_slot(self.api_payloads.deployment_update, payload.provider_data)

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -32,21 +32,18 @@ from uuid import UUID
 from fastapi import HTTPException, status
 from lfx.services.adapters.deployment.payloads import DeploymentPayloadFields
 from lfx.services.adapters.deployment.schema import (
+    BaseDeploymentData,
     BaseDeploymentDataUpdate,
     BaseFlowArtifact,
-    ConfigDeploymentBindingUpdate,
-    ConfigItem,
     ConfigListParams,
     ConfigListResult,
     DeploymentCreateResult,
     DeploymentListLlmsResult,
     DeploymentListResult,
-    DeploymentType,
     DeploymentUpdateResult,
     ExecutionCreate,
     ExecutionCreateResult,
     ExecutionStatusResult,
-    SnapshotItems,
     SnapshotListParams,
     SnapshotListResult,
     VerifyCredentials,
@@ -89,7 +86,7 @@ from .contracts import (
     FlowVersionPatch,
     UpdateSnapshotBindings,
 )
-from .helpers import build_project_scoped_flow_artifacts_from_flow_versions, page_offset
+from .helpers import page_offset
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -154,38 +151,14 @@ class BaseDeploymentMapper:
         db: AsyncSession,
         payload: DeploymentCreateRequest,
     ) -> AdapterDeploymentCreate:
-        snapshot_payloads: list[BaseFlowArtifact] | None = None
-        if payload.flow_version_ids:
-            flow_artifacts = await build_project_scoped_flow_artifacts_from_flow_versions(
-                reference_ids=payload.flow_version_ids,
-                user_id=user_id,
-                project_id=project_id,
-                db=db,
-            )
-            snapshot_payloads = [
-                artifact.model_copy(
-                    update={
-                        "provider_data": self.util_create_flow_artifact_provider_data(
-                            project_id=project_id,
-                            flow_version_id=flow_version_id,
-                        ).model_dump(exclude_none=True),
-                    }
-                )
-                for flow_version_id, artifact in flow_artifacts
-            ]
-        adapter_snapshot = SnapshotItems(raw_payloads=snapshot_payloads) if snapshot_payloads else None
-        adapter_config = (
-            ConfigItem(reference_id=payload.config.reference_id)
-            if payload.config is not None and payload.config.reference_id is not None
-            else ConfigItem(raw_payload=payload.config.raw_payload)
-            if payload.config is not None
-            else None
-        )
+        _ = (user_id, project_id)
         provider_data = self._validate_slot(self.api_payloads.deployment_create, payload.provider_data)
         return AdapterDeploymentCreate(
-            spec=payload.spec,
-            snapshot=adapter_snapshot,
-            config=adapter_config,
+            spec=BaseDeploymentData(
+                name=payload.spec.name,
+                description=payload.spec.description,
+                type=payload.spec.type,
+            ),
             provider_data=provider_data,
         )
 
@@ -221,15 +194,17 @@ class BaseDeploymentMapper:
         payload: DeploymentUpdateRequest,
     ) -> AdapterDeploymentUpdate:
         _ = (user_id, deployment_db_id)
-        adapter_config = (
-            ConfigDeploymentBindingUpdate(**payload.config.model_dump(exclude_unset=True))
-            if payload.config is not None
+        adapter_spec = (
+            BaseDeploymentDataUpdate(
+                name=payload.spec.name,
+                description=payload.spec.description,
+            )
+            if payload.spec is not None
             else None
         )
         provider_data = self._validate_slot(self.api_payloads.deployment_update, payload.provider_data)
         return AdapterDeploymentUpdate(
-            spec=payload.spec,
-            config=adapter_config,
+            spec=adapter_spec,
             provider_data=provider_data,
         )
 
@@ -528,7 +503,8 @@ class BaseDeploymentMapper:
 
     def util_create_flow_version_ids(self, payload: DeploymentCreateRequest) -> list[UUID]:
         """Resolve flow-version ids referenced by create payload."""
-        return list(payload.flow_version_ids or [])
+        _ = payload
+        return []
 
     def util_existing_deployment_resource_key_for_create(
         self,
@@ -616,10 +592,8 @@ class BaseDeploymentMapper:
 
         Contract schema: ``FlowVersionPatch``.
         """
-        return FlowVersionPatch(
-            add_flow_version_ids=list(payload.add_flow_version_ids or []),
-            remove_flow_version_ids=list(payload.remove_flow_version_ids or []),
-        )
+        _ = payload
+        return FlowVersionPatch()
 
     def util_snapshot_ids_to_verify(
         self,
@@ -666,8 +640,6 @@ class BaseDeploymentMapper:
     def shape_deployment_list_result(
         self,
         result: DeploymentListResult,
-        *,
-        deployment_type: DeploymentType | None,
     ) -> DeploymentListResponse:
         entries = [
             {
@@ -686,7 +658,6 @@ class BaseDeploymentMapper:
         ]
         return DeploymentListResponse(
             deployments=[],
-            deployment_type=deployment_type,
             page=1,
             size=len(entries),
             total=len(entries),

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -306,10 +306,13 @@ class BaseDeploymentMapper:
         *,
         rows_with_counts: list[tuple[Deployment, int, list[tuple[UUID, str | None]]]],
         has_flow_filter: bool = False,
+        provider_key: str,
     ) -> list[DeploymentListItem]:
         return [
             DeploymentListItem(
                 id=row.id,
+                provider_id=row.deployment_provider_account_id,
+                provider_key=provider_key,
                 resource_key=row.resource_key,
                 type=row.deployment_type,
                 name=row.name,
@@ -363,10 +366,14 @@ class BaseDeploymentMapper:
         self,
         result: DeploymentCreateResult,
         deployment_row: Deployment,
+        *,
+        provider_key: str,
     ) -> DeploymentCreateResponse:
         provider_data = result.provider_result if isinstance(result.provider_result, dict) else None
         return DeploymentCreateResponse(
             id=deployment_row.id,
+            provider_id=deployment_row.deployment_provider_account_id,
+            provider_key=provider_key,
             name=deployment_row.name,
             description=deployment_row.description,
             type=deployment_row.deployment_type,
@@ -379,10 +386,14 @@ class BaseDeploymentMapper:
         self,
         result: DeploymentUpdateResult,
         deployment_row: Deployment,
+        *,
+        provider_key: str,
     ) -> DeploymentUpdateResponse:
         provider_data = result.provider_result if isinstance(result.provider_result, dict) else None
         return DeploymentUpdateResponse(
             id=deployment_row.id,
+            provider_id=deployment_row.deployment_provider_account_id,
+            provider_key=provider_key,
             name=deployment_row.name,
             description=deployment_row.description,
             type=deployment_row.deployment_type,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -493,7 +493,8 @@ async def resolve_adapter_from_deployment(
     deployment_id: UUID,
     user_id: UUID,
     db: DbSession,
-) -> tuple[Deployment, DeploymentServiceProtocol]:
+) -> tuple[Deployment, DeploymentServiceProtocol, str]:
+    """Returns ``(deployment_row, adapter, provider_key)``."""
     deployment_row = await get_deployment_row_or_404(deployment_id=deployment_id, user_id=user_id, db=db)
     provider_account = await get_owned_provider_account_or_404(
         provider_id=deployment_row.deployment_provider_account_id,
@@ -501,7 +502,7 @@ async def resolve_adapter_from_deployment(
         db=db,
     )
     deployment_adapter = resolve_deployment_adapter(provider_account.provider_key)
-    return deployment_row, deployment_adapter
+    return deployment_row, deployment_adapter, provider_account.provider_key
 
 
 async def resolve_adapter_mapper_from_deployment(
@@ -509,7 +510,8 @@ async def resolve_adapter_mapper_from_deployment(
     deployment_id: UUID,
     user_id: UUID,
     db: DbSession,
-) -> tuple[Deployment, DeploymentServiceProtocol, BaseDeploymentMapper]:
+) -> tuple[Deployment, DeploymentServiceProtocol, BaseDeploymentMapper, str]:
+    """Returns ``(deployment_row, adapter, mapper, provider_key)``."""
     from langflow.api.v1.mappers.deployments.registry import get_deployment_mapper
 
     deployment_row = await get_deployment_row_or_404(deployment_id=deployment_id, user_id=user_id, db=db)
@@ -520,7 +522,7 @@ async def resolve_adapter_mapper_from_deployment(
     )
     deployment_adapter = resolve_deployment_adapter(provider_account.provider_key)
     deployment_mapper = get_deployment_mapper(provider_account.provider_key)
-    return deployment_row, deployment_adapter, deployment_mapper
+    return deployment_row, deployment_adapter, deployment_mapper, provider_account.provider_key
 
 
 async def resolve_project_id_for_deployment_create(

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -1037,6 +1037,7 @@ async def list_deployment_flow_versions_synced(
     db: DbSession,
     page: int,
     size: int,
+    flow_ids: list[UUID] | None = None,
 ) -> tuple[list[tuple[FlowVersionDeploymentAttachment, FlowVersion, str | None]], int, SnapshotListResult | None]:
     """Return a paginated deployment attachment view synced against provider snapshots.
 
@@ -1048,6 +1049,7 @@ async def list_deployment_flow_versions_synced(
         db,
         user_id=user_id,
         deployment_id=deployment_id,
+        flow_ids=flow_ids,
     )
     snapshot_result: SnapshotListResult | None = None
     snapshot_ids = list(dict.fromkeys(deployment_mapper.util_snapshot_ids_to_verify(attachments)))
@@ -1085,11 +1087,13 @@ async def list_deployment_flow_versions_synced(
         deployment_id=deployment_id,
         offset=page_offset(page, size),
         limit=size,
+        flow_ids=flow_ids,
     )
     total = await count_deployment_attachments(
         db,
         user_id=user_id,
         deployment_id=deployment_id,
+        flow_ids=flow_ids,
     )
     return rows, total, snapshot_result
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -355,11 +355,11 @@ def resolve_provider_tenant_id(
     *,
     deployment_mapper: BaseDeploymentMapper,
     provider_url: str,
-    tenant_id: str | None,
+    provider_data: dict[str, Any],
 ) -> str | None:
     return deployment_mapper.resolve_provider_tenant_id(
         provider_url=provider_url,
-        tenant_id=tenant_id,
+        provider_data=provider_data,
     )
 
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -355,11 +355,11 @@ def resolve_provider_tenant_id(
     *,
     deployment_mapper: BaseDeploymentMapper,
     provider_url: str,
-    provider_tenant_id: str | None,
+    tenant_id: str | None,
 ) -> str | None:
     return deployment_mapper.resolve_provider_tenant_id(
         provider_url=provider_url,
-        provider_tenant_id=provider_tenant_id,
+        tenant_id=tenant_id,
     )
 
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/helpers.py
@@ -310,27 +310,8 @@ def raise_http_for_value_error(exc: ValueError) -> None:
     raise HTTPException(status_code=status_code, detail=str(exc)) from exc
 
 
-def _friendly_conflict_message(raw_message: str) -> str:
-    """Rewrite provider conflict errors into user-friendly messages."""
-    lower = raw_message.lower()
-    if "agent" in lower and ("already exists" in lower or "conflict" in lower):
-        return (
-            "An agent with this name already exists in the provider. "
-            "Please choose a different name or delete the existing agent first."
-        )
-    if "connection" in lower or "app_id" in lower:
-        return (
-            "A connection referenced in this request already exists in the provider. "
-            "Reference it as an existing connection instead of creating a new one."
-        )
-    if "tool" in lower and ("already exists" in lower or "conflict" in lower):
-        return "A tool with this name already exists in the provider. Please choose a different name."
-    # Fall back to a cleaned-up version of the raw message.
-    return f"A resource with this name already exists in the provider. {raw_message}"
-
-
 @contextmanager
-def handle_adapter_errors():
+def handle_adapter_errors(*, mapper: BaseDeploymentMapper | None = None):
     """Map deployment adapter exceptions to appropriate HTTP responses.
 
     Domain exceptions (subclasses of :class:`DeploymentServiceError`) are
@@ -344,8 +325,8 @@ def handle_adapter_errors():
     except DeploymentServiceError as exc:
         http_status = http_status_for_deployment_error(exc)
         detail = exc.message
-        if isinstance(exc, DeploymentConflictError):
-            detail = _friendly_conflict_message(exc.message)
+        if isinstance(exc, DeploymentConflictError) and mapper is not None:
+            detail = mapper.format_conflict_detail(exc.message)
         logger.exception("Adapter error (status=%s): %s", http_status, detail)
         raise HTTPException(
             status_code=http_status,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -57,11 +57,11 @@ from langflow.api.v1.mappers.deployments.helpers import (
 )
 from langflow.api.v1.mappers.deployments.registry import register_mapper
 from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
+    WatsonxApiAddFlowItem,
     WatsonxApiAgentExecutionCreateResultData,
     WatsonxApiAgentExecutionStatusResultData,
-    WatsonxApiBindOperation,
-    WatsonxApiBindToolOperation,
     WatsonxApiConfigListProviderData,
+    WatsonxApiCreateUpsertToolItem,
     WatsonxApiDeploymentCreatePayload,
     WatsonxApiDeploymentCreateResultData,
     WatsonxApiDeploymentFlowVersionItemData,
@@ -71,12 +71,10 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
     WatsonxApiDeploymentUpdateResultData,
     WatsonxApiFlowArtifactProviderData,
     WatsonxApiProviderDeploymentListItem,
-    WatsonxApiRemoveToolByIdOperation,
-    WatsonxApiRemoveToolOperation,
     WatsonxApiSnapshotListProviderData,
     WatsonxApiToolAppBinding,
-    WatsonxApiUnbindOperation,
-    WatsonxApiUnbindToolOperation,
+    WatsonxApiUpsertFlowItem,
+    WatsonxApiUpsertToolItem,
 )
 from langflow.api.v1.schemas.deployments import (
     DeploymentConfigListResponse,
@@ -261,7 +259,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             slot_name="deployment_create",
             raw=payload.provider_data,
         )
-        return self._extract_bind_flow_version_ids(api_provider_payload.operations)
+        return list(dict.fromkeys(item.flow_version_id for item in api_provider_payload.add_flows))
 
     def util_existing_deployment_resource_key_for_create(
         self,
@@ -287,7 +285,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             slot_name="deployment_create",
             raw=payload.provider_data,
         )
-        return bool(api_provider_payload.operations)
+        return bool(api_provider_payload.add_flows or api_provider_payload.upsert_tools)
 
     def util_create_result_from_existing_update(
         self,
@@ -351,7 +349,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             slot_name="deployment_create",
             raw=payload.provider_data,
         )
-        flow_version_ids = self._extract_bind_flow_version_ids(api_provider_payload.operations)
+        flow_version_ids = list(dict.fromkeys(item.flow_version_id for item in api_provider_payload.add_flows))
         flow_artifacts = await build_project_scoped_flow_artifacts_from_flow_versions(
             db=db,
             user_id=user_id,
@@ -360,11 +358,12 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         )
         raw_name_by_flow_version_id = {flow_version_id: artifact.name for flow_version_id, artifact in flow_artifacts}
         # Override with user-provided tool names when present
-        for op in api_provider_payload.operations:
-            if isinstance(op, WatsonxApiBindOperation) and op.tool_name:
-                raw_name_by_flow_version_id[op.flow_version_id] = op.tool_name
+        for item in api_provider_payload.add_flows:
+            if item.tool_name:
+                raw_name_by_flow_version_id[item.flow_version_id] = item.tool_name
         provider_operations = self._build_provider_operations(
-            operations=api_provider_payload.operations,
+            add_flows=api_provider_payload.add_flows,
+            upsert_tools=api_provider_payload.upsert_tools,
             raw_name_by_flow_version_id=raw_name_by_flow_version_id,
         )
         if slot is None:
@@ -471,7 +470,13 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             slot_name="deployment_update",
             raw=payload.provider_data,
         )
-        ordered_flow_version_ids = self._extract_bind_flow_version_ids(api_provider_payload.operations)
+        ordered_flow_version_ids = list(
+            dict.fromkeys(
+                item.flow_version_id
+                for item in api_provider_payload.upsert_flows
+                if item.add_app_ids or not item.remove_app_ids
+            )
+        )
         flow_artifacts = await build_flow_artifacts_from_flow_versions(
             db=db,
             user_id=user_id,
@@ -482,9 +487,9 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             flow_version_id: artifact.name for flow_version_id, _version_number, _project_id, artifact in flow_artifacts
         }
         # Override with user-provided tool names when present
-        for op in api_provider_payload.operations:
-            if isinstance(op, WatsonxApiBindOperation) and op.tool_name:
-                raw_name_by_flow_version_id[op.flow_version_id] = op.tool_name
+        for item in api_provider_payload.upsert_flows:
+            if item.tool_name and item.flow_version_id in raw_name_by_flow_version_id:
+                raw_name_by_flow_version_id[item.flow_version_id] = item.tool_name
         raw_payloads = [
             artifact.model_copy(
                 update={
@@ -498,37 +503,31 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             for flow_version_id, _version_number, project_id, artifact in flow_artifacts
         ]
 
-        # Single DB query for all flow_version_ids across operation types,
-        # then selective strict validation for unbind/remove only.
-        #
-        # - bind: missing attachment = "create new tool" (expected)
-        # - unbind: missing = error (tool must exist to modify connections)
-        # - remove_tool: missing = error (tool must exist to detach)
-        bind_fv_ids = [
-            op.flow_version_id for op in api_provider_payload.operations if isinstance(op, WatsonxApiBindOperation)
-        ]
-        unbind_fv_ids = [
-            op.flow_version_id for op in api_provider_payload.operations if isinstance(op, WatsonxApiUnbindOperation)
-        ]
-        remove_fv_ids = [
-            op.flow_version_id
-            for op in api_provider_payload.operations
-            if isinstance(op, WatsonxApiRemoveToolOperation)
-        ]
-        all_fv_ids = list(dict.fromkeys(bind_fv_ids + unbind_fv_ids + remove_fv_ids))
+        upsert_fv_ids = list(dict.fromkeys(item.flow_version_id for item in api_provider_payload.upsert_flows))
+        remove_fv_ids = list(dict.fromkeys(api_provider_payload.remove_flows))
+        all_fv_ids = list(dict.fromkeys(upsert_fv_ids + remove_fv_ids))
         flow_version_snapshot_id_map = await self._lookup_snapshot_ids(
             user_id=user_id,
             deployment_db_id=deployment_db_id,
             db=db,
             flow_version_ids=all_fv_ids,
         )
-        strict_fv_ids = list(dict.fromkeys(unbind_fv_ids + remove_fv_ids))
+        strict_fv_ids = list(
+            dict.fromkeys(
+                [item.flow_version_id for item in api_provider_payload.upsert_flows if item.remove_app_ids]
+                + remove_fv_ids
+            )
+        )
         missing_strict = [str(fv) for fv in strict_fv_ids if fv not in flow_version_snapshot_id_map]
         if missing_strict:
             msg = f"Cannot resolve provider snapshot ids for flow_version_ids in watsonx operations: {missing_strict}"
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=msg)
 
-        reused_fv_ids = {fv for fv in bind_fv_ids if fv in flow_version_snapshot_id_map}
+        reused_fv_ids = {
+            item.flow_version_id
+            for item in api_provider_payload.upsert_flows
+            if (item.add_app_ids or not item.remove_app_ids) and item.flow_version_id in flow_version_snapshot_id_map
+        }
         filtered_raw_payloads = (
             [
                 raw_payload
@@ -542,7 +541,10 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         )
 
         provider_operations = self._build_provider_operations(
-            operations=api_provider_payload.operations,
+            upsert_flows=api_provider_payload.upsert_flows,
+            upsert_tools=api_provider_payload.upsert_tools,
+            remove_flows=api_provider_payload.remove_flows,
+            remove_tools=api_provider_payload.remove_tools,
             raw_name_by_flow_version_id=raw_name_by_flow_version_id,
             flow_version_snapshot_id_map=flow_version_snapshot_id_map,
         )
@@ -859,14 +861,14 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             slot_name="deployment_update",
             raw=payload.provider_data,
         )
-        add_ids = self._extract_bind_flow_version_ids(api_provider_payload.operations)
-        remove_ids = list(
+        add_ids = list(
             dict.fromkeys(
-                operation.flow_version_id
-                for operation in api_provider_payload.operations
-                if isinstance(operation, (WatsonxApiUnbindOperation, WatsonxApiRemoveToolOperation))
+                item.flow_version_id
+                for item in api_provider_payload.upsert_flows
+                if item.add_app_ids or not item.remove_app_ids
             )
         )
+        remove_ids = list(dict.fromkeys(api_provider_payload.remove_flows))
         return FlowVersionPatch(
             add_flow_version_ids=add_ids,
             remove_flow_version_ids=remove_ids,
@@ -1220,13 +1222,6 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 detail=f"Invalid provider_data payload: {detail}",
             ) from exc
 
-    def _extract_bind_flow_version_ids(self, operations: list[Any]) -> list[UUID]:
-        return list(
-            dict.fromkeys(
-                operation.flow_version_id for operation in operations if isinstance(operation, WatsonxApiBindOperation)
-            )
-        )
-
     def _to_bind_provider_operation(self, *, raw_name: str, app_ids: list[str]) -> AdapterPayload:
         return {
             "op": "bind",
@@ -1277,119 +1272,156 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
     def _build_provider_operations(
         self,
         *,
-        operations: list[Any],
+        add_flows: list[WatsonxApiAddFlowItem] | None = None,
+        upsert_flows: list[WatsonxApiUpsertFlowItem] | None = None,
+        upsert_tools: list[WatsonxApiUpsertToolItem] | list[WatsonxApiCreateUpsertToolItem] | None = None,
+        remove_flows: list[UUID] | None = None,
+        remove_tools: list[str] | None = None,
         raw_name_by_flow_version_id: dict[UUID, str],
         flow_version_snapshot_id_map: dict[UUID, str] | None = None,
     ) -> list[AdapterPayload]:
         provider_operations: list[AdapterPayload] = []
-        for operation in operations:
-            if isinstance(operation, WatsonxApiBindOperation):
-                flow_version_id = operation.flow_version_id
-                existing_tool_id = (flow_version_snapshot_id_map or {}).get(flow_version_id)
+        add_flows = add_flows or []
+        upsert_flows = upsert_flows or []
+        upsert_tools = upsert_tools or []
+        remove_flows = remove_flows or []
+        remove_tools = remove_tools or []
 
-                if existing_tool_id:
-                    # Reuse existing tool -- no new artifact creation needed.
-                    if operation.app_ids:
-                        provider_operations.append(
-                            self._to_bind_existing_tool_provider_operation(
-                                tool_id=existing_tool_id,
-                                source_ref=str(flow_version_id),
-                                app_ids=operation.app_ids,
-                            )
-                        )
-                    else:
-                        provider_operations.append(
-                            self._to_attach_tool_provider_operation(
-                                tool_id=existing_tool_id,
-                                source_ref=str(flow_version_id),
-                            )
-                        )
-                else:
-                    # No existing tool -- create new via raw payload (current behavior).
-                    if flow_version_id not in raw_name_by_flow_version_id:
-                        msg = f"bind.flow_version_id not found: [{flow_version_id}]"
-                        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=msg)
-                    if not operation.app_ids:
-                        # Raw tool is still created via tools.raw_payloads;
-                        # no provider bind operation needed.
-                        continue
-                    provider_operations.append(
-                        self._to_bind_provider_operation(
-                            raw_name=raw_name_by_flow_version_id[flow_version_id],
-                            app_ids=operation.app_ids,
-                        )
-                    )
-                continue
-
-            if isinstance(operation, WatsonxApiUnbindOperation):
-                flow_version_id = operation.flow_version_id
-                if flow_version_snapshot_id_map is None:
-                    msg = "Snapshot id map is required for unbind operations."
-                    raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
-                provider_operations.append(
-                    self._to_unbind_provider_operation(
-                        tool_id=flow_version_snapshot_id_map[flow_version_id],
-                        source_ref=str(flow_version_id),
-                        app_ids=operation.app_ids,
-                    )
-                )
-                continue
-
-            if isinstance(operation, WatsonxApiRemoveToolOperation):
-                flow_version_id = operation.flow_version_id
-                if flow_version_snapshot_id_map is None:
-                    msg = "Snapshot id map is required for remove_tool operations."
-                    raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
-                provider_operations.append(
-                    self._to_remove_tool_provider_operation(
-                        tool_id=flow_version_snapshot_id_map[flow_version_id],
-                        source_ref=str(flow_version_id),
-                    )
-                )
-                continue
-
-            # Tool-id-based operations: use tool_id as source_ref.
-            # These do not create/modify flow_version_deployment_attachment
-            # records -- they are purely provider-side agent composition.
-            if isinstance(operation, WatsonxApiBindToolOperation):
-                tool_id = operation.tool_id.strip()
-                if operation.app_ids:
+        # Create path flow semantics.
+        for item in add_flows:
+            flow_version_id = item.flow_version_id
+            existing_tool_id = (flow_version_snapshot_id_map or {}).get(flow_version_id)
+            if existing_tool_id:
+                if item.app_ids:
                     provider_operations.append(
                         self._to_bind_existing_tool_provider_operation(
-                            tool_id=tool_id,
-                            source_ref=tool_id,
-                            app_ids=operation.app_ids,
+                            tool_id=existing_tool_id,
+                            source_ref=str(flow_version_id),
+                            app_ids=item.app_ids,
                         )
                     )
                 else:
                     provider_operations.append(
                         self._to_attach_tool_provider_operation(
-                            tool_id=tool_id,
-                            source_ref=tool_id,
+                            tool_id=existing_tool_id,
+                            source_ref=str(flow_version_id),
                         )
                     )
                 continue
 
-            if isinstance(operation, WatsonxApiUnbindToolOperation):
-                tool_id = operation.tool_id.strip()
+            if flow_version_id not in raw_name_by_flow_version_id:
+                msg = f"add_flows.flow_version_id not found: [{flow_version_id}]"
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=msg)
+            if not item.app_ids:
+                # Raw tool is still created via tools.raw_payloads;
+                # no provider bind operation needed.
+                continue
+            provider_operations.append(
+                self._to_bind_provider_operation(
+                    raw_name=raw_name_by_flow_version_id[flow_version_id],
+                    app_ids=item.app_ids,
+                )
+            )
+
+        # Update path flow semantics.
+        for item in upsert_flows:
+            flow_version_id = item.flow_version_id
+            existing_tool_id = (flow_version_snapshot_id_map or {}).get(flow_version_id)
+            if existing_tool_id:
+                if item.add_app_ids:
+                    provider_operations.append(
+                        self._to_bind_existing_tool_provider_operation(
+                            tool_id=existing_tool_id,
+                            source_ref=str(flow_version_id),
+                            app_ids=item.add_app_ids,
+                        )
+                    )
+                elif not item.remove_app_ids:
+                    # Empty add/remove means ensure attached.
+                    provider_operations.append(
+                        self._to_attach_tool_provider_operation(
+                            tool_id=existing_tool_id,
+                            source_ref=str(flow_version_id),
+                        )
+                    )
+                if item.remove_app_ids:
+                    provider_operations.append(
+                        self._to_unbind_provider_operation(
+                            tool_id=existing_tool_id,
+                            source_ref=str(flow_version_id),
+                            app_ids=item.remove_app_ids,
+                        )
+                    )
+                continue
+
+            if item.remove_app_ids:
+                msg = (
+                    "Cannot resolve provider snapshot ids for flow_version_ids "
+                    f"in watsonx operations: [{flow_version_id}]"
+                )
+                raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=msg)
+            if flow_version_id not in raw_name_by_flow_version_id:
+                msg = f"upsert_flows.flow_version_id not found: [{flow_version_id}]"
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=msg)
+            if item.add_app_ids:
+                provider_operations.append(
+                    self._to_bind_provider_operation(
+                        raw_name=raw_name_by_flow_version_id[flow_version_id],
+                        app_ids=item.add_app_ids,
+                    )
+                )
+
+        # Update flow removals.
+        for flow_version_id in remove_flows:
+            if flow_version_snapshot_id_map is None or flow_version_id not in flow_version_snapshot_id_map:
+                msg = (
+                    "Cannot resolve provider snapshot ids for flow_version_ids "
+                    f"in watsonx operations: [{flow_version_id}]"
+                )
+                raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=msg)
+            provider_operations.append(
+                self._to_remove_tool_provider_operation(
+                    tool_id=flow_version_snapshot_id_map[flow_version_id],
+                    source_ref=str(flow_version_id),
+                )
+            )
+
+        # Tool-id-based semantics (create + update).
+        for item in upsert_tools:
+            tool_id = item.tool_id.strip()
+            remove_app_ids = getattr(item, "remove_app_ids", []) or []
+            if item.add_app_ids:
+                provider_operations.append(
+                    self._to_bind_existing_tool_provider_operation(
+                        tool_id=tool_id,
+                        source_ref=tool_id,
+                        app_ids=item.add_app_ids,
+                    )
+                )
+            elif not remove_app_ids:
+                provider_operations.append(
+                    self._to_attach_tool_provider_operation(
+                        tool_id=tool_id,
+                        source_ref=tool_id,
+                    )
+                )
+            if remove_app_ids:
                 provider_operations.append(
                     self._to_unbind_provider_operation(
                         tool_id=tool_id,
                         source_ref=tool_id,
-                        app_ids=operation.app_ids,
+                        app_ids=remove_app_ids,
                     )
                 )
-                continue
 
-            if isinstance(operation, WatsonxApiRemoveToolByIdOperation):
-                tool_id = operation.tool_id.strip()
-                provider_operations.append(
-                    self._to_remove_tool_provider_operation(
-                        tool_id=tool_id,
-                        source_ref=tool_id,
-                    )
+        for tool_id in remove_tools:
+            normalized_tool_id = str(tool_id).strip()
+            provider_operations.append(
+                self._to_remove_tool_provider_operation(
+                    tool_id=normalized_tool_id,
+                    source_ref=normalized_tool_id,
                 )
-                continue
+            )
 
         return provider_operations
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -8,11 +8,11 @@ from uuid import UUID
 
 from fastapi import HTTPException, status
 from lfx.services.adapters.deployment.schema import (
+    BaseDeploymentData,
     BaseDeploymentDataUpdate,
     DeploymentCreateResult,
     DeploymentListLlmsResult,
     DeploymentListResult,
-    DeploymentType,
     DeploymentUpdateResult,
     ExecutionCreateResult,
     ExecutionStatusResult,
@@ -350,12 +350,6 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         slot: PayloadSlot | None,
         slot_name: str,
     ) -> AdapterPayload:
-        if payload.config is not None or payload.flow_version_ids is not None:
-            msg = (
-                "Watsonx create does not support top-level 'config' or 'flow_version_ids'. "
-                "Use provider_data.operations instead."
-            )
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=msg)
         if payload.provider_data is None:
             msg = "Watsonx create requires provider_data operations."
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=msg)
@@ -429,7 +423,11 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             slot_name="deployment_create",
         )
         return AdapterDeploymentCreate(
-            spec=payload.spec,
+            spec=BaseDeploymentData(
+                name=payload.spec.name,
+                description=payload.spec.description,
+                type=payload.spec.type,
+            ),
             provider_data=provider_payload,
         )
 
@@ -465,16 +463,16 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         db: AsyncSession,
         payload: DeploymentUpdateRequest,
     ) -> AdapterDeploymentUpdate:
-        if (
-            payload.config is not None
-            or payload.add_flow_version_ids is not None
-            or payload.remove_flow_version_ids is not None
-        ):
-            msg = "Watsonx update does not support top-level 'config'. Use provider_data.operations instead."
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=msg)
-
+        adapter_spec = (
+            BaseDeploymentDataUpdate(
+                name=payload.spec.name,
+                description=payload.spec.description,
+            )
+            if payload.spec is not None
+            else None
+        )
         if payload.provider_data is None:  # pure metadata update, e.g., name, description
-            return AdapterDeploymentUpdate(spec=payload.spec, provider_data=None)
+            return AdapterDeploymentUpdate(spec=adapter_spec, provider_data=None)
 
         api_provider_payload: WatsonxApiDeploymentUpdatePayload = self._parse_api_payload_slot(
             slot=self.api_payloads.deployment_update,
@@ -578,7 +576,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 detail=f"Invalid provider_data payload: {detail}",
             ) from exc
         return AdapterDeploymentUpdate(
-            spec=payload.spec,
+            spec=adapter_spec,
             provider_data=provider_payload,
         )
 
@@ -854,12 +852,6 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         return UpdateSnapshotBindings(snapshot_bindings=flow_version_bindings)
 
     def util_flow_version_patch(self, payload: DeploymentUpdateRequest) -> FlowVersionPatch:
-        if payload.add_flow_version_ids is not None or payload.remove_flow_version_ids is not None:
-            msg = (
-                "Watsonx flow version patch must be expressed via provider_data.operations. "
-                "Top-level 'add_flow_version_ids'/'remove_flow_version_ids' are not supported for this provider."
-            )
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=msg)
         if payload.provider_data is None:
             return FlowVersionPatch()
         api_provider_payload: WatsonxApiDeploymentUpdatePayload = self._parse_api_payload_slot(
@@ -945,8 +937,6 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
     def shape_deployment_list_result(
         self,
         result: DeploymentListResult,
-        *,
-        deployment_type: DeploymentType | None,
     ) -> DeploymentListResponse:
         provider_result = {
             "entries": [
@@ -969,7 +959,6 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         total = len(validated_payload.get("entries", []))
         return DeploymentListResponse(
             deployments=[],
-            deployment_type=deployment_type,
             page=1,
             size=total,
             total=total,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -97,7 +97,6 @@ from langflow.services.adapters.deployment.watsonx_orchestrate.constants import 
 from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import (
     PAYLOAD_SCHEMAS as WXO_ADAPTER_PAYLOAD_SCHEMAS,
 )
-from langflow.services.auth import utils as auth_utils
 from langflow.services.database.models.deployment_provider_account.utils import extract_tenant_from_url
 from langflow.services.database.models.flow_version_deployment_attachment.crud import (
     list_deployment_attachments_for_flow_version_ids,
@@ -169,9 +168,9 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         ),
     )
 
-    def resolve_provider_tenant_id(self, *, provider_url: str, provider_tenant_id: str | None) -> str | None:
-        if provider_tenant_id:
-            return provider_tenant_id
+    def resolve_provider_tenant_id(self, *, provider_url: str, tenant_id: str | None) -> str | None:
+        if tenant_id:
+            return tenant_id
         return extract_tenant_from_url(provider_url, WATSONX_ORCHESTRATE_DEPLOYMENT_ADAPTER_KEY)
 
     def format_conflict_detail(self, raw_message: str) -> str:
@@ -216,7 +215,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
     ) -> VerifyCredentials:
         validated = self._validate_provider_data(payload.provider_data)
         return VerifyCredentials(
-            base_url=payload.provider_url,
+            base_url=payload.url,
             provider_data=validated,
         )
 
@@ -226,59 +225,19 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         payload: DeploymentProviderAccountUpdateRequest,
         existing_account: DeploymentProviderAccount,
     ) -> VerifyCredentials | None:
-        url_changed = "provider_url" in payload.model_fields_set
         provider_data_changed = "provider_data" in payload.model_fields_set
-        if not url_changed and not provider_data_changed:
+        if not provider_data_changed:
             return None
 
-        effective_url = payload.provider_url if url_changed else existing_account.provider_url
-        if effective_url is None:
-            msg = "'provider_url' cannot be null when provided."
+        if payload.provider_data is None:
+            msg = "'provider_data' cannot be null when provided."
             raise ValueError(msg)
-        if provider_data_changed:
-            if payload.provider_data is None:
-                msg = "'provider_data' cannot be null when provided."
-                raise ValueError(msg)
-            provider_data = self.resolve_credential_fields(provider_data=payload.provider_data)
-        else:
-            decrypted_api_key = auth_utils.decrypt_api_key((existing_account.api_key or "").strip())
-            provider_data = self.resolve_credential_fields(provider_data={"api_key": decrypted_api_key})
+        provider_data = self.resolve_credential_fields(provider_data=payload.provider_data)
 
         return VerifyCredentials(
-            base_url=effective_url,
+            base_url=existing_account.provider_url,
             provider_data=provider_data,
         )
-
-    def resolve_provider_account_update(
-        self,
-        *,
-        payload: DeploymentProviderAccountUpdateRequest,
-        existing_account: DeploymentProviderAccount,
-    ) -> dict[str, Any]:
-        """WXO override: re-derive tenant when provider_url changes.
-
-        For WXO the tenant id is embedded in the URL path, so changing the URL
-        without updating the tenant would create an inconsistent pair.  This
-        override always re-resolves the tenant whenever *either*
-        ``provider_url`` or ``provider_tenant_id`` is in the update set.
-        """
-        update_kwargs = super().resolve_provider_account_update(
-            payload=payload,
-            existing_account=existing_account,
-        )
-        url_changed = "provider_url" in payload.model_fields_set
-        tenant_changed = "provider_tenant_id" in payload.model_fields_set
-        if url_changed or tenant_changed:
-            effective_url = payload.provider_url if url_changed else existing_account.provider_url
-            if effective_url is None:
-                msg = "'provider_url' cannot be null when provided."
-                raise ValueError(msg)
-            effective_tenant = payload.provider_tenant_id if tenant_changed else None
-            update_kwargs["provider_tenant_id"] = self.resolve_provider_tenant_id(
-                provider_url=effective_url,
-                provider_tenant_id=effective_tenant,
-            )
-        return update_kwargs
 
     def util_create_flow_artifact_provider_data(
         self,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -1213,17 +1213,15 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             ) from exc
 
     def _shape_config_list_item(self, item: ConfigListItem) -> dict[str, Any]:
-        dumped = item.model_dump(mode="json", exclude_none=True)
-        item_provider_data = dumped.pop("provider_data", None)
-        if not isinstance(item_provider_data, dict):
-            return dumped
-        scheme = str(item_provider_data.get("security_scheme", "")).strip()
-        if not scheme:
-            item_id = dumped.get("id")
-            msg = f"Config list item '{item_id}' is missing required security_scheme in provider_data."
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
-        dumped["type"] = scheme
-        return dumped
+        payload: dict[str, Any] = {
+            "connection_id": str(item.id).strip(),
+            "app_id": str(item.name).strip(),
+        }
+        item_provider_data = item.provider_data if isinstance(item.provider_data, dict) else {}
+        config_type = str(item_provider_data.get("type") or "").strip()
+        if config_type:
+            payload["type"] = config_type
+        return payload
 
     def _parse_required_payload_slot(
         self,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -207,7 +207,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 "An agent with this name already exists in the provider. "
                 "Please choose a different name or delete the existing agent first."
             )
-        if "connection" in lower or "app_id" in lower:
+        if ("connection" in lower or "app_id" in lower) and ("already exists" in lower or "conflict" in lower):
             return (
                 "A connection referenced in this request already exists in the provider. "
                 "Reference it as an existing connection instead of creating a new one."

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -61,6 +61,7 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
     WatsonxApiAgentExecutionCreateResultData,
     WatsonxApiAgentExecutionStatusResultData,
     WatsonxApiConfigListProviderData,
+    WatsonxApiCreatedTool,
     WatsonxApiCreateUpsertToolItem,
     WatsonxApiDeploymentCreatePayload,
     WatsonxApiDeploymentCreateResultData,
@@ -72,7 +73,6 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
     WatsonxApiFlowArtifactProviderData,
     WatsonxApiProviderDeploymentListItem,
     WatsonxApiSnapshotListProviderData,
-    WatsonxApiToolAppBinding,
     WatsonxApiUpsertFlowItem,
     WatsonxApiUpsertToolItem,
 )
@@ -310,11 +310,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                     "app_ids": list(adapter_provider_result.created_app_ids),
                     "tools_with_refs": [
                         {"source_ref": binding.source_ref, "tool_id": binding.tool_id}
-                        for binding in adapter_provider_result.added_snapshot_bindings
-                    ],
-                    "tool_app_bindings": [
-                        {"tool_id": binding.tool_id, "app_ids": list(binding.app_ids)}
-                        for binding in (adapter_provider_result.tool_app_bindings or [])
+                        for binding in adapter_provider_result.created_snapshot_bindings
                     ],
                 }
             )
@@ -639,14 +635,11 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         *,
         provider_key: str,
     ) -> DeploymentCreateResponse:
-        """Shape create result provider_data with explicit ref-domain semantics.
+        """Shape create result provider_data with created-tools semantics.
 
-        ``tools_with_refs[*].source_ref`` can come from two domains:
-        - flow-version-id operations: ``source_ref`` is a Langflow flow_version UUID.
-        - tool-id operations: ``source_ref`` is the provider tool_id (non-UUID).
-
-        The API response normalizes this into ``tool_app_bindings[*].flow_version_id``:
-        UUID source_ref -> parsed UUID, non-UUID source_ref -> None.
+        ``created_tools`` is populated directly from ``tools_with_refs``. Each
+        entry must carry a flow-version UUID ``source_ref`` and a non-empty
+        provider ``tool_id``.
         """
         adapter_provider_result = self._parse_required_payload_slot(
             slot=WXO_ADAPTER_PAYLOAD_SCHEMAS.deployment_create_result,
@@ -655,7 +648,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             missing_payload_detail="Deployment provider create result is missing provider_result payload.",
             malformed_payload_detail="Deployment provider create result contains invalid provider_result payload.",
         )
-        tool_id_to_flow_version: dict[str, UUID | None] = {}
+        created_tools: list[WatsonxApiCreatedTool] = []
         for binding in adapter_provider_result.tools_with_refs:
             tool_id = str(binding.tool_id or "").strip()
             source_ref = str(binding.source_ref or "").strip()
@@ -669,30 +662,20 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 )
                 raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
             try:
-                tool_id_to_flow_version[tool_id] = UUID(source_ref)
-            except ValueError:
-                # Non-UUID source_ref is expected for tool-id-based operations.
-                tool_id_to_flow_version[tool_id] = None
-
-        tool_app_bindings: list[WatsonxApiToolAppBinding] = []
-        for binding in adapter_provider_result.tool_app_bindings:
-            raw_tool_id = str(binding.tool_id or "").strip()
-            if raw_tool_id not in tool_id_to_flow_version:
+                created_tool = WatsonxApiCreatedTool(
+                    flow_version_id=source_ref,
+                    tool_id=tool_id,
+                )
+            except ValidationError as exc:
                 msg = (
-                    f"Deployment provider create result has tool_app_binding tool_id={raw_tool_id!r} "
-                    "with no matching tools_with_refs entry."
+                    "Deployment provider create result contains a created tool binding with a non-UUID "
+                    f"source_ref={source_ref!r} for tool_id={tool_id!r}. A flow version id was expected."
                 )
-                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
-            tool_app_bindings.append(
-                WatsonxApiToolAppBinding(
-                    flow_version_id=tool_id_to_flow_version[raw_tool_id],
-                    tool_id=raw_tool_id,
-                    app_ids=list(binding.app_ids),
-                )
-            )
+                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg) from exc
+            created_tools.append(created_tool)
         provider_api_result = WatsonxApiDeploymentCreateResultData(
             created_app_ids=list(adapter_provider_result.app_ids),
-            tool_app_bindings=tool_app_bindings or None,
+            created_tools=created_tools,
         )
         return DeploymentCreateResponse(
             id=deployment_row.id,
@@ -703,6 +686,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             type=deployment_row.deployment_type,
             created_at=deployment_row.created_at,
             updated_at=deployment_row.updated_at,
+            resource_key=deployment_row.resource_key,
             provider_data=provider_api_result.to_api_provider_data(),
         )
 
@@ -720,17 +704,12 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             missing_payload_detail="Deployment provider update result is missing provider_result payload.",
             malformed_payload_detail="Deployment provider update result contains invalid provider_result payload.",
         )
-        tool_app_bindings = (
-            self._to_api_tool_app_bindings(
-                adapter_tool_app_bindings=adapter_provider_result.tool_app_bindings,
-                adapter_snapshot_bindings=adapter_provider_result.referenced_snapshot_bindings,
-            )
-            if adapter_provider_result.tool_app_bindings is not None
-            else None
+        created_tools = self._to_api_created_tools(
+            adapter_created_snapshot_bindings=adapter_provider_result.created_snapshot_bindings
         )
         provider_api_result = WatsonxApiDeploymentUpdateResultData(
             created_app_ids=list(adapter_provider_result.created_app_ids),
-            tool_app_bindings=tool_app_bindings,
+            created_tools=created_tools,
         )
         return DeploymentUpdateResponse(
             id=deployment_row.id,
@@ -741,6 +720,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             type=deployment_row.deployment_type,
             created_at=deployment_row.created_at,
             updated_at=deployment_row.updated_at,
+            resource_key=deployment_row.resource_key,
             provider_data=provider_api_result.model_dump(mode="json", exclude_none=True),
         )
 
@@ -1430,7 +1410,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         *,
         llm: str,
         raw_tool_payloads: list[dict[str, Any]],
-        connections: Any,
+        connections: list[Any],
         operations: list[AdapterPayload],
     ) -> dict[str, Any]:
         return {
@@ -1439,58 +1419,37 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 "raw_payloads": raw_tool_payloads or None,
             },
             "connections": {
-                "raw_payloads": self._dump_key_value_connection_payloads(connections.key_value),
+                "raw_payloads": self._dump_key_value_connection_payloads(connections),
             },
             "operations": operations,
         }
 
-    def _to_api_tool_app_bindings(
+    def _to_api_created_tools(
         self,
         *,
-        adapter_tool_app_bindings: list[Any],
-        adapter_snapshot_bindings: list[Any],
-    ) -> list[WatsonxApiToolAppBinding]:
-        """Map adapter-level tool bindings to API response shapes.
-
-        ``flow_version_id`` is populated by attempting to parse the
-        snapshot binding's ``source_ref`` as a UUID.  For tool-id-based
-        operations the ``source_ref`` is the provider tool_id (not a UUID),
-        so ``flow_version_id`` will be ``None`` -- this is intentional.
-        """
-        tool_id_to_flow_version: dict[str, UUID | None] = {}
-        for binding in adapter_snapshot_bindings:
+        adapter_created_snapshot_bindings: list[Any],
+    ) -> list[WatsonxApiCreatedTool]:
+        """Map adapter created snapshot bindings to API ``created_tools``."""
+        created_tools: list[WatsonxApiCreatedTool] = []
+        for binding in adapter_created_snapshot_bindings:
             tool_id = str(binding.tool_id or "").strip()
             source_ref = str(binding.source_ref or "").strip()
             if not tool_id or not source_ref:
                 msg = (
-                    f"Snapshot binding has empty tool_id={binding.tool_id!r} or "
+                    f"Created snapshot binding has empty tool_id={binding.tool_id!r} or "
                     f"source_ref={binding.source_ref!r}; cannot map tool binding."
                 )
                 raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
             try:
-                tool_id_to_flow_version[tool_id] = UUID(source_ref)
-            except ValueError:
-                # Non-UUID source_ref means this is a tool-id-based binding;
-                # flow_version_id will be None in the response.
-                tool_id_to_flow_version[tool_id] = None
-
-        api_bindings: list[WatsonxApiToolAppBinding] = []
-        for binding in adapter_tool_app_bindings:
-            raw_tool_id = str(binding.tool_id or "").strip()
-            if raw_tool_id not in tool_id_to_flow_version:
-                msg = (
-                    f"tool_app_binding tool_id={raw_tool_id!r} has no matching snapshot "
-                    f"binding source_ref; available refs: {sorted(tool_id_to_flow_version)}."
+                created_tool = WatsonxApiCreatedTool(
+                    flow_version_id=source_ref,
+                    tool_id=tool_id,
                 )
-                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
-            api_bindings.append(
-                WatsonxApiToolAppBinding(
-                    flow_version_id=tool_id_to_flow_version[raw_tool_id],
-                    tool_id=raw_tool_id,
-                    app_ids=list(binding.app_ids),
-                )
-            )
-        return api_bindings
+            except ValidationError as exc:
+                msg = f"Created snapshot binding has non-UUID source_ref={source_ref!r} for tool_id={tool_id!r}."
+                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg) from exc
+            created_tools.append(created_tool)
+        return created_tools
 
     def _dump_key_value_connection_payloads(self, key_value_payloads: list[Any] | None) -> list[dict[str, Any]] | None:
         if not key_value_payloads:

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -195,7 +195,13 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         ),
     )
 
-    def resolve_provider_tenant_id(self, *, provider_url: str, tenant_id: str | None) -> str | None:
+    def resolve_provider_tenant_id(
+        self,
+        *,
+        provider_url: str,
+        provider_data: dict[str, Any],
+    ) -> str | None:
+        tenant_id = self.resolve_provider_tenant_id_from_data(provider_data=provider_data)
         if tenant_id:
             return tenant_id
         return extract_tenant_from_url(provider_url, WATSONX_ORCHESTRATE_DEPLOYMENT_ADAPTER_KEY)
@@ -218,10 +224,17 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
 
     def _validate_provider_data(self, provider_data: dict[str, Any]) -> dict[str, Any]:
         verify_slot = WXO_ADAPTER_PAYLOAD_SCHEMAS.verify_credentials
+        credential_payload = self._credential_provider_data(provider_data)
         if verify_slot:
-            validated = verify_slot.apply(provider_data)
+            validated = verify_slot.apply(credential_payload)
             return validated if isinstance(validated, dict) else dict(validated)
-        return provider_data
+        return credential_payload
+
+    def _credential_provider_data(self, provider_data: dict[str, Any]) -> dict[str, Any]:
+        """Return provider_data minus mapper-owned metadata keys."""
+        credential_payload: dict[str, Any] = dict(provider_data)
+        credential_payload.pop("tenant_id", None)
+        return credential_payload
 
     def resolve_credential_fields(
         self,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -57,6 +57,7 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
     WatsonxApiAgentExecutionStatusResultData,
     WatsonxApiBindOperation,
     WatsonxApiBindToolOperation,
+    WatsonxApiConfigListProviderData,
     WatsonxApiDeploymentCreatePayload,
     WatsonxApiDeploymentCreateResultData,
     WatsonxApiDeploymentFlowVersionItemData,
@@ -67,6 +68,7 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
     WatsonxApiFlowArtifactProviderData,
     WatsonxApiRemoveToolByIdOperation,
     WatsonxApiRemoveToolOperation,
+    WatsonxApiSnapshotListProviderData,
     WatsonxApiToolAppBinding,
     WatsonxApiUnbindOperation,
     WatsonxApiUnbindToolOperation,
@@ -135,6 +137,14 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         ),
         deployment_list_result=PayloadSlot(
             adapter_model=WatsonxApiDeploymentListProviderData,
+            policy=PayloadSlotPolicy.VALIDATE_ONLY,
+        ),
+        config_list_result=PayloadSlot(
+            adapter_model=WatsonxApiConfigListProviderData,
+            policy=PayloadSlotPolicy.VALIDATE_ONLY,
+        ),
+        snapshot_list_result=PayloadSlot(
+            adapter_model=WatsonxApiSnapshotListProviderData,
             policy=PayloadSlotPolicy.VALIDATE_ONLY,
         ),
         deployment_item_data=PayloadSlot(

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -174,6 +174,22 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             return provider_tenant_id
         return extract_tenant_from_url(provider_url, WATSONX_ORCHESTRATE_DEPLOYMENT_ADAPTER_KEY)
 
+    def format_conflict_detail(self, raw_message: str) -> str:
+        lower = raw_message.lower()
+        if "agent" in lower and ("already exists" in lower or "conflict" in lower):
+            return (
+                "An agent with this name already exists in the provider. "
+                "Please choose a different name or delete the existing agent first."
+            )
+        if "connection" in lower or "app_id" in lower:
+            return (
+                "A connection referenced in this request already exists in the provider. "
+                "Reference it as an existing connection instead of creating a new one."
+            )
+        if "tool" in lower and ("already exists" in lower or "conflict" in lower):
+            return "A tool with this name already exists in the provider. Please choose a different name."
+        return super().format_conflict_detail(raw_message)
+
     def _validate_provider_data(self, provider_data: dict[str, Any]) -> dict[str, Any]:
         verify_slot = WXO_ADAPTER_PAYLOAD_SCHEMAS.verify_credentials
         if verify_slot:

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -656,6 +656,8 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         self,
         result: DeploymentCreateResult,
         deployment_row: Deployment,
+        *,
+        provider_key: str,
     ) -> DeploymentCreateResponse:
         """Shape create result provider_data with explicit ref-domain semantics.
 
@@ -714,6 +716,8 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         )
         return DeploymentCreateResponse(
             id=deployment_row.id,
+            provider_id=deployment_row.deployment_provider_account_id,
+            provider_key=provider_key,
             name=deployment_row.name,
             description=deployment_row.description,
             type=deployment_row.deployment_type,
@@ -726,6 +730,8 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         self,
         result: DeploymentUpdateResult,
         deployment_row: Deployment,
+        *,
+        provider_key: str,
     ) -> DeploymentUpdateResponse:
         adapter_provider_result = self._parse_required_payload_slot(
             slot=WXO_ADAPTER_PAYLOAD_SCHEMAS.deployment_update_result,
@@ -748,6 +754,8 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         )
         return DeploymentUpdateResponse(
             id=deployment_row.id,
+            provider_id=deployment_row.deployment_provider_account_id,
+            provider_key=provider_key,
             name=deployment_row.name,
             description=deployment_row.description,
             type=deployment_row.deployment_type,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -1408,13 +1408,12 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
     def _build_provider_payload_body(
         self,
         *,
-        llm: str,
+        llm: str | None,
         raw_tool_payloads: list[dict[str, Any]],
         connections: list[Any],
         operations: list[AdapterPayload],
     ) -> dict[str, Any]:
-        return {
-            "llm": llm,
+        payload = {
             "tools": {
                 "raw_payloads": raw_tool_payloads or None,
             },
@@ -1423,6 +1422,9 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             },
             "operations": operations,
         }
+        if llm is not None:
+            payload["llm"] = llm
+        return payload
 
     def _to_api_created_tools(
         self,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -34,6 +34,7 @@ from lfx.services.adapters.payload import (
     PayloadSlotPolicy,
 )
 from lfx.services.adapters.schema import AdapterType
+from pydantic import ValidationError
 
 from langflow.api.v1.mappers.deployments.base import (
     BaseDeploymentMapper,
@@ -68,6 +69,7 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
     WatsonxApiDeploymentUpdatePayload,
     WatsonxApiDeploymentUpdateResultData,
     WatsonxApiFlowArtifactProviderData,
+    WatsonxApiProviderDeploymentListItem,
     WatsonxApiRemoveToolByIdOperation,
     WatsonxApiRemoveToolOperation,
     WatsonxApiSnapshotListProviderData,
@@ -1143,15 +1145,28 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         if item_provider_data is not None and not isinstance(item_provider_data, dict):
             msg = "Invalid deployment list item provider_data payload: expected object or null."
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
-        return {
-            "resource_key": str(item.id),
-            "name": item.name,
-            "type": item.type,
-            "description": getattr(item, "description", None),
-            "created_at": item.created_at,
-            "updated_at": item.updated_at,
-            "provider_data": self.shape_deployment_item_data(item_provider_data),
-        }
+        try:
+            return WatsonxApiProviderDeploymentListItem.model_validate(
+                {
+                    "id": str(item.id),
+                    "name": item.name,
+                    "type": item.type,
+                    "description": getattr(item, "description", None),
+                    "created_at": item.created_at,
+                    "updated_at": item.updated_at,
+                    **(item_provider_data or {}),
+                }
+            ).model_dump(
+                mode="json",
+                exclude_none=True,
+            )
+        except ValidationError as exc:
+            first_error = exc.errors()[0] if exc.errors() else {}
+            detail = str(first_error.get("msg") or exc)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Invalid deployment list item provider_data payload: {detail}",
+            ) from exc
 
     def _parse_required_payload_slot(
         self,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException, status
 from lfx.services.adapters.deployment.schema import (
     BaseDeploymentData,
     BaseDeploymentDataUpdate,
+    ConfigListResult,
     DeploymentCreateResult,
     DeploymentListLlmsResult,
     DeploymentListResult,
@@ -50,6 +51,7 @@ from langflow.api.v1.mappers.deployments.contracts import (
 from langflow.api.v1.mappers.deployments.helpers import (
     build_flow_artifacts_from_flow_versions,
     build_project_scoped_flow_artifacts_from_flow_versions,
+    page_offset,
 )
 from langflow.api.v1.mappers.deployments.registry import register_mapper
 from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
@@ -74,6 +76,7 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
     WatsonxApiUnbindToolOperation,
 )
 from langflow.api.v1.schemas.deployments import (
+    DeploymentConfigListResponse,
     DeploymentCreateRequest,
     DeploymentCreateResponse,
     DeploymentFlowVersionListItem,
@@ -82,6 +85,7 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentLlmListResponse,
     DeploymentProviderAccountCreateRequest,
     DeploymentProviderAccountUpdateRequest,
+    DeploymentSnapshotListResponse,
     DeploymentUpdateRequest,
     DeploymentUpdateResponse,
     ExecutionCreateResponse,
@@ -973,6 +977,87 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             size=total,
             total=total,
             provider_data=validated_payload,
+        )
+
+    def shape_config_list_result(
+        self,
+        result: ConfigListResult,
+        *,
+        page: int,
+        size: int,
+    ) -> DeploymentConfigListResponse:
+        slot = self.api_payloads.config_list_result
+        if slot is None:
+            msg = "Watsonx config_list_result payload slot is not configured."
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
+
+        items_all = [item.model_dump(mode="json", exclude_none=True) for item in result.configs]
+        total = len(items_all)
+        offset = page_offset(page, size)
+        provider_result = result.provider_result if isinstance(result.provider_result, dict) else {}
+        provider_payload = {
+            **provider_result,
+            "configs": items_all[offset : offset + size],
+        }
+        try:
+            validated_payload = slot.parse(provider_payload).model_dump(mode="json", exclude_none=True)
+        except AdapterPayloadValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Invalid config list provider_data payload: {exc.format_first_error()}",
+            ) from exc
+
+        return DeploymentConfigListResponse(
+            provider_data=validated_payload or None,
+            page=page,
+            size=size,
+            total=total,
+        )
+
+    def shape_snapshot_list_result(
+        self,
+        result: SnapshotListResult,
+        *,
+        page: int,
+        size: int,
+    ) -> DeploymentSnapshotListResponse:
+        slot = self.api_payloads.snapshot_list_result
+        if slot is None:
+            msg = "Watsonx snapshot_list_result payload slot is not configured."
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
+
+        items_all: list[dict[str, Any]] = []
+        for item in result.snapshots:
+            item_provider_data = item.provider_data if isinstance(item.provider_data, dict) else {}
+            connections = item_provider_data.get("connections")
+            items_all.append(
+                {
+                    "id": str(item.id).strip(),
+                    "name": str(item.name or "").strip(),
+                    "connections": connections if isinstance(connections, dict) else {},
+                }
+            )
+
+        total = len(items_all)
+        offset = page_offset(page, size)
+        provider_result = result.provider_result if isinstance(result.provider_result, dict) else {}
+        provider_payload = {
+            **provider_result,
+            "snapshots": items_all[offset : offset + size],
+        }
+        try:
+            validated_payload = slot.parse(provider_payload).model_dump(mode="json", exclude_none=True)
+        except AdapterPayloadValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Invalid snapshot list provider_data payload: {exc.format_first_error()}",
+            ) from exc
+
+        return DeploymentSnapshotListResponse(
+            provider_data=validated_payload or None,
+            page=page,
+            size=size,
+            total=total,
         )
 
     def shape_flow_version_list_result(

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -413,9 +413,9 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         )
         return AdapterDeploymentCreate(
             spec=BaseDeploymentData(
-                name=payload.spec.name,
-                description=payload.spec.description,
-                type=payload.spec.type,
+                name=payload.name,
+                description=payload.description,
+                type=payload.type,
             ),
             provider_data=provider_payload,
         )
@@ -438,8 +438,8 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         )
         return AdapterDeploymentUpdate(
             spec=BaseDeploymentDataUpdate(
-                name=payload.spec.name,
-                description=payload.spec.description,
+                name=payload.name,
+                description=payload.description,
             ),
             provider_data=provider_payload,
         )
@@ -454,10 +454,10 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
     ) -> AdapterDeploymentUpdate:
         adapter_spec = (
             BaseDeploymentDataUpdate(
-                name=payload.spec.name,
-                description=payload.spec.description,
+                name=payload.name,
+                description=payload.description,
             )
-            if payload.spec is not None
+            if payload.name is not None or payload.description is not None
             else None
         )
         if payload.provider_data is None:  # pure metadata update, e.g., name, description

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException, status
 from lfx.services.adapters.deployment.schema import (
     BaseDeploymentData,
     BaseDeploymentDataUpdate,
+    ConfigListItem,
     ConfigListResult,
     DeploymentCreateResult,
     DeploymentListLlmsResult,
@@ -972,16 +973,10 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             msg = "Watsonx config_list_result payload slot is not configured."
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
 
-        items_all = [item.model_dump(mode="json", exclude_none=True) for item in result.configs]
+        items_all = [self._shape_config_list_item(item) for item in result.configs]
         total = len(items_all)
         offset = page_offset(page, size)
-        provider_result = (
-            {key: value for key, value in result.provider_result.items() if key != "deployment_id"}
-            if isinstance(result.provider_result, dict)
-            else {}
-        )
         provider_payload = {
-            **provider_result,
             "connections": items_all[offset : offset + size],
             "page": page,
             "size": size,
@@ -1023,13 +1018,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
 
         total = len(items_all)
         offset = page_offset(page, size)
-        provider_result = (
-            {key: value for key, value in result.provider_result.items() if key != "deployment_id"}
-            if isinstance(result.provider_result, dict)
-            else {}
-        )
         provider_payload = {
-            **provider_result,
             "tools": items_all[offset : offset + size],
             "page": page,
             "size": size,
@@ -1167,6 +1156,19 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Invalid deployment list item provider_data payload: {detail}",
             ) from exc
+
+    def _shape_config_list_item(self, item: ConfigListItem) -> dict[str, Any]:
+        dumped = item.model_dump(mode="json", exclude_none=True)
+        item_provider_data = dumped.pop("provider_data", None)
+        if not isinstance(item_provider_data, dict):
+            return dumped
+        scheme = str(item_provider_data.get("security_scheme", "")).strip()
+        if not scheme:
+            item_id = dumped.get("id")
+            msg = f"Config list item '{item_id}' is missing required security_scheme in provider_data."
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
+        dumped["type"] = scheme
+        return dumped
 
     def _parse_required_payload_slot(
         self,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -938,7 +938,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         result: DeploymentListResult,
     ) -> DeploymentListResponse:
         provider_result = {
-            "entries": [
+            "deployments": [
                 self._shape_provider_deployment_list_entry(item) for item in result.deployments if str(item.id).strip()
             ]
         }
@@ -955,12 +955,8 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Invalid deployment list provider_data payload: {detail}",
             ) from exc
-        total = len(validated_payload.get("entries", []))
         return DeploymentListResponse(
-            deployments=[],
-            page=1,
-            size=total,
-            total=total,
+            deployments=None,
             provider_data=validated_payload,
         )
 
@@ -979,10 +975,17 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         items_all = [item.model_dump(mode="json", exclude_none=True) for item in result.configs]
         total = len(items_all)
         offset = page_offset(page, size)
-        provider_result = result.provider_result if isinstance(result.provider_result, dict) else {}
+        provider_result = (
+            {key: value for key, value in result.provider_result.items() if key != "deployment_id"}
+            if isinstance(result.provider_result, dict)
+            else {}
+        )
         provider_payload = {
             **provider_result,
-            "configs": items_all[offset : offset + size],
+            "connections": items_all[offset : offset + size],
+            "page": page,
+            "size": size,
+            "total": total,
         }
         try:
             validated_payload = slot.parse(provider_payload).model_dump(mode="json", exclude_none=True)
@@ -992,12 +995,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 detail=f"Invalid config list provider_data payload: {exc.format_first_error()}",
             ) from exc
 
-        return DeploymentConfigListResponse(
-            provider_data=validated_payload or None,
-            page=page,
-            size=size,
-            total=total,
-        )
+        return DeploymentConfigListResponse(provider_data=validated_payload or None)
 
     def shape_snapshot_list_result(
         self,
@@ -1025,10 +1023,17 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
 
         total = len(items_all)
         offset = page_offset(page, size)
-        provider_result = result.provider_result if isinstance(result.provider_result, dict) else {}
+        provider_result = (
+            {key: value for key, value in result.provider_result.items() if key != "deployment_id"}
+            if isinstance(result.provider_result, dict)
+            else {}
+        )
         provider_payload = {
             **provider_result,
-            "snapshots": items_all[offset : offset + size],
+            "tools": items_all[offset : offset + size],
+            "page": page,
+            "size": size,
+            "total": total,
         }
         try:
             validated_payload = slot.parse(provider_payload).model_dump(mode="json", exclude_none=True)
@@ -1038,12 +1043,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 detail=f"Invalid snapshot list provider_data payload: {exc.format_first_error()}",
             ) from exc
 
-        return DeploymentSnapshotListResponse(
-            provider_data=validated_payload or None,
-            page=page,
-            size=size,
-            total=total,
-        )
+        return DeploymentSnapshotListResponse(provider_data=validated_payload or None)
 
     def shape_flow_version_list_result(
         self,
@@ -1405,7 +1405,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 "raw_payloads": raw_tool_payloads or None,
             },
             "connections": {
-                "raw_payloads": self._dump_raw_connection_payloads(connections.raw_payloads),
+                "raw_payloads": self._dump_key_value_connection_payloads(connections.key_value),
             },
             "operations": operations,
         }
@@ -1458,10 +1458,28 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             )
         return api_bindings
 
-    def _dump_raw_connection_payloads(self, raw_payloads: list[Any] | None) -> list[dict[str, Any]] | None:
-        if not raw_payloads:
+    def _dump_key_value_connection_payloads(self, key_value_payloads: list[Any] | None) -> list[dict[str, Any]] | None:
+        if not key_value_payloads:
             return None
-        return [raw_payload.model_dump(exclude_none=True) for raw_payload in raw_payloads]
+        normalized: list[dict[str, Any]] = []
+        for payload in key_value_payloads:
+            item: dict[str, Any] = {"app_id": payload.app_id}
+            environment_variables = self._to_adapter_environment_variables(payload.credentials)
+            if environment_variables is not None:
+                item["environment_variables"] = environment_variables
+            normalized.append(item)
+        return normalized
+
+    def _to_adapter_environment_variables(self, credentials: list[Any] | None) -> dict[str, dict[str, Any]] | None:
+        if not credentials:
+            return None
+        return {
+            credential.key: {
+                "value": credential.value,
+                "source": credential.source,
+            }
+            for credential in credentials
+        }
 
     async def _lookup_snapshot_ids(
         self,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -453,6 +453,7 @@ class WatsonxApiConfigListItem(BaseModel):
 
     id: str = Field(min_length=1)
     name: str = Field(min_length=1)
+    type: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -471,18 +472,10 @@ class WatsonxApiConfigListProviderData(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    tool_ids: list[str] | None = None
     connections: list[WatsonxApiConfigListItem] = Field(default_factory=list)
     page: int | None = Field(default=None, ge=1)
     size: int | None = Field(default=None, ge=1)
     total: int | None = Field(default=None, ge=0)
-
-    @field_validator("tool_ids", mode="before")
-    @classmethod
-    def normalize_tool_ids(cls, value: Any) -> list[str] | None:
-        if value is None:
-            return None
-        return [str(tool_id).strip() for tool_id in value if str(tool_id).strip()]
 
 
 class WatsonxApiSnapshotListItem(BaseModel):

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -404,6 +404,26 @@ class WatsonxApiDeploymentListProviderData(BaseModel):
     entries: list[WatsonxApiProviderDeploymentListItem] = Field(default_factory=list)
 
 
+class WatsonxApiConfigListItem(BaseModel):
+    """API-facing config list item payload under config-list provider_data."""
+
+    model_config = {"extra": "forbid"}
+
+    id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @field_validator("id", "name", mode="before")
+    @classmethod
+    def normalize_required_strings(cls, value: Any) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            msg = "Config list item fields 'id' and 'name' must be non-empty strings."
+            raise ValueError(msg)
+        return normalized
+
+
 class WatsonxApiConfigListProviderData(BaseModel):
     """Provider-level metadata attached to DeploymentConfigListResponse.
 
@@ -416,6 +436,7 @@ class WatsonxApiConfigListProviderData(BaseModel):
 
     deployment_id: str | None = None
     tool_ids: list[str] | None = None
+    configs: list[WatsonxApiConfigListItem] = Field(default_factory=list)
 
     @field_validator("deployment_id", mode="before")
     @classmethod
@@ -431,6 +452,25 @@ class WatsonxApiConfigListProviderData(BaseModel):
         return [str(tool_id).strip() for tool_id in value if str(tool_id).strip()]
 
 
+class WatsonxApiSnapshotListItem(BaseModel):
+    """API-facing snapshot list item payload under snapshot-list provider_data."""
+
+    model_config = {"extra": "forbid"}
+
+    id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    connections: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("id", "name", mode="before")
+    @classmethod
+    def normalize_required_strings(cls, value: Any) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            msg = "Snapshot list item fields 'id' and 'name' must be non-empty strings."
+            raise ValueError(msg)
+        return normalized
+
+
 class WatsonxApiSnapshotListProviderData(BaseModel):
     """Provider-level metadata attached to DeploymentSnapshotListResponse.
 
@@ -441,6 +481,7 @@ class WatsonxApiSnapshotListProviderData(BaseModel):
     model_config = {"extra": "forbid"}
 
     deployment_id: str | None = None
+    snapshots: list[WatsonxApiSnapshotListItem] = Field(default_factory=list)
 
     @field_validator("deployment_id", mode="before")
     @classmethod

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from lfx.services.adapters.deployment.schema import DeploymentType
+from lfx.services.adapters.deployment.schema import DeploymentType, EnvVarKey, EnvVarValueSpec
 from pydantic import BaseModel, Field, StringConstraints, field_validator, model_validator
 
 from langflow.api.v1.mappers.deployments.contracts import CreateFlowArtifactProviderData
@@ -146,8 +146,7 @@ class WatsonxApiUpdateConnectionRawPayload(BaseModel):
     model_config = {"extra": "forbid"}
 
     app_id: str = Field(min_length=1)
-    environment_variables: dict[str, Any] | None = None
-    provider_config: dict[str, Any] | None = None
+    environment_variables: dict[EnvVarKey, EnvVarValueSpec] | None = None
 
 
 class WatsonxApiUpdateConnections(BaseModel):

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -213,7 +213,13 @@ class WatsonxApiDeploymentUpdatePayload(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    llm: WatsonxApiLlmName = Field(description="Provider model identifier to use for the deployment agent.")
+    llm: WatsonxApiLlmName | None = Field(
+        default=None,
+        description=(
+            "Optional provider model identifier to use for the deployment agent. "
+            "When omitted, the current model is preserved."
+        ),
+    )
     connections: list[WatsonxApiKeyValueConnectionPayload] = Field(default_factory=list)
     upsert_flows: list[WatsonxApiUpsertFlowItem] = Field(default_factory=list)
     upsert_tools: list[WatsonxApiUpsertToolItem] = Field(default_factory=list)

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -404,6 +404,51 @@ class WatsonxApiDeploymentListProviderData(BaseModel):
     entries: list[WatsonxApiProviderDeploymentListItem] = Field(default_factory=list)
 
 
+class WatsonxApiConfigListProviderData(BaseModel):
+    """Provider-level metadata attached to DeploymentConfigListResponse.
+
+    ``deployment_id`` is present for deployment-scoped listings and absent for
+    tenant-scoped listings; no explicit scope discriminator is needed because the
+    caller already knows which mode it requested.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    deployment_id: str | None = None
+    tool_ids: list[str] | None = None
+
+    @field_validator("deployment_id", mode="before")
+    @classmethod
+    def normalize_deployment_id(cls, value: Any) -> str | None:
+        normalized = str(value or "").strip()
+        return normalized or None
+
+    @field_validator("tool_ids", mode="before")
+    @classmethod
+    def normalize_tool_ids(cls, value: Any) -> list[str] | None:
+        if value is None:
+            return None
+        return [str(tool_id).strip() for tool_id in value if str(tool_id).strip()]
+
+
+class WatsonxApiSnapshotListProviderData(BaseModel):
+    """Provider-level metadata attached to DeploymentSnapshotListResponse.
+
+    ``deployment_id`` is present for deployment-scoped listings and absent for
+    tenant-scoped listings.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    deployment_id: str | None = None
+
+    @field_validator("deployment_id", mode="before")
+    @classmethod
+    def normalize_deployment_id(cls, value: Any) -> str | None:
+        normalized = str(value or "").strip()
+        return normalized or None
+
+
 class WatsonxApiDeploymentFlowVersionItemData(BaseModel):
     """API-facing provider_data contract for deployment flow-version list items."""
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -8,7 +8,14 @@ from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from lfx.services.adapters.deployment.schema import DeploymentType
-from pydantic import BaseModel, Field, StringConstraints, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    StringConstraints,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 from langflow.api.v1.mappers.deployments.contracts import CreateFlowArtifactProviderData
 
@@ -445,20 +452,25 @@ class WatsonxApiConfigListItem(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    id: str = Field(min_length=1)
-    name: str = Field(min_length=1)
+    connection_id: str = Field(min_length=1)
+    app_id: str = Field(min_length=1)
     type: str | None = None
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
 
-    @field_validator("id", "name", mode="before")
+    @field_validator("connection_id", "app_id", mode="before")
     @classmethod
-    def normalize_required_strings(cls, value: Any) -> str:
+    def normalize_required_strings(cls, value: Any, info: ValidationInfo) -> str:
         normalized = str(value or "").strip()
         if not normalized:
-            msg = "Config list item fields 'id' and 'name' must be non-empty strings."
+            field_name = str(info.field_name)
+            msg = f"Config list item field '{field_name}' must be a non-empty string."
             raise ValueError(msg)
         return normalized
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def normalize_optional_type(cls, value: Any) -> str | None:
+        normalized = str(value or "").strip()
+        return normalized or None
 
 
 class WatsonxApiConfigListProviderData(BaseModel):

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from datetime import datetime
 from typing import Annotated, Any, Literal
 from uuid import UUID
@@ -104,7 +105,13 @@ class WatsonxApiConnectionCredentialItem(BaseModel):
 
 
 class WatsonxApiKeyValueConnectionPayload(BaseModel):
-    """API-facing key-value connection payload for app id."""
+    """API-facing key-value connection payload for app id.
+
+    Today this API only accepts key-value connections, so ``connections`` is a
+    flat list of this payload shape with no explicit ``type`` discriminator.
+    When additional connection types are introduced, a ``type`` field can be
+    added with a default of ``"key_value"`` for backward compatibility.
+    """
 
     model_config = {"extra": "forbid"}
 
@@ -131,14 +138,6 @@ class WatsonxApiKeyValueConnectionPayload(BaseModel):
         return value
 
 
-class WatsonxApiUpdateConnections(BaseModel):
-    """Connection declarations used by update operations."""
-
-    model_config = {"extra": "forbid"}
-
-    key_value: list[WatsonxApiKeyValueConnectionPayload] | None = None
-
-
 def _collect_api_referenced_app_ids(operations: list[Any], *, attr_name: str = "app_ids") -> set[str]:
     referenced_app_ids: set[str] = set()
     for operation in operations:
@@ -156,7 +155,7 @@ def _validate_api_remove_not_raw(*, operations: list[Any], raw_app_ids: set[str]
             continue
         invalid_raw = sorted(raw_app_ids.intersection(set(remove_app_ids)))
         if invalid_raw:
-            msg = f"{label} must not reference connections.key_value app_ids: {invalid_raw}"
+            msg = f"{label} must not reference connections app_ids: {invalid_raw}"
             raise ValueError(msg)
 
 
@@ -192,7 +191,15 @@ def _validate_api_remove_conflicts(
 def _validate_api_unused_raw_app_ids(*, raw_app_ids: set[str], referenced_app_ids: set[str]) -> None:
     unused_raw_app_ids = sorted(raw_app_ids.difference(referenced_app_ids))
     if unused_raw_app_ids:
-        msg = f"connections.key_value contains app_id values not referenced by operations: {unused_raw_app_ids}"
+        msg = f"connections contains app_id values not referenced by operations: {unused_raw_app_ids}"
+        raise ValueError(msg)
+
+
+def _validate_api_unique_connection_app_ids(*, connections: list[WatsonxApiKeyValueConnectionPayload]) -> None:
+    app_id_counts = Counter(connection.app_id for connection in connections)
+    duplicates = sorted(app_id for app_id, count in app_id_counts.items() if count > 1)
+    if duplicates:
+        msg = f"connections contains duplicate app_id values: {duplicates}"
         raise ValueError(msg)
 
 
@@ -207,7 +214,7 @@ class WatsonxApiDeploymentUpdatePayload(BaseModel):
     model_config = {"extra": "forbid"}
 
     llm: WatsonxApiLlmName = Field(description="Provider model identifier to use for the deployment agent.")
-    connections: WatsonxApiUpdateConnections = Field(default_factory=WatsonxApiUpdateConnections)
+    connections: list[WatsonxApiKeyValueConnectionPayload] = Field(default_factory=list)
     upsert_flows: list[WatsonxApiUpsertFlowItem] = Field(default_factory=list)
     upsert_tools: list[WatsonxApiUpsertToolItem] = Field(default_factory=list)
     remove_flows: list[UUID] = Field(default_factory=list)
@@ -215,7 +222,8 @@ class WatsonxApiDeploymentUpdatePayload(BaseModel):
 
     @model_validator(mode="after")
     def validate_operation_references(self) -> WatsonxApiDeploymentUpdatePayload:
-        raw_app_ids = {raw.app_id for raw in (self.connections.key_value or [])}
+        _validate_api_unique_connection_app_ids(connections=self.connections)
+        raw_app_ids = {raw.app_id for raw in self.connections}
         referenced_app_ids = _collect_api_referenced_app_ids(self.upsert_flows, attr_name="add_app_ids")
         referenced_app_ids.update(_collect_api_referenced_app_ids(self.upsert_tools, attr_name="add_app_ids"))
         _validate_api_remove_not_raw(
@@ -254,7 +262,7 @@ class WatsonxApiDeploymentCreatePayload(BaseModel):
     model_config = {"extra": "forbid"}
 
     llm: WatsonxApiLlmName = Field(description="Provider model identifier to use for the deployment agent.")
-    connections: WatsonxApiUpdateConnections = Field(default_factory=WatsonxApiUpdateConnections)
+    connections: list[WatsonxApiKeyValueConnectionPayload] = Field(default_factory=list)
     add_flows: list[WatsonxApiAddFlowItem] = Field(default_factory=list)
     upsert_tools: list[WatsonxApiCreateUpsertToolItem] = Field(default_factory=list)
     existing_agent_id: str | None = Field(
@@ -282,35 +290,35 @@ class WatsonxApiDeploymentCreatePayload(BaseModel):
         if self.existing_agent_id is None and not has_operations:
             msg = "provider_data must include at least one add_flows or upsert_tools item for new agent creation."
             raise ValueError(msg)
-        raw_app_ids = {raw.app_id for raw in (self.connections.key_value or [])}
+        _validate_api_unique_connection_app_ids(connections=self.connections)
+        raw_app_ids = {raw.app_id for raw in self.connections}
         referenced_app_ids = _collect_api_referenced_app_ids(self.add_flows, attr_name="app_ids")
         referenced_app_ids.update(_collect_api_referenced_app_ids(self.upsert_tools, attr_name="add_app_ids"))
         _validate_api_unused_raw_app_ids(raw_app_ids=raw_app_ids, referenced_app_ids=referenced_app_ids)
         return self
 
 
-class WatsonxApiToolAppBinding(BaseModel):
-    """API response shape for a Watsonx tool binding.
-
-    Always includes ``tool_id`` (the provider-owned tool identifier).
-    ``flow_version_id`` is populated when the tool was created or
-    referenced through a flow-version-id operation; it is ``None``
-    for tool-id-based operations whose ``source_ref`` is not a valid
-    Langflow UUID.
-    """
+class WatsonxApiCreatedTool(BaseModel):
+    """API response shape for a tool created from a Langflow flow version."""
 
     model_config = {"extra": "forbid"}
 
-    flow_version_id: UUID | None = None
+    flow_version_id: UUID
     tool_id: str = Field(min_length=1, description="Provider-owned tool identifier.")
-    app_ids: list[str] = Field(default_factory=list)
 
-    @field_validator("app_ids", mode="before")
+    @field_validator("flow_version_id", mode="before")
     @classmethod
-    def normalize_app_ids(cls, value: Any) -> list[str]:
-        if value is None:
-            return []
-        return [str(app_id).strip() for app_id in value if str(app_id).strip()]
+    def normalize_flow_version_id(cls, value: Any) -> UUID:
+        if isinstance(value, UUID):
+            return value
+        if not isinstance(value, str):
+            msg = "flow_version_id must be provided as a UUID string or UUID object."
+            raise ValueError(msg)  # noqa: TRY004
+        try:
+            return UUID(value)
+        except ValueError as exc:
+            msg = "flow_version_id must be a valid UUID."
+            raise ValueError(msg) from exc
 
 
 class WatsonxApiDeploymentCreateResultData(BaseModel):
@@ -319,7 +327,7 @@ class WatsonxApiDeploymentCreateResultData(BaseModel):
     model_config = {"extra": "ignore"}
 
     created_app_ids: list[str] = Field(default_factory=list)
-    tool_app_bindings: list[WatsonxApiToolAppBinding] | None = None
+    created_tools: list[WatsonxApiCreatedTool] = Field(default_factory=list)
 
     @field_validator("created_app_ids", mode="before")
     @classmethod
@@ -336,7 +344,7 @@ class WatsonxApiDeploymentCreateResultData(BaseModel):
 
     def to_api_provider_data(self) -> dict[str, Any] | None:
         """Return API-safe provider_data subset for deployment create responses."""
-        payload = self.model_dump(mode="json", include={"created_app_ids", "tool_app_bindings"}, exclude_none=True)
+        payload = self.model_dump(mode="json", include={"created_app_ids", "created_tools"}, exclude_none=True)
         return payload or None
 
 
@@ -346,7 +354,7 @@ class WatsonxApiDeploymentUpdateResultData(BaseModel):
     model_config = {"extra": "ignore"}
 
     created_app_ids: list[str] = Field(default_factory=list)
-    tool_app_bindings: list[WatsonxApiToolAppBinding] | None = None
+    created_tools: list[WatsonxApiCreatedTool] = Field(default_factory=list)
 
     @field_validator("created_app_ids", mode="before")
     @classmethod
@@ -363,7 +371,7 @@ class WatsonxApiDeploymentUpdateResultData(BaseModel):
 
     def to_api_provider_data(self) -> dict[str, Any] | None:
         """Return API-safe provider_data subset for deployment update responses."""
-        payload = self.model_dump(mode="json", include={"created_app_ids", "tool_app_bindings"}, exclude_none=True)
+        payload = self.model_dump(mode="json", include={"created_app_ids", "created_tools"}, exclude_none=True)
         return payload or None
 
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -26,14 +26,14 @@ class WatsonxApiFlowArtifactProviderData(CreateFlowArtifactProviderData):
     project_id: str = Field(min_length=1)
 
 
-class WatsonxApiBindOperation(BaseModel):
-    """Bind operation using a flow-version reference."""
+class WatsonxApiAddFlowItem(BaseModel):
+    """Create-time flow item (tool is created/attached if absent)."""
 
     model_config = {"extra": "forbid"}
 
-    op: Literal["bind"]
     flow_version_id: UUID
     app_ids: list[str] = Field(
+        default_factory=list,
         description=(
             "Connection app ids to bind. Use an empty list to create/attach "
             "the flow version as a tool with no connection bindings."
@@ -45,99 +45,52 @@ class WatsonxApiBindOperation(BaseModel):
     )
 
 
-class WatsonxApiUnbindOperation(BaseModel):
-    """Unbind operation for an attached flow-version tool."""
+class WatsonxApiUpsertFlowItem(BaseModel):
+    """Update-time flow item with per-item add/remove app-id deltas."""
 
     model_config = {"extra": "forbid"}
 
-    op: Literal["unbind"]
     flow_version_id: UUID
-    app_ids: list[str] = Field(min_length=1)
-
-
-class WatsonxApiRemoveToolOperation(BaseModel):
-    """Remove-tool operation for an attached flow-version tool.
-
-    Resolves tool_id from flow_version_deployment_attachment and detaches
-    the tool from the agent.  The attachment record is also deleted.
-    """
-
-    model_config = {"extra": "forbid"}
-
-    op: Literal["remove_tool"]
-    flow_version_id: UUID
-
-
-# ---------------------------------------------------------------------------
-# Tool-id-based operations
-#
-# These operations give clients direct control over WXO tools by provider
-# tool_id, without requiring a Langflow flow_version_id.  They run in
-# parallel to the flow-version-id operations above:
-#
-# - flow_version_id ops are convenient: Langflow resolves the tool_id
-#   from internal attachment state and manages the attachment lifecycle.
-# - tool_id ops are explicit: the client supplies the provider tool_id
-#   directly.  These operations do NOT create or modify
-#   flow_version_deployment_attachment records -- they are purely
-#   provider-side agent composition changes.
-# ---------------------------------------------------------------------------
-
-
-class WatsonxApiBindToolOperation(BaseModel):
-    """Attach an existing tool to the agent and optionally bind connections.
-
-    Subsumes a separate "add_tool" operation: at the adapter level, a bind
-    with ``tool_id_with_ref`` handles both "add tool to agent if not
-    present" and "bind connections" in a single code path.  Empty
-    ``app_ids`` means attach-only (no connection bindings).
-    """
-
-    model_config = {"extra": "forbid"}
-
-    op: Literal["bind_tool"]
-    tool_id: str = Field(min_length=1, description="Provider-owned tool identifier.")
-    app_ids: list[str] = Field(
+    add_app_ids: list[str] = Field(
         default_factory=list,
-        description=(
-            "Connection app ids to bind.  Use an empty list to attach "
-            "the tool to the agent without binding connections."
-        ),
+        description=("Connection app ids to bind. Use an empty list to avoid adding new bindings."),
+    )
+    remove_app_ids: list[str] = Field(
+        default_factory=list,
+        description=("Connection app ids to unbind. Use an empty list to avoid removing bindings."),
+    )
+    tool_name: str | None = Field(
+        default=None,
+        description=("Optional user-provided tool name. When omitted, the tool name is derived from the flow name."),
     )
 
 
-class WatsonxApiUnbindToolOperation(BaseModel):
-    """Unbind connections from an existing tool (tool stays attached).
-
-    Only modifies connection bindings on the tool; does not detach
-    the tool from the agent.
-    """
+class WatsonxApiCreateUpsertToolItem(BaseModel):
+    """Create-time existing provider tool item (add connections only)."""
 
     model_config = {"extra": "forbid"}
 
-    op: Literal["unbind_tool"]
     tool_id: str = Field(min_length=1, description="Provider-owned tool identifier.")
-    app_ids: list[str] = Field(min_length=1)
+    add_app_ids: list[str] = Field(
+        default_factory=list,
+        description=("Connection app ids to bind. Use an empty list to attach the tool without connection bindings."),
+    )
 
 
-class WatsonxApiRemoveToolByIdOperation(BaseModel):
-    """Detach a tool from the agent by provider tool_id."""
+class WatsonxApiUpsertToolItem(BaseModel):
+    """Update-time existing provider tool item with per-item add/remove app-id deltas."""
 
     model_config = {"extra": "forbid"}
 
-    op: Literal["remove_tool_by_id"]
     tool_id: str = Field(min_length=1, description="Provider-owned tool identifier.")
-
-
-WatsonxApiUpdateOperation = Annotated[
-    WatsonxApiBindOperation
-    | WatsonxApiUnbindOperation
-    | WatsonxApiRemoveToolOperation
-    | WatsonxApiBindToolOperation
-    | WatsonxApiUnbindToolOperation
-    | WatsonxApiRemoveToolByIdOperation,
-    Field(discriminator="op"),
-]
+    add_app_ids: list[str] = Field(
+        default_factory=list,
+        description=("Connection app ids to bind. Use an empty list to avoid adding new bindings."),
+    )
+    remove_app_ids: list[str] = Field(
+        default_factory=list,
+        description=("Connection app ids to unbind. Use an empty list to avoid removing bindings."),
+    )
 
 
 class WatsonxApiConnectionCredentialItem(BaseModel):
@@ -186,50 +139,53 @@ class WatsonxApiUpdateConnections(BaseModel):
     key_value: list[WatsonxApiKeyValueConnectionPayload] | None = None
 
 
-def _collect_api_referenced_app_ids(operations: list[Any]) -> set[str]:
+def _collect_api_referenced_app_ids(operations: list[Any], *, attr_name: str = "app_ids") -> set[str]:
     referenced_app_ids: set[str] = set()
     for operation in operations:
-        operation_app_ids = getattr(operation, "app_ids", None)
+        operation_app_ids = getattr(operation, attr_name, None)
         if not operation_app_ids:
             continue
         referenced_app_ids.update(operation_app_ids)
     return referenced_app_ids
 
 
-def _validate_api_unbind_not_raw(*, operations: list[Any], raw_app_ids: set[str]) -> None:
+def _validate_api_remove_not_raw(*, operations: list[Any], raw_app_ids: set[str], attr_name: str, label: str) -> None:
     for operation in operations:
-        if isinstance(operation, WatsonxApiUnbindOperation):
-            invalid_raw = sorted(raw_app_ids.intersection(set(operation.app_ids)))
-            if invalid_raw:
-                msg = f"unbind.operation app_ids must not reference connections.key_value app_ids: {invalid_raw}"
-                raise ValueError(msg)
+        remove_app_ids = getattr(operation, attr_name, None)
+        if not remove_app_ids:
             continue
-        if isinstance(operation, WatsonxApiUnbindToolOperation):
-            invalid_raw = sorted(raw_app_ids.intersection(set(operation.app_ids)))
-            if invalid_raw:
-                msg = f"unbind_tool.operation app_ids must not reference connections.key_value app_ids: {invalid_raw}"
-                raise ValueError(msg)
+        invalid_raw = sorted(raw_app_ids.intersection(set(remove_app_ids)))
+        if invalid_raw:
+            msg = f"{label} must not reference connections.key_value app_ids: {invalid_raw}"
+            raise ValueError(msg)
 
 
-def _validate_api_tool_id_operations(operations: list[Any]) -> None:
-    bind_tool_ids: set[str] = set()
-    unbind_tool_ids: set[str] = set()
-    remove_tool_ids: set[str] = set()
+def _validate_api_add_remove_overlap(*, operations: list[Any], label: str) -> None:
     for operation in operations:
-        if isinstance(operation, WatsonxApiBindToolOperation):
-            bind_tool_ids.add(operation.tool_id.strip())
-            continue
-        if isinstance(operation, WatsonxApiUnbindToolOperation):
-            unbind_tool_ids.add(operation.tool_id.strip())
-            continue
-        if isinstance(operation, WatsonxApiRemoveToolByIdOperation):
-            remove_tool_ids.add(operation.tool_id.strip())
-    remove_conflicts = remove_tool_ids.intersection(bind_tool_ids | unbind_tool_ids)
-    if remove_conflicts:
-        msg = (
-            "remove_tool_by_id cannot be combined with bind_tool/unbind_tool "
-            f"for the same tool_id: {sorted(remove_conflicts)}"
-        )
+        add_app_ids = set(getattr(operation, "add_app_ids", []) or [])
+        remove_app_ids = set(getattr(operation, "remove_app_ids", []) or [])
+        overlap = sorted(add_app_ids.intersection(remove_app_ids))
+        if overlap:
+            msg = f"{label} add_app_ids and remove_app_ids must not overlap: {overlap}"
+            raise ValueError(msg)
+
+
+def _validate_api_remove_conflicts(
+    *,
+    remove_ids: list[Any],
+    upsert_operations: list[Any],
+    remove_label: str,
+    upsert_attr_name: str,
+) -> None:
+    normalized_remove_ids = {str(remove_id).strip() for remove_id in remove_ids if str(remove_id).strip()}
+    normalized_upsert_ids = {
+        str(getattr(operation, upsert_attr_name, "")).strip()
+        for operation in upsert_operations
+        if str(getattr(operation, upsert_attr_name, "")).strip()
+    }
+    conflicts = sorted(normalized_remove_ids.intersection(normalized_upsert_ids))
+    if conflicts:
+        msg = f"{remove_label} cannot be combined with upsert for the same id: {conflicts}"
         raise ValueError(msg)
 
 
@@ -243,31 +199,53 @@ def _validate_api_unused_raw_app_ids(*, raw_app_ids: set[str], referenced_app_id
 class WatsonxApiDeploymentUpdatePayload(BaseModel):
     """Watsonx provider_data API contract for deployment update operations.
 
-    ``operations`` defaults to an empty list so that LLM-only updates
+    All operation fields default to empty lists so LLM-only updates
     (changing the model without any tool/connection changes) can be
-    expressed without providing operations.
+    expressed without providing operation entries.
     """
 
     model_config = {"extra": "forbid"}
 
     llm: WatsonxApiLlmName = Field(description="Provider model identifier to use for the deployment agent.")
     connections: WatsonxApiUpdateConnections = Field(default_factory=WatsonxApiUpdateConnections)
-    operations: list[WatsonxApiUpdateOperation] = Field(default_factory=list)
+    upsert_flows: list[WatsonxApiUpsertFlowItem] = Field(default_factory=list)
+    upsert_tools: list[WatsonxApiUpsertToolItem] = Field(default_factory=list)
+    remove_flows: list[UUID] = Field(default_factory=list)
+    remove_tools: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def validate_operation_references(self) -> WatsonxApiDeploymentUpdatePayload:
         raw_app_ids = {raw.app_id for raw in (self.connections.key_value or [])}
-        referenced_app_ids = _collect_api_referenced_app_ids(self.operations)
-        _validate_api_unbind_not_raw(operations=self.operations, raw_app_ids=raw_app_ids)
-        _validate_api_tool_id_operations(self.operations)
+        referenced_app_ids = _collect_api_referenced_app_ids(self.upsert_flows, attr_name="add_app_ids")
+        referenced_app_ids.update(_collect_api_referenced_app_ids(self.upsert_tools, attr_name="add_app_ids"))
+        _validate_api_remove_not_raw(
+            operations=self.upsert_flows,
+            raw_app_ids=raw_app_ids,
+            attr_name="remove_app_ids",
+            label="upsert_flows.remove_app_ids",
+        )
+        _validate_api_remove_not_raw(
+            operations=self.upsert_tools,
+            raw_app_ids=raw_app_ids,
+            attr_name="remove_app_ids",
+            label="upsert_tools.remove_app_ids",
+        )
+        _validate_api_add_remove_overlap(operations=self.upsert_flows, label="upsert_flows")
+        _validate_api_add_remove_overlap(operations=self.upsert_tools, label="upsert_tools")
+        _validate_api_remove_conflicts(
+            remove_ids=self.remove_flows,
+            upsert_operations=self.upsert_flows,
+            remove_label="remove_flows",
+            upsert_attr_name="flow_version_id",
+        )
+        _validate_api_remove_conflicts(
+            remove_ids=self.remove_tools,
+            upsert_operations=self.upsert_tools,
+            remove_label="remove_tools",
+            upsert_attr_name="tool_id",
+        )
         _validate_api_unused_raw_app_ids(raw_app_ids=raw_app_ids, referenced_app_ids=referenced_app_ids)
         return self
-
-
-WatsonxApiCreateOperation = Annotated[
-    WatsonxApiBindOperation | WatsonxApiBindToolOperation,
-    Field(discriminator="op"),
-]
 
 
 class WatsonxApiDeploymentCreatePayload(BaseModel):
@@ -277,12 +255,13 @@ class WatsonxApiDeploymentCreatePayload(BaseModel):
 
     llm: WatsonxApiLlmName = Field(description="Provider model identifier to use for the deployment agent.")
     connections: WatsonxApiUpdateConnections = Field(default_factory=WatsonxApiUpdateConnections)
-    operations: list[WatsonxApiCreateOperation] = Field(default_factory=list)
+    add_flows: list[WatsonxApiAddFlowItem] = Field(default_factory=list)
+    upsert_tools: list[WatsonxApiCreateUpsertToolItem] = Field(default_factory=list)
     existing_agent_id: str | None = Field(
         default=None,
         description=(
             "Provider-owned agent id to update/reuse instead of creating a new agent. "
-            "When provided, operations are optional and may be empty for DB-only onboarding."
+            "When provided, add_flows/upsert_tools are optional and may be empty for DB-only onboarding."
         ),
     )
 
@@ -299,12 +278,13 @@ class WatsonxApiDeploymentCreatePayload(BaseModel):
 
     @model_validator(mode="after")
     def validate_create_operation_requirements(self) -> WatsonxApiDeploymentCreatePayload:
-        has_operations = bool(self.operations)
+        has_operations = bool(self.add_flows or self.upsert_tools)
         if self.existing_agent_id is None and not has_operations:
-            msg = "operations must include at least one bind or bind_tool operation for new agent creation."
+            msg = "provider_data must include at least one add_flows or upsert_tools item for new agent creation."
             raise ValueError(msg)
         raw_app_ids = {raw.app_id for raw in (self.connections.key_value or [])}
-        referenced_app_ids = _collect_api_referenced_app_ids(self.operations)
+        referenced_app_ids = _collect_api_referenced_app_ids(self.add_flows, attr_name="app_ids")
+        referenced_app_ids.update(_collect_api_referenced_app_ids(self.upsert_tools, attr_name="add_app_ids"))
         _validate_api_unused_raw_app_ids(raw_app_ids=raw_app_ids, referenced_app_ids=referenced_app_ids)
         return self
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -388,13 +388,29 @@ class WatsonxApiDeploymentLlmListResultData(BaseModel):
 class WatsonxApiProviderDeploymentListItem(BaseModel):
     """Provider-only deployment item returned in list provider_data."""
 
-    resource_key: str = Field(min_length=1, description="Provider-owned deployment identifier.")
+    model_config = {"extra": "forbid"}
+
+    id: str = Field(min_length=1, description="Provider-owned deployment identifier.")
     name: str
     type: DeploymentType
     description: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
-    provider_data: dict[str, Any] | None = None
+    tool_ids: list[str] = Field(default_factory=list)
+    environment: str | None = None
+
+    @field_validator("tool_ids", mode="before")
+    @classmethod
+    def normalize_tool_ids(cls, value: Any) -> list[str]:
+        if value is None:
+            return []
+        return [normalized for tool_id in value if (normalized := str(tool_id).strip())]
+
+    @field_validator("environment", mode="before")
+    @classmethod
+    def normalize_environment(cls, value: Any) -> str | None:
+        normalized = str(value or "").strip()
+        return normalized or None
 
 
 class WatsonxApiDeploymentListProviderData(BaseModel):

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from lfx.services.adapters.deployment.schema import DeploymentType, EnvVarKey, EnvVarValueSpec
+from lfx.services.adapters.deployment.schema import DeploymentType
 from pydantic import BaseModel, Field, StringConstraints, field_validator, model_validator
 
 from langflow.api.v1.mappers.deployments.contracts import CreateFlowArtifactProviderData
@@ -140,13 +140,42 @@ WatsonxApiUpdateOperation = Annotated[
 ]
 
 
-class WatsonxApiUpdateConnectionRawPayload(BaseModel):
-    """Raw connection payload for app id."""
+class WatsonxApiConnectionCredentialItem(BaseModel):
+    """API-facing connection credential declaration."""
+
+    model_config = {"extra": "forbid"}
+
+    key: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+    value: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+    source: Literal["raw", "variable"] = "variable"
+
+
+class WatsonxApiKeyValueConnectionPayload(BaseModel):
+    """API-facing key-value connection payload for app id."""
 
     model_config = {"extra": "forbid"}
 
     app_id: str = Field(min_length=1)
-    environment_variables: dict[EnvVarKey, EnvVarValueSpec] | None = None
+    credentials: list[WatsonxApiConnectionCredentialItem] | None = None
+
+    @field_validator("credentials")
+    @classmethod
+    def validate_unique_credential_keys(
+        cls,
+        value: list[WatsonxApiConnectionCredentialItem] | None,
+    ) -> list[WatsonxApiConnectionCredentialItem] | None:
+        if value is None:
+            return None
+        seen: set[str] = set()
+        duplicates: set[str] = set()
+        for item in value:
+            if item.key in seen:
+                duplicates.add(item.key)
+            seen.add(item.key)
+        if duplicates:
+            msg = f"credentials contains duplicate key values: {sorted(duplicates)}"
+            raise ValueError(msg)
+        return value
 
 
 class WatsonxApiUpdateConnections(BaseModel):
@@ -154,7 +183,7 @@ class WatsonxApiUpdateConnections(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    raw_payloads: list[WatsonxApiUpdateConnectionRawPayload] | None = None
+    key_value: list[WatsonxApiKeyValueConnectionPayload] | None = None
 
 
 def _collect_api_referenced_app_ids(operations: list[Any]) -> set[str]:
@@ -172,15 +201,13 @@ def _validate_api_unbind_not_raw(*, operations: list[Any], raw_app_ids: set[str]
         if isinstance(operation, WatsonxApiUnbindOperation):
             invalid_raw = sorted(raw_app_ids.intersection(set(operation.app_ids)))
             if invalid_raw:
-                msg = f"unbind.operation app_ids must not reference connections.raw_payloads app_ids: {invalid_raw}"
+                msg = f"unbind.operation app_ids must not reference connections.key_value app_ids: {invalid_raw}"
                 raise ValueError(msg)
             continue
         if isinstance(operation, WatsonxApiUnbindToolOperation):
             invalid_raw = sorted(raw_app_ids.intersection(set(operation.app_ids)))
             if invalid_raw:
-                msg = (
-                    f"unbind_tool.operation app_ids must not reference connections.raw_payloads app_ids: {invalid_raw}"
-                )
+                msg = f"unbind_tool.operation app_ids must not reference connections.key_value app_ids: {invalid_raw}"
                 raise ValueError(msg)
 
 
@@ -209,7 +236,7 @@ def _validate_api_tool_id_operations(operations: list[Any]) -> None:
 def _validate_api_unused_raw_app_ids(*, raw_app_ids: set[str], referenced_app_ids: set[str]) -> None:
     unused_raw_app_ids = sorted(raw_app_ids.difference(referenced_app_ids))
     if unused_raw_app_ids:
-        msg = f"connections.raw_payloads contains app_id values not referenced by operations: {unused_raw_app_ids}"
+        msg = f"connections.key_value contains app_id values not referenced by operations: {unused_raw_app_ids}"
         raise ValueError(msg)
 
 
@@ -229,7 +256,7 @@ class WatsonxApiDeploymentUpdatePayload(BaseModel):
 
     @model_validator(mode="after")
     def validate_operation_references(self) -> WatsonxApiDeploymentUpdatePayload:
-        raw_app_ids = {raw.app_id for raw in (self.connections.raw_payloads or [])}
+        raw_app_ids = {raw.app_id for raw in (self.connections.key_value or [])}
         referenced_app_ids = _collect_api_referenced_app_ids(self.operations)
         _validate_api_unbind_not_raw(operations=self.operations, raw_app_ids=raw_app_ids)
         _validate_api_tool_id_operations(self.operations)
@@ -276,7 +303,7 @@ class WatsonxApiDeploymentCreatePayload(BaseModel):
         if self.existing_agent_id is None and not has_operations:
             msg = "operations must include at least one bind or bind_tool operation for new agent creation."
             raise ValueError(msg)
-        raw_app_ids = {raw.app_id for raw in (self.connections.raw_payloads or [])}
+        raw_app_ids = {raw.app_id for raw in (self.connections.key_value or [])}
         referenced_app_ids = _collect_api_referenced_app_ids(self.operations)
         _validate_api_unused_raw_app_ids(raw_app_ids=raw_app_ids, referenced_app_ids=referenced_app_ids)
         return self
@@ -416,7 +443,7 @@ class WatsonxApiProviderDeploymentListItem(BaseModel):
 class WatsonxApiDeploymentListProviderData(BaseModel):
     """Provider-level metadata attached to DeploymentListResponse.provider_data."""
 
-    entries: list[WatsonxApiProviderDeploymentListItem] = Field(default_factory=list)
+    deployments: list[WatsonxApiProviderDeploymentListItem] = Field(default_factory=list)
 
 
 class WatsonxApiConfigListItem(BaseModel):
@@ -440,24 +467,15 @@ class WatsonxApiConfigListItem(BaseModel):
 
 
 class WatsonxApiConfigListProviderData(BaseModel):
-    """Provider-level metadata attached to DeploymentConfigListResponse.
-
-    ``deployment_id`` is present for deployment-scoped listings and absent for
-    tenant-scoped listings; no explicit scope discriminator is needed because the
-    caller already knows which mode it requested.
-    """
+    """Provider-level metadata attached to DeploymentConfigListResponse."""
 
     model_config = {"extra": "forbid"}
 
-    deployment_id: str | None = None
     tool_ids: list[str] | None = None
-    configs: list[WatsonxApiConfigListItem] = Field(default_factory=list)
-
-    @field_validator("deployment_id", mode="before")
-    @classmethod
-    def normalize_deployment_id(cls, value: Any) -> str | None:
-        normalized = str(value or "").strip()
-        return normalized or None
+    connections: list[WatsonxApiConfigListItem] = Field(default_factory=list)
+    page: int | None = Field(default=None, ge=1)
+    size: int | None = Field(default=None, ge=1)
+    total: int | None = Field(default=None, ge=0)
 
     @field_validator("tool_ids", mode="before")
     @classmethod
@@ -487,22 +505,14 @@ class WatsonxApiSnapshotListItem(BaseModel):
 
 
 class WatsonxApiSnapshotListProviderData(BaseModel):
-    """Provider-level metadata attached to DeploymentSnapshotListResponse.
-
-    ``deployment_id`` is present for deployment-scoped listings and absent for
-    tenant-scoped listings.
-    """
+    """Provider-level metadata attached to DeploymentSnapshotListResponse."""
 
     model_config = {"extra": "forbid"}
 
-    deployment_id: str | None = None
-    snapshots: list[WatsonxApiSnapshotListItem] = Field(default_factory=list)
-
-    @field_validator("deployment_id", mode="before")
-    @classmethod
-    def normalize_deployment_id(cls, value: Any) -> str | None:
-        normalized = str(value or "").strip()
-        return normalized or None
+    tools: list[WatsonxApiSnapshotListItem] = Field(default_factory=list)
+    page: int | None = Field(default=None, ge=1)
+    size: int | None = Field(default=None, ge=1)
+    total: int | None = Field(default=None, ge=0)
 
 
 class WatsonxApiDeploymentFlowVersionItemData(BaseModel):

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -295,7 +295,7 @@ class DeploymentListResponse(_PaginatedResponse):
 
 
 class DeploymentProviderAccountListResponse(_PaginatedResponse):
-    providers: list[DeploymentProviderAccountGetResponse]
+    provider_accounts: list[DeploymentProviderAccountGetResponse]
 
 
 class DeploymentConfigListResponse(_PaginatedResponse):

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -281,13 +281,13 @@ class DeploymentListItem(_DeploymentResponseCommon):
 class _PaginatedResponse(BaseModel):
     """Shared pagination fields for list responses."""
 
-    page: int = Field(default=1, ge=1)
-    size: int = Field(default=20, ge=1)
-    total: int = Field(default=0, ge=0)
+    page: int | None = Field(default=None, ge=1)
+    size: int | None = Field(default=None, ge=1)
+    total: int | None = Field(default=None, ge=0)
 
 
 class DeploymentListResponse(_PaginatedResponse):
-    deployments: list[DeploymentListItem]
+    deployments: list[DeploymentListItem] | None = None
     provider_data: dict[str, Any] | None = Field(
         default=None,
         description="Provider-owned opaque payload for list-specific provider metadata.",
@@ -304,7 +304,7 @@ class DeploymentConfigListResponse(_PaginatedResponse):
     provider_data: dict[str, Any] | None = Field(
         default=None,
         description=(
-            "Provider-owned opaque payload containing the list of configs "
+            "Provider-owned opaque payload containing the list of connections "
             "and any response-level metadata supplied by the provider."
         ),
     )

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -9,9 +9,10 @@ Two identifier domains coexist in these schemas:
   ``provider_id`` maps to ``deployment_provider_account.id``.
 
 * **Provider-owned (str)** -- ``reference_id``, ``config_id``,
-  ``execution_id``, and provider-account fields ``tenant_id``, ``provider_key``,
-  and ``url``. Opaque values assigned or consumed by the external deployment
-  provider.
+  ``execution_id``, and provider-account fields ``provider_key`` and ``url``.
+  Opaque values assigned or consumed by the external deployment provider.
+  Provider-specific metadata (for example tenant/account identifiers) belongs
+  inside ``provider_data``.
 
 * **Provider-originated but Langflow-owned once persisted** -- ``resource_key``.
   Langflow stores and indexes this as part of its own deployment record.
@@ -142,10 +143,6 @@ class DeploymentProviderAccountCreateRequest(BaseModel):
             "User-chosen display name for this provider account. Must be unique per user within a provider_key."
         ),
     )
-    tenant_id: NonEmptyStr | None = Field(
-        default=None,
-        description="Provider-owned tenant/organization id. Langflow persists this opaque value.",
-    )
     provider_key: DeploymentProviderKey = Field(description="Deployment provider key.")
     url: ValidatedUrl = Field(
         description="Provider service URL persisted in Langflow DB for provider-account resolution.",
@@ -153,9 +150,10 @@ class DeploymentProviderAccountCreateRequest(BaseModel):
     provider_data: dict[str, Any] = Field(
         min_length=1,
         description=(
-            "Provider-specific credential payload. "
+            "Provider-specific credential/metadata payload. "
             "Contents are opaque to the API schema; the deployment mapper "
-            "for the target provider_key validates and extracts credentials."
+            "for the target provider_key validates and extracts credentials "
+            "and provider metadata (for example tenant/account identifiers)."
         ),
     )
 
@@ -196,12 +194,15 @@ class DeploymentProviderAccountUpdateRequest(BaseModel):
 class DeploymentProviderAccountGetResponse(BaseModel):
     id: UUID = Field(description="Langflow DB provider-account UUID (`deployment_provider_account.id`).")
     name: str = Field(description="User-chosen display name for this provider account.")
-    tenant_id: str | None = Field(
-        default=None,
-        description="Provider-owned tenant/organization identifier persisted as opaque text.",
-    )
     provider_key: DeploymentProviderKey = Field(description="Official provider name used by Langflow.")
     url: str = Field(description="Provider service URL persisted in Langflow DB.")
+    provider_data: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Provider-owned non-sensitive metadata for this provider account "
+            "(for example tenant/account identifiers). Credentials are excluded."
+        ),
+    )
     created_at: datetime | None = Field(default=None, description="Langflow DB row creation timestamp.")
     updated_at: datetime | None = Field(default=None, description="Langflow DB row update timestamp.")
 

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -9,9 +9,12 @@ Two identifier domains coexist in these schemas:
   ``provider_id`` maps to ``deployment_provider_account.id``.
 
 * **Provider-owned (str)** -- ``reference_id``, ``config_id``,
-  ``resource_key``, ``execution_id``, ``provider_tenant_id``,
+  ``execution_id``, ``provider_tenant_id``,
   ``provider_key``, and ``provider_url``. Opaque values assigned or
   consumed by the external deployment provider.
+
+* **Provider-originated but Langflow-owned once persisted** -- ``resource_key``.
+  Langflow stores and indexes this as part of its own deployment record.
 
 ``provider_data`` dicts are opaque pass-through containers whose contents
 are defined by the provider adapter. Langflow forwards them without
@@ -268,7 +271,7 @@ class DeploymentGetResponse(_DeploymentResponseBase):
     list item stays lean.
     """
 
-    resource_key: str = Field(description="Provider-owned stable resource identifier.")
+    resource_key: str = Field(description="Langflow-persisted stable provider resource identifier.")
     attached_count: int = Field(default=0, ge=0, description="Number of flow versions attached to this deployment.")
 
 
@@ -291,7 +294,7 @@ class DeploymentListItem(_DeploymentResponseBase):
     See ``DeploymentGetResponse`` docstring for rationale on the separate class.
     """
 
-    resource_key: str = Field(description="Provider-owned stable resource identifier.")
+    resource_key: str = Field(description="Langflow-persisted stable provider resource identifier.")
     attached_count: int = Field(default=0, ge=0, description="Number of flow versions attached to this deployment.")
     matched_attachments: list[DeploymentListItemAttachment] | None = Field(
         default=None,
@@ -322,38 +325,28 @@ class DeploymentProviderAccountListResponse(_PaginatedResponse):
     providers: list[DeploymentProviderAccountGetResponse]
 
 
-class DeploymentConfigListItem(BaseModel):
-    """Lean config representation used in list responses."""
-
-    id: str = Field(description="Provider-owned config identifier.")
-    name: str
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
-    provider_data: dict[str, Any] | None = Field(
-        default=None,
-        description="Provider-owned opaque payload returned by the deployment provider.",
-    )
-
-
 class DeploymentConfigListResponse(_PaginatedResponse):
-    configs: list[DeploymentConfigListItem]
+    """Paginated config list with all provider-owned data in a single opaque blob."""
 
-
-class DeploymentSnapshotListItem(BaseModel):
-    """Lean snapshot/tool representation used in list responses."""
-
-    id: str = Field(description="Provider-owned snapshot/tool identifier.")
-    name: str
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
     provider_data: dict[str, Any] | None = Field(
         default=None,
-        description="Provider-owned opaque payload returned by the deployment provider.",
+        description=(
+            "Provider-owned opaque payload containing the list of configs "
+            "and any response-level metadata supplied by the provider."
+        ),
     )
 
 
 class DeploymentSnapshotListResponse(_PaginatedResponse):
-    snapshots: list[DeploymentSnapshotListItem]
+    """Paginated snapshot list with all provider-owned data in a single opaque blob."""
+
+    provider_data: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Provider-owned opaque payload containing the list of snapshots "
+            "and any response-level metadata supplied by the provider."
+        ),
+    )
 
 
 class DeploymentFlowVersionListItem(BaseModel):

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -251,6 +251,8 @@ class _DeploymentResponseBase(BaseModel):
     """Shared fields for deployment response schemas."""
 
     id: UUID = Field(description="Langflow DB deployment UUID.")
+    provider_id: UUID = Field(description="Langflow DB provider-account UUID (`deployment_provider_account.id`).")
+    provider_key: str = Field(description="Provider identifier (e.g. 'watsonx-orchestrate').")
     name: str
     description: str | None = None
     type: DeploymentType
@@ -462,13 +464,6 @@ class DeploymentUpdateRequest(BaseModel):
 class ExecutionCreateRequest(BaseModel):
     model_config = {"extra": "forbid"}
 
-    provider_id: UUID = Field(
-        description=(
-            "Langflow DB provider-account UUID (`deployment_provider_account.id`). "
-            "Included alongside deployment_id to allow provider routing without an extra DB lookup."
-        ),
-    )
-    deployment_id: UUID = Field(description="Langflow DB deployment UUID.")
     provider_data: dict[str, Any] | None = Field(
         default=None,
         description="Provider-owned opaque execution input payload.",

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -17,30 +17,9 @@ Two identifier domains coexist in these schemas:
 are defined by the provider adapter. Langflow forwards them without
 interpreting their schema.
 
-Service-layer schema reuse (shared-kernel pattern)
----------------------------------------------------
-Three service-layer data schemas are imported and subclassed (via
-``_Strict*`` wrappers) rather than redefined in this module.  They act as
-a **shared kernel**: field definitions owned by the service layer that the
-API layer extends with stricter validation (``extra = "forbid"``).
-
-* ``BaseDeploymentData`` -- deployment metadata for creation
-* ``BaseDeploymentDataUpdate`` -- deployment metadata for partial updates
-* ``DeploymentConfig`` -- deployment configuration payload
-
-Additionally, ``DeploymentType`` is imported as a shared vocabulary enum.
-
-This coupling is intentional -- these schemas carry no Langflow-managed
-identifiers and describe provider-facing data whose shape the API should
-track automatically.  If the service layer later introduces fields that
-must *not* be API-visible, replace the ``_Strict*`` subclass with an
-API-owned model and a mapping function.
-
-``BaseDeploymentData`` also carries an optional ``provider_spec`` dict
-(inherited from ``ProviderSpecModel``), an opaque provider-owned input
-payload similar to ``provider_data``.  ``DeploymentConfig`` carries an
-analogous ``provider_config`` dict.  ``BaseDeploymentDataUpdate`` has no
-opaque provider fields.
+DeploymentType is imported from the adapter service layer as shared
+vocabulary. Request/response models in this module are API-owned to keep
+the client-facing schema minimal and avoid exposing service-only fields.
 """
 
 from __future__ import annotations
@@ -49,13 +28,8 @@ from datetime import datetime
 from typing import Annotated, Any
 from uuid import UUID
 
-from lfx.services.adapters.deployment.schema import (
-    BaseDeploymentData,
-    BaseDeploymentDataUpdate,
-    DeploymentConfig,
-    DeploymentType,
-)
-from pydantic import AfterValidator, BaseModel, Field, ValidationInfo, field_validator, model_validator
+from lfx.services.adapters.deployment.schema import DeploymentType
+from pydantic import AfterValidator, BaseModel, Field, ValidationInfo, model_validator
 
 from langflow.services.database.models.deployment_provider_account.schemas import (
     DeploymentProviderKey,
@@ -338,7 +312,6 @@ class _PaginatedResponse(BaseModel):
 
 class DeploymentListResponse(_PaginatedResponse):
     deployments: list[DeploymentListItem]
-    deployment_type: DeploymentType | None = None
     provider_data: dict[str, Any] | None = Field(
         default=None,
         description="Provider-owned opaque payload for list-specific provider metadata.",
@@ -423,216 +396,55 @@ class DeploymentStatusResponse(_DeploymentResponseBase):
     """API response for deployment status/health."""
 
 
-class DeploymentRedeployResponse(_DeploymentResponseBase):
-    """API response for redeployment."""
-
-
-class DeploymentDuplicateResponse(_DeploymentResponseBase):
-    """API response for deployment duplication."""
-
-
-# ---------------------------------------------------------------------------
-# Flow versions sub-resource schemas
-# ---------------------------------------------------------------------------
-
-
-class FlowVersionsAttach(BaseModel):
-    """Flow version ids to attach to a deployment."""
-
-    model_config = {"extra": "forbid"}
-
-    ids: list[UUID] = Field(
-        min_length=1,
-        description="Langflow flow version ids to attach to the deployment.",
-    )
-
-    @field_validator("ids")
-    @classmethod
-    def validate_ids(cls, values: list[UUID]) -> list[UUID]:
-        return _validate_uuid_list(values, field_name="ids")
-
-
-class FlowVersionsPatch(BaseModel):
-    """Add or remove flow version bindings on an existing deployment."""
-
-    model_config = {"extra": "forbid"}
-
-    add: list[UUID] | None = Field(
-        None,
-        description="Langflow flow version ids to attach to the deployment. Omit to leave unchanged.",
-    )
-    remove: list[UUID] | None = Field(
-        None,
-        description="Langflow flow version ids to detach from the deployment. Omit to leave unchanged.",
-    )
-
-    @field_validator("add", "remove")
-    @classmethod
-    def validate_id_lists(cls, values: list[UUID] | None, info: ValidationInfo) -> list[UUID] | None:
-        if values is None:
-            return None
-        return _validate_uuid_list(values, field_name=info.field_name)
-
-    @model_validator(mode="after")
-    def validate_operations(self):
-        add_values = self.add or []
-        remove_values = self.remove or []
-
-        if not add_values and not remove_values:
-            msg = "At least one of 'add' or 'remove' must be provided."
-            raise ValueError(msg)
-
-        overlap = set(add_values).intersection(remove_values)
-        if overlap:
-            ids = ", ".join(sorted(str(v) for v in overlap))
-            msg = f"Flow version ids cannot be present in both 'add' and 'remove': {ids}."
-            raise ValueError(msg)
-        return self
-
-
-# ---------------------------------------------------------------------------
-# Strict API-layer wrappers (shared-kernel boundary)
-# ---------------------------------------------------------------------------
-# These thin subclasses inherit field definitions from the service layer and
-# add ``extra = "forbid"`` so API callers receive a 422 for unexpected fields
-# instead of having data silently dropped.  Subclassing (rather than
-# redefining fields) keeps the API in lock-step with the service contract.
-# If a service-layer field should NOT be API-visible, replace the relevant
-# subclass with an API-owned model and a mapping function.
-
-
-class _StrictBaseDeploymentData(BaseDeploymentData):
-    model_config = {"extra": "forbid"}
-
-
-class _StrictBaseDeploymentDataUpdate(BaseDeploymentDataUpdate):
-    model_config = {"extra": "forbid"}
-
-
-class _StrictDeploymentConfig(DeploymentConfig):
-    model_config = {"extra": "forbid"}
-
-
-# ---------------------------------------------------------------------------
-# Deployment config sub-resource schemas (API-owned)
-# ---------------------------------------------------------------------------
-
-
-class DeploymentConfigCreate(BaseModel):
-    """Config input for deployment creation.
-
-    Exactly one of ``reference_id`` or ``raw_payload`` must be provided.
-    """
-
-    model_config = {"extra": "forbid"}
-
-    reference_id: NonEmptyStr | None = Field(
-        default=None,
-        description="Provider-owned config reference id to bind to the deployment.",
-    )
-    raw_payload: _StrictDeploymentConfig | None = Field(
-        default=None,
-        description="Config payload to create and bind to the deployment.",
-    )
-
-    @model_validator(mode="after")
-    def validate_exactly_one(self) -> DeploymentConfigCreate:
-        if (self.reference_id is None) == (self.raw_payload is None):
-            msg = "Exactly one of 'reference_id' or 'raw_payload' must be provided."
-            raise ValueError(msg)
-        return self
-
-
-class DeploymentConfigBindingUpdate(BaseModel):
-    """Config binding patch for an existing deployment.
-
-    Exactly one of ``config_id``, ``raw_payload``, or ``unbind`` must be
-    provided:
-
-    * ``config_id`` — bind an existing config by reference.
-    * ``raw_payload`` — create a new config and bind it.
-    * ``unbind = true`` — detach the current config.
-    """
-
-    model_config = {"extra": "forbid"}
-
-    config_id: NonEmptyStr | None = Field(
-        default=None,
-        description="Provider-owned config id to bind to the deployment.",
-    )
-
-    raw_payload: _StrictDeploymentConfig | None = Field(
-        default=None,
-        description="Config payload to create and bind to the deployment.",
-    )
-
-    unbind: bool = Field(
-        default=False,
-        description="Set to true to detach the current config from the deployment.",
-    )
-
-    @model_validator(mode="after")
-    def validate_config_update(self) -> DeploymentConfigBindingUpdate:
-        provided = sum(
-            [
-                self.config_id is not None,
-                self.raw_payload is not None,
-                self.unbind,
-            ]
-        )
-        if provided != 1:
-            msg = "Exactly one of 'config_id', 'raw_payload', or 'unbind=true' must be provided."
-            raise ValueError(msg)
-        return self
-
-
 # ---------------------------------------------------------------------------
 # Deployment create / update request schemas
 # ---------------------------------------------------------------------------
+
+
+class DeploymentSpec(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    name: NonEmptyStr = Field(description="Deployment display name.")
+    description: str = Field(default="", description="Deployment description.")
+    type: DeploymentType = Field(description="Deployment type.")
+
+
+class DeploymentSpecUpdate(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    name: NonEmptyStr | None = Field(default=None, description="Updated deployment display name.")
+    description: str | None = Field(default=None, description="Updated deployment description.")
+
+    @model_validator(mode="after")
+    def ensure_any_field_provided(self) -> DeploymentSpecUpdate:
+        if not self.model_fields_set:
+            msg = "At least one of 'name' or 'description' must be provided in 'spec'."
+            raise ValueError(msg)
+        if self.name is None and self.description is None:
+            msg = "At least one of 'name' or 'description' must be provided in 'spec'."
+            raise ValueError(msg)
+        return self
 
 
 class DeploymentCreateRequest(BaseModel):
     model_config = {"extra": "forbid"}
 
     provider_id: UUID = Field(description="Langflow DB provider-account UUID (`deployment_provider_account.id`).")
-    spec: _StrictBaseDeploymentData = Field(description="Deployment metadata (service-layer schema, no ID fields).")
+    spec: DeploymentSpec = Field(description="Deployment metadata.")
     project_id: UUID | None = Field(
         default=None,
         description="Langflow DB project id to persist the deployment under. Defaults to user's Starter Project.",
     )
-    flow_version_ids: list[UUID] | None = Field(
-        default=None,
-        description="Flow version ids to attach to the deployment.",
-    )
-    config: DeploymentConfigCreate | None = Field(default=None, description="Deployment configuration.")
     provider_data: dict[str, Any] | None = Field(
         default=None,
         description="Provider-owned opaque create payload.",
     )
 
-    @field_validator("flow_version_ids")
-    @classmethod
-    def validate_create_flow_version_ids(cls, values: list[UUID] | None) -> list[UUID] | None:
-        if values is None:
-            return None
-        return _validate_uuid_list(values, field_name="flow_version_ids")
-
 
 class DeploymentUpdateRequest(BaseModel):
     model_config = {"extra": "forbid"}
 
-    spec: _StrictBaseDeploymentDataUpdate | None = Field(
-        default=None, description="Deployment metadata updates (service-layer schema, no ID fields)."
-    )
-    add_flow_version_ids: list[UUID] | None = Field(
-        default=None,
-        description="Flow version ids to attach to the deployment.",
-    )
-    remove_flow_version_ids: list[UUID] | None = Field(
-        default=None,
-        description="Flow version ids to detach from the deployment.",
-    )
-    config: DeploymentConfigBindingUpdate | None = Field(default=None, description="Deployment configuration update.")
+    spec: DeploymentSpecUpdate | None = Field(default=None, description="Deployment metadata updates.")
     provider_data: dict[str, Any] | None = Field(
         default=None,
         description="Provider-owned opaque update payload.",
@@ -641,40 +453,10 @@ class DeploymentUpdateRequest(BaseModel):
     @model_validator(mode="after")
     def ensure_any_field_provided(self) -> DeploymentUpdateRequest:
         if not self.model_fields_set:
-            msg = (
-                "At least one of 'spec', 'add_flow_version_ids', "
-                "'remove_flow_version_ids', 'config', or 'provider_data' must be provided."
-            )
+            msg = "At least one of 'spec' or 'provider_data' must be provided."
             raise ValueError(msg)
-        if (
-            self.spec is None
-            and self.add_flow_version_ids is None
-            and self.remove_flow_version_ids is None
-            and self.config is None
-            and self.provider_data is None
-        ):
-            msg = (
-                "At least one of 'spec', 'add_flow_version_ids', "
-                "'remove_flow_version_ids', 'config', or 'provider_data' must be provided."
-            )
-            raise ValueError(msg)
-        return self
-
-    @field_validator("add_flow_version_ids", "remove_flow_version_ids")
-    @classmethod
-    def validate_update_flow_version_ids(cls, values: list[UUID] | None, info: ValidationInfo) -> list[UUID] | None:
-        if values is None:
-            return None
-        return _validate_uuid_list(values, field_name=info.field_name)
-
-    @model_validator(mode="after")
-    def validate_update_flow_version_operations(self) -> DeploymentUpdateRequest:
-        add_values = self.add_flow_version_ids or []
-        remove_values = self.remove_flow_version_ids or []
-        overlap = set(add_values).intersection(remove_values)
-        if overlap:
-            ids = ", ".join(sorted(str(v) for v in overlap))
-            msg = f"Flow version ids cannot be present in both add/remove operations: {ids}."
+        if self.spec is None and self.provider_data is None:
+            msg = "At least one of 'spec' or 'provider_data' must be provided."
             raise ValueError(msg)
         return self
 

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -376,36 +376,13 @@ class DeploymentStatusResponse(_DeploymentResponseBase):
 # ---------------------------------------------------------------------------
 
 
-class DeploymentSpec(BaseModel):
-    model_config = {"extra": "forbid"}
-
-    name: NonEmptyStr = Field(description="Deployment display name.")
-    description: str = Field(default="", description="Deployment description.")
-    type: DeploymentType = Field(description="Deployment type.")
-
-
-class DeploymentSpecUpdate(BaseModel):
-    model_config = {"extra": "forbid"}
-
-    name: NonEmptyStr | None = Field(default=None, description="Updated deployment display name.")
-    description: str | None = Field(default=None, description="Updated deployment description.")
-
-    @model_validator(mode="after")
-    def ensure_any_field_provided(self) -> DeploymentSpecUpdate:
-        if not self.model_fields_set:
-            msg = "At least one of 'name' or 'description' must be provided in 'spec'."
-            raise ValueError(msg)
-        if self.name is None and self.description is None:
-            msg = "At least one of 'name' or 'description' must be provided in 'spec'."
-            raise ValueError(msg)
-        return self
-
-
 class DeploymentCreateRequest(BaseModel):
     model_config = {"extra": "forbid"}
 
     provider_id: UUID = Field(description="Langflow DB provider-account UUID (`deployment_provider_account.id`).")
-    spec: DeploymentSpec = Field(description="Deployment metadata.")
+    name: NonEmptyStr = Field(description="Deployment display name.")
+    description: str = Field(default="", description="Deployment description.")
+    type: DeploymentType = Field(description="Deployment type.")
     project_id: UUID | None = Field(
         default=None,
         description="Langflow DB project id to persist the deployment under. Defaults to user's Starter Project.",
@@ -419,7 +396,8 @@ class DeploymentCreateRequest(BaseModel):
 class DeploymentUpdateRequest(BaseModel):
     model_config = {"extra": "forbid"}
 
-    spec: DeploymentSpecUpdate | None = Field(default=None, description="Deployment metadata updates.")
+    name: NonEmptyStr | None = Field(default=None, description="Updated deployment display name.")
+    description: str | None = Field(default=None, description="Updated deployment description.")
     provider_data: dict[str, Any] | None = Field(
         default=None,
         description="Provider-owned opaque update payload.",
@@ -428,10 +406,10 @@ class DeploymentUpdateRequest(BaseModel):
     @model_validator(mode="after")
     def ensure_any_field_provided(self) -> DeploymentUpdateRequest:
         if not self.model_fields_set:
-            msg = "At least one of 'spec' or 'provider_data' must be provided."
+            msg = "At least one of 'name', 'description', or 'provider_data' must be provided."
             raise ValueError(msg)
-        if self.spec is None and self.provider_data is None:
-            msg = "At least one of 'spec' or 'provider_data' must be provided."
+        if self.name is None and self.description is None and self.provider_data is None:
+            msg = "At least one of 'name', 'description', or 'provider_data' must be provided."
             raise ValueError(msg)
         return self
 

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -31,7 +31,7 @@ from datetime import datetime
 from typing import Annotated, Any
 from uuid import UUID
 
-from lfx.services.adapters.deployment.schema import DeploymentType
+from lfx.services.adapters.deployment.schema import DEPLOYMENT_DESCRIPTION_MAX_LENGTH, DeploymentType
 from pydantic import AfterValidator, BaseModel, Field, ValidationInfo, model_validator
 
 from langflow.services.database.models.deployment_provider_account.schemas import (
@@ -128,7 +128,6 @@ def _validate_flow_ids(values: list[UUID] | None) -> list[UUID] | None:
 
 FlowIdsQuery = Annotated[list[UUID] | None, AfterValidator(_validate_flow_ids)]
 """Query parameter type that validates and cleans an optional list of flow id UUIDs (max 1 today)."""
-
 
 # ---------------------------------------------------------------------------
 # Provider sub-resource schemas
@@ -227,8 +226,8 @@ class DeploymentLlmListResponse(BaseModel):
     )
 
 
-class _DeploymentResponseBase(BaseModel):
-    """Shared fields for deployment response schemas."""
+class _DeploymentResponseCommon(BaseModel):
+    """Shared non-provider-data fields for deployment response schemas."""
 
     id: UUID = Field(description="Langflow DB deployment UUID.")
     provider_id: UUID = Field(description="Langflow DB provider-account UUID (`deployment_provider_account.id`).")
@@ -238,13 +237,18 @@ class _DeploymentResponseBase(BaseModel):
     type: DeploymentType
     created_at: datetime | None = None
     updated_at: datetime | None = None
+
+
+class _DeploymentResponseWithProviderData(_DeploymentResponseCommon):
+    """Shared fields for responses that include provider_data."""
+
     provider_data: dict[str, Any] | None = Field(
         default=None,
         description="Provider-owned opaque payload returned by the deployment provider.",
     )
 
 
-class DeploymentGetResponse(_DeploymentResponseBase):
+class DeploymentGetResponse(_DeploymentResponseWithProviderData):
     """Full deployment detail.
 
     Intentionally separate from ``DeploymentListItem`` even though both
@@ -257,20 +261,7 @@ class DeploymentGetResponse(_DeploymentResponseBase):
     attached_count: int = Field(default=0, ge=0, description="Number of flow versions attached to this deployment.")
 
 
-class DeploymentListItemAttachment(BaseModel):
-    """A matched flow-version attachment on a deployment list item.
-
-    Populated only when a ``flow_ids`` or ``flow_version_ids`` filter is
-    active, giving the caller the attachment-level detail it needs
-    (e.g. the ``provider_snapshot_id`` required by the snapshot-update
-    endpoint) without a second round-trip.
-    """
-
-    flow_version_id: UUID
-    provider_snapshot_id: str | None = None
-
-
-class DeploymentListItem(_DeploymentResponseBase):
+class DeploymentListItem(_DeploymentResponseCommon):
     """Deployment representation used in list responses.
 
     See ``DeploymentGetResponse`` docstring for rationale on the separate class.
@@ -278,11 +269,11 @@ class DeploymentListItem(_DeploymentResponseBase):
 
     resource_key: str = Field(description="Langflow-persisted stable provider resource identifier.")
     attached_count: int = Field(default=0, ge=0, description="Number of flow versions attached to this deployment.")
-    matched_attachments: list[DeploymentListItemAttachment] | None = Field(
+    flow_version_ids: list[UUID] | None = Field(
         default=None,
         description=(
-            "Flow-version attachments that matched the active flow_ids or "
-            "flow_version_ids filter.  None when no such filter is active."
+            "Flow-version ids that matched the active flow_ids or "
+            "flow_version_ids filter. Omitted when no such filter is active."
         ),
     )
 
@@ -359,15 +350,15 @@ class DeploymentFlowVersionListResponse(_PaginatedResponse):
     flow_versions: list[DeploymentFlowVersionListItem]
 
 
-class DeploymentCreateResponse(_DeploymentResponseBase):
+class DeploymentCreateResponse(_DeploymentResponseWithProviderData):
     """API response for deployment creation."""
 
 
-class DeploymentUpdateResponse(_DeploymentResponseBase):
+class DeploymentUpdateResponse(_DeploymentResponseWithProviderData):
     """API response for deployment update."""
 
 
-class DeploymentStatusResponse(_DeploymentResponseBase):
+class DeploymentStatusResponse(_DeploymentResponseWithProviderData):
     """API response for deployment status/health."""
 
 
@@ -381,7 +372,11 @@ class DeploymentCreateRequest(BaseModel):
 
     provider_id: UUID = Field(description="Langflow DB provider-account UUID (`deployment_provider_account.id`).")
     name: NonEmptyStr = Field(description="Deployment display name.")
-    description: str = Field(default="", description="Deployment description.")
+    description: str = Field(
+        default="",
+        max_length=DEPLOYMENT_DESCRIPTION_MAX_LENGTH,
+        description="Deployment description.",
+    )
     type: DeploymentType = Field(description="Deployment type.")
     project_id: UUID | None = Field(
         default=None,
@@ -397,7 +392,11 @@ class DeploymentUpdateRequest(BaseModel):
     model_config = {"extra": "forbid"}
 
     name: NonEmptyStr | None = Field(default=None, description="Updated deployment display name.")
-    description: str | None = Field(default=None, description="Updated deployment description.")
+    description: str | None = Field(
+        default=None,
+        max_length=DEPLOYMENT_DESCRIPTION_MAX_LENGTH,
+        description="Updated deployment description.",
+    )
     provider_data: dict[str, Any] | None = Field(
         default=None,
         description="Provider-owned opaque update payload.",

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -9,9 +9,9 @@ Two identifier domains coexist in these schemas:
   ``provider_id`` maps to ``deployment_provider_account.id``.
 
 * **Provider-owned (str)** -- ``reference_id``, ``config_id``,
-  ``execution_id``, ``provider_tenant_id``,
-  ``provider_key``, and ``provider_url``. Opaque values assigned or
-  consumed by the external deployment provider.
+  ``execution_id``, and provider-account fields ``tenant_id``, ``provider_key``,
+  and ``url``. Opaque values assigned or consumed by the external deployment
+  provider.
 
 * **Provider-originated but Langflow-owned once persisted** -- ``resource_key``.
   Langflow stores and indexes this as part of its own deployment record.
@@ -40,7 +40,6 @@ from langflow.services.database.models.deployment_provider_account.schemas impor
 from langflow.services.database.models.deployment_provider_account.utils import (
     check_provider_url_allowed,
     validate_provider_url,
-    validate_provider_url_optional,
 )
 
 # ---------------------------------------------------------------------------
@@ -100,9 +99,6 @@ NonEmptyStr = Annotated[str, AfterValidator(_strip_nonempty)]
 ValidatedUrl = Annotated[str, AfterValidator(validate_provider_url)]
 """URL type that enforces HTTPS and normalizes."""
 
-ValidatedUrlOptional = Annotated[str | None, AfterValidator(validate_provider_url_optional)]
-"""Optional URL type that enforces HTTPS and normalizes (None passes through)."""
-
 
 def _validate_flow_version_ids(values: list[str] | None) -> list[str] | None:
     """AfterValidator for optional flow_version_ids query parameter."""
@@ -147,12 +143,12 @@ class DeploymentProviderAccountCreateRequest(BaseModel):
             "User-chosen display name for this provider account. Must be unique per user within a provider_key."
         ),
     )
-    provider_tenant_id: NonEmptyStr | None = Field(
+    tenant_id: NonEmptyStr | None = Field(
         default=None,
         description="Provider-owned tenant/organization id. Langflow persists this opaque value.",
     )
     provider_key: DeploymentProviderKey = Field(description="Deployment provider key.")
-    provider_url: ValidatedUrl = Field(
+    url: ValidatedUrl = Field(
         description="Provider service URL persisted in Langflow DB for provider-account resolution.",
     )
     provider_data: dict[str, Any] = Field(
@@ -166,7 +162,7 @@ class DeploymentProviderAccountCreateRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_provider_url_allowed(self) -> DeploymentProviderAccountCreateRequest:
-        check_provider_url_allowed(self.provider_url, self.provider_key)
+        check_provider_url_allowed(self.url, self.provider_key)
         return self
 
 
@@ -176,14 +172,6 @@ class DeploymentProviderAccountUpdateRequest(BaseModel):
     name: NonEmptyStr | None = Field(
         default=None,
         description="User-chosen display name. Omit to keep existing value; cannot be set to null.",
-    )
-    provider_tenant_id: NonEmptyStr | None = Field(
-        default=None,
-        description="Provider-owned tenant/organization id. Omit to keep existing value, null to clear.",
-    )
-    provider_url: ValidatedUrlOptional = Field(
-        default=None,
-        description="Provider service URL. Omit to keep existing value; cannot be set to null.",
     )
     provider_data: dict[str, Any] | None = Field(
         default=None,
@@ -199,30 +187,22 @@ class DeploymentProviderAccountUpdateRequest(BaseModel):
         if not self.model_fields_set:
             msg = "At least one field must be provided for update."
             raise ValueError(msg)
-        for field_name in ("name", "provider_url", "provider_data"):
+        for field_name in ("name", "provider_data"):
             if field_name in self.model_fields_set and getattr(self, field_name) is None:
                 msg = f"'{field_name}' cannot be set to null."
                 raise ValueError(msg)
-        return self
-
-    def validate_provider_url_allowed(
-        self,
-        provider_key: DeploymentProviderKey,
-    ) -> DeploymentProviderAccountUpdateRequest:
-        if "provider_url" in self.model_fields_set and self.provider_url is not None:
-            check_provider_url_allowed(self.provider_url, provider_key)
         return self
 
 
 class DeploymentProviderAccountGetResponse(BaseModel):
     id: UUID = Field(description="Langflow DB provider-account UUID (`deployment_provider_account.id`).")
     name: str = Field(description="User-chosen display name for this provider account.")
-    provider_tenant_id: str | None = Field(
+    tenant_id: str | None = Field(
         default=None,
         description="Provider-owned tenant/organization identifier persisted as opaque text.",
     )
     provider_key: DeploymentProviderKey = Field(description="Official provider name used by Langflow.")
-    provider_url: str = Field(description="Provider service URL persisted in Langflow DB.")
+    url: str = Field(description="Provider service URL persisted in Langflow DB.")
     created_at: datetime | None = Field(default=None, description="Langflow DB row creation timestamp.")
     updated_at: datetime | None = Field(default=None, description="Langflow DB row update timestamp.")
 

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -353,9 +353,13 @@ class DeploymentFlowVersionListResponse(_PaginatedResponse):
 class DeploymentCreateResponse(_DeploymentResponseWithProviderData):
     """API response for deployment creation."""
 
+    resource_key: str = Field(description="Langflow-persisted stable provider resource identifier.")
+
 
 class DeploymentUpdateResponse(_DeploymentResponseWithProviderData):
     """API response for deployment update."""
+
+    resource_key: str = Field(description="Langflow-persisted stable provider resource identifier.")
 
 
 class DeploymentStatusResponse(_DeploymentResponseWithProviderData):

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/config.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/config.py
@@ -6,8 +6,6 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-logger = logging.getLogger(__name__)
-
 from ibm_watsonx_orchestrate_core.types.connections import (
     ConnectionConfiguration,
     ConnectionEnvironment,
@@ -22,6 +20,8 @@ from lfx.services.adapters.deployment.schema import ConfigItem, DeploymentConfig
 
 from langflow.services.adapters.deployment.watsonx_orchestrate.client import resolve_runtime_credentials
 from langflow.services.adapters.deployment.watsonx_orchestrate.utils import validate_wxo_name
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ibm_watsonx_orchestrate_clients.connections.connections_client import ConnectionsClient, GetConnectionResponse
@@ -157,5 +157,9 @@ async def validate_connection(connections_client: ConnectionsClient, *, app_id: 
         msg = f"Connection '{app_id}' is missing draft runtime credentials."
         raise InvalidContentError(message=msg)
 
-    logger.debug("validate_connection: passed for app_id='%s', connection_id='%s'", app_id, getattr(connection, 'connection_id', 'unknown'))
+    logger.debug(
+        "validate_connection: passed for app_id='%s', connection_id='%s'",
+        app_id,
+        getattr(connection, "connection_id", "unknown"),
+    )
     return connection

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
@@ -569,6 +569,31 @@ class WatsonxSnapshotConnectionsProviderData(BaseModel):
     connections: dict[NormalizedId, NormalizedId] = Field(default_factory=dict)
 
 
+class WatsonxConfigListResultData(BaseModel):
+    """Provider-result metadata contract for config listing.
+
+    ``deployment_id`` is present for deployment-scoped listings and absent for
+    tenant-scoped listings.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    deployment_id: NormalizedId | None = None
+    tool_ids: list[NormalizedId] | None = None
+
+
+class WatsonxSnapshotListResultData(BaseModel):
+    """Provider-result metadata contract for snapshot listing.
+
+    ``deployment_id`` is present for deployment-scoped listings and absent for
+    tenant-scoped listings.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    deployment_id: NormalizedId | None = None
+
+
 class WatsonxProviderUpdateApplyResult(BaseModel):
     """Public adapter contract for update helper apply results.
 
@@ -622,5 +647,7 @@ PAYLOAD_SCHEMAS = DeploymentPayloadSchemas(
     execution_create_result=PayloadSlot(WatsonxAgentExecutionResultData),
     execution_status_result=PayloadSlot(WatsonxAgentExecutionResultData),
     deployment_llm_list_result=PayloadSlot(WatsonxDeploymentLlmListResultData),
+    config_list_result=PayloadSlot(WatsonxConfigListResultData),
+    snapshot_list_result=PayloadSlot(WatsonxSnapshotListResultData),
     verify_credentials=PayloadSlot(WatsonxVerifyCredentialsPayload),
 )

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
@@ -328,9 +328,6 @@ class WatsonxDeploymentUpdatePayload(BaseModel):
                 msg = "put_tools is a standalone full replacement and cannot be combined with other fields."
                 raise ValueError(msg)
             return self
-        if self.llm is None:
-            msg = "llm is required for deployment update operations."
-            raise ValueError(msg)
         if not self.operations:
             has_connections = self.connections.raw_payloads
             if has_connections:
@@ -343,6 +340,8 @@ class WatsonxDeploymentUpdatePayload(BaseModel):
             #   (connectionless-tool flow). The plan builder auto-creates
             #   entries for all declared raw_payloads even without explicit
             #   bind/attach_tool operations referencing them.
+            # - empty/no-op provider_data can pass schema validation; the
+            #   service layer rejects it when there are no spec updates.
             return self
         return self
 

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -358,7 +358,7 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                     data=agent,
                     deployment_type=DeploymentType.AGENT,
                     provider_data={
-                        "snapshot_ids": extract_agent_tool_ids(agent),
+                        "tool_ids": extract_agent_tool_ids(agent),
                         "environment": derive_agent_environment(agent),
                     },
                 )

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -740,26 +740,12 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                 )
 
             configs: list[ConfigListItem] = []
-            seen_ids: set[str] = set()
             for connection in raw_connections or []:
                 if not isinstance(connection, ListConfigsResponse):
-                    logger.debug(
-                        "list_configs: skipping unexpected connection entry type: %s",
-                        type(connection).__name__,
-                    )
-                    continue
-                config_id = str(connection.connection_id or "").strip()
-                config_name = str(connection.app_id or "").strip()
-                if not config_id or not config_name:
-                    logger.debug(
-                        "list_configs: skipping config with missing connection_id/app_id: connection_id=%s app_id=%s",
-                        connection.connection_id,
-                        connection.app_id,
-                    )
-                    continue
-                if config_id in seen_ids:
-                    continue
-                seen_ids.add(config_id)
+                    msg = f"wxO list_configs returned an unexpected connection entry type: {type(connection).__name__}."
+                    raise InvalidContentError(message=msg)
+                config_id = connection.connection_id
+                config_name = connection.app_id
                 config_type = self._normalize_optional_text(connection.security_scheme)
                 configs.append(
                     self._build_config_list_item(
@@ -817,14 +803,7 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             if not connections:
                 continue
             for app_id, connection_id in connections.items():
-                normalized_app_id = str(app_id).strip()
-                normalized_connection_id = str(connection_id).strip()
-                if not normalized_app_id:
-                    continue
-                app_to_connection_id.setdefault(
-                    normalized_app_id,
-                    normalized_connection_id or normalized_app_id,
-                )
+                app_to_connection_id.setdefault(app_id, connection_id)
 
         connection_type_by_id: dict[str, str] = {}
         connection_ids = dedupe_list(
@@ -842,7 +821,7 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                 for connection in detailed_connections or []:
                     if not isinstance(connection, ListConfigsResponse):
                         continue
-                    connection_id = str(connection.connection_id or "").strip()
+                    connection_id = connection.connection_id
                     if not connection_id:
                         continue
                     config_type = self._normalize_optional_text(connection.security_scheme)

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -961,15 +961,14 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             for tool in (tools or [])
             if isinstance(tool, dict) and tool.get("id")
         ]
-        if not snapshots and requested_tool_ids:
-            snapshots = [
-                SnapshotItem(
-                    id=tool_id,
-                    name=tool_id,
-                    provider_data=self._validate_snapshot_item_provider_data({"connections": {}}),
-                )
-                for tool_id in requested_tool_ids
-            ]
+        resolved_ids = {s.id for s in snapshots}
+        stale_ids = [tid for tid in requested_tool_ids if tid not in resolved_ids]
+        if stale_ids:
+            logger.warning(
+                "list_snapshots: agent '%s' references tool IDs that no longer exist on the provider: %s",
+                agent_id,
+                stale_ids,
+            )
 
         return SnapshotListResult(
             snapshots=snapshots,

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
 from ibm_cloud_sdk_core import ApiException
+from ibm_watsonx_orchestrate_clients.connections.connections_client import ListConfigsResponse
 from ibm_watsonx_orchestrate_clients.tools.tool_client import ClientAPIException
 from lfx.services.adapters.deployment.base import BaseDeploymentService
 from lfx.services.adapters.deployment.exceptions import (
@@ -138,6 +139,49 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             raise RuntimeError(msg)
         self.settings_service = settings_service
         self.set_ready()
+
+    @staticmethod
+    def _build_config_list_item(
+        *,
+        connection_id: str,
+        app_id: str,
+        config_type: str | None = None,
+    ) -> ConfigListItem:
+        """Build a normalized config list item from resolved identifiers."""
+        provider_data = {"type": config_type} if config_type else None
+        return ConfigListItem(
+            id=connection_id,
+            name=app_id,
+            provider_data=provider_data,
+        )
+
+    @staticmethod
+    def _normalize_optional_text(value: object | None) -> str | None:
+        """Normalize SDK scalar/enum/tuple values to optional text.
+
+        Guards against two quirks in the upstream SDK model definitions:
+
+        * **Tuple defaults** - Several ``ListConfigsResponse`` fields are
+          declared with trailing commas (e.g. ``security_scheme: ... = None,``)
+          which makes the Python default ``(None,)`` instead of ``None``.
+          Pydantic coerces this away when the field *is* supplied, but we
+          unwrap single-element tuples defensively in case a future SDK
+          version or edge case surfaces the raw default.
+        * **str-Enum coercion** - ``ConnectionSecurityScheme(str, Enum)``
+          inherits from ``str``, yet ``str()`` returns the class-qualified
+          name (``"ConnectionSecurityScheme.KEY_VALUE"``) in Python 3.11+.
+          Extracting ``.value`` yields the raw string we need.
+        """
+        if isinstance(value, tuple):
+            if len(value) == 1:
+                value = value[0]
+            else:
+                logger.debug("_normalize_optional_text: ignoring multi-element tuple: %s", value)
+                return None
+        if hasattr(value, "value"):
+            value = value.value
+        normalized = str(value or "").strip()
+        return normalized or None
 
     async def _get_provider_clients(self, *, user_id: IdLike, db: AsyncSession) -> WxOClient:
         """Resolve provider clients through a service-level seam.
@@ -698,26 +742,30 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             configs: list[ConfigListItem] = []
             seen_ids: set[str] = set()
             for connection in raw_connections or []:
-                if isinstance(connection, dict):
-                    conn_dict = connection
-                elif hasattr(connection, "model_dump"):
-                    conn_dict = connection.model_dump()
-                else:
+                if not isinstance(connection, ListConfigsResponse):
+                    logger.debug(
+                        "list_configs: skipping unexpected connection entry type: %s",
+                        type(connection).__name__,
+                    )
                     continue
-                config_id = str(conn_dict.get("app_id") or conn_dict.get("id") or "").strip()
-                if not config_id or config_id in seen_ids:
+                config_id = str(connection.connection_id or "").strip()
+                config_name = str(connection.app_id or "").strip()
+                if not config_id or not config_name:
+                    logger.debug(
+                        "list_configs: skipping config with missing connection_id/app_id: connection_id=%s app_id=%s",
+                        connection.connection_id,
+                        connection.app_id,
+                    )
+                    continue
+                if config_id in seen_ids:
                     continue
                 seen_ids.add(config_id)
-                config_name = (
-                    str(conn_dict.get("name") or conn_dict.get("display_name") or config_id).strip() or config_id
-                )
+                config_type = self._normalize_optional_text(connection.security_scheme)
                 configs.append(
-                    ConfigListItem(
-                        id=config_id,
-                        name=config_name,
-                        created_at=conn_dict.get("created_at"),
-                        updated_at=conn_dict.get("updated_at"),
-                        provider_data=conn_dict,
+                    self._build_config_list_item(
+                        connection_id=config_id,
+                        app_id=config_name,
+                        config_type=config_type,
                     )
                 )
             return ConfigListResult(
@@ -761,17 +809,59 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                 log_msg="Unexpected error while listing wxO tools for config extraction",
             )
 
-        app_ids: set[str] = set()
+        app_to_connection_id: dict[str, str] = {}
         for tool in tools or []:
             if not isinstance(tool, dict):
                 continue
             connections = extract_langflow_connections_binding(tool)
             if not connections:
                 continue
-            app_ids.update(connections.keys())
+            for app_id, connection_id in connections.items():
+                normalized_app_id = str(app_id).strip()
+                normalized_connection_id = str(connection_id).strip()
+                if not normalized_app_id:
+                    continue
+                app_to_connection_id.setdefault(
+                    normalized_app_id,
+                    normalized_connection_id or normalized_app_id,
+                )
+
+        connection_type_by_id: dict[str, str] = {}
+        connection_ids = dedupe_list(
+            [connection_id for connection_id in app_to_connection_id.values() if connection_id]
+        )
+        if connection_ids:
+            try:
+                detailed_connections = await asyncio.to_thread(clients.connections.get_drafts_by_ids, connection_ids)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "list_configs: failed to enrich deployment configs with connection types",
+                    exc_info=exc,
+                )
+            else:
+                for connection in detailed_connections or []:
+                    if not isinstance(connection, ListConfigsResponse):
+                        continue
+                    connection_id = str(connection.connection_id or "").strip()
+                    if not connection_id:
+                        continue
+                    config_type = self._normalize_optional_text(connection.security_scheme)
+                    if config_type:
+                        connection_type_by_id[connection_id] = config_type
+
+        # Preserve first-seen binding order (tool order + per-tool connection order)
+        # instead of re-sorting app_ids alphabetically.
+        configs = [
+            self._build_config_list_item(
+                connection_id=connection_id,
+                app_id=app_id,
+                config_type=connection_type_by_id.get(connection_id),
+            )
+            for app_id, connection_id in app_to_connection_id.items()
+        ]
 
         return ConfigListResult(
-            configs=[ConfigListItem(id=app_id, name=app_id) for app_id in app_ids],
+            configs=configs,
             provider_result=self.payload_schemas.config_list_result.parse({"deployment_id": agent_id}).model_dump(
                 exclude_none=True
             ),

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -713,12 +713,11 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                         name=config_name,
                         created_at=connection.get("created_at"),
                         updated_at=connection.get("updated_at"),
-                        provider_data=connection,
                     )
                 )
             return ConfigListResult(
                 configs=configs,
-                provider_result={"scope": "tenant"},
+                provider_result=self.payload_schemas.config_list_result.parse({}).model_dump(exclude_none=True),
             )
 
         agent_id = _require_single_deployment_id(params, resource_label="config")
@@ -741,7 +740,9 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
         if not tool_ids:
             return ConfigListResult(
                 configs=[],
-                provider_result={"deployment_id": agent_id, "tool_ids": []},
+                provider_result=self.payload_schemas.config_list_result.parse(
+                    {"deployment_id": agent_id, "tool_ids": []}
+                ).model_dump(exclude_none=True),
             )
 
         tools: list[dict]
@@ -766,7 +767,9 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
 
         return ConfigListResult(
             configs=[ConfigListItem(id=app_id, name=app_id) for app_id in app_ids],
-            provider_result={"deployment_id": agent_id},
+            provider_result=self.payload_schemas.config_list_result.parse({"deployment_id": agent_id}).model_dump(
+                exclude_none=True
+            ),
         )
 
     async def list_snapshots(
@@ -822,7 +825,7 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             ]
             return SnapshotListResult(
                 snapshots=snapshots,
-                provider_result={"scope": "tenant"},
+                provider_result=self.payload_schemas.snapshot_list_result.parse({}).model_dump(exclude_none=True),
             )
 
         agent_id = _require_single_deployment_id(params, resource_label="snapshot")
@@ -875,7 +878,9 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
 
         return SnapshotListResult(
             snapshots=snapshots,
-            provider_result={"deployment_id": agent_id},
+            provider_result=self.payload_schemas.snapshot_list_result.parse({"deployment_id": agent_id}).model_dump(
+                exclude_none=True
+            ),
         )
 
     async def _list_snapshots_by_ids(

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/utils.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/utils.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from lfx.services.adapters.deployment.schema import (
-        BaseDeploymentData,
         ConfigListParams,
         SnapshotListParams,
     )
@@ -158,25 +157,6 @@ def raise_as_deployment_error(
     logger.exception(log_msg)
     msg = f"{error_prefix.value} Please check server logs for details."
     raise DeploymentError(message=msg, error_code="deployment_error") from exc
-
-
-def build_agent_payload(
-    *,
-    data: BaseDeploymentData,
-    tool_ids: Sequence[str],
-    llm: str,
-) -> dict[str, Any]:
-    if data.provider_spec is None:
-        msg = "Deployment data must include provider_spec with a non-empty name and display_name."
-        raise InvalidContentError(message=msg)
-    return build_agent_payload_from_values(
-        agent_name=str(data.provider_spec["name"]),
-        agent_display_name=str(data.provider_spec["display_name"]),
-        deployment_name=str(data.name),
-        description=str(data.description or ""),
-        tool_ids=tool_ids,
-        llm=llm,
-    )
 
 
 def build_agent_payload_from_values(

--- a/src/backend/base/langflow/services/database/models/deployment/crud.py
+++ b/src/backend/base/langflow/services/database/models/deployment/crud.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from lfx.log.logger import logger
+from lfx.services.adapters.deployment.schema import DEPLOYMENT_DESCRIPTION_MAX_LENGTH
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, delete, func, select
 
@@ -29,6 +30,14 @@ def _strip_or_raise(value: str, field_name: str) -> str:
     return stripped
 
 
+def _validate_description_max_length(description: str | None) -> str | None:
+    """Reject descriptions that exceed the deployment max length."""
+    if description is not None and len(description) > DEPLOYMENT_DESCRIPTION_MAX_LENGTH:
+        msg = f"description must be at most {DEPLOYMENT_DESCRIPTION_MAX_LENGTH} characters"
+        raise ValueError(msg)
+    return description
+
+
 async def create_deployment(
     db: AsyncSession,
     *,
@@ -42,6 +51,7 @@ async def create_deployment(
 ) -> Deployment:
     resource_key_s = _strip_or_raise(resource_key, "resource_key")
     name_s = _strip_or_raise(name, "name")
+    description_s = _validate_description_max_length(description)
 
     row = Deployment(
         user_id=user_id,
@@ -50,7 +60,7 @@ async def create_deployment(
         resource_key=resource_key_s,
         name=name_s,
         deployment_type=deployment_type,
-        description=description,
+        description=description_s,
     )
     db.add(row)
     try:
@@ -127,7 +137,7 @@ async def update_deployment(
     if deployment_type is not _UNSET:
         deployment.deployment_type = deployment_type  # type: ignore[assignment]
     if description is not _UNSET:
-        deployment.description = description  # type: ignore[assignment]
+        deployment.description = _validate_description_max_length(description)  # type: ignore[assignment]
     deployment.updated_at = datetime.now(timezone.utc)
     db.add(deployment)
     try:

--- a/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
+++ b/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
@@ -71,15 +71,19 @@ async def list_deployment_attachments(
     *,
     user_id: UUID,
     deployment_id: UUID,
+    flow_ids: list[UUID] | None = None,
 ) -> list[FlowVersionDeploymentAttachment]:
-    stmt = (
-        select(FlowVersionDeploymentAttachment)
-        .where(
-            FlowVersionDeploymentAttachment.user_id == user_id,
-            FlowVersionDeploymentAttachment.deployment_id == deployment_id,
-        )
-        .order_by(FlowVersionDeploymentAttachment.created_at)
+    stmt = select(FlowVersionDeploymentAttachment).where(
+        FlowVersionDeploymentAttachment.user_id == user_id,
+        FlowVersionDeploymentAttachment.deployment_id == deployment_id,
     )
+    if flow_ids:
+        from langflow.services.database.models.flow_version.model import FlowVersion
+
+        stmt = stmt.join(FlowVersion, FlowVersion.id == FlowVersionDeploymentAttachment.flow_version_id).where(
+            col(FlowVersion.flow_id).in_(flow_ids),
+        )
+    stmt = stmt.order_by(FlowVersionDeploymentAttachment.created_at)
     return list((await db.exec(stmt)).all())
 
 
@@ -90,6 +94,7 @@ async def list_deployment_attachments_with_versions(
     deployment_id: UUID,
     offset: int,
     limit: int,
+    flow_ids: list[UUID] | None = None,
 ) -> list[tuple[FlowVersionDeploymentAttachment, FlowVersion, str | None]]:
     """Return paginated attachment rows joined with version metadata and flow name."""
     from langflow.services.database.models.flow.model import Flow
@@ -106,7 +111,11 @@ async def list_deployment_attachments_with_versions(
             FlowVersionDeploymentAttachment.user_id == user_id,
             FlowVersionDeploymentAttachment.deployment_id == deployment_id,
         )
-        .order_by(
+    )
+    if flow_ids:
+        stmt = stmt.where(col(FlowVersion.flow_id).in_(flow_ids))
+    stmt = (
+        stmt.order_by(
             col(FlowVersionDeploymentAttachment.created_at).desc(),
             col(FlowVersionDeploymentAttachment.updated_at).desc(),
         )
@@ -327,10 +336,21 @@ async def count_deployment_attachments(
     *,
     user_id: UUID,
     deployment_id: UUID,
+    flow_ids: list[UUID] | None = None,
 ) -> int:
-    stmt = select(func.count()).where(
-        FlowVersionDeploymentAttachment.user_id == user_id,
-        FlowVersionDeploymentAttachment.deployment_id == deployment_id,
+    stmt = (
+        select(func.count())
+        .select_from(FlowVersionDeploymentAttachment)
+        .where(
+            FlowVersionDeploymentAttachment.user_id == user_id,
+            FlowVersionDeploymentAttachment.deployment_id == deployment_id,
+        )
     )
+    if flow_ids:
+        from langflow.services.database.models.flow_version.model import FlowVersion
+
+        stmt = stmt.join(FlowVersion, FlowVersion.id == FlowVersionDeploymentAttachment.flow_version_id).where(
+            col(FlowVersion.flow_id).in_(flow_ids),
+        )
     total = (await db.exec(stmt)).one()
     return int(total or 0)

--- a/src/backend/tests/unit/api/v1/test_deployment_description_and_type.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_description_and_type.py
@@ -12,9 +12,18 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from uuid import uuid4
 
+import pytest
 from langflow.api.v1.mappers.deployments.base import BaseDeploymentMapper
 from langflow.services.database.models.deployment.model import Deployment, DeploymentRead
-from lfx.services.adapters.deployment.schema import DeploymentCreateResult, DeploymentType, DeploymentUpdateResult
+from lfx.services.adapters.deployment.schema import (
+    DEPLOYMENT_DESCRIPTION_MAX_LENGTH,
+    BaseDeploymentData,
+    BaseDeploymentDataUpdate,
+    DeploymentCreateResult,
+    DeploymentType,
+    DeploymentUpdateResult,
+)
+from pydantic import ValidationError
 
 # ---------------------------------------------------------------------------
 # Model-level tests
@@ -89,6 +98,20 @@ class TestDeploymentModel:
         )
         assert read.description is None
         assert read.deployment_type == DeploymentType.AGENT
+
+
+class TestAdapterDescriptionValidation:
+    def test_create_payload_rejects_description_over_max_length(self):
+        with pytest.raises(ValidationError, match="at most"):
+            BaseDeploymentData(
+                name="test",
+                description="x" * (DEPLOYMENT_DESCRIPTION_MAX_LENGTH + 1),
+                type=DeploymentType.AGENT,
+            )
+
+    def test_update_payload_rejects_description_over_max_length(self):
+        with pytest.raises(ValidationError, match="at most"):
+            BaseDeploymentDataUpdate(description="x" * (DEPLOYMENT_DESCRIPTION_MAX_LENGTH + 1))
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/api/v1/test_deployment_description_and_type.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_description_and_type.py
@@ -2,7 +2,7 @@
 
 Covers:
 - Model: Deployment and DeploymentRead require DeploymentType enum and accept description
-- API responses: to_deployment_create_response surfaces persisted description
+- API responses: shape_deployment_create_result surfaces persisted description
 - Mapper: shape_deployment_update_result reads description from the DB row
 """
 
@@ -13,7 +13,6 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 from langflow.api.v1.mappers.deployments.base import BaseDeploymentMapper
-from langflow.api.v1.mappers.deployments.helpers import to_deployment_create_response
 from langflow.services.database.models.deployment.model import Deployment, DeploymentRead
 from lfx.services.adapters.deployment.schema import DeploymentCreateResult, DeploymentType, DeploymentUpdateResult
 
@@ -93,15 +92,18 @@ class TestDeploymentModel:
 
 
 # ---------------------------------------------------------------------------
-# to_deployment_create_response tests
+# shape_deployment_create_result tests
 # ---------------------------------------------------------------------------
 
 
 class TestCreateResponse:
     def test_surfaces_description_from_db_row(self):
+        mapper = BaseDeploymentMapper()
         now = datetime.now(timezone.utc)
+        provider_account_id = uuid4()
         row = SimpleNamespace(
             id=uuid4(),
+            deployment_provider_account_id=provider_account_id,
             name="deploy",
             description="my description",
             deployment_type=DeploymentType.AGENT,
@@ -109,13 +111,18 @@ class TestCreateResponse:
             updated_at=now,
         )
         result = DeploymentCreateResult(id="prov-1")
-        response = to_deployment_create_response(result, row)
+        response = mapper.shape_deployment_create_result(result, row, provider_key="test-provider")
         assert response.description == "my description"
+        assert response.provider_id == provider_account_id
+        assert response.provider_key == "test-provider"
 
     def test_description_none_when_not_set(self):
+        mapper = BaseDeploymentMapper()
         now = datetime.now(timezone.utc)
+        provider_account_id = uuid4()
         row = SimpleNamespace(
             id=uuid4(),
+            deployment_provider_account_id=provider_account_id,
             name="deploy",
             description=None,
             deployment_type=DeploymentType.AGENT,
@@ -123,13 +130,18 @@ class TestCreateResponse:
             updated_at=now,
         )
         result = DeploymentCreateResult(id="prov-1")
-        response = to_deployment_create_response(result, row)
+        response = mapper.shape_deployment_create_result(result, row, provider_key="test-provider")
         assert response.description is None
+        assert response.provider_id == provider_account_id
+        assert response.provider_key == "test-provider"
 
     def test_uses_enum_type_from_row(self):
+        mapper = BaseDeploymentMapper()
         now = datetime.now(timezone.utc)
+        provider_account_id = uuid4()
         row = SimpleNamespace(
             id=uuid4(),
+            deployment_provider_account_id=provider_account_id,
             name="deploy",
             description=None,
             deployment_type=DeploymentType.AGENT,
@@ -137,8 +149,10 @@ class TestCreateResponse:
             updated_at=now,
         )
         result = DeploymentCreateResult(id="prov-1")
-        response = to_deployment_create_response(result, row)
+        response = mapper.shape_deployment_create_result(result, row, provider_key="test-provider")
         assert response.type == DeploymentType.AGENT
+        assert response.provider_id == provider_account_id
+        assert response.provider_key == "test-provider"
 
 
 # ---------------------------------------------------------------------------
@@ -150,8 +164,10 @@ class TestMapperUpdateResult:
     def test_reads_description_from_row(self):
         mapper = BaseDeploymentMapper()
         now = datetime.now(timezone.utc)
+        provider_account_id = uuid4()
         row = SimpleNamespace(
             id=uuid4(),
+            deployment_provider_account_id=provider_account_id,
             name="deploy",
             description="persisted desc",
             deployment_type=DeploymentType.AGENT,
@@ -159,15 +175,19 @@ class TestMapperUpdateResult:
             updated_at=now,
         )
         result = DeploymentUpdateResult(id="prov-1", provider_result={"ok": True})
-        shaped = mapper.shape_deployment_update_result(result, row)
+        shaped = mapper.shape_deployment_update_result(result, row, provider_key="test-provider")
         assert shaped.description == "persisted desc"
         assert shaped.type == DeploymentType.AGENT
+        assert shaped.provider_id == provider_account_id
+        assert shaped.provider_key == "test-provider"
 
     def test_description_none_from_row(self):
         mapper = BaseDeploymentMapper()
         now = datetime.now(timezone.utc)
+        provider_account_id = uuid4()
         row = SimpleNamespace(
             id=uuid4(),
+            deployment_provider_account_id=provider_account_id,
             name="deploy",
             description=None,
             deployment_type=DeploymentType.AGENT,
@@ -175,8 +195,10 @@ class TestMapperUpdateResult:
             updated_at=now,
         )
         result = DeploymentUpdateResult(id="prov-1")
-        shaped = mapper.shape_deployment_update_result(result, row)
+        shaped = mapper.shape_deployment_update_result(result, row, provider_key="test-provider")
         assert shaped.description is None
+        assert shaped.provider_id == provider_account_id
+        assert shaped.provider_key == "test-provider"
 
     def test_no_description_kwarg_needed(self):
         """Signature no longer accepts a description keyword argument."""

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
@@ -202,7 +202,7 @@ async def test_base_mapper_resolve_deployment_create_validates_provider_data_whe
     payload = DeploymentCreateRequest(
         provider_id=uuid4(),
         spec={"name": "create-deploy", "description": "", "type": "agent"},
-        provider_data={"some_key": "some_value"},
+        provider_data={"label": "some_value"},
     )
 
     resolved = await mapper.resolve_deployment_create(
@@ -212,7 +212,7 @@ async def test_base_mapper_resolve_deployment_create_validates_provider_data_whe
         payload=payload,
     )
 
-    assert resolved.provider_data == {"some_key": "some_value"}
+    assert resolved.provider_data == {"label": "some_value"}
 
 
 @pytest.mark.asyncio
@@ -347,7 +347,6 @@ def test_mapper_has_shape_method_for_all_outbound_slots() -> None:
 @pytest.mark.parametrize(
     "method_name",
     [
-        "shape_deployment_create_result",
         "shape_deployment_operation_result",
         "shape_deployment_item_data",
         "shape_deployment_status_data",
@@ -359,6 +358,28 @@ def test_base_mapper_shapers_passthrough_provider_payload(method_name: str) -> N
     shaper = getattr(mapper, method_name)
     shaped = shaper(payload)
     assert shaped is payload
+
+
+def test_base_mapper_shapes_deployment_create_result() -> None:
+    mapper = BaseDeploymentMapper()
+    timestamp = datetime.now(tz=timezone.utc)
+    deployment_id = uuid4()
+    result = DeploymentCreateResult(id="provider-id", provider_result={"ok": True})
+    deployment_row = SimpleNamespace(
+        id=deployment_id,
+        name="Deployment 1",
+        description="desc",
+        deployment_type=DeploymentType.AGENT,
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+
+    shaped = mapper.shape_deployment_create_result(result, deployment_row=deployment_row)
+
+    assert shaped.id == deployment_id
+    assert shaped.name == "Deployment 1"
+    assert shaped.type == DeploymentType.AGENT
+    assert shaped.provider_data == {"ok": True}
 
 
 def test_base_mapper_shapes_deployment_list_result() -> None:
@@ -377,12 +398,8 @@ def test_base_mapper_shapes_deployment_list_result() -> None:
         ]
     )
 
-    shaped = mapper.shape_deployment_list_result(
-        result,
-        deployment_type=DeploymentType.AGENT,
-    )
+    shaped = mapper.shape_deployment_list_result(result)
 
-    assert shaped.deployment_type == DeploymentType.AGENT
     assert shaped.page == 1
     assert shaped.size == 1
     assert shaped.total == 1
@@ -604,17 +621,14 @@ def test_base_mapper_shapes_execution_status_result_with_none_execution_id() -> 
 
 def test_base_mapper_exposes_reconciliation_resolvers() -> None:
     mapper = BaseDeploymentMapper()
-    add_id = uuid4()
-    remove_id = uuid4()
     payload = DeploymentUpdateRequest(
-        add_flow_version_ids=[add_id],
-        remove_flow_version_ids=[remove_id],
+        provider_data={"operations": []},
     )
     patch = mapper.util_flow_version_patch(payload)
     assert isinstance(patch, FlowVersionPatch)
     add_ids, remove_ids = patch.add_flow_version_ids, patch.remove_flow_version_ids
-    assert add_ids == [add_id]
-    assert remove_ids == [remove_id]
+    assert add_ids == []
+    assert remove_ids == []
 
     create_result = DeploymentCreateResult(
         id="provider-id",

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
@@ -410,13 +410,13 @@ def test_base_mapper_shapes_deployment_list_result() -> None:
     assert shaped.provider_data == {
         "entries": [
             {
-                "resource_key": "dep-1",
+                "id": "dep-1",
                 "name": "Deployment 1",
                 "type": DeploymentType.AGENT,
                 "description": None,
                 "created_at": timestamp,
                 "updated_at": timestamp,
-                "provider_data": {"ok": True},
+                "ok": True,
             }
         ]
     }
@@ -490,7 +490,7 @@ def test_base_mapper_flow_version_item_data_defaults_to_none() -> None:
 
 
 def test_shape_deployment_list_items_without_filter() -> None:
-    """Without a flow filter, matched_attachments is None."""
+    """Without a flow filter, flow_version_ids is omitted."""
     mapper = BaseDeploymentMapper()
     provider_account_id = uuid4()
     row = SimpleNamespace(
@@ -511,11 +511,11 @@ def test_shape_deployment_list_items_without_filter() -> None:
     assert len(items) == 1
     assert items[0].provider_id == provider_account_id
     assert items[0].provider_key == "test-provider"
-    assert items[0].matched_attachments is None
+    assert items[0].flow_version_ids is None
 
 
 def test_shape_deployment_list_items_with_filter() -> None:
-    """With a flow filter, matched_attachments is populated from matched tuples."""
+    """With a flow filter, flow_version_ids is populated from matched tuples."""
     mapper = BaseDeploymentMapper()
     fv_id = uuid4()
     provider_account_id = uuid4()
@@ -537,14 +537,11 @@ def test_shape_deployment_list_items_with_filter() -> None:
     assert len(items) == 1
     assert items[0].provider_id == provider_account_id
     assert items[0].provider_key == "test-provider"
-    assert items[0].matched_attachments is not None
-    assert len(items[0].matched_attachments) == 1
-    assert items[0].matched_attachments[0].flow_version_id == fv_id
-    assert items[0].matched_attachments[0].provider_snapshot_id == "snap-1"
+    assert items[0].flow_version_ids == [fv_id]
 
 
 def test_shape_deployment_list_items_with_filter_empty_matches() -> None:
-    """With a flow filter active but no matches, matched_attachments is an empty list."""
+    """With a flow filter active but no matches, flow_version_ids is empty."""
     mapper = BaseDeploymentMapper()
     provider_account_id = uuid4()
     row = SimpleNamespace(
@@ -565,7 +562,7 @@ def test_shape_deployment_list_items_with_filter_empty_matches() -> None:
     assert len(items) == 1
     assert items[0].provider_id == provider_account_id
     assert items[0].provider_key == "test-provider"
-    assert items[0].matched_attachments == []
+    assert items[0].flow_version_ids == []
 
 
 def test_base_mapper_execution_provider_data_shapers_passthrough() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
@@ -570,6 +570,14 @@ def test_base_mapper_execution_provider_data_shapers_passthrough() -> None:
     assert mapper.shape_execution_status_provider_data(payload) is payload
 
 
+def test_base_mapper_formats_conflict_detail_with_generic_fallback() -> None:
+    mapper = BaseDeploymentMapper()
+
+    detail = mapper.format_conflict_detail("provider conflict detail")
+
+    assert detail == "A resource with this name already exists in the provider. provider conflict detail"
+
+
 def test_base_mapper_shapes_deployment_update_result() -> None:
     mapper = BaseDeploymentMapper()
     deployment_id = uuid4()

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
@@ -371,6 +371,7 @@ def test_base_mapper_shapes_deployment_create_result() -> None:
         name="Deployment 1",
         description="desc",
         deployment_type=DeploymentType.AGENT,
+        resource_key="provider-id",
         created_at=timestamp,
         updated_at=timestamp,
         deployment_provider_account_id=provider_account_id,
@@ -592,6 +593,7 @@ def test_base_mapper_shapes_deployment_update_result() -> None:
         name="Deployment Name",
         description="desc",
         deployment_type=DeploymentType.AGENT,
+        resource_key="provider-id",
         created_at=timestamp,
         updated_at=timestamp,
         deployment_provider_account_id=provider_account_id,
@@ -694,14 +696,14 @@ def test_base_mapper_resolve_provider_tenant_id_passthrough() -> None:
     assert (
         mapper.resolve_provider_tenant_id(
             provider_url="https://example.com/instances/abc",
-            tenant_id="tenant-1",
+            provider_data={"tenant_id": "tenant-1"},
         )
         == "tenant-1"
     )
     assert (
         mapper.resolve_provider_tenant_id(
             provider_url="https://example.com/instances/abc",
-            tenant_id=None,
+            provider_data={},
         )
         is None
     )
@@ -723,7 +725,7 @@ def test_base_mapper_shapes_provider_account_response() -> None:
     shaped = mapper.shape_provider_account_response(account)
     assert shaped.id == account.id
     assert shaped.name == "staging"
-    assert shaped.tenant_id == "tenant-1"
+    assert shaped.provider_data == {"tenant_id": "tenant-1"}
     assert shaped.provider_key == "watsonx-orchestrate"
     assert shaped.url == "https://provider.example"
 

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
@@ -691,14 +691,14 @@ def test_base_mapper_resolve_provider_tenant_id_passthrough() -> None:
     assert (
         mapper.resolve_provider_tenant_id(
             provider_url="https://example.com/instances/abc",
-            provider_tenant_id="tenant-1",
+            tenant_id="tenant-1",
         )
         == "tenant-1"
     )
     assert (
         mapper.resolve_provider_tenant_id(
             provider_url="https://example.com/instances/abc",
-            provider_tenant_id=None,
+            tenant_id=None,
         )
         is None
     )
@@ -720,9 +720,9 @@ def test_base_mapper_shapes_provider_account_response() -> None:
     shaped = mapper.shape_provider_account_response(account)
     assert shaped.id == account.id
     assert shaped.name == "staging"
-    assert shaped.provider_tenant_id == "tenant-1"
+    assert shaped.tenant_id == "tenant-1"
     assert shaped.provider_key == "watsonx-orchestrate"
-    assert shaped.provider_url == "https://provider.example"
+    assert shaped.url == "https://provider.example"
 
 
 def test_mapper_registry_returns_default_when_unregistered() -> None:
@@ -771,8 +771,8 @@ def test_mapper_registry_get_returns_cached_instance_for_key() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_base_mapper_resolve_verify_credentials_extracts_provider_url() -> None:
-    """Base mapper builds VerifyCredentials with provider_url only."""
+def test_base_mapper_resolve_verify_credentials_extracts_url() -> None:
+    """Base mapper builds VerifyCredentials with url only."""
     from langflow.api.v1.schemas.deployments import DeploymentProviderAccountCreateRequest
     from lfx.services.adapters.deployment.schema import VerifyCredentials
 
@@ -780,7 +780,7 @@ def test_base_mapper_resolve_verify_credentials_extracts_provider_url() -> None:
     payload = DeploymentProviderAccountCreateRequest(
         name="test-account",
         provider_key="watsonx-orchestrate",
-        provider_url="https://api.us-south.wxo.cloud.ibm.com",
+        url="https://api.us-south.wxo.cloud.ibm.com",
         provider_data={"api_key": "secret-key"},  # pragma: allowlist secret
     )
     result = mapper.resolve_verify_credentials(payload=payload)
@@ -821,36 +821,6 @@ def test_base_mapper_resolve_provider_account_update_name_only() -> None:
         existing_account=_make_existing_account(),
     )
     assert result == {"name": "new-name"}
-
-
-def test_base_mapper_resolve_provider_account_update_url_only() -> None:
-    """Only provider_url is set."""
-    from langflow.api.v1.schemas.deployments import DeploymentProviderAccountUpdateRequest
-
-    mapper = BaseDeploymentMapper()
-    payload = DeploymentProviderAccountUpdateRequest(
-        provider_url="https://api.eu-de.wxo.cloud.ibm.com/instances/new-tenant/agents",
-    )
-    result = mapper.resolve_provider_account_update(
-        payload=payload,
-        existing_account=_make_existing_account(),
-    )
-    assert "provider_url" in result
-    assert "name" not in result
-    assert "provider_tenant_id" not in result
-
-
-def test_base_mapper_resolve_provider_account_update_tenant_uses_existing_url() -> None:
-    """When only tenant is set, resolve uses existing_account.provider_url."""
-    from langflow.api.v1.schemas.deployments import DeploymentProviderAccountUpdateRequest
-
-    mapper = BaseDeploymentMapper()
-    payload = DeploymentProviderAccountUpdateRequest(provider_tenant_id="explicit-tenant")
-    result = mapper.resolve_provider_account_update(
-        payload=payload,
-        existing_account=_make_existing_account(),
-    )
-    assert result["provider_tenant_id"] == "explicit-tenant"
 
 
 def test_base_mapper_resolve_provider_account_update_provider_data_raises() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
@@ -180,7 +180,9 @@ async def test_base_mapper_resolve_deployment_create_passthrough_without_flow_ve
     mapper = BaseDeploymentMapper()
     payload = DeploymentCreateRequest(
         provider_id=uuid4(),
-        spec={"name": "create-deploy", "description": "", "type": "agent"},
+        name="create-deploy",
+        description="",
+        type="agent",
         provider_data={"some_key": "some_value"},
     )
 
@@ -201,7 +203,9 @@ async def test_base_mapper_resolve_deployment_create_validates_provider_data_whe
     mapper = _TypedMapper()
     payload = DeploymentCreateRequest(
         provider_id=uuid4(),
-        spec={"name": "create-deploy", "description": "", "type": "agent"},
+        name="create-deploy",
+        description="",
+        type="agent",
         provider_data={"label": "some_value"},
     )
 
@@ -220,7 +224,9 @@ async def test_base_mapper_resolve_deployment_create_rejects_invalid_provider_da
     mapper = _TypedMapper()
     payload = DeploymentCreateRequest(
         provider_id=uuid4(),
-        spec={"name": "create-deploy", "description": "", "type": "agent"},
+        name="create-deploy",
+        description="",
+        type="agent",
         provider_data={"invalid": "value"},
     )
 

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_base.py
@@ -283,8 +283,6 @@ async def test_base_mapper_resolve_deployment_update_rejects_invalid_provider_da
 async def test_base_mapper_resolve_execution_create_passthrough_when_slot_not_configured() -> None:
     mapper = BaseDeploymentMapper()
     payload = ExecutionCreateRequest(
-        provider_id=uuid4(),
-        deployment_id=uuid4(),
         provider_data={"invocation_id": "inv-1"},
     )
 
@@ -302,8 +300,6 @@ async def test_base_mapper_resolve_execution_create_passthrough_when_slot_not_co
 async def test_base_mapper_resolve_execution_create_validates_provider_data_when_slot_configured() -> None:
     mapper = _TypedMapper()
     payload = ExecutionCreateRequest(
-        provider_id=uuid4(),
-        deployment_id=uuid4(),
         provider_data={"invocation_id": "inv-1"},
     )
 
@@ -321,8 +317,6 @@ async def test_base_mapper_resolve_execution_create_validates_provider_data_when
 async def test_base_mapper_resolve_execution_create_rejects_invalid_provider_data_when_slot_configured() -> None:
     mapper = _TypedMapper()
     payload = ExecutionCreateRequest(
-        provider_id=uuid4(),
-        deployment_id=uuid4(),
         provider_data={"invalid": "value"},
     )
 
@@ -364,6 +358,7 @@ def test_base_mapper_shapes_deployment_create_result() -> None:
     mapper = BaseDeploymentMapper()
     timestamp = datetime.now(tz=timezone.utc)
     deployment_id = uuid4()
+    provider_account_id = uuid4()
     result = DeploymentCreateResult(id="provider-id", provider_result={"ok": True})
     deployment_row = SimpleNamespace(
         id=deployment_id,
@@ -372,11 +367,14 @@ def test_base_mapper_shapes_deployment_create_result() -> None:
         deployment_type=DeploymentType.AGENT,
         created_at=timestamp,
         updated_at=timestamp,
+        deployment_provider_account_id=provider_account_id,
     )
 
-    shaped = mapper.shape_deployment_create_result(result, deployment_row=deployment_row)
+    shaped = mapper.shape_deployment_create_result(result, deployment_row=deployment_row, provider_key="test-provider")
 
     assert shaped.id == deployment_id
+    assert shaped.provider_id == provider_account_id
+    assert shaped.provider_key == "test-provider"
     assert shaped.name == "Deployment 1"
     assert shaped.type == DeploymentType.AGENT
     assert shaped.provider_data == {"ok": True}
@@ -488,6 +486,7 @@ def test_base_mapper_flow_version_item_data_defaults_to_none() -> None:
 def test_shape_deployment_list_items_without_filter() -> None:
     """Without a flow filter, matched_attachments is None."""
     mapper = BaseDeploymentMapper()
+    provider_account_id = uuid4()
     row = SimpleNamespace(
         id=uuid4(),
         resource_key="rk-1",
@@ -496,12 +495,16 @@ def test_shape_deployment_list_items_without_filter() -> None:
         description=None,
         created_at=None,
         updated_at=None,
+        deployment_provider_account_id=provider_account_id,
     )
     items = mapper.shape_deployment_list_items(
         rows_with_counts=[(row, 0, [])],
         has_flow_filter=False,
+        provider_key="test-provider",
     )
     assert len(items) == 1
+    assert items[0].provider_id == provider_account_id
+    assert items[0].provider_key == "test-provider"
     assert items[0].matched_attachments is None
 
 
@@ -509,6 +512,7 @@ def test_shape_deployment_list_items_with_filter() -> None:
     """With a flow filter, matched_attachments is populated from matched tuples."""
     mapper = BaseDeploymentMapper()
     fv_id = uuid4()
+    provider_account_id = uuid4()
     row = SimpleNamespace(
         id=uuid4(),
         resource_key="rk-1",
@@ -517,12 +521,16 @@ def test_shape_deployment_list_items_with_filter() -> None:
         description=None,
         created_at=None,
         updated_at=None,
+        deployment_provider_account_id=provider_account_id,
     )
     items = mapper.shape_deployment_list_items(
         rows_with_counts=[(row, 1, [(fv_id, "snap-1")])],
         has_flow_filter=True,
+        provider_key="test-provider",
     )
     assert len(items) == 1
+    assert items[0].provider_id == provider_account_id
+    assert items[0].provider_key == "test-provider"
     assert items[0].matched_attachments is not None
     assert len(items[0].matched_attachments) == 1
     assert items[0].matched_attachments[0].flow_version_id == fv_id
@@ -532,6 +540,7 @@ def test_shape_deployment_list_items_with_filter() -> None:
 def test_shape_deployment_list_items_with_filter_empty_matches() -> None:
     """With a flow filter active but no matches, matched_attachments is an empty list."""
     mapper = BaseDeploymentMapper()
+    provider_account_id = uuid4()
     row = SimpleNamespace(
         id=uuid4(),
         resource_key="rk-1",
@@ -540,12 +549,16 @@ def test_shape_deployment_list_items_with_filter_empty_matches() -> None:
         description=None,
         created_at=None,
         updated_at=None,
+        deployment_provider_account_id=provider_account_id,
     )
     items = mapper.shape_deployment_list_items(
         rows_with_counts=[(row, 0, [])],
         has_flow_filter=True,
+        provider_key="test-provider",
     )
     assert len(items) == 1
+    assert items[0].provider_id == provider_account_id
+    assert items[0].provider_key == "test-provider"
     assert items[0].matched_attachments == []
 
 
@@ -560,6 +573,7 @@ def test_base_mapper_execution_provider_data_shapers_passthrough() -> None:
 def test_base_mapper_shapes_deployment_update_result() -> None:
     mapper = BaseDeploymentMapper()
     deployment_id = uuid4()
+    provider_account_id = uuid4()
     timestamp = datetime.now(tz=timezone.utc)
     result = DeploymentUpdateResult(id="provider-id", provider_result={"ok": True})
     deployment_row = SimpleNamespace(
@@ -569,14 +583,18 @@ def test_base_mapper_shapes_deployment_update_result() -> None:
         deployment_type=DeploymentType.AGENT,
         created_at=timestamp,
         updated_at=timestamp,
+        deployment_provider_account_id=provider_account_id,
     )
 
     shaped = mapper.shape_deployment_update_result(
         result,
         deployment_row,
+        provider_key="test-provider",
     )
 
     assert shaped.id == deployment_id
+    assert shaped.provider_id == provider_account_id
+    assert shaped.provider_key == "test-provider"
     assert shaped.name == "Deployment Name"
     assert shaped.description == "desc"
     assert shaped.type == DeploymentType.AGENT

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -1503,14 +1503,14 @@ def test_watsonx_mapper_resolve_provider_tenant_id_from_url() -> None:
     assert (
         mapper.resolve_provider_tenant_id(
             provider_url="https://api.example.com/orchestrate/instances/account-123/agents",
-            tenant_id=None,
+            provider_data={},
         )
         == "account-123"
     )
     assert (
         mapper.resolve_provider_tenant_id(
             provider_url="https://api.example.com/orchestrate/instances/account-123/agents",
-            tenant_id="tenant-explicit",
+            provider_data={"tenant_id": "tenant-explicit"},
         )
         == "tenant-explicit"
     )
@@ -1534,8 +1534,8 @@ def test_watsonx_mapper_trusts_top_level_deployment_id() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_wxo_mapper_resolve_verify_credentials_forwards_provider_data() -> None:
-    """WXO mapper forwards provider_data through the adapter slot."""
+def test_wxo_mapper_resolve_verify_credentials_filters_non_credential_fields() -> None:
+    """WXO mapper forwards only credential fields to adapter verification."""
     from langflow.api.v1.schemas.deployments import DeploymentProviderAccountCreateRequest
     from lfx.services.adapters.deployment.schema import VerifyCredentials
 
@@ -1544,13 +1544,17 @@ def test_wxo_mapper_resolve_verify_credentials_forwards_provider_data() -> None:
         name="test-account",
         provider_key="watsonx-orchestrate",
         url="https://api.us-south.wxo.cloud.ibm.com",
-        provider_data={"api_key": "my-secret-key"},  # pragma: allowlist secret
+        provider_data={
+            "tenant_id": "tenant-123",
+            "api_key": "my-secret-key",  # pragma: allowlist secret
+        },
     )
     result = mapper.resolve_verify_credentials(payload=payload)
     assert isinstance(result, VerifyCredentials)
     assert "cloud.ibm.com" in result.base_url
     assert result.provider_data is not None
     assert result.provider_data["api_key"] == "my-secret-key"  # pragma: allowlist secret
+    assert "tenant_id" not in result.provider_data
 
 
 def test_wxo_mapper_resolve_credential_fields_returns_api_key() -> None:
@@ -1558,6 +1562,38 @@ def test_wxo_mapper_resolve_credential_fields_returns_api_key() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     result = mapper.resolve_credential_fields(provider_data={"api_key": "my-key"})  # pragma: allowlist secret
     assert result == {"api_key": "my-key"}  # pragma: allowlist secret
+
+
+def test_wxo_mapper_resolve_credential_fields_ignores_tenant_metadata() -> None:
+    """Tenant metadata in provider_data should not break credential extraction."""
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    result = mapper.resolve_credential_fields(
+        provider_data={
+            "tenant_id": "tenant-123",
+            "api_key": "my-key",  # pragma: allowlist secret
+        }
+    )
+    assert result == {"api_key": "my-key"}  # pragma: allowlist secret
+
+
+def test_wxo_mapper_resolve_verify_credentials_rejects_unknown_non_metadata_fields() -> None:
+    """Mapper strips tenant metadata but still rejects unexpected credential keys."""
+    from langflow.api.v1.schemas.deployments import DeploymentProviderAccountCreateRequest
+    from lfx.services.adapters.payload import AdapterPayloadValidationError
+
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    payload = DeploymentProviderAccountCreateRequest(
+        name="test-account",
+        provider_key="watsonx-orchestrate",
+        url="https://api.us-south.wxo.cloud.ibm.com",
+        provider_data={
+            "tenant_id": "tenant-123",
+            "api_key": "my-secret-key",  # pragma: allowlist secret
+            "unexpected": "field",
+        },
+    )
+    with pytest.raises(AdapterPayloadValidationError):
+        mapper.resolve_verify_credentials(payload=payload)
 
 
 def test_wxo_mapper_resolve_credential_fields_strips_whitespace() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -102,6 +102,37 @@ def test_watsonx_mapper_provider_list_entry_rejects_non_dict_provider_data() -> 
     assert exc_info.value.detail == "Invalid deployment list item provider_data payload: expected object or null."
 
 
+@pytest.mark.parametrize(
+    ("raw_message", "expected"),
+    [
+        (
+            "Agent already exists in provider",
+            "An agent with this name already exists in the provider. "
+            "Please choose a different name or delete the existing agent first.",
+        ),
+        (
+            "connection conflict for app_id xyz",
+            "A connection referenced in this request already exists in the provider. "
+            "Reference it as an existing connection instead of creating a new one.",
+        ),
+        (
+            "tool already exists",
+            "A tool with this name already exists in the provider. Please choose a different name.",
+        ),
+        (
+            "unexpected conflict",
+            "A resource with this name already exists in the provider. unexpected conflict",
+        ),
+    ],
+)
+def test_watsonx_mapper_formats_conflict_detail(raw_message: str, expected: str) -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+
+    detail = mapper.format_conflict_detail(raw_message)
+
+    assert detail == expected
+
+
 def test_watsonx_mapper_shapes_flow_version_item_data_from_connections() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
 

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -599,21 +599,21 @@ def test_watsonx_api_payload_accepts_llm_only_update_contract() -> None:
     assert payload.remove_tools == []
 
 
-def test_watsonx_api_payload_rejects_update_without_llm() -> None:
+def test_watsonx_api_payload_accepts_update_without_llm() -> None:
     flow_version_id = uuid4()
-    with pytest.raises(ValidationError, match="llm"):
-        WatsonxApiDeploymentUpdatePayload.model_validate(
-            {
-                "connections": [],
-                "upsert_flows": [
-                    {
-                        "flow_version_id": str(flow_version_id),
-                        "add_app_ids": ["app-one"],
-                        "remove_app_ids": [],
-                    }
-                ],
-            }
-        )
+    payload = WatsonxApiDeploymentUpdatePayload.model_validate(
+        {
+            "connections": [],
+            "upsert_flows": [
+                {
+                    "flow_version_id": str(flow_version_id),
+                    "add_app_ids": ["app-one"],
+                    "remove_app_ids": [],
+                }
+            ],
+        }
+    )
+    assert payload.llm is None
 
 
 def test_watsonx_api_payload_accepts_flow_version_unbind_and_remove_contract() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -381,6 +381,7 @@ def test_watsonx_mapper_shapes_config_list_result_with_full_slot_validation() ->
                 name="Config 1",
                 created_at=now,
                 updated_at=now,
+                provider_data={"security_scheme": "key_value_creds"},
             ),
             ConfigListItem(id="cfg-2", name="Config 2"),
         ],
@@ -394,14 +395,54 @@ def test_watsonx_mapper_shapes_config_list_result_with_full_slot_validation() ->
     assert shaped.size is None
     assert shaped.provider_data is not None
     assert "deployment_id" not in shaped.provider_data
-    assert shaped.provider_data["tool_ids"] == ["tool-1"]
+    assert "tool_ids" not in shaped.provider_data
     assert shaped.provider_data["page"] == 1
     assert shaped.provider_data["size"] == 1
     assert shaped.provider_data["total"] == 2
     assert len(shaped.provider_data["connections"]) == 1
     assert shaped.provider_data["connections"][0]["id"] == "cfg-1"
     assert shaped.provider_data["connections"][0]["name"] == "Config 1"
+    assert shaped.provider_data["connections"][0]["type"] == "key_value_creds"
     assert "provider_data" not in shaped.provider_data["connections"][0]
+
+
+def test_watsonx_mapper_config_list_fails_fast_on_missing_security_scheme() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    result = ConfigListResult(
+        configs=[
+            ConfigListItem(
+                id="cfg-bad",
+                name="Bad Config",
+                provider_data={"app_id": "cfg-bad"},
+            ),
+        ],
+        provider_result={},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        mapper.shape_config_list_result(result, page=1, size=10)
+
+    assert exc_info.value.status_code == 500
+    assert "cfg-bad" in exc_info.value.detail
+    assert "security_scheme" in exc_info.value.detail
+
+
+def test_watsonx_mapper_config_list_omits_type_when_no_provider_data() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    result = ConfigListResult(
+        configs=[
+            ConfigListItem(id="cfg-dep", name="Dep Config"),
+        ],
+        provider_result={},
+    )
+
+    shaped = mapper.shape_config_list_result(result, page=1, size=10)
+
+    assert shaped.provider_data is not None
+    assert "tool_ids" not in shaped.provider_data
+    assert len(shaped.provider_data["connections"]) == 1
+    assert "type" not in shaped.provider_data["connections"][0]
+    assert shaped.provider_data["connections"][0]["id"] == "cfg-dep"
 
 
 def test_watsonx_mapper_shapes_snapshot_list_result_without_nested_provider_data() -> None:
@@ -437,18 +478,18 @@ def test_watsonx_mapper_shapes_snapshot_list_result_without_nested_provider_data
     assert "provider_data" not in shaped.provider_data["tools"][0]
 
 
-def test_watsonx_mapper_snapshot_list_result_rejects_malformed_item_payload() -> None:
+def test_watsonx_mapper_snapshot_list_result_ignores_extra_provider_result_fields() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     result = SnapshotListResult(
         snapshots=[SnapshotItem(id="tool-1", name="Tool 1", provider_data={"connections": {"cfg-1": "conn-1"}})],
         provider_result={"deployment_id": "dep-1", "unexpected": True},
     )
 
-    with pytest.raises(HTTPException) as exc:
-        mapper.shape_snapshot_list_result(result, page=1, size=20)
+    shaped = mapper.shape_snapshot_list_result(result, page=1, size=20)
 
-    assert exc.value.status_code == 500
-    assert "Invalid snapshot list provider_data payload:" in str(exc.value.detail)
+    assert shaped.provider_data is not None
+    assert "unexpected" not in shaped.provider_data
+    assert "deployment_id" not in shaped.provider_data
 
 
 @pytest.mark.parametrize("provider_snapshot_id", [None, "   "])

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -649,39 +649,6 @@ async def test_watsonx_mapper_maps_create_adapter_payload_validation_errors_to_4
     assert exc_info.value.detail == "Invalid provider_data payload: simulated adapter validation failure"
 
 
-@pytest.mark.asyncio
-async def test_watsonx_mapper_rejects_top_level_flow_version_and_config_on_create() -> None:
-    mapper = WatsonxOrchestrateDeploymentMapper()
-    payload = DeploymentCreateRequest(
-        provider_id=uuid4(),
-        spec={"name": "create-deploy", "description": "", "type": "agent"},
-        flow_version_ids=[uuid4()],
-        provider_data={
-            "llm": TEST_WXO_LLM,
-            "connections": {},
-            "operations": [
-                {
-                    "op": "bind",
-                    "flow_version_id": str(uuid4()),
-                    "app_ids": ["app-one"],
-                }
-            ],
-        },
-    )
-
-    with pytest.raises(
-        HTTPException,
-        match="Watsonx create does not support top-level 'config' or 'flow_version_ids'",
-    ):
-        await mapper.resolve_deployment_create(
-            user_id=uuid4(),
-            project_id=uuid4(),
-            db=_FakeDb([]),
-            payload=payload,
-        )
-
-
-@pytest.mark.asyncio
 async def test_watsonx_mapper_create_reports_missing_llm_field_name() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     payload = DeploymentCreateRequest(
@@ -830,12 +797,12 @@ async def test_watsonx_mapper_translates_flow_version_bind_into_raw_tool_payload
     provider_data = resolved.provider_data or {}
 
     assert provider_data["llm"] == TEST_WXO_LLM
-    assert provider_data["tools"]["raw_payloads"][0]["name"] == "Flow A_v1"
+    assert provider_data["tools"]["raw_payloads"][0]["name"] == "Flow A"
     assert provider_data["tools"]["raw_payloads"][0]["provider_data"] == {
         "project_id": str(project_id),
         "source_ref": str(flow_version_id),
     }
-    assert provider_data["operations"][0]["tool"]["name_of_raw"] == "Flow A_v1"
+    assert provider_data["operations"][0]["tool"]["name_of_raw"] == "Flow A"
 
 
 @pytest.mark.asyncio
@@ -894,12 +861,9 @@ async def test_watsonx_mapper_skips_empty_bind_operations_but_keeps_raw_tools() 
     provider_data = resolved.provider_data or {}
 
     assert len(provider_data["tools"]["raw_payloads"]) == 2
-    assert sorted(item["name"] for item in provider_data["tools"]["raw_payloads"]) == [
-        "Flow Bound_v2",
-        "Flow Unbound_v1",
-    ]
+    assert sorted(item["name"] for item in provider_data["tools"]["raw_payloads"]) == ["Flow Bound", "Flow Unbound"]
     assert len(provider_data["operations"]) == 1
-    assert provider_data["operations"][0]["tool"]["name_of_raw"] == "Flow Bound_v2"
+    assert provider_data["operations"][0]["tool"]["name_of_raw"] == "Flow Bound"
     assert provider_data["operations"][0]["app_ids"] == ["app-one"]
 
 
@@ -920,23 +884,6 @@ async def test_watsonx_mapper_translates_llm_only_update_payload() -> None:
     assert provider_data["operations"] == []
     assert provider_data["tools"]["raw_payloads"] is None
     assert provider_data["connections"] == {"raw_payloads": None}
-
-
-@pytest.mark.asyncio
-async def test_watsonx_mapper_rejects_top_level_config_updates() -> None:
-    mapper = WatsonxOrchestrateDeploymentMapper()
-    payload = DeploymentUpdateRequest(config={"config_id": "cfg-1"})
-
-    with pytest.raises(
-        HTTPException,
-        match="Watsonx update does not support top-level 'config'",
-    ):
-        await mapper.resolve_deployment_update(
-            user_id=uuid4(),
-            deployment_db_id=uuid4(),
-            db=_FakeDb([]),
-            payload=payload,
-        )
 
 
 @pytest.mark.asyncio
@@ -1557,7 +1504,7 @@ async def test_watsonx_mapper_bind_creates_new_tool_when_no_attachment() -> None
     )
     provider_data = resolved.provider_data or {}
 
-    assert provider_data["operations"][0]["tool"]["name_of_raw"] == "Flow B_v1"
+    assert provider_data["operations"][0]["tool"]["name_of_raw"] == "Flow B"
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -150,8 +150,12 @@ def test_watsonx_mapper_shapes_deployment_list_result_with_flattened_entries() -
 
     shaped = mapper.shape_deployment_list_result(result)
 
+    assert shaped.deployments is None
+    assert shaped.page is None
+    assert shaped.size is None
+    assert shaped.total is None
     assert shaped.provider_data is not None
-    assert shaped.provider_data["entries"] == [
+    assert shaped.provider_data["deployments"] == [
         {
             "id": "agent-1",
             "name": "Agent 1",
@@ -385,16 +389,19 @@ def test_watsonx_mapper_shapes_config_list_result_with_full_slot_validation() ->
 
     shaped = mapper.shape_config_list_result(result, page=1, size=1)
 
-    assert shaped.total == 2
-    assert shaped.page == 1
-    assert shaped.size == 1
+    assert shaped.total is None
+    assert shaped.page is None
+    assert shaped.size is None
     assert shaped.provider_data is not None
-    assert shaped.provider_data["deployment_id"] == "dep-1"
+    assert "deployment_id" not in shaped.provider_data
     assert shaped.provider_data["tool_ids"] == ["tool-1"]
-    assert len(shaped.provider_data["configs"]) == 1
-    assert shaped.provider_data["configs"][0]["id"] == "cfg-1"
-    assert shaped.provider_data["configs"][0]["name"] == "Config 1"
-    assert "provider_data" not in shaped.provider_data["configs"][0]
+    assert shaped.provider_data["page"] == 1
+    assert shaped.provider_data["size"] == 1
+    assert shaped.provider_data["total"] == 2
+    assert len(shaped.provider_data["connections"]) == 1
+    assert shaped.provider_data["connections"][0]["id"] == "cfg-1"
+    assert shaped.provider_data["connections"][0]["name"] == "Config 1"
+    assert "provider_data" not in shaped.provider_data["connections"][0]
 
 
 def test_watsonx_mapper_shapes_snapshot_list_result_without_nested_provider_data() -> None:
@@ -412,17 +419,22 @@ def test_watsonx_mapper_shapes_snapshot_list_result_without_nested_provider_data
 
     shaped = mapper.shape_snapshot_list_result(result, page=1, size=20)
 
-    assert shaped.total == 1
+    assert shaped.total is None
+    assert shaped.page is None
+    assert shaped.size is None
     assert shaped.provider_data is not None
-    assert shaped.provider_data["deployment_id"] == "dep-1"
-    assert shaped.provider_data["snapshots"] == [
+    assert "deployment_id" not in shaped.provider_data
+    assert shaped.provider_data["page"] == 1
+    assert shaped.provider_data["size"] == 20
+    assert shaped.provider_data["total"] == 1
+    assert shaped.provider_data["tools"] == [
         {
             "id": "tool-1",
             "name": "Tool 1",
             "connections": {"cfg-1": "conn-1"},
         }
     ]
-    assert "provider_data" not in shaped.provider_data["snapshots"][0]
+    assert "provider_data" not in shaped.provider_data["tools"][0]
 
 
 def test_watsonx_mapper_snapshot_list_result_rejects_malformed_item_payload() -> None:
@@ -1470,7 +1482,7 @@ def test_wxo_mapper_resolve_verify_credentials_rejects_extra_fields() -> None:
 
 @pytest.mark.asyncio
 async def test_watsonx_mapper_create_preserves_env_var_source_in_connection_payloads() -> None:
-    """Connections with environment_variables should preserve source.
+    """Connections with credentials should preserve source.
 
     Preserve raw-vs-variable semantics all the way to the adapter payload.
     """
@@ -1486,13 +1498,17 @@ async def test_watsonx_mapper_create_preserves_env_var_source_in_connection_payl
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {
-                "raw_payloads": [
+                "key_value": [
                     {
                         "app_id": "app-new",
-                        "environment_variables": {
-                            "RAW_TOKEN": {"value": "literal-secret", "source": "raw"},  # pragma: allowlist secret
-                            "VAR_REF": {"value": "MY_GLOBAL_VAR", "source": "variable"},
-                        },
+                        "credentials": [
+                            {
+                                "key": "RAW_TOKEN",
+                                "value": "literal-secret",
+                                "source": "raw",
+                            },  # pragma: allowlist secret
+                            {"key": "VAR_REF", "value": "MY_GLOBAL_VAR", "source": "variable"},
+                        ],
                     }
                 ],
             },
@@ -1788,17 +1804,40 @@ def test_watsonx_api_payload_rejects_conflicting_tool_id_operations() -> None:
         )
 
 
-def test_watsonx_api_payload_unbind_tool_rejects_raw_app_ids() -> None:
-    """unbind_tool referencing raw app_ids should be rejected."""
-    with pytest.raises(ValidationError, match=r"must not reference connections\.raw_payloads app_ids"):
+def test_watsonx_api_payload_unbind_tool_rejects_key_value_app_ids() -> None:
+    """unbind_tool referencing key_value app_ids should be rejected."""
+    with pytest.raises(ValidationError, match=r"must not reference connections\.key_value app_ids"):
         WatsonxApiDeploymentUpdatePayload.model_validate(
             {
                 "llm": TEST_WXO_LLM,
                 "connections": {
-                    "raw_payloads": [{"app_id": "app-new"}],
+                    "key_value": [{"app_id": "app-new"}],
                 },
                 "operations": [
                     {"op": "unbind_tool", "tool_id": "tid", "app_ids": ["app-new"]},
+                ],
+            }
+        )
+
+
+def test_watsonx_api_payload_rejects_duplicate_credential_keys() -> None:
+    with pytest.raises(ValidationError, match="duplicate key values"):
+        WatsonxApiDeploymentUpdatePayload.model_validate(
+            {
+                "llm": TEST_WXO_LLM,
+                "connections": {
+                    "key_value": [
+                        {
+                            "app_id": "app-new",
+                            "credentials": [
+                                {"key": "TOKEN", "value": "secret-a", "source": "raw"},  # pragma: allowlist secret
+                                {"key": "TOKEN", "value": "secret-b", "source": "raw"},  # pragma: allowlist secret
+                            ],
+                        }
+                    ]
+                },
+                "operations": [
+                    {"op": "bind_tool", "tool_id": "tid", "app_ids": ["app-new"]},
                 ],
             }
         )

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -532,7 +532,7 @@ def test_watsonx_mapper_create_result_from_existing_update_normalizes_slot_paylo
     }
 
 
-def test_watsonx_mapper_resolve_verify_credentials_for_update_uses_decrypted_stored_key(monkeypatch) -> None:
+def test_watsonx_mapper_resolve_verify_credentials_for_update_returns_none_without_provider_data() -> None:
     from langflow.services.database.models.deployment_provider_account.model import DeploymentProviderAccount
 
     mapper = WatsonxOrchestrateDeploymentMapper()
@@ -545,26 +545,13 @@ def test_watsonx_mapper_resolve_verify_credentials_for_update_uses_decrypted_sto
         provider_url="https://api.us-south.wxo.cloud.ibm.com/instances/tenant-1",
         api_key="encrypted-api-key",  # pragma: allowlist secret
     )
-    payload = DeploymentProviderAccountUpdateRequest(
-        provider_url="https://api.eu-de.wxo.cloud.ibm.com/instances/tenant-2",
-    )
+    payload = DeploymentProviderAccountUpdateRequest(name="renamed")
 
-    monkeypatch.setattr(
-        "langflow.api.v1.mappers.deployments.watsonx_orchestrate.mapper.auth_utils.decrypt_api_key",
-        lambda _encrypted_api_key: "stored-api-key",  # pragma: allowlist secret
-    )
-
-    verify_input = mapper.resolve_verify_credentials_for_update(
-        payload=payload,
-        existing_account=existing_account,
-    )
-
-    assert verify_input is not None
-    assert verify_input.base_url == payload.provider_url
-    assert verify_input.provider_data == {"api_key": "stored-api-key"}  # pragma: allowlist secret
+    verify_input = mapper.resolve_verify_credentials_for_update(payload=payload, existing_account=existing_account)
+    assert verify_input is None
 
 
-def test_watsonx_mapper_resolve_verify_credentials_for_update_prefers_new_provider_data(monkeypatch) -> None:
+def test_watsonx_mapper_resolve_verify_credentials_for_update_prefers_new_provider_data() -> None:
     from langflow.services.database.models.deployment_provider_account.model import DeploymentProviderAccount
 
     mapper = WatsonxOrchestrateDeploymentMapper()
@@ -578,15 +565,6 @@ def test_watsonx_mapper_resolve_verify_credentials_for_update_prefers_new_provid
         api_key="encrypted-api-key",  # pragma: allowlist secret
     )
     payload = DeploymentProviderAccountUpdateRequest(provider_data={"api_key": "new-api-key"})
-
-    def _fail_decrypt(_encrypted_api_key: str) -> str:
-        msg = "decrypt_api_key should not be called when new provider_data is supplied"
-        raise AssertionError(msg)
-
-    monkeypatch.setattr(
-        "langflow.api.v1.mappers.deployments.watsonx_orchestrate.mapper.auth_utils.decrypt_api_key",
-        _fail_decrypt,
-    )
 
     verify_input = mapper.resolve_verify_credentials_for_update(
         payload=payload,
@@ -1274,14 +1252,14 @@ def test_watsonx_mapper_resolve_provider_tenant_id_from_url() -> None:
     assert (
         mapper.resolve_provider_tenant_id(
             provider_url="https://api.example.com/orchestrate/instances/account-123/agents",
-            provider_tenant_id=None,
+            tenant_id=None,
         )
         == "account-123"
     )
     assert (
         mapper.resolve_provider_tenant_id(
             provider_url="https://api.example.com/orchestrate/instances/account-123/agents",
-            provider_tenant_id="tenant-explicit",
+            tenant_id="tenant-explicit",
         )
         == "tenant-explicit"
     )
@@ -1314,7 +1292,7 @@ def test_wxo_mapper_resolve_verify_credentials_forwards_provider_data() -> None:
     payload = DeploymentProviderAccountCreateRequest(
         name="test-account",
         provider_key="watsonx-orchestrate",
-        provider_url="https://api.us-south.wxo.cloud.ibm.com",
+        url="https://api.us-south.wxo.cloud.ibm.com",
         provider_data={"api_key": "my-secret-key"},  # pragma: allowlist secret
     )
     result = mapper.resolve_verify_credentials(payload=payload)
@@ -1367,40 +1345,8 @@ def _make_wxo_existing_account():
     )
 
 
-def test_wxo_mapper_update_rederives_tenant_when_url_changes() -> None:
-    """Changing provider_url re-derives tenant even if provider_tenant_id is not set."""
-    from langflow.api.v1.schemas.deployments import DeploymentProviderAccountUpdateRequest
-
-    mapper = WatsonxOrchestrateDeploymentMapper()
-    payload = DeploymentProviderAccountUpdateRequest(
-        provider_url="https://api.eu-de.wxo.cloud.ibm.com/instances/new-tenant/agents",
-    )
-    result = mapper.resolve_provider_account_update(
-        payload=payload,
-        existing_account=_make_wxo_existing_account(),
-    )
-    assert result["provider_tenant_id"] == "new-tenant"
-    assert "provider_url" in result
-
-
-def test_wxo_mapper_update_uses_existing_url_when_only_tenant_changes() -> None:
-    """Changing only provider_tenant_id still uses existing URL for resolution."""
-    from langflow.api.v1.schemas.deployments import DeploymentProviderAccountUpdateRequest
-
-    mapper = WatsonxOrchestrateDeploymentMapper()
-    payload = DeploymentProviderAccountUpdateRequest(
-        provider_tenant_id="explicit-override",
-    )
-    result = mapper.resolve_provider_account_update(
-        payload=payload,
-        existing_account=_make_wxo_existing_account(),
-    )
-    assert result["provider_tenant_id"] == "explicit-override"
-    assert "provider_url" not in result
-
-
-def test_wxo_mapper_update_leaves_tenant_untouched_when_neither_set() -> None:
-    """When neither provider_url nor provider_tenant_id is set, tenant is not in kwargs."""
+def test_wxo_mapper_update_allows_name_changes_only_for_non_credential_fields() -> None:
+    """Provider-account update keeps URL/tenant immutable."""
     from langflow.api.v1.schemas.deployments import DeploymentProviderAccountUpdateRequest
 
     mapper = WatsonxOrchestrateDeploymentMapper()
@@ -1410,23 +1356,8 @@ def test_wxo_mapper_update_leaves_tenant_untouched_when_neither_set() -> None:
         existing_account=_make_wxo_existing_account(),
     )
     assert "provider_tenant_id" not in result
+    assert "provider_url" not in result
     assert result["name"] == "renamed"
-
-
-def test_wxo_mapper_update_with_url_and_explicit_tenant() -> None:
-    """When both provider_url and provider_tenant_id are set, explicit tenant wins."""
-    from langflow.api.v1.schemas.deployments import DeploymentProviderAccountUpdateRequest
-
-    mapper = WatsonxOrchestrateDeploymentMapper()
-    payload = DeploymentProviderAccountUpdateRequest(
-        provider_url="https://api.eu-de.wxo.cloud.ibm.com/instances/url-tenant/agents",
-        provider_tenant_id="explicit-tenant",
-    )
-    result = mapper.resolve_provider_account_update(
-        payload=payload,
-        existing_account=_make_wxo_existing_account(),
-    )
-    assert result["provider_tenant_id"] == "explicit-tenant"
 
 
 def test_wxo_mapper_resolve_verify_credentials_rejects_extra_fields() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -209,6 +209,10 @@ def test_watsonx_mapper_deployment_list_result_rejects_unknown_flattened_entry_f
             "A tool with this name already exists in the provider. Please choose a different name.",
         ),
         (
+            "app_id is required",
+            "A resource with this name already exists in the provider. app_id is required",
+        ),
+        (
             "unexpected conflict",
             "A resource with this name already exists in the provider. unexpected conflict",
         ),

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -25,8 +25,10 @@ from lfx.services.adapters.deployment.schema import (
     ConfigListResult,
     DeploymentCreateResult,
     DeploymentListLlmsResult,
+    DeploymentListResult,
     DeploymentType,
     DeploymentUpdateResult,
+    ItemResult,
     SnapshotItem,
     SnapshotListResult,
 )
@@ -100,6 +102,89 @@ def test_watsonx_mapper_provider_list_entry_rejects_non_dict_provider_data() -> 
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == "Invalid deployment list item provider_data payload: expected object or null."
+
+
+def test_watsonx_mapper_provider_list_entry_flattens_provider_data_and_uses_id() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    now = datetime.now(tz=timezone.utc)
+    item = SimpleNamespace(
+        id="agent-1",
+        name="Agent 1",
+        type=DeploymentType.AGENT,
+        description="desc",
+        created_at=now,
+        updated_at=now,
+        provider_data={"tool_ids": ["tool-1", "  ", "tool-2"], "environment": "draft"},
+    )
+
+    shaped = mapper._shape_provider_deployment_list_entry(item)
+
+    assert shaped["id"] == "agent-1"
+    assert shaped["name"] == "Agent 1"
+    assert shaped["type"] == DeploymentType.AGENT.value
+    assert shaped["description"] == "desc"
+    assert shaped["created_at"] == now.isoformat().replace("+00:00", "Z")
+    assert shaped["updated_at"] == now.isoformat().replace("+00:00", "Z")
+    assert shaped["tool_ids"] == ["tool-1", "tool-2"]
+    assert shaped["environment"] == "draft"
+    assert "provider_data" not in shaped
+    assert "resource_key" not in shaped
+
+
+def test_watsonx_mapper_shapes_deployment_list_result_with_flattened_entries() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    now = datetime.now(tz=timezone.utc)
+    result = DeploymentListResult(
+        deployments=[
+            ItemResult(
+                id="agent-1",
+                name="Agent 1",
+                type=DeploymentType.AGENT,
+                description="desc",
+                created_at=now,
+                updated_at=now,
+                provider_data={"tool_ids": ["tool-1"], "environment": "live"},
+            )
+        ]
+    )
+
+    shaped = mapper.shape_deployment_list_result(result)
+
+    assert shaped.provider_data is not None
+    assert shaped.provider_data["entries"] == [
+        {
+            "id": "agent-1",
+            "name": "Agent 1",
+            "type": DeploymentType.AGENT.value,
+            "created_at": now.isoformat().replace("+00:00", "Z"),
+            "updated_at": now.isoformat().replace("+00:00", "Z"),
+            "tool_ids": ["tool-1"],
+            "environment": "live",
+        }
+    ]
+
+
+def test_watsonx_mapper_deployment_list_result_rejects_unknown_flattened_entry_fields() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    now = datetime.now(tz=timezone.utc)
+    result = DeploymentListResult(
+        deployments=[
+            ItemResult(
+                id="agent-1",
+                name="Agent 1",
+                type=DeploymentType.AGENT,
+                created_at=now,
+                updated_at=now,
+                provider_data={"unexpected": "value"},
+            )
+        ]
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        mapper.shape_deployment_list_result(result)
+
+    assert exc_info.value.status_code == 500
+    assert "Invalid deployment list item provider_data payload:" in str(exc_info.value.detail)
 
 
 @pytest.mark.parametrize(

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -377,13 +377,13 @@ def test_watsonx_mapper_shapes_config_list_result_with_full_slot_validation() ->
     result = ConfigListResult(
         configs=[
             ConfigListItem(
-                id="cfg-1",
-                name="Config 1",
+                id="conn-1",
+                name="cfg-1",
                 created_at=now,
                 updated_at=now,
-                provider_data={"security_scheme": "key_value_creds"},
+                provider_data={"type": "key_value_creds"},
             ),
-            ConfigListItem(id="cfg-2", name="Config 2"),
+            ConfigListItem(id="conn-2", name="cfg-2"),
         ],
         provider_result={"deployment_id": " dep-1 ", "tool_ids": ["tool-1", "  "]},
     )
@@ -400,38 +400,39 @@ def test_watsonx_mapper_shapes_config_list_result_with_full_slot_validation() ->
     assert shaped.provider_data["size"] == 1
     assert shaped.provider_data["total"] == 2
     assert len(shaped.provider_data["connections"]) == 1
-    assert shaped.provider_data["connections"][0]["id"] == "cfg-1"
-    assert shaped.provider_data["connections"][0]["name"] == "Config 1"
+    assert shaped.provider_data["connections"][0]["app_id"] == "cfg-1"
+    assert shaped.provider_data["connections"][0]["connection_id"] == "conn-1"
     assert shaped.provider_data["connections"][0]["type"] == "key_value_creds"
-    assert "provider_data" not in shaped.provider_data["connections"][0]
+    assert set(shaped.provider_data["connections"][0].keys()) == {
+        "app_id",
+        "connection_id",
+        "type",
+    }
 
 
-def test_watsonx_mapper_config_list_fails_fast_on_missing_security_scheme() -> None:
+def test_watsonx_mapper_config_list_accepts_items_without_type() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     result = ConfigListResult(
         configs=[
             ConfigListItem(
-                id="cfg-bad",
-                name="Bad Config",
-                provider_data={"app_id": "cfg-bad"},
+                id="conn-bad",
+                name="cfg-bad",
+                provider_data={},
             ),
         ],
         provider_result={},
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        mapper.shape_config_list_result(result, page=1, size=10)
-
-    assert exc_info.value.status_code == 500
-    assert "cfg-bad" in exc_info.value.detail
-    assert "security_scheme" in exc_info.value.detail
+    shaped = mapper.shape_config_list_result(result, page=1, size=10)
+    assert shaped.provider_data is not None
+    assert shaped.provider_data["connections"] == [{"connection_id": "conn-bad", "app_id": "cfg-bad"}]
 
 
-def test_watsonx_mapper_config_list_omits_type_when_no_provider_data() -> None:
+def test_watsonx_mapper_config_list_exposes_connection_id_and_app_id() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     result = ConfigListResult(
         configs=[
-            ConfigListItem(id="cfg-dep", name="Dep Config"),
+            ConfigListItem(id="conn-dep", name="cfg-dep"),
         ],
         provider_result={},
     )
@@ -441,8 +442,28 @@ def test_watsonx_mapper_config_list_omits_type_when_no_provider_data() -> None:
     assert shaped.provider_data is not None
     assert "tool_ids" not in shaped.provider_data
     assert len(shaped.provider_data["connections"]) == 1
-    assert "type" not in shaped.provider_data["connections"][0]
-    assert shaped.provider_data["connections"][0]["id"] == "cfg-dep"
+    assert shaped.provider_data["connections"][0] == {
+        "connection_id": "conn-dep",
+        "app_id": "cfg-dep",
+    }
+
+
+def test_watsonx_mapper_config_list_ignores_unexpected_provider_data_keys() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    result = ConfigListResult(
+        configs=[
+            ConfigListItem(
+                id="conn-1",
+                name="cfg-1",
+                provider_data={"security_scheme": "key_value_creds"},
+            )
+        ],
+        provider_result={},
+    )
+
+    shaped = mapper.shape_config_list_result(result, page=1, size=10)
+    assert shaped.provider_data is not None
+    assert shaped.provider_data["connections"] == [{"connection_id": "conn-1", "app_id": "cfg-1"}]
 
 
 def test_watsonx_mapper_shapes_snapshot_list_result_without_nested_provider_data() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -77,6 +77,8 @@ def test_watsonx_mapper_is_registered() -> None:
     assert mapper.api_payloads.deployment_create is not None
     assert mapper.api_payloads.deployment_update is not None
     assert mapper.api_payloads.deployment_update_result is not None
+    assert mapper.api_payloads.config_list_result is not None
+    assert mapper.api_payloads.snapshot_list_result is not None
 
 
 def test_watsonx_mapper_provider_list_entry_rejects_non_dict_provider_data() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -524,16 +524,15 @@ def test_watsonx_api_payload_accepts_flow_version_create_bind_contract() -> None
         {
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "add_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
                     "app_ids": ["app-one"],
                 }
             ],
         }
     )
-    assert payload.operations[0].op == "bind"
+    assert payload.add_flows[0].flow_version_id == flow_version_id
 
 
 def test_watsonx_api_payload_accepts_flow_version_bind_contract() -> None:
@@ -542,16 +541,16 @@ def test_watsonx_api_payload_accepts_flow_version_bind_contract() -> None:
         {
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "upsert_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
-                    "app_ids": ["app-one"],
+                    "add_app_ids": ["app-one"],
+                    "remove_app_ids": [],
                 }
             ],
         }
     )
-    assert payload.operations[0].op == "bind"
+    assert payload.upsert_flows[0].add_app_ids == ["app-one"]
 
 
 def test_watsonx_api_payload_accepts_bind_with_empty_app_ids() -> None:
@@ -559,16 +558,16 @@ def test_watsonx_api_payload_accepts_bind_with_empty_app_ids() -> None:
     payload = WatsonxApiDeploymentUpdatePayload.model_validate(
         {
             "llm": TEST_WXO_LLM,
-            "operations": [
+            "upsert_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
-                    "app_ids": [],
+                    "add_app_ids": [],
+                    "remove_app_ids": [],
                 }
             ],
         }
     )
-    assert payload.operations[0].app_ids == []
+    assert payload.upsert_flows[0].add_app_ids == []
 
 
 def test_watsonx_api_payload_rejects_create_without_llm() -> None:
@@ -577,9 +576,8 @@ def test_watsonx_api_payload_rejects_create_without_llm() -> None:
         WatsonxApiDeploymentCreatePayload.model_validate(
             {
                 "connections": {},
-                "operations": [
+                "add_flows": [
                     {
-                        "op": "bind",
                         "flow_version_id": str(flow_version_id),
                         "app_ids": ["app-one"],
                     }
@@ -595,7 +593,10 @@ def test_watsonx_api_payload_accepts_llm_only_update_contract() -> None:
         }
     )
     assert payload.llm == TEST_WXO_LLM
-    assert payload.operations == []
+    assert payload.upsert_flows == []
+    assert payload.upsert_tools == []
+    assert payload.remove_flows == []
+    assert payload.remove_tools == []
 
 
 def test_watsonx_api_payload_rejects_update_without_llm() -> None:
@@ -604,11 +605,11 @@ def test_watsonx_api_payload_rejects_update_without_llm() -> None:
         WatsonxApiDeploymentUpdatePayload.model_validate(
             {
                 "connections": {},
-                "operations": [
+                "upsert_flows": [
                     {
-                        "op": "bind",
                         "flow_version_id": str(flow_version_id),
-                        "app_ids": ["app-one"],
+                        "add_app_ids": ["app-one"],
+                        "remove_app_ids": [],
                     }
                 ],
             }
@@ -617,25 +618,23 @@ def test_watsonx_api_payload_rejects_update_without_llm() -> None:
 
 def test_watsonx_api_payload_accepts_flow_version_unbind_and_remove_contract() -> None:
     flow_version_id = uuid4()
+    remove_flow_version_id = uuid4()
     payload = WatsonxApiDeploymentUpdatePayload.model_validate(
         {
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "upsert_flows": [
                 {
-                    "op": "unbind",
                     "flow_version_id": str(flow_version_id),
-                    "app_ids": ["app-one"],
-                },
-                {
-                    "op": "remove_tool",
-                    "flow_version_id": str(flow_version_id),
+                    "add_app_ids": [],
+                    "remove_app_ids": ["app-one"],
                 },
             ],
+            "remove_flows": [str(remove_flow_version_id)],
         }
     )
-    assert payload.operations[0].op == "unbind"
-    assert payload.operations[1].op == "remove_tool"
+    assert payload.upsert_flows[0].remove_app_ids == ["app-one"]
+    assert payload.remove_flows == [remove_flow_version_id]
 
 
 def test_watsonx_mapper_create_result_from_existing_update_normalizes_slot_payload() -> None:
@@ -744,9 +743,8 @@ async def test_watsonx_mapper_translates_create_bind_into_raw_tool_payload() -> 
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "add_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
                     "app_ids": ["app-one"],
                 }
@@ -794,9 +792,8 @@ async def test_watsonx_mapper_translates_existing_create_bind_into_update_payloa
             "llm": TEST_WXO_LLM,
             "existing_agent_id": "21b2b5a4-ef72-4697-8731-132163669a46",
             "connections": {},
-            "operations": [
+            "add_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
                     "app_ids": ["app-one"],
                 }
@@ -839,9 +836,8 @@ async def test_watsonx_mapper_maps_create_adapter_payload_validation_errors_to_4
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "add_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
                     "app_ids": ["app-one"],
                 }
@@ -887,9 +883,8 @@ async def test_watsonx_mapper_create_reports_missing_llm_field_name() -> None:
         type="agent",
         provider_data={
             "connections": {},
-            "operations": [
+            "add_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(uuid4()),
                     "app_ids": ["app-one"],
                 }
@@ -920,11 +915,10 @@ async def test_watsonx_mapper_create_reports_unknown_field_name() -> None:
         provider_data={
             "llm": TEST_WXO_LLM,
             "resource_name_prefix": "lf_test_",
-            "operations": [
+            "upsert_tools": [
                 {
-                    "op": "bind_tool",
                     "tool_id": "existing-tool",
-                    "app_ids": [],
+                    "add_app_ids": [],
                 }
             ],
         },
@@ -963,9 +957,8 @@ async def test_watsonx_mapper_create_skips_empty_bind_operations_but_keeps_raw_t
         type="agent",
         provider_data={
             "llm": TEST_WXO_LLM,
-            "operations": [
+            "add_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
                     "app_ids": [],
                 }
@@ -1011,11 +1004,11 @@ async def test_watsonx_mapper_translates_flow_version_bind_into_raw_tool_payload
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "upsert_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
-                    "app_ids": ["app-one"],
+                    "add_app_ids": ["app-one"],
+                    "remove_app_ids": [],
                 }
             ],
         }
@@ -1070,21 +1063,20 @@ async def test_watsonx_mapper_skips_empty_bind_operations_but_keeps_raw_tools() 
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "upsert_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id_unbound),
-                    "app_ids": [],
+                    "add_app_ids": [],
+                    "remove_app_ids": [],
                 },
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id_bound),
-                    "app_ids": ["app-one"],
+                    "add_app_ids": ["app-one"],
+                    "remove_app_ids": [],
                 },
             ],
         }
     )
-
     db = _MultiQueryFakeDb(flow_rows=[row_unbound, row_bound], attachment_rows=[])
 
     resolved = await mapper.resolve_deployment_update(
@@ -1132,17 +1124,14 @@ async def test_watsonx_mapper_translates_unbind_and_remove_via_attachment_snapsh
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "upsert_flows": [
                 {
-                    "op": "unbind",
                     "flow_version_id": str(flow_version_id_unbind),
-                    "app_ids": ["app-one"],
-                },
-                {
-                    "op": "remove_tool",
-                    "flow_version_id": str(flow_version_id_remove),
+                    "add_app_ids": [],
+                    "remove_app_ids": ["app-one"],
                 },
             ],
+            "remove_flows": [str(flow_version_id_remove)],
         }
     )
     db = _FakeDb(
@@ -1347,16 +1336,26 @@ def test_watsonx_mapper_llm_list_result_raises_for_missing_provider_payload() ->
 def test_watsonx_mapper_exposes_reconciliation_resolvers() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     add_id = uuid4()
+    unbind_only_id = uuid4()
     remove_id = uuid4()
     patch = mapper.util_flow_version_patch(
         DeploymentUpdateRequest(
             provider_data={
                 "llm": TEST_WXO_LLM,
                 "connections": {},
-                "operations": [
-                    {"op": "bind", "flow_version_id": str(add_id), "app_ids": ["app-one"]},
-                    {"op": "unbind", "flow_version_id": str(remove_id), "app_ids": ["app-one"]},
+                "upsert_flows": [
+                    {
+                        "flow_version_id": str(add_id),
+                        "add_app_ids": ["app-one"],
+                        "remove_app_ids": [],
+                    },
+                    {
+                        "flow_version_id": str(unbind_only_id),
+                        "add_app_ids": [],
+                        "remove_app_ids": ["app-one"],
+                    },
                 ],
+                "remove_flows": [str(remove_id)],
             }
         )
     )
@@ -1553,9 +1552,8 @@ async def test_watsonx_mapper_create_preserves_env_var_source_in_connection_payl
                     }
                 ],
             },
-            "operations": [
+            "add_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
                     "app_ids": ["app-new"],
                 }
@@ -1640,11 +1638,11 @@ async def test_watsonx_mapper_bind_reuses_existing_tool_when_attachment_exists()
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "upsert_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
-                    "app_ids": ["app-one"],
+                    "add_app_ids": ["app-one"],
+                    "remove_app_ids": [],
                 }
             ],
         }
@@ -1688,11 +1686,11 @@ async def test_watsonx_mapper_bind_creates_new_tool_when_no_attachment() -> None
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "upsert_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
-                    "app_ids": ["app-one"],
+                    "add_app_ids": ["app-one"],
+                    "remove_app_ids": [],
                 }
             ],
         }
@@ -1736,11 +1734,11 @@ async def test_watsonx_mapper_bind_reuse_with_empty_app_ids_emits_attach_tool() 
     payload = DeploymentUpdateRequest(
         provider_data={
             "llm": TEST_WXO_LLM,
-            "operations": [
+            "upsert_flows": [
                 {
-                    "op": "bind",
                     "flow_version_id": str(flow_version_id),
-                    "app_ids": [],
+                    "add_app_ids": [],
+                    "remove_app_ids": [],
                 }
             ],
         }
@@ -1771,11 +1769,11 @@ def test_watsonx_api_payload_accepts_bind_tool_operation() -> None:
         {
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "upsert_tools": [
                 {
-                    "op": "bind_tool",
                     "tool_id": "some-tool-id",
-                    "app_ids": ["app-one"],
+                    "add_app_ids": ["app-one"],
+                    "remove_app_ids": [],
                 }
             ],
         }
@@ -1787,11 +1785,11 @@ def test_watsonx_api_payload_accepts_bind_tool_with_empty_app_ids() -> None:
     WatsonxApiDeploymentUpdatePayload.model_validate(
         {
             "llm": TEST_WXO_LLM,
-            "operations": [
+            "upsert_tools": [
                 {
-                    "op": "bind_tool",
                     "tool_id": "some-tool-id",
-                    "app_ids": [],
+                    "add_app_ids": [],
+                    "remove_app_ids": [],
                 }
             ],
         }
@@ -1804,11 +1802,11 @@ def test_watsonx_api_payload_accepts_unbind_tool_operation() -> None:
         {
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
+            "upsert_tools": [
                 {
-                    "op": "unbind_tool",
                     "tool_id": "some-tool-id",
-                    "app_ids": ["app-one"],
+                    "add_app_ids": [],
+                    "remove_app_ids": ["app-one"],
                 }
             ],
         }
@@ -1820,27 +1818,26 @@ def test_watsonx_api_payload_accepts_remove_tool_by_id_operation() -> None:
     WatsonxApiDeploymentUpdatePayload.model_validate(
         {
             "llm": TEST_WXO_LLM,
-            "operations": [
-                {
-                    "op": "remove_tool_by_id",
-                    "tool_id": "some-tool-id",
-                }
-            ],
+            "remove_tools": ["some-tool-id"],
         }
     )
 
 
 def test_watsonx_api_payload_rejects_conflicting_tool_id_operations() -> None:
     """remove_tool_by_id + bind_tool for same tool_id is rejected."""
-    with pytest.raises(ValidationError, match="remove_tool_by_id cannot be combined"):
+    with pytest.raises(ValidationError, match="remove_tools cannot be combined"):
         WatsonxApiDeploymentUpdatePayload.model_validate(
             {
                 "llm": TEST_WXO_LLM,
                 "connections": {},
-                "operations": [
-                    {"op": "bind_tool", "tool_id": "tid", "app_ids": ["app-one"]},
-                    {"op": "remove_tool_by_id", "tool_id": "tid"},
+                "upsert_tools": [
+                    {
+                        "tool_id": "tid",
+                        "add_app_ids": ["app-one"],
+                        "remove_app_ids": [],
+                    },
                 ],
+                "remove_tools": ["tid"],
             }
         )
 
@@ -1854,8 +1851,12 @@ def test_watsonx_api_payload_unbind_tool_rejects_key_value_app_ids() -> None:
                 "connections": {
                     "key_value": [{"app_id": "app-new"}],
                 },
-                "operations": [
-                    {"op": "unbind_tool", "tool_id": "tid", "app_ids": ["app-new"]},
+                "upsert_tools": [
+                    {
+                        "tool_id": "tid",
+                        "add_app_ids": [],
+                        "remove_app_ids": ["app-new"],
+                    },
                 ],
             }
         )
@@ -1877,8 +1878,12 @@ def test_watsonx_api_payload_rejects_duplicate_credential_keys() -> None:
                         }
                     ]
                 },
-                "operations": [
-                    {"op": "bind_tool", "tool_id": "tid", "app_ids": ["app-new"]},
+                "upsert_tools": [
+                    {
+                        "tool_id": "tid",
+                        "add_app_ids": ["app-new"],
+                        "remove_app_ids": [],
+                    },
                 ],
             }
         )
@@ -1892,8 +1897,8 @@ async def test_watsonx_mapper_translates_bind_tool_into_provider_operations() ->
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
-                {"op": "bind_tool", "tool_id": "external-tool", "app_ids": ["app-one"]},
+            "upsert_tools": [
+                {"tool_id": "external-tool", "add_app_ids": ["app-one"], "remove_app_ids": []},
             ],
         }
     )
@@ -1920,8 +1925,8 @@ async def test_watsonx_mapper_translates_unbind_tool_into_provider_operations() 
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {},
-            "operations": [
-                {"op": "unbind_tool", "tool_id": "external-tool", "app_ids": ["app-one"]},
+            "upsert_tools": [
+                {"tool_id": "external-tool", "add_app_ids": [], "remove_app_ids": ["app-one"]},
             ],
         }
     )
@@ -1947,9 +1952,7 @@ async def test_watsonx_mapper_translates_remove_tool_by_id_into_provider_operati
     payload = DeploymentUpdateRequest(
         provider_data={
             "llm": TEST_WXO_LLM,
-            "operations": [
-                {"op": "remove_tool_by_id", "tool_id": "external-tool"},
-            ],
+            "remove_tools": ["external-tool"],
         }
     )
     db = _FakeDb([])
@@ -2114,29 +2117,29 @@ def test_watsonx_mapper_update_snapshot_bindings_filters_non_uuid_source_refs() 
 
 
 # ---------------------------------------------------------------------------
-# Create payload: bind_tool operations
+# Create payload: upsert_tools
 # ---------------------------------------------------------------------------
 
 
 def test_watsonx_create_payload_accepts_bind_tool_operation() -> None:
-    """Create payload should accept bind_tool operations."""
+    """Create payload should accept upsert_tools items."""
     WatsonxApiDeploymentCreatePayload.model_validate(
         {
             "llm": TEST_WXO_LLM,
-            "operations": [
-                {"op": "bind_tool", "tool_id": "existing-tool", "app_ids": []},
+            "upsert_tools": [
+                {"tool_id": "existing-tool", "add_app_ids": []},
             ],
         }
     )
 
 
 def test_watsonx_create_payload_bind_tool_without_prefix() -> None:
-    """bind_tool on create accepts minimal payload."""
+    """upsert_tools on create accepts minimal payload."""
     _payload = WatsonxApiDeploymentCreatePayload.model_validate(
         {
             "llm": TEST_WXO_LLM,
-            "operations": [
-                {"op": "bind_tool", "tool_id": "existing-tool", "app_ids": []},
+            "upsert_tools": [
+                {"tool_id": "existing-tool", "add_app_ids": []},
             ],
         }
     )

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -21,6 +21,8 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentUpdateRequest,
 )
 from lfx.services.adapters.deployment.schema import (
+    ConfigListItem,
+    ConfigListResult,
     DeploymentCreateResult,
     DeploymentListLlmsResult,
     DeploymentType,
@@ -247,6 +249,78 @@ def test_watsonx_mapper_flow_version_list_result_degrades_when_required_snapshot
     assert len(shaped.flow_versions) == 1
     assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
     assert shaped.flow_versions[0].provider_data is None
+
+
+def test_watsonx_mapper_shapes_config_list_result_with_full_slot_validation() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    now = datetime.now(tz=timezone.utc)
+    result = ConfigListResult(
+        configs=[
+            ConfigListItem(
+                id="cfg-1",
+                name="Config 1",
+                created_at=now,
+                updated_at=now,
+            ),
+            ConfigListItem(id="cfg-2", name="Config 2"),
+        ],
+        provider_result={"deployment_id": " dep-1 ", "tool_ids": ["tool-1", "  "]},
+    )
+
+    shaped = mapper.shape_config_list_result(result, page=1, size=1)
+
+    assert shaped.total == 2
+    assert shaped.page == 1
+    assert shaped.size == 1
+    assert shaped.provider_data is not None
+    assert shaped.provider_data["deployment_id"] == "dep-1"
+    assert shaped.provider_data["tool_ids"] == ["tool-1"]
+    assert len(shaped.provider_data["configs"]) == 1
+    assert shaped.provider_data["configs"][0]["id"] == "cfg-1"
+    assert shaped.provider_data["configs"][0]["name"] == "Config 1"
+    assert "provider_data" not in shaped.provider_data["configs"][0]
+
+
+def test_watsonx_mapper_shapes_snapshot_list_result_without_nested_provider_data() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    result = SnapshotListResult(
+        snapshots=[
+            SnapshotItem(
+                id="tool-1",
+                name="Tool 1",
+                provider_data={"connections": {"cfg-1": "conn-1"}},
+            )
+        ],
+        provider_result={"deployment_id": "dep-1"},
+    )
+
+    shaped = mapper.shape_snapshot_list_result(result, page=1, size=20)
+
+    assert shaped.total == 1
+    assert shaped.provider_data is not None
+    assert shaped.provider_data["deployment_id"] == "dep-1"
+    assert shaped.provider_data["snapshots"] == [
+        {
+            "id": "tool-1",
+            "name": "Tool 1",
+            "connections": {"cfg-1": "conn-1"},
+        }
+    ]
+    assert "provider_data" not in shaped.provider_data["snapshots"][0]
+
+
+def test_watsonx_mapper_snapshot_list_result_rejects_malformed_item_payload() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    result = SnapshotListResult(
+        snapshots=[SnapshotItem(id="tool-1", name="Tool 1", provider_data={"connections": {"cfg-1": "conn-1"}})],
+        provider_result={"deployment_id": "dep-1", "unexpected": True},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        mapper.shape_snapshot_list_result(result, page=1, size=20)
+
+    assert exc.value.status_code == 500
+    assert "Invalid snapshot list provider_data payload:" in str(exc.value.detail)
 
 
 @pytest.mark.parametrize("provider_snapshot_id", [None, "   "])

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -1036,8 +1036,10 @@ def test_watsonx_mapper_shapes_update_response_from_result_schema() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     timestamp = datetime.now(tz=timezone.utc)
     deployment_id = uuid4()
+    provider_account_id = uuid4()
     deployment_row = SimpleNamespace(
         id=deployment_id,
+        deployment_provider_account_id=provider_account_id,
         name="WXO Deployment",
         description="updated",
         deployment_type=DeploymentType.AGENT,
@@ -1064,9 +1066,11 @@ def test_watsonx_mapper_shapes_update_response_from_result_schema() -> None:
         },
     )
 
-    shaped = mapper.shape_deployment_update_result(result, deployment_row)
+    shaped = mapper.shape_deployment_update_result(result, deployment_row, provider_key="watsonx-orchestrate")
 
     assert shaped.id == deployment_id
+    assert shaped.provider_id == provider_account_id
+    assert shaped.provider_key == "watsonx-orchestrate"
     assert shaped.provider_data == {
         "created_app_ids": ["created-app-1"],
         "tool_app_bindings": [
@@ -1080,8 +1084,10 @@ def test_watsonx_mapper_update_response_tolerates_non_uuid_source_ref() -> None:
     """Non-UUID source_ref (from tool_id ops) produces flow_version_id=None."""
     mapper = WatsonxOrchestrateDeploymentMapper()
     timestamp = datetime.now(tz=timezone.utc)
+    provider_account_id = uuid4()
     deployment_row = SimpleNamespace(
         id=uuid4(),
+        deployment_provider_account_id=provider_account_id,
         name="WXO Deployment",
         description="updated",
         deployment_type=DeploymentType.AGENT,
@@ -1101,7 +1107,9 @@ def test_watsonx_mapper_update_response_tolerates_non_uuid_source_ref() -> None:
         },
     )
 
-    shaped = mapper.shape_deployment_update_result(result, deployment_row)
+    shaped = mapper.shape_deployment_update_result(result, deployment_row, provider_key="watsonx-orchestrate")
+    assert shaped.provider_id == provider_account_id
+    assert shaped.provider_key == "watsonx-orchestrate"
     bindings = shaped.provider_data["tool_app_bindings"]
     assert len(bindings) == 1
     assert "flow_version_id" not in bindings[0]
@@ -1113,8 +1121,10 @@ def test_watsonx_mapper_update_response_raises_on_unmapped_tool_binding() -> Non
     mapper = WatsonxOrchestrateDeploymentMapper()
     timestamp = datetime.now(tz=timezone.utc)
     mapped_fv_id = uuid4()
+    provider_account_id = uuid4()
     deployment_row = SimpleNamespace(
         id=uuid4(),
+        deployment_provider_account_id=provider_account_id,
         name="WXO Deployment",
         description="updated",
         deployment_type=DeploymentType.AGENT,
@@ -1136,7 +1146,7 @@ def test_watsonx_mapper_update_response_raises_on_unmapped_tool_binding() -> Non
     )
 
     with pytest.raises(HTTPException) as exc:
-        mapper.shape_deployment_update_result(result, deployment_row)
+        mapper.shape_deployment_update_result(result, deployment_row, provider_key="watsonx-orchestrate")
     assert exc.value.status_code == 500
     assert "orphan-tool" in exc.value.detail
     assert "no matching snapshot binding" in exc.value.detail
@@ -1846,9 +1856,11 @@ def test_watsonx_mapper_shapes_update_response_with_tool_id() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     timestamp = datetime.now(tz=timezone.utc)
     deployment_id = uuid4()
+    provider_account_id = uuid4()
     flow_version_id = uuid4()
     deployment_row = SimpleNamespace(
         id=deployment_id,
+        deployment_provider_account_id=provider_account_id,
         name="WXO Deployment",
         description="test",
         deployment_type=DeploymentType.AGENT,
@@ -1875,7 +1887,9 @@ def test_watsonx_mapper_shapes_update_response_with_tool_id() -> None:
         ),
     )
 
-    response = mapper.shape_deployment_update_result(result, deployment_row)
+    response = mapper.shape_deployment_update_result(result, deployment_row, provider_key="watsonx-orchestrate")
+    assert response.provider_id == provider_account_id
+    assert response.provider_key == "watsonx-orchestrate"
     bindings = response.provider_data["tool_app_bindings"]
     assert len(bindings) == 1
     assert bindings[0]["tool_id"] == "tool-1"
@@ -1886,8 +1900,10 @@ def test_watsonx_mapper_shapes_update_response_with_non_uuid_source_ref() -> Non
     """Non-UUID source_ref (from tool_id ops) should produce flow_version_id=None."""
     mapper = WatsonxOrchestrateDeploymentMapper()
     timestamp = datetime.now(tz=timezone.utc)
+    provider_account_id = uuid4()
     deployment_row = SimpleNamespace(
         id=uuid4(),
+        deployment_provider_account_id=provider_account_id,
         name="WXO Deployment",
         description="test",
         deployment_type=DeploymentType.AGENT,
@@ -1914,7 +1930,9 @@ def test_watsonx_mapper_shapes_update_response_with_non_uuid_source_ref() -> Non
         ),
     )
 
-    response = mapper.shape_deployment_update_result(result, deployment_row)
+    response = mapper.shape_deployment_update_result(result, deployment_row, provider_key="watsonx-orchestrate")
+    assert response.provider_id == provider_account_id
+    assert response.provider_key == "watsonx-orchestrate"
     bindings = response.provider_data["tool_app_bindings"]
     assert len(bindings) == 1
     assert bindings[0]["tool_id"] == "external-tool-id"

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -523,7 +523,7 @@ def test_watsonx_api_payload_accepts_flow_version_create_bind_contract() -> None
     payload = WatsonxApiDeploymentCreatePayload.model_validate(
         {
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "add_flows": [
                 {
                     "flow_version_id": str(flow_version_id),
@@ -540,7 +540,7 @@ def test_watsonx_api_payload_accepts_flow_version_bind_contract() -> None:
     payload = WatsonxApiDeploymentUpdatePayload.model_validate(
         {
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "upsert_flows": [
                 {
                     "flow_version_id": str(flow_version_id),
@@ -575,7 +575,7 @@ def test_watsonx_api_payload_rejects_create_without_llm() -> None:
     with pytest.raises(ValidationError, match="llm"):
         WatsonxApiDeploymentCreatePayload.model_validate(
             {
-                "connections": {},
+                "connections": [],
                 "add_flows": [
                     {
                         "flow_version_id": str(flow_version_id),
@@ -604,7 +604,7 @@ def test_watsonx_api_payload_rejects_update_without_llm() -> None:
     with pytest.raises(ValidationError, match="llm"):
         WatsonxApiDeploymentUpdatePayload.model_validate(
             {
-                "connections": {},
+                "connections": [],
                 "upsert_flows": [
                     {
                         "flow_version_id": str(flow_version_id),
@@ -622,7 +622,7 @@ def test_watsonx_api_payload_accepts_flow_version_unbind_and_remove_contract() -
     payload = WatsonxApiDeploymentUpdatePayload.model_validate(
         {
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "upsert_flows": [
                 {
                     "flow_version_id": str(flow_version_id),
@@ -644,14 +644,13 @@ def test_watsonx_mapper_create_result_from_existing_update_normalizes_slot_paylo
         {
             "created_app_ids": ["app-one"],
             "created_snapshot_ids": ["tool-1"],
-            "added_snapshot_bindings": [
+            "created_snapshot_bindings": [
                 {
                     "source_ref": str(flow_version_id),
                     "tool_id": "tool-1",
                     "created": True,
                 }
             ],
-            "tool_app_bindings": [{"tool_id": "tool-1", "app_ids": ["app-one"]}],
         }
     )
     update_result = SimpleNamespace(provider_result=provider_result)
@@ -665,7 +664,7 @@ def test_watsonx_mapper_create_result_from_existing_update_normalizes_slot_paylo
     assert create_result.provider_result == {
         "app_ids": ["app-one"],
         "tools_with_refs": [{"source_ref": str(flow_version_id), "tool_id": "tool-1"}],
-        "tool_app_bindings": [{"tool_id": "tool-1", "app_ids": ["app-one"]}],
+        "tool_app_bindings": [],
     }
 
 
@@ -742,7 +741,7 @@ async def test_watsonx_mapper_translates_create_bind_into_raw_tool_payload() -> 
         type="agent",
         provider_data={
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "add_flows": [
                 {
                     "flow_version_id": str(flow_version_id),
@@ -791,7 +790,7 @@ async def test_watsonx_mapper_translates_existing_create_bind_into_update_payloa
         provider_data={
             "llm": TEST_WXO_LLM,
             "existing_agent_id": "21b2b5a4-ef72-4697-8731-132163669a46",
-            "connections": {},
+            "connections": [],
             "add_flows": [
                 {
                     "flow_version_id": str(flow_version_id),
@@ -835,7 +834,7 @@ async def test_watsonx_mapper_maps_create_adapter_payload_validation_errors_to_4
         type="agent",
         provider_data={
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "add_flows": [
                 {
                     "flow_version_id": str(flow_version_id),
@@ -882,7 +881,7 @@ async def test_watsonx_mapper_create_reports_missing_llm_field_name() -> None:
         description="",
         type="agent",
         provider_data={
-            "connections": {},
+            "connections": [],
             "add_flows": [
                 {
                     "flow_version_id": str(uuid4()),
@@ -1003,7 +1002,7 @@ async def test_watsonx_mapper_translates_flow_version_bind_into_raw_tool_payload
     payload = DeploymentUpdateRequest(
         provider_data={
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "upsert_flows": [
                 {
                     "flow_version_id": str(flow_version_id),
@@ -1062,7 +1061,7 @@ async def test_watsonx_mapper_skips_empty_bind_operations_but_keeps_raw_tools() 
     payload = DeploymentUpdateRequest(
         provider_data={
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "upsert_flows": [
                 {
                     "flow_version_id": str(flow_version_id_unbound),
@@ -1123,7 +1122,7 @@ async def test_watsonx_mapper_translates_unbind_and_remove_via_attachment_snapsh
     payload = DeploymentUpdateRequest(
         provider_data={
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "upsert_flows": [
                 {
                     "flow_version_id": str(flow_version_id_unbind),
@@ -1166,18 +1165,17 @@ def test_watsonx_update_result_data_normalizes_fields() -> None:
     data = WatsonxApiDeploymentUpdateResultData.from_provider_result(
         {
             "created_app_ids": ["  app-one  ", "", "app-two"],
-            "tool_app_bindings": [
-                {"flow_version_id": str(flow_version_id), "tool_id": "tool-1", "app_ids": [" app-a ", "", "app-b"]},
+            "created_tools": [
+                {"flow_version_id": str(flow_version_id), "tool_id": "tool-1"},
             ],
             "ignored_key": True,
         }
     )
 
     assert data.created_app_ids == ["app-one", "app-two"]
-    assert data.tool_app_bindings is not None
-    assert data.tool_app_bindings[0].flow_version_id == flow_version_id
-    assert data.tool_app_bindings[0].tool_id == "tool-1"
-    assert data.tool_app_bindings[0].app_ids == ["app-a", "app-b"]
+    assert data.created_tools is not None
+    assert data.created_tools[0].flow_version_id == flow_version_id
+    assert data.created_tools[0].tool_id == "tool-1"
 
 
 def test_watsonx_mapper_shapes_update_response_from_result_schema() -> None:
@@ -1188,6 +1186,7 @@ def test_watsonx_mapper_shapes_update_response_from_result_schema() -> None:
     deployment_row = SimpleNamespace(
         id=deployment_id,
         deployment_provider_account_id=provider_account_id,
+        resource_key="agent-123",
         name="WXO Deployment",
         description="updated",
         deployment_type=DeploymentType.AGENT,
@@ -1195,21 +1194,12 @@ def test_watsonx_mapper_shapes_update_response_from_result_schema() -> None:
         updated_at=timestamp,
     )
     new_flow_version_id = uuid4()
-    existing_flow_version_id = uuid4()
     result = DeploymentUpdateResult(
         id="provider-id",
         provider_result={
             "created_app_ids": ["created-app-1"],
-            "added_snapshot_bindings": [
+            "created_snapshot_bindings": [
                 {"source_ref": str(new_flow_version_id), "tool_id": "new-tool-1", "created": True}
-            ],
-            "referenced_snapshot_bindings": [
-                {"source_ref": str(new_flow_version_id), "tool_id": "new-tool-1", "created": True},
-                {"source_ref": str(existing_flow_version_id), "tool_id": "existing-tool-1", "created": False},
-            ],
-            "tool_app_bindings": [
-                {"tool_id": "new-tool-1", "app_ids": ["app-a"]},
-                {"tool_id": "existing-tool-1", "app_ids": ["app-b"]},
             ],
         },
     )
@@ -1219,23 +1209,24 @@ def test_watsonx_mapper_shapes_update_response_from_result_schema() -> None:
     assert shaped.id == deployment_id
     assert shaped.provider_id == provider_account_id
     assert shaped.provider_key == "watsonx-orchestrate"
+    assert shaped.resource_key == "agent-123"
     assert shaped.provider_data == {
         "created_app_ids": ["created-app-1"],
-        "tool_app_bindings": [
-            {"flow_version_id": str(new_flow_version_id), "tool_id": "new-tool-1", "app_ids": ["app-a"]},
-            {"flow_version_id": str(existing_flow_version_id), "tool_id": "existing-tool-1", "app_ids": ["app-b"]},
+        "created_tools": [
+            {"flow_version_id": str(new_flow_version_id), "tool_id": "new-tool-1"},
         ],
     }
 
 
-def test_watsonx_mapper_update_response_tolerates_non_uuid_source_ref() -> None:
-    """Non-UUID source_ref (from tool_id ops) produces flow_version_id=None."""
+def test_watsonx_mapper_update_response_rejects_non_uuid_source_ref() -> None:
+    """Non-UUID source_ref in created_snapshot_bindings raises HTTP 500."""
     mapper = WatsonxOrchestrateDeploymentMapper()
     timestamp = datetime.now(tz=timezone.utc)
     provider_account_id = uuid4()
     deployment_row = SimpleNamespace(
         id=uuid4(),
         deployment_provider_account_id=provider_account_id,
+        resource_key="agent-123",
         name="WXO Deployment",
         description="updated",
         deployment_type=DeploymentType.AGENT,
@@ -1246,49 +1237,8 @@ def test_watsonx_mapper_update_response_tolerates_non_uuid_source_ref() -> None:
         id="provider-id",
         provider_result={
             "created_app_ids": [],
-            "referenced_snapshot_bindings": [
-                {"source_ref": "not-a-uuid", "tool_id": "tool-1", "created": False},
-            ],
-            "tool_app_bindings": [
-                {"tool_id": "tool-1", "app_ids": ["app-a"]},
-            ],
-        },
-    )
-
-    shaped = mapper.shape_deployment_update_result(result, deployment_row, provider_key="watsonx-orchestrate")
-    assert shaped.provider_id == provider_account_id
-    assert shaped.provider_key == "watsonx-orchestrate"
-    bindings = shaped.provider_data["tool_app_bindings"]
-    assert len(bindings) == 1
-    assert "flow_version_id" not in bindings[0]
-    assert bindings[0]["tool_id"] == "tool-1"
-
-
-def test_watsonx_mapper_update_response_raises_on_unmapped_tool_binding() -> None:
-    """tool_app_binding whose tool_id has no matching snapshot ref raises HTTP 500."""
-    mapper = WatsonxOrchestrateDeploymentMapper()
-    timestamp = datetime.now(tz=timezone.utc)
-    mapped_fv_id = uuid4()
-    provider_account_id = uuid4()
-    deployment_row = SimpleNamespace(
-        id=uuid4(),
-        deployment_provider_account_id=provider_account_id,
-        name="WXO Deployment",
-        description="updated",
-        deployment_type=DeploymentType.AGENT,
-        created_at=timestamp,
-        updated_at=timestamp,
-    )
-    result = DeploymentUpdateResult(
-        id="provider-id",
-        provider_result={
-            "created_app_ids": [],
-            "referenced_snapshot_bindings": [
-                {"source_ref": str(mapped_fv_id), "tool_id": "mapped-tool", "created": True},
-            ],
-            "tool_app_bindings": [
-                {"tool_id": "mapped-tool", "app_ids": ["app-a"]},
-                {"tool_id": "orphan-tool", "app_ids": ["app-b"]},
+            "created_snapshot_bindings": [
+                {"source_ref": "not-a-uuid", "tool_id": "tool-1", "created": True},
             ],
         },
     )
@@ -1296,8 +1246,39 @@ def test_watsonx_mapper_update_response_raises_on_unmapped_tool_binding() -> Non
     with pytest.raises(HTTPException) as exc:
         mapper.shape_deployment_update_result(result, deployment_row, provider_key="watsonx-orchestrate")
     assert exc.value.status_code == 500
+    assert "non-UUID source_ref" in exc.value.detail
+
+
+def test_watsonx_mapper_create_response_rejects_non_uuid_source_ref_in_created_tools() -> None:
+    """Create result must reject non-UUID source_ref in created tools."""
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    timestamp = datetime.now(tz=timezone.utc)
+    provider_account_id = uuid4()
+    deployment_row = SimpleNamespace(
+        id=uuid4(),
+        deployment_provider_account_id=provider_account_id,
+        resource_key="agent-123",
+        name="WXO Deployment",
+        description="updated",
+        deployment_type=DeploymentType.AGENT,
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+    result = DeploymentCreateResult(
+        id="provider-id",
+        provider_result={
+            "app_ids": [],
+            "tools_with_refs": [
+                {"source_ref": "not-a-uuid", "tool_id": "orphan-tool"},
+            ],
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        mapper.shape_deployment_create_result(result, deployment_row, provider_key="watsonx-orchestrate")
+    assert exc.value.status_code == 500
     assert "orphan-tool" in exc.value.detail
-    assert "no matching snapshot binding" in exc.value.detail
+    assert "non-UUID source_ref" in exc.value.detail
 
 
 def test_watsonx_mapper_shapes_llm_list_result() -> None:
@@ -1342,7 +1323,7 @@ def test_watsonx_mapper_exposes_reconciliation_resolvers() -> None:
         DeploymentUpdateRequest(
             provider_data={
                 "llm": TEST_WXO_LLM,
-                "connections": {},
+                "connections": [],
                 "upsert_flows": [
                     {
                         "flow_version_id": str(add_id),
@@ -1537,21 +1518,19 @@ async def test_watsonx_mapper_create_preserves_env_var_source_in_connection_payl
         type="agent",
         provider_data={
             "llm": TEST_WXO_LLM,
-            "connections": {
-                "key_value": [
-                    {
-                        "app_id": "app-new",
-                        "credentials": [
-                            {
-                                "key": "RAW_TOKEN",
-                                "value": "literal-secret",
-                                "source": "raw",
-                            },  # pragma: allowlist secret
-                            {"key": "VAR_REF", "value": "MY_GLOBAL_VAR", "source": "variable"},
-                        ],
-                    }
-                ],
-            },
+            "connections": [
+                {
+                    "app_id": "app-new",
+                    "credentials": [
+                        {
+                            "key": "RAW_TOKEN",
+                            "value": "literal-secret",
+                            "source": "raw",
+                        },  # pragma: allowlist secret
+                        {"key": "VAR_REF", "value": "MY_GLOBAL_VAR", "source": "variable"},
+                    ],
+                }
+            ],
             "add_flows": [
                 {
                     "flow_version_id": str(flow_version_id),
@@ -1637,7 +1616,7 @@ async def test_watsonx_mapper_bind_reuses_existing_tool_when_attachment_exists()
     payload = DeploymentUpdateRequest(
         provider_data={
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "upsert_flows": [
                 {
                     "flow_version_id": str(flow_version_id),
@@ -1685,7 +1664,7 @@ async def test_watsonx_mapper_bind_creates_new_tool_when_no_attachment() -> None
     payload = DeploymentUpdateRequest(
         provider_data={
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "upsert_flows": [
                 {
                     "flow_version_id": str(flow_version_id),
@@ -1768,7 +1747,7 @@ def test_watsonx_api_payload_accepts_bind_tool_operation() -> None:
     WatsonxApiDeploymentUpdatePayload.model_validate(
         {
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "upsert_tools": [
                 {
                     "tool_id": "some-tool-id",
@@ -1801,7 +1780,7 @@ def test_watsonx_api_payload_accepts_unbind_tool_operation() -> None:
     WatsonxApiDeploymentUpdatePayload.model_validate(
         {
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "upsert_tools": [
                 {
                     "tool_id": "some-tool-id",
@@ -1829,7 +1808,7 @@ def test_watsonx_api_payload_rejects_conflicting_tool_id_operations() -> None:
         WatsonxApiDeploymentUpdatePayload.model_validate(
             {
                 "llm": TEST_WXO_LLM,
-                "connections": {},
+                "connections": [],
                 "upsert_tools": [
                     {
                         "tool_id": "tid",
@@ -1842,15 +1821,13 @@ def test_watsonx_api_payload_rejects_conflicting_tool_id_operations() -> None:
         )
 
 
-def test_watsonx_api_payload_unbind_tool_rejects_key_value_app_ids() -> None:
-    """unbind_tool referencing key_value app_ids should be rejected."""
-    with pytest.raises(ValidationError, match=r"must not reference connections\.key_value app_ids"):
+def test_watsonx_api_payload_unbind_tool_rejects_connection_app_ids() -> None:
+    """unbind_tool referencing raw connections app_ids should be rejected."""
+    with pytest.raises(ValidationError, match=r"must not reference connections app_ids"):
         WatsonxApiDeploymentUpdatePayload.model_validate(
             {
                 "llm": TEST_WXO_LLM,
-                "connections": {
-                    "key_value": [{"app_id": "app-new"}],
-                },
+                "connections": [{"app_id": "app-new"}],
                 "upsert_tools": [
                     {
                         "tool_id": "tid",
@@ -1867,17 +1844,15 @@ def test_watsonx_api_payload_rejects_duplicate_credential_keys() -> None:
         WatsonxApiDeploymentUpdatePayload.model_validate(
             {
                 "llm": TEST_WXO_LLM,
-                "connections": {
-                    "key_value": [
-                        {
-                            "app_id": "app-new",
-                            "credentials": [
-                                {"key": "TOKEN", "value": "secret-a", "source": "raw"},  # pragma: allowlist secret
-                                {"key": "TOKEN", "value": "secret-b", "source": "raw"},  # pragma: allowlist secret
-                            ],
-                        }
-                    ]
-                },
+                "connections": [
+                    {
+                        "app_id": "app-new",
+                        "credentials": [
+                            {"key": "TOKEN", "value": "secret-a", "source": "raw"},  # pragma: allowlist secret
+                            {"key": "TOKEN", "value": "secret-b", "source": "raw"},  # pragma: allowlist secret
+                        ],
+                    }
+                ],
                 "upsert_tools": [
                     {
                         "tool_id": "tid",
@@ -1896,7 +1871,7 @@ async def test_watsonx_mapper_translates_bind_tool_into_provider_operations() ->
     payload = DeploymentUpdateRequest(
         provider_data={
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "upsert_tools": [
                 {"tool_id": "external-tool", "add_app_ids": ["app-one"], "remove_app_ids": []},
             ],
@@ -1924,7 +1899,7 @@ async def test_watsonx_mapper_translates_unbind_tool_into_provider_operations() 
     payload = DeploymentUpdateRequest(
         provider_data={
             "llm": TEST_WXO_LLM,
-            "connections": {},
+            "connections": [],
             "upsert_tools": [
                 {"tool_id": "external-tool", "add_app_ids": [], "remove_app_ids": ["app-one"]},
             ],
@@ -1971,32 +1946,27 @@ async def test_watsonx_mapper_translates_remove_tool_by_id_into_provider_operati
 
 
 # ---------------------------------------------------------------------------
-# tool_id in WatsonxApiToolAppBinding response
+# tool_id in WatsonxApiCreatedTool response
 # ---------------------------------------------------------------------------
 
 
-def test_watsonx_tool_app_binding_includes_tool_id() -> None:
-    """WatsonxApiToolAppBinding now requires tool_id and makes flow_version_id optional."""
-    from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import WatsonxApiToolAppBinding
+def test_watsonx_created_tool_includes_tool_id() -> None:
+    """WatsonxApiCreatedTool requires tool_id and non-null flow_version_id."""
+    from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import WatsonxApiCreatedTool
 
-    binding = WatsonxApiToolAppBinding(
+    binding = WatsonxApiCreatedTool(
         flow_version_id=uuid4(),
         tool_id="tool-123",
-        app_ids=["app-one"],
     )
     assert binding.tool_id == "tool-123"
     assert binding.flow_version_id is not None
 
-    binding_no_fv = WatsonxApiToolAppBinding(
-        tool_id="tool-456",
-        app_ids=[],
-    )
-    assert binding_no_fv.flow_version_id is None
-    assert binding_no_fv.tool_id == "tool-456"
+    with pytest.raises(ValidationError):
+        WatsonxApiCreatedTool(tool_id="tool-456")
 
 
 def test_watsonx_mapper_shapes_update_response_with_tool_id() -> None:
-    """shape_deployment_update_result should include tool_id in bindings."""
+    """shape_deployment_update_result should include tool_id in created_tools."""
     mapper = WatsonxOrchestrateDeploymentMapper()
     timestamp = datetime.now(tz=timezone.utc)
     deployment_id = uuid4()
@@ -2005,6 +1975,7 @@ def test_watsonx_mapper_shapes_update_response_with_tool_id() -> None:
     deployment_row = SimpleNamespace(
         id=deployment_id,
         deployment_provider_account_id=provider_account_id,
+        resource_key="agent-123",
         name="WXO Deployment",
         description="test",
         deployment_type=DeploymentType.AGENT,
@@ -2021,11 +1992,8 @@ def test_watsonx_mapper_shapes_update_response_with_tool_id() -> None:
         provider_result=WXO_SCHEMAS.deployment_update_result.apply(
             WatsonxDeploymentUpdateResultData(
                 created_app_ids=[],
-                referenced_snapshot_bindings=[
+                created_snapshot_bindings=[
                     {"source_ref": str(flow_version_id), "tool_id": "tool-1", "created": True},
-                ],
-                tool_app_bindings=[
-                    {"tool_id": "tool-1", "app_ids": ["app-one"]},
                 ],
             )
         ),
@@ -2034,20 +2002,22 @@ def test_watsonx_mapper_shapes_update_response_with_tool_id() -> None:
     response = mapper.shape_deployment_update_result(result, deployment_row, provider_key="watsonx-orchestrate")
     assert response.provider_id == provider_account_id
     assert response.provider_key == "watsonx-orchestrate"
-    bindings = response.provider_data["tool_app_bindings"]
+    assert response.resource_key == "agent-123"
+    bindings = response.provider_data["created_tools"]
     assert len(bindings) == 1
     assert bindings[0]["tool_id"] == "tool-1"
     assert bindings[0]["flow_version_id"] == str(flow_version_id)
 
 
 def test_watsonx_mapper_shapes_update_response_with_non_uuid_source_ref() -> None:
-    """Non-UUID source_ref (from tool_id ops) should produce flow_version_id=None."""
+    """Non-UUID source_ref in created_snapshot_bindings should fail."""
     mapper = WatsonxOrchestrateDeploymentMapper()
     timestamp = datetime.now(tz=timezone.utc)
     provider_account_id = uuid4()
     deployment_row = SimpleNamespace(
         id=uuid4(),
         deployment_provider_account_id=provider_account_id,
+        resource_key="agent-123",
         name="WXO Deployment",
         description="test",
         deployment_type=DeploymentType.AGENT,
@@ -2064,23 +2034,17 @@ def test_watsonx_mapper_shapes_update_response_with_non_uuid_source_ref() -> Non
         provider_result=WXO_SCHEMAS.deployment_update_result.apply(
             WatsonxDeploymentUpdateResultData(
                 created_app_ids=[],
-                referenced_snapshot_bindings=[
-                    {"source_ref": "external-tool-id", "tool_id": "external-tool-id", "created": False},
-                ],
-                tool_app_bindings=[
-                    {"tool_id": "external-tool-id", "app_ids": ["app-one"]},
+                created_snapshot_bindings=[
+                    {"source_ref": "external-tool-id", "tool_id": "external-tool-id", "created": True},
                 ],
             )
         ),
     )
 
-    response = mapper.shape_deployment_update_result(result, deployment_row, provider_key="watsonx-orchestrate")
-    assert response.provider_id == provider_account_id
-    assert response.provider_key == "watsonx-orchestrate"
-    bindings = response.provider_data["tool_app_bindings"]
-    assert len(bindings) == 1
-    assert bindings[0]["tool_id"] == "external-tool-id"
-    assert "flow_version_id" not in bindings[0]
+    with pytest.raises(HTTPException) as exc:
+        mapper.shape_deployment_update_result(result, deployment_row, provider_key="watsonx-orchestrate")
+    assert exc.value.status_code == 500
+    assert "non-UUID source_ref" in exc.value.detail
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -579,7 +579,7 @@ def test_watsonx_mapper_resolve_verify_credentials_for_update_prefers_new_provid
 @pytest.mark.asyncio
 async def test_watsonx_mapper_resolve_update_passthrough_without_provider_data() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
-    payload = DeploymentUpdateRequest(spec={"name": "n"})
+    payload = DeploymentUpdateRequest(name="n")
 
     resolved = await mapper.resolve_deployment_update(
         user_id=uuid4(),
@@ -600,7 +600,9 @@ async def test_watsonx_mapper_translates_create_bind_into_raw_tool_payload() -> 
     project_id = uuid4()
     payload = DeploymentCreateRequest(
         provider_id=uuid4(),
-        spec={"name": "create-deploy", "description": "", "type": "agent"},
+        name="create-deploy",
+        description="",
+        type="agent",
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {},
@@ -647,7 +649,9 @@ async def test_watsonx_mapper_translates_existing_create_bind_into_update_payloa
     project_id = uuid4()
     payload = DeploymentCreateRequest(
         provider_id=uuid4(),
-        spec={"name": "existing-create", "description": "desc", "type": "agent"},
+        name="existing-create",
+        description="desc",
+        type="agent",
         provider_data={
             "llm": TEST_WXO_LLM,
             "existing_agent_id": "21b2b5a4-ef72-4697-8731-132163669a46",
@@ -691,7 +695,9 @@ async def test_watsonx_mapper_maps_create_adapter_payload_validation_errors_to_4
     flow_id = uuid4()
     payload = DeploymentCreateRequest(
         provider_id=uuid4(),
-        spec={"name": "create-deploy", "description": "", "type": "agent"},
+        name="create-deploy",
+        description="",
+        type="agent",
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {},
@@ -738,7 +744,9 @@ async def test_watsonx_mapper_create_reports_missing_llm_field_name() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     payload = DeploymentCreateRequest(
         provider_id=uuid4(),
-        spec={"name": "create-deploy", "description": "", "type": "agent"},
+        name="create-deploy",
+        description="",
+        type="agent",
         provider_data={
             "connections": {},
             "operations": [
@@ -768,7 +776,9 @@ async def test_watsonx_mapper_create_reports_unknown_field_name() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     payload = DeploymentCreateRequest(
         provider_id=uuid4(),
-        spec={"name": "create-deploy", "description": "", "type": "agent"},
+        name="create-deploy",
+        description="",
+        type="agent",
         provider_data={
             "llm": TEST_WXO_LLM,
             "resource_name_prefix": "lf_test_",
@@ -810,7 +820,9 @@ async def test_watsonx_mapper_create_skips_empty_bind_operations_but_keeps_raw_t
     )
     payload = DeploymentCreateRequest(
         provider_id=uuid4(),
-        spec={"name": "create-deploy", "description": "", "type": "agent"},
+        name="create-deploy",
+        description="",
+        type="agent",
         provider_data={
             "llm": TEST_WXO_LLM,
             "operations": [
@@ -1383,7 +1395,9 @@ async def test_watsonx_mapper_create_preserves_env_var_source_in_connection_payl
     project_id = uuid4()
     payload = DeploymentCreateRequest(
         provider_id=uuid4(),
-        spec={"name": "deploy-with-vars", "description": "", "type": "agent"},
+        name="deploy-with-vars",
+        description="",
+        type="agent",
         provider_data={
             "llm": TEST_WXO_LLM,
             "connections": {

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -879,31 +879,40 @@ class TestListDeploymentFlowVersionsRoute:
 
 class TestProviderAccountRoutes:
     @pytest.mark.asyncio
+    @patch(f"{ROUTES_MODULE}.to_provider_account_response", return_value={"ok": True})
+    @patch(f"{ROUTES_MODULE}.update_provider_account_row", new_callable=AsyncMock)
     @patch(f"{ROUTES_MODULE}.resolve_deployment_adapter")
     @patch(f"{ROUTES_MODULE}.get_deployment_mapper")
     @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
-    async def test_update_provider_account_rejects_disallowed_url(
+    async def test_update_provider_account_name_only_skips_credential_verification(
         self,
         mock_get_provider_account,
         mock_get_mapper,
         mock_resolve_adapter,
+        mock_update_provider_account,
+        mock_to_provider_response,  # noqa: ARG002
     ):
-        """PATCH rejects provider URLs that do not match the provider allowlist."""
+        """PATCH skips credential verification when only name changes."""
         from langflow.api.v1.deployments import update_provider_account
 
-        mock_get_provider_account.return_value = _fake_provider_account()
+        existing_account = _fake_provider_account()
+        mock_get_provider_account.return_value = existing_account
+        mapper = MagicMock()
+        mapper.resolve_provider_account_update.return_value = {"name": "renamed"}
+        mock_get_mapper.return_value = mapper
+        mock_update_provider_account.return_value = existing_account
 
-        with pytest.raises(HTTPException) as exc_info:
-            await update_provider_account(
-                provider_id=uuid4(),
-                session=AsyncMock(),
-                payload=DeploymentProviderAccountUpdateRequest(provider_url="https://new.example.com/api"),
-                current_user=_fake_user(),
-            )
+        session = AsyncMock()
+        await update_provider_account(
+            provider_id=existing_account.id,
+            session=session,
+            payload=DeploymentProviderAccountUpdateRequest(name="renamed"),
+            current_user=_fake_user(),
+        )
 
-        assert exc_info.value.status_code == 400
-        mock_get_mapper.assert_not_called()
+        mapper.resolve_verify_credentials_for_update.assert_not_called()
         mock_resolve_adapter.assert_not_called()
+        mock_update_provider_account.assert_awaited_once()
 
     @pytest.mark.asyncio
     @patch(f"{ROUTES_MODULE}.update_provider_account_row", new_callable=AsyncMock)
@@ -971,7 +980,7 @@ class TestProviderAccountRoutes:
         payload = DeploymentProviderAccountCreateRequest(
             name="prod",
             provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-            provider_url="https://api.us-south.wxo.cloud.ibm.com/instances/tenant-1",
+            url="https://api.us-south.wxo.cloud.ibm.com/instances/tenant-1",
             provider_data={"api_key": "api-key"},  # pragma: allowlist secret
         )
 

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -9,6 +9,7 @@ Covers the integration behaviour of the FastAPI route handlers:
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -701,7 +702,7 @@ class TestConfigAndSnapshotListRoutes:
                 ConfigListItem(id="cfg-1", name="Config 1"),
                 ConfigListItem(id="cfg-2", name="Config 2"),
             ],
-            provider_result={"scope": "tenant"},
+            provider_result={},
         )
         mock_resolve_adapter.return_value = adapter
         mapper = MagicMock()
@@ -759,7 +760,7 @@ class TestConfigAndSnapshotListRoutes:
                 SnapshotItem(id="tool-1", name="Tool 1"),
                 SnapshotItem(id="tool-2", name="Tool 2"),
             ],
-            provider_result={"scope": "deployment"},
+            provider_result={"deployment_id": "dep-1"},
         )
         mock_resolve_adapter.return_value = adapter
         mapper = MagicMock()
@@ -1516,6 +1517,53 @@ class TestGetDeploymentSync:
 
         assert exc_info.value.status_code == 503
         mock_delete_row.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch(f"{ROUTES_MODULE}.list_deployment_attachments", new_callable=AsyncMock, return_value=[])
+    @patch(f"{ROUTES_MODULE}.resolve_adapter_mapper_from_deployment", new_callable=AsyncMock)
+    async def test_get_deployment_does_not_inject_resource_key_into_provider_data(
+        self,
+        mock_resolve,
+        mock_list_att,  # noqa: ARG002
+    ):
+        from langflow.api.v1.deployments import get_deployment
+        from langflow.api.v1.mappers.deployments.base import BaseDeploymentMapper
+
+        created_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        updated_at = datetime(2026, 1, 3, 4, 5, 6, tzinfo=timezone.utc)
+        dep_row = _fake_deployment_row(
+            resource_key="provider-rk-1",
+            name="db-owned-name",
+            description="db-owned-description",
+            deployment_type="agent",
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+        adapter = AsyncMock()
+        provider_deployment = MagicMock()
+        provider_deployment.name = "provider-owned-name"
+        provider_deployment.description = "provider-owned-description"
+        provider_deployment.type = "worker"
+        provider_deployment.created_at = None
+        provider_deployment.updated_at = None
+        provider_deployment.model_dump.return_value = {
+            "provider_data": {
+                "llm": "virtual-model/bedrock/openai.gpt-oss-120b-1:0",
+            }
+        }
+        adapter.get.return_value = provider_deployment
+        mock_resolve.return_value = (dep_row, adapter, BaseDeploymentMapper())
+
+        session = AsyncMock()
+        result = await get_deployment(deployment_id=dep_row.id, session=session, current_user=_fake_user())
+
+        assert result.resource_key == "provider-rk-1"
+        assert result.name == "db-owned-name"
+        assert result.description == "db-owned-description"
+        assert result.type == "agent"
+        assert result.created_at == created_at
+        assert result.updated_at == updated_at
+        assert result.provider_data == {"llm": "virtual-model/bedrock/openai.gpt-oss-120b-1:0"}
 
     @pytest.mark.asyncio
     @patch(f"{ROUTES_MODULE}.sync_attachment_snapshot_ids", new_callable=AsyncMock)

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -464,7 +464,11 @@ class TestCreateDeploymentExistingAgent:
             existing_resource_key="existing-agent-1",
             result=adapter.update.return_value,
         )
-        mapper.shape_deployment_create_result.assert_called_once_with(mapped_create_result, dep_row)
+        mapper.shape_deployment_create_result.assert_called_once_with(
+            mapped_create_result,
+            dep_row,
+            provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
+        )
 
     @pytest.mark.asyncio
     @patch(f"{ROUTES_MODULE}.create_deployment_db", new_callable=AsyncMock)
@@ -823,7 +827,7 @@ class TestListDeploymentFlowVersionsRoute:
                 )
             ]
         )
-        mock_resolve.return_value = (deployment_row, adapter, mapper)
+        mock_resolve.return_value = (deployment_row, adapter, mapper, "watsonx-orchestrate")
         mock_list_flow_versions_synced.return_value = (rows, 7, snapshot_result)
         mapper.shape_flow_version_list_result.return_value = SimpleNamespace(
             page=2,
@@ -1128,7 +1132,7 @@ class TestUpdateDeploymentRollback:
         adapter.update.return_value = update_result
         mapper.resolve_deployment_update = AsyncMock(return_value=MagicMock())
         mapper.shape_deployment_update_result.return_value = MagicMock()
-        mock_resolve_amm.return_value = (dep_row, adapter, mapper)
+        mock_resolve_amm.return_value = (dep_row, adapter, mapper, "watsonx-orchestrate")
 
         session = AsyncMock()
         session.commit.side_effect = RuntimeError("DB commit failed")
@@ -1179,7 +1183,7 @@ class TestUpdateDeploymentRollback:
         adapter.update.return_value = update_result
         mapper.resolve_deployment_update = AsyncMock(return_value=MagicMock())
         mapper.shape_deployment_update_result.return_value = MagicMock()
-        mock_resolve_amm.return_value = (dep_row, adapter, mapper)
+        mock_resolve_amm.return_value = (dep_row, adapter, mapper, "watsonx-orchestrate")
 
         session = AsyncMock()
         session.commit.return_value = None
@@ -1234,7 +1238,7 @@ class TestUpdateDeploymentAlreadyAttachedFiltering:
         adapter.update.return_value = update_result
         mapper.resolve_deployment_update = AsyncMock(return_value=MagicMock())
         mapper.shape_deployment_update_result.return_value = MagicMock()
-        mock_resolve_amm.return_value = (dep_row, adapter, mapper)
+        mock_resolve_amm.return_value = (dep_row, adapter, mapper, "watsonx-orchestrate")
 
         reused_fv_id = uuid4()
         new_fv_id = uuid4()
@@ -1291,7 +1295,7 @@ class TestUpdateDeploymentAlreadyAttachedFiltering:
         adapter.update.return_value = update_result
         mapper.resolve_deployment_update = AsyncMock(return_value=MagicMock())
         mapper.shape_deployment_update_result.return_value = MagicMock()
-        mock_resolve_amm.return_value = (dep_row, adapter, mapper)
+        mock_resolve_amm.return_value = (dep_row, adapter, mapper, "watsonx-orchestrate")
 
         fv_id_1 = uuid4()
         fv_id_2 = uuid4()
@@ -1344,7 +1348,7 @@ class TestUpdateDeploymentAlreadyAttachedFiltering:
         adapter.update.return_value = update_result
         mapper.resolve_deployment_update = AsyncMock(return_value=MagicMock())
         mapper.shape_deployment_update_result.return_value = MagicMock()
-        mock_resolve_amm.return_value = (dep_row, adapter, mapper)
+        mock_resolve_amm.return_value = (dep_row, adapter, mapper, "watsonx-orchestrate")
 
         fv_id_1 = uuid4()
         fv_id_2 = uuid4()
@@ -1404,7 +1408,7 @@ class TestUpdateDeploymentMetadataPersistence:
         adapter.update.return_value = update_result
         mapper.resolve_deployment_update = AsyncMock(return_value=MagicMock())
         mapper.shape_deployment_update_result.return_value = MagicMock()
-        mock_resolve_amm.return_value = (dep_row, adapter, mapper)
+        mock_resolve_amm.return_value = (dep_row, adapter, mapper, "watsonx-orchestrate")
         mock_update_db.return_value = updated_row
 
         session = AsyncMock()
@@ -1456,7 +1460,7 @@ class TestGetDeploymentSync:
         dep_row = _fake_deployment_row()
         adapter = AsyncMock()
         adapter.get.side_effect = DeploymentNotFoundError(message="gone")
-        mock_resolve.return_value = (dep_row, adapter, BaseDeploymentMapper())
+        mock_resolve.return_value = (dep_row, adapter, BaseDeploymentMapper(), "watsonx-orchestrate")
 
         user = _fake_user()
         session = AsyncMock()
@@ -1483,7 +1487,7 @@ class TestGetDeploymentSync:
         dep_row = _fake_deployment_row()
         adapter = AsyncMock()
         adapter.get.side_effect = AuthenticationError(message="bad creds", error_code="authentication_error")
-        mock_resolve.return_value = (dep_row, adapter, BaseDeploymentMapper())
+        mock_resolve.return_value = (dep_row, adapter, BaseDeploymentMapper(), "watsonx-orchestrate")
 
         session = AsyncMock()
 
@@ -1508,7 +1512,7 @@ class TestGetDeploymentSync:
         dep_row = _fake_deployment_row()
         adapter = AsyncMock()
         adapter.get.side_effect = ServiceUnavailableError(message="provider down")
-        mock_resolve.return_value = (dep_row, adapter, BaseDeploymentMapper())
+        mock_resolve.return_value = (dep_row, adapter, BaseDeploymentMapper(), "watsonx-orchestrate")
 
         session = AsyncMock()
 
@@ -1552,7 +1556,7 @@ class TestGetDeploymentSync:
             }
         }
         adapter.get.return_value = provider_deployment
-        mock_resolve.return_value = (dep_row, adapter, BaseDeploymentMapper())
+        mock_resolve.return_value = (dep_row, adapter, BaseDeploymentMapper(), "watsonx-orchestrate")
 
         session = AsyncMock()
         result = await get_deployment(deployment_id=dep_row.id, session=session, current_user=_fake_user())
@@ -1597,7 +1601,7 @@ class TestGetDeploymentSync:
         provider_deployment.updated_at = None
         provider_deployment.model_dump.return_value = {}
         adapter.get.return_value = provider_deployment
-        mock_resolve.return_value = (dep_row, adapter, _SnapshotMapper())
+        mock_resolve.return_value = (dep_row, adapter, _SnapshotMapper(), "watsonx-orchestrate")
 
         att_good = _fake_attachment(provider_snapshot_id="snap-1")
         att_stale = _fake_attachment(provider_snapshot_id="snap-stale")
@@ -1644,7 +1648,7 @@ class TestGetDeploymentSync:
         provider_deployment.updated_at = None
         provider_deployment.model_dump.return_value = {}
         adapter.get.return_value = provider_deployment
-        mock_resolve.return_value = (dep_row, adapter, _SnapshotMapper())
+        mock_resolve.return_value = (dep_row, adapter, _SnapshotMapper(), "watsonx-orchestrate")
         mock_list_att.return_value = [_fake_attachment(provider_snapshot_id=None)]
 
         session = AsyncMock()
@@ -1686,7 +1690,7 @@ class TestGetDeploymentSync:
         provider_deployment.updated_at = None
         provider_deployment.model_dump.return_value = {}
         adapter.get.return_value = provider_deployment
-        mock_resolve.return_value = (dep_row, adapter, _SnapshotMapper())
+        mock_resolve.return_value = (dep_row, adapter, _SnapshotMapper(), "watsonx-orchestrate")
 
         att1 = _fake_attachment(provider_snapshot_id="snap-1")
         att2 = _fake_attachment(provider_snapshot_id="snap-2")
@@ -1720,7 +1724,7 @@ class TestDeleteDeployment:
         dep_row = _fake_deployment_row()
         adapter = AsyncMock()
         adapter.delete.side_effect = DeploymentNotFoundError(message="gone")
-        mock_resolve.return_value = (dep_row, adapter)
+        mock_resolve.return_value = (dep_row, adapter, "watsonx-orchestrate")
 
         user = _fake_user()
         session = AsyncMock()
@@ -1746,7 +1750,7 @@ class TestDeleteDeployment:
         dep_row = _fake_deployment_row()
         adapter = AsyncMock()
         adapter.delete.side_effect = AuthenticationError(message="bad creds", error_code="authentication_error")
-        mock_resolve.return_value = (dep_row, adapter)
+        mock_resolve.return_value = (dep_row, adapter, "watsonx-orchestrate")
 
         session = AsyncMock()
 
@@ -1770,7 +1774,7 @@ class TestDeleteDeployment:
 
         dep_row = _fake_deployment_row()
         adapter = AsyncMock()
-        mock_resolve.return_value = (dep_row, adapter)
+        mock_resolve.return_value = (dep_row, adapter, "watsonx-orchestrate")
 
         user = _fake_user()
         session = AsyncMock()
@@ -1796,7 +1800,7 @@ class TestDeleteDeployment:
 
         dep_row = _fake_deployment_row()
         adapter = AsyncMock()
-        mock_resolve.return_value = (dep_row, adapter)
+        mock_resolve.return_value = (dep_row, adapter, "watsonx-orchestrate")
 
         session = AsyncMock()
         session.commit.side_effect = [RuntimeError("commit failed"), RuntimeError("still failing")]
@@ -1822,7 +1826,7 @@ class TestDeleteDeployment:
 
         dep_row = _fake_deployment_row()
         adapter = AsyncMock()
-        mock_resolve.return_value = (dep_row, adapter)
+        mock_resolve.return_value = (dep_row, adapter, "watsonx-orchestrate")
 
         user = _fake_user()
         session = AsyncMock()
@@ -1848,7 +1852,7 @@ class TestDeleteDeployment:
 
         dep_row = _fake_deployment_row()
         adapter = AsyncMock()
-        mock_resolve.return_value = (dep_row, adapter)
+        mock_resolve.return_value = (dep_row, adapter, "watsonx-orchestrate")
 
         user = _fake_user()
         session = AsyncMock()
@@ -2092,7 +2096,7 @@ class TestUpdateDeploymentProjectValidation:
         adapter = AsyncMock()
         mapper = MagicMock()
         mapper.resolve_deployment_update = AsyncMock(return_value=MagicMock())
-        mock_resolve_amm.return_value = (dep_row, adapter, mapper)
+        mock_resolve_amm.return_value = (dep_row, adapter, mapper, "watsonx-orchestrate")
 
         add_ids = [uuid4()]
         remove_ids = [uuid4()]

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -842,12 +842,14 @@ class TestListDeploymentFlowVersionsRoute:
             ],
         )
 
+        flow_id = uuid4()
         response = await list_deployment_flow_versions(
             deployment_id=deployment_row.id,
             session=AsyncMock(),
             current_user=_fake_user(),
             page=2,
             size=5,
+            flow_ids=[flow_id],
         )
 
         assert response.page == 2
@@ -863,6 +865,7 @@ class TestListDeploymentFlowVersionsRoute:
         assert helper_kwargs["deployment_id"] == deployment_row.id
         assert helper_kwargs["page"] == 2
         assert helper_kwargs["size"] == 5
+        assert helper_kwargs["flow_ids"] == [flow_id]
         mapper.shape_flow_version_list_result.assert_called_once_with(
             rows=rows,
             snapshot_result=snapshot_result,

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -373,7 +373,7 @@ class TestCreateDeploymentExistingAgent:
         mapper.util_should_mutate_provider_for_existing_deployment_create.return_value = True
         mapper.util_create_flow_version_ids.return_value = []
         mapper.resolve_deployment_update_for_existing_create = AsyncMock(
-            return_value=MagicMock(provider_data={"operations": [{}]})
+            return_value=MagicMock(provider_data={"upsert_flows": []})
         )
         mock_get_mapper.return_value = mapper
         mock_resolve_project.return_value = uuid4()
@@ -435,7 +435,7 @@ class TestCreateDeploymentExistingAgent:
         mapper.util_should_mutate_provider_for_existing_deployment_create.return_value = True
         mapper.util_create_flow_version_ids.return_value = []
         mapper.resolve_deployment_update_for_existing_create = AsyncMock(
-            return_value=MagicMock(provider_data={"operations": [{}]})
+            return_value=MagicMock(provider_data={"upsert_flows": []})
         )
         mapped_create_result = DeploymentCreateResult(id="existing-agent-1", provider_result={"ok": True})
         mapper.util_create_result_from_existing_update.return_value = mapped_create_result

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -4,7 +4,6 @@ Covers the integration behaviour of the FastAPI route handlers:
 - Rollback on commit failure (create / update)
 - GET single-deployment synchronization (deployment-level and snapshot-level)
 - Project-scoped flow-version validation (create / update)
-- Stubbed 501 routes (redeploy / duplicate)
 - resolve_deployment_adapter edge cases
 """
 
@@ -978,6 +977,7 @@ class TestProviderAccountRoutes:
             )
 
         assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == "Provider account is already tracked by user."
 
     @pytest.mark.asyncio
     @patch(f"{ROUTES_MODULE}.update_provider_account_row", new_callable=AsyncMock)
@@ -1015,6 +1015,7 @@ class TestProviderAccountRoutes:
             )
 
         assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == "Provider account is already tracked by user."
 
     @pytest.mark.asyncio
     @patch(f"{ROUTES_MODULE}.delete_provider_account_row", new_callable=AsyncMock)
@@ -2144,39 +2145,6 @@ class TestListDeploymentLlms:
 
         assert exc_info.value.status_code == 503
         mapper.shape_llm_list_result.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Stubbed 501 routes
-# ---------------------------------------------------------------------------
-
-
-class TestStubbedRoutes:
-    @pytest.mark.asyncio
-    async def test_redeploy_returns_501(self):
-        from langflow.api.v1.deployments import redeploy_deployment
-
-        with pytest.raises(HTTPException) as exc_info:
-            await redeploy_deployment(
-                deployment_id=uuid4(),
-                session=AsyncMock(),
-                current_user=_fake_user(),
-            )
-
-        assert exc_info.value.status_code == 501
-
-    @pytest.mark.asyncio
-    async def test_duplicate_returns_501(self):
-        from langflow.api.v1.deployments import duplicate_deployment
-
-        with pytest.raises(HTTPException) as exc_info:
-            await duplicate_deployment(
-                deployment_id=uuid4(),
-                session=AsyncMock(),
-                current_user=_fake_user(),
-            )
-
-        assert exc_info.value.status_code == 501
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -25,6 +25,7 @@ from langflow.api.v1.schemas.deployments import (
 from langflow.services.database.models.deployment_provider_account.schemas import DeploymentProviderKey
 from lfx.services.adapters.deployment.exceptions import (
     AuthenticationError,
+    DeploymentConflictError,
     DeploymentNotFoundError,
     ServiceUnavailableError,
 )
@@ -2284,6 +2285,28 @@ class TestHandleAdapterErrors:
             raise DeploymentNotFoundError(message="gone")
 
         assert exc_info.value.status_code == 404
+
+    def test_maps_conflict_with_mapper_formatter(self):
+        from langflow.api.v1.mappers.deployments.helpers import handle_adapter_errors
+
+        deployment_mapper = MagicMock()
+        deployment_mapper.format_conflict_detail.return_value = "friendly detail"
+
+        with pytest.raises(HTTPException) as exc_info, handle_adapter_errors(mapper=deployment_mapper):
+            raise DeploymentConflictError(message="raw provider conflict")
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == "friendly detail"
+        deployment_mapper.format_conflict_detail.assert_called_once_with("raw provider conflict")
+
+    def test_maps_conflict_without_mapper_passthrough(self):
+        from langflow.api.v1.mappers.deployments.helpers import handle_adapter_errors
+
+        with pytest.raises(HTTPException) as exc_info, handle_adapter_errors():
+            raise DeploymentConflictError(message="raw provider conflict")
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == "raw provider conflict"
 
     def test_passes_through_http_exception(self):
         from langflow.api.v1.mappers.deployments.helpers import handle_adapter_errors

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -144,9 +144,9 @@ class TestCreateDeploymentRollback:
 
         payload = MagicMock()
         payload.provider_id = pa.id
-        payload.spec.name = "test"
-        payload.spec.type = "agent"
-        payload.spec.description = None
+        payload.name = "test"
+        payload.type = "agent"
+        payload.description = None
 
         with pytest.raises(RuntimeError, match="DB commit failed"):
             await create_deployment(session=session, payload=payload, current_user=_fake_user())
@@ -202,9 +202,9 @@ class TestCreateDeploymentRollback:
 
         payload = MagicMock()
         payload.provider_id = pa.id
-        payload.spec.name = "test"
-        payload.spec.type = "agent"
-        payload.spec.description = None
+        payload.name = "test"
+        payload.type = "agent"
+        payload.description = None
 
         mapper.shape_deployment_create_result.return_value = MagicMock()
         await create_deployment(session=session, payload=payload, current_user=_fake_user())
@@ -263,9 +263,9 @@ class TestCreateDeploymentRollback:
 
         payload = MagicMock()
         payload.provider_id = pa.id
-        payload.spec.name = "existing"
-        payload.spec.type = "agent"
-        payload.spec.description = "desc"
+        payload.name = "existing"
+        payload.type = "agent"
+        payload.description = "desc"
 
         with pytest.raises(RuntimeError, match="DB commit failed"):
             await create_deployment(session=session, payload=payload, current_user=_fake_user())
@@ -324,9 +324,9 @@ class TestCreateDeploymentExistingAgent:
 
         payload = MagicMock()
         payload.provider_id = pa.id
-        payload.spec.name = "existing"
-        payload.spec.type = "agent"
-        payload.spec.description = None
+        payload.name = "existing"
+        payload.type = "agent"
+        payload.description = None
 
         mapper.shape_deployment_create_result.return_value = MagicMock()
         await create_deployment(session=session, payload=payload, current_user=_fake_user())
@@ -385,9 +385,9 @@ class TestCreateDeploymentExistingAgent:
 
         payload = MagicMock()
         payload.provider_id = pa.id
-        payload.spec.name = "existing"
-        payload.spec.type = "agent"
-        payload.spec.description = "desc"
+        payload.name = "existing"
+        payload.type = "agent"
+        payload.description = "desc"
 
         mapper.shape_deployment_create_result.return_value = MagicMock()
         await create_deployment(session=session, payload=payload, current_user=_fake_user())
@@ -449,9 +449,9 @@ class TestCreateDeploymentExistingAgent:
 
         payload = MagicMock()
         payload.provider_id = pa.id
-        payload.spec.name = "existing"
-        payload.spec.type = "agent"
-        payload.spec.description = "desc"
+        payload.name = "existing"
+        payload.type = "agent"
+        payload.description = "desc"
 
         mapper.shape_deployment_create_result.return_value = MagicMock()
         await create_deployment(session=session, payload=payload, current_user=_fake_user())
@@ -500,9 +500,9 @@ class TestCreateDeploymentExistingAgent:
 
         payload = MagicMock()
         payload.provider_id = pa.id
-        payload.spec.name = "existing"
-        payload.spec.type = "agent"
-        payload.spec.description = None
+        payload.name = "existing"
+        payload.type = "agent"
+        payload.description = None
 
         with pytest.raises(HTTPException) as exc_info:
             await create_deployment(session=AsyncMock(), payload=payload, current_user=_fake_user())
@@ -1148,7 +1148,8 @@ class TestUpdateDeploymentRollback:
         session.commit.side_effect = RuntimeError("DB commit failed")
 
         payload = MagicMock()
-        payload.spec = None
+        payload.name = None
+        payload.description = None
 
         with pytest.raises(RuntimeError, match="DB commit failed"):
             await update_deployment(
@@ -1199,7 +1200,8 @@ class TestUpdateDeploymentRollback:
         session.commit.return_value = None
 
         payload = MagicMock()
-        payload.spec = None
+        payload.name = None
+        payload.description = None
 
         await update_deployment(
             deployment_id=dep_row.id,
@@ -1262,7 +1264,8 @@ class TestUpdateDeploymentAlreadyAttachedFiltering:
         session.commit.return_value = None
 
         payload = MagicMock()
-        payload.spec = None
+        payload.name = None
+        payload.description = None
 
         await update_deployment(
             deployment_id=dep_row.id,
@@ -1320,7 +1323,8 @@ class TestUpdateDeploymentAlreadyAttachedFiltering:
         session.commit.return_value = None
 
         payload = MagicMock()
-        payload.spec = None
+        payload.name = None
+        payload.description = None
 
         await update_deployment(
             deployment_id=dep_row.id,
@@ -1370,7 +1374,8 @@ class TestUpdateDeploymentAlreadyAttachedFiltering:
         session.commit.return_value = None
 
         payload = MagicMock()
-        payload.spec = None
+        payload.name = None
+        payload.description = None
 
         await update_deployment(
             deployment_id=dep_row.id,
@@ -1426,10 +1431,8 @@ class TestUpdateDeploymentMetadataPersistence:
 
         payload = DeploymentUpdateRequest.model_validate(
             {
-                "spec": {
-                    "name": "renamed",
-                    "description": None,
-                }
+                "name": "renamed",
+                "description": None,
             }
         )
 
@@ -1898,7 +1901,7 @@ class TestCreateDeploymentDuplicateName:
 
         payload = MagicMock()
         payload.provider_id = pa.id
-        payload.spec.name = "duplicate-name"
+        payload.name = "duplicate-name"
 
         with pytest.raises(HTTPException) as exc_info:
             await create_deployment(session=AsyncMock(), payload=payload, current_user=_fake_user())
@@ -1924,7 +1927,7 @@ class TestCreateDeploymentDuplicateName:
 
         payload = MagicMock()
         payload.provider_id = pa.id
-        payload.spec.name = "taken"
+        payload.name = "taken"
 
         with pytest.raises(HTTPException):
             await create_deployment(session=AsyncMock(), payload=payload, current_user=_fake_user())
@@ -2018,9 +2021,9 @@ class TestCreateDeploymentProjectValidation:
 
         payload = MagicMock()
         payload.provider_id = pa.id
-        payload.spec.name = "test"
-        payload.spec.type = "agent"
-        payload.spec.description = None
+        payload.name = "test"
+        payload.type = "agent"
+        payload.description = None
 
         session = AsyncMock()
         session.commit.return_value = None

--- a/src/backend/tests/unit/api/v1/test_deployment_schemas.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_schemas.py
@@ -44,7 +44,7 @@ class TestCredentialSecurity:
             id=uuid4(),
             name="staging",
             provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-            provider_url="https://api.us-south.wxo.cloud.ibm.com",
+            url="https://api.us-south.wxo.cloud.ibm.com",
         )
         dumped = response.model_dump()
         assert "api_key" not in dumped
@@ -61,7 +61,7 @@ class TestProviderAccountName:
         account = DeploymentProviderAccountCreateRequest(
             name="production",
             provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-            provider_url="https://api.us-south.wxo.cloud.ibm.com",
+            url="https://api.us-south.wxo.cloud.ibm.com",
             provider_data={"api_key": "key"},
         )
         assert account.name == "production"
@@ -70,7 +70,7 @@ class TestProviderAccountName:
         account = DeploymentProviderAccountCreateRequest(
             name="  staging  ",
             provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-            provider_url="https://api.us-south.wxo.cloud.ibm.com",
+            url="https://api.us-south.wxo.cloud.ibm.com",
             provider_data={"api_key": "key"},
         )
         assert account.name == "staging"
@@ -80,7 +80,7 @@ class TestProviderAccountName:
             DeploymentProviderAccountCreateRequest(
                 name="",
                 provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-                provider_url="https://example.com",
+                url="https://example.com",
                 provider_data={"api_key": "key"},
             )
 
@@ -89,7 +89,7 @@ class TestProviderAccountName:
             DeploymentProviderAccountCreateRequest(
                 name="   ",
                 provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-                provider_url="https://example.com",
+                url="https://example.com",
                 provider_data={"api_key": "key"},
             )
 
@@ -97,7 +97,7 @@ class TestProviderAccountName:
         with pytest.raises(ValidationError):
             DeploymentProviderAccountCreateRequest(
                 provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-                provider_url="https://example.com",
+                url="https://example.com",
                 provider_data={"api_key": "key"},
             )
 
@@ -114,37 +114,37 @@ class TestProviderAccountName:
 
 
 # ---------------------------------------------------------------------------
-# provider_url URL validation
+# url validation
 # ---------------------------------------------------------------------------
 
 
 class TestProviderUrlSchemaValidation:
-    """URL validation for provider_url on create and update schemas."""
+    """URL validation for create schema."""
 
     def test_create_accepts_valid_https_url(self):
         account = DeploymentProviderAccountCreateRequest(
             name="staging",
             provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-            provider_url="https://api.us-south.wxo.cloud.ibm.com/v1",
+            url="https://api.us-south.wxo.cloud.ibm.com/v1",
             provider_data={"api_key": "key"},
         )
-        assert account.provider_url == "https://api.us-south.wxo.cloud.ibm.com/v1"
+        assert account.url == "https://api.us-south.wxo.cloud.ibm.com/v1"
 
     def test_create_normalizes_scheme_and_host(self):
         account = DeploymentProviderAccountCreateRequest(
             name="staging",
             provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-            provider_url="HTTPS://API.US-SOUTH.WXO.CLOUD.IBM.COM/v1",
+            url="HTTPS://API.US-SOUTH.WXO.CLOUD.IBM.COM/v1",
             provider_data={"api_key": "key"},
         )
-        assert account.provider_url == "https://api.us-south.wxo.cloud.ibm.com/v1"
+        assert account.url == "https://api.us-south.wxo.cloud.ibm.com/v1"
 
     def test_create_rejects_http(self):
         with pytest.raises(ValidationError, match="https"):
             DeploymentProviderAccountCreateRequest(
                 name="staging",
                 provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-                provider_url="http://example.com",
+                url="http://example.com",
                 provider_data={"api_key": "key"},
             )
 
@@ -153,36 +153,17 @@ class TestProviderUrlSchemaValidation:
             DeploymentProviderAccountCreateRequest(
                 name="staging",
                 provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-                provider_url="example.com",
+                url="example.com",
                 provider_data={"api_key": "key"},
             )
 
-    def test_update_accepts_valid_https_url(self):
-        update = DeploymentProviderAccountUpdateRequest(provider_url="https://new.example.com/api")
-        assert update.provider_url == "https://new.example.com/api"
+    def test_update_rejects_url_field(self):
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            DeploymentProviderAccountUpdateRequest(url="https://new.example.com/api")
 
-    def test_update_validate_provider_url_allowed_accepts_provider_hostname(self):
-        update = DeploymentProviderAccountUpdateRequest(
-            provider_url="https://api.us-south.wxo.cloud.ibm.com/instances/tenant-1",
-        )
-
-        validated = update.validate_provider_url_allowed(DeploymentProviderKey.WATSONX_ORCHESTRATE)
-
-        assert validated is update
-
-    def test_update_validate_provider_url_allowed_rejects_disallowed_provider_hostname(self):
-        update = DeploymentProviderAccountUpdateRequest(provider_url="https://new.example.com/api")
-
-        with pytest.raises(ValueError, match="not allowed"):
-            update.validate_provider_url_allowed(DeploymentProviderKey.WATSONX_ORCHESTRATE)
-
-    def test_update_rejects_http(self):
-        with pytest.raises(ValidationError, match="https"):
-            DeploymentProviderAccountUpdateRequest(provider_url="http://example.com")
-
-    def test_update_omits_url_without_error(self):
-        update = DeploymentProviderAccountUpdateRequest(name="new-name")
-        assert update.provider_url is None
+    def test_update_rejects_tenant_id_field(self):
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            DeploymentProviderAccountUpdateRequest(tenant_id="tenant-1")
 
 
 class TestProviderKeyEnum:
@@ -190,7 +171,7 @@ class TestProviderKeyEnum:
         account = DeploymentProviderAccountCreateRequest(
             name="staging",
             provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
-            provider_url="https://api.us-south.wxo.cloud.ibm.com",
+            url="https://api.us-south.wxo.cloud.ibm.com",
             provider_data={"api_key": "key"},
         )
         assert account.provider_key == DeploymentProviderKey.WATSONX_ORCHESTRATE
@@ -199,7 +180,7 @@ class TestProviderKeyEnum:
         account = DeploymentProviderAccountCreateRequest(
             name="staging",
             provider_key="watsonx-orchestrate",
-            provider_url="https://api.us-south.wxo.cloud.ibm.com",
+            url="https://api.us-south.wxo.cloud.ibm.com",
             provider_data={"api_key": "key"},
         )
         assert account.provider_key == DeploymentProviderKey.WATSONX_ORCHESTRATE
@@ -209,7 +190,7 @@ class TestProviderKeyEnum:
             DeploymentProviderAccountCreateRequest(
                 name="staging",
                 provider_key="unknown-provider",
-                provider_url="https://example.com",
+                url="https://example.com",
                 provider_data={"api_key": "key"},
             )
 
@@ -218,7 +199,7 @@ class TestProviderKeyEnum:
             DeploymentProviderAccountCreateRequest(
                 name="staging",
                 provider_key="",
-                provider_url="https://example.com",
+                url="https://example.com",
                 provider_data={"api_key": "key"},
             )
 
@@ -462,7 +443,14 @@ class TestDeploymentListItemAttachment:
 
 class TestDeploymentListItemMatchedAttachments:
     def _make_item(self, **kwargs):
-        defaults = {"id": uuid4(), "name": "dep", "type": "agent", "resource_key": "rk-1"}
+        defaults = {
+            "id": uuid4(),
+            "provider_id": uuid4(),
+            "provider_key": DeploymentProviderKey.WATSONX_ORCHESTRATE,
+            "name": "dep",
+            "type": "agent",
+            "resource_key": "rk-1",
+        }
         defaults.update(kwargs)
         return DeploymentListItem(**defaults)
 

--- a/src/backend/tests/unit/api/v1/test_deployment_schemas.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_schemas.py
@@ -7,12 +7,12 @@ from uuid import uuid4
 
 import pytest
 from langflow.api.v1.schemas.deployments import (
+    DEPLOYMENT_DESCRIPTION_MAX_LENGTH,
     DeploymentConfigListResponse,
     DeploymentCreateRequest,
     DeploymentFlowVersionListItem,
     DeploymentFlowVersionListResponse,
     DeploymentListItem,
-    DeploymentListItemAttachment,
     DeploymentProviderAccountCreateRequest,
     DeploymentProviderAccountGetResponse,
     DeploymentProviderAccountUpdateRequest,
@@ -217,6 +217,10 @@ class TestDeploymentUpdateRequest:
         with pytest.raises(ValidationError, match="At least one of"):
             DeploymentUpdateRequest(description=None)
 
+    def test_rejects_description_over_max_length(self):
+        with pytest.raises(ValidationError, match="at most"):
+            DeploymentUpdateRequest(description="x" * (DEPLOYMENT_DESCRIPTION_MAX_LENGTH + 1))
+
 
 class TestDeploymentSpecPayloadCompatibility:
     def test_create_request_rejects_provider_spec_dict(self):
@@ -238,6 +242,16 @@ class TestDeploymentSpecPayloadCompatibility:
             provider_data={"operations": []},
         )
         assert request.provider_data == {"operations": []}
+
+    def test_create_request_rejects_description_over_max_length(self):
+        with pytest.raises(ValidationError, match="at most"):
+            DeploymentCreateRequest(
+                provider_id=uuid4(),
+                name="deployment",
+                description="x" * (DEPLOYMENT_DESCRIPTION_MAX_LENGTH + 1),
+                type="agent",
+                provider_data={"operations": []},
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -420,24 +434,11 @@ class TestFlowIdsQueryValidation:
 
 
 # ---------------------------------------------------------------------------
-# DeploymentListItemAttachment / matched_attachments
+# DeploymentListItem.flow_version_ids
 # ---------------------------------------------------------------------------
 
 
-class TestDeploymentListItemAttachment:
-    def test_basic_construction(self):
-        fv_id = uuid4()
-        att = DeploymentListItemAttachment(flow_version_id=fv_id, provider_snapshot_id="snap-1")
-        assert att.flow_version_id == fv_id
-        assert att.provider_snapshot_id == "snap-1"
-
-    def test_provider_snapshot_id_defaults_to_none(self):
-        fv_id = uuid4()
-        att = DeploymentListItemAttachment(flow_version_id=fv_id)
-        assert att.provider_snapshot_id is None
-
-
-class TestDeploymentListItemMatchedAttachments:
+class TestDeploymentListItemFlowVersionIds:
     def _make_item(self, **kwargs):
         defaults = {
             "id": uuid4(),
@@ -452,18 +453,15 @@ class TestDeploymentListItemMatchedAttachments:
 
     def test_defaults_to_none(self):
         item = self._make_item()
-        assert item.matched_attachments is None
+        assert item.flow_version_ids is None
 
-    def test_accepts_attachment_list(self):
+    def test_accepts_flow_version_ids_list(self):
         fv_id = uuid4()
         item = self._make_item(
-            matched_attachments=[
-                DeploymentListItemAttachment(flow_version_id=fv_id, provider_snapshot_id="snap-1"),
-            ],
+            flow_version_ids=[fv_id],
         )
-        assert len(item.matched_attachments) == 1
-        assert item.matched_attachments[0].flow_version_id == fv_id
+        assert item.flow_version_ids == [fv_id]
 
     def test_accepts_empty_list(self):
-        item = self._make_item(matched_attachments=[])
-        assert item.matched_attachments == []
+        item = self._make_item(flow_version_ids=[])
+        assert item.flow_version_ids == []

--- a/src/backend/tests/unit/api/v1/test_deployment_schemas.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_schemas.py
@@ -7,8 +7,6 @@ from uuid import uuid4
 
 import pytest
 from langflow.api.v1.schemas.deployments import (
-    DeploymentConfigBindingUpdate,
-    DeploymentConfigCreate,
     DeploymentConfigListItem,
     DeploymentConfigListResponse,
     DeploymentCreateRequest,
@@ -21,8 +19,6 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentProviderAccountUpdateRequest,
     DeploymentUpdateRequest,
     FlowIdsQuery,
-    FlowVersionsAttach,
-    FlowVersionsPatch,
 )
 from langflow.services.database.models.deployment_provider_account.schemas import DeploymentProviderKey
 from pydantic import ValidationError
@@ -228,97 +224,6 @@ class TestProviderKeyEnum:
             )
 
 
-# ---------------------------------------------------------------------------
-# Duplicate rejection in id lists
-# ---------------------------------------------------------------------------
-
-
-class TestUuidIdListDedup:
-    """UUID id lists silently deduplicate while preserving order."""
-
-    def test_flow_versions_attach_deduplicates(self):
-        u1, u2 = uuid4(), uuid4()
-        result = FlowVersionsAttach(ids=[u1, u2, u1])
-        assert result.ids == [u1, u2]
-
-    def test_flow_versions_patch_deduplicates_add(self):
-        u1, u2 = uuid4(), uuid4()
-        result = FlowVersionsPatch(add=[u1, u2, u1, u2])
-        assert result.add == [u1, u2]
-
-    def test_flow_versions_patch_deduplicates_remove(self):
-        u1, u2 = uuid4(), uuid4()
-        result = FlowVersionsPatch(remove=[u2, u1, u2, u1])
-        assert result.remove == [u2, u1]
-
-    def test_flow_versions_patch_rejects_overlap(self):
-        u1 = uuid4()
-        with pytest.raises(ValidationError, match="both"):
-            FlowVersionsPatch(add=[u1], remove=[u1])
-
-
-# ---------------------------------------------------------------------------
-# DeploymentConfigBindingUpdate validation
-# ---------------------------------------------------------------------------
-
-
-class TestDeploymentConfigBindingUpdate:
-    def test_accepts_config_id_only(self):
-        update = DeploymentConfigBindingUpdate(config_id="cfg_1")
-        assert update.config_id == "cfg_1"
-        assert update.raw_payload is None
-        assert update.unbind is False
-
-    def test_accepts_raw_payload_only(self):
-        raw_payload = {
-            "name": "new cfg",
-            "description": "cfg desc",
-            "environment_variables": {
-                "OPENAI_API_KEY": {"value": "OPENAI_API_KEY", "source": "variable"},
-            },
-            "provider_config": {"region": "us-east-1", "flags": {"dry_run": True}},
-        }
-        update = DeploymentConfigBindingUpdate(raw_payload=raw_payload)
-        assert update.raw_payload is not None
-        assert update.raw_payload.model_dump() == raw_payload
-        assert update.config_id is None
-        assert update.unbind is False
-
-    def test_accepts_unbind(self):
-        update = DeploymentConfigBindingUpdate(unbind=True)
-        assert update.unbind is True
-        assert update.config_id is None
-        assert update.raw_payload is None
-
-    def test_rejects_both_config_id_and_raw_payload(self):
-        with pytest.raises(ValidationError, match="Exactly one of"):
-            DeploymentConfigBindingUpdate(config_id="cfg_1", raw_payload={"name": "cfg"})
-
-    def test_rejects_config_id_with_unbind(self):
-        with pytest.raises(ValidationError, match="Exactly one of"):
-            DeploymentConfigBindingUpdate(config_id="cfg_1", unbind=True)
-
-    def test_rejects_raw_payload_with_unbind(self):
-        with pytest.raises(ValidationError, match="Exactly one of"):
-            DeploymentConfigBindingUpdate(raw_payload={"name": "cfg"}, unbind=True)
-
-    def test_rejects_all_three(self):
-        with pytest.raises(ValidationError, match="Exactly one of"):
-            DeploymentConfigBindingUpdate(config_id="cfg_1", raw_payload={"name": "cfg"}, unbind=True)
-
-    def test_rejects_noop_empty_payload(self):
-        with pytest.raises(ValidationError, match="Exactly one of"):
-            DeploymentConfigBindingUpdate()
-
-    def test_rejects_unbind_false_alone(self):
-        with pytest.raises(ValidationError, match="Exactly one of"):
-            DeploymentConfigBindingUpdate(unbind=False)
-
-    def test_rejects_extra_fields(self):
-        with pytest.raises(ValidationError, match="Extra inputs"):
-            DeploymentConfigBindingUpdate(config_id="cfg_1", unknown_field="x")
-
-
 class TestDeploymentUpdateRequest:
     def test_accepts_provider_data_only(self):
         payload = DeploymentUpdateRequest(provider_data={"mode": "dry_run"})
@@ -333,18 +238,18 @@ class TestDeploymentUpdateRequest:
             DeploymentUpdateRequest(spec=None)
 
 
-class TestSharedKernelProviderPayloadCompatibility:
-    def test_create_request_accepts_provider_spec_dict_through_strict_wrapper(self):
-        request = DeploymentCreateRequest(
-            provider_id=uuid4(),
-            spec={
-                "name": "deployment",
-                "description": "",
-                "type": "agent",
-                "provider_spec": {"region": "us-east-1", "size": "small"},
-            },
-        )
-        assert request.spec.provider_spec == {"region": "us-east-1", "size": "small"}
+class TestDeploymentSpecPayloadCompatibility:
+    def test_create_request_rejects_provider_spec_dict(self):
+        with pytest.raises(ValidationError, match="provider_spec"):
+            DeploymentCreateRequest(
+                provider_id=uuid4(),
+                spec={
+                    "name": "deployment",
+                    "description": "",
+                    "type": "agent",
+                    "provider_spec": {"region": "us-east-1", "size": "small"},
+                },
+            )
 
     def test_create_request_accepts_provider_data_payload(self):
         request = DeploymentCreateRequest(
@@ -357,17 +262,6 @@ class TestSharedKernelProviderPayloadCompatibility:
             provider_data={"operations": []},
         )
         assert request.provider_data == {"operations": []}
-
-    def test_config_create_accepts_provider_config_dict_through_strict_wrapper(self):
-        payload = DeploymentConfigCreate(
-            raw_payload={
-                "name": "cfg",
-                "description": "cfg-desc",
-                "provider_config": {"timeout_s": 30, "flags": {"dry_run": True}},
-            }
-        )
-        assert payload.raw_payload is not None
-        assert payload.raw_payload.provider_config == {"timeout_s": 30, "flags": {"dry_run": True}}
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/api/v1/test_deployment_schemas.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_schemas.py
@@ -35,9 +35,9 @@ class TestCredentialSecurity:
         """DeploymentProviderAccountGetResponse.model_fields must not contain api_key."""
         assert "api_key" not in DeploymentProviderAccountGetResponse.model_fields
 
-    def test_provider_account_response_excludes_provider_data(self):
-        """DeploymentProviderAccountGetResponse.model_fields must not contain provider_data."""
-        assert "provider_data" not in DeploymentProviderAccountGetResponse.model_fields
+    def test_provider_account_response_includes_provider_data(self):
+        """DeploymentProviderAccountGetResponse includes non-sensitive provider metadata."""
+        assert "provider_data" in DeploymentProviderAccountGetResponse.model_fields
 
     def test_provider_account_response_dump_excludes_credentials(self):
         """model_dump() on a response instance must never contain credential fields."""
@@ -46,10 +46,12 @@ class TestCredentialSecurity:
             name="staging",
             provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
             url="https://api.us-south.wxo.cloud.ibm.com",
+            provider_data={"tenant_id": "tenant-1"},
         )
         dumped = response.model_dump()
         assert "api_key" not in dumped
-        assert "provider_data" not in dumped
+        assert dumped["provider_data"] == {"tenant_id": "tenant-1"}
+        assert "api_key" not in (dumped["provider_data"] or {})
 
 
 # ---------------------------------------------------------------------------
@@ -165,6 +167,16 @@ class TestProviderUrlSchemaValidation:
     def test_update_rejects_tenant_id_field(self):
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
             DeploymentProviderAccountUpdateRequest(tenant_id="tenant-1")
+
+    def test_create_rejects_top_level_tenant_id_field(self):
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            DeploymentProviderAccountCreateRequest(
+                name="staging",
+                tenant_id="tenant-1",
+                provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
+                url="https://api.us-south.wxo.cloud.ibm.com/v1",
+                provider_data={"api_key": "key"},
+            )
 
 
 class TestProviderKeyEnum:

--- a/src/backend/tests/unit/api/v1/test_deployment_schemas.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_schemas.py
@@ -215,7 +215,7 @@ class TestDeploymentUpdateRequest:
 
     def test_rejects_explicit_null_only_payload(self):
         with pytest.raises(ValidationError, match="At least one of"):
-            DeploymentUpdateRequest(spec=None)
+            DeploymentUpdateRequest(description=None)
 
 
 class TestDeploymentSpecPayloadCompatibility:
@@ -223,22 +223,18 @@ class TestDeploymentSpecPayloadCompatibility:
         with pytest.raises(ValidationError, match="provider_spec"):
             DeploymentCreateRequest(
                 provider_id=uuid4(),
-                spec={
-                    "name": "deployment",
-                    "description": "",
-                    "type": "agent",
-                    "provider_spec": {"region": "us-east-1", "size": "small"},
-                },
+                name="deployment",
+                description="",
+                type="agent",
+                provider_spec={"region": "us-east-1", "size": "small"},
             )
 
     def test_create_request_accepts_provider_data_payload(self):
         request = DeploymentCreateRequest(
             provider_id=uuid4(),
-            spec={
-                "name": "deployment",
-                "description": "",
-                "type": "agent",
-            },
+            name="deployment",
+            description="",
+            type="agent",
             provider_data={"operations": []},
         )
         assert request.provider_data == {"operations": []}

--- a/src/backend/tests/unit/api/v1/test_deployment_schemas.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_schemas.py
@@ -13,6 +13,7 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentFlowVersionListItem,
     DeploymentFlowVersionListResponse,
     DeploymentListItem,
+    DeploymentListResponse,
     DeploymentProviderAccountCreateRequest,
     DeploymentProviderAccountGetResponse,
     DeploymentProviderAccountUpdateRequest,
@@ -260,10 +261,10 @@ class TestDeploymentSpecPayloadCompatibility:
 
 
 class TestDeploymentConfigListResponse:
-    def test_provider_data_contains_configs(self):
+    def test_provider_data_contains_connections(self):
         response = DeploymentConfigListResponse(
             provider_data={
-                "configs": [
+                "connections": [
                     {"id": "cfg_1", "name": "Config 1"},
                     {"id": "cfg_2", "name": "Config 2"},
                 ],
@@ -273,7 +274,7 @@ class TestDeploymentConfigListResponse:
             size=20,
             total=2,
         )
-        assert len(response.provider_data["configs"]) == 2
+        assert len(response.provider_data["connections"]) == 2
         assert response.provider_data["scope"] == "shared"
         assert response.page == 1
         assert response.total == 2
@@ -281,9 +282,9 @@ class TestDeploymentConfigListResponse:
     def test_allows_null_provider_data(self):
         response = DeploymentConfigListResponse()
         assert response.provider_data is None
-        assert response.page == 1
-        assert response.size == 20
-        assert response.total == 0
+        assert response.page is None
+        assert response.size is None
+        assert response.total is None
 
     def test_has_provider_data_and_pagination_fields_only(self):
         assert set(DeploymentConfigListResponse.model_fields.keys()) == {
@@ -295,12 +296,12 @@ class TestDeploymentConfigListResponse:
 
 
 class TestDeploymentSnapshotListResponse:
-    def test_provider_data_contains_snapshots(self):
+    def test_provider_data_contains_tools(self):
         from langflow.api.v1.schemas.deployments import DeploymentSnapshotListResponse
 
         response = DeploymentSnapshotListResponse(
             provider_data={
-                "snapshots": [
+                "tools": [
                     {"id": "tool-1", "name": "Tool 1"},
                     {"id": "tool-2", "name": "Tool 2"},
                 ],
@@ -310,7 +311,7 @@ class TestDeploymentSnapshotListResponse:
             size=20,
             total=2,
         )
-        assert len(response.provider_data["snapshots"]) == 2
+        assert len(response.provider_data["tools"]) == 2
         assert response.page == 1
 
     def test_allows_null_provider_data(self):
@@ -371,6 +372,16 @@ class TestDeploymentFlowVersionListSchemas:
         assert response.page == 2
         assert response.size == 5
         assert response.total == 9
+
+
+class TestDeploymentListResponse:
+    def test_allows_provider_only_shape(self):
+        response = DeploymentListResponse(provider_data={"deployments": []})
+        assert response.deployments is None
+        assert response.page is None
+        assert response.size is None
+        assert response.total is None
+        assert response.provider_data == {"deployments": []}
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/api/v1/test_deployment_schemas.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_schemas.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 
 import pytest
 from langflow.api.v1.schemas.deployments import (
-    DeploymentConfigListItem,
     DeploymentConfigListResponse,
     DeploymentCreateRequest,
     DeploymentFlowVersionListItem,
@@ -265,57 +264,79 @@ class TestDeploymentSpecPayloadCompatibility:
 
 
 # ---------------------------------------------------------------------------
-# DeploymentConfigListItem / DeploymentConfigListResponse
+# DeploymentConfigListResponse / DeploymentSnapshotListResponse
 # ---------------------------------------------------------------------------
 
 
-class TestDeploymentConfigListItem:
-    def test_accepts_minimal_fields(self):
-        item = DeploymentConfigListItem(id="cfg_1", name="Config")
-        assert item.id == "cfg_1"
-        assert item.name == "Config"
-        assert item.created_at is None
-        assert item.updated_at is None
-        assert item.provider_data is None
-
-    def test_does_not_have_description(self):
-        assert "description" not in DeploymentConfigListItem.model_fields
-
-    def test_accepts_all_fields(self):
-        from datetime import datetime, timezone
-
-        now = datetime.now(tz=timezone.utc)
-        item = DeploymentConfigListItem(
-            id="cfg_1",
-            name="Config",
-            created_at=now,
-            updated_at=now,
-            provider_data={"region": "us-east-1"},
-        )
-        assert item.created_at == now
-        assert item.provider_data == {"region": "us-east-1"}
-
-
 class TestDeploymentConfigListResponse:
-    def test_wraps_items_with_pagination(self):
+    def test_provider_data_contains_configs(self):
         response = DeploymentConfigListResponse(
-            configs=[
-                DeploymentConfigListItem(id="cfg_1", name="Config 1"),
-                DeploymentConfigListItem(id="cfg_2", name="Config 2"),
-            ],
+            provider_data={
+                "configs": [
+                    {"id": "cfg_1", "name": "Config 1"},
+                    {"id": "cfg_2", "name": "Config 2"},
+                ],
+                "scope": "shared",
+            },
             page=1,
             size=20,
             total=2,
         )
-        assert len(response.configs) == 2
+        assert len(response.provider_data["configs"]) == 2
+        assert response.provider_data["scope"] == "shared"
         assert response.page == 1
         assert response.total == 2
 
-    def test_pagination_defaults(self):
-        response = DeploymentConfigListResponse(configs=[])
+    def test_allows_null_provider_data(self):
+        response = DeploymentConfigListResponse()
+        assert response.provider_data is None
         assert response.page == 1
         assert response.size == 20
         assert response.total == 0
+
+    def test_has_provider_data_and_pagination_fields_only(self):
+        assert set(DeploymentConfigListResponse.model_fields.keys()) == {
+            "provider_data",
+            "page",
+            "size",
+            "total",
+        }
+
+
+class TestDeploymentSnapshotListResponse:
+    def test_provider_data_contains_snapshots(self):
+        from langflow.api.v1.schemas.deployments import DeploymentSnapshotListResponse
+
+        response = DeploymentSnapshotListResponse(
+            provider_data={
+                "snapshots": [
+                    {"id": "tool-1", "name": "Tool 1"},
+                    {"id": "tool-2", "name": "Tool 2"},
+                ],
+                "scope": "shared",
+            },
+            page=1,
+            size=20,
+            total=2,
+        )
+        assert len(response.provider_data["snapshots"]) == 2
+        assert response.page == 1
+
+    def test_allows_null_provider_data(self):
+        from langflow.api.v1.schemas.deployments import DeploymentSnapshotListResponse
+
+        response = DeploymentSnapshotListResponse()
+        assert response.provider_data is None
+
+    def test_has_provider_data_and_pagination_fields_only(self):
+        from langflow.api.v1.schemas.deployments import DeploymentSnapshotListResponse
+
+        assert set(DeploymentSnapshotListResponse.model_fields.keys()) == {
+            "provider_data",
+            "page",
+            "size",
+            "total",
+        }
 
 
 class TestDeploymentFlowVersionListSchemas:

--- a/src/backend/tests/unit/api/v1/test_deployment_sync.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_sync.py
@@ -1214,6 +1214,7 @@ class TestWxoResolveRollbackUpdate:
         )
 
         assert result is not None
+        assert result.spec is not None
         assert result.spec.name == "test-dep"
         assert result.spec.description == "desc"
         provider_data = result.provider_data
@@ -1241,6 +1242,7 @@ class TestWxoResolveRollbackUpdate:
 
         assert result is not None
         assert result.provider_data["put_tools"] == []
+        assert result.spec is not None
         assert result.spec.description == ""
 
 

--- a/src/backend/tests/unit/api/v1/test_deployment_sync.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_sync.py
@@ -684,16 +684,26 @@ def test_resolve_flow_version_patch_for_update_watsonx_operations():
     from langflow.api.v1.mappers.deployments.helpers import resolve_flow_version_patch_for_update
 
     add_id = uuid4()
+    unbind_only_id = uuid4()
     remove_id = uuid4()
     add_ids, remove_ids = resolve_flow_version_patch_for_update(
         deployment_mapper=WatsonxOrchestrateDeploymentMapper(),
         payload=DeploymentUpdateRequest(
             provider_data={
                 "llm": "test-llm",
-                "operations": [
-                    {"op": "bind", "flow_version_id": str(add_id), "app_ids": ["app-one"]},
-                    {"op": "unbind", "flow_version_id": str(remove_id), "app_ids": ["app-one"]},
+                "upsert_flows": [
+                    {
+                        "flow_version_id": str(add_id),
+                        "add_app_ids": ["app-one"],
+                        "remove_app_ids": [],
+                    },
+                    {
+                        "flow_version_id": str(unbind_only_id),
+                        "add_app_ids": [],
+                        "remove_app_ids": ["app-one"],
+                    },
                 ],
+                "remove_flows": [str(remove_id)],
             }
         ),
     )

--- a/src/backend/tests/unit/api/v1/test_deployment_sync.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_sync.py
@@ -690,8 +690,6 @@ def test_resolve_flow_version_patch_for_update_watsonx_operations():
         payload=DeploymentUpdateRequest(
             provider_data={
                 "llm": "test-llm",
-                "resource_name_prefix": "lf_test_",
-                "connections": {"existing_app_ids": ["app-one"]},
                 "operations": [
                     {"op": "bind", "flow_version_id": str(add_id), "app_ids": ["app-one"]},
                     {"op": "unbind", "flow_version_id": str(remove_id), "app_ids": ["app-one"]},

--- a/src/backend/tests/unit/api/v1/test_deployment_sync.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_sync.py
@@ -1631,6 +1631,39 @@ class TestListDeploymentFlowVersionsSynced:
         mock_sync_snapshot_ids.assert_not_awaited()
         mock_count_attachments.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.count_deployment_attachments", new_callable=AsyncMock, return_value=0)
+    @patch(f"{MODULE}.list_deployment_attachments_with_versions", new_callable=AsyncMock, return_value=[])
+    @patch(f"{MODULE}.list_deployment_attachments", new_callable=AsyncMock, return_value=[])
+    async def test_forwards_flow_ids_filter_to_attachment_queries(
+        self,
+        mock_list_attachments,
+        mock_list_with_versions,
+        mock_count_attachments,
+    ):
+        deployment_id = uuid4()
+        flow_id = uuid4()
+        adapter = AsyncMock()
+        mapper = WatsonxOrchestrateDeploymentMapper()
+
+        from langflow.api.v1.mappers.deployments.helpers import list_deployment_flow_versions_synced
+
+        await list_deployment_flow_versions_synced(
+            deployment_adapter=adapter,
+            deployment_mapper=mapper,
+            user_id=uuid4(),
+            provider_id=uuid4(),
+            deployment_id=deployment_id,
+            db=AsyncMock(),
+            page=1,
+            size=10,
+            flow_ids=[flow_id],
+        )
+
+        assert mock_list_attachments.call_args.kwargs["flow_ids"] == [flow_id]
+        assert mock_list_with_versions.call_args.kwargs["flow_ids"] == [flow_id]
+        assert mock_count_attachments.call_args.kwargs["flow_ids"] == [flow_id]
+
 
 # ---------------------------------------------------------------------------
 # flow_version_deployment_attachment CRUD helpers

--- a/src/backend/tests/unit/api/v1/test_deployment_sync.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_sync.py
@@ -686,10 +686,17 @@ def test_resolve_flow_version_patch_for_update_watsonx_operations():
     add_id = uuid4()
     remove_id = uuid4()
     add_ids, remove_ids = resolve_flow_version_patch_for_update(
-        deployment_mapper=_FakeMapper(),
+        deployment_mapper=WatsonxOrchestrateDeploymentMapper(),
         payload=DeploymentUpdateRequest(
-            add_flow_version_ids=[add_id],
-            remove_flow_version_ids=[remove_id],
+            provider_data={
+                "llm": "test-llm",
+                "resource_name_prefix": "lf_test_",
+                "connections": {"existing_app_ids": ["app-one"]},
+                "operations": [
+                    {"op": "bind", "flow_version_id": str(add_id), "app_ids": ["app-one"]},
+                    {"op": "unbind", "flow_version_id": str(remove_id), "app_ids": ["app-one"]},
+                ],
+            }
         ),
     )
 

--- a/src/backend/tests/unit/api/v1/test_deployments_response_mapping.py
+++ b/src/backend/tests/unit/api/v1/test_deployments_response_mapping.py
@@ -2,14 +2,17 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from uuid import uuid4
 
-from langflow.api.v1.mappers.deployments.helpers import to_deployment_create_response
+from langflow.api.v1.mappers.deployments.base import BaseDeploymentMapper
 from lfx.services.adapters.deployment.schema import DeploymentCreateResult, DeploymentType
 
 
-def test_to_deployment_create_response_maps_db_identity_and_provider_result() -> None:
+def test_shape_deployment_create_result_maps_db_identity_and_provider_result() -> None:
+    mapper = BaseDeploymentMapper()
+    provider_account_id = uuid4()
     now = datetime.now(timezone.utc)
     deployment_row = SimpleNamespace(
         id=uuid4(),
+        deployment_provider_account_id=provider_account_id,
         name="db-deployment-name",
         description="db-description",
         deployment_type=DeploymentType.AGENT,
@@ -21,9 +24,11 @@ def test_to_deployment_create_response_maps_db_identity_and_provider_result() ->
         provider_result={"snapshot_bindings": [{"source_ref": "fv-1", "snapshot_id": "tool-1"}]},
     )
 
-    response = to_deployment_create_response(adapter_result, deployment_row)
+    response = mapper.shape_deployment_create_result(adapter_result, deployment_row, provider_key="test-provider")
 
     assert response.id == deployment_row.id
+    assert response.provider_id == provider_account_id
+    assert response.provider_key == "test-provider"
     assert response.name == deployment_row.name
     assert response.description == "db-description"
     assert response.created_at == now

--- a/src/backend/tests/unit/api/v1/test_deployments_routes.py
+++ b/src/backend/tests/unit/api/v1/test_deployments_routes.py
@@ -31,6 +31,16 @@ def _resolve_endpoint_name(routes: list[APIRoute], *, path: str, method: str = "
     raise AssertionError(msg)
 
 
+def _resolve_route(routes: list[APIRoute], *, path: str, method: str = "GET") -> APIRoute:
+    scope = {"type": "http", "path": path, "method": method}
+    for route in routes:
+        match, _ = route.matches(scope)
+        if match == Match.FULL:
+            return route
+    msg = f"No matching route for {method} {path}"
+    raise AssertionError(msg)
+
+
 def test_configs_path_matches_configs_endpoint(deployment_routes: list[APIRoute]) -> None:
     assert _resolve_endpoint_name(deployment_routes, path="/deployments/configs") == "list_deployment_configs"
 
@@ -45,6 +55,16 @@ def test_llms_path_matches_llms_endpoint(deployment_routes: list[APIRoute]) -> N
 
 def test_snapshots_path_matches_snapshots_endpoint(deployment_routes: list[APIRoute]) -> None:
     assert _resolve_endpoint_name(deployment_routes, path="/deployments/snapshots") == "list_deployment_snapshots"
+
+
+def test_configs_route_excludes_none_fields_in_response_model(deployment_routes: list[APIRoute]) -> None:
+    route = _resolve_route(deployment_routes, path="/deployments/configs")
+    assert route.response_model_exclude_none is True
+
+
+def test_snapshots_route_excludes_none_fields_in_response_model(deployment_routes: list[APIRoute]) -> None:
+    route = _resolve_route(deployment_routes, path="/deployments/snapshots")
+    assert route.response_model_exclude_none is True
 
 
 def test_snapshot_patch_path_matches_update_endpoint(deployment_routes: list[APIRoute]) -> None:

--- a/src/backend/tests/unit/services/database/test_deployment_crud_description.py
+++ b/src/backend/tests/unit/services/database/test_deployment_crud_description.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+from langflow.services.database.models.deployment.crud import create_deployment, update_deployment
+from langflow.services.database.models.deployment.model import Deployment
+from lfx.services.adapters.deployment.schema import DEPLOYMENT_DESCRIPTION_MAX_LENGTH, DeploymentType
+
+
+def _fake_db():
+    return SimpleNamespace(
+        add=Mock(),
+        flush=AsyncMock(),
+        refresh=AsyncMock(),
+        rollback=AsyncMock(),
+    )
+
+
+@pytest.mark.anyio
+async def test_create_deployment_rejects_description_over_max_length():
+    db = _fake_db()
+
+    with pytest.raises(ValueError, match="at most"):
+        await create_deployment(
+            db,
+            user_id=uuid4(),
+            project_id=uuid4(),
+            deployment_provider_account_id=uuid4(),
+            resource_key="rk-1",
+            name="deployment",
+            deployment_type=DeploymentType.AGENT,
+            description="x" * (DEPLOYMENT_DESCRIPTION_MAX_LENGTH + 1),
+        )
+
+    db.add.assert_not_called()
+    db.flush.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_update_deployment_rejects_description_over_max_length():
+    db = _fake_db()
+    deployment = Deployment(
+        resource_key="rk-1",
+        user_id=uuid4(),
+        project_id=uuid4(),
+        deployment_provider_account_id=uuid4(),
+        name="deployment",
+        deployment_type=DeploymentType.AGENT,
+    )
+
+    with pytest.raises(ValueError, match="at most"):
+        await update_deployment(
+            db,
+            deployment=deployment,
+            description="x" * (DEPLOYMENT_DESCRIPTION_MAX_LENGTH + 1),
+        )
+
+    db.add.assert_not_called()
+    db.flush.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_create_deployment_accepts_description_at_max_length():
+    db = _fake_db()
+    description = "x" * DEPLOYMENT_DESCRIPTION_MAX_LENGTH
+
+    row = await create_deployment(
+        db,
+        user_id=uuid4(),
+        project_id=uuid4(),
+        deployment_provider_account_id=uuid4(),
+        resource_key="rk-1",
+        name="deployment",
+        deployment_type=DeploymentType.AGENT,
+        description=description,
+    )
+
+    assert row.description == description
+    db.flush.assert_awaited_once()
+    db.refresh.assert_awaited_once()

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -588,29 +588,32 @@ async def test_update_provider_data_llm_only_updates_agent(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_update_provider_data_rejects_missing_llm(monkeypatch):
+async def test_update_provider_data_accepts_missing_llm(monkeypatch):
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     fake_agent = FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]})
+    fake_tool = FakeToolClient([{"id": "tool-1", "name": "tool-1", "binding": {"langflow": {"connections": {}}}}])
+    fake_connections = FakeConnectionsClient(existing_app_id="cfg-1")
 
     async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
-        return SimpleNamespace(agent=fake_agent)
+        return SimpleNamespace(agent=fake_agent, tool=fake_tool, connections=fake_connections)
 
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
 
-    with pytest.raises(InvalidContentError, match="llm is required for deployment update operations"):
-        await service.update(
-            user_id="user-1",
-            deployment_id="dep-1",
-            payload=DeploymentUpdate(
-                provider_data={
-                    "connections": {},
-                    "operations": [
-                        {"op": "bind", "tool": {"tool_id_with_ref": _tool_ref("tool-1")}, "app_ids": ["cfg-1"]}
-                    ],
-                }
-            ),
-            db=object(),
-        )
+    result = await service.update(
+        user_id="user-1",
+        deployment_id="dep-1",
+        payload=DeploymentUpdate(
+            provider_data={
+                "connections": {},
+                "operations": [{"op": "bind", "tool": {"tool_id_with_ref": _tool_ref("tool-1")}, "app_ids": ["cfg-1"]}],
+            }
+        ),
+        db=object(),
+    )
+
+    assert result.id == "dep-1"
+    assert fake_agent.update_calls
+    assert all("llm" not in payload for _, payload in fake_agent.update_calls)
 
 
 def test_update_payload_rejects_connections_without_bind_or_unbind_operations():

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -71,6 +71,9 @@ ToolConnectionOps = update_core_module.ToolConnectionOps
 OrderedUniqueStrs = shared_core_module.OrderedUniqueStrs
 WatsonxDeploymentUpdatePayload = payloads_module.WatsonxDeploymentUpdatePayload
 WatsonxRenameToolOperation = payloads_module.WatsonxRenameToolOperation
+ListConfigsResponse = importlib.import_module(
+    "ibm_watsonx_orchestrate_clients.connections.connections_client"
+).ListConfigsResponse
 
 TEST_WXO_LLM = "ibm/granite-3.3-8b"
 
@@ -208,6 +211,7 @@ class FakeConnectionsClient:
         self.delete_calls: list[str] = []
         self.delete_credentials_calls: list[tuple[str, object, bool]] = []
         self._list_entries: list[dict] = []
+        self._draft_entries_by_id: list[object] = []
         self.create_calls: list[dict] = []
         self.create_config_calls: list[tuple[str, dict]] = []
         self.create_credentials_calls: list[tuple[str, object, bool, dict]] = []
@@ -245,6 +249,15 @@ class FakeConnectionsClient:
 
     def list(self):
         return self._list_entries
+
+    def get_drafts_by_ids(self, conn_ids: list[str]):
+        requested = set(conn_ids)
+        entries = []
+        for entry in self._draft_entries_by_id:
+            connection_id = str(getattr(entry, "connection_id", "") or "")
+            if connection_id in requested:
+                entries.append(entry)
+        return entries
 
 
 class FakeBaseClient:
@@ -3061,10 +3074,20 @@ async def test_list_configs_single_deployment_scope(monkeypatch):
             }
         ]
     )
+    connections_client = FakeConnectionsClient()
+    connections_client._draft_entries_by_id = [
+        ListConfigsResponse.model_validate(
+            {
+                "connection_id": "conn-1",
+                "app_id": "cfg-1",
+                "security_scheme": "key_value_creds",
+            }
+        )
+    ]
     fake_clients = SimpleNamespace(
         agent=fake_agent,
         tool=fake_tool,
-        connections=FakeConnectionsClient(),
+        connections=connections_client,
     )
 
     async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
@@ -3079,8 +3102,57 @@ async def test_list_configs_single_deployment_scope(monkeypatch):
     )
 
     assert len(result.configs) == 1
-    assert result.configs[0].id == "cfg-1"
+    assert result.configs[0].id == "conn-1"
     assert result.configs[0].name == "cfg-1"
+    assert result.configs[0].provider_data == {"type": "key_value_creds"}
+
+
+@pytest.mark.anyio
+async def test_list_configs_scopes_return_same_normalized_item_shape(monkeypatch):
+    """Tenant-scope and deployment-scope must return the same ConfigListItem shape, including type metadata."""
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    connections_client = FakeConnectionsClient()
+    connections_client._list_entries = [
+        ListConfigsResponse.model_validate(
+            {"connection_id": "conn-1", "app_id": "cfg-1", "name": "Config One", "security_scheme": "key_value_creds"}
+        )
+    ]
+    connections_client._draft_entries_by_id = [
+        ListConfigsResponse.model_validate(
+            {"connection_id": "conn-1", "app_id": "cfg-1", "security_scheme": "key_value_creds"}
+        )
+    ]
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]}),
+        tool=FakeToolClient(
+            [
+                {
+                    "id": "tool-1",
+                    "name": "Tool One",
+                    "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}},
+                }
+            ]
+        ),
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    tenant_result = await service.list_configs(user_id="user-1", db=object(), params=None)
+    deployment_result = await service.list_configs(
+        user_id="user-1",
+        db=object(),
+        params=ConfigListParams(deployment_ids=["dep-1"]),
+    )
+
+    expected = {"id": "conn-1", "name": "cfg-1", "provider_data": {"type": "key_value_creds"}}
+    assert len(tenant_result.configs) == 1
+    assert len(deployment_result.configs) == 1
+    assert tenant_result.configs[0].model_dump(exclude_none=True) == expected
+    assert deployment_result.configs[0].model_dump(exclude_none=True) == expected
 
 
 @pytest.mark.anyio
@@ -3145,8 +3217,8 @@ async def test_list_configs_without_deployment_id_lists_tenant_scope(monkeypatch
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
-        {"app_id": "cfg-1", "name": "Config One"},
-        {"app_id": "cfg-2", "display_name": "Config Two"},
+        ListConfigsResponse.model_validate({"connection_id": "conn-1", "app_id": "cfg-1", "name": "Config One"}),
+        ListConfigsResponse.model_validate({"connection_id": "conn-2", "app_id": "cfg-2", "name": "Config Two"}),
     ]
     fake_clients = SimpleNamespace(
         agent=FakeAgentClient({"id": "dep-1", "tools": []}),
@@ -3160,25 +3232,23 @@ async def test_list_configs_without_deployment_id_lists_tenant_scope(monkeypatch
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
 
     result = await service.list_configs(user_id="user-1", db=object(), params=None)
-    assert [config.id for config in result.configs] == ["cfg-1", "cfg-2"]
+    assert [config.id for config in result.configs] == ["conn-1", "conn-2"]
+    assert [config.name for config in result.configs] == ["cfg-1", "cfg-2"]
     assert result.provider_result == {}
 
 
 @pytest.mark.anyio
-async def test_list_configs_tenant_scope_handles_pydantic_models(monkeypatch):
-    """SDK ConnectionsClient.list() returns Pydantic model objects, not dicts."""
-    from pydantic import BaseModel
-
-    class FakeListConfigsResponse(BaseModel):
-        app_id: str = ""
-        name: str = ""
-        connection_id: str | None = None
-
+async def test_list_configs_tenant_scope_handles_sdk_models(monkeypatch):
+    """SDK ConnectionsClient.list() returns ListConfigsResponse objects."""
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
-        FakeListConfigsResponse(app_id="cfg-pydantic-1", name="Pydantic One"),
-        FakeListConfigsResponse(app_id="cfg-pydantic-2", name="Pydantic Two"),
+        ListConfigsResponse.model_validate(
+            {"connection_id": "conn-pydantic-1", "app_id": "cfg-pydantic-1", "name": "Pydantic One"}
+        ),
+        ListConfigsResponse.model_validate(
+            {"connection_id": "conn-pydantic-2", "app_id": "cfg-pydantic-2", "name": "Pydantic Two"}
+        ),
     ]
     fake_clients = SimpleNamespace(
         agent=FakeAgentClient({"id": "dep-1", "tools": []}),
@@ -3192,25 +3262,24 @@ async def test_list_configs_tenant_scope_handles_pydantic_models(monkeypatch):
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
 
     result = await service.list_configs(user_id="user-1", db=object(), params=None)
-    assert [config.id for config in result.configs] == ["cfg-pydantic-1", "cfg-pydantic-2"]
-    assert [config.name for config in result.configs] == ["Pydantic One", "Pydantic Two"]
-    assert result.provider_result == {"scope": "tenant"}
+    assert [config.id for config in result.configs] == ["conn-pydantic-1", "conn-pydantic-2"]
+    assert [config.name for config in result.configs] == ["cfg-pydantic-1", "cfg-pydantic-2"]
+    assert result.provider_result == {}
 
 
 @pytest.mark.anyio
-async def test_list_configs_tenant_scope_mixed_dicts_and_models(monkeypatch):
-    """list_configs handles a mix of dicts and Pydantic models in the same response."""
-    from pydantic import BaseModel
-
-    class FakeListConfigsResponse(BaseModel):
-        app_id: str = ""
-        name: str = ""
-
+async def test_list_configs_tenant_scope_preserves_type_metadata(monkeypatch):
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
-        {"app_id": "dict-cfg", "name": "Dict Config"},
-        FakeListConfigsResponse(app_id="model-cfg", name="Model Config"),
+        ListConfigsResponse.model_validate(
+            {
+                "connection_id": "conn-auth",
+                "app_id": "cfg-auth",
+                "name": "Auth Config",
+                "security_scheme": "key_value_creds",
+            }
+        )
     ]
     fake_clients = SimpleNamespace(
         agent=FakeAgentClient({"id": "dep-1", "tools": []}),
@@ -3224,26 +3293,46 @@ async def test_list_configs_tenant_scope_mixed_dicts_and_models(monkeypatch):
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
 
     result = await service.list_configs(user_id="user-1", db=object(), params=None)
-    assert [config.id for config in result.configs] == ["dict-cfg", "model-cfg"]
-    assert [config.name for config in result.configs] == ["Dict Config", "Model Config"]
+    assert len(result.configs) == 1
+    assert result.configs[0].id == "conn-auth"
+    assert result.configs[0].name == "cfg-auth"
+    assert result.configs[0].provider_data == {"type": "key_value_creds"}
+
+
+@pytest.mark.anyio
+async def test_list_configs_tenant_scope_ignores_dict_entries(monkeypatch):
+    """list_configs ignores dict entries and accepts only SDK models."""
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    connections_client = FakeConnectionsClient()
+    connections_client._list_entries = [
+        {"connection_id": "dict-conn", "app_id": "dict-cfg", "name": "Dict Config"},
+        ListConfigsResponse.model_validate({"connection_id": "model-conn", "app_id": "model-cfg", "name": "Model"}),
+    ]
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": []}),
+        tool=FakeToolClient([]),
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_configs(user_id="user-1", db=object(), params=None)
+    assert [config.id for config in result.configs] == ["model-conn"]
+    assert [config.name for config in result.configs] == ["model-cfg"]
 
 
 @pytest.mark.anyio
 async def test_list_configs_tenant_scope_deduplicates(monkeypatch):
     """Duplicate app_ids are deduplicated in tenant-scope listing."""
-    from pydantic import BaseModel
-
-    class FakeListConfigsResponse(BaseModel):
-        app_id: str = ""
-        name: str = ""
-
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
-        FakeListConfigsResponse(app_id="cfg-dup", name="First"),
-        FakeListConfigsResponse(app_id="cfg-dup", name="Second"),
-        {"app_id": "cfg-dup", "name": "Third"},
-        {"app_id": "cfg-unique", "name": "Unique"},
+        ListConfigsResponse.model_validate({"connection_id": "conn-dup", "app_id": "cfg-dup", "name": "First"}),
+        ListConfigsResponse.model_validate({"connection_id": "conn-dup", "app_id": "cfg-dup", "name": "Second"}),
+        ListConfigsResponse.model_validate({"connection_id": "conn-unique", "app_id": "cfg-unique", "name": "Unique"}),
     ]
     fake_clients = SimpleNamespace(
         agent=FakeAgentClient({"id": "dep-1", "tools": []}),
@@ -3257,18 +3346,22 @@ async def test_list_configs_tenant_scope_deduplicates(monkeypatch):
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
 
     result = await service.list_configs(user_id="user-1", db=object(), params=None)
-    assert [config.id for config in result.configs] == ["cfg-dup", "cfg-unique"]
+    assert [config.id for config in result.configs] == ["conn-dup", "conn-unique"]
+    assert [config.name for config in result.configs] == ["cfg-dup", "cfg-unique"]
 
 
 @pytest.mark.anyio
-async def test_list_configs_tenant_scope_skips_non_dict_non_model(monkeypatch):
-    """Objects without model_dump and that aren't dicts are skipped."""
+async def test_list_configs_tenant_scope_skips_non_sdk_entries(monkeypatch):
+    """Objects that are not SDK ListConfigsResponse are skipped."""
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
         "just-a-string",
         42,
-        {"app_id": "valid-cfg", "name": "Valid"},
+        {"connection_id": "dict-conn", "app_id": "dict-cfg"},
+        ListConfigsResponse.model_validate({"connection_id": "valid-conn", "app_id": "valid-cfg", "name": "Valid"}),
+        ListConfigsResponse.model_validate({"connection_id": "", "app_id": "missing-connection-id"}),
+        ListConfigsResponse.model_validate({"connection_id": "missing-app-id", "app_id": ""}),
     ]
     fake_clients = SimpleNamespace(
         agent=FakeAgentClient({"id": "dep-1", "tools": []}),
@@ -3282,7 +3375,8 @@ async def test_list_configs_tenant_scope_skips_non_dict_non_model(monkeypatch):
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
 
     result = await service.list_configs(user_id="user-1", db=object(), params=None)
-    assert [config.id for config in result.configs] == ["valid-cfg"]
+    assert [config.id for config in result.configs] == ["valid-conn"]
+    assert [config.name for config in result.configs] == ["valid-cfg"]
 
 
 @pytest.mark.anyio

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -3160,7 +3160,12 @@ async def test_list_snapshots_single_deployment_scope(monkeypatch):
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     fake_clients = SimpleNamespace(
         agent=FakeAgentClient({"id": "dep-1", "tools": ["tool-1", "tool-2"]}),
-        tool=FakeToolClient([]),
+        tool=FakeToolClient(
+            [
+                {"id": "tool-1", "name": "Tool One"},
+                {"id": "tool-2", "name": "Tool Two"},
+            ]
+        ),
         connections=FakeConnectionsClient(),
     )
 
@@ -3176,8 +3181,60 @@ async def test_list_snapshots_single_deployment_scope(monkeypatch):
     )
 
     assert [snapshot.id for snapshot in result.snapshots] == ["tool-1", "tool-2"]
-    assert result.snapshots[0].provider_data == {"connections": {}}
-    assert result.snapshots[1].provider_data == {"connections": {}}
+    assert [snapshot.name for snapshot in result.snapshots] == ["Tool One", "Tool Two"]
+
+
+@pytest.mark.anyio
+async def test_list_snapshots_stale_tool_ids_returns_empty(monkeypatch):
+    """When the agent references tool IDs that no longer exist, return no snapshots."""
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": ["deleted-tool-1", "deleted-tool-2"]}),
+        tool=FakeToolClient([]),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_snapshots(
+        user_id="user-1",
+        db=object(),
+        params=SnapshotListParams(deployment_ids=["dep-1"]),
+    )
+
+    assert result.snapshots == []
+
+
+@pytest.mark.anyio
+async def test_list_snapshots_partial_resolution_logs_stale_ids(monkeypatch, caplog):
+    """When some tool IDs resolve and others don't, return only resolved ones and log the stale IDs."""
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": ["tool-1", "deleted-tool"]}),
+        tool=FakeToolClient([{"id": "tool-1", "name": "Tool One"}]),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        result = await service.list_snapshots(
+            user_id="user-1",
+            db=object(),
+            params=SnapshotListParams(deployment_ids=["dep-1"]),
+        )
+
+    assert [snapshot.id for snapshot in result.snapshots] == ["tool-1"]
+    assert "deleted-tool" in caplog.text
+    assert "dep-1" in caplog.text
 
 
 @pytest.mark.anyio

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -3357,8 +3357,8 @@ async def test_list_configs_tenant_scope_preserves_type_metadata(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_list_configs_tenant_scope_ignores_dict_entries(monkeypatch):
-    """list_configs ignores dict entries and accepts only SDK models."""
+async def test_list_configs_tenant_scope_fails_fast_on_dict_entries(monkeypatch):
+    """Tenant-scope list_configs raises when wxO returns unexpected entry types."""
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
@@ -3376,14 +3376,13 @@ async def test_list_configs_tenant_scope_ignores_dict_entries(monkeypatch):
 
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
 
-    result = await service.list_configs(user_id="user-1", db=object(), params=None)
-    assert [config.id for config in result.configs] == ["model-conn"]
-    assert [config.name for config in result.configs] == ["model-cfg"]
+    with pytest.raises(InvalidContentError, match="unexpected connection entry type: dict"):
+        await service.list_configs(user_id="user-1", db=object(), params=None)
 
 
 @pytest.mark.anyio
-async def test_list_configs_tenant_scope_deduplicates(monkeypatch):
-    """Duplicate app_ids are deduplicated in tenant-scope listing."""
+async def test_list_configs_tenant_scope_preserves_duplicates(monkeypatch):
+    """Tenant-scope list_configs keeps duplicate wxO entries as returned."""
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
@@ -3403,13 +3402,13 @@ async def test_list_configs_tenant_scope_deduplicates(monkeypatch):
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
 
     result = await service.list_configs(user_id="user-1", db=object(), params=None)
-    assert [config.id for config in result.configs] == ["conn-dup", "conn-unique"]
-    assert [config.name for config in result.configs] == ["cfg-dup", "cfg-unique"]
+    assert [config.id for config in result.configs] == ["conn-dup", "conn-dup", "conn-unique"]
+    assert [config.name for config in result.configs] == ["cfg-dup", "cfg-dup", "cfg-unique"]
 
 
 @pytest.mark.anyio
-async def test_list_configs_tenant_scope_skips_non_sdk_entries(monkeypatch):
-    """Objects that are not SDK ListConfigsResponse are skipped."""
+async def test_list_configs_tenant_scope_fails_fast_on_non_sdk_entries(monkeypatch):
+    """Tenant-scope list_configs raises on the first non-SDK entry."""
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
@@ -3431,9 +3430,8 @@ async def test_list_configs_tenant_scope_skips_non_sdk_entries(monkeypatch):
 
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
 
-    result = await service.list_configs(user_id="user-1", db=object(), params=None)
-    assert [config.id for config in result.configs] == ["valid-conn"]
-    assert [config.name for config in result.configs] == ["valid-cfg"]
+    with pytest.raises(InvalidContentError, match="unexpected connection entry type: str"):
+        await service.list_configs(user_id="user-1", db=object(), params=None)
 
 
 @pytest.mark.anyio

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -3080,7 +3080,7 @@ async def test_list_configs_without_deployment_id_lists_tenant_scope(monkeypatch
 
     result = await service.list_configs(user_id="user-1", db=object(), params=None)
     assert [config.id for config in result.configs] == ["cfg-1", "cfg-2"]
-    assert result.provider_result == {"scope": "tenant"}
+    assert result.provider_result == {}
 
 
 @pytest.mark.anyio
@@ -3112,7 +3112,7 @@ async def test_list_snapshots_without_deployment_id_lists_tenant_scope(monkeypat
     assert [snapshot.id for snapshot in result.snapshots] == ["tool-1", "tool-2"]
     assert result.snapshots[0].provider_data == {"connections": {"cfg-1": "conn-1"}}
     assert result.snapshots[1].provider_data == {"connections": {}}
-    assert result.provider_result == {"scope": "tenant"}
+    assert result.provider_result == {}
 
 
 @pytest.mark.anyio

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -4381,23 +4381,17 @@ def test_raise_as_deployment_error_maps_forbidden_to_authorization_error():
         )
 
 
-def test_build_agent_payload_requires_provider_spec():
-    from langflow.services.adapters.deployment.watsonx_orchestrate.utils import build_agent_payload
+def test_build_agent_payload_from_values_structure():
+    from langflow.services.adapters.deployment.watsonx_orchestrate.utils import build_agent_payload_from_values
 
-    data = SimpleNamespace(provider_spec=None, description="desc", name="test")
-    with pytest.raises(InvalidContentError, match="provider_spec"):
-        build_agent_payload(data=data, tool_ids=[], llm=TEST_WXO_LLM)
-
-
-def test_build_agent_payload_structure():
-    from langflow.services.adapters.deployment.watsonx_orchestrate.utils import build_agent_payload
-
-    data = SimpleNamespace(
-        provider_spec={"name": "agent_name", "display_name": "Agent Name"},
+    payload = build_agent_payload_from_values(
+        agent_name="agent_name",
+        agent_display_name="Agent Name",
+        deployment_name="test",
         description="test description",
-        name="test",
+        tool_ids=["tool-1", "tool-2"],
+        llm=TEST_WXO_LLM,
     )
-    payload = build_agent_payload(data=data, tool_ids=["tool-1", "tool-2"], llm=TEST_WXO_LLM)
     assert payload["name"] == "agent_name"
     assert payload["display_name"] == "Agent Name"
     assert payload["description"] == "test description"

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate_update_schema.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate_update_schema.py
@@ -369,13 +369,13 @@ def test_update_schema_rejects_unbind_raw_app_ids() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_update_schema_rejects_empty_payload_without_llm() -> None:
-    """Empty payload (no llm, no operations, no put_tools) → must reject."""
-    with pytest.raises(AdapterPayloadValidationError) as exc:
-        WatsonxOrchestrateDeploymentService.payload_schemas.deployment_update.apply(  # type: ignore[union-attr]
-            {}
-        )
-    assert "llm is required for deployment update operations" in str(exc.value.error)
+def test_update_schema_accepts_empty_payload_without_llm() -> None:
+    """Empty update payload is allowed; service layer decides if the request has actionable work."""
+    applied = WatsonxOrchestrateDeploymentService.payload_schemas.deployment_update.apply(  # type: ignore[union-attr]
+        {}
+    )
+    assert applied["llm"] is None
+    assert applied["operations"] == []
 
 
 def test_update_schema_accepts_put_tools_alone() -> None:

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/deployment-phase.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/deployment-phase.tsx
@@ -7,14 +7,16 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import type { ProviderAccount } from "@/pages/MainPage/pages/deploymentsPage/types";
-import type { FlowAttachment } from "./types";
+import type {
+  Deployment,
+  ProviderAccount,
+} from "@/pages/MainPage/pages/deploymentsPage/types";
 
 const NEW_DEPLOYMENT_VALUE = "__new__";
 
 interface DeploymentPhaseContentProps {
   selectedProvider: ProviderAccount | null;
-  attachments: FlowAttachment[];
+  deployments: Deployment[];
   selectedDeployment: string;
   onSelectDeployment: (id: string) => void;
   isLoading: boolean;
@@ -29,7 +31,7 @@ export { NEW_DEPLOYMENT_VALUE };
 
 export default function DeploymentPhaseContent({
   selectedProvider,
-  attachments,
+  deployments,
   selectedDeployment,
   onSelectDeployment,
   isLoading,
@@ -62,24 +64,22 @@ export default function DeploymentPhaseContent({
           value={selectedDeployment}
           onValueChange={onSelectDeployment}
         >
-          {attachments.map((attachment) => (
+          {deployments.map((deployment) => (
             <div
-              key={attachment.provider_snapshot_id}
+              key={deployment.id}
               className="flex items-center gap-3 rounded-lg border p-3"
             >
               <RadioGroupItem
-                value={attachment.provider_snapshot_id}
-                id={`deploy-${attachment.provider_snapshot_id}`}
+                value={deployment.id}
+                id={`deploy-${deployment.id}`}
               />
               <Label
-                htmlFor={`deploy-${attachment.provider_snapshot_id}`}
+                htmlFor={`deploy-${deployment.id}`}
                 className="flex flex-1 cursor-pointer flex-col gap-0.5"
               >
-                <span className="text-sm font-medium">
-                  {attachment.deployment_name}
-                </span>
+                <span className="text-sm font-medium">{deployment.name}</span>
                 <span className="text-xs text-muted-foreground">
-                  {attachment.deployment_type} deployment
+                  {deployment.type} deployment
                 </span>
               </Label>
             </div>

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/hooks/use-prepare-deploy.ts
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/hooks/use-prepare-deploy.ts
@@ -54,7 +54,7 @@ export function usePrepareDeploy() {
       setPendingSnapshotVersionId(snapshot.id);
 
       const { data } = await fetchProviderAccounts();
-      const providerList = data?.providers ?? [];
+      const providerList = data?.provider_accounts ?? [];
 
       if (providerList.length === 0) {
         setStepperInitialProvider(undefined);

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/index.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { usePatchSnapshot } from "@/controllers/API/queries/deployments";
+import { useGetDeploymentAttachments } from "@/controllers/API/queries/deployments/use-get-deployment-attachments";
 import { useGetDeployments } from "@/controllers/API/queries/deployments/use-get-deployments";
 import { useErrorAlert } from "@/pages/MainPage/pages/deploymentsPage/hooks/use-error-alert";
 import type {
@@ -12,7 +13,7 @@ import DeploymentPhaseContent, {
 } from "./deployment-phase";
 import ProviderPhaseContent from "./provider-phase";
 import ReviewPhaseContent from "./review-phase";
-import { type FlowAttachment, flattenToAttachments } from "./types";
+import { type FlowAttachment, toReviewAttachment } from "./types";
 import UpdatePhaseContent from "./update-phase";
 
 const PROVIDER_KEY_MAP: Record<string, DeploymentProvider> = {
@@ -88,18 +89,82 @@ export default function DeployChoiceDialog({
       { enabled: shouldFetchDeployments },
     );
 
-  const attachments = useMemo(
-    () => flattenToAttachments(deploymentsData?.deployments ?? []),
+  const deployments = useMemo(
+    () => deploymentsData?.deployments ?? [],
     [deploymentsData],
   );
 
+  const selectedDeploymentEntry = useMemo(
+    () =>
+      deployments.find((deployment) => deployment.id === selectedDeployment),
+    [deployments, selectedDeployment],
+  );
+
+  const shouldFetchSelectedDeploymentAttachments =
+    open &&
+    phase === "review" &&
+    !!selectedProvider &&
+    selectedDeployment !== NEW_DEPLOYMENT_VALUE &&
+    !!selectedDeploymentEntry;
+
+  const {
+    data: selectedDeploymentAttachmentsData,
+    isLoading: isLoadingSelectedDeploymentAttachments,
+    isFetching: isFetchingSelectedDeploymentAttachments,
+  } = useGetDeploymentAttachments(
+    {
+      deploymentId: selectedDeploymentEntry?.id ?? "",
+      flow_ids: flowId,
+    },
+    { enabled: shouldFetchSelectedDeploymentAttachments },
+  );
+
   useEffect(() => {
-    if (attachments.length === 1) {
-      setSelectedDeployment(attachments[0].provider_snapshot_id);
+    if (deployments.length === 1) {
+      setSelectedDeployment(deployments[0].id);
     } else {
       setSelectedDeployment(NEW_DEPLOYMENT_VALUE);
     }
-  }, [attachments]);
+  }, [deployments]);
+
+  useEffect(() => {
+    if (
+      phase !== "review" ||
+      selectedDeployment === NEW_DEPLOYMENT_VALUE ||
+      !selectedDeploymentEntry
+    ) {
+      return;
+    }
+    if (
+      isLoadingSelectedDeploymentAttachments ||
+      isFetchingSelectedDeploymentAttachments
+    ) {
+      return;
+    }
+
+    const nextReviewAttachment = toReviewAttachment(
+      selectedDeploymentEntry,
+      selectedDeploymentAttachmentsData?.flow_versions ?? [],
+    );
+    if (!nextReviewAttachment) {
+      showError(
+        "Failed to load deployment details",
+        "No provider snapshot was found for this flow on the selected deployment.",
+      );
+      setPhase("deployments");
+      setReviewAttachment(null);
+      return;
+    }
+    setReviewAttachment(nextReviewAttachment);
+  }, [
+    phase,
+    selectedDeployment,
+    selectedDeploymentEntry,
+    selectedDeploymentAttachmentsData,
+    isLoadingSelectedDeploymentAttachments,
+    isFetchingSelectedDeploymentAttachments,
+    showError,
+  ]);
 
   useEffect(() => {
     if (!open) return;
@@ -137,13 +202,8 @@ export default function DeployChoiceDialog({
       onChooseNew(buildProviderPreselection());
       return;
     }
-
-    const attachment = attachments.find(
-      (a) => a.provider_snapshot_id === selectedDeployment,
-    );
-    if (!attachment) return;
-
-    setReviewAttachment(attachment);
+    if (!selectedDeploymentEntry) return;
+    setReviewAttachment(null);
     setPhase("review");
   };
 
@@ -178,7 +238,12 @@ export default function DeployChoiceDialog({
   const isUpdating = updatePhase === "updating";
   const isUpdated = updatePhase === "updated";
   const isInUpdatePhase = isUpdating || isUpdated;
-  const isBusy = isUpdating || isLoadingDeployments;
+  const isLoadingReviewAttachment =
+    phase === "review" &&
+    (isLoadingSelectedDeploymentAttachments ||
+      isFetchingSelectedDeploymentAttachments);
+  const isBusy =
+    isUpdating || isLoadingDeployments || isLoadingReviewAttachment;
 
   return (
     <Dialog
@@ -227,10 +292,16 @@ export default function DeployChoiceDialog({
             onConfirm={handleReviewConfirm}
             onCancel={() => setOpen(false)}
           />
+        ) : phase === "review" && isLoadingReviewAttachment ? (
+          <div className="flex min-h-52 items-center justify-center">
+            <div className="text-sm text-muted-foreground">
+              Loading deployment attachment details...
+            </div>
+          </div>
         ) : (
           <DeploymentPhaseContent
             selectedProvider={selectedProvider}
-            attachments={attachments}
+            deployments={deployments}
             selectedDeployment={selectedDeployment}
             onSelectDeployment={setSelectedDeployment}
             isLoading={isLoadingDeployments}

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/provider-phase.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/provider-phase.tsx
@@ -49,7 +49,7 @@ export default function ProviderPhaseContent({
             >
               <span className="text-sm font-medium">{provider.name}</span>
               <span className="text-xs text-muted-foreground">
-                {provider.provider_url}
+                {provider.url}
               </span>
             </Label>
           </div>

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/types.ts
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/types.ts
@@ -1,3 +1,4 @@
+import type { DeploymentFlowVersionItem } from "@/controllers/API/queries/deployments/use-get-deployment-attachments";
 import type {
   Deployment,
   DeploymentType,
@@ -11,22 +12,22 @@ export interface FlowAttachment {
   provider_snapshot_id: string;
 }
 
-export function flattenToAttachments(
-  deployments: Deployment[],
-): FlowAttachment[] {
-  const result: FlowAttachment[] = [];
-  for (const dep of deployments) {
-    if (!dep.matched_attachments) continue;
-    for (const att of dep.matched_attachments) {
-      if (!att.provider_snapshot_id) continue;
-      result.push({
-        deployment_id: dep.id,
-        deployment_name: dep.name,
-        deployment_type: dep.type,
-        flow_version_id: att.flow_version_id,
-        provider_snapshot_id: att.provider_snapshot_id,
-      });
-    }
+export function toReviewAttachment(
+  deployment: Deployment,
+  flowVersions: DeploymentFlowVersionItem[],
+): FlowAttachment | null {
+  const selectedFlowVersion = flowVersions.find(
+    (item) => !!item.provider_snapshot_id,
+  );
+  if (!selectedFlowVersion?.provider_snapshot_id) {
+    return null;
   }
-  return result;
+
+  return {
+    deployment_id: deployment.id,
+    deployment_name: deployment.name,
+    deployment_type: deployment.type,
+    flow_version_id: selectedFlowVersion.id,
+    provider_snapshot_id: selectedFlowVersion.provider_snapshot_id,
+  };
 }

--- a/src/frontend/src/controllers/API/queries/deployment-provider-accounts/use-post-provider-account.ts
+++ b/src/frontend/src/controllers/API/queries/deployment-provider-accounts/use-post-provider-account.ts
@@ -7,7 +7,7 @@ import { UseRequestProcessor } from "../../services/request-processor";
 export interface ProviderAccountCreateRequest {
   name: string;
   provider_key: string;
-  provider_url: string;
+  url: string;
   provider_data: {
     api_key: string;
   };

--- a/src/frontend/src/controllers/API/queries/deployments/use-get-deployment-attachments.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-get-deployment-attachments.ts
@@ -27,21 +27,26 @@ export interface DeploymentFlowVersionListResponse {
 
 interface GetDeploymentAttachmentsParams {
   deploymentId: string;
+  flow_ids?: string;
 }
 
 export const useGetDeploymentAttachments: useQueryFunctionType<
   GetDeploymentAttachmentsParams,
   DeploymentFlowVersionListResponse
-> = ({ deploymentId }, options) => {
+> = ({ deploymentId, flow_ids }, options) => {
   const { query } = UseRequestProcessor();
 
   const fn = async (): Promise<DeploymentFlowVersionListResponse> => {
     const { data } = await api.get<DeploymentFlowVersionListResponse>(
       `${getURL("DEPLOYMENTS")}/${deploymentId}/flows`,
-      { params: { size: 50 } },
+      { params: { size: 50, flow_ids } },
     );
     return data;
   };
 
-  return query(["useGetDeploymentAttachments", { deploymentId }], fn, options);
+  return query(
+    ["useGetDeploymentAttachments", { deploymentId, flow_ids }],
+    fn,
+    options,
+  );
 };

--- a/src/frontend/src/controllers/API/queries/deployments/use-get-deployment-configs.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-get-deployment-configs.ts
@@ -4,11 +4,9 @@ import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
 
 export interface DeploymentConfigItem {
-  id: string;
-  name: string;
-  created_at: string | null;
-  updated_at: string | null;
-  provider_data: Record<string, unknown> | null;
+  connection_id: string;
+  app_id: string;
+  type?: string;
 }
 
 export interface DeploymentConfigListResponse {
@@ -16,6 +14,19 @@ export interface DeploymentConfigListResponse {
   page: number;
   size: number;
   total: number;
+}
+
+interface DeploymentConfigListApiResponse {
+  page?: number;
+  size?: number;
+  total?: number;
+  provider_data?: {
+    connections?: DeploymentConfigItem[];
+    configs?: DeploymentConfigItem[];
+    page?: number;
+    size?: number;
+    total?: number;
+  } | null;
 }
 
 interface GetDeploymentConfigsParams {
@@ -30,11 +41,20 @@ export const useGetDeploymentConfigs: useQueryFunctionType<
 
   const getDeploymentConfigsFn =
     async (): Promise<DeploymentConfigListResponse> => {
-      const { data } = await api.get<DeploymentConfigListResponse>(
+      const { data } = await api.get<DeploymentConfigListApiResponse>(
         `${getURL("DEPLOYMENTS")}/configs`,
         { params: { provider_id: providerId, size: 10000 } },
       );
-      return data;
+      const providerData = data.provider_data;
+      // Normalize provider-shaped list payloads into a stable FE shape.
+      const providerConfigs =
+        providerData?.connections ?? providerData?.configs ?? [];
+      return {
+        configs: providerConfigs,
+        page: providerData?.page ?? data.page ?? 1,
+        size: providerData?.size ?? data.size ?? providerConfigs.length,
+        total: providerData?.total ?? data.total ?? providerConfigs.length,
+      };
     };
 
   return query(

--- a/src/frontend/src/controllers/API/queries/deployments/use-get-deployment-execution.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-get-deployment-execution.ts
@@ -5,8 +5,8 @@ import { UseRequestProcessor } from "../../services/request-processor";
 import type { DeploymentExecutionResponse } from "./use-post-deployment-execution";
 
 export interface GetDeploymentExecutionParams {
+  deployment_id: string;
   execution_id: string;
-  provider_id: string;
 }
 
 export const useGetDeploymentExecution: useMutationFunctionType<
@@ -17,12 +17,11 @@ export const useGetDeploymentExecution: useMutationFunctionType<
   const { mutate } = UseRequestProcessor();
 
   const fn = async ({
+    deployment_id,
     execution_id,
-    provider_id,
   }: GetDeploymentExecutionParams): Promise<DeploymentExecutionResponse> => {
     const res = await api.get<DeploymentExecutionResponse>(
-      `${getURL("DEPLOYMENTS")}/executions/${encodeURIComponent(execution_id)}`,
-      { params: { provider_id } },
+      `${getURL("DEPLOYMENTS")}/${encodeURIComponent(deployment_id)}/executions/${encodeURIComponent(execution_id)}`,
     );
     return res.data;
   };

--- a/src/frontend/src/controllers/API/queries/deployments/use-patch-deployment.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-patch-deployment.ts
@@ -5,10 +5,8 @@ import { UseRequestProcessor } from "../../services/request-processor";
 
 export interface DeploymentUpdateRequest {
   deployment_id: string;
-  spec?: {
-    name?: string;
-    description?: string;
-  };
+  name?: string;
+  description?: string;
   provider_data?: Record<string, unknown>;
 }
 

--- a/src/frontend/src/controllers/API/queries/deployments/use-post-deployment-execution.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-post-deployment-execution.ts
@@ -4,7 +4,6 @@ import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
 
 export interface DeploymentExecutionRequest {
-  provider_id: string;
   deployment_id: string;
   provider_data: {
     input: string;
@@ -40,9 +39,10 @@ export const usePostDeploymentExecution: useMutationFunctionType<
   const fn = async (
     payload: DeploymentExecutionRequest,
   ): Promise<DeploymentExecutionResponse> => {
+    const { deployment_id, ...body } = payload;
     const res = await api.post<DeploymentExecutionResponse>(
-      `${getURL("DEPLOYMENTS")}/executions`,
-      payload,
+      `${getURL("DEPLOYMENTS")}/${encodeURIComponent(deployment_id)}/executions`,
+      body,
     );
     return res.data;
   };

--- a/src/frontend/src/controllers/API/queries/deployments/use-post-deployment.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-post-deployment.ts
@@ -5,11 +5,9 @@ import { UseRequestProcessor } from "../../services/request-processor";
 
 export interface DeploymentCreateRequest {
   provider_id: string;
-  spec: {
-    name: string;
-    description: string;
-    type: string;
-  };
+  name: string;
+  description: string;
+  type: string;
   provider_data: {
     llm: string;
     operations: Array<{

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
@@ -24,10 +24,8 @@ const mockDeployment: Deployment = {
   type: "agent",
   created_at: "2025-01-01T00:00:00Z",
   updated_at: "2025-01-02T00:00:00Z",
-  provider_data: null,
   resource_key: "my-agent-key",
   attached_count: 2,
-  matched_attachments: null,
 };
 
 const initialVersions = new Map([
@@ -133,18 +131,18 @@ describe("Edit mode — buildDeploymentUpdatePayload", () => {
     expect(payload.deployment_id).toBe("deploy-1");
   });
 
-  it("sends description change in spec", () => {
+  it("sends description change at top level", () => {
     const { result } = renderEditHook();
     act(() => result.current.setDeploymentDescription("Updated description"));
     const payload = result.current.buildDeploymentUpdatePayload();
-    expect(payload.spec).toEqual({ description: "Updated description" });
+    expect(payload.description).toBe("Updated description");
   });
 
-  it("does NOT include name in spec", () => {
+  it("does NOT include name on update payload", () => {
     const { result } = renderEditHook();
     act(() => result.current.setDeploymentDescription("Updated"));
     const payload = result.current.buildDeploymentUpdatePayload();
-    expect(payload.spec?.name).toBeUndefined();
+    expect(payload.name).toBeUndefined();
   });
 
   it("sends LLM in provider_data", () => {
@@ -204,7 +202,7 @@ describe("Edit mode — buildDeploymentUpdatePayload", () => {
     expect(ops.filter((o) => o.op === "remove_tool")).toHaveLength(0);
   });
 
-  it("sends fallback spec when nothing changed", () => {
+  it("sends fallback description when nothing changed", () => {
     const { result } = renderEditHook();
     const payload = result.current.buildDeploymentUpdatePayload();
     // LLM is set so provider_data exists, but also check spec fallback logic

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-review.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-review.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useGetRefreshFlowsQuery } from "@/controllers/API/queries/flows/use-get-refresh-flows-query";
+import { useFolderStore } from "@/stores/foldersStore";
+import StepReview from "../components/step-review";
+import { useDeploymentStepper } from "../contexts/deployment-stepper-context";
+
+jest.mock("../contexts/deployment-stepper-context", () => ({
+  useDeploymentStepper: jest.fn(),
+}));
+
+jest.mock(
+  "@/controllers/API/queries/flows/use-get-refresh-flows-query",
+  () => ({
+    useGetRefreshFlowsQuery: jest.fn(),
+  }),
+);
+
+jest.mock("@/stores/foldersStore", () => ({
+  useFolderStore: jest.fn(),
+}));
+
+jest.mock("react-router-dom", () => ({
+  useParams: () => ({ folderId: "folder-1" }),
+}));
+
+const mockedUseDeploymentStepper = useDeploymentStepper as jest.MockedFunction<
+  typeof useDeploymentStepper
+>;
+const mockedUseGetRefreshFlowsQuery =
+  useGetRefreshFlowsQuery as jest.MockedFunction<
+    typeof useGetRefreshFlowsQuery
+  >;
+const mockedUseFolderStore = useFolderStore as jest.MockedFunction<
+  typeof useFolderStore
+>;
+
+describe("StepReview tool name editing", () => {
+  it("persists tool name edits when input loses focus", () => {
+    const setToolNameByFlow = jest.fn();
+
+    mockedUseFolderStore.mockImplementation((selector) =>
+      selector({ myCollectionId: "folder-1" } as never),
+    );
+    mockedUseGetRefreshFlowsQuery.mockReturnValue({
+      data: [{ id: "flow-1", name: "New Flow", folder_id: "folder-1" }],
+    } as never);
+    mockedUseDeploymentStepper.mockReturnValue({
+      isEditMode: false,
+      deploymentType: "agent",
+      deploymentName: "Agent One",
+      selectedLlm: "meta-llama/llama-3-3-70b-instruct",
+      connections: [],
+      selectedVersionByFlow: new Map([
+        ["flow-1", { versionId: "ver-1", versionTag: "v1" }],
+      ]),
+      toolNameByFlow: new Map(),
+      setToolNameByFlow,
+      attachedConnectionByFlow: new Map(),
+      removedFlowIds: new Set(),
+    } as never);
+
+    render(<StepReview />);
+
+    fireEvent.click(screen.getByTestId("edit-tool-name"));
+    const input = screen.getByTestId("tool-name-input");
+    fireEvent.change(input, { target: { value: "My Tool Name" } });
+    fireEvent.blur(input);
+
+    expect(setToolNameByFlow).toHaveBeenCalled();
+    const updater = setToolNameByFlow.mock.calls[0][0] as (
+      prev: Map<string, string>,
+    ) => Map<string, string>;
+    const updated = updater(new Map());
+    expect(updated.get("flow-1")).toBe("My Tool Name");
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/add-provider-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/add-provider-modal.tsx
@@ -20,7 +20,7 @@ interface AddProviderModalProps {
 const EMPTY_CREDENTIALS: ProviderCredentials = {
   name: "",
   provider_key: "watsonx-orchestrate",
-  provider_url: "",
+  url: "",
   api_key: "",
 };
 
@@ -38,7 +38,7 @@ export default function AddProviderModal({
   const canSave =
     credentials.name.trim() !== "" &&
     credentials.api_key.trim() !== "" &&
-    credentials.provider_url.trim() !== "";
+    credentials.url.trim() !== "";
 
   function handleClose() {
     if (isSaving) return;
@@ -53,7 +53,7 @@ export default function AddProviderModal({
       await createProviderAccount({
         name: credentials.name.trim(),
         provider_key: credentials.provider_key,
-        provider_url: credentials.provider_url.trim(),
+        url: credentials.url.trim(),
         provider_data: { api_key: credentials.api_key.trim() },
       });
       setCredentials(EMPTY_CREDENTIALS);

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-details-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-details-modal.tsx
@@ -59,17 +59,14 @@ export default function DeploymentDetailsModal({
       ? deploymentData.provider_data.llm
       : "";
 
-  const configMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const cfg of configsData?.configs ?? []) {
-      map.set(cfg.id, cfg.name);
-    }
-    return map;
-  }, [configsData]);
+  const configAppIds = useMemo(
+    () => new Set((configsData?.configs ?? []).map((cfg) => cfg.app_id)),
+    [configsData],
+  );
 
   const getConnectionNames = (fv: DeploymentFlowVersionItem): string[] => {
     const appIds = fv.provider_data?.app_ids ?? [];
-    return appIds.map((id) => configMap.get(id) ?? id).filter(Boolean);
+    return appIds.filter((id) => id && configAppIds.has(id));
   };
 
   return (

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/provider-credentials-form.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/provider-credentials-form.tsx
@@ -56,11 +56,11 @@ export default function ProviderCredentialsForm({
           type="url"
           placeholder="https://api.example.com"
           className="bg-muted"
-          value={credentials.provider_url}
+          value={credentials.url}
           onChange={(e) =>
             onCredentialsChange({
               ...credentials,
-              provider_url: e.target.value,
+              url: e.target.value,
             })
           }
         />

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/providers-table.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/providers-table.tsx
@@ -63,7 +63,7 @@ export default function ProvidersTable({
               </TableCell>
               <TableCell>
                 <span className="max-w-[300px] truncate text-sm text-muted-foreground">
-                  {provider.provider_url}
+                  {provider.url}
                 </span>
               </TableCell>
               <TableCell>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-connection-panel.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-connection-panel.tsx
@@ -72,9 +72,9 @@ export const ConnectionPanel = memo(function ConnectionPanel({
       <div className="border-b border-border p-4 text-sm text-muted-foreground">
         Select or Create New Connection
       </div>
-      <div className="flex flex-1 flex-col overflow-hidden px-4 py-4">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden px-4 py-4">
         {/* Tab toggle */}
-        <div className="rounded-xl border border-border bg-muted p-1">
+        <div className="shrink-0 rounded-xl border border-border bg-muted p-1">
           <div className="grid grid-cols-2">
             {(["available", "create"] as const).map((tab) => (
               <button
@@ -82,7 +82,7 @@ export const ConnectionPanel = memo(function ConnectionPanel({
                 type="button"
                 onClick={() => onTabChange(tab)}
                 className={cn(
-                  "rounded-lg py-2 text-sm transition-colors",
+                  "min-w-0 rounded-lg px-3 py-2 text-sm transition-colors",
                   connectionTab === tab
                     ? "bg-background"
                     : "text-muted-foreground hover:text-foreground",
@@ -97,9 +97,9 @@ export const ConnectionPanel = memo(function ConnectionPanel({
         </div>
 
         {/* Tab content */}
-        <div className="mt-4 flex-1 overflow-y-auto">
+        <div className="mt-4 flex-1 overflow-x-hidden overflow-y-auto">
           {connectionTab === "available" ? (
-            <div className="space-y-3">
+            <div className="min-w-0 space-y-3">
               {connections.length === 0 ? (
                 <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
                   <ForwardedIconComponent
@@ -124,7 +124,7 @@ export const ConnectionPanel = memo(function ConnectionPanel({
                 </div>
               ) : (
                 <>
-                  <div className="relative">
+                  <div className="relative min-w-0">
                     <ForwardedIconComponent
                       name="Search"
                       className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
@@ -149,9 +149,11 @@ export const ConnectionPanel = memo(function ConnectionPanel({
                         onChange={() => onToggleConnection(conn.id)}
                         data-testid={`connection-item-${conn.id}`}
                       >
-                        <span className="text-sm font-medium leading-tight">
-                          {conn.name}
-                        </span>
+                        <div className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-medium leading-tight">
+                            {conn.name}
+                          </span>
+                        </div>
                       </CheckboxSelectItem>
                     ))
                   )}
@@ -243,7 +245,7 @@ export const ConnectionPanel = memo(function ConnectionPanel({
         </div>
 
         {/* Footer buttons */}
-        <div className="flex items-center gap-3 pt-4">
+        <div className="flex min-w-0 flex-wrap items-center gap-3 pt-4">
           <Button variant="outline" onClick={onChangeFlow}>
             Change Flow
           </Button>
@@ -252,7 +254,7 @@ export const ConnectionPanel = memo(function ConnectionPanel({
           </Button>
           {connectionTab === "available" ? (
             <Button
-              className="flex-1"
+              className="ml-auto w-full text-center whitespace-normal sm:w-auto sm:min-w-[220px] sm:whitespace-nowrap"
               disabled={selectedConnections.size === 0}
               onClick={onAttachConnection}
             >
@@ -260,7 +262,7 @@ export const ConnectionPanel = memo(function ConnectionPanel({
             </Button>
           ) : (
             <Button
-              className="flex-1"
+              className="ml-auto w-full text-center whitespace-normal sm:w-auto sm:min-w-[220px] sm:whitespace-nowrap"
               disabled={newConnectionName.trim() === "" || isDuplicateName}
               onClick={onCreateConnection}
             >

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
@@ -80,8 +80,8 @@ export default function StepAttachFlows() {
 
     const existingConnections: ConnectionItem[] = configsData.configs.map(
       (cfg) => ({
-        id: cfg.id,
-        name: cfg.name,
+        id: cfg.app_id,
+        name: cfg.app_id,
         variableCount: 0,
         isNew: false,
         environmentVariables: {},
@@ -401,7 +401,7 @@ export default function StepAttachFlows() {
         />
 
         {/* Right panel */}
-        <div className="flex flex-1 flex-col">
+        <div className="flex min-w-0 flex-1 flex-col">
           {rightPanel === "versions" ? (
             <VersionPanel
               selectedFlow={selectedFlow}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-provider.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-provider.tsx
@@ -84,7 +84,7 @@ function EnvironmentList({
                   {environment.name}
                 </span>
                 <span className="text-sm leading-tight text-muted-foreground">
-                  {environment.provider_url}
+                  {environment.url}
                 </span>
               </span>
             </RadioSelectItem>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-provider.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-provider.tsx
@@ -104,7 +104,7 @@ export default function StepProvider() {
     setCredentials,
   } = useDeploymentStepper();
   const { data: providerAccountsData } = useGetProviderAccounts({});
-  const environments = providerAccountsData?.providers ?? [];
+  const environments = providerAccountsData?.provider_accounts ?? [];
 
   useEffect(() => {
     setSelectedProvider(PROVIDERS[0]);

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review.tsx
@@ -46,6 +46,7 @@ function EditableToolName({
           value={draft}
           placeholder={placeholder}
           onChange={(e) => setDraft(e.target.value)}
+          onBlur={confirm}
           onKeyDown={(e) => {
             if (e.key === "Enter") confirm();
             if (e.key === "Escape") cancel();

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/use-deployment-chat.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/use-deployment-chat.ts
@@ -97,7 +97,6 @@ export function useDeploymentChat({
 
       try {
         const createResponse = await postExecution({
-          provider_id: providerId,
           deployment_id: deploymentId,
           provider_data: {
             input: text,
@@ -183,8 +182,8 @@ export function useDeploymentChat({
 
           try {
             const statusResponse = await getExecution({
+              deployment_id: deploymentId,
               execution_id: currentExecutionId,
-              provider_id: providerId,
             });
 
             if (!isMountedRef.current) return;

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
@@ -9,8 +9,8 @@ import {
   useState,
 } from "react";
 import type { ProviderAccountCreateRequest } from "@/controllers/API/queries/deployment-provider-accounts/use-post-provider-account";
-import type { DeploymentCreateRequest } from "@/controllers/API/queries/deployments/use-post-deployment";
 import type { DeploymentUpdateRequest } from "@/controllers/API/queries/deployments/use-patch-deployment";
+import type { DeploymentCreateRequest } from "@/controllers/API/queries/deployments/use-post-deployment";
 import type {
   ConnectionItem,
   Deployment,
@@ -118,7 +118,7 @@ export function DeploymentStepperProvider({
   const [credentials, setCredentials] = useState<ProviderCredentials>({
     name: "",
     provider_key: "",
-    provider_url: "",
+    url: "",
     api_key: "",
   });
 
@@ -192,7 +192,7 @@ export function DeploymentStepperProvider({
   const hasValidCredentials =
     credentials.name.trim() !== "" &&
     credentials.api_key.trim() !== "" &&
-    credentials.provider_url.trim() !== "";
+    credentials.url.trim() !== "";
 
   // In edit mode, steps are shifted: 1=Type, 2=Attach, 3=Review.
   const getLogicalStep = useCallback(
@@ -242,7 +242,7 @@ export function DeploymentStepperProvider({
     setCredentials({
       name: "",
       provider_key: "",
-      provider_url: "",
+      url: "",
       api_key: "",
     });
   }, []);
@@ -267,7 +267,7 @@ export function DeploymentStepperProvider({
       return {
         name: credentials.name.trim(),
         provider_key: "watsonx-orchestrate",
-        provider_url: credentials.provider_url.trim(),
+        url: credentials.url.trim(),
         provider_data: { api_key: credentials.api_key.trim() },
       };
     }, [credentials, hasValidCredentials]);

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
@@ -323,11 +323,9 @@ export function DeploymentStepperProvider({
 
       return {
         provider_id: providerId,
-        spec: {
-          name: deploymentName,
-          description: deploymentDescription,
-          type: deploymentType,
-        },
+        name: deploymentName,
+        description: deploymentDescription,
+        type: deploymentType,
         provider_data: {
           llm: selectedLlm,
           operations,
@@ -361,11 +359,11 @@ export function DeploymentStepperProvider({
         deployment_id: editingDeployment.id,
       };
 
-      // Spec changes (description only — name is not editable after creation).
+      // Metadata changes (description only — name is not editable after creation).
       const descriptionChanged =
         deploymentDescription !== (editingDeployment.description ?? "");
       if (descriptionChanged) {
-        result.spec = { description: deploymentDescription };
+        result.description = deploymentDescription;
       }
 
       // Build provider_data with operations for attach/detach + LLM.
@@ -462,8 +460,8 @@ export function DeploymentStepperProvider({
       }
 
       // Backend requires at least one field.
-      if (!result.spec && !result.provider_data) {
-        result.spec = { description: deploymentDescription };
+      if (result.description === undefined && !result.provider_data) {
+        result.description = deploymentDescription;
       }
 
       return result;

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/deployments-page.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/deployments-page.tsx
@@ -16,7 +16,7 @@ export default function DeploymentsPage() {
 
   const { data: providersData, isLoading: isLoadingProviders } =
     useGetProviderAccounts({});
-  const providers = providersData?.providers ?? [];
+  const providers = providersData?.provider_accounts ?? [];
 
   return (
     <div className="flex flex-col gap-4 pt-4">

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/types.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/types.ts
@@ -42,11 +42,6 @@ export interface ProviderCredentials {
 
 export type DeploymentType = "agent" | "mcp";
 
-export interface DeploymentMatchedAttachment {
-  flow_version_id: string;
-  provider_snapshot_id?: string;
-}
-
 export interface Deployment {
   id: string;
   name: string;
@@ -57,7 +52,7 @@ export interface Deployment {
   provider_data?: Record<string, unknown>;
   resource_key: string;
   attached_count: number;
-  matched_attachments?: DeploymentMatchedAttachment[];
+  flow_version_ids?: string[];
   /** Populated client-side when merging deployments from multiple providers. */
   provider_account_id?: string;
 }

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/types.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/types.ts
@@ -26,9 +26,9 @@ export interface DeploymentProvider {
 export interface ProviderAccount {
   id: string;
   name: string;
-  provider_tenant_id: string | null;
+  tenant_id: string | null;
   provider_key: string;
-  provider_url: string;
+  url: string;
   created_at: string | null;
   updated_at: string | null;
 }
@@ -36,7 +36,7 @@ export interface ProviderAccount {
 export interface ProviderCredentials {
   name: string;
   provider_key: string;
-  provider_url: string;
+  url: string;
   api_key: string;
 }
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/types.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/types.ts
@@ -26,9 +26,9 @@ export interface DeploymentProvider {
 export interface ProviderAccount {
   id: string;
   name: string;
-  tenant_id: string | null;
   provider_key: string;
   url: string;
+  provider_data?: Record<string, unknown>;
   created_at: string | null;
   updated_at: string | null;
 }

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/types.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/types.ts
@@ -44,20 +44,20 @@ export type DeploymentType = "agent" | "mcp";
 
 export interface DeploymentMatchedAttachment {
   flow_version_id: string;
-  provider_snapshot_id: string | null;
+  provider_snapshot_id?: string;
 }
 
 export interface Deployment {
   id: string;
   name: string;
-  description: string | null;
+  description?: string;
   type: DeploymentType;
   created_at: string;
   updated_at: string;
-  provider_data: Record<string, unknown> | null;
+  provider_data?: Record<string, unknown>;
   resource_key: string;
   attached_count: number;
-  matched_attachments: DeploymentMatchedAttachment[] | null;
+  matched_attachments?: DeploymentMatchedAttachment[];
   /** Populated client-side when merging deployments from multiple providers. */
   provider_account_id?: string;
 }

--- a/src/lfx/src/lfx/services/adapters/deployment/schema.py
+++ b/src/lfx/src/lfx/services/adapters/deployment/schema.py
@@ -45,6 +45,7 @@ DeploymentProviderName = Annotated[
 
 NormalizedId = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 IdLike = UUID | NormalizedId
+DEPLOYMENT_DESCRIPTION_MAX_LENGTH = 500
 
 
 class DeploymentType(str, Enum):
@@ -338,7 +339,11 @@ class BaseDeploymentData(BaseModel):
     """Model representing a data for a deployment."""
 
     name: str = Field(description="The name of the deployment")
-    description: str = Field(default="", description="The description of the deployment")
+    description: str = Field(
+        default="",
+        max_length=DEPLOYMENT_DESCRIPTION_MAX_LENGTH,
+        description="The description of the deployment",
+    )
     type: DeploymentType = Field(description="The type of the deployment")
 
 
@@ -526,7 +531,11 @@ class BaseDeploymentDataUpdate(BaseModel):
     """Deployment base update payload."""
 
     name: str | None = Field(None, description="The name of the deployment")
-    description: str | None = Field(None, description="The description of the deployment")
+    description: str | None = Field(
+        None,
+        max_length=DEPLOYMENT_DESCRIPTION_MAX_LENGTH,
+        description="The description of the deployment",
+    )
 
     @model_validator(mode="after")
     def validate_has_changes(self) -> "BaseDeploymentDataUpdate":

--- a/src/lfx/src/lfx/services/adapters/deployment/schema.py
+++ b/src/lfx/src/lfx/services/adapters/deployment/schema.py
@@ -2,7 +2,7 @@ import datetime
 import json
 from enum import Enum
 from functools import lru_cache
-from typing import Annotated, Generic
+from typing import Annotated, Any, Generic
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator, model_validator
@@ -321,6 +321,7 @@ class ConfigListItem(BaseModel):
     name: str = Field(description="The name of the config item")
     created_at: datetime.datetime | None = Field(None, description="The created timestamp of the config item")
     updated_at: datetime.datetime | None = Field(None, description="The last updated timestamp of the config item")
+    provider_data: dict[str, Any] | None = Field(None, description="Provider-specific data for the config item")
 
 
 class ProviderDataModel(BaseModel, Generic[T_ProviderData]):

--- a/src/lfx/src/lfx/services/adapters/deployment/schema.py
+++ b/src/lfx/src/lfx/services/adapters/deployment/schema.py
@@ -18,7 +18,6 @@ from lfx.services.adapters.deployment.payloads import (
     T_DeploymentListResult,
     T_DeploymentLlmListResult,
     T_DeploymentOperationResult,
-    T_DeploymentSpec,
     T_DeploymentStatusData,
     T_DeploymentUpdate,
     T_DeploymentUpdateResult,
@@ -336,13 +335,7 @@ class ProviderResultModel(BaseModel, Generic[T_ProviderResult]):
     provider_result: T_ProviderResult | None = Field(None, description="The result from the provider")
 
 
-class ProviderSpecModel(BaseModel, Generic[T_DeploymentSpec]):
-    """Base model for provider-specific input payloads."""
-
-    provider_spec: T_DeploymentSpec | None = Field(None, description="The data of the deployment from the provider")
-
-
-class BaseDeploymentData(ProviderSpecModel[T_DeploymentSpec]):
+class BaseDeploymentData(BaseModel):
     """Model representing a data for a deployment."""
 
     name: str = Field(description="The name of the deployment")

--- a/src/lfx/src/lfx/services/adapters/deployment/schema.py
+++ b/src/lfx/src/lfx/services/adapters/deployment/schema.py
@@ -320,7 +320,6 @@ class ConfigListItem(BaseModel):
     name: str = Field(description="The name of the config item")
     created_at: datetime.datetime | None = Field(None, description="The created timestamp of the config item")
     updated_at: datetime.datetime | None = Field(None, description="The last updated timestamp of the config item")
-    provider_data: dict | None = Field(None, description="The data of the config item from the provider")
 
 
 class ProviderDataModel(BaseModel, Generic[T_ProviderData]):

--- a/src/lfx/tests/unit/services/deployment/test_deployment_schema.py
+++ b/src/lfx/tests/unit/services/deployment/test_deployment_schema.py
@@ -600,7 +600,6 @@ def test_config_list_item_accepts_minimal_fields() -> None:
     assert item.name == "Config"
     assert item.created_at is None
     assert item.updated_at is None
-    assert item.provider_data is None
 
 
 def test_config_list_item_accepts_uuid_id() -> None:
@@ -622,11 +621,9 @@ def test_config_list_item_accepts_all_fields() -> None:
         name="Config",
         created_at=now,
         updated_at=now,
-        provider_data={"region": "us-east-1"},
     )
     assert item.created_at == now
     assert item.updated_at == now
-    assert item.provider_data == {"region": "us-east-1"}
 
 
 # ---------------------------------------------------------------------------

--- a/src/lfx/tests/unit/services/deployment/test_payload_formalization.py
+++ b/src/lfx/tests/unit/services/deployment/test_payload_formalization.py
@@ -10,7 +10,6 @@ from uuid import UUID
 import pytest
 from lfx.services.adapters.deployment.payloads import DeploymentPayloadSchemas
 from lfx.services.adapters.deployment.schema import (
-    BaseDeploymentData,
     ConfigListParams,
     ConfigListResult,
     DeploymentCreateResult,
@@ -226,19 +225,12 @@ def test_deployment_payload_schemas_defaults_to_no_active_slots() -> None:
 
 
 def test_generic_parametrization_applies_to_provider_fields() -> None:
-    typed_spec = BaseDeploymentData[_SpecModel](
-        name="dep",
-        description="",
-        type=DeploymentType.AGENT,
-        provider_spec={"region": "us-east-1"},
-    )
     typed_status = DeploymentStatusResult[_StatusModel](
         id="dep_1",
         provider_data={"healthy": True},
     )
     typed_params = DeploymentListParams[_FilterModel](provider_params={"env": "prod"})
 
-    assert isinstance(typed_spec.provider_spec, _SpecModel)
     assert isinstance(typed_status.provider_data, _StatusModel)
     assert isinstance(typed_params.provider_params, _FilterModel)
 
@@ -306,16 +298,7 @@ def test_generic_parametrization_applies_to_result_and_list_models() -> None:
     assert isinstance(typed_snapshot_params.provider_params, _SnapshotFilterModel)
 
 
-def test_unparametrized_models_keep_dict_passthrough_behavior() -> None:
-    payload = {"region": "us-east-1"}
-    data = BaseDeploymentData(
-        name="dep",
-        description="",
-        type=DeploymentType.AGENT,
-        provider_spec=payload,
-    )
-    assert data.provider_spec == payload
-
+def test_payload_slot_dump_json_serializes_rich_payload() -> None:
     now = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     rich_slot = PayloadSlot(_RichPayload)
     dumped = rich_slot.dump(


### PR DESCRIPTION
## Summary

This PR reshapes the v1 deployments API layer for Watsonx Orchestrate into a stricter, API-owned contract with clearer request/response semantics and stronger validation.

Compared to `origin/wxo-fe`, the API layer now:
- standardizes deployment request/response shapes around explicit top-level fields and provider_data payloads,
- replaces operation-tag-driven API payloads with typed, entity-scoped fields,
- tightens mapper/schema validation and normalization,
- and clarifies provider tool identity semantics (`provider_snapshot_id` as source of truth).

Primary API-layer files changed:
- `src/backend/base/langflow/api/v1/deployments.py`
- `src/backend/base/langflow/api/v1/schemas/deployments.py`
- `src/backend/base/langflow/api/v1/mappers/deployments/base.py`
- `src/backend/base/langflow/api/v1/mappers/deployments/helpers.py`
- `src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py`
- `src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py`
- `src/backend/base/langflow/api/v1/mappers/deployments/RULES.md`

---

## API Contract Changes

### 1) Deployment create/update API shape is flattened and API-owned
- Create/update request handling is aligned to top-level deployment fields (`name`, `description`, `type`) plus `provider_data`.
- Legacy nested/opaque patterns were trimmed in favor of explicit schema validation at API boundary.

### 2) Watsonx provider_data contract is flattened (no API-level operations array)
- **Create** uses:
  - `add_flows[]`
  - `upsert_tools[]`
  - `connections[]` with `credentials[]`
  - `llm` required
- **Update** uses:
  - `upsert_flows[]`
  - `upsert_tools[]`
  - `remove_flows[]`
  - `remove_tools[]`
  - `connections[]`
  - `llm` optional (PATCH semantics preserved)

### 3) Connection payload contract is explicit
- API accepts flattened key/value credential entries (`credentials[]`) with source typing.
- Duplicate `app_id` and invalid reference combinations are rejected with schema-level checks.

### 4) Flow/tool mutation semantics are explicit
- `upsert_flows.remove_app_ids` is unbind-only behavior.
- Detach/remove semantics are driven by `remove_flows`.
- `tool_name` is validated/normalized and correctly mapped for create/update paths.

---

## Response Contract Changes

### 1) Deployment responses expose provider identity metadata
- Provider ownership metadata is surfaced consistently on deployment responses.

### 2) Config/snapshot/list contracts are normalized
- Provider-list/config/snapshot response shaping is standardized with provider_data envelopes and strict mapper-side normalization.
- Null/noise response fields are trimmed where appropriate.

### 3) Created-tool result contract is explicit
- API-facing create/update result shaping uses `created_tools` with strict `flow_version_id` handling.
- Result shaping is aligned with mapper normalization logic.

### 4) Attachment flow-version identity now includes provider tool name semantics
- Flow attachment payloads include `tool_name` for display.
- `provider_snapshot_id` remains the identity key for operations.
- Schema/docs clarify rename/delete/recreate edge cases in provider systems.

---

## Validation and Mapper Hardening

- Stronger schema validation in `watsonx_orchestrate/payloads.py`:
  - add/remove overlap checks,
  - remove-vs-upsert conflict checks,
  - app_id reference integrity checks,
  - strict unknown-field rejection.
- Mapper improvements in `watsonx_orchestrate/mapper.py`:
  - tool-name normalization guard,
  - deterministic precedence of custom `tool_name`,
  - consistent payload shaping for flattened API fields.

---

## Backward Compatibility / Migration Notes

- API consumers must use flattened Watsonx payload fields (`add_flows` / `upsert_flows` / `remove_flows` etc.) instead of API-level `operations`.
- PATCH callers may omit `provider_data.llm`; CREATE still requires it.
- Consumers should treat `provider_snapshot_id` as immutable tool identity and use `tool_name` only for display.

---

## Test Plan

- [x] API payload validation and mapper contract tests updated for flattened create/update payloads.
- [x] Mapper tests cover:
  - tool_name normalization/override behavior,
  - mixed add/remove flow update semantics,
  - rename behavior for existing attachments.
- [x] Service-level tests cover update-path safety/consistency for bind/unbind/rename interactions.
- [x] Frontend callers aligned to flattened API contract and validated in deployment stepper tests.