### PR TITLE
fix: return JSON 404 for API routes instead of HTML

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -583,7 +583,7 @@ def setup_static_files(app: FastAPI, static_files_dir: Path) -> None:
     """
     app.mount(
         "/",
-        StaticFiles(directory=static_files_dir, html=True),
+        StaticFiles(directory=static_files_dir, html=False),
         name="static",
     )
 


### PR DESCRIPTION
## Summary
- Set `StaticFiles(html=False)` so unmatched routes raise 404 exceptions instead of silently serving `index.html`
- The existing `custom_404_handler` already correctly returns JSON for `/api/*` routes and serves `index.html` for frontend SPA routes — it just never fires when `html=True`

## Root Cause
`StaticFiles(html=True)` catches all unmatched routes and serves `index.html` **before** the 404 exception handler runs. API clients requesting non-existent endpoints like `/api/v1/projects/{invalid-id}` receive `200 OK` with HTML instead of `404` with JSON.

## Test plan
- [ ] Request non-existent API endpoint → should return 404 JSON
- [ ] Request frontend SPA route (e.g., `/flow/123`) → should serve index.html
- [ ] Static assets (CSS, JS) → should still be served correctly

Fixes #11458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected static file serving configuration to prevent automatic directory index generation when accessing static file directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->