### PR TITLE
fix: skip provider API key DB lookup when model connected via edge

### DIFF
--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -348,6 +348,26 @@ class Vertex:
         # Process field parameters
         field_params, load_from_db_fields = param_handler.process_field_parameters()
 
+        # When a model-type input is connected via edge (e.g. Ollama connected to Agent),
+        # remove provider-specific fields (like api_key) from load_from_db_fields.
+        # Without this, the backend tries to load the provider's API key (e.g. OPENAI_API_KEY)
+        # from the database even though no API key is needed for the externally connected model.
+        if load_from_db_fields and edge_params:
+            template = self.data.get("node", {}).get("template", {})
+            has_external_model = any(
+                isinstance(template.get(field_name), dict)
+                and template[field_name].get("type") == "model"
+                for field_name in edge_params
+            )
+            if has_external_model:
+                try:
+                    from lfx.base.models.unified_models import _get_all_provider_specific_field_names
+
+                    provider_fields = _get_all_provider_specific_field_names()
+                    load_from_db_fields = [f for f in load_from_db_fields if f not in provider_fields]
+                except ImportError:
+                    pass
+
         # Combine parameters, edge_params take precedence
         self.params = {**field_params, **edge_params}
         self.load_from_db_fields = load_from_db_fields


### PR DESCRIPTION
Fixes #12379

## Problem

When an external LLM (e.g. Ollama) is connected to the Agent component's model input via an edge, the backend still tries to load the provider's API key (e.g. `OPENAI_API_KEY`) from the global variables database. This happens because `build_params()` builds `load_from_db_fields` from the component template, which retains the default provider settings (OpenAI) even when `update_build_config()` was never called for the connected model's provider.

The result is an error like:
```
Variable OPENAI_API_KEY not found
```
...even when the user has Ollama (which needs no API key) connected directly.

## Root Cause

`build_params()` in `vertex/base.py` calls `param_handler.process_field_parameters()`, which iterates the template and adds any field with `load_from_db=True` to `load_from_db_fields`. The Agent template defaults to OpenAI, so `api_key` (with `load_from_db=True, value="OPENAI_API_KEY"`) is included. When a model is connected via edge, `update_build_config()` is only triggered by UI dropdown interaction — not by the edge connection itself — so the provider-specific fields are never updated to reflect the externally connected model.

In `loading.py`, `update_params_with_load_from_db_fields()` raises immediately if the variable is not found in the DB and `fallback_to_env_vars=False` (the default).

## Solution

After `process_field_parameters()` runs, check whether any `model`-type field is being provided via an edge connection. If so, remove all provider-specific fields (like `api_key`) from `load_from_db_fields` — since when a model is connected externally, `get_llm()` returns it directly as a `BaseLanguageModel` instance, making the provider's API key irrelevant.

## Testing

- Connect Ollama (no API key) to Agent component's model input
- Run the flow — should execute without "Variable OPENAI_API_KEY not found" error
- Verify flows using OpenAI directly (no external model connection) still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced field data handling to exclude sensitive credentials from being loaded in specific data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->