### PR TITLE
feat(wxo): tool name handling, rename support, and ownership safety

### DIFF
--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -67,6 +67,7 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
     WatsonxApiFlowArtifactProviderData,
     WatsonxApiRemoveToolByIdOperation,
     WatsonxApiRemoveToolOperation,
+    WatsonxApiRenameToolOperation,
     WatsonxApiToolAppBinding,
     WatsonxApiUnbindOperation,
     WatsonxApiUnbindToolOperation,
@@ -85,6 +86,7 @@ from langflow.api.v1.schemas.deployments import (
     ExecutionCreateResponse,
     ExecutionStatusResponse,
 )
+from langflow.services.adapters.deployment.watsonx_orchestrate.utils import normalize_wxo_name
 from langflow.services.adapters.deployment.watsonx_orchestrate.constants import (
     WATSONX_ORCHESTRATE_DEPLOYMENT_ADAPTER_KEY,
 )
@@ -114,6 +116,31 @@ class _NormalizedAttachmentRow:
     flow_version: FlowVersion
     flow_name: str | None
     snapshot_id: str
+
+
+def _validate_tool_name(name: str) -> str:
+    """Normalize and validate a wxO tool name at the API boundary.
+
+    Called for both flow-name-derived defaults and user-provided
+    ``tool_name`` overrides on bind operations.  Normalization is
+    idempotent (``normalize_wxo_name`` applied downstream in
+    ``create_wxo_flow_tool`` is a no-op on already-normalized input).
+
+    Raises ``HTTPException(422)`` when the name cannot produce a valid
+    wxO identifier (e.g. empty after sanitisation, starts with a digit).
+    This surfaces a clear error to the caller rather than letting the
+    ADK or wxO API reject it with a less actionable message.
+    """
+    normalized = normalize_wxo_name(name)
+    if not normalized or not normalized[0].isalpha():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Tool name derived from '{name}' is not valid for watsonx Orchestrate. "
+                "Names must contain at least one alphanumeric character and start with a letter."
+            ),
+        )
+    return normalized
 
 
 @register_mapper(AdapterType.DEPLOYMENT, WATSONX_ORCHESTRATE_DEPLOYMENT_ADAPTER_KEY)
@@ -372,11 +399,19 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             project_id=project_id,
             reference_ids=flow_version_ids,
         )
-        raw_name_by_flow_version_id = {flow_version_id: artifact.name for flow_version_id, artifact in flow_artifacts}
-        # Override with user-provided tool names when present
+        # Start with flow names as defaults, then let user-provided tool_name
+        # overrides replace them. Validation runs on the final map so that an
+        # invalid flow name doesn't block a user who provided a valid custom
+        # tool_name for that flow.
+        raw_name_by_flow_version_id: dict[str, str] = {
+            flow_version_id: artifact.name for flow_version_id, artifact in flow_artifacts
+        }
         for op in api_provider_payload.operations:
             if isinstance(op, WatsonxApiBindOperation) and op.tool_name:
                 raw_name_by_flow_version_id[op.flow_version_id] = op.tool_name
+        raw_name_by_flow_version_id = {
+            fv_id: _validate_tool_name(name) for fv_id, name in raw_name_by_flow_version_id.items()
+        }
         provider_operations = self._build_provider_operations(
             operations=api_provider_payload.operations,
             raw_name_by_flow_version_id=raw_name_by_flow_version_id,
@@ -488,13 +523,20 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             deployment_db_id=deployment_db_id,
             flow_version_ids=ordered_flow_version_ids,
         )
