### PR TITLE
fix: prevent ForeignKeyViolation when deleting flows with traces

### DIFF
--- a/src/backend/base/langflow/alembic/versions/a3f8b2c91d04_add_ondelete_cascade_to_span_trace_id_fk.py
+++ b/src/backend/base/langflow/alembic/versions/a3f8b2c91d04_add_ondelete_cascade_to_span_trace_id_fk.py
@@ -1,0 +1,68 @@
+"""Add ON DELETE CASCADE to span.trace_id foreign key
+
+Revision ID: a3f8b2c91d04
+Revises: 0e6138e7a0c2
+Create Date: 2026-04-04 10:00:00.000000
+
+Phase: EXPAND
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+
+# revision identifiers, used by Alembic.
+revision: str = "a3f8b2c91d04"  # pragma: allowlist secret
+down_revision: str | None = "0e6138e7a0c2"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _get_fk_constraint_name(conn, table_name: str, column_name: str) -> str | None:
+    """Find the foreign key constraint name for a given column."""
+    inspector = sa.inspect(conn)
+    for fk in inspector.get_foreign_keys(table_name):
+        if column_name in fk["constrained_columns"]:
+            return fk["name"]
+    return None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if not migration.table_exists("span", conn):
+        return
+
+    fk_name = _get_fk_constraint_name(conn, "span", "trace_id")
+
+    if fk_name is None:
+        with op.batch_alter_table("span", schema=None) as batch_op:
+            batch_op.create_foreign_key(
+                "fk_span_trace_id_trace", "trace", ["trace_id"], ["id"], ondelete="CASCADE"
+            )
+    else:
+        with op.batch_alter_table("span", schema=None) as batch_op:
+            batch_op.drop_constraint(fk_name, type_="foreignkey")
+            batch_op.create_foreign_key(
+                "fk_span_trace_id_trace", "trace", ["trace_id"], ["id"], ondelete="CASCADE"
+            )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    if not migration.table_exists("span", conn):
+        return
+
+    fk_name = _get_fk_constraint_name(conn, "span", "trace_id")
+
+    if fk_name is None:
+        return
+
+    with op.batch_alter_table("span", schema=None) as batch_op:
+        batch_op.drop_constraint(fk_name, type_="foreignkey")
+        batch_op.create_foreign_key(
+            "fk_span_trace_id_trace", "trace", ["trace_id"], ["id"]
+        )

--- a/src/backend/base/langflow/api/utils/core.py
+++ b/src/backend/base/langflow/api/utils/core.py
@@ -13,12 +13,14 @@ from lfx.log.logger import logger
 from lfx.services.deps import injectable_session_scope, injectable_session_scope_readonly, session_scope
 from lfx.utils.validate_cloud import raise_error_if_astra_cloud_disable_component
 from sqlalchemy import delete
+from sqlmodel import select as sm_select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from langflow.services.auth.utils import get_current_active_user, get_current_active_user_mcp
 from langflow.services.database.models.flow.model import Flow
 from langflow.services.database.models.flow_version.model import FlowVersion
 from langflow.services.database.models.message.model import MessageTable
+from langflow.services.database.models.traces.model import SpanTable, TraceTable
 from langflow.services.database.models.transactions.model import TransactionTable
 from langflow.services.database.models.user.model import User
 from langflow.services.database.models.vertex_builds.model import VertexBuildTable
@@ -349,6 +351,12 @@ async def cascade_delete_flow(session: AsyncSession, flow_id: uuid.UUID) -> None
         # Explicit delete despite FK CASCADE — SQLite doesn't enforce FK cascades
         # by default (requires PRAGMA foreign_keys = ON), and this function follows
         # the existing pattern of explicitly deleting all child records.
+        # Spans must be deleted before traces due to the span.trace_id FK constraint,
+        # which lacks ON DELETE CASCADE in existing deployments.
+        trace_ids = (await session.exec(sm_select(TraceTable.id).where(TraceTable.flow_id == flow_id))).all()
+        if trace_ids:
+            await session.exec(delete(SpanTable).where(SpanTable.trace_id.in_(trace_ids)))
+        await session.exec(delete(TraceTable).where(TraceTable.flow_id == flow_id))
         await session.exec(delete(FlowVersion).where(FlowVersion.flow_id == flow_id))
         await session.exec(delete(Flow).where(Flow.id == flow_id))
     except Exception as e:

--- a/src/backend/base/langflow/services/database/models/traces/model.py
+++ b/src/backend/base/langflow/services/database/models/traces/model.py
@@ -251,7 +251,7 @@ class SpanTable(SpanBase, table=True):  # type: ignore[call-arg]
     __tablename__ = "span"
 
     id: UUID = Field(default_factory=uuid4, primary_key=True)
-    trace_id: UUID = Field(foreign_key="trace.id", index=True, description="Parent trace ID")
+    trace_id: UUID = Field(foreign_key="trace.id", ondelete="CASCADE", index=True, description="Parent trace ID")
     parent_span_id: UUID | None = Field(
         default=None,
         foreign_key="span.id",


### PR DESCRIPTION
Fixes #12346

## Problem

Deleting a flow that has associated execution traces raises a `ForeignKeyViolation` in PostgreSQL. The root cause is that the `span.trace_id` FK was created without `ON DELETE CASCADE` in migration `3478f0bd6ccb`. When PostgreSQL cascades the `flow → trace` deletion, it then tries to delete `trace` rows, but `span` records still reference them — causing a constraint error.

There are two compounding issues:
1. `span.trace_id` FK missing `ON DELETE CASCADE` at the database level
2. `cascade_delete_flow()` never explicitly deletes `TraceTable` or `SpanTable` records, relying entirely on the broken DB-level cascade chain

## Solution

**Application-level (defence-in-depth):** `cascade_delete_flow()` now explicitly deletes `SpanTable` rows (keyed by trace IDs for the flow) and `TraceTable` rows before deleting the `Flow`, matching the existing pattern for `MessageTable`, `TransactionTable`, `VertexBuildTable`, and `FlowVersion`.

**Database-level:** New Alembic migration `a3f8b2c91d04` drops and re-creates the `span.trace_id` FK with `ON DELETE CASCADE`. Uses `batch_alter_table` for SQLite compatibility and introspects the actual FK constraint name (handles both auto-generated and named constraints).

**ORM model:** `SpanTable.trace_id` Field gains `ondelete="CASCADE"` so new deployments get the correct schema from the start.

## Testing

- Create a flow, execute it to generate traces/spans, then delete the flow — should succeed without `ForeignKeyViolation`
- Run `alembic upgrade head` on both PostgreSQL and SQLite
- Run `alembic downgrade -1` to verify reversibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic cleanup of trace and span data when deleting flows, ensuring no orphaned records remain in the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->