### PR TITLE
fix(graph): treat missing frozen cache as cache miss

### DIFF
--- a/src/backend/tests/unit/graph/test_cache_restoration.py
+++ b/src/backend/tests/unit/graph/test_cache_restoration.py
@@ -19,6 +19,7 @@ runs fully and sets vertex.result correctly.
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from lfx.graph.graph.base import Graph
 from lfx.services.cache.utils import CacheMiss
 
 
@@ -240,15 +241,42 @@ class TestCacheRestorationEdgeCases:
         assert should_build is True, "Cache miss should trigger build"
 
     @pytest.mark.asyncio
-    async def test_service_unavailable_fallback_returns_cache_miss(self):
-        """Fallback cache getter should behave like a cache miss, not a cache hit."""
+    async def test_service_unavailable_graph_step_uses_cache_miss_fallback(self, monkeypatch):
+        """Graph execution should use a cache-miss fallback when chat service is unavailable."""
 
-        async def get_cache_func(*args, **kwargs):  # noqa: ARG001
-            return CacheMiss()
+        monkeypatch.setattr("lfx.graph.graph.base.get_chat_service", lambda: None)
 
-        cached_result = await get_cache_func(key="frozen-vertex")
+        graph = Graph()
+        graph._prepared = True  # noqa: SLF001
+        graph.extend_run_queue(["frozen-vertex"])
+        graph.get_next_runnable_vertices = AsyncMock(return_value=[])
+        graph.reset_inactivated_vertices = Mock()
+        graph.reset_activated_vertices = Mock()
 
-        assert isinstance(cached_result, CacheMiss)
+        vertex = Mock()
+        vertex.id = "frozen-vertex"
+        vertex.frozen = True
+        vertex.built = False
+        vertex.is_loop = False
+        vertex.display_name = "TestComponent"
+        vertex.result = None
+        vertex.artifacts = {}
+        vertex.results = {}
+        vertex.built_object = {}
+        vertex.built_result = {}
+        vertex.full_data = {}
+        vertex.built_object_repr = Mock(return_value="built")
+
+        async def build_vertex(*args, **kwargs):  # noqa: ARG001
+            vertex.result = {"result": "fresh-build"}
+
+        vertex.build = AsyncMock(side_effect=build_vertex)
+        graph.get_vertex = Mock(return_value=vertex)
+
+        await graph.astep()
+
+        vertex.build.assert_awaited_once()
+        assert vertex.result == {"result": "fresh-build"}
 
     def test_loop_component_should_always_build_even_when_frozen(self):
         """Test that Loop component always builds even when frozen and built.

--- a/src/backend/tests/unit/graph/test_cache_restoration.py
+++ b/src/backend/tests/unit/graph/test_cache_restoration.py
@@ -19,6 +19,7 @@ runs fully and sets vertex.result correctly.
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from lfx.services.cache.utils import CacheMiss
 
 
 class TestCacheRestorationBuiltFlagReset:
@@ -237,6 +238,17 @@ class TestCacheRestorationEdgeCases:
 
         # Assert
         assert should_build is True, "Cache miss should trigger build"
+
+    @pytest.mark.asyncio
+    async def test_service_unavailable_fallback_returns_cache_miss(self):
+        """Fallback cache getter should behave like a cache miss, not a cache hit."""
+
+        async def get_cache_func(*args, **kwargs):  # noqa: ARG001
+            return CacheMiss()
+
+        cached_result = await get_cache_func(key="frozen-vertex")
+
+        assert isinstance(cached_result, CacheMiss)
 
     def test_loop_component_should_always_build_even_when_frozen(self):
         """Test that Loop component always builds even when frozen and built.

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -1446,7 +1446,7 @@ class Graph:
         else:
             # Fallback no-op cache functions for tests or when service unavailable
             async def get_cache_func(*args, **kwargs):  # noqa: ARG001
-                return None
+                return CacheMiss()
 
             async def set_cache_func(*args, **kwargs) -> bool:  # noqa: ARG001
                 return True
@@ -1671,7 +1671,7 @@ class Graph:
         else:
             # Fallback no-op cache functions for tests or when service unavailable
             async def get_cache_func(*args, **kwargs):  # noqa: ARG001
-                return None
+                return CacheMiss()
 
             async def set_cache_func(*args, **kwargs):
                 pass


### PR DESCRIPTION
## Summary
- return `CacheMiss()` from the fallback frozen-cache getter when the chat service is unavailable
- apply the same fallback in both graph execution paths that currently create no-op cache functions
- add a small regression test covering the fallback cache-miss behavior

## Testing
- `python3 -m py_compile src/lfx/src/lfx/graph/graph/base.py src/backend/tests/unit/graph/test_cache_restoration.py`
- `git diff --check`
- not run: `pytest src/backend/tests/unit/graph/test_cache_restoration.py -q` (`pytest` is not installed in this environment)

Closes #12408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache miss handling when the cache service is unavailable, ensuring consistent behavior by returning explicit cache miss indicators instead of null values.

* **Tests**
  * Added test coverage for cache fallback behavior to verify proper handling of service-unavailability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->