### PR TITLE
fix(ui): Fix update banner hidden behind canvas controls

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx
@@ -278,7 +278,7 @@ export default function UpdateAllComponents() {
   return (
     <AnimatePresence mode="wait">
       {!shouldHide && (
-        <div className="absolute bottom-2 left-1/2 z-50 w-[530px] -translate-x-1/2">
+        <div className="absolute bottom-16 left-1/2 z-50 w-[530px] -translate-x-1/2">
           <motion.div
             initial="hidden"
             animate="visible"


### PR DESCRIPTION
OBJECTIVE: Reposition the component update banner so it appears above the canvas controls instead of being obscured behind them.                                
                                                                                                                                                                  
CHANGES:                                                                                                                                                        
  - Change UpdateAllComponents bottom positioning from `bottom-2` to `bottom-16` to match FlowBuildingComponent placement  

<img width="1061" height="750" alt="image" src="https://github.com/user-attachments/assets/c2696282-98cb-4984-ab42-663dcc0b094a" />
