### PR TITLE
fix(flows): escape wildcard flow names when deduplicating

### DIFF
--- a/src/backend/base/langflow/api/v1/flows_helpers.py
+++ b/src/backend/base/langflow/api/v1/flows_helpers.py
@@ -191,9 +191,12 @@ async def _deduplicate_flow_name(session: AsyncSession, name: str, user_id: UUID
     if not (await session.exec(select(Flow).where(Flow.name == name).where(Flow.user_id == user_id))).first():
         return name
 
+    escaped_name = name.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
     flows = (
         await session.exec(
-            select(Flow).where(Flow.name.like(f"{name} (%")).where(Flow.user_id == user_id)  # type: ignore[attr-defined]
+            select(Flow)
+            .where(Flow.name.like(f"{escaped_name} (%", escape="\\"))  # type: ignore[attr-defined]
+            .where(Flow.user_id == user_id)
         )
     ).all()
 

--- a/src/backend/tests/unit/api/v1/test_rename_flow_to_save.py
+++ b/src/backend/tests/unit/api/v1/test_rename_flow_to_save.py
@@ -159,3 +159,31 @@ async def test_duplicate_flow_name_regex_patterns(client: AsyncClient, logged_in
     response2 = await client.post("api/v1/flows/", json=base_flow, headers=logged_in_headers)
     assert response2.status_code == status.HTTP_201_CREATED
     assert response2.json()["name"] == "Flow (.*) [test] (1)"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_flow_name_escapes_like_wildcards(client: AsyncClient, logged_in_headers):
+    """Test that SQL LIKE wildcards in flow names do not affect numbering."""
+    unrelated_flow = {
+        "name": "flow_a (7)",
+        "description": "Test flow description",
+        "data": {},
+        "is_component": False,
+    }
+    wildcard_flow = {
+        "name": "flow_%",
+        "description": "Test flow description",
+        "data": {},
+        "is_component": False,
+    }
+
+    response = await client.post("api/v1/flows/", json=unrelated_flow, headers=logged_in_headers)
+    assert response.status_code == status.HTTP_201_CREATED
+
+    response = await client.post("api/v1/flows/", json=wildcard_flow, headers=logged_in_headers)
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["name"] == "flow_%"
+
+    response = await client.post("api/v1/flows/", json=wildcard_flow, headers=logged_in_headers)
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["name"] == "flow_% (1)"


### PR DESCRIPTION
## Summary
- escape SQL `LIKE` wildcards when searching for existing numbered copies in `_deduplicate_flow_name()`
- keep exact numbered-suffix matching with the existing regex-based copy-number extraction
- add a regression test covering `%` and `_` in flow names so unrelated matches no longer inflate the next suffix

## Testing
- `git diff --check -- src/backend/base/langflow/api/v1/flows_helpers.py src/backend/tests/unit/api/v1/test_rename_flow_to_save.py`
- `python3 -m py_compile src/backend/base/langflow/api/v1/flows_helpers.py src/backend/tests/unit/api/v1/test_rename_flow_to_save.py`
- `uvx ruff check src/backend/base/langflow/api/v1/flows_helpers.py src/backend/tests/unit/api/v1/test_rename_flow_to_save.py`
- `uv run python -m pytest -q tests/unit/api/v1/test_rename_flow_to_save.py -k "duplicate_flow_name_escapes_like_wildcards or duplicate_flow_name_regex_patterns"` *(started locally but did not return in a reasonable time window in this checkout; repository CI should provide the authoritative run)*