### PR TITLE
fix(projects): keep paginated flow visibility scoped to current user

### DIFF
--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -268,7 +268,7 @@ async def read_project(
     try:
         # Check if pagination is explicitly requested by the user (both page and size provided)
         if page is not None and size is not None:
-            stmt = select(Flow).where(Flow.folder_id == project_id)
+            stmt = select(Flow).where(Flow.folder_id == project_id, Flow.user_id == current_user.id)
 
             if Flow.updated_at is not None:
                 stmt = stmt.order_by(Flow.updated_at.desc())  # type: ignore[attr-defined]

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -62,7 +62,9 @@ from langflow.services.deps import (
 
 def update_projects_components_with_latest_component_versions(project_data, all_types_dict):
     # Flatten the all_types_dict for easy access
-    all_types_dict_flat = {key: component for category in all_types_dict.values() for key, component in category.items()}
+    all_types_dict_flat = {
+        key: component for category in all_types_dict.values() for key, component in category.items()
+    }
 
     node_changes_log = defaultdict(list)
     project_data_copy = deepcopy(project_data)

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -62,10 +62,7 @@ from langflow.services.deps import (
 
 def update_projects_components_with_latest_component_versions(project_data, all_types_dict):
     # Flatten the all_types_dict for easy access
-    all_types_dict_flat = {}
-    for category in all_types_dict.values():
-        for key, component in category.items():
-            all_types_dict_flat[key] = component
+    all_types_dict_flat = {key: component for category in all_types_dict.values() for key, component in category.items()}
 
     node_changes_log = defaultdict(list)
     project_data_copy = deepcopy(project_data)

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -1545,6 +1545,49 @@ class TestReadProjectBugFix:
                 f"Error message should mention 'not found' for params: {params}"
             )
 
+    async def test_read_project_paginated_flows_match_current_user_visibility(
+        self, client: AsyncClient, logged_in_headers, basic_case
+    ):
+        project_response = await client.post("api/v1/projects/", json=basic_case, headers=logged_in_headers)
+        assert project_response.status_code == status.HTTP_201_CREATED
+        project_id = project_response.json()["id"]
+
+        own_flow_payload = {
+            "name": "Owned flow",
+            "description": "Visible to the project owner",
+            "data": {},
+            "folder_id": project_id,
+        }
+        own_flow_response = await client.post("api/v1/flows/", json=own_flow_payload, headers=logged_in_headers)
+        assert own_flow_response.status_code == status.HTTP_201_CREATED
+        own_flow_id = own_flow_response.json()["id"]
+
+        other_user_flow_id = uuid4()
+        async with session_scope() as session:
+            flow_create = FlowCreate(
+                id=other_user_flow_id,
+                name="Other user's flow",
+                description="Should stay hidden from paginated project reads",
+                data={},
+                folder_id=project_id,
+                user_id=uuid4(),
+            )
+            flow = Flow.model_validate(flow_create, from_attributes=True)
+            session.add(flow)
+            await session.commit()
+
+        response = await client.get(
+            f"api/v1/projects/{project_id}?page=1&size=10",
+            headers=logged_in_headers,
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        result = response.json()
+        flow_ids = {flow["id"] for flow in result["flows"]["items"]}
+
+        assert own_flow_id in flow_ids
+        assert str(other_user_flow_id) not in flow_ids
+
 
 async def test_download_file_starter_project(client: AsyncClient, logged_in_headers, active_user, json_flow):
     """Test downloading a project with multiple flows.


### PR DESCRIPTION
## Summary
- apply the same `current_user.id` filter in the paginated `read_project` query that the non-paginated branch already uses
- keep `page`/`size` responses from exposing flows owned by another user in the same project folder
- add a regression test that injects a second user-owned flow into the folder and verifies it stays hidden from the paginated response

## Testing
- not run locally in a full checkout in this session; covered with a focused regression test in `test_projects.py` and left for repo CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated pagination logic for project flows to include user ownership filtering in paginated results.

* **Tests**
  * Added unit test to verify paginated flow results respect user ownership visibility.

* **Chores**
  * Updated Google dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->