### PR TITLE
feat(deployments): replace Duplicate with Details modal

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/connection-item.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/connection-item.tsx
@@ -1,0 +1,17 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+
+interface ConnectionItemProps {
+  name: string;
+}
+
+export default function ConnectionItem({ name }: ConnectionItemProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <ForwardedIconComponent
+        name="Plug"
+        className="h-3 w-3 shrink-0 text-muted-foreground"
+      />
+      <span className="text-xs text-muted-foreground">{name}</span>
+    </div>
+  );
+}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-details-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-details-modal.tsx
@@ -1,0 +1,116 @@
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import Loading from "@/components/ui/loading";
+import { useGetDeployment } from "@/controllers/API/queries/deployments/use-get-deployment";
+import {
+  type DeploymentFlowVersionItem,
+  useGetDeploymentAttachments,
+} from "@/controllers/API/queries/deployments/use-get-deployment-attachments";
+import { useGetDeploymentConfigs } from "@/controllers/API/queries/deployments/use-get-deployment-configs";
+import type { Deployment } from "../../types";
+import DeploymentFlowList from "./deployment-flow-list";
+import DeploymentInfoGrid from "./deployment-info-grid";
+
+interface DeploymentDetailsModalProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  deployment: Deployment | null;
+  providerName: string;
+}
+
+export default function DeploymentDetailsModal({
+  open,
+  setOpen,
+  deployment,
+  providerName,
+}: DeploymentDetailsModalProps) {
+  const deploymentId = deployment?.id ?? "";
+
+  const { data: details, isFetching: isFetchingDetails } = useGetDeployment(
+    { deploymentId },
+    { enabled: open && !!deploymentId },
+  );
+
+  const { data: attachmentsData, isFetching: isFetchingAttachments } =
+    useGetDeploymentAttachments(
+      { deploymentId },
+      { enabled: open && !!deploymentId },
+    );
+
+  const providerId = deployment?.provider_account_id ?? "";
+
+  const { data: configsData, isFetching: isFetchingConfigs } =
+    useGetDeploymentConfigs({ providerId }, { enabled: open && !!providerId });
+
+  const isLoading =
+    isFetchingDetails || isFetchingAttachments || isFetchingConfigs;
+
+  const deploymentData = details?.id === deploymentId ? details : deployment;
+  const flowVersions = attachmentsData?.flow_versions ?? [];
+
+  const llm =
+    typeof deploymentData?.provider_data?.llm === "string"
+      ? deploymentData.provider_data.llm
+      : "";
+
+  const configMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const cfg of configsData?.configs ?? []) {
+      map.set(cfg.id, cfg.name);
+    }
+    return map;
+  }, [configsData]);
+
+  const getConnectionNames = (fv: DeploymentFlowVersionItem): string[] => {
+    const appIds = fv.provider_data?.app_ids ?? [];
+    return appIds.map((id) => configMap.get(id) ?? id).filter(Boolean);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="flex w-[700px] !max-w-none flex-col gap-0 overflow-hidden rounded-xl border bg-background p-0 shadow-lg">
+        <div className="flex flex-col items-start border-b px-6 py-4">
+          <DialogTitle className="text-lg font-semibold">
+            Deployment Details
+          </DialogTitle>
+          <DialogDescription className="text-sm text-muted-foreground">
+            View deployment configuration and attached flows.
+          </DialogDescription>
+        </div>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loading />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-5 overflow-y-auto px-6 py-4">
+            <DeploymentInfoGrid
+              deployment={deploymentData}
+              providerName={providerName}
+              llm={llm}
+            />
+
+            <div className="border-t border-border" />
+
+            <DeploymentFlowList
+              flowVersions={flowVersions}
+              getConnectionNames={getConnectionNames}
+            />
+          </div>
+        )}
+
+        <div className="flex justify-end border-t px-6 py-4">
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-flow-list.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-flow-list.tsx
@@ -1,0 +1,34 @@
+import type { DeploymentFlowVersionItem } from "@/controllers/API/queries/deployments/use-get-deployment-attachments";
+import FlowVersionItem from "./flow-version-item";
+
+interface DeploymentFlowListProps {
+  flowVersions: DeploymentFlowVersionItem[];
+  getConnectionNames: (fv: DeploymentFlowVersionItem) => string[];
+}
+
+export default function DeploymentFlowList({
+  flowVersions,
+  getConnectionNames,
+}: DeploymentFlowListProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="text-sm font-medium text-foreground">
+        Attached Flows ({flowVersions.length})
+      </span>
+      {flowVersions.length === 0 ? (
+        <span className="text-sm text-muted-foreground">No flows attached</span>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {flowVersions.map((fv) => (
+            <FlowVersionItem
+              key={fv.id}
+              flowName={fv.flow_name}
+              versionNumber={fv.version_number}
+              connectionNames={getConnectionNames(fv)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-info-grid.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-info-grid.tsx
@@ -1,0 +1,71 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import type { Deployment } from "../../types";
+
+interface DeploymentInfoGridProps {
+  deployment: Deployment | null;
+  providerName: string;
+  llm: string;
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function DeploymentInfoGrid({
+  deployment,
+  providerName,
+  llm,
+}: DeploymentInfoGridProps) {
+  return (
+    <div className="grid grid-cols-[auto_1fr_auto_1fr] items-baseline gap-x-3 gap-y-2">
+      <span className="text-xs text-muted-foreground">Type</span>
+      <div className="flex items-center gap-1.5">
+        <ForwardedIconComponent
+          name={deployment?.type === "agent" ? "Bot" : "Server"}
+          className="h-3.5 w-3.5 text-muted-foreground"
+        />
+        <span className="text-sm text-foreground capitalize">
+          {deployment?.type}
+        </span>
+      </div>
+      <span className="text-xs text-muted-foreground">Created</span>
+      <span className="text-sm text-foreground">
+        {deployment?.created_at ? formatDate(deployment.created_at) : "—"}
+      </span>
+
+      <span className="text-xs text-muted-foreground">Name</span>
+      <span className="text-sm text-foreground">{deployment?.name || "—"}</span>
+      <span className="text-xs text-muted-foreground">Modified</span>
+      <span className="text-sm text-foreground">
+        {deployment?.updated_at ? formatDate(deployment.updated_at) : "—"}
+      </span>
+
+      {deployment?.description && (
+        <>
+          <span className="text-xs text-muted-foreground">Desc</span>
+          <span className="col-span-3 text-sm text-foreground">
+            {deployment.description}
+          </span>
+        </>
+      )}
+
+      {llm && (
+        <>
+          <span className="text-xs text-muted-foreground">Model</span>
+          <span className="col-span-3 break-words text-sm text-foreground">
+            {llm}
+          </span>
+        </>
+      )}
+
+      <span className="text-xs text-muted-foreground">Provider</span>
+      <span className="col-span-3 text-sm text-foreground">
+        {providerName || "—"}
+      </span>
+    </div>
+  );
+}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/flow-version-item.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/flow-version-item.tsx
@@ -1,0 +1,44 @@
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Badge } from "@/components/ui/badge";
+import ConnectionItem from "./connection-item";
+
+interface FlowVersionItemProps {
+  flowName: string | null;
+  versionNumber: number;
+  connectionNames: string[];
+}
+
+export default function FlowVersionItem({
+  flowName,
+  versionNumber,
+  connectionNames,
+}: FlowVersionItemProps) {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border p-3">
+      <div className="flex items-center gap-2">
+        <ForwardedIconComponent
+          name="Workflow"
+          className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+        />
+        <span className="text-sm font-medium text-foreground">
+          {flowName ?? "Unknown flow"}
+        </span>
+        <Badge
+          variant="secondaryStatic"
+          size="tag"
+          className="bg-accent-purple-muted text-accent-purple-muted-foreground"
+        >
+          v{versionNumber}
+        </Badge>
+      </div>
+
+      {connectionNames.length > 0 && (
+        <div className="flex flex-col gap-1 pl-5">
+          {connectionNames.map((name) => (
+            <ConnectionItem key={name} name={name} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-content.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-content.tsx
@@ -13,6 +13,7 @@ import { useDeleteWithConfirmation } from "../hooks/use-delete-with-confirmation
 import { ALL_PROVIDERS, useProviderFilter } from "../hooks/use-provider-filter";
 import { useTestDeploymentModal } from "../hooks/use-test-deployment-modal";
 import type { Deployment, ProviderAccount } from "../types";
+import DeploymentDetailsModal from "./deployment-details-modal/deployment-details-modal";
 import DeploymentStepperModal from "./deployment-stepper-modal";
 import DeploymentsEmptyState from "./deployments-empty-state";
 import DeploymentsLoadingSkeleton from "./deployments-loading-skeleton";
@@ -58,6 +59,10 @@ export default function DeploymentsContent({
     null,
   );
 
+  const [detailsDeployment, setDetailsDeployment] = useState<Deployment | null>(
+    null,
+  );
+
   const isLoading = isLoadingProviders || isLoadingDeployments;
   const hasProviders = providers.length > 0;
   const isEmpty = !hasProviders || deployments.length === 0;
@@ -76,6 +81,7 @@ export default function DeploymentsContent({
         providerMap={providerMap}
         deletingId={deploymentDelete.deletingId}
         onTestDeployment={testModal.handleTestDeployment}
+        onViewDetails={(deployment) => setDetailsDeployment(deployment)}
         onUpdateDeployment={(deployment) => {
           setEditingDeployment(deployment);
           setStepperOpen(true);
@@ -133,6 +139,19 @@ export default function DeploymentsContent({
         setOpen={testModal.setOpen}
         deployment={testModal.testTarget}
         providerId={testModal.testProviderId}
+      />
+
+      <DeploymentDetailsModal
+        open={!!detailsDeployment}
+        setOpen={(open) => {
+          if (!open) setDetailsDeployment(null);
+        }}
+        deployment={detailsDeployment}
+        providerName={
+          detailsDeployment
+            ? (providerMap[detailsDeployment.provider_account_id ?? ""] ?? "—")
+            : ""
+        }
       />
 
       <DeleteConfirmationModal

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-table.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-table.tsx
@@ -27,7 +27,7 @@ interface DeploymentsTableProps {
   providerMap: Record<string, string>;
   deletingId?: string | null;
   onTestDeployment: (deployment: Deployment) => void;
-  onDuplicateDeployment?: (deployment: Deployment) => void;
+  onViewDetails?: (deployment: Deployment) => void;
   onUpdateDeployment?: (deployment: Deployment) => void;
   onDeleteDeployment?: (deployment: Deployment) => void;
 }
@@ -74,7 +74,7 @@ export default function DeploymentsTable({
   providerMap,
   deletingId,
   onTestDeployment,
-  onDuplicateDeployment,
+  onViewDetails,
   onUpdateDeployment,
   onDeleteDeployment,
 }: DeploymentsTableProps) {
@@ -201,13 +201,13 @@ export default function DeploymentsTable({
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
                         <DropdownMenuItem
-                          onClick={() => onDuplicateDeployment?.(deployment)}
+                          onClick={() => onViewDetails?.(deployment)}
                         >
                           <ForwardedIconComponent
-                            name="Copy"
+                            name="Info"
                             className="mr-2 h-4 w-4"
                           />
-                          Duplicate
+                          Details
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onClick={() => onUpdateDeployment?.(deployment)}


### PR DESCRIPTION
## Summary
- Replace the unused "Duplicate" action menu item with "Details" in the deployment list action menu
- Add a read-only modal that shows deployment info (type, name, description, model, provider, dates), attached flows with version badges, and connections per flow
- Data is fetched via `useGetDeployment`, `useGetDeploymentAttachments`, and `useGetDeploymentConfigs`
- Modal is organized into focused subcomponents: `DeploymentInfoGrid`, `DeploymentFlowList`, `FlowVersionItem`, `ConnectionItem`


https://github.com/user-attachments/assets/5fc1a738-1907-49af-8938-5c801d6e39a2

