### PR TITLE
feat(deployments): improve attach flow step UX in deploy modal

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/radio-select-item.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/radio-select-item.tsx
@@ -87,15 +87,11 @@ export function RadioSelectItem({
       />
       <span
         className={cn(
-          "flex h-5 w-5 flex-shrink-0 items-center justify-center rounded",
-          selected
-            ? "bg-primary text-primary-foreground"
-            : "border border-muted-foreground bg-background",
+          "flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border-2",
+          selected ? "border-primary" : "border-muted-foreground bg-background",
         )}
       >
-        {selected && (
-          <ForwardedIconComponent name="Check" className="h-3.5 w-3.5" />
-        )}
+        {selected && <span className="h-2.5 w-2.5 rounded-full bg-primary" />}
       </span>
       {children}
     </label>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-connection-panel.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-connection-panel.tsx
@@ -54,9 +54,15 @@ export const ConnectionPanel = memo(function ConnectionPanel({
 }) {
   const [searchQuery, setSearchQuery] = useState("");
   const filteredConnections = useMemo(() => {
-    if (!searchQuery.trim()) return connections;
+    // Sort newly created connections to the top
+    const sorted = [...connections].sort((a, b) => {
+      if (a.isNew && !b.isNew) return -1;
+      if (!a.isNew && b.isNew) return 1;
+      return 0;
+    });
+    if (!searchQuery.trim()) return sorted;
     const q = searchQuery.toLowerCase();
-    return connections.filter(
+    return sorted.filter(
       (c) => c.name.toLowerCase().includes(q) || c.id.toLowerCase().includes(q),
     );
   }, [connections, searchQuery]);
@@ -143,13 +149,8 @@ export const ConnectionPanel = memo(function ConnectionPanel({
                         onChange={() => onToggleConnection(conn.id)}
                         data-testid={`connection-item-${conn.id}`}
                       >
-                        <span className="flex flex-col">
-                          <span className="text-sm font-medium leading-tight">
-                            {conn.name}
-                          </span>
-                          <span className="text-sm leading-tight text-muted-foreground">
-                            {conn.variableCount} variables
-                          </span>
+                        <span className="text-sm font-medium leading-tight">
+                          {conn.name}
                         </span>
                       </CheckboxSelectItem>
                     ))

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-version-panel.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-version-panel.tsx
@@ -1,31 +1,21 @@
 import { memo } from "react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import type { FlowType } from "@/types/flow";
 import type { FlowVersionEntry } from "@/types/flow/version";
-import { RadioSelectItem } from "./radio-select-item";
+import { cn } from "@/utils/utils";
 
 export const VersionPanel = memo(function VersionPanel({
   selectedFlow,
   versions,
   isLoadingVersions,
-  pendingVersion,
   selectedVersionByFlow,
-  toolName,
-  onToolNameChange,
-  onSelectPending,
   onAttach,
 }: {
   selectedFlow: FlowType | undefined;
   versions: FlowVersionEntry[];
   isLoadingVersions: boolean;
-  pendingVersion: string | null;
   selectedVersionByFlow: Map<string, { versionId: string; versionTag: string }>;
-  toolName: string;
-  onToolNameChange: (name: string) => void;
-  onSelectPending: (id: string) => void;
-  onAttach: () => void;
+  onAttach: (versionId: string) => void;
 }) {
   if (!selectedFlow) {
     return (
@@ -44,11 +34,7 @@ export const VersionPanel = memo(function VersionPanel({
       </div>
       <div className="flex flex-1 flex-col overflow-hidden px-4 py-2">
         <h3 className="py-2 text-lg font-semibold">{selectedFlow.name}</h3>
-        <div
-          className="flex-1 space-y-3 overflow-y-auto py-3"
-          role="radiogroup"
-          aria-label="Flow versions"
-        >
+        <div className="flex-1 space-y-3 overflow-y-auto py-3">
           {isLoadingVersions ? (
             <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
               Loading versions...
@@ -60,15 +46,18 @@ export const VersionPanel = memo(function VersionPanel({
           ) : (
             versions.map((version) => {
               const isAttachedVersion = attachedEntry?.versionId === version.id;
-              const isSelected = pendingVersion === version.id;
               return (
-                <RadioSelectItem
+                <button
                   key={version.id}
-                  name="flow-version"
-                  value={version.id}
-                  selected={isSelected}
-                  onChange={() => onSelectPending(version.id)}
+                  type="button"
                   data-testid={`version-item-${version.id}`}
+                  onClick={() => onAttach(version.id)}
+                  className={cn(
+                    "flex w-full cursor-pointer items-center gap-4 rounded-xl border p-3 text-left transition-colors",
+                    isAttachedVersion
+                      ? "border-accent-blue-foreground bg-accent-blue-muted/40"
+                      : "border-transparent bg-muted hover:border-border",
+                  )}
                 >
                   <span className="flex flex-col">
                     <span className="flex items-center gap-2 text-sm font-medium leading-tight">
@@ -88,32 +77,11 @@ export const VersionPanel = memo(function VersionPanel({
                       {new Date(version.created_at).toLocaleDateString()}
                     </span>
                   </span>
-                </RadioSelectItem>
+                </button>
               );
             })
           )}
         </div>
-        {pendingVersion && !attachedEntry && (
-          <div className="flex flex-col gap-1 pb-2">
-            <span className="text-xs font-medium text-muted-foreground">
-              Tool Name
-            </span>
-            <Input
-              placeholder={selectedFlow.name}
-              className="bg-muted"
-              value={toolName}
-              onChange={(e) => onToolNameChange(e.target.value)}
-              data-testid="tool-name-input"
-            />
-          </div>
-        )}
-        <Button
-          className="w-full"
-          disabled={!pendingVersion}
-          onClick={onAttach}
-        >
-          Attach Flow
-        </Button>
       </div>
     </>
   );

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
@@ -90,7 +90,12 @@ export default function StepAttachFlows() {
   const [selectedFlowId, setSelectedFlowId] = useState<string | null>(
     initialFlowId ?? null,
   );
-  const [pendingVersion, setPendingVersion] = useState<string | null>(null);
+  // Track the version the user clicked but hasn't finished the connection step for yet.
+  const [pendingAttachment, setPendingAttachment] = useState<{
+    flowId: string;
+    versionId: string;
+    versionTag: string;
+  } | null>(null);
   const [rightPanel, setRightPanel] = useState<RightPanelView>("versions");
   const [connectionTab, setConnectionTab] =
     useState<ConnectionTab>("available");
@@ -162,15 +167,16 @@ export default function StepAttachFlows() {
 
   const selectedFlow = flows.find((f) => f.id === effectiveFlowId);
 
-  const handleAttachFlow = useCallback(async () => {
-    if (effectiveFlowId && pendingVersion) {
-      const version = versions.find((v) => v.id === pendingVersion);
-      onSelectVersion(
-        effectiveFlowId,
-        pendingVersion,
-        version?.version_tag ?? "",
-      );
-      setPendingVersion(null);
+  const handleAttachFlow = useCallback(
+    async (versionId: string) => {
+      if (!effectiveFlowId) return;
+      const version = versions.find((v) => v.id === versionId);
+      // Don't commit to context yet — wait for connection step to complete.
+      setPendingAttachment({
+        flowId: effectiveFlowId,
+        versionId,
+        versionTag: version?.version_tag ?? "",
+      });
       setRightPanel("connections");
       setSelectedConnections(
         new Set(attachedConnectionByFlow.get(effectiveFlowId) ?? []),
@@ -183,7 +189,7 @@ export default function StepAttachFlows() {
       // Auto-detect global variable references via the backend detection endpoint
       try {
         const result = await detectEnvVars({
-          flow_version_ids: [pendingVersion],
+          flow_version_ids: [versionId],
         });
         const detected = result.variables ?? [];
         if (detected.length > 0) {
@@ -208,21 +214,32 @@ export default function StepAttachFlows() {
           list: ["Add them manually in the connection form."],
         });
       }
+    },
+    [
+      effectiveFlowId,
+      versions,
+      connections,
+      detectEnvVars,
+      attachedConnectionByFlow,
+      setErrorData,
+    ],
+  );
+
+  const commitPendingAttachment = useCallback(() => {
+    if (pendingAttachment) {
+      onSelectVersion(
+        pendingAttachment.flowId,
+        pendingAttachment.versionId,
+        pendingAttachment.versionTag,
+      );
+      setPendingAttachment(null);
     }
-  }, [
-    effectiveFlowId,
-    pendingVersion,
-    versions,
-    connections,
-    detectEnvVars,
-    onSelectVersion,
-    attachedConnectionByFlow,
-    setErrorData,
-  ]);
+  }, [pendingAttachment, onSelectVersion]);
 
   const handleAttachConnection = useCallback(() => {
     if (!effectiveFlowId) return;
     if (connectionTab === "available" && selectedConnections.size > 0) {
+      commitPendingAttachment();
       onAttachConnection((prev) => {
         const next = new Map(prev);
         next.set(effectiveFlowId, Array.from(selectedConnections));
@@ -231,7 +248,13 @@ export default function StepAttachFlows() {
       setRightPanel("versions");
       setSelectedConnections(new Set());
     }
-  }, [effectiveFlowId, connectionTab, selectedConnections, onAttachConnection]);
+  }, [
+    effectiveFlowId,
+    connectionTab,
+    selectedConnections,
+    onAttachConnection,
+    commitPendingAttachment,
+  ]);
 
   const handleCreateConnection = useCallback(() => {
     const filteredVars = envVars.filter((v) => v.key.trim());
@@ -268,6 +291,7 @@ export default function StepAttachFlows() {
   }, [envVars, newConnectionName, setConnections]);
 
   const handleSkipConnection = useCallback(() => {
+    commitPendingAttachment();
     if (effectiveFlowId) {
       onAttachConnection((prev) => {
         const next = new Map(prev);
@@ -277,18 +301,32 @@ export default function StepAttachFlows() {
     }
     setRightPanel("versions");
     setSelectedConnections(new Set());
-  }, [effectiveFlowId, onAttachConnection]);
+  }, [effectiveFlowId, onAttachConnection, commitPendingAttachment]);
 
   const handleChangeFlow = useCallback(() => {
+    setPendingAttachment(null);
     setRightPanel("versions");
     setSelectedConnections(new Set());
     setDetectedVarCount(0);
     setEnvVars([{ id: crypto.randomUUID(), key: "", value: "" }]);
   }, []);
 
+  const handleDetachFlow = useCallback(
+    (flowId: string) => {
+      handleRemoveAttachedFlow(flowId);
+      setToolNameByFlow((prev) => {
+        const next = new Map(prev);
+        next.delete(flowId);
+        return next;
+      });
+      // Reset right panel to versions if we're currently viewing the detached flow
+      setRightPanel("versions");
+    },
+    [handleRemoveAttachedFlow, setToolNameByFlow],
+  );
+
   const handleSelectFlow = useCallback((flowId: string) => {
     setSelectedFlowId(flowId);
-    setPendingVersion(null);
     setRightPanel("versions");
     setSelectedConnections(new Set());
     setDetectedVarCount(0);
@@ -349,7 +387,7 @@ export default function StepAttachFlows() {
           connections={connections}
           removedFlowIds={isEditMode ? removedFlowIds : undefined}
           onSelectFlow={handleSelectFlow}
-          onRemoveFlow={isEditMode ? handleRemoveAttachedFlow : undefined}
+          onRemoveFlow={handleDetachFlow}
           onUndoRemoveFlow={isEditMode ? handleUndoRemoveFlow : undefined}
         />
 
@@ -360,27 +398,7 @@ export default function StepAttachFlows() {
               selectedFlow={selectedFlow}
               versions={versions}
               isLoadingVersions={isLoadingVersions}
-              pendingVersion={pendingVersion}
               selectedVersionByFlow={selectedVersionByFlow}
-              toolName={
-                effectiveFlowId
-                  ? (toolNameByFlow.get(effectiveFlowId) ?? "")
-                  : ""
-              }
-              onToolNameChange={(name) => {
-                if (effectiveFlowId) {
-                  setToolNameByFlow((prev) => {
-                    const next = new Map(prev);
-                    if (name) {
-                      next.set(effectiveFlowId, name);
-                    } else {
-                      next.delete(effectiveFlowId);
-                    }
-                    return next;
-                  });
-                }
-              }}
-              onSelectPending={setPendingVersion}
               onAttach={handleAttachFlow}
             />
           ) : (

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review.tsx
@@ -1,9 +1,89 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { useGetRefreshFlowsQuery } from "@/controllers/API/queries/flows/use-get-refresh-flows-query";
 import { useFolderStore } from "@/stores/foldersStore";
 import { useDeploymentStepper } from "../contexts/deployment-stepper-context";
+
+function EditableToolName({
+  value,
+  placeholder,
+  onSave,
+}: {
+  value: string;
+  placeholder: string;
+  onSave: (name: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  const confirm = useCallback(() => {
+    onSave(draft);
+    setEditing(false);
+  }, [draft, onSave]);
+
+  const cancel = useCallback(() => {
+    setDraft(value);
+    setEditing(false);
+  }, [value]);
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-1.5">
+        <Input
+          ref={inputRef}
+          className="h-7 w-48 text-sm"
+          value={draft}
+          placeholder={placeholder}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") confirm();
+            if (e.key === "Escape") cancel();
+          }}
+          data-testid="tool-name-input"
+        />
+        <button
+          type="button"
+          onClick={confirm}
+          className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          title="Confirm"
+        >
+          <ForwardedIconComponent name="Check" className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-sm font-medium text-foreground">
+        {value || placeholder}
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          setDraft(value);
+          setEditing(true);
+        }}
+        className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+        title="Edit tool name"
+        data-testid="edit-tool-name"
+      >
+        <ForwardedIconComponent name="Pencil" className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
 
 export default function StepReview() {
   const {
@@ -14,6 +94,7 @@ export default function StepReview() {
     connections,
     selectedVersionByFlow,
     toolNameByFlow,
+    setToolNameByFlow,
     attachedConnectionByFlow,
     removedFlowIds,
   } = useDeploymentStepper();
@@ -48,7 +129,7 @@ export default function StepReview() {
               masked: "••••••••",
             }))
           : [];
-        return { name: conn.name, envVars };
+        return { name: conn.name, isNew: conn.isNew ?? false, envVars };
       });
 
       const flowName = flow?.name ?? "Unknown";
@@ -156,9 +237,21 @@ export default function StepReview() {
                       name="Wrench"
                       className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
                     />
-                    <span className="text-sm font-medium text-foreground">
-                      {item.toolName}
-                    </span>
+                    <EditableToolName
+                      value={toolNameByFlow.get(item.flowId)?.trim() ?? ""}
+                      placeholder={item.flowName}
+                      onSave={(name) => {
+                        setToolNameByFlow((prev) => {
+                          const next = new Map(prev);
+                          if (name.trim()) {
+                            next.set(item.flowId, name.trim());
+                          } else {
+                            next.delete(item.flowId);
+                          }
+                          return next;
+                        });
+                      }}
+                    />
                   </div>
                   <div className="flex items-center gap-2 pl-5">
                     <ForwardedIconComponent
@@ -178,44 +271,73 @@ export default function StepReview() {
                   </div>
                 </div>
 
-                {item.connectionDetails.length > 0 && (
-                  <div className="flex flex-col gap-3">
-                    {item.connectionDetails.map((conn) => (
-                      <div key={conn.name} className="flex flex-col gap-1.5">
-                        <div className="flex items-center gap-1.5">
-                          <span className="text-xs text-muted-foreground">
-                            Connection:
-                          </span>
-                          <span className="text-xs font-medium text-foreground">
-                            {conn.name}
-                          </span>
-                        </div>
-                        {conn.envVars.length > 0 && (
-                          <div className="flex flex-col divide-y divide-border overflow-hidden rounded-md border border-border">
-                            {conn.envVars.map(({ key, masked }) => (
-                              <div
-                                key={key}
-                                className="flex items-center justify-between bg-muted/40 px-3 py-1.5"
+                {item.connectionDetails.length > 0 &&
+                  (() => {
+                    const newConns = item.connectionDetails.filter(
+                      (c) => c.isNew,
+                    );
+                    const existingConns = item.connectionDetails.filter(
+                      (c) => !c.isNew,
+                    );
+                    return (
+                      <div className="flex flex-col gap-4">
+                        {existingConns.length > 0 && (
+                          <div className="flex flex-col gap-2">
+                            <span className="text-xs font-medium text-muted-foreground">
+                              Existing Connections
+                            </span>
+                            {existingConns.map((conn) => (
+                              <span
+                                key={conn.name}
+                                className="text-xs font-medium text-foreground"
                               >
-                                <span className="font-mono text-xs text-foreground">
-                                  {key}
+                                {conn.name}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                        {newConns.length > 0 && (
+                          <div className="flex flex-col gap-2">
+                            <span className="text-xs font-medium text-muted-foreground">
+                              New Connections
+                            </span>
+                            {newConns.map((conn) => (
+                              <div
+                                key={conn.name}
+                                className="flex flex-col gap-1.5"
+                              >
+                                <span className="text-xs font-medium text-foreground">
+                                  {conn.name}
                                 </span>
-                                <div className="flex items-center gap-2">
-                                  <span className="text-muted-foreground">
-                                    =
-                                  </span>
-                                  <span className="font-mono text-xs text-muted-foreground">
-                                    {masked}
-                                  </span>
-                                </div>
+                                {conn.envVars.length > 0 && (
+                                  <div className="flex flex-col divide-y divide-border overflow-hidden rounded-md border border-border">
+                                    {conn.envVars.map(({ key, masked }) => (
+                                      <div
+                                        key={key}
+                                        className="flex items-center justify-between bg-muted/40 px-3 py-1.5"
+                                      >
+                                        <span className="font-mono text-xs text-foreground">
+                                          {key}
+                                        </span>
+                                        <div className="flex items-center gap-2">
+                                          <span className="text-muted-foreground">
+                                            =
+                                          </span>
+                                          <span className="font-mono text-xs text-muted-foreground">
+                                            {masked}
+                                          </span>
+                                        </div>
+                                      </div>
+                                    ))}
+                                  </div>
+                                )}
                               </div>
                             ))}
                           </div>
                         )}
                       </div>
-                    ))}
-                  </div>
-                )}
+                    );
+                  })()}
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- Add detach (X) button for attached flows in both create and edit modes
- Defer version attachment until the connection step is completed (skip or attach), so "ATTACHED" badge only appears after the full flow
- Replace radio indicators with directly clickable version items that auto-advance to the connections panel
- Move tool name editing to the review page with an inline edit/confirm pattern (pencil icon → input + check icon, confirm with Enter)
- Sort newly created connections to the top of the available connections list and remove variable count display
- Add visual distinction (blue border + tinted background) for the currently attached version in the version list
- Split review page connections into "Existing Connections" and "New Connections" sections


https://github.com/user-attachments/assets/29d42e2e-a80e-4b8a-826d-73bae30d100b

