### PR TITLE
feat(deployments): add expandable rows to show attached flows

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-expanded-row.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-expanded-row.tsx
@@ -1,0 +1,71 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Badge } from "@/components/ui/badge";
+import Loading from "@/components/ui/loading";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { useGetDeploymentAttachments } from "@/controllers/API/queries/deployments/use-get-deployment-attachments";
+
+interface DeploymentExpandedRowProps {
+  deploymentId: string;
+  colSpan: number;
+}
+
+export default function DeploymentExpandedRow({
+  deploymentId,
+  colSpan,
+}: DeploymentExpandedRowProps) {
+  const { data, isLoading, isError } = useGetDeploymentAttachments({
+    deploymentId,
+  });
+
+  const flows = data?.flow_versions ?? [];
+
+  return (
+    <TableRow className="hover:bg-transparent">
+      <TableCell colSpan={colSpan} className="p-0">
+        <div className="border-t bg-muted/30 px-8 py-3">
+          {isLoading ? (
+            <div className="flex items-center gap-2 py-2">
+              <Loading size={14} className="text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">
+                Loading attached flows...
+              </span>
+            </div>
+          ) : isError ? (
+            <span className="text-sm text-destructive">
+              Failed to load attached flows
+            </span>
+          ) : flows.length === 0 ? (
+            <span className="text-sm text-muted-foreground">
+              No flows attached
+            </span>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-muted-foreground">
+                Attached Flows
+              </span>
+              <div className="flex flex-wrap gap-2">
+                {flows.map((flow) => (
+                  <Badge
+                    key={flow.id}
+                    variant="secondaryStatic"
+                    size="tag"
+                    className="gap-1.5"
+                  >
+                    <ForwardedIconComponent
+                      name="Workflow"
+                      className="h-3 w-3 text-muted-foreground"
+                    />
+                    <span>{flow.flow_name ?? "Untitled"}</span>
+                    <span className="text-muted-foreground">
+                      v{flow.version_number}
+                    </span>
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-table.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-table.tsx
@@ -1,3 +1,4 @@
+import { Fragment, useState } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -19,6 +20,7 @@ import {
 } from "@/components/ui/table";
 import { cn } from "@/utils/utils";
 import type { Deployment, DeploymentType } from "../types";
+import DeploymentExpandedRow from "./deployment-expanded-row";
 
 interface DeploymentsTableProps {
   deployments: Deployment[];
@@ -29,6 +31,16 @@ interface DeploymentsTableProps {
   onUpdateDeployment?: (deployment: Deployment) => void;
   onDeleteDeployment?: (deployment: Deployment) => void;
 }
+
+const COLUMNS = [
+  "Name",
+  "Type",
+  "Attached",
+  "Provider",
+  "Last Modified",
+  "Test",
+  "Actions",
+] as const;
 
 const TYPE_CONFIG: Record<DeploymentType, { icon: string; className: string }> =
   {
@@ -66,6 +78,20 @@ export default function DeploymentsTable({
   onUpdateDeployment,
   onDeleteDeployment,
 }: DeploymentsTableProps) {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  const toggleExpanded = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
   return (
     <Table>
       <TableHeader>
@@ -82,109 +108,139 @@ export default function DeploymentsTable({
       <TableBody>
         {deployments.map((deployment) => {
           const isDeleting = deletingId === deployment.id;
+          const isExpanded = expandedIds.has(deployment.id);
+          const hasAttachments = deployment.attached_count > 0;
           return (
-            <TableRow
-              key={deployment.id}
-              data-testid={`deployment-row-${deployment.id}`}
-              className={cn(isDeleting && "pointer-events-none opacity-50")}
-            >
-              <TableCell>
-                <div className="flex flex-col">
-                  <span className="font-medium">{deployment.name}</span>
-                  {deployment.description && (
-                    <span className="text-xs text-muted-foreground">
-                      {deployment.description}
-                    </span>
-                  )}
-                </div>
-              </TableCell>
-              <TableCell>
-                <TypeBadge type={deployment.type} />
-              </TableCell>
-              <TableCell>
-                <span className="text-sm">
-                  {deployment.attached_count}{" "}
-                  {deployment.attached_count === 1 ? "item" : "items"}
-                </span>
-              </TableCell>
-              <TableCell>
-                <span className="text-sm">
-                  {providerMap[deployment.provider_account_id ?? ""] ?? "—"}
-                </span>
-              </TableCell>
-              <TableCell>
-                <span className="text-sm">
-                  {formatDate(deployment.updated_at)}
-                </span>
-              </TableCell>
-              <TableCell>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8"
-                  data-testid={`test-deployment-${deployment.id}`}
-                  aria-label={`Test ${deployment.name}`}
-                  onClick={() => onTestDeployment(deployment)}
-                >
-                  <ForwardedIconComponent name="Play" className="h-4 w-4" />
-                </Button>
-              </TableCell>
-              <TableCell>
-                {isDeleting ? (
-                  <div className="flex h-8 w-8 items-center justify-center">
-                    <Loading size={16} className="text-muted-foreground" />
-                  </div>
-                ) : (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8"
-                        data-testid={`actions-deployment-${deployment.id}`}
-                        aria-label={`Actions for ${deployment.name}`}
-                      >
-                        <ForwardedIconComponent
-                          name="EllipsisVertical"
-                          className="h-4 w-4"
-                        />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem
-                        onClick={() => onDuplicateDeployment?.(deployment)}
-                      >
-                        <ForwardedIconComponent
-                          name="Copy"
-                          className="mr-2 h-4 w-4"
-                        />
-                        Duplicate
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => onUpdateDeployment?.(deployment)}
-                      >
-                        <ForwardedIconComponent
-                          name="Pencil"
-                          className="mr-2 h-4 w-4"
-                        />
-                        Update
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        className="text-destructive focus:text-destructive"
-                        onClick={() => onDeleteDeployment?.(deployment)}
-                      >
-                        <ForwardedIconComponent
-                          name="Trash2"
-                          className="mr-2 h-4 w-4"
-                        />
-                        Delete
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+            <Fragment key={deployment.id}>
+              <TableRow
+                data-testid={`deployment-row-${deployment.id}`}
+                className={cn(
+                  isDeleting && "pointer-events-none opacity-50",
+                  isExpanded && "border-b-0",
                 )}
-              </TableCell>
-            </TableRow>
+              >
+                <TableCell>
+                  <div className="flex flex-col">
+                    <span className="font-medium">{deployment.name}</span>
+                    {deployment.description && (
+                      <span className="text-xs text-muted-foreground">
+                        {deployment.description}
+                      </span>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <TypeBadge type={deployment.type} />
+                </TableCell>
+                <TableCell>
+                  <button
+                    type="button"
+                    disabled={!hasAttachments}
+                    aria-expanded={hasAttachments ? isExpanded : undefined}
+                    className={cn(
+                      "flex items-center gap-1.5 text-sm",
+                      hasAttachments
+                        ? "cursor-pointer text-foreground hover:text-primary"
+                        : "cursor-default text-muted-foreground",
+                    )}
+                    onClick={() => toggleExpanded(deployment.id)}
+                    data-testid={`toggle-attachments-${deployment.id}`}
+                  >
+                    {hasAttachments && (
+                      <ForwardedIconComponent
+                        name={isExpanded ? "ChevronDown" : "ChevronRight"}
+                        className="h-3.5 w-3.5"
+                      />
+                    )}
+                    {deployment.attached_count}{" "}
+                    {deployment.attached_count === 1 ? "flow" : "flows"}
+                  </button>
+                </TableCell>
+                <TableCell>
+                  <span className="text-sm">
+                    {providerMap[deployment.provider_account_id ?? ""] ?? "—"}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <span className="text-sm">
+                    {formatDate(deployment.updated_at)}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    data-testid={`test-deployment-${deployment.id}`}
+                    aria-label={`Test ${deployment.name}`}
+                    onClick={() => onTestDeployment(deployment)}
+                  >
+                    <ForwardedIconComponent name="Play" className="h-4 w-4" />
+                  </Button>
+                </TableCell>
+                <TableCell>
+                  {isDeleting ? (
+                    <div className="flex h-8 w-8 items-center justify-center">
+                      <Loading size={16} className="text-muted-foreground" />
+                    </div>
+                  ) : (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8"
+                          data-testid={`actions-deployment-${deployment.id}`}
+                          aria-label={`Actions for ${deployment.name}`}
+                        >
+                          <ForwardedIconComponent
+                            name="EllipsisVertical"
+                            className="h-4 w-4"
+                          />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={() => onDuplicateDeployment?.(deployment)}
+                        >
+                          <ForwardedIconComponent
+                            name="Copy"
+                            className="mr-2 h-4 w-4"
+                          />
+                          Duplicate
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => onUpdateDeployment?.(deployment)}
+                        >
+                          <ForwardedIconComponent
+                            name="Pencil"
+                            className="mr-2 h-4 w-4"
+                          />
+                          Update
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          className="text-destructive focus:text-destructive"
+                          onClick={() => onDeleteDeployment?.(deployment)}
+                        >
+                          <ForwardedIconComponent
+                            name="Trash2"
+                            className="mr-2 h-4 w-4"
+                          />
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </TableCell>
+              </TableRow>
+              {isExpanded && (
+                <DeploymentExpandedRow
+                  deploymentId={deployment.id}
+                  colSpan={COLUMNS.length}
+                />
+              )}
+            </Fragment>
           );
         })}
       </TableBody>


### PR DESCRIPTION
## Summary
- Add expandable rows in the deployments table so users can view attached flows inline
- Clicking the "Attached" count toggles an expanded row showing flow name + version badges
- Flows are fetched lazily via `GET /deployments/{id}/flows` only when the row is expanded (no N+1 on page load)

## Changes
- **`deployment-expanded-row.tsx`** (new): renders the expanded content with loading, error, and empty states
- **`deployments-table.tsx`** (updated): adds expand/collapse state, chevron toggle on the attached count, accessibility attrs (`disabled`, `aria-expanded`), and replaces magic `COLUMN_COUNT` with a `COLUMNS` array


https://github.com/user-attachments/assets/d9210b2f-4b14-4dc5-ab24-0fa024425b2e