-        raw_name_by_flow_version_id = {
-            flow_version_id: artifact.name for flow_version_id, _version_number, _project_id, artifact in flow_artifacts
+        # Start with normalized flow names as defaults, then let user-provided
+        # tool_name overrides replace them. Validation runs on the final map
+        # so that an invalid flow name doesn't block a user who provided a
+        # valid custom tool_name for that flow.
+        raw_name_by_flow_version_id: dict[str, str] = {
+            flow_version_id: artifact.name
+            for flow_version_id, _version_number, _project_id, artifact in flow_artifacts
         }
-        # Override with user-provided tool names when present
         for op in api_provider_payload.operations:
             if isinstance(op, WatsonxApiBindOperation) and op.tool_name:
                 raw_name_by_flow_version_id[op.flow_version_id] = op.tool_name
+        raw_name_by_flow_version_id = {
+            fv_id: _validate_tool_name(name) for fv_id, name in raw_name_by_flow_version_id.items()
+        }
         raw_payloads = [
             artifact.model_copy(
                 update={
@@ -514,6 +556,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         # - bind: missing attachment = "create new tool" (expected)
         # - unbind: missing = error (tool must exist to modify connections)
         # - remove_tool: missing = error (tool must exist to detach)
+        # - rename_tool: missing = error (tool must exist to rename)
         bind_fv_ids = [
             op.flow_version_id for op in api_provider_payload.operations if isinstance(op, WatsonxApiBindOperation)
         ]
@@ -525,14 +568,19 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             for op in api_provider_payload.operations
             if isinstance(op, WatsonxApiRemoveToolOperation)
         ]
-        all_fv_ids = list(dict.fromkeys(bind_fv_ids + unbind_fv_ids + remove_fv_ids))
+        rename_fv_ids = [
+            op.flow_version_id
+            for op in api_provider_payload.operations
+            if isinstance(op, WatsonxApiRenameToolOperation)
+        ]
+        all_fv_ids = list(dict.fromkeys(bind_fv_ids + unbind_fv_ids + remove_fv_ids + rename_fv_ids))
         flow_version_snapshot_id_map = await self._lookup_snapshot_ids(
             user_id=user_id,
             deployment_db_id=deployment_db_id,
             db=db,
             flow_version_ids=all_fv_ids,
         )
-        strict_fv_ids = list(dict.fromkeys(unbind_fv_ids + remove_fv_ids))
+        strict_fv_ids = list(dict.fromkeys(unbind_fv_ids + remove_fv_ids + rename_fv_ids))
         missing_strict = [str(fv) for fv in strict_fv_ids if fv not in flow_version_snapshot_id_map]
         if missing_strict:
             msg = f"Cannot resolve provider snapshot ids for flow_version_ids in watsonx operations: {missing_strict}"
@@ -989,6 +1037,9 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         snapshot_data_by_id = self._resolve_snapshot_data_by_id(
             snapshot_result=snapshot_result,
         )
+        snapshot_name_by_id = self._resolve_snapshot_name_by_id(
+            snapshot_result=snapshot_result,
+        )
 
         flow_versions = [
             DeploymentFlowVersionListItem(
@@ -998,6 +1049,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 version_number=row.flow_version.version_number,
                 attached_at=row.attachment.created_at,
                 provider_snapshot_id=row.snapshot_id,
+                tool_name=snapshot_name_by_id.get(row.snapshot_id),
                 provider_data=self.shape_deployment_flow_version_item_data(snapshot_data_by_id.get(row.snapshot_id)),
             )
             for row in normalized_rows
@@ -1049,6 +1101,36 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             snapshot_data_by_id[snapshot_id] = provider_data if isinstance(provider_data, dict) else None
 
         return snapshot_data_by_id
+
+    @staticmethod
+    def _resolve_snapshot_name_by_id(
+        *,
+        snapshot_result: SnapshotListResult | None,
+    ) -> dict[str, str]:
+        """Map snapshot IDs to their provider tool names.
+
+        The tool name is the wxO-side name, which may differ from the
+        Langflow flow name if the user provided a custom ``tool_name``
+        at deploy time or renamed the tool directly in the wxO console.
+
+        Edge cases:
+        - Provider unreachable / snapshot_result is None: returns ``{}``.
+          The ``tool_name`` field in the response will be ``None`` and the
+          frontend falls back to the Langflow flow name for display.
+        - Tool renamed in wxO console: the new name is returned here since
+          ``snapshot_result`` is fetched fresh on each request.
+        - Tool deleted in wxO: missing from ``snapshot_result.snapshots``,
+          so no entry in the returned dict. ``tool_name`` will be ``None``.
+        """
+        if not snapshot_result or not snapshot_result.snapshots:
+            return {}
+        result: dict[str, str] = {}
+        for snapshot in snapshot_result.snapshots:
+            snapshot_id = str(snapshot.id).strip()
+            name = str(snapshot.name or "").strip()
+            if snapshot_id and name:
+                result[snapshot_id] = name
+        return result
 
     def shape_deployment_flow_version_item_data(
         self,
@@ -1248,6 +1330,23 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                         source_ref=str(flow_version_id),
                         app_ids=operation.app_ids,
                     )
+                )
+                continue
+
+            if isinstance(operation, WatsonxApiRenameToolOperation):
+                flow_version_id = operation.flow_version_id
+                if flow_version_snapshot_id_map is None:
+                    msg = "Snapshot id map is required for rename_tool operations."
+                    raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
+                provider_operations.append(
+                    {
+                        "op": "rename_tool",
+                        "tool": {
+                            "source_ref": str(flow_version_id),
+                            "tool_id": flow_version_snapshot_id_map[flow_version_id],
+                        },
+                        "new_name": _validate_tool_name(operation.tool_name),
+                    }
                 )
                 continue
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -409,8 +409,8 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         for op in api_provider_payload.operations:
             if isinstance(op, WatsonxApiBindOperation) and op.tool_name:
                 raw_name_by_flow_version_id[op.flow_version_id] = op.tool_name
-        for fv_id in raw_name_by_flow_version_id:
-            raw_name_by_flow_version_id[fv_id] = _validate_tool_name(raw_name_by_flow_version_id[fv_id])
+        for fv_id, name in raw_name_by_flow_version_id.items():
+            raw_name_by_flow_version_id[fv_id] = _validate_tool_name(name)
         provider_operations = self._build_provider_operations(
             operations=api_provider_payload.operations,
             raw_name_by_flow_version_id=raw_name_by_flow_version_id,
@@ -532,8 +532,8 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         for op in api_provider_payload.operations:
             if isinstance(op, WatsonxApiBindOperation) and op.tool_name:
                 raw_name_by_flow_version_id[op.flow_version_id] = op.tool_name
-        for fv_id in raw_name_by_flow_version_id:
-            raw_name_by_flow_version_id[fv_id] = _validate_tool_name(raw_name_by_flow_version_id[fv_id])
+        for fv_id, name in raw_name_by_flow_version_id.items():
+            raw_name_by_flow_version_id[fv_id] = _validate_tool_name(name)
         raw_payloads = [
             artifact.model_copy(
                 update={

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -403,15 +403,14 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         # overrides replace them. Validation runs on the final map so that an
         # invalid flow name doesn't block a user who provided a valid custom
         # tool_name for that flow.
-        raw_name_by_flow_version_id: dict[str, str] = {
+        raw_name_by_flow_version_id: dict[UUID, str] = {
             flow_version_id: artifact.name for flow_version_id, artifact in flow_artifacts
         }
         for op in api_provider_payload.operations:
             if isinstance(op, WatsonxApiBindOperation) and op.tool_name:
                 raw_name_by_flow_version_id[op.flow_version_id] = op.tool_name
-        raw_name_by_flow_version_id = {
-            fv_id: _validate_tool_name(name) for fv_id, name in raw_name_by_flow_version_id.items()
-        }
+        for fv_id in raw_name_by_flow_version_id:
+            raw_name_by_flow_version_id[fv_id] = _validate_tool_name(raw_name_by_flow_version_id[fv_id])
         provider_operations = self._build_provider_operations(
             operations=api_provider_payload.operations,
             raw_name_by_flow_version_id=raw_name_by_flow_version_id,
@@ -527,15 +526,14 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         # tool_name overrides replace them. Validation runs on the final map
         # so that an invalid flow name doesn't block a user who provided a
         # valid custom tool_name for that flow.
-        raw_name_by_flow_version_id: dict[str, str] = {
+        raw_name_by_flow_version_id: dict[UUID, str] = {
             flow_version_id: artifact.name for flow_version_id, _version_number, _project_id, artifact in flow_artifacts
         }
         for op in api_provider_payload.operations:
             if isinstance(op, WatsonxApiBindOperation) and op.tool_name:
                 raw_name_by_flow_version_id[op.flow_version_id] = op.tool_name
-        raw_name_by_flow_version_id = {
-            fv_id: _validate_tool_name(name) for fv_id, name in raw_name_by_flow_version_id.items()
-        }
+        for fv_id in raw_name_by_flow_version_id:
+            raw_name_by_flow_version_id[fv_id] = _validate_tool_name(raw_name_by_flow_version_id[fv_id])
         raw_payloads = [
             artifact.model_copy(
                 update={

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -86,13 +86,13 @@ from langflow.api.v1.schemas.deployments import (
     ExecutionCreateResponse,
     ExecutionStatusResponse,
 )
-from langflow.services.adapters.deployment.watsonx_orchestrate.utils import normalize_wxo_name
 from langflow.services.adapters.deployment.watsonx_orchestrate.constants import (
     WATSONX_ORCHESTRATE_DEPLOYMENT_ADAPTER_KEY,
 )
 from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import (
     PAYLOAD_SCHEMAS as WXO_ADAPTER_PAYLOAD_SCHEMAS,
 )
+from langflow.services.adapters.deployment.watsonx_orchestrate.utils import normalize_wxo_name
 from langflow.services.auth import utils as auth_utils
 from langflow.services.database.models.deployment_provider_account.utils import extract_tenant_from_url
 from langflow.services.database.models.flow_version_deployment_attachment.crud import (
@@ -528,8 +528,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         # so that an invalid flow name doesn't block a user who provided a
         # valid custom tool_name for that flow.
         raw_name_by_flow_version_id: dict[str, str] = {
-            flow_version_id: artifact.name
-            for flow_version_id, _version_number, _project_id, artifact in flow_artifacts
+            flow_version_id: artifact.name for flow_version_id, _version_number, _project_id, artifact in flow_artifacts
         }
         for op in api_provider_payload.operations:
             if isinstance(op, WatsonxApiBindOperation) and op.tool_name:

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -55,6 +55,21 @@ class WatsonxApiUnbindOperation(BaseModel):
     app_ids: list[str] = Field(min_length=1)
 
 
+class WatsonxApiRenameToolOperation(BaseModel):
+    """Rename a Langflow-managed tool on the provider.
+
+    Resolves tool_id from flow_version_deployment_attachment, verifies the
+    tool is Langflow-managed (has ``binding.langflow``), and updates its
+    name on the provider.  Does not modify the attachment record.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    op: Literal["rename_tool"]
+    flow_version_id: UUID
+    tool_name: str = Field(min_length=1, description="New tool name.")
+
+
 class WatsonxApiRemoveToolOperation(BaseModel):
     """Remove-tool operation for an attached flow-version tool.
 
@@ -132,6 +147,7 @@ class WatsonxApiRemoveToolByIdOperation(BaseModel):
 WatsonxApiUpdateOperation = Annotated[
     WatsonxApiBindOperation
     | WatsonxApiUnbindOperation
+    | WatsonxApiRenameToolOperation
     | WatsonxApiRemoveToolOperation
     | WatsonxApiBindToolOperation
     | WatsonxApiUnbindToolOperation

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -384,7 +384,24 @@ class DeploymentSnapshotListResponse(_PaginatedResponse):
 
 
 class DeploymentFlowVersionListItem(BaseModel):
-    """Flow version metadata attached to a deployment."""
+    """Flow version metadata attached to a deployment.
+
+    **Identity model:** Langflow tracks provider tools by their immutable
+    ``provider_snapshot_id`` (the wxO tool_id), never by name.  This
+    distinguishes the following cases:
+
+    * **Tool renamed in provider** — Same ``provider_snapshot_id``, different
+      ``tool_name``.  Langflow picks up the new name on the next fetch.
+    * **Tool deleted in provider** — ``provider_snapshot_id`` no longer
+      resolves.  ``tool_name`` and ``provider_data`` will be ``None``.
+    * **Tool deleted + new tool created with same name** — The new tool has
+      a different ID.  Langflow's attachment still points to the old
+      (missing) ID.  The new tool is invisible to Langflow until explicitly
+      attached via an update operation.
+
+    Frontends should use ``tool_name`` for display and
+    ``provider_snapshot_id`` for identity / operations.
+    """
 
     id: UUID = Field(description="Langflow flow version UUID (`flow_version.id`).")
     flow_id: UUID = Field(description="Langflow flow UUID (`flow.id`) for this version.")
@@ -400,6 +417,15 @@ class DeploymentFlowVersionListItem(BaseModel):
     provider_snapshot_id: str | None = Field(
         default=None,
         description="Provider-owned snapshot/tool identifier linked by the attachment.",
+    )
+    tool_name: str | None = Field(
+        default=None,
+        description=(
+            "Provider tool name for this snapshot. May differ from ``flow_name`` "
+            "if the user set a custom name at deploy time or renamed the tool in "
+            "the provider console. ``None`` when the provider is unreachable or "
+            "the tool has been deleted — frontends should fall back to ``flow_name``."
+        ),
     )
     provider_data: dict[str, Any] | None = Field(
         default=None,

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/config.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/config.py
@@ -157,5 +157,9 @@ async def validate_connection(connections_client: ConnectionsClient, *, app_id: 
         msg = f"Connection '{app_id}' is missing draft runtime credentials."
         raise InvalidContentError(message=msg)
 
-    logger.debug("validate_connection: passed for app_id='%s', connection_id='%s'", app_id, getattr(connection, 'connection_id', 'unknown'))
+    logger.debug(
+        "validate_connection: passed for app_id='%s', connection_id='%s'",
+        app_id,
+        getattr(connection, "connection_id", "unknown"),
+    )
     return connection

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/config.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/config.py
@@ -6,8 +6,6 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-logger = logging.getLogger(__name__)
-
 from ibm_watsonx_orchestrate_core.types.connections import (
     ConnectionConfiguration,
     ConnectionEnvironment,
@@ -22,6 +20,8 @@ from lfx.services.adapters.deployment.schema import ConfigItem, DeploymentConfig
 
 from langflow.services.adapters.deployment.watsonx_orchestrate.client import resolve_runtime_credentials
 from langflow.services.adapters.deployment.watsonx_orchestrate.utils import validate_wxo_name
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ibm_watsonx_orchestrate_clients.connections.connections_client import ConnectionsClient, GetConnectionResponse

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/create.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/create.py
@@ -38,6 +38,7 @@ from langflow.services.adapters.deployment.watsonx_orchestrate.core.tools import
     create_and_upload_wxo_flow_tools_with_bindings,
     ensure_langflow_connections_binding,
     to_writable_tool_payload,
+    verify_langflow_owned,
 )
 from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import (
     WatsonxAttachToolOperation,
@@ -361,7 +362,10 @@ async def _bind_existing_tools_for_create(
 
     tool_updates: list[tuple[str, dict[str, Any]]] = []
     for tool_id in tool_ids:
-        original_tool = to_writable_tool_payload(tool_by_id[tool_id])
+        tool = tool_by_id[tool_id]
+        verify_langflow_owned(tool, tool_id=tool_id)
+
+        original_tool = to_writable_tool_payload(tool)
         original_tools[tool_id] = original_tool
         writable_tool = copy.deepcopy(original_tool)
         connections = ensure_langflow_connections_binding(writable_tool)

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/create.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/create.py
@@ -172,7 +172,8 @@ async def apply_provider_create_plan_with_rollback(
 ) -> WatsonxProviderCreateApplyResult:
     """Apply provider create operations with rollback protection."""
     logger.debug(
-        "apply_provider_create_plan: name='%s', %d existing tools, %d raw tools, %d raw connections, %d existing app_ids",
+        "apply_provider_create_plan: name='%s', %d existing tools, %d raw tools, "
+        "%d raw connections, %d existing app_ids",
         plan.deployment_name,
         len(plan.existing_tool_ids),
         len(plan.raw_tools_to_create),

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/create.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/create.py
@@ -171,6 +171,14 @@ async def apply_provider_create_plan_with_rollback(
     plan: ProviderCreatePlan,
 ) -> WatsonxProviderCreateApplyResult:
     """Apply provider create operations with rollback protection."""
+    logger.debug(
+        "apply_provider_create_plan: name='%s', %d existing tools, %d raw tools, %d raw connections, %d existing app_ids",
+        plan.deployment_name,
+        len(plan.existing_tool_ids),
+        len(plan.raw_tools_to_create),
+        len(plan.raw_connections_to_create),
+        len(plan.existing_app_ids),
+    )
     # Rollback journals — tracked so partial failures can undo side-effects:
     # - created_tool_ids: provider tool ids created during this operation.
     # - created_app_ids: provider app ids (connections) created during this operation.
@@ -290,6 +298,12 @@ async def apply_provider_create_plan_with_rollback(
         msg = f"{ErrorPrefix.CREATE.value} Deployment response was empty."
         raise DeploymentError(message=msg, error_code="deployment_error")
 
+    logger.debug(
+        "apply_provider_create_plan: created agent_id='%s', %d tools, %d connections",
+        agent_create_response.id,
+        len(created_tool_ids),
+        len(created_app_ids),
+    )
     return WatsonxProviderCreateApplyResult(
         agent_id=str(agent_create_response.id),
         app_ids=created_app_ids,

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/shared.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/shared.py
@@ -127,14 +127,13 @@ async def create_connection_with_conflict_mapping(
         provider_config=payload.provider_config,
     )
     try:
-        result = await retry_create(
+        return await retry_create(
             create_config,
             clients=clients,
             config=config_payload,
             user_id=user_id,
             db=db,
         )
-        return result
     except (ClientAPIException, HTTPException) as exc:
         if isinstance(exc, ClientAPIException):
             status_code = exc.response.status_code

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/shared.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/shared.py
@@ -166,7 +166,11 @@ async def resolve_connections_for_operations(
     validate_connection_fn: Callable[..., Awaitable[object]] = validate_connection,
     create_connection_fn: Callable[..., Awaitable[str]] = create_connection_with_conflict_mapping,
 ) -> ConnectionResolutionResult:
-    logger.debug("resolve_connections_for_operations: existing_app_ids=%s, raw_to_create=%d", existing_app_ids, len(raw_connections_to_create))
+    logger.debug(
+        "resolve_connections_for_operations: existing_app_ids=%s, raw_to_create=%d",
+        existing_app_ids,
+        len(raw_connections_to_create),
+    )
     operation_to_provider_app_id = {app_id: app_id for app_id in existing_app_ids}
     resolved_connections: dict[str, str] = {}
 
@@ -213,7 +217,11 @@ async def resolve_connections_for_operations(
         created_app_ids_journal.append(result)
     created_app_ids = list(dict.fromkeys(created_app_ids_journal))
     if create_connection_errors:
-        logger.debug("resolve_connections_for_operations: %d errors, created_app_ids=%s", len(create_connection_errors), created_app_ids)
+        logger.debug(
+            "resolve_connections_for_operations: %d errors, created_app_ids=%s",
+            len(create_connection_errors),
+            created_app_ids,
+        )
         raise ConnectionCreateBatchError(created_app_ids=created_app_ids, errors=create_connection_errors)
 
     validated_created_connections: list[object] = await asyncio.gather(
@@ -230,7 +238,11 @@ async def resolve_connections_for_operations(
         operation_to_provider_app_id[create_plan.operation_app_id] = create_plan.provider_app_id
         resolved_connections[create_plan.provider_app_id] = connection.connection_id  # type: ignore[attr-defined]
 
-    logger.debug("resolve_connections_for_operations: resolved_connections=%s, created_app_ids=%s", resolved_connections, created_app_ids)
+    logger.debug(
+        "resolve_connections_for_operations: resolved_connections=%s, created_app_ids=%s",
+        resolved_connections,
+        created_app_ids,
+    )
 
     return ConnectionResolutionResult(
         operation_to_provider_app_id=operation_to_provider_app_id,

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
@@ -268,7 +268,12 @@ def create_wxo_flow_tool(
     """
     # provider_data might break tool runtime expectations with unexpected top-level keys
     flow_definition = flow_payload.model_dump(exclude={"provider_data"})
-    logger.debug("create_wxo_flow_tool: flow name='%s', id='%s', connections=%s", flow_definition.get("name"), flow_definition.get("id"), connections)
+    logger.debug(
+        "create_wxo_flow_tool: flow name='%s', id='%s', connections=%s",
+        flow_definition.get("name"),
+        flow_definition.get("id"),
+        connections,
+    )
 
     flow_provider_data = flow_payload.provider_data
     if not isinstance(flow_provider_data, WatsonxFlowArtifactProviderData):
@@ -316,7 +321,12 @@ def create_wxo_flow_tool(
         tool_payload["name"] = normalize_wxo_name(current_name)
 
     (tool_payload.setdefault("binding", {}).setdefault("langflow", {})["project_id"]) = project_id
-    logger.debug("create_wxo_flow_tool: tool name='%s', project_id='%s', binding=%s", tool_payload.get("name"), project_id, tool_payload.get("binding", {}).get("langflow"))
+    logger.debug(
+        "create_wxo_flow_tool: tool name='%s', project_id='%s', binding=%s",
+        tool_payload.get("name"),
+        project_id,
+        tool_payload.get("binding", {}).get("langflow"),
+    )
 
     artifacts: bytes = build_langflow_artifact_bytes(
         tool=tool,
@@ -409,7 +419,9 @@ async def upload_wxo_flow_tool(
 ) -> str:
     tool_response = await retry_create(asyncio.to_thread, clients.tool.create, tool_payload)
     tool_id = require_tool_id(tool_response)
-    logger.debug("upload_wxo_flow_tool: created tool_id='%s', uploading artifact (%d bytes)", tool_id, len(artifact_bytes))
+    logger.debug(
+        "upload_wxo_flow_tool: created tool_id='%s', uploading artifact (%d bytes)", tool_id, len(artifact_bytes)
+    )
     if created_tool_ids_journal is not None:
         created_tool_ids_journal.append(tool_id)
 

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
@@ -510,11 +510,11 @@ def _resolve_lfx_requirement() -> str:
         return override
     try:
         return _pin_requirement_name("lfx")
-    except (md.PackageNotFoundError, ValueError):
+    except (md.PackageNotFoundError, ValueError) as exc:
         # Prefer failing fast here instead of falling back, as wxO does not
         # return useful error messages on dependency failures during deployment.
         message = "Could not determine installed lfx version. Failing deployment."
-        raise ValueError(message)
+        raise ValueError(message) from exc
 
 
 async def verify_tools_by_ids(

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
@@ -103,6 +103,19 @@ def ensure_langflow_connections_binding(tool_payload: dict[str, Any]) -> dict[st
     return _ensure_dict(langflow, "connections")
 
 
+def verify_langflow_owned(tool: dict[str, Any], *, tool_id: str) -> None:
+    """Raise ``InvalidContentError`` if the tool lacks ``binding.langflow``.
+
+    Call before any mutating operation on an existing tool to ensure
+    Langflow created it.  Tools created manually in the wxO console or
+    by other integrations will not have this marker.
+    """
+    binding = tool.get("binding")
+    if not isinstance(binding, dict) or "langflow" not in binding:
+        msg = f"Cannot modify tool '{tool_id}': it does not have a Langflow binding and may not be managed by Langflow."
+        raise InvalidContentError(message=msg)
+
+
 def extract_langflow_connections_binding(tool_payload: dict[str, Any]) -> dict[str, str]:
     """Extract ``binding.langflow.connections`` from a provider tool payload.
 
@@ -144,7 +157,10 @@ async def update_existing_tool_connection_bindings(
 
     tool_updates: list[tuple[str, dict[str, Any]]] = []
     for tool_id in existing_target_tool_ids:
-        original_tool = to_writable_tool_payload(tool_by_id[tool_id])
+        tool = tool_by_id[tool_id]
+        verify_langflow_owned(tool, tool_id=tool_id)
+
+        original_tool = to_writable_tool_payload(tool)
         original_tools[tool_id] = original_tool
         writable_tool = copy.deepcopy(original_tool)
         connections = ensure_langflow_connections_binding(writable_tool)

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/update.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/update.py
@@ -415,6 +415,14 @@ async def apply_provider_update_plan_with_rollback(
     plan: ProviderUpdatePlan,
 ) -> WatsonxProviderUpdateApplyResult:
     """Apply provider_data update operations with rollback protection."""
+    logger.debug(
+        "apply_provider_update_plan: agent_id='%s', %d raw tools, %d renames, %d connection deltas, %d raw connections",
+        agent_id,
+        len(plan.raw_tools_to_create),
+        len(plan.tool_renames),
+        len(plan.existing_tool_deltas),
+        len(plan.raw_connections_to_create),
+    )
     # Rollback journals — tracked so partial failures can undo side-effects:
     # - created_tool_ids: provider tool ids created during this update.
     # - created_app_ids: provider app ids created during this update.
@@ -464,29 +472,19 @@ async def apply_provider_update_plan_with_rollback(
     #   connection_id seen. All tools should agree on the mapping, but if
     #   they diverge, the explicit operation result will overwrite it.
     agent_tool_ids = extract_agent_tool_ids(agent)
-    logger.debug("apply_provider_update_plan: agent_tool_ids=%s", agent_tool_ids)
     if agent_tool_ids:
         existing_tools = await asyncio.to_thread(clients.tool.get_drafts_by_ids, agent_tool_ids)
-        logger.debug("apply_provider_update_plan: fetched %d existing tools", len(existing_tools or []))
         for tool in existing_tools or []:
             if not isinstance(tool, dict):
-                logger.debug("apply_provider_update_plan: skipping non-dict tool: %s", type(tool).__name__)
                 continue
-            tool_id = tool.get("id", "?")
-            bindings = extract_langflow_connections_binding(tool)
-            logger.debug(
-                "apply_provider_update_plan: tool_id='%s', binding.langflow.connections=%s, raw binding=%s",
-                tool_id,
-                bindings,
-                tool.get("binding"),
-            )
-            for app_id, connection_id in bindings.items():
+            for app_id, connection_id in extract_langflow_connections_binding(tool).items():
                 if app_id and connection_id:
                     operation_to_provider_app_id.setdefault(app_id, app_id)
                     resolved_connections.setdefault(app_id, connection_id)
         logger.debug(
-            "apply_provider_update_plan: pre-seeded resolved_connections=%s",
-            resolved_connections,
+            "apply_provider_update_plan: pre-seeded %d connections from %d agent tools",
+            len(resolved_connections),
+            len(agent_tool_ids),
         )
 
     try:

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/update.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/update.py
@@ -35,7 +35,9 @@ from langflow.services.adapters.deployment.watsonx_orchestrate.core.tools import
     ToolUploadBatchError,
     create_and_upload_wxo_flow_tools_with_bindings,
     ensure_langflow_connections_binding,
+    extract_langflow_connections_binding,
     to_writable_tool_payload,
+    verify_langflow_owned,
 )
 from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import (
     WatsonxAttachToolOperation,
@@ -43,6 +45,7 @@ from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import (
     WatsonxDeploymentUpdatePayload,
     WatsonxProviderUpdateApplyResult,
     WatsonxRemoveToolOperation,
+    WatsonxRenameToolOperation,
     WatsonxResultToolRefBinding,
     WatsonxUnbindOperation,
 )
@@ -88,6 +91,7 @@ class ProviderUpdatePlan:
     raw_connections_to_create: list[RawConnectionCreatePlan]
     existing_tool_deltas: dict[str, ToolConnectionOps]
     raw_tools_to_create: list[RawToolCreatePlan]
+    tool_renames: dict[str, str]  # tool_id → new_name
     final_existing_tool_ids: list[str]
     added_existing_tool_refs: list[WatsonxResultToolRefBinding]
     removed_existing_tool_refs: list[WatsonxResultToolRefBinding]
@@ -118,6 +122,7 @@ def build_provider_update_plan(
             raw_connections_to_create=[],
             existing_tool_deltas={},
             raw_tools_to_create=[],
+            tool_renames={},
             final_existing_tool_ids=list(dict.fromkeys(provider_update.put_tools)),
             added_existing_tool_refs=[],
             removed_existing_tool_refs=[],
@@ -151,6 +156,8 @@ def build_provider_update_plan(
     #   then merged directly into the update result alongside newly-created
     #   snapshot bindings.
     existing_tool_refs: list[WatsonxResultToolRefBinding] = []
+    # tool_renames: tool_id → new_name for rename_tool operations.
+    tool_renames: dict[str, str] = {}
 
     for operation in provider_update.operations:
         if isinstance(operation, WatsonxBindOperation):
@@ -196,6 +203,13 @@ def build_provider_update_plan(
             )
             delta = _get_or_create_tool_connection_ops(existing_tool_deltas, tool_id=tool_id)
             delta.unbind.extend(operation.app_ids)
+            continue
+
+        if isinstance(operation, WatsonxRenameToolOperation):
+            tool_renames[operation.tool.tool_id] = operation.new_name
+            existing_tool_refs.append(
+                WatsonxResultToolRefBinding(source_ref=operation.tool.source_ref, tool_id=operation.tool.tool_id, created=False)
+            )
             continue
 
         if isinstance(operation, WatsonxRemoveToolOperation):
@@ -247,6 +261,7 @@ def build_provider_update_plan(
         raw_connections_to_create=raw_connections_to_create,
         existing_tool_deltas=existing_tool_deltas,
         raw_tools_to_create=raw_tools_to_create,
+        tool_renames=tool_renames,
         final_existing_tool_ids=final_existing_tool_ids.to_list(),
         added_existing_tool_refs=deduped_added_existing_tool_refs,
         removed_existing_tool_refs=deduped_removed_existing_tool_refs,
@@ -276,8 +291,11 @@ async def _update_existing_tool_connection_deltas(
 
     tool_updates: list[tuple[str, dict[str, Any]]] = []
     for tool_id in tool_ids:
+        tool = tool_by_id[tool_id]
+        verify_langflow_owned(tool, tool_id=tool_id)
+
         delta = existing_tool_deltas[tool_id]
-        original_tool = to_writable_tool_payload(tool_by_id[tool_id])
+        original_tool = to_writable_tool_payload(tool)
         original_tools[tool_id] = original_tool
         writable_tool = copy.deepcopy(original_tool)
         connections = ensure_langflow_connections_binding(writable_tool)
@@ -303,6 +321,64 @@ async def _update_existing_tool_connection_deltas(
             for tool_id, writable_tool in tool_updates
         )
     )
+
+
+async def _apply_tool_renames(
+    *,
+    clients: WxOClient,
+    agent_tool_ids: list[str],
+    tool_renames: dict[str, str],
+    original_tools: dict[str, dict[str, Any]],
+) -> None:
+    """Rename tools on the provider with safety checks.
+
+    Guards against destructive operations on tools we don't own:
+    1. Tool must be attached to this agent (tool_id in agent_tool_ids).
+    2. Tool must be a Langflow-managed tool (has ``binding.langflow``).
+    3. Tool must exist on the provider.
+
+    Captures original tool payloads in ``original_tools`` for rollback.
+    """
+    if not tool_renames:
+        return
+
+    # Verify all tools belong to this agent before fetching
+    for tool_id in tool_renames:
+        if tool_id not in agent_tool_ids:
+            msg = f"Cannot rename tool '{tool_id}': not attached to this agent."
+            raise InvalidContentError(message=msg)
+
+    tool_ids = list(tool_renames.keys())
+    tools = await asyncio.to_thread(clients.tool.get_drafts_by_ids, tool_ids)
+    tool_by_id = {str(t.get("id")): t for t in tools if isinstance(t, dict) and t.get("id")}
+
+    missing = [tid for tid in tool_ids if tid not in tool_by_id]
+    if missing:
+        msg = f"Cannot rename tool(s) not found in provider: {', '.join(missing)}"
+        raise InvalidContentError(message=msg)
+
+    tool_updates: list[tuple[str, dict[str, Any]]] = []
+    for tool_id, new_name in tool_renames.items():
+        tool = tool_by_id[tool_id]
+
+        verify_langflow_owned(tool, tool_id=tool_id)
+
+        # Capture original for rollback (if not already captured by delta updates)
+        if tool_id not in original_tools:
+            original_tools[tool_id] = to_writable_tool_payload(tool)
+
+        writable = copy.deepcopy(original_tools[tool_id])
+        writable["name"] = new_name
+        writable["display_name"] = new_name
+        tool_updates.append((tool_id, writable))
+
+    await asyncio.gather(
+        *(
+            retry_update(asyncio.to_thread, clients.tool.update, tool_id, writable)
+            for tool_id, writable in tool_updates
+        )
+    )
+    logger.debug("_apply_tool_renames: renamed %d tools: %s", len(tool_updates), tool_renames)
 
 
 def _build_agent_rollback_payload(*, agent: dict[str, Any], final_update_payload: dict[str, Any]) -> dict[str, Any]:
@@ -372,6 +448,48 @@ async def apply_provider_update_plan_with_rollback(
     final_update_payload = dict(update_payload)
     rollback_agent_payload: dict[str, Any] = {}
 
+    # Pre-seed resolved_connections with bindings already attached to the
+    # agent's existing tools.  This lets new tools reuse the same connections
+    # without the caller having to redeclare them in the update payload, and
+    # ensures they are checked first during resolution.
+    #
+    # Edge cases:
+    # - Connection deleted in wxO but still in tool binding: the stale
+    #   connection_id is pre-seeded here. If a new operation explicitly
+    #   references this app_id, resolve_connections_for_operations will
+    #   re-validate it and fail fast. If no operation references it, the
+    #   stale entry is harmless (unused).
+    # - Tool deleted in wxO but still in agent.tools: get_drafts_by_ids
+    #   silently omits missing tools, so we just get fewer bindings.
+    # - Multiple tools share the same app_id: setdefault keeps the first
+    #   connection_id seen. All tools should agree on the mapping, but if
+    #   they diverge, the explicit operation result will overwrite it.
+    agent_tool_ids = extract_agent_tool_ids(agent)
+    logger.debug("apply_provider_update_plan: agent_tool_ids=%s", agent_tool_ids)
+    if agent_tool_ids:
+        existing_tools = await asyncio.to_thread(clients.tool.get_drafts_by_ids, agent_tool_ids)
+        logger.debug("apply_provider_update_plan: fetched %d existing tools", len(existing_tools or []))
+        for tool in existing_tools or []:
+            if not isinstance(tool, dict):
+                logger.debug("apply_provider_update_plan: skipping non-dict tool: %s", type(tool).__name__)
+                continue
+            tool_id = tool.get("id", "?")
+            bindings = extract_langflow_connections_binding(tool)
+            logger.debug(
+                "apply_provider_update_plan: tool_id='%s', binding.langflow.connections=%s, raw binding=%s",
+                tool_id,
+                bindings,
+                tool.get("binding"),
+            )
+            for app_id, connection_id in bindings.items():
+                if app_id and connection_id:
+                    operation_to_provider_app_id.setdefault(app_id, app_id)
+                    resolved_connections.setdefault(app_id, connection_id)
+        logger.debug(
+            "apply_provider_update_plan: pre-seeded resolved_connections=%s",
+            resolved_connections,
+        )
+
     try:
         try:
             connection_result = await resolve_connections_for_operations(
@@ -384,7 +502,7 @@ async def apply_provider_update_plan_with_rollback(
                 validate_connection_fn=validate_connection,
                 create_connection_fn=create_connection_with_conflict_mapping,
             )
-            operation_to_provider_app_id = connection_result.operation_to_provider_app_id
+            operation_to_provider_app_id.update(connection_result.operation_to_provider_app_id)
             resolved_connections.update(connection_result.resolved_connections)
             created_app_ids.extend(connection_result.created_app_ids)
         except ConnectionCreateBatchError as exc:
@@ -417,6 +535,14 @@ async def apply_provider_update_plan_with_rollback(
                 existing_tool_deltas=plan.existing_tool_deltas,
                 resolved_connections=resolved_connections,
                 operation_to_provider_app_id=operation_to_provider_app_id,
+                original_tools=original_tools,
+            )
+
+        if plan.tool_renames:
+            await _apply_tool_renames(
+                clients=clients,
+                agent_tool_ids=extract_agent_tool_ids(agent),
+                tool_renames=plan.tool_renames,
                 original_tools=original_tools,
             )
 

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/update.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/update.py
@@ -208,7 +208,9 @@ def build_provider_update_plan(
         if isinstance(operation, WatsonxRenameToolOperation):
             tool_renames[operation.tool.tool_id] = operation.new_name
             existing_tool_refs.append(
-                WatsonxResultToolRefBinding(source_ref=operation.tool.source_ref, tool_id=operation.tool.tool_id, created=False)
+                WatsonxResultToolRefBinding(
+                    source_ref=operation.tool.source_ref, tool_id=operation.tool.tool_id, created=False
+                )
             )
             continue
 
@@ -373,10 +375,7 @@ async def _apply_tool_renames(
         tool_updates.append((tool_id, writable))
 
     await asyncio.gather(
-        *(
-            retry_update(asyncio.to_thread, clients.tool.update, tool_id, writable)
-            for tool_id, writable in tool_updates
-        )
+        *(retry_update(asyncio.to_thread, clients.tool.update, tool_id, writable) for tool_id, writable in tool_updates)
     )
     logger.debug("_apply_tool_renames: renamed %d tools: %s", len(tool_updates), tool_renames)
 

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
@@ -274,7 +274,11 @@ class WatsonxAttachToolOperation(BaseModel):
 
 
 WatsonxUpdateOperation = Annotated[
-    WatsonxBindOperation | WatsonxUnbindOperation | WatsonxRenameToolOperation | WatsonxRemoveToolOperation | WatsonxAttachToolOperation,
+    WatsonxBindOperation
+    | WatsonxUnbindOperation
+    | WatsonxRenameToolOperation
+    | WatsonxRemoveToolOperation
+    | WatsonxAttachToolOperation,
     Field(discriminator="op"),
 ]
 

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
@@ -239,6 +239,18 @@ class WatsonxUnbindOperation(BaseModel):
         return list(dict.fromkeys(value))
 
 
+class WatsonxRenameToolOperation(BaseModel):
+    """Rename a Langflow-managed tool on the provider."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    op: Literal["rename_tool"]
+    tool: WatsonxToolRefBinding = Field(
+        description="Existing provider tool reference with source_ref correlation.",
+    )
+    new_name: str = Field(min_length=1, description="Validated wxO tool name.")
+
+
 class WatsonxRemoveToolOperation(BaseModel):
     """Detach an existing tool from the deployment."""
 
@@ -262,7 +274,7 @@ class WatsonxAttachToolOperation(BaseModel):
 
 
 WatsonxUpdateOperation = Annotated[
-    WatsonxBindOperation | WatsonxUnbindOperation | WatsonxRemoveToolOperation | WatsonxAttachToolOperation,
+    WatsonxBindOperation | WatsonxUnbindOperation | WatsonxRenameToolOperation | WatsonxRemoveToolOperation | WatsonxAttachToolOperation,
     Field(discriminator="op"),
 ]
 

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -978,6 +978,36 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
         This is a content-only mutation -- it re-uploads the artifact zip
         without touching the tool's name, metadata, or connection bindings.
 
+        The tool name is fetched from wxO at call time, not derived from the
+        Langflow flow name. This is intentional: the user may have set a
+        custom tool name during initial deployment, or renamed the tool
+        directly in the wxO console. Either way, the provider is the source
+        of truth for the tool name.
+
+        **Edge cases:**
+
+        * **Tool renamed in wxO console** — The new name is picked up
+          automatically on the next update since we always fetch it fresh.
+          Langflow never stores the tool name locally.
+        * **Tool deleted in wxO** — ``get_drafts_by_ids`` returns empty
+          and we raise ``InvalidContentError`` before any mutation.
+        * **Tool exists but name is empty/null** — Defensive check raises
+          ``InvalidContentError`` rather than passing an empty name to the
+          ADK, which would produce a cryptic validation error.
+        * **Race condition (rename between fetch and upload)** — The
+          artifact zip will contain the name as of the fetch. The tool's
+          API-level name (set by wxO, not by the artifact) is unaffected
+          by the zip contents, so this is harmless.
+        * **Tool deleted + recreated with same name** — The new tool has
+          a different ``tool_id``.  Our attachment still references the
+          old (deleted) ID, so ``get_drafts_by_ids`` returns nothing and
+          we fail with ``InvalidContentError``.  The user must re-deploy
+          (or update the agent) to bind the new tool — we never silently
+          adopt an unrelated tool just because the name matches.
+
+        **Identity model:** we track tools by immutable ``tool_id``, not
+        by name.  A rename preserves identity; a delete+recreate does not.
+
         **Blast-radius boundary:** callers must verify that ``snapshot_id``
         is tracked by a Langflow attachment record before calling this
         method; this prevents accidental overwrites of externally managed
@@ -987,10 +1017,22 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             create_langflow_tool as _create_langflow_tool,
         )
 
-        from langflow.services.adapters.deployment.watsonx_orchestrate.utils import normalize_wxo_name
         from langflow.utils.version import get_version_info
 
         clients = await self._get_provider_clients(user_id=user_id, db=db)
+
+        # Fetch the existing tool to preserve its wxO name — the tool may have
+        # been deployed with a custom name that differs from the Langflow flow
+        # name, and we must not overwrite it with the flow name.
+        existing_tools = await asyncio.to_thread(clients.tool.get_drafts_by_ids, [snapshot_id])
+        if not existing_tools or not isinstance(existing_tools[0], dict):
+            msg = f"Snapshot tool '{snapshot_id}' not found in provider."
+            raise InvalidContentError(message=msg)
+        existing_tool_name = str(existing_tools[0].get("name") or "").strip()
+        if not existing_tool_name:
+            msg = f"Snapshot tool '{snapshot_id}' exists but has no name. Cannot update artifact."
+            raise InvalidContentError(message=msg)
+        logger.debug("update_snapshot: snapshot_id='%s', existing tool name='%s'", snapshot_id, existing_tool_name)
 
         flow_definition = flow_artifact.model_dump(exclude={"provider_data"})
         flow_id = flow_definition.get("id")
@@ -998,7 +1040,7 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             msg = "flow_definition must have an id"
             raise ValueError(msg)
         flow_definition["id"] = str(flow_id)
-        flow_definition["name"] = normalize_wxo_name(flow_definition.get("name") or "")
+        flow_definition["name"] = existing_tool_name
         if not flow_definition.get("last_tested_version"):
             detected_version = (get_version_info() or {}).get("version")
             if detected_version:

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -66,6 +66,12 @@ WxOCredentials = importlib.import_module(
     "langflow.services.adapters.deployment.watsonx_orchestrate.types"
 ).WxOCredentials
 
+# Aliases for classes used in tests (module-level to satisfy N806).
+ToolConnectionOps = update_core_module.ToolConnectionOps
+OrderedUniqueStrs = shared_core_module.OrderedUniqueStrs
+WatsonxDeploymentUpdatePayload = payloads_module.WatsonxDeploymentUpdatePayload
+WatsonxRenameToolOperation = payloads_module.WatsonxRenameToolOperation
+
 TEST_WXO_LLM = "ibm/granite-3.3-8b"
 
 
@@ -5881,8 +5887,6 @@ def _make_unbound_tool(tool_id: str) -> dict[str, Any]:
 async def test_update_connection_deltas_rejects_non_langflow_tool():
     """_update_existing_tool_connection_deltas must refuse to modify tools without binding.langflow."""
     _update_deltas = update_core_module._update_existing_tool_connection_deltas
-    ToolConnectionOps = update_core_module.ToolConnectionOps
-    OrderedUniqueStrs = shared_core_module.OrderedUniqueStrs
 
     external_tool = _make_external_tool("ext-1")
     clients = FakeWXOClients(tool=FakeToolClient([external_tool]))
@@ -5902,8 +5906,6 @@ async def test_update_connection_deltas_rejects_non_langflow_tool():
 async def test_update_connection_deltas_accepts_langflow_tool():
     """_update_existing_tool_connection_deltas succeeds for tools with binding.langflow."""
     _update_deltas = update_core_module._update_existing_tool_connection_deltas
-    ToolConnectionOps = update_core_module.ToolConnectionOps
-    OrderedUniqueStrs = shared_core_module.OrderedUniqueStrs
 
     lf_tool = _make_langflow_tool("lf-1")
     clients = FakeWXOClients(tool=FakeToolClient([lf_tool]))
@@ -6142,7 +6144,6 @@ def test_validate_tool_name_is_idempotent():
 def test_build_update_plan_includes_rename():
     """build_provider_update_plan collects rename_tool operations into tool_renames."""
     build_plan = update_core_module.build_provider_update_plan
-    WatsonxDeploymentUpdatePayload = payloads_module.WatsonxDeploymentUpdatePayload
 
     agent = {"id": "agent-1", "tools": ["tool-1"]}
     payload = WatsonxDeploymentUpdatePayload(
@@ -6162,7 +6163,6 @@ def test_build_update_plan_includes_rename():
 def test_build_update_plan_without_renames_has_empty_dict():
     """build_provider_update_plan returns empty tool_renames when no renames present."""
     build_plan = update_core_module.build_provider_update_plan
-    WatsonxDeploymentUpdatePayload = payloads_module.WatsonxDeploymentUpdatePayload
 
     agent = {"id": "agent-1", "tools": ["tool-1"]}
     payload = WatsonxDeploymentUpdatePayload(
@@ -6234,8 +6234,6 @@ def test_rename_tool_api_payload_rejects_empty_name():
 
 def test_rename_tool_provider_payload_parses():
     """WatsonxRenameToolOperation parses correctly at provider level."""
-    WatsonxRenameToolOperation = payloads_module.WatsonxRenameToolOperation
-
     op = WatsonxRenameToolOperation(
         op="rename_tool",
         tool={"source_ref": "fv-1", "tool_id": "tool-1"},

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -5842,3 +5842,437 @@ async def test_verify_credentials_provider_unreachable(monkeypatch):
     )
     with pytest.raises(DeploymentError, match="failed unexpectedly"):
         await svc.verify_credentials(user_id="u1", payload=payload)
+
+
+# ---------------------------------------------------------------------------
+# Ownership checks: binding.langflow verification
+# ---------------------------------------------------------------------------
+
+
+def _make_langflow_tool(tool_id: str, *, connections: dict[str, str] | None = None) -> dict[str, Any]:
+    """Build a tool dict that looks Langflow-managed (has binding.langflow)."""
+    return {
+        "id": tool_id,
+        "name": f"tool_{tool_id}",
+        "binding": {
+            "langflow": {
+                "project_id": "proj-1",
+                "connections": connections or {},
+            }
+        },
+    }
+
+
+def _make_external_tool(tool_id: str) -> dict[str, Any]:
+    """Build a tool dict that is NOT Langflow-managed (no binding.langflow)."""
+    return {
+        "id": tool_id,
+        "name": f"external_{tool_id}",
+        "binding": {"some_other_platform": {}},
+    }
+
+
+def _make_unbound_tool(tool_id: str) -> dict[str, Any]:
+    """Build a tool dict with no binding at all."""
+    return {"id": tool_id, "name": f"bare_{tool_id}"}
+
+
+@pytest.mark.anyio
+async def test_update_connection_deltas_rejects_non_langflow_tool():
+    """_update_existing_tool_connection_deltas must refuse to modify tools without binding.langflow."""
+    _update_deltas = update_core_module._update_existing_tool_connection_deltas
+    ToolConnectionOps = update_core_module.ToolConnectionOps
+    OrderedUniqueStrs = shared_core_module.OrderedUniqueStrs
+
+    external_tool = _make_external_tool("ext-1")
+    clients = FakeWXOClients(tool=FakeToolClient([external_tool]))
+
+    ops = ToolConnectionOps(bind=OrderedUniqueStrs.from_values(["app-1"]))
+    with pytest.raises(InvalidContentError, match="does not have a Langflow binding"):
+        await _update_deltas(
+            clients=clients,
+            existing_tool_deltas={"ext-1": ops},
+            resolved_connections={"app-1": "conn-1"},
+            operation_to_provider_app_id={"app-1": "app-1"},
+            original_tools={},
+        )
+
+
+@pytest.mark.anyio
+async def test_update_connection_deltas_accepts_langflow_tool():
+    """_update_existing_tool_connection_deltas succeeds for tools with binding.langflow."""
+    _update_deltas = update_core_module._update_existing_tool_connection_deltas
+    ToolConnectionOps = update_core_module.ToolConnectionOps
+    OrderedUniqueStrs = shared_core_module.OrderedUniqueStrs
+
+    lf_tool = _make_langflow_tool("lf-1")
+    clients = FakeWXOClients(tool=FakeToolClient([lf_tool]))
+
+    ops = ToolConnectionOps(bind=OrderedUniqueStrs.from_values(["app-1"]))
+    original_tools: dict[str, dict] = {}
+    await _update_deltas(
+        clients=clients,
+        existing_tool_deltas={"lf-1": ops},
+        resolved_connections={"app-1": "conn-1"},
+        operation_to_provider_app_id={"app-1": "app-1"},
+        original_tools=original_tools,
+    )
+    assert "lf-1" in original_tools
+    assert clients.tool.update_calls
+
+
+@pytest.mark.anyio
+async def test_bind_existing_tools_for_create_rejects_non_langflow_tool():
+    """_bind_existing_tools_for_create must refuse to modify tools without binding.langflow."""
+    _bind_existing = create_core_module._bind_existing_tools_for_create
+
+    external_tool = _make_external_tool("ext-1")
+    clients = FakeWXOClients(tool=FakeToolClient([external_tool]))
+
+    with pytest.raises(InvalidContentError, match="does not have a Langflow binding"):
+        await _bind_existing(
+            clients=clients,
+            existing_tool_bindings={"ext-1": ["app-1"]},
+            operation_to_provider_app_id={"app-1": "app-1"},
+            resolved_connections={"app-1": "conn-1"},
+            original_tools={},
+        )
+
+
+@pytest.mark.anyio
+async def test_bind_existing_tools_for_create_accepts_langflow_tool():
+    """_bind_existing_tools_for_create succeeds for tools with binding.langflow."""
+    _bind_existing = create_core_module._bind_existing_tools_for_create
+
+    lf_tool = _make_langflow_tool("lf-1")
+    clients = FakeWXOClients(tool=FakeToolClient([lf_tool]))
+
+    original_tools: dict[str, dict] = {}
+    await _bind_existing(
+        clients=clients,
+        existing_tool_bindings={"lf-1": ["app-1"]},
+        operation_to_provider_app_id={"app-1": "app-1"},
+        resolved_connections={"app-1": "conn-1"},
+        original_tools=original_tools,
+    )
+    assert "lf-1" in original_tools
+    assert clients.tool.update_calls
+
+
+@pytest.mark.anyio
+async def test_update_existing_tool_connection_bindings_rejects_non_langflow_tool():
+    """update_existing_tool_connection_bindings must refuse to modify tools without binding.langflow."""
+    _update_bindings = tools_module.update_existing_tool_connection_bindings
+
+    external_tool = _make_external_tool("ext-1")
+    clients = FakeWXOClients(tool=FakeToolClient([external_tool]))
+
+    with pytest.raises(InvalidContentError, match="does not have a Langflow binding"):
+        await _update_bindings(
+            clients=clients,
+            existing_target_tool_ids=["ext-1"],
+            resolved_connections={"app-1": "conn-1"},
+            original_tools={},
+        )
+
+
+@pytest.mark.anyio
+async def test_update_existing_tool_connection_bindings_rejects_unbound_tool():
+    """update_existing_tool_connection_bindings must refuse tools with no binding at all."""
+    _update_bindings = tools_module.update_existing_tool_connection_bindings
+
+    bare_tool = _make_unbound_tool("bare-1")
+    clients = FakeWXOClients(tool=FakeToolClient([bare_tool]))
+
+    with pytest.raises(InvalidContentError, match="does not have a Langflow binding"):
+        await _update_bindings(
+            clients=clients,
+            existing_target_tool_ids=["bare-1"],
+            resolved_connections={"app-1": "conn-1"},
+            original_tools={},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool rename safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_apply_tool_renames_succeeds_for_langflow_tool():
+    """_apply_tool_renames renames a Langflow-owned tool on the agent."""
+    _apply_renames = update_core_module._apply_tool_renames
+
+    lf_tool = _make_langflow_tool("lf-1")
+    clients = FakeWXOClients(tool=FakeToolClient([lf_tool]))
+
+    original_tools: dict[str, dict] = {}
+    await _apply_renames(
+        clients=clients,
+        agent_tool_ids=["lf-1"],
+        tool_renames={"lf-1": "new_name"},
+        original_tools=original_tools,
+    )
+    assert clients.tool.update_calls
+    tool_id, payload = clients.tool.update_calls[0]
+    assert tool_id == "lf-1"
+    assert payload["name"] == "new_name"
+    assert payload["display_name"] == "new_name"
+    assert "lf-1" in original_tools
+
+
+@pytest.mark.anyio
+async def test_apply_tool_renames_rejects_non_langflow_tool():
+    """_apply_tool_renames must refuse to rename tools without binding.langflow."""
+    _apply_renames = update_core_module._apply_tool_renames
+
+    external_tool = _make_external_tool("ext-1")
+    clients = FakeWXOClients(tool=FakeToolClient([external_tool]))
+
+    with pytest.raises(InvalidContentError, match="does not have a Langflow binding"):
+        await _apply_renames(
+            clients=clients,
+            agent_tool_ids=["ext-1"],
+            tool_renames={"ext-1": "stolen_name"},
+            original_tools={},
+        )
+    assert not clients.tool.update_calls
+
+
+@pytest.mark.anyio
+async def test_apply_tool_renames_rejects_tool_not_on_agent():
+    """_apply_tool_renames must refuse to rename tools not attached to the agent."""
+    _apply_renames = update_core_module._apply_tool_renames
+
+    lf_tool = _make_langflow_tool("lf-1")
+    clients = FakeWXOClients(tool=FakeToolClient([lf_tool]))
+
+    with pytest.raises(InvalidContentError, match="not attached to this agent"):
+        await _apply_renames(
+            clients=clients,
+            agent_tool_ids=["other-tool"],
+            tool_renames={"lf-1": "new_name"},
+            original_tools={},
+        )
+    assert not clients.tool.update_calls
+
+
+@pytest.mark.anyio
+async def test_apply_tool_renames_rejects_missing_tool():
+    """_apply_tool_renames must fail if tool doesn't exist on provider."""
+    _apply_renames = update_core_module._apply_tool_renames
+
+    clients = FakeWXOClients(tool=FakeToolClient([]))
+
+    with pytest.raises(InvalidContentError, match="not found in provider"):
+        await _apply_renames(
+            clients=clients,
+            agent_tool_ids=["ghost-1"],
+            tool_renames={"ghost-1": "new_name"},
+            original_tools={},
+        )
+
+
+@pytest.mark.anyio
+async def test_apply_tool_renames_captures_original_for_rollback():
+    """_apply_tool_renames must capture original payload before renaming for rollback."""
+    _apply_renames = update_core_module._apply_tool_renames
+
+    lf_tool = _make_langflow_tool("lf-1")
+    lf_tool["name"] = "original_name"
+    lf_tool["display_name"] = "original_name"
+    clients = FakeWXOClients(tool=FakeToolClient([lf_tool]))
+
+    original_tools: dict[str, dict] = {}
+    await _apply_renames(
+        clients=clients,
+        agent_tool_ids=["lf-1"],
+        tool_renames={"lf-1": "new_name"},
+        original_tools=original_tools,
+    )
+    assert original_tools["lf-1"]["name"] == "original_name"
+
+
+# ---------------------------------------------------------------------------
+# Tool name validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_tool_name_accepts_valid_name():
+    """_validate_tool_name accepts a name that normalizes to a valid wxO identifier."""
+    from langflow.api.v1.mappers.deployments.watsonx_orchestrate.mapper import _validate_tool_name
+
+    assert _validate_tool_name("My Flow") == "My_Flow"
+    assert _validate_tool_name("hello_world") == "hello_world"
+    assert _validate_tool_name("flow-with-dashes") == "flow_with_dashes"
+
+
+def test_validate_tool_name_rejects_empty():
+    """_validate_tool_name rejects names that normalize to empty string."""
+    from langflow.api.v1.mappers.deployments.watsonx_orchestrate.mapper import _validate_tool_name
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_tool_name("!@#$%")
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_validate_tool_name_rejects_leading_digit():
+    """_validate_tool_name rejects names that start with a digit after normalization."""
+    from langflow.api.v1.mappers.deployments.watsonx_orchestrate.mapper import _validate_tool_name
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_tool_name("123flow")
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_validate_tool_name_is_idempotent():
+    """Running _validate_tool_name twice produces the same result."""
+    from langflow.api.v1.mappers.deployments.watsonx_orchestrate.mapper import _validate_tool_name
+
+    first = _validate_tool_name("My Flow!")
+    second = _validate_tool_name(first)
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Rename operation in plan builder
+# ---------------------------------------------------------------------------
+
+
+def test_build_update_plan_includes_rename():
+    """build_provider_update_plan collects rename_tool operations into tool_renames."""
+    build_plan = update_core_module.build_provider_update_plan
+    WatsonxDeploymentUpdatePayload = payloads_module.WatsonxDeploymentUpdatePayload
+
+    agent = {"id": "agent-1", "tools": ["tool-1"]}
+    payload = WatsonxDeploymentUpdatePayload(
+        llm=TEST_WXO_LLM,
+        operations=[
+            {
+                "op": "rename_tool",
+                "tool": {"source_ref": "fv-1", "tool_id": "tool-1"},
+                "new_name": "better_name",
+            },
+        ],
+    )
+    plan = build_plan(agent=agent, provider_update=payload)
+    assert plan.tool_renames == {"tool-1": "better_name"}
+
+
+def test_build_update_plan_without_renames_has_empty_dict():
+    """build_provider_update_plan returns empty tool_renames when no renames present."""
+    build_plan = update_core_module.build_provider_update_plan
+    WatsonxDeploymentUpdatePayload = payloads_module.WatsonxDeploymentUpdatePayload
+
+    agent = {"id": "agent-1", "tools": ["tool-1"]}
+    payload = WatsonxDeploymentUpdatePayload(
+        llm=TEST_WXO_LLM,
+        operations=[
+            {
+                "op": "remove_tool",
+                "tool": {"source_ref": "fv-1", "tool_id": "tool-1"},
+            },
+        ],
+    )
+    plan = build_plan(agent=agent, provider_update=payload)
+    assert plan.tool_renames == {}
+
+
+# ---------------------------------------------------------------------------
+# WXO_LFX_REQUIREMENT_OVERRIDE
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_lfx_requirement_uses_override(monkeypatch):
+    """_resolve_lfx_requirement returns the env var value when set."""
+    _resolve = tools_module._resolve_lfx_requirement
+
+    monkeypatch.setenv("WXO_LFX_REQUIREMENT_OVERRIDE", "lfx-nightly==0.4.0.dev32")
+    assert _resolve() == "lfx-nightly==0.4.0.dev32"
+
+
+def test_resolve_lfx_requirement_ignores_blank_override(monkeypatch):
+    """_resolve_lfx_requirement ignores empty/whitespace-only override."""
+    _resolve = tools_module._resolve_lfx_requirement
+
+    monkeypatch.setenv("WXO_LFX_REQUIREMENT_OVERRIDE", "   ")
+    # Should not return blank — should fall through to installed version or raise
+    result = _resolve()
+    assert result.strip()
+    assert result != "   "
+
+
+# ---------------------------------------------------------------------------
+# Rename operation API payload parsing
+# ---------------------------------------------------------------------------
+
+
+def test_rename_tool_api_payload_parses():
+    """WatsonxApiRenameToolOperation parses correctly."""
+    from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import WatsonxApiRenameToolOperation
+
+    op = WatsonxApiRenameToolOperation(
+        op="rename_tool",
+        flow_version_id="00000000-0000-0000-0000-000000000001",
+        tool_name="new_tool_name",
+    )
+    assert op.op == "rename_tool"
+    assert op.tool_name == "new_tool_name"
+
+
+def test_rename_tool_api_payload_rejects_empty_name():
+    """WatsonxApiRenameToolOperation rejects empty tool_name."""
+    from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import WatsonxApiRenameToolOperation
+
+    with pytest.raises(ValidationError):
+        WatsonxApiRenameToolOperation(
+            op="rename_tool",
+            flow_version_id="00000000-0000-0000-0000-000000000001",
+            tool_name="",
+        )
+
+
+def test_rename_tool_provider_payload_parses():
+    """WatsonxRenameToolOperation parses correctly at provider level."""
+    WatsonxRenameToolOperation = payloads_module.WatsonxRenameToolOperation
+
+    op = WatsonxRenameToolOperation(
+        op="rename_tool",
+        tool={"source_ref": "fv-1", "tool_id": "tool-1"},
+        new_name="better_name",
+    )
+    assert op.new_name == "better_name"
+    assert op.tool.tool_id == "tool-1"
+
+
+# ---------------------------------------------------------------------------
+# DeploymentFlowVersionListItem includes tool_name
+# ---------------------------------------------------------------------------
+
+
+def test_flow_version_list_item_includes_tool_name():
+    """DeploymentFlowVersionListItem accepts and serializes tool_name."""
+    from langflow.api.v1.schemas.deployments import DeploymentFlowVersionListItem
+
+    item = DeploymentFlowVersionListItem(
+        id="00000000-0000-0000-0000-000000000001",
+        flow_id="00000000-0000-0000-0000-000000000002",
+        flow_name="My Flow",
+        version_number=1,
+        tool_name="my_custom_tool",
+    )
+    assert item.tool_name == "my_custom_tool"
+    data = item.model_dump()
+    assert data["tool_name"] == "my_custom_tool"
+
+
+def test_flow_version_list_item_tool_name_defaults_to_none():
+    """DeploymentFlowVersionListItem defaults tool_name to None."""
+    from langflow.api.v1.schemas.deployments import DeploymentFlowVersionListItem
+
+    item = DeploymentFlowVersionListItem(
+        id="00000000-0000-0000-0000-000000000001",
+        flow_id="00000000-0000-0000-0000-000000000002",
+        version_number=1,
+    )
+    assert item.tool_name is None

--- a/src/frontend/src/controllers/API/queries/deployments/use-get-deployment-attachments.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-get-deployment-attachments.ts
@@ -3,6 +3,20 @@ import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
 
+/**
+ * Attachment item from the /{deployment_id}/flows endpoint.
+ *
+ * Identity contract: Langflow tracks provider tools by their immutable
+ * `provider_snapshot_id` (wxO tool_id), never by name.
+ * - Tool renamed in provider → same snapshot ID, new `tool_name`.
+ * - Tool deleted in provider → snapshot ID unresolvable, `tool_name` is null.
+ * - Tool deleted + new tool created with same name → different ID, our
+ *   attachment still points to the old (missing) ID. The new tool is
+ *   invisible to Langflow until explicitly attached.
+ *
+ * Use `tool_name` for display, fall back to `flow_name` when null.
+ * Use `provider_snapshot_id` for operations.
+ */
 export interface DeploymentFlowVersionItem {
   id: string;
   flow_id: string;
@@ -10,12 +24,11 @@ export interface DeploymentFlowVersionItem {
   version_number: number;
   attached_at: string | null;
   provider_snapshot_id: string | null;
+  /** Provider tool name — null when the tool was deleted or provider is unreachable. */
+  tool_name: string | null;
   provider_data: {
     app_ids?: string[];
   } | null;
-  // TODO: Add tool_name field once the BE endpoint includes it.
-  // The provider tool name (from the snapshot) is not yet surfaced
-  // in the /flows response. For now, use flow_name as display fallback.
 }
 
 export interface DeploymentFlowVersionListResponse {

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
@@ -17,6 +17,15 @@ jest.mock("@/controllers/API/queries/deployments/use-patch-deployment", () => ({
   usePatchDeployment: jest.fn(),
 }));
 
+const initialToolNames = new Map([
+  ["flow-1", "custom_tool_one"],
+  ["flow-2", "custom_tool_two"],
+]);
+
+const initialConnections = new Map([
+  ["flow-1", ["app-1"]],
+]);
+
 const mockDeployment: Deployment = {
   id: "deploy-1",
   name: "My Agent",
@@ -42,6 +51,8 @@ function renderEditHook() {
         editingDeployment: mockDeployment,
         selectedVersionByFlow: initialVersions,
         initialLlm: "test-model",
+        initialToolNameByFlow: initialToolNames,
+        initialConnectionsByFlow: initialConnections,
       }}
     >
       {children}
@@ -259,5 +270,83 @@ describe("Edit mode — throws outside edit mode", () => {
     expect(() => result.current.buildDeploymentUpdatePayload()).toThrow(
       "buildDeploymentUpdatePayload called outside edit mode",
     );
+  });
+});
+
+describe("Edit mode — pre-populated provider data", () => {
+  it("pre-fills toolNameByFlow from initialToolNameByFlow", () => {
+    const { result } = renderEditHook();
+    expect(result.current.toolNameByFlow.get("flow-1")).toBe(
+      "custom_tool_one",
+    );
+    expect(result.current.toolNameByFlow.get("flow-2")).toBe(
+      "custom_tool_two",
+    );
+  });
+
+  it("pre-fills attachedConnectionByFlow from initialConnectionsByFlow", () => {
+    const { result } = renderEditHook();
+    expect(result.current.attachedConnectionByFlow.get("flow-1")).toEqual([
+      "app-1",
+    ]);
+  });
+
+  it("preExistingFlowIds contains initially attached flows", () => {
+    const { result } = renderEditHook();
+    expect(result.current.preExistingFlowIds.has("flow-1")).toBe(true);
+    expect(result.current.preExistingFlowIds.has("flow-2")).toBe(true);
+    expect(result.current.preExistingFlowIds.has("flow-new")).toBe(false);
+  });
+});
+
+describe("Edit mode — rename_tool operations", () => {
+  it("sends rename_tool when pre-existing flow tool name changes", () => {
+    const { result } = renderEditHook();
+
+    act(() => {
+      result.current.setToolNameByFlow(
+        new Map([
+          ["flow-1", "renamed_tool"],
+          ["flow-2", "custom_tool_two"],
+        ]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const ops =
+      (payload.provider_data?.operations as Array<{
+        op: string;
+        flow_version_id?: string;
+        tool_name?: string;
+      }>) ?? [];
+    const renameOps = ops.filter((o) => o.op === "rename_tool");
+    expect(renameOps).toHaveLength(1);
+    expect(renameOps[0].flow_version_id).toBe("ver-1");
+    expect(renameOps[0].tool_name).toBe("renamed_tool");
+  });
+
+  it("does NOT send rename_tool when name is unchanged", () => {
+    const { result } = renderEditHook();
+    // toolNameByFlow is pre-filled with initialToolNames, no changes
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const ops =
+      (payload.provider_data?.operations as Array<{ op: string }>) ?? [];
+    expect(ops.filter((o) => o.op === "rename_tool")).toHaveLength(0);
+  });
+
+  it("does NOT send rename_tool when name is cleared (falls back to flow name)", () => {
+    const { result } = renderEditHook();
+
+    act(() => {
+      result.current.setToolNameByFlow(
+        new Map([["flow-2", "custom_tool_two"]]),
+      ); // flow-1 removed from map
+    });
+
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const ops =
+      (payload.provider_data?.operations as Array<{ op: string }>) ?? [];
+    // Empty string !== original, but we only send rename when currentName is truthy
+    expect(ops.filter((o) => o.op === "rename_tool")).toHaveLength(0);
   });
 });

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
@@ -22,9 +22,7 @@ const initialToolNames = new Map([
   ["flow-2", "custom_tool_two"],
 ]);
 
-const initialConnections = new Map([
-  ["flow-1", ["app-1"]],
-]);
+const initialConnections = new Map([["flow-1", ["app-1"]]]);
 
 const mockDeployment: Deployment = {
   id: "deploy-1",
@@ -276,12 +274,8 @@ describe("Edit mode — throws outside edit mode", () => {
 describe("Edit mode — pre-populated provider data", () => {
   it("pre-fills toolNameByFlow from initialToolNameByFlow", () => {
     const { result } = renderEditHook();
-    expect(result.current.toolNameByFlow.get("flow-1")).toBe(
-      "custom_tool_one",
-    );
-    expect(result.current.toolNameByFlow.get("flow-2")).toBe(
-      "custom_tool_two",
-    );
+    expect(result.current.toolNameByFlow.get("flow-1")).toBe("custom_tool_one");
+    expect(result.current.toolNameByFlow.get("flow-2")).toBe("custom_tool_two");
   });
 
   it("pre-fills attachedConnectionByFlow from initialConnectionsByFlow", () => {

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-stepper-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-stepper-modal.tsx
@@ -66,6 +66,17 @@ export default function DeploymentStepperModal({
     );
 
   // Build initial maps from attachments for the stepper context.
+  // Tool names and connection bindings come from the provider (wxO) via
+  // the /flows endpoint, NOT from the Langflow database. This means:
+  //
+  // - If a user renames a tool in the wxO console, the new name appears
+  //   here on the next edit. Langflow doesn't cache tool names locally.
+  // - If a tool is deleted in wxO, its tool_name will be null and the
+  //   review page falls back to the Langflow flow name.
+  // - If a connection is deleted in wxO but the tool still references it,
+  //   the app_id will appear in connectionsByFlow. The backend will fail
+  //   fast during the update if the caller tries to bind a new tool to
+  //   that stale connection.
   const editInitialState = useMemo(() => {
     if (!isEditMode || !attachmentsData?.flow_versions) return null;
 
@@ -73,11 +84,23 @@ export default function DeploymentStepperModal({
       string,
       { versionId: string; versionTag: string }
     >();
+    const toolNames = new Map<string, string>();
+    const connectionsByFlow = new Map<string, string[]>();
+
     for (const fv of attachmentsData.flow_versions) {
       versionMap.set(fv.flow_id, {
         versionId: fv.id,
         versionTag: `v${fv.version_number}`,
       });
+      // Pre-populate tool names from the provider (may differ from flow name).
+      if (fv.tool_name) {
+        toolNames.set(fv.flow_id, fv.tool_name);
+      }
+      // Pre-populate attached connections from existing tool bindings.
+      const appIds = fv.provider_data?.app_ids;
+      if (appIds && appIds.length > 0) {
+        connectionsByFlow.set(fv.flow_id, appIds);
+      }
     }
 
     const llm =
@@ -85,7 +108,7 @@ export default function DeploymentStepperModal({
         ? (deploymentDetail.provider_data.llm as string)
         : "";
 
-    return { versionMap, llm };
+    return { versionMap, llm, toolNames, connectionsByFlow };
   }, [isEditMode, attachmentsData, deploymentDetail]);
 
   const isLoadingEditData =
@@ -125,6 +148,8 @@ export default function DeploymentStepperModal({
                   : 1,
               editingDeployment: editingDeployment ?? undefined,
               initialLlm: editInitialState?.llm,
+              initialToolNameByFlow: editInitialState?.toolNames,
+              initialConnectionsByFlow: editInitialState?.connectionsByFlow,
             }}
           >
             <DeploymentStepperModalContent

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
@@ -48,12 +48,21 @@ export default function StepAttachFlows() {
   );
   const flows = useMemo(() => {
     const list = Array.isArray(flowsData) ? flowsData : [];
-    return list.filter(
+    const filtered = list.filter(
       (f) =>
         !f.is_component &&
         (f.folder_id === currentFolderId || f.id === initialFlowId),
     );
-  }, [flowsData, currentFolderId, initialFlowId]);
+    // In edit mode, sort already-attached flows to the top.
+    if (selectedVersionByFlow.size > 0) {
+      filtered.sort((a, b) => {
+        const aAttached = selectedVersionByFlow.has(a.id) ? 0 : 1;
+        const bAttached = selectedVersionByFlow.has(b.id) ? 0 : 1;
+        return aAttached - bAttached;
+      });
+    }
+    return filtered;
+  }, [flowsData, currentFolderId, initialFlowId, selectedVersionByFlow]);
 
   // Fetch existing connections from the provider (tenant-scoped)
   const providerId = selectedInstance?.id ?? "";

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
@@ -33,6 +33,10 @@ interface DeploymentStepperInitialState {
   editingDeployment?: Deployment;
   /** Pre-populated initial LLM from provider (edit mode). */
   initialLlm?: string;
+  /** Pre-populated tool names from provider (edit mode). Key = flowId. */
+  initialToolNameByFlow?: Map<string, string>;
+  /** Pre-populated connection bindings from provider (edit mode). Key = flowId. */
+  initialConnectionsByFlow?: Map<string, string[]>;
 }
 
 interface DeploymentStepperContextType {
@@ -81,6 +85,8 @@ interface DeploymentStepperContextType {
   /** User-provided tool names per flow. Key = flowId. */
   toolNameByFlow: Map<string, string>;
   setToolNameByFlow: Dispatch<SetStateAction<Map<string, string>>>;
+  /** Flow IDs that were already attached before this edit session (edit mode). */
+  preExistingFlowIds: Set<string>;
   /** Flow IDs that were originally attached but the user chose to detach (edit mode). */
   removedFlowIds: Set<string>;
   handleRemoveAttachedFlow: (flowId: string) => void;
@@ -141,17 +147,26 @@ export function DeploymentStepperProvider({
   >(initialState?.selectedVersionByFlow ?? new Map());
   const [connections, setConnections] = useState<ConnectionItem[]>([]);
   const [toolNameByFlow, setToolNameByFlow] = useState<Map<string, string>>(
-    new Map(),
+    initialState?.initialToolNameByFlow ?? new Map(),
   );
   const [attachedConnectionByFlow, setAttachedConnectionByFlow] = useState<
     Map<string, string[]>
-  >(new Map());
+  >(initialState?.initialConnectionsByFlow ?? new Map());
 
   // Edit mode: track which pre-existing flows the user wants to detach.
   const [removedFlowIds, setRemovedFlowIds] = useState<Set<string>>(new Set());
   // Cache removed flow data so undo can restore it.
   const initialVersionByFlow = useMemo(
     () => initialState?.selectedVersionByFlow ?? new Map(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const preExistingFlowIds = useMemo(
+    () => new Set(initialVersionByFlow.keys()),
+    [initialVersionByFlow],
+  );
+  const initialToolNameByFlow = useMemo(
+    () => initialState?.initialToolNameByFlow ?? new Map<string, string>(),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
@@ -384,6 +399,20 @@ export function DeploymentStepperProvider({
         });
       }
 
+      // Renamed tools on pre-existing flows.
+      for (const [flowId, versionEntry] of Array.from(selectedVersionByFlow)) {
+        if (!initialVersionByFlow.has(flowId)) continue; // new flow, handled above
+        const currentName = toolNameByFlow.get(flowId)?.trim() ?? "";
+        const originalName = initialToolNameByFlow.get(flowId)?.trim() ?? "";
+        if (currentName && currentName !== originalName) {
+          operations.push({
+            op: "rename_tool",
+            flow_version_id: versionEntry.versionId,
+            tool_name: currentName,
+          });
+        }
+      }
+
       // Detached flows.
       for (const flowId of Array.from(removedFlowIds)) {
         const originalVersion = initialVersionByFlow.get(flowId);
@@ -411,7 +440,6 @@ export function DeploymentStepperProvider({
         connectionIds.forEach((id) => newConnectionIds.add(id));
       }
 
-      const existingAppIds: string[] = [];
       const rawPayloads: Array<{
         app_id: string;
         environment_variables: Record<
@@ -422,39 +450,34 @@ export function DeploymentStepperProvider({
 
       Array.from(newConnectionIds).forEach((id) => {
         const conn = connections.find((c) => c.id === id);
-        if (conn?.isNew) {
-          const envVarsWrapped: Record<
-            string,
-            { value: string; source: "raw" | "variable" }
-          > = {};
-          Object.entries(conn.environmentVariables).forEach(([k, v]) => {
-            const isGlobalVar = conn.globalVarKeys?.has(k) ?? false;
-            envVarsWrapped[k] = {
-              value: v,
-              source: isGlobalVar ? "variable" : "raw",
-            };
-          });
-          rawPayloads.push({
-            app_id: id,
-            environment_variables: envVarsWrapped,
-          });
-        } else {
-          existingAppIds.push(id);
-        }
+        if (!conn?.isNew) return; // existing connections are referenced via bind op app_ids
+        const envVarsWrapped: Record<
+          string,
+          { value: string; source: "raw" | "variable" }
+        > = {};
+        Object.entries(conn.environmentVariables).forEach(([k, v]) => {
+          const isGlobalVar = conn.globalVarKeys?.has(k) ?? false;
+          envVarsWrapped[k] = {
+            value: v,
+            source: isGlobalVar ? "variable" : "raw",
+          };
+        });
+        rawPayloads.push({
+          app_id: id,
+          environment_variables: envVarsWrapped,
+        });
       });
 
       const hasOperations = operations.length > 0;
-      const hasConnections =
-        existingAppIds.length > 0 || rawPayloads.length > 0;
+      const hasNewConnections = rawPayloads.length > 0;
       const llmToSend = selectedLlm;
 
-      if (llmToSend || hasOperations || hasConnections) {
+      if (llmToSend || hasOperations || hasNewConnections) {
         result.provider_data = {
           ...(llmToSend && { llm: llmToSend }),
           ...(hasOperations && { operations }),
-          ...(hasConnections && {
+          ...(hasNewConnections && {
             connections: {
-              existing_app_ids: existingAppIds,
               raw_payloads: rawPayloads,
             },
           }),
@@ -472,6 +495,7 @@ export function DeploymentStepperProvider({
       deploymentDescription,
       selectedLlm,
       initialVersionByFlow,
+      initialToolNameByFlow,
       removedFlowIds,
       selectedVersionByFlow,
       toolNameByFlow,
@@ -512,6 +536,7 @@ export function DeploymentStepperProvider({
       setToolNameByFlow,
       attachedConnectionByFlow,
       setAttachedConnectionByFlow,
+      preExistingFlowIds,
       removedFlowIds,
       handleRemoveAttachedFlow,
       handleUndoRemoveFlow,
@@ -542,6 +567,7 @@ export function DeploymentStepperProvider({
       handleSelectVersion,
       toolNameByFlow,
       attachedConnectionByFlow,
+      preExistingFlowIds,
       removedFlowIds,
       handleRemoveAttachedFlow,
       handleUndoRemoveFlow,


### PR DESCRIPTION
- Fix update_snapshot to preserve existing wxO tool name instead of deriving from flow name (prevents overwriting custom tool names)
- Add _validate_tool_name at API boundary with deferred validation so user-provided tool_name overrides aren't blocked by invalid flow names
- Add rename_tool operation (API + provider + plan + apply) with safety checks: tool must be on agent, must exist, must have binding.langflow
- Add verify_langflow_owned guard to all tool mutation paths (create, update, rename) to prevent modifying non-Langflow-managed tools
- Add WXO_LFX_REQUIREMENT_OVERRIDE env var for lfx version pinning
- Pre-seed resolved_connections from existing agent tools during update
- Surface tool_name in /flows endpoint response from wxO snapshot data
- Pre-populate tool names and connections in edit mode stepper (FE)
- Emit rename_tool operations from FE when pre-existing tool name changes
- Sort attached flows to top of flow list in edit mode (FE)
- Fix FE sending unsupported existing_app_ids field in update payload
- Add 24 backend + 6 frontend tests covering ownership checks, rename safety, name validation, plan building, env var override, and payloads