### PR TITLE
test(deployments): add comprehensive frontend test suite for WXO deployments

### DIFF
--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -71,6 +71,7 @@ env:
   # This path is used for caching across workflows
   PLAYWRIGHT_BROWSERS_PATH: "ms-playwright"
   PLAYWRIGHT_VERSION: "1.57.0"
+  LANGFLOW_FEATURE_WXO_DEPLOYMENTS: "true"
 
 jobs:
   determine-test-suite:

--- a/src/backend/tests/unit/api/v1/test_deployment_description_and_type.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_description_and_type.py
@@ -126,6 +126,7 @@ class TestCreateResponse:
         provider_account_id = uuid4()
         row = SimpleNamespace(
             id=uuid4(),
+            resource_key="rk-1",
             deployment_provider_account_id=provider_account_id,
             name="deploy",
             description="my description",
@@ -145,6 +146,7 @@ class TestCreateResponse:
         provider_account_id = uuid4()
         row = SimpleNamespace(
             id=uuid4(),
+            resource_key="rk-1",
             deployment_provider_account_id=provider_account_id,
             name="deploy",
             description=None,
@@ -164,6 +166,7 @@ class TestCreateResponse:
         provider_account_id = uuid4()
         row = SimpleNamespace(
             id=uuid4(),
+            resource_key="rk-1",
             deployment_provider_account_id=provider_account_id,
             name="deploy",
             description=None,
@@ -190,6 +193,7 @@ class TestMapperUpdateResult:
         provider_account_id = uuid4()
         row = SimpleNamespace(
             id=uuid4(),
+            resource_key="rk-1",
             deployment_provider_account_id=provider_account_id,
             name="deploy",
             description="persisted desc",
@@ -210,6 +214,7 @@ class TestMapperUpdateResult:
         provider_account_id = uuid4()
         row = SimpleNamespace(
             id=uuid4(),
+            resource_key="rk-1",
             deployment_provider_account_id=provider_account_id,
             name="deploy",
             description=None,

--- a/src/frontend/src/components/core/flowToolbarComponent/components/__tests__/deploy-button.test.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/__tests__/deploy-button.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockCurrentFlowId: string | undefined = "flow-1";
+let mockIsPreparingDeploy = false;
+let mockChoiceDialogOpen = false;
+let mockDeployModalOpen = false;
+const mockHandleDeploy = jest.fn();
+const mockSetChoiceDialogOpen = jest.fn();
+const mockSetDeployModalOpen = jest.fn();
+
+jest.mock("@/customization/feature-flags", () => ({
+  ENABLE_DEPLOYMENTS: true,
+}));
+
+jest.mock("../deploy-choice-dialog/hooks/use-prepare-deploy", () => ({
+  usePrepareDeploy: () => ({
+    currentFlowId: mockCurrentFlowId,
+    isPreparingDeploy: mockIsPreparingDeploy,
+    choiceDialogOpen: mockChoiceDialogOpen,
+    setChoiceDialogOpen: mockSetChoiceDialogOpen,
+    deployModalOpen: mockDeployModalOpen,
+    setDeployModalOpen: mockSetDeployModalOpen,
+    providers: [],
+    pendingSnapshotVersionId: "",
+    initialVersionByFlow: new Map(),
+    stepperInitialProvider: undefined,
+    stepperInitialInstance: undefined,
+    handleDeploy: mockHandleDeploy,
+    handleChooseNew: jest.fn(),
+    handleUpdateComplete: jest.fn(),
+    resetChoiceState: jest.fn(),
+  }),
+}));
+
+jest.mock(
+  "@/pages/MainPage/pages/deploymentsPage/hooks/use-navigate-to-test",
+  () => ({
+    useNavigateToTest: () => jest.fn(),
+  }),
+);
+
+jest.mock("../deploy-choice-dialog", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock(
+  "@/pages/MainPage/pages/deploymentsPage/components/deployment-stepper-modal",
+  () => ({
+    __esModule: true,
+    default: () => null,
+  }),
+);
+
+// Override global mock to forward className so animate-pulse can be tested
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name, className }: { name: string; className?: string }) => (
+    <span data-testid={`icon-${name}`} className={className ?? ""} />
+  ),
+}));
+
+import DeployButton from "../deploy-button";
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCurrentFlowId = "flow-1";
+  mockIsPreparingDeploy = false;
+  mockChoiceDialogOpen = false;
+  mockDeployModalOpen = false;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeployButton — rendering", () => {
+  it("renders the deploy button with data-testid", () => {
+    render(<DeployButton />);
+
+    expect(screen.getByTestId("deploy-btn-flow")).toBeInTheDocument();
+  });
+
+  it("renders Deploy text label", () => {
+    render(<DeployButton />);
+
+    expect(screen.getByText("Deploy")).toBeInTheDocument();
+  });
+
+  it("renders the Rocket icon", () => {
+    render(<DeployButton />);
+
+    expect(screen.getByTestId("icon-Rocket")).toBeInTheDocument();
+  });
+});
+
+describe("DeployButton — disabled states", () => {
+  it("is enabled when currentFlowId is set and nothing is busy", () => {
+    render(<DeployButton />);
+
+    expect(screen.getByTestId("deploy-btn-flow")).not.toBeDisabled();
+  });
+
+  it("is disabled when currentFlowId is undefined", () => {
+    mockCurrentFlowId = undefined;
+    render(<DeployButton />);
+
+    expect(screen.getByTestId("deploy-btn-flow")).toBeDisabled();
+  });
+
+  it("is disabled when isPreparingDeploy is true", () => {
+    mockIsPreparingDeploy = true;
+    render(<DeployButton />);
+
+    expect(screen.getByTestId("deploy-btn-flow")).toBeDisabled();
+  });
+
+  it("is disabled when choiceDialogOpen is true", () => {
+    mockChoiceDialogOpen = true;
+    render(<DeployButton />);
+
+    expect(screen.getByTestId("deploy-btn-flow")).toBeDisabled();
+  });
+
+  it("is disabled when deployModalOpen is true", () => {
+    mockDeployModalOpen = true;
+    render(<DeployButton />);
+
+    expect(screen.getByTestId("deploy-btn-flow")).toBeDisabled();
+  });
+});
+
+describe("DeployButton — click interaction", () => {
+  it("calls handleDeploy when button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DeployButton />);
+
+    await user.click(screen.getByTestId("deploy-btn-flow"));
+
+    expect(mockHandleDeploy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call handleDeploy when disabled with no currentFlowId", async () => {
+    const user = userEvent.setup();
+    mockCurrentFlowId = undefined;
+    render(<DeployButton />);
+
+    await user.click(screen.getByTestId("deploy-btn-flow"));
+
+    expect(mockHandleDeploy).not.toHaveBeenCalled();
+  });
+
+  it("does not call handleDeploy when disabled while preparing", async () => {
+    const user = userEvent.setup();
+    mockIsPreparingDeploy = true;
+    render(<DeployButton />);
+
+    await user.click(screen.getByTestId("deploy-btn-flow"));
+
+    expect(mockHandleDeploy).not.toHaveBeenCalled();
+  });
+});
+
+describe("DeployButton — loading pulse", () => {
+  it("applies animate-pulse to Rocket icon when isPreparingDeploy is true", () => {
+    mockIsPreparingDeploy = true;
+    render(<DeployButton />);
+
+    expect(screen.getByTestId("icon-Rocket").className).toContain(
+      "animate-pulse",
+    );
+  });
+
+  it("does not apply animate-pulse when isPreparingDeploy is false", () => {
+    mockIsPreparingDeploy = false;
+    render(<DeployButton />);
+
+    expect(screen.getByTestId("icon-Rocket").className).not.toContain(
+      "animate-pulse",
+    );
+  });
+});

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/__tests__/index.test.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/__tests__/index.test.tsx
@@ -1,0 +1,491 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type {
+  Deployment,
+  ProviderAccount,
+} from "@/pages/MainPage/pages/deploymentsPage/types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockDeploymentsData: { deployments: Deployment[] } | undefined = undefined;
+let mockIsLoadingDeployments = false;
+const mockPatchSnapshot = jest.fn();
+const mockShowError = jest.fn();
+
+jest.mock("@/controllers/API/queries/deployments/use-get-deployments", () => ({
+  useGetDeployments: (_params: unknown, options?: { enabled?: boolean }) => ({
+    // Mirror react-query's enabled behaviour: when disabled, data is undefined
+    // so deploymentsData changes reference when the phase flips to "deployments",
+    // which triggers the attachments useMemo and the auto-select useEffect.
+    data: options?.enabled === false ? undefined : mockDeploymentsData,
+    isLoading: options?.enabled === false ? false : mockIsLoadingDeployments,
+  }),
+}));
+
+jest.mock("@/controllers/API/queries/deployments", () => ({
+  usePatchSnapshot: () => ({
+    mutateAsync: mockPatchSnapshot,
+  }),
+}));
+
+jest.mock(
+  "@/pages/MainPage/pages/deploymentsPage/hooks/use-error-alert",
+  () => ({
+    useErrorAlert: () => mockShowError,
+  }),
+);
+
+jest.mock(
+  "@/controllers/API/queries/flow-version/use-get-flow-version-entry",
+  () => ({
+    useGetFlowVersionEntry: () => ({
+      data: { version_tag: "v1.0" },
+      isLoading: false,
+    }),
+  }),
+);
+
+// Stub StepDeployStatus to expose phase as text for assertions
+jest.mock(
+  "@/pages/MainPage/pages/deploymentsPage/components/step-deploy-status",
+  () => ({
+    __esModule: true,
+    default: ({ phase }: { phase: string }) => (
+      <div data-testid="step-deploy-status">{phase}</div>
+    ),
+  }),
+);
+
+import DeployChoiceDialog from "../index";
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+const makeProvider = (
+  id = "p1",
+  name = "WxO Prod",
+  providerKey = "watsonx-orchestrate",
+): ProviderAccount => ({
+  id,
+  name,
+  provider_tenant_id: null,
+  provider_key: providerKey,
+  provider_url: "https://wxo.example.com",
+  created_at: null,
+  updated_at: null,
+});
+
+const makeDeployment = (
+  id = "dep-1",
+  name = "My Bot",
+  snapshotId = "snap-1",
+  versionId = "v-1",
+): Deployment => ({
+  id,
+  name,
+  description: null,
+  type: "agent",
+  created_at: "2025-01-01",
+  updated_at: "2025-01-01",
+  provider_data: null,
+  resource_key: "my_bot",
+  attached_count: 1,
+  matched_attachments: [
+    { flow_version_id: versionId, provider_snapshot_id: snapshotId },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOptions {
+  open?: boolean;
+  providers?: ProviderAccount[];
+  flowId?: string;
+  snapshotVersionId?: string;
+  snapshotVersionTag?: string;
+  onTestDeployment?: jest.Mock;
+}
+
+function renderDialog(options: RenderOptions = {}) {
+  const setOpen = jest.fn();
+  const onChooseNew = jest.fn();
+  const onUpdateComplete = jest.fn();
+  const onTestDeployment = options.onTestDeployment ?? jest.fn();
+
+  render(
+    <TooltipProvider>
+      <DeployChoiceDialog
+        open={options.open ?? true}
+        setOpen={setOpen}
+        providers={options.providers ?? [makeProvider()]}
+        flowId={options.flowId ?? "flow-1"}
+        snapshotVersionId={options.snapshotVersionId ?? "snap-new"}
+        snapshotVersionTag={options.snapshotVersionTag ?? "v2.0"}
+        onChooseNew={onChooseNew}
+        onUpdateComplete={onUpdateComplete}
+        onTestDeployment={onTestDeployment}
+      />
+    </TooltipProvider>,
+  );
+
+  return { setOpen, onChooseNew, onUpdateComplete, onTestDeployment };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDeploymentsData = undefined;
+  mockIsLoadingDeployments = false;
+  mockPatchSnapshot.mockResolvedValue({
+    flow_version_id: "v-new",
+    provider_snapshot_id: "snap-1",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — closed state
+// ---------------------------------------------------------------------------
+
+describe("DeployChoiceDialog — closed state", () => {
+  it("does not render dialog content when open is false", () => {
+    renderDialog({ open: false });
+
+    expect(screen.queryByText("Select Provider")).not.toBeInTheDocument();
+    expect(screen.queryByText("Select Deployment")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — provider phase
+// ---------------------------------------------------------------------------
+
+describe("DeployChoiceDialog — provider phase", () => {
+  it("shows provider phase title when 2+ providers given", () => {
+    renderDialog({
+      providers: [makeProvider("p1"), makeProvider("p2", "WxO Dev")],
+    });
+
+    expect(screen.getByText("Select Provider")).toBeInTheDocument();
+  });
+
+  it("renders all provider names", () => {
+    renderDialog({
+      providers: [
+        makeProvider("p1", "WxO Prod"),
+        makeProvider("p2", "WxO Dev"),
+      ],
+    });
+
+    expect(screen.getByText("WxO Prod")).toBeInTheDocument();
+    expect(screen.getByText("WxO Dev")).toBeInTheDocument();
+  });
+
+  it("Cancel button calls setOpen(false)", async () => {
+    const user = userEvent.setup();
+    const { setOpen } = renderDialog({
+      providers: [makeProvider("p1"), makeProvider("p2", "WxO Dev")],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("Continue button advances to deployments phase", async () => {
+    const user = userEvent.setup();
+    renderDialog({
+      providers: [makeProvider("p1"), makeProvider("p2", "WxO Dev")],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(screen.getByText("Select Deployment")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — deployments phase
+// ---------------------------------------------------------------------------
+
+describe("DeployChoiceDialog — deployments phase", () => {
+  it("skips provider phase when exactly 1 provider", () => {
+    renderDialog({ providers: [makeProvider()] });
+
+    expect(screen.getByText("Select Deployment")).toBeInTheDocument();
+    expect(screen.queryByText("Select Provider")).not.toBeInTheDocument();
+  });
+
+  it("always shows Create new deployment option", () => {
+    renderDialog({ providers: [makeProvider()] });
+
+    expect(screen.getByText("Create new deployment")).toBeInTheDocument();
+  });
+
+  it("shows existing deployment names from API data", () => {
+    mockDeploymentsData = { deployments: [makeDeployment("d1", "Sales Bot")] };
+    renderDialog({ providers: [makeProvider()] });
+
+    expect(screen.getByText("Sales Bot")).toBeInTheDocument();
+  });
+
+  it("shows loading spinner when isLoadingDeployments is true", () => {
+    mockIsLoadingDeployments = true;
+    mockDeploymentsData = undefined;
+    renderDialog({ providers: [makeProvider()] });
+
+    // RadioGroup hidden, spinner shown — no deployment labels
+    expect(screen.queryByText("Create new deployment")).not.toBeInTheDocument();
+  });
+
+  it("hides Back button when only 1 provider", () => {
+    renderDialog({ providers: [makeProvider()] });
+
+    expect(
+      screen.queryByRole("button", { name: "Back" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Back button in deployments phase when 2+ providers", async () => {
+    const user = userEvent.setup();
+    renderDialog({
+      providers: [makeProvider("p1"), makeProvider("p2", "WxO Dev")],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+  });
+
+  it("Back from deployments returns to provider phase", async () => {
+    const user = userEvent.setup();
+    renderDialog({
+      providers: [makeProvider("p1"), makeProvider("p2", "WxO Dev")],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    expect(screen.getByText("Select Deployment")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.getByText("Select Provider")).toBeInTheDocument();
+  });
+
+  it("calls onChooseNew with provider preselection for known provider key", async () => {
+    const user = userEvent.setup();
+    mockDeploymentsData = { deployments: [] };
+    const { onChooseNew } = renderDialog({ providers: [makeProvider("p1")] });
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(onChooseNew).toHaveBeenCalledWith({
+      provider: {
+        id: "watsonx",
+        type: "watsonx",
+        name: "watsonx Orchestrate",
+        icon: "Bot",
+      },
+      instance: makeProvider("p1"),
+    });
+  });
+
+  it("calls onChooseNew with undefined when provider key has no mapping", async () => {
+    const user = userEvent.setup();
+    mockDeploymentsData = { deployments: [] };
+    const { onChooseNew } = renderDialog({
+      providers: [makeProvider("p1", "Unknown", "some-unknown-provider")],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(onChooseNew).toHaveBeenCalledWith(undefined);
+  });
+
+  it("auto-selects the single existing attachment", async () => {
+    const user = userEvent.setup();
+    mockDeploymentsData = { deployments: [makeDeployment()] };
+    renderDialog({ providers: [makeProvider()] });
+
+    // Clicking Continue should go to review (not call onChooseNew) because
+    // the single attachment was auto-selected instead of __new__
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(screen.getByText("Review Update")).toBeInTheDocument();
+  });
+
+  it("advances to review phase when existing attachment selected and continued", async () => {
+    const user = userEvent.setup();
+    mockDeploymentsData = {
+      deployments: [makeDeployment("dep-1", "My Bot", "snap-1")],
+    };
+    renderDialog({ providers: [makeProvider()] });
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(screen.getByText("Review Update")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — review phase
+// ---------------------------------------------------------------------------
+
+describe("DeployChoiceDialog — review phase", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+  let callbacks: ReturnType<typeof renderDialog>;
+
+  beforeEach(async () => {
+    mockDeploymentsData = {
+      deployments: [makeDeployment("dep-1", "My Bot", "snap-1", "v-1")],
+    };
+    user = userEvent.setup();
+    callbacks = renderDialog({
+      providers: [makeProvider("p1")],
+      snapshotVersionId: "snap-new",
+      snapshotVersionTag: "v2.0",
+    });
+    // Single attachment auto-selected; Continue goes straight to review
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+  });
+
+  it("shows Review Update title", () => {
+    expect(screen.getByText("Review Update")).toBeInTheDocument();
+  });
+
+  it("shows deployment name", () => {
+    expect(screen.getByText("My Bot")).toBeInTheDocument();
+  });
+
+  it("shows current version tag from API", () => {
+    expect(screen.getByText("v1.0")).toBeInTheDocument();
+  });
+
+  it("shows new version tag from props", () => {
+    expect(screen.getByText("v2.0")).toBeInTheDocument();
+  });
+
+  it("Back button returns to deployments phase", async () => {
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.getByText("Select Deployment")).toBeInTheDocument();
+  });
+
+  it("Cancel button calls setOpen(false)", async () => {
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(callbacks.setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("Update button calls patchSnapshot with correct args", async () => {
+    await user.click(screen.getByRole("button", { name: "Update" }));
+
+    expect(mockPatchSnapshot).toHaveBeenCalledWith({
+      providerSnapshotId: "snap-1",
+      flowVersionId: "snap-new",
+    });
+  });
+
+  it("shows deploying state immediately after clicking Update", async () => {
+    let resolve!: (v: unknown) => void;
+    mockPatchSnapshot.mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolve = r;
+        }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Update" }));
+
+    expect(screen.getByTestId("step-deploy-status")).toHaveTextContent(
+      "deploying",
+    );
+    resolve({});
+  });
+
+  it("shows deployed state after patchSnapshot resolves", async () => {
+    await user.click(screen.getByRole("button", { name: "Update" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("step-deploy-status")).toHaveTextContent(
+        "deployed",
+      ),
+    );
+  });
+
+  it("calls showError and returns to review when patchSnapshot fails", async () => {
+    mockPatchSnapshot.mockRejectedValue(new Error("Network error"));
+
+    await user.click(screen.getByRole("button", { name: "Update" }));
+
+    await waitFor(() =>
+      expect(mockShowError).toHaveBeenCalledWith(
+        "Failed to update deployment",
+        expect.any(Error),
+      ),
+    );
+    expect(screen.getByText("Review Update")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — update phase
+// ---------------------------------------------------------------------------
+
+describe("DeployChoiceDialog — update phase", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+  let callbacks: ReturnType<typeof renderDialog>;
+
+  beforeEach(async () => {
+    mockDeploymentsData = {
+      deployments: [makeDeployment("dep-1", "My Bot", "snap-1")],
+    };
+    mockPatchSnapshot.mockResolvedValue({});
+    user = userEvent.setup();
+    callbacks = renderDialog({ providers: [makeProvider("p1")] });
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await user.click(screen.getByRole("button", { name: "Update" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("step-deploy-status")).toHaveTextContent(
+        "deployed",
+      ),
+    );
+  });
+
+  it("shows Close button after update completes", () => {
+    // getAllByRole because Radix Dialog's X button also has accessible name "Close"
+    const closeButtons = screen.getAllByRole("button", { name: "Close" });
+    // Our custom Close button (no SVG icon) is the first one in DOM order
+    const customClose = closeButtons.find((btn) => !btn.querySelector("svg"));
+    expect(customClose).toBeInTheDocument();
+  });
+
+  it("Close button calls onUpdateComplete with deployment name", async () => {
+    const closeButtons = screen.getAllByRole("button", { name: "Close" });
+    const customClose = closeButtons.find((btn) => !btn.querySelector("svg"))!;
+    await user.click(customClose);
+
+    expect(callbacks.onUpdateComplete).toHaveBeenCalledWith("My Bot");
+  });
+
+  it("shows Test button when onTestDeployment is provided", () => {
+    expect(screen.getByRole("button", { name: "Test" })).toBeInTheDocument();
+  });
+
+  it("Test button calls onTestDeployment with deployment id and provider id", async () => {
+    await user.click(screen.getByRole("button", { name: "Test" }));
+
+    expect(callbacks.onTestDeployment).toHaveBeenCalledWith(
+      { id: "dep-1", name: "My Bot" },
+      "p1",
+    );
+  });
+});

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/__tests__/index.test.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/__tests__/index.test.tsx
@@ -15,14 +15,21 @@ let mockIsLoadingDeployments = false;
 const mockPatchSnapshot = jest.fn();
 const mockShowError = jest.fn();
 
+// Simulate react-query caching: data is undefined until the first enabled
+// fetch, then persists even when the query is later disabled.
+let _deploymentsCache: typeof mockDeploymentsData = undefined;
+
 jest.mock("@/controllers/API/queries/deployments/use-get-deployments", () => ({
-  useGetDeployments: (_params: unknown, options?: { enabled?: boolean }) => ({
-    // Mirror react-query's enabled behaviour: when disabled, data is undefined
-    // so deploymentsData changes reference when the phase flips to "deployments",
-    // which triggers the attachments useMemo and the auto-select useEffect.
-    data: options?.enabled === false ? undefined : mockDeploymentsData,
-    isLoading: options?.enabled === false ? false : mockIsLoadingDeployments,
-  }),
+  useGetDeployments: (_params: unknown, options?: { enabled?: boolean }) => {
+    if (options?.enabled !== false && mockDeploymentsData !== undefined) {
+      _deploymentsCache = mockDeploymentsData;
+    }
+    return {
+      data:
+        options?.enabled === false ? _deploymentsCache : mockDeploymentsData,
+      isLoading: options?.enabled === false ? false : mockIsLoadingDeployments,
+    };
+  },
 }));
 
 jest.mock("@/controllers/API/queries/deployments", () => ({
@@ -35,6 +42,26 @@ jest.mock(
   "@/pages/MainPage/pages/deploymentsPage/hooks/use-error-alert",
   () => ({
     useErrorAlert: () => mockShowError,
+  }),
+);
+
+// biome-ignore lint/suspicious/noExplicitAny: test mock
+let mockAttachmentsData: Record<string, any> | undefined = undefined;
+let mockIsLoadingAttachments = false;
+let mockIsFetchingAttachments = false;
+
+jest.mock(
+  "@/controllers/API/queries/deployments/use-get-deployment-attachments",
+  () => ({
+    useGetDeploymentAttachments: (
+      _params: unknown,
+      options?: { enabled?: boolean },
+    ) => ({
+      data: options?.enabled === false ? undefined : mockAttachmentsData,
+      isLoading: options?.enabled === false ? false : mockIsLoadingAttachments,
+      isFetching:
+        options?.enabled === false ? false : mockIsFetchingAttachments,
+    }),
   }),
 );
 
@@ -145,6 +172,10 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockDeploymentsData = undefined;
   mockIsLoadingDeployments = false;
+  _deploymentsCache = undefined;
+  mockAttachmentsData = undefined;
+  mockIsLoadingAttachments = false;
+  mockIsFetchingAttachments = false;
   mockPatchSnapshot.mockResolvedValue({
     flow_version_id: "v-new",
     provider_snapshot_id: "snap-1",
@@ -312,13 +343,32 @@ describe("DeployChoiceDialog — deployments phase", () => {
   it("auto-selects the single existing attachment", async () => {
     const user = userEvent.setup();
     mockDeploymentsData = { deployments: [makeDeployment()] };
+    mockAttachmentsData = {
+      flow_versions: [
+        {
+          id: "v-1",
+          flow_id: "flow-1",
+          flow_name: "My Flow",
+          version_number: 1,
+          attached_at: "2025-01-01",
+          provider_snapshot_id: "snap-1",
+          tool_name: null,
+          provider_data: null,
+        },
+      ],
+      page: 1,
+      size: 50,
+      total: 1,
+    };
     renderDialog({ providers: [makeProvider()] });
 
     // Clicking Continue should go to review (not call onChooseNew) because
     // the single attachment was auto-selected instead of __new__
     await user.click(screen.getByRole("button", { name: "Continue" }));
 
-    expect(screen.getByText("Review Update")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("Review Update")).toBeInTheDocument(),
+    );
   });
 
   it("advances to review phase when existing attachment selected and continued", async () => {
@@ -326,11 +376,30 @@ describe("DeployChoiceDialog — deployments phase", () => {
     mockDeploymentsData = {
       deployments: [makeDeployment("dep-1", "My Bot", "snap-1")],
     };
+    mockAttachmentsData = {
+      flow_versions: [
+        {
+          id: "v-1",
+          flow_id: "flow-1",
+          flow_name: "My Flow",
+          version_number: 1,
+          attached_at: "2025-01-01",
+          provider_snapshot_id: "snap-1",
+          tool_name: null,
+          provider_data: null,
+        },
+      ],
+      page: 1,
+      size: 50,
+      total: 1,
+    };
     renderDialog({ providers: [makeProvider()] });
 
     await user.click(screen.getByRole("button", { name: "Continue" }));
 
-    expect(screen.getByText("Review Update")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("Review Update")).toBeInTheDocument(),
+    );
   });
 });
 
@@ -346,6 +415,23 @@ describe("DeployChoiceDialog — review phase", () => {
     mockDeploymentsData = {
       deployments: [makeDeployment("dep-1", "My Bot", "snap-1", "v-1")],
     };
+    mockAttachmentsData = {
+      flow_versions: [
+        {
+          id: "v-1",
+          flow_id: "flow-1",
+          flow_name: "My Flow",
+          version_number: 1,
+          attached_at: "2025-01-01",
+          provider_snapshot_id: "snap-1",
+          tool_name: null,
+          provider_data: null,
+        },
+      ],
+      page: 1,
+      size: 50,
+      total: 1,
+    };
     user = userEvent.setup();
     callbacks = renderDialog({
       providers: [makeProvider("p1")],
@@ -354,6 +440,9 @@ describe("DeployChoiceDialog — review phase", () => {
     });
     // Single attachment auto-selected; Continue goes straight to review
     await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() =>
+      expect(screen.getByText("Review Update")).toBeInTheDocument(),
+    );
   });
 
   it("shows Review Update title", () => {
@@ -447,11 +536,31 @@ describe("DeployChoiceDialog — update phase", () => {
     mockDeploymentsData = {
       deployments: [makeDeployment("dep-1", "My Bot", "snap-1")],
     };
+    mockAttachmentsData = {
+      flow_versions: [
+        {
+          id: "v-1",
+          flow_id: "flow-1",
+          flow_name: "My Flow",
+          version_number: 1,
+          attached_at: "2025-01-01",
+          provider_snapshot_id: "snap-1",
+          tool_name: null,
+          provider_data: null,
+        },
+      ],
+      page: 1,
+      size: 50,
+      total: 1,
+    };
     mockPatchSnapshot.mockResolvedValue({});
     user = userEvent.setup();
     callbacks = renderDialog({ providers: [makeProvider("p1")] });
 
     await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() =>
+      expect(screen.getByText("Review Update")).toBeInTheDocument(),
+    );
     await user.click(screen.getByRole("button", { name: "Update" }));
     await waitFor(() =>
       expect(screen.getByTestId("step-deploy-status")).toHaveTextContent(

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/hooks/__tests__/use-prepare-deploy.test.ts
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/hooks/__tests__/use-prepare-deploy.test.ts
@@ -91,7 +91,7 @@ beforeEach(() => {
   mockCurrentFlowId = "flow-1";
   mockSaveFlow.mockResolvedValue(undefined);
   mockCreateSnapshot.mockResolvedValue({ id: "snap-1", version_tag: "v1.0" });
-  mockFetchProviders.mockResolvedValue({ data: { providers: [] } });
+  mockFetchProviders.mockResolvedValue({ data: { provider_accounts: [] } });
 });
 
 // ---------------------------------------------------------------------------
@@ -247,7 +247,9 @@ describe("usePrepareDeploy — handleDeploy: no providers", () => {
 describe("usePrepareDeploy — handleDeploy: with providers", () => {
   it("opens choiceDialog and sets providers when accounts are returned", async () => {
     const providers = [makeProvider()];
-    mockFetchProviders.mockResolvedValue({ data: { providers } });
+    mockFetchProviders.mockResolvedValue({
+      data: { provider_accounts: providers },
+    });
     const { result } = renderHook(() => usePrepareDeploy());
 
     await act(async () => {
@@ -261,7 +263,7 @@ describe("usePrepareDeploy — handleDeploy: with providers", () => {
 
   it("does not open deployModal when providers are available", async () => {
     mockFetchProviders.mockResolvedValue({
-      data: { providers: [makeProvider()] },
+      data: { provider_accounts: [makeProvider()] },
     });
     const { result } = renderHook(() => usePrepareDeploy());
 
@@ -413,7 +415,7 @@ describe("usePrepareDeploy — handleUpdateComplete", () => {
 
   it("clears providers list", async () => {
     mockFetchProviders.mockResolvedValue({
-      data: { providers: [makeProvider()] },
+      data: { provider_accounts: [makeProvider()] },
     });
     const { result } = renderHook(() => usePrepareDeploy());
 
@@ -474,7 +476,7 @@ describe("usePrepareDeploy — resetChoiceState", () => {
 
   it("clears providers list", async () => {
     mockFetchProviders.mockResolvedValue({
-      data: { providers: [makeProvider()] },
+      data: { provider_accounts: [makeProvider()] },
     });
     const { result } = renderHook(() => usePrepareDeploy());
 

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/hooks/__tests__/use-prepare-deploy.test.ts
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-choice-dialog/hooks/__tests__/use-prepare-deploy.test.ts
@@ -1,0 +1,507 @@
+import { act, renderHook } from "@testing-library/react";
+import type {
+  DeploymentProvider,
+  ProviderAccount,
+} from "@/pages/MainPage/pages/deploymentsPage/types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockCurrentFlowId: string | undefined = "flow-1";
+
+jest.mock("@/stores/flowStore", () => ({
+  __esModule: true,
+  default: (selector: (state: { currentFlow?: { id: string } }) => unknown) =>
+    selector({
+      currentFlow: mockCurrentFlowId ? { id: mockCurrentFlowId } : undefined,
+    }),
+}));
+
+const mockSaveFlow = jest.fn();
+jest.mock("@/hooks/flows/use-save-flow", () => ({
+  __esModule: true,
+  default: () => mockSaveFlow,
+}));
+
+const mockCreateSnapshot = jest.fn();
+jest.mock(
+  "@/controllers/API/queries/flow-version/use-post-create-snapshot",
+  () => ({
+    usePostCreateSnapshot: () => ({
+      mutateAsync: mockCreateSnapshot,
+    }),
+  }),
+);
+
+const mockFetchProviders = jest.fn();
+jest.mock(
+  "@/controllers/API/queries/deployment-provider-accounts/use-get-provider-accounts",
+  () => ({
+    useGetProviderAccounts: () => ({
+      refetch: mockFetchProviders,
+    }),
+  }),
+);
+
+const mockShowError = jest.fn();
+jest.mock(
+  "@/pages/MainPage/pages/deploymentsPage/hooks/use-error-alert",
+  () => ({
+    useErrorAlert: () => mockShowError,
+  }),
+);
+
+const mockSetSuccessData = jest.fn();
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: (selector: (state: { setSuccessData: jest.Mock }) => unknown) =>
+    selector({ setSuccessData: mockSetSuccessData }),
+}));
+
+import { usePrepareDeploy } from "../use-prepare-deploy";
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+const makeProvider = (): ProviderAccount => ({
+  id: "p1",
+  name: "WxO Prod",
+  provider_tenant_id: null,
+  provider_key: "watsonx-orchestrate",
+  provider_url: "https://wxo.example.com",
+  created_at: null,
+  updated_at: null,
+});
+
+const makeDeploymentProvider = (): DeploymentProvider => ({
+  id: "watsonx",
+  type: "watsonx",
+  name: "watsonx Orchestrate",
+  icon: "Bot",
+});
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCurrentFlowId = "flow-1";
+  mockSaveFlow.mockResolvedValue(undefined);
+  mockCreateSnapshot.mockResolvedValue({ id: "snap-1", version_tag: "v1.0" });
+  mockFetchProviders.mockResolvedValue({ data: { providers: [] } });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("usePrepareDeploy — initial state", () => {
+  it("exposes currentFlowId from flowStore", () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    expect(result.current.currentFlowId).toBe("flow-1");
+  });
+
+  it("exposes undefined currentFlowId when flow store has no flow", () => {
+    mockCurrentFlowId = undefined;
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    expect(result.current.currentFlowId).toBeUndefined();
+  });
+
+  it("starts with isPreparingDeploy false", () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    expect(result.current.isPreparingDeploy).toBe(false);
+  });
+
+  it("starts with choiceDialogOpen false", () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    expect(result.current.choiceDialogOpen).toBe(false);
+  });
+
+  it("starts with deployModalOpen false", () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    expect(result.current.deployModalOpen).toBe(false);
+  });
+
+  it("starts with empty providers list", () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    expect(result.current.providers).toHaveLength(0);
+  });
+});
+
+describe("usePrepareDeploy — handleDeploy: no flow", () => {
+  it("bails early without calling saveFlow when currentFlowId is undefined", async () => {
+    mockCurrentFlowId = undefined;
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(mockSaveFlow).not.toHaveBeenCalled();
+    expect(mockCreateSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("does not open any modal when currentFlowId is undefined", async () => {
+    mockCurrentFlowId = undefined;
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(result.current.choiceDialogOpen).toBe(false);
+    expect(result.current.deployModalOpen).toBe(false);
+  });
+});
+
+describe("usePrepareDeploy — handleDeploy: no providers", () => {
+  it("calls saveFlow before creating snapshot", async () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(mockSaveFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls createSnapshot with the current flowId", async () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(mockCreateSnapshot).toHaveBeenCalledWith({ flowId: "flow-1" });
+  });
+
+  it("calls fetchProviderAccounts after snapshot is created", async () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(mockFetchProviders).toHaveBeenCalledTimes(1);
+  });
+
+  it("stores snapshot id from createSnapshot result", async () => {
+    mockCreateSnapshot.mockResolvedValue({ id: "snap-abc", version_tag: "v2" });
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(result.current.pendingSnapshotVersionId).toBe("snap-abc");
+  });
+
+  it("builds initialVersionByFlow mapping current flow to snapshot", async () => {
+    mockCreateSnapshot.mockResolvedValue({
+      id: "snap-xyz",
+      version_tag: "v3.0",
+    });
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(result.current.initialVersionByFlow.get("flow-1")).toEqual({
+      versionId: "snap-xyz",
+      versionTag: "v3.0",
+    });
+  });
+
+  it("opens deployModal when providers list is empty", async () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(result.current.deployModalOpen).toBe(true);
+    expect(result.current.choiceDialogOpen).toBe(false);
+  });
+
+  it("resets isPreparingDeploy to false after completion", async () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(result.current.isPreparingDeploy).toBe(false);
+  });
+});
+
+describe("usePrepareDeploy — handleDeploy: with providers", () => {
+  it("opens choiceDialog and sets providers when accounts are returned", async () => {
+    const providers = [makeProvider()];
+    mockFetchProviders.mockResolvedValue({ data: { providers } });
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(result.current.choiceDialogOpen).toBe(true);
+    expect(result.current.deployModalOpen).toBe(false);
+    expect(result.current.providers).toEqual(providers);
+  });
+
+  it("does not open deployModal when providers are available", async () => {
+    mockFetchProviders.mockResolvedValue({
+      data: { providers: [makeProvider()] },
+    });
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(result.current.deployModalOpen).toBe(false);
+  });
+});
+
+describe("usePrepareDeploy — handleDeploy: error handling", () => {
+  it("calls showError when saveFlow throws", async () => {
+    mockSaveFlow.mockRejectedValue(new Error("save failed"));
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(mockShowError).toHaveBeenCalledWith(
+      "Failed to prepare deployment",
+      expect.any(Error),
+    );
+  });
+
+  it("calls showError when createSnapshot throws", async () => {
+    mockCreateSnapshot.mockRejectedValue(new Error("snapshot failed"));
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(mockShowError).toHaveBeenCalledWith(
+      "Failed to prepare deployment",
+      expect.any(Error),
+    );
+  });
+
+  it("clears pendingSnapshotVersionId on error", async () => {
+    mockCreateSnapshot.mockRejectedValue(new Error("fail"));
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(result.current.pendingSnapshotVersionId).toBe("");
+  });
+
+  it("resets isPreparingDeploy to false on error", async () => {
+    mockSaveFlow.mockRejectedValue(new Error("fail"));
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(result.current.isPreparingDeploy).toBe(false);
+  });
+
+  it("does not open any modal on error", async () => {
+    mockSaveFlow.mockRejectedValue(new Error("fail"));
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+
+    expect(result.current.choiceDialogOpen).toBe(false);
+    expect(result.current.deployModalOpen).toBe(false);
+  });
+});
+
+describe("usePrepareDeploy — handleChooseNew", () => {
+  it("closes choiceDialog", () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    act(() => {
+      result.current.setChoiceDialogOpen(true);
+    });
+
+    act(() => {
+      result.current.handleChooseNew();
+    });
+
+    expect(result.current.choiceDialogOpen).toBe(false);
+  });
+
+  it("opens deployModal", () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    act(() => {
+      result.current.handleChooseNew();
+    });
+
+    expect(result.current.deployModalOpen).toBe(true);
+  });
+
+  it("sets stepperInitialProvider and stepperInitialInstance from preselected", () => {
+    const provider = makeDeploymentProvider();
+    const instance = makeProvider();
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    act(() => {
+      result.current.handleChooseNew({ provider, instance });
+    });
+
+    expect(result.current.stepperInitialProvider).toEqual(provider);
+    expect(result.current.stepperInitialInstance).toEqual(instance);
+  });
+
+  it("sets stepperInitialProvider to undefined when no preselected given", () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    // First call with a value
+    act(() => {
+      result.current.handleChooseNew({
+        provider: makeDeploymentProvider(),
+        instance: makeProvider(),
+      });
+    });
+
+    // Second call without preselected clears them
+    act(() => {
+      result.current.handleChooseNew(undefined);
+    });
+
+    expect(result.current.stepperInitialProvider).toBeUndefined();
+    expect(result.current.stepperInitialInstance).toBeUndefined();
+  });
+});
+
+describe("usePrepareDeploy — handleUpdateComplete", () => {
+  it("closes choiceDialog", () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    act(() => {
+      result.current.setChoiceDialogOpen(true);
+    });
+
+    act(() => {
+      result.current.handleUpdateComplete("My Deployment");
+    });
+
+    expect(result.current.choiceDialogOpen).toBe(false);
+  });
+
+  it("clears providers list", async () => {
+    mockFetchProviders.mockResolvedValue({
+      data: { providers: [makeProvider()] },
+    });
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+    expect(result.current.providers).toHaveLength(1);
+
+    act(() => {
+      result.current.handleUpdateComplete("My Deployment");
+    });
+
+    expect(result.current.providers).toHaveLength(0);
+  });
+
+  it("clears pendingSnapshotVersionId", async () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+    expect(result.current.pendingSnapshotVersionId).toBe("snap-1");
+
+    act(() => {
+      result.current.handleUpdateComplete("My Deployment");
+    });
+
+    expect(result.current.pendingSnapshotVersionId).toBe("");
+  });
+
+  it("shows success notification with the deployment name", () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    act(() => {
+      result.current.handleUpdateComplete("Sales Bot");
+    });
+
+    expect(mockSetSuccessData).toHaveBeenCalledWith({
+      title: 'Deployment "Sales Bot" updated successfully',
+    });
+  });
+});
+
+describe("usePrepareDeploy — resetChoiceState", () => {
+  it("closes choiceDialog", () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    act(() => {
+      result.current.setChoiceDialogOpen(true);
+    });
+
+    act(() => {
+      result.current.resetChoiceState();
+    });
+
+    expect(result.current.choiceDialogOpen).toBe(false);
+  });
+
+  it("clears providers list", async () => {
+    mockFetchProviders.mockResolvedValue({
+      data: { providers: [makeProvider()] },
+    });
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+    expect(result.current.providers).toHaveLength(1);
+
+    act(() => {
+      result.current.resetChoiceState();
+    });
+
+    expect(result.current.providers).toHaveLength(0);
+  });
+
+  it("clears pendingSnapshotVersionId", async () => {
+    const { result } = renderHook(() => usePrepareDeploy());
+
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+    expect(result.current.pendingSnapshotVersionId).toBe("snap-1");
+
+    act(() => {
+      result.current.resetChoiceState();
+    });
+
+    expect(result.current.pendingSnapshotVersionId).toBe("");
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployment-provider-accounts/__tests__/use-delete-provider-account.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployment-provider-accounts/__tests__/use-delete-provider-account.test.ts
@@ -1,0 +1,67 @@
+const mockApiDelete = jest.fn();
+const mockQueryClient = {
+  refetchQueries: jest.fn(),
+  invalidateQueries: jest.fn(),
+};
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { delete: mockApiDelete },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments/providers"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mutate: jest.fn((_key: any, fn: any, options: any) => ({
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      mutate: async (payload: any) => {
+        const result = await fn(payload);
+        options?.onSuccess?.(result, payload, undefined);
+        options?.onSettled?.(result);
+        return result;
+      },
+    })),
+    queryClient: mockQueryClient,
+  })),
+}));
+
+import { useDeleteProviderAccount } from "../use-delete-provider-account";
+
+describe("useDeleteProviderAccount", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls DELETE with provider_id in URL", async () => {
+    mockApiDelete.mockResolvedValue({});
+
+    const mutation = useDeleteProviderAccount();
+    await mutation.mutate({ provider_id: "prov-1" });
+
+    expect(mockApiDelete).toHaveBeenCalledWith(
+      "/api/v1/deployments/providers/prov-1",
+    );
+  });
+
+  it("refetches useGetProviderAccounts on success", async () => {
+    mockApiDelete.mockResolvedValue({});
+
+    const mutation = useDeleteProviderAccount();
+    await mutation.mutate({ provider_id: "prov-1" });
+
+    expect(mockQueryClient.refetchQueries).toHaveBeenCalledWith({
+      queryKey: ["useGetProviderAccounts"],
+    });
+  });
+
+  it("forwards caller onSuccess callback", async () => {
+    mockApiDelete.mockResolvedValue({});
+
+    const callerOnSuccess = jest.fn();
+    const mutation = useDeleteProviderAccount({ onSuccess: callerOnSuccess });
+    await mutation.mutate({ provider_id: "prov-1" });
+
+    expect(callerOnSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployment-provider-accounts/__tests__/use-get-provider-accounts.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployment-provider-accounts/__tests__/use-get-provider-accounts.test.ts
@@ -36,7 +36,7 @@ describe("useGetProviderAccounts", () => {
 
   it("calls API with default pagination", async () => {
     mockApiGet.mockResolvedValue({
-      data: { providers: [], page: 1, size: 20, total: 0 },
+      data: { provider_accounts: [], page: 1, size: 20, total: 0 },
     });
 
     useGetProviderAccounts({});
@@ -49,7 +49,7 @@ describe("useGetProviderAccounts", () => {
 
   it("calls API with custom pagination", async () => {
     mockApiGet.mockResolvedValue({
-      data: { providers: [], page: 2, size: 10, total: 15 },
+      data: { provider_accounts: [], page: 2, size: 10, total: 15 },
     });
 
     useGetProviderAccounts({ page: 2, size: 10 });
@@ -74,7 +74,7 @@ describe("useGetProviderAccounts", () => {
 
   it("returns provider accounts from response", async () => {
     const responseData = {
-      providers: [
+      provider_accounts: [
         {
           id: "prov-1",
           name: "My WxO",
@@ -97,7 +97,9 @@ describe("useGetProviderAccounts", () => {
     expect(result.data).toBeDefined();
     if (!result.data) return;
     expect(result.data).toEqual(responseData);
-    expect(result.data.providers).toHaveLength(1);
-    expect(result.data.providers[0].provider_key).toBe("watsonx_orchestrate");
+    expect(result.data.provider_accounts).toHaveLength(1);
+    expect(result.data.provider_accounts[0].provider_key).toBe(
+      "watsonx_orchestrate",
+    );
   });
 });

--- a/src/frontend/src/controllers/API/queries/deployment-provider-accounts/__tests__/use-get-provider-accounts.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployment-provider-accounts/__tests__/use-get-provider-accounts.test.ts
@@ -1,0 +1,103 @@
+const mockApiGet = jest.fn();
+const mockQuery = jest.fn(
+  (_key: unknown, fn: () => Promise<unknown>, _options?: unknown) => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const result: { data: any; isLoading: boolean; error: unknown } = {
+      data: null,
+      isLoading: false,
+      error: null,
+    };
+    void fn().then((data) => {
+      result.data = data;
+    });
+    return result;
+  },
+);
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { get: mockApiGet },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments/providers"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({ query: mockQuery })),
+}));
+
+import { useGetProviderAccounts } from "../use-get-provider-accounts";
+
+const flushPromises = () =>
+  new Promise((r) => jest.requireActual("timers").setImmediate(r));
+
+describe("useGetProviderAccounts", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls API with default pagination", async () => {
+    mockApiGet.mockResolvedValue({
+      data: { providers: [], page: 1, size: 20, total: 0 },
+    });
+
+    useGetProviderAccounts({});
+    await flushPromises();
+
+    expect(mockApiGet).toHaveBeenCalledWith("/api/v1/deployments/providers", {
+      params: { page: 1, size: 20 },
+    });
+  });
+
+  it("calls API with custom pagination", async () => {
+    mockApiGet.mockResolvedValue({
+      data: { providers: [], page: 2, size: 10, total: 15 },
+    });
+
+    useGetProviderAccounts({ page: 2, size: 10 });
+    await flushPromises();
+
+    expect(mockApiGet).toHaveBeenCalledWith("/api/v1/deployments/providers", {
+      params: { page: 2, size: 10 },
+    });
+  });
+
+  it("uses correct query key", () => {
+    mockApiGet.mockResolvedValue({ data: { providers: [] } });
+
+    useGetProviderAccounts({ page: 1, size: 20 });
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      ["useGetProviderAccounts", { page: 1, size: 20 }],
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it("returns provider accounts from response", async () => {
+    const responseData = {
+      providers: [
+        {
+          id: "prov-1",
+          name: "My WxO",
+          provider_tenant_id: "tenant-1",
+          provider_key: "watsonx_orchestrate",
+          provider_url: "https://api.wxo.ibm.com",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: null,
+        },
+      ],
+      page: 1,
+      size: 20,
+      total: 1,
+    };
+    mockApiGet.mockResolvedValue({ data: responseData });
+
+    const result = useGetProviderAccounts({});
+    await flushPromises();
+
+    expect(result.data).toBeDefined();
+    if (!result.data) return;
+    expect(result.data).toEqual(responseData);
+    expect(result.data.providers).toHaveLength(1);
+    expect(result.data.providers[0].provider_key).toBe("watsonx_orchestrate");
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployment-provider-accounts/__tests__/use-post-provider-account.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployment-provider-accounts/__tests__/use-post-provider-account.test.ts
@@ -1,0 +1,96 @@
+const mockApiPost = jest.fn();
+const mockQueryClient = {
+  refetchQueries: jest.fn(),
+  invalidateQueries: jest.fn(),
+};
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { post: mockApiPost },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments/providers"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mutate: jest.fn((_key: any, fn: any, options: any) => ({
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      mutate: async (payload: any) => {
+        const result = await fn(payload);
+        options?.onSuccess?.(result);
+        options?.onSettled?.(result);
+        return result;
+      },
+    })),
+    queryClient: mockQueryClient,
+  })),
+}));
+
+import type { ProviderAccountCreateRequest } from "../use-post-provider-account";
+import { usePostProviderAccount } from "../use-post-provider-account";
+
+describe("usePostProviderAccount", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const validPayload: ProviderAccountCreateRequest = {
+    name: "My WxO Environment",
+    provider_key: "watsonx_orchestrate",
+    provider_url: "https://api.wxo.ibm.com",
+    provider_data: { api_key: "secret-key" }, // pragma: allowlist secret
+  };
+
+  it("posts to providers endpoint with full payload", async () => {
+    mockApiPost.mockResolvedValue({
+      data: { id: "prov-1", name: "My WxO Environment" },
+    });
+
+    const mutation = usePostProviderAccount();
+    await mutation.mutate(validPayload);
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/v1/deployments/providers",
+      validPayload,
+    );
+  });
+
+  it("sends api_key inside provider_data", async () => {
+    mockApiPost.mockResolvedValue({ data: { id: "prov-1" } });
+
+    const mutation = usePostProviderAccount();
+    await mutation.mutate(validPayload);
+
+    const sentPayload = mockApiPost.mock.calls[0][1];
+    expect(sentPayload.provider_data.api_key).toBe("secret-key");
+  });
+
+  it("refetches useGetProviderAccounts on success", async () => {
+    mockApiPost.mockResolvedValue({ data: { id: "prov-1" } });
+
+    const mutation = usePostProviderAccount();
+    await mutation.mutate(validPayload);
+
+    expect(mockQueryClient.refetchQueries).toHaveBeenCalledWith({
+      queryKey: ["useGetProviderAccounts"],
+    });
+  });
+
+  it("returns created provider account", async () => {
+    const created = {
+      id: "prov-1",
+      name: "My WxO Environment",
+      provider_key: "watsonx_orchestrate",
+      provider_url: "https://api.wxo.ibm.com",
+      provider_tenant_id: "tenant-1",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: null,
+    };
+    mockApiPost.mockResolvedValue({ data: created });
+
+    const mutation = usePostProviderAccount();
+    const result = await mutation.mutate(validPayload);
+
+    expect(result).toEqual(created);
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployment-provider-accounts/use-get-provider-accounts.ts
+++ b/src/frontend/src/controllers/API/queries/deployment-provider-accounts/use-get-provider-accounts.ts
@@ -5,7 +5,7 @@ import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
 
 export interface ProviderAccountListResponse {
-  providers: ProviderAccount[];
+  provider_accounts: ProviderAccount[];
   page: number;
   size: number;
   total: number;

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-delete-deployment.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-delete-deployment.test.ts
@@ -1,0 +1,65 @@
+const mockApiDelete = jest.fn();
+const mockQueryClient = {
+  refetchQueries: jest.fn(),
+  invalidateQueries: jest.fn(),
+};
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { delete: mockApiDelete },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mutate: jest.fn((_key: any, fn: any, options: any) => ({
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      mutate: async (payload: any) => {
+        const result = await fn(payload);
+        options?.onSuccess?.(result, payload, undefined);
+        options?.onSettled?.(result);
+        return result;
+      },
+    })),
+    queryClient: mockQueryClient,
+  })),
+}));
+
+import { useDeleteDeployment } from "../use-delete-deployment";
+
+describe("useDeleteDeployment", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls DELETE with deployment_id in URL", async () => {
+    mockApiDelete.mockResolvedValue({});
+
+    const mutation = useDeleteDeployment();
+    await mutation.mutate({ deployment_id: "dep-1" });
+
+    expect(mockApiDelete).toHaveBeenCalledWith("/api/v1/deployments/dep-1");
+  });
+
+  it("refetches useGetDeployments on success", async () => {
+    mockApiDelete.mockResolvedValue({});
+
+    const mutation = useDeleteDeployment();
+    await mutation.mutate({ deployment_id: "dep-1" });
+
+    expect(mockQueryClient.refetchQueries).toHaveBeenCalledWith({
+      queryKey: ["useGetDeployments"],
+    });
+  });
+
+  it("forwards caller onSuccess callback", async () => {
+    mockApiDelete.mockResolvedValue({});
+
+    const callerOnSuccess = jest.fn();
+    const mutation = useDeleteDeployment({ onSuccess: callerOnSuccess });
+    await mutation.mutate({ deployment_id: "dep-1" });
+
+    expect(callerOnSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-attachments.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-attachments.test.ts
@@ -1,0 +1,103 @@
+const mockApiGet = jest.fn();
+const mockQuery = jest.fn(
+  (_key: unknown, fn: () => Promise<unknown>, _options?: unknown) => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const result: { data: any; isLoading: boolean; error: unknown } = {
+      data: null,
+      isLoading: false,
+      error: null,
+    };
+    void fn().then((data) => {
+      result.data = data;
+    });
+    return result;
+  },
+);
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { get: mockApiGet },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({ query: mockQuery })),
+}));
+
+import { useGetDeploymentAttachments } from "../use-get-deployment-attachments";
+
+const flushPromises = () =>
+  new Promise((r) => jest.requireActual("timers").setImmediate(r));
+
+describe("useGetDeploymentAttachments", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls API with deployment ID and size=50", async () => {
+    mockApiGet.mockResolvedValue({
+      data: { flow_versions: [], page: 1, size: 50, total: 0 },
+    });
+
+    useGetDeploymentAttachments({ deploymentId: "dep-1" });
+    await flushPromises();
+
+    expect(mockApiGet).toHaveBeenCalledWith("/api/v1/deployments/dep-1/flows", {
+      params: { size: 50 },
+    });
+  });
+
+  it("uses correct query key", () => {
+    mockApiGet.mockResolvedValue({ data: { flow_versions: [] } });
+
+    useGetDeploymentAttachments({ deploymentId: "dep-1" });
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      ["useGetDeploymentAttachments", { deploymentId: "dep-1" }],
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it("returns flow versions with provider_snapshot_id and tool_name", async () => {
+    const responseData = {
+      flow_versions: [
+        {
+          id: "fv-1",
+          flow_id: "f-1",
+          flow_name: "My Flow",
+          version_number: 1,
+          attached_at: "2026-01-01T00:00:00Z",
+          provider_snapshot_id: "tool-abc",
+          tool_name: "my_flow_tool",
+          provider_data: { app_ids: ["app-1"] },
+        },
+        {
+          id: "fv-2",
+          flow_id: "f-2",
+          flow_name: "Other Flow",
+          version_number: 3,
+          attached_at: "2026-01-02T00:00:00Z",
+          provider_snapshot_id: "tool-xyz",
+          tool_name: null,
+          provider_data: null,
+        },
+      ],
+      page: 1,
+      size: 50,
+      total: 2,
+    };
+    mockApiGet.mockResolvedValue({ data: responseData });
+
+    const result = useGetDeploymentAttachments({ deploymentId: "dep-1" });
+    await flushPromises();
+
+    expect(result.data).toBeDefined();
+    if (!result.data) return;
+    expect(result.data).toEqual(responseData);
+    expect(result.data.flow_versions).toHaveLength(2);
+    expect(result.data.flow_versions[0].provider_snapshot_id).toBe("tool-abc");
+    expect(result.data.flow_versions[0].tool_name).toBe("my_flow_tool");
+    expect(result.data.flow_versions[1].tool_name).toBeNull();
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-configs.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-configs.test.ts
@@ -60,37 +60,28 @@ describe("useGetDeploymentConfigs", () => {
   });
 
   it("returns config list with provider_data", async () => {
-    const responseData = {
-      configs: [
-        {
-          id: "cfg-1",
-          name: "my_connection",
-          created_at: "2026-01-01T00:00:00Z",
-          updated_at: null,
-          provider_data: { scheme: "key_value" },
-        },
-        {
-          id: "cfg-2",
-          name: "other_conn",
-          created_at: "2026-01-02T00:00:00Z",
-          updated_at: "2026-01-03T00:00:00Z",
-          provider_data: null,
-        },
-      ],
-      page: 1,
-      size: 10000,
-      total: 2,
+    const apiResponse = {
+      provider_data: {
+        connections: [
+          { connection_id: "cfg-1", app_id: "app-1", type: "key_value" },
+          { connection_id: "cfg-2", app_id: "app-2" },
+        ],
+        page: 1,
+        size: 10000,
+        total: 2,
+      },
     };
-    mockApiGet.mockResolvedValue({ data: responseData });
+    mockApiGet.mockResolvedValue({ data: apiResponse });
 
     const result = useGetDeploymentConfigs({ providerId: "prov-1" });
     await flushPromises();
 
     expect(result.data).toBeDefined();
     if (!result.data) return;
-    expect(result.data).toEqual(responseData);
     expect(result.data.configs).toHaveLength(2);
-    expect(result.data.configs[0].name).toBe("my_connection");
-    expect(result.data.configs[1].provider_data).toBeNull();
+    expect(result.data.configs[0].connection_id).toBe("cfg-1");
+    expect(result.data.configs[1].connection_id).toBe("cfg-2");
+    expect(result.data.page).toBe(1);
+    expect(result.data.total).toBe(2);
   });
 });

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-configs.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-configs.test.ts
@@ -1,0 +1,96 @@
+const mockApiGet = jest.fn();
+const mockQuery = jest.fn(
+  (_key: unknown, fn: () => Promise<unknown>, _options?: unknown) => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const result: { data: any; isLoading: boolean; error: unknown } = {
+      data: null,
+      isLoading: false,
+      error: null,
+    };
+    void fn().then((data) => {
+      result.data = data;
+    });
+    return result;
+  },
+);
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { get: mockApiGet },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({ query: mockQuery })),
+}));
+
+import { useGetDeploymentConfigs } from "../use-get-deployment-configs";
+
+const flushPromises = () =>
+  new Promise((r) => jest.requireActual("timers").setImmediate(r));
+
+describe("useGetDeploymentConfigs", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls API with provider_id and size=10000", async () => {
+    mockApiGet.mockResolvedValue({
+      data: { configs: [], page: 1, size: 10000, total: 0 },
+    });
+
+    useGetDeploymentConfigs({ providerId: "prov-1" });
+    await flushPromises();
+
+    expect(mockApiGet).toHaveBeenCalledWith("/api/v1/deployments/configs", {
+      params: { provider_id: "prov-1", size: 10000 },
+    });
+  });
+
+  it("uses correct query key", () => {
+    mockApiGet.mockResolvedValue({ data: { configs: [] } });
+
+    useGetDeploymentConfigs({ providerId: "prov-1" });
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      ["useGetDeploymentConfigs", { providerId: "prov-1" }],
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it("returns config list with provider_data", async () => {
+    const responseData = {
+      configs: [
+        {
+          id: "cfg-1",
+          name: "my_connection",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: null,
+          provider_data: { scheme: "key_value" },
+        },
+        {
+          id: "cfg-2",
+          name: "other_conn",
+          created_at: "2026-01-02T00:00:00Z",
+          updated_at: "2026-01-03T00:00:00Z",
+          provider_data: null,
+        },
+      ],
+      page: 1,
+      size: 10000,
+      total: 2,
+    };
+    mockApiGet.mockResolvedValue({ data: responseData });
+
+    const result = useGetDeploymentConfigs({ providerId: "prov-1" });
+    await flushPromises();
+
+    expect(result.data).toBeDefined();
+    if (!result.data) return;
+    expect(result.data).toEqual(responseData);
+    expect(result.data.configs).toHaveLength(2);
+    expect(result.data.configs[0].name).toBe("my_connection");
+    expect(result.data.configs[1].provider_data).toBeNull();
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-execution.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-execution.test.ts
@@ -28,7 +28,7 @@ import type { DeploymentExecutionResponse } from "../use-post-deployment-executi
 describe("useGetDeploymentExecution", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("calls GET with encoded execution_id and provider_id param", async () => {
+  it("calls GET with encoded deployment_id and execution_id", async () => {
     const response = {
       deployment_id: "dep-1",
       provider_data: { execution_id: "exec-1", status: "completed" },
@@ -37,13 +37,12 @@ describe("useGetDeploymentExecution", () => {
 
     const mutation = useGetDeploymentExecution();
     await mutation.mutate({
+      deployment_id: "dep-1",
       execution_id: "exec-1",
-      provider_id: "prov-1",
     });
 
     expect(mockApiGet).toHaveBeenCalledWith(
-      "/api/v1/deployments/executions/exec-1",
-      { params: { provider_id: "prov-1" } },
+      "/api/v1/deployments/dep-1/executions/exec-1",
     );
   });
 
@@ -54,13 +53,12 @@ describe("useGetDeploymentExecution", () => {
 
     const mutation = useGetDeploymentExecution();
     await mutation.mutate({
+      deployment_id: "dep-1",
       execution_id: "exec/with spaces",
-      provider_id: "prov-1",
     });
 
     expect(mockApiGet).toHaveBeenCalledWith(
-      "/api/v1/deployments/executions/exec%2Fwith%20spaces",
-      { params: { provider_id: "prov-1" } },
+      "/api/v1/deployments/dep-1/executions/exec%2Fwith%20spaces",
     );
   });
 
@@ -78,8 +76,8 @@ describe("useGetDeploymentExecution", () => {
 
     const mutation = useGetDeploymentExecution();
     const result = (await mutation.mutate({
+      deployment_id: "dep-1",
       execution_id: "exec-1",
-      provider_id: "prov-1",
     })) as unknown as DeploymentExecutionResponse;
 
     expect(result).toEqual(response);

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-execution.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-execution.test.ts
@@ -1,0 +1,91 @@
+const mockApiGet = jest.fn();
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { get: mockApiGet },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mutate: jest.fn((_key: any, fn: any, options: any) => ({
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      mutate: async (payload: any) => {
+        const result = await fn(payload);
+        options?.onSettled?.(result);
+        return result;
+      },
+    })),
+  })),
+}));
+
+import { useGetDeploymentExecution } from "../use-get-deployment-execution";
+import type { DeploymentExecutionResponse } from "../use-post-deployment-execution";
+
+describe("useGetDeploymentExecution", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls GET with encoded execution_id and provider_id param", async () => {
+    const response = {
+      deployment_id: "dep-1",
+      provider_data: { execution_id: "exec-1", status: "completed" },
+    };
+    mockApiGet.mockResolvedValue({ data: response });
+
+    const mutation = useGetDeploymentExecution();
+    await mutation.mutate({
+      execution_id: "exec-1",
+      provider_id: "prov-1",
+    });
+
+    expect(mockApiGet).toHaveBeenCalledWith(
+      "/api/v1/deployments/executions/exec-1",
+      { params: { provider_id: "prov-1" } },
+    );
+  });
+
+  it("encodes special characters in execution_id", async () => {
+    mockApiGet.mockResolvedValue({
+      data: { deployment_id: "dep-1", provider_data: null },
+    });
+
+    const mutation = useGetDeploymentExecution();
+    await mutation.mutate({
+      execution_id: "exec/with spaces",
+      provider_id: "prov-1",
+    });
+
+    expect(mockApiGet).toHaveBeenCalledWith(
+      "/api/v1/deployments/executions/exec%2Fwith%20spaces",
+      { params: { provider_id: "prov-1" } },
+    );
+  });
+
+  it("returns execution status response", async () => {
+    const response = {
+      deployment_id: "dep-1",
+      provider_data: {
+        execution_id: "exec-1",
+        status: "failed",
+        last_error: "Model timeout",
+        failed_at: "2026-01-01T00:00:05Z",
+      },
+    };
+    mockApiGet.mockResolvedValue({ data: response });
+
+    const mutation = useGetDeploymentExecution();
+    const result = (await mutation.mutate({
+      execution_id: "exec-1",
+      provider_id: "prov-1",
+    })) as unknown as DeploymentExecutionResponse;
+
+    expect(result).toEqual(response);
+    expect(result.provider_data).toBeDefined();
+    if (!result.provider_data) return;
+    expect(result.provider_data.status).toBe("failed");
+    expect(result.provider_data.last_error).toBe("Model timeout");
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-llms.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment-llms.test.ts
@@ -1,0 +1,98 @@
+const mockApiGet = jest.fn();
+const mockQuery = jest.fn(
+  (_key: unknown, fn: () => Promise<unknown>, _options?: unknown) => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const result: { data: any; isLoading: boolean; error: unknown } = {
+      data: null,
+      isLoading: false,
+      error: null,
+    };
+    void fn().then((data) => {
+      result.data = data;
+    });
+    return result;
+  },
+);
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { get: mockApiGet },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({ query: mockQuery })),
+}));
+
+import { useGetDeploymentLlms } from "../use-get-deployment-llms";
+
+const flushPromises = () =>
+  new Promise((r) => jest.requireActual("timers").setImmediate(r));
+
+describe("useGetDeploymentLlms", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls API with provider_id", async () => {
+    mockApiGet.mockResolvedValue({
+      data: { provider_data: { models: [] } },
+    });
+
+    useGetDeploymentLlms({ providerId: "prov-1" });
+    await flushPromises();
+
+    expect(mockApiGet).toHaveBeenCalledWith("/api/v1/deployments/llms", {
+      params: { provider_id: "prov-1" },
+    });
+  });
+
+  it("uses correct query key", () => {
+    mockApiGet.mockResolvedValue({ data: { provider_data: null } });
+
+    useGetDeploymentLlms({ providerId: "prov-1" });
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      ["useGetDeploymentLlms", { providerId: "prov-1" }],
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it("returns LLM model list from provider_data", async () => {
+    const responseData = {
+      provider_data: {
+        models: [
+          { model_name: "ibm/granite-3-8b-instruct" },
+          { model_name: "meta-llama/llama-3-70b-instruct" },
+        ],
+      },
+    };
+    mockApiGet.mockResolvedValue({ data: responseData });
+
+    const result = useGetDeploymentLlms({ providerId: "prov-1" });
+    await flushPromises();
+
+    expect(result.data).toBeDefined();
+    if (!result.data) return;
+    expect(result.data).toEqual(responseData);
+    expect(result.data.provider_data).toBeDefined();
+    if (!result.data.provider_data) return;
+    expect(result.data.provider_data.models).toHaveLength(2);
+    expect(result.data.provider_data.models[0].model_name).toBe(
+      "ibm/granite-3-8b-instruct",
+    );
+  });
+
+  it("handles null provider_data", async () => {
+    mockApiGet.mockResolvedValue({ data: { provider_data: null } });
+
+    const result = useGetDeploymentLlms({ providerId: "prov-1" });
+    await flushPromises();
+
+    expect(result.data).toBeDefined();
+    if (!result.data) return;
+    expect(result.data).toEqual({ provider_data: null });
+    expect(result.data.provider_data).toBeNull();
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployment.test.ts
@@ -1,0 +1,77 @@
+const mockApiGet = jest.fn();
+const mockQuery = jest.fn(
+  (_key: unknown, fn: () => Promise<unknown>, _options?: unknown) => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const result: { data: any; isLoading: boolean; error: unknown } = {
+      data: null,
+      isLoading: false,
+      error: null,
+    };
+    void fn().then((data) => {
+      result.data = data;
+    });
+    return result;
+  },
+);
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { get: mockApiGet },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({ query: mockQuery })),
+}));
+
+import { useGetDeployment } from "../use-get-deployment";
+
+const flushPromises = () =>
+  new Promise((r) => jest.requireActual("timers").setImmediate(r));
+
+describe("useGetDeployment", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls API with deployment ID in URL path", async () => {
+    mockApiGet.mockResolvedValue({ data: { id: "dep-1", name: "Agent" } });
+
+    useGetDeployment({ deploymentId: "dep-1" });
+    await flushPromises();
+
+    expect(mockApiGet).toHaveBeenCalledWith("/api/v1/deployments/dep-1");
+  });
+
+  it("uses correct query key", () => {
+    mockApiGet.mockResolvedValue({ data: {} });
+
+    useGetDeployment({ deploymentId: "dep-42" });
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      ["useGetDeployment", { deploymentId: "dep-42" }],
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it("returns deployment data from response", async () => {
+    const deployment = {
+      id: "dep-1",
+      name: "Agent",
+      type: "agent",
+      resource_key: "rk-1",
+      attached_count: 2,
+    };
+    mockApiGet.mockResolvedValue({ data: deployment });
+
+    const result = useGetDeployment({ deploymentId: "dep-1" });
+    await flushPromises();
+
+    expect(result.data).toBeDefined();
+    if (!result.data) return;
+    expect(result.data).toEqual(deployment);
+    expect(result.data.type).toBe("agent");
+    expect(result.data.attached_count).toBe(2);
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployments-by-providers.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployments-by-providers.test.ts
@@ -1,0 +1,142 @@
+const mockApiGet = jest.fn();
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { get: mockApiGet },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+// Capture the config passed to useQueries so we can test combine and queryFn
+// biome-ignore lint/suspicious/noExplicitAny: test mock
+let capturedConfig: any = null;
+jest.mock("@tanstack/react-query", () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  useQueries: jest.fn((config: any) => {
+    capturedConfig = config;
+    // Simulate executing the combine function with mock results
+    return config.combine
+      ? config.combine([])
+      : { deployments: [], isLoading: false };
+  }),
+}));
+
+import { useQueries } from "@tanstack/react-query";
+import { useGetDeploymentsByProviders } from "../use-get-deployments-by-providers";
+
+describe("useGetDeploymentsByProviders", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedConfig = null;
+  });
+
+  it("creates one query per provider ID", () => {
+    useGetDeploymentsByProviders(["prov-1", "prov-2", "prov-3"]);
+
+    expect(useQueries).toHaveBeenCalledTimes(1);
+    expect(capturedConfig.queries).toHaveLength(3);
+  });
+
+  it("uses correct query key per provider", () => {
+    useGetDeploymentsByProviders(["prov-1", "prov-2"]);
+
+    expect(capturedConfig.queries[0].queryKey).toEqual([
+      "useGetDeployments",
+      { provider_id: "prov-1", page: 1, size: 20 },
+    ]);
+    expect(capturedConfig.queries[1].queryKey).toEqual([
+      "useGetDeployments",
+      { provider_id: "prov-2", page: 1, size: 20 },
+    ]);
+  });
+
+  it("disables query when provider ID is empty", () => {
+    useGetDeploymentsByProviders(["prov-1", ""]);
+
+    expect(capturedConfig.queries[0].enabled).toBe(true);
+    expect(capturedConfig.queries[1].enabled).toBe(false);
+  });
+
+  it("calls fetchDeployments with correct API params", async () => {
+    mockApiGet.mockResolvedValue({
+      data: { deployments: [], page: 1, size: 20, total: 0 },
+    });
+
+    useGetDeploymentsByProviders(["prov-1"]);
+    await capturedConfig.queries[0].queryFn();
+
+    expect(mockApiGet).toHaveBeenCalledWith("/api/v1/deployments", {
+      params: { provider_id: "prov-1", page: 1, size: 20 },
+    });
+  });
+
+  it("combine merges deployments and injects provider_account_id", () => {
+    useGetDeploymentsByProviders(["prov-1", "prov-2"]);
+
+    const mockResults = [
+      {
+        data: {
+          deployments: [
+            { id: "d1", name: "Agent 1" },
+            { id: "d2", name: "Agent 2" },
+          ],
+        },
+        isLoading: false,
+      },
+      {
+        data: {
+          deployments: [{ id: "d3", name: "Agent 3" }],
+        },
+        isLoading: false,
+      },
+    ];
+
+    const combined = capturedConfig.combine(mockResults);
+
+    expect(combined.deployments).toHaveLength(3);
+    expect(combined.deployments[0]).toEqual(
+      expect.objectContaining({ id: "d1", provider_account_id: "prov-1" }),
+    );
+    expect(combined.deployments[2]).toEqual(
+      expect.objectContaining({ id: "d3", provider_account_id: "prov-2" }),
+    );
+    expect(combined.isLoading).toBe(false);
+  });
+
+  it("combine reports isLoading when any query is loading", () => {
+    useGetDeploymentsByProviders(["prov-1", "prov-2"]);
+
+    const mockResults = [
+      { data: { deployments: [] }, isLoading: false },
+      { data: undefined, isLoading: true },
+    ];
+
+    const combined = capturedConfig.combine(mockResults);
+
+    expect(combined.isLoading).toBe(true);
+  });
+
+  it("combine skips providers with no data yet", () => {
+    useGetDeploymentsByProviders(["prov-1", "prov-2"]);
+
+    const mockResults = [
+      { data: undefined, isLoading: true },
+      {
+        data: { deployments: [{ id: "d1", name: "Agent" }] },
+        isLoading: false,
+      },
+    ];
+
+    const combined = capturedConfig.combine(mockResults);
+
+    expect(combined.deployments).toHaveLength(1);
+    expect(combined.deployments[0].provider_account_id).toBe("prov-2");
+  });
+
+  it("returns empty deployments for empty provider list", () => {
+    useGetDeploymentsByProviders([]);
+
+    expect(capturedConfig.queries).toHaveLength(0);
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployments.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-get-deployments.test.ts
@@ -1,0 +1,113 @@
+const mockApiGet = jest.fn();
+
+// Mock query that properly resolves data via async execution
+const mockQuery = jest.fn(
+  (_key: unknown, fn: () => Promise<unknown>, _options?: unknown) => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const result: { data: any; isLoading: boolean; error: unknown } = {
+      data: null,
+      isLoading: false,
+      error: null,
+    };
+    void fn().then((data) => {
+      result.data = data;
+    });
+    return result;
+  },
+);
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { get: mockApiGet },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({ query: mockQuery })),
+}));
+
+import { useGetDeployments } from "../use-get-deployments";
+
+const flushPromises = () =>
+  new Promise((r) => jest.requireActual("timers").setImmediate(r));
+
+describe("useGetDeployments", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls API with provider_id and default pagination", async () => {
+    mockApiGet.mockResolvedValue({
+      data: { deployments: [], page: 1, size: 20, total: 0 },
+    });
+
+    useGetDeployments({ provider_id: "prov-1" });
+    await flushPromises();
+
+    expect(mockApiGet).toHaveBeenCalledWith("/api/v1/deployments", {
+      params: {
+        provider_id: "prov-1",
+        flow_ids: undefined,
+        page: 1,
+        size: 20,
+      },
+    });
+  });
+
+  it("forwards flow_ids and custom pagination", async () => {
+    mockApiGet.mockResolvedValue({
+      data: { deployments: [], page: 2, size: 10, total: 50 },
+    });
+
+    useGetDeployments({
+      provider_id: "prov-1",
+      flow_ids: "f1,f2",
+      page: 2,
+      size: 10,
+    });
+    await flushPromises();
+
+    expect(mockApiGet).toHaveBeenCalledWith("/api/v1/deployments", {
+      params: { provider_id: "prov-1", flow_ids: "f1,f2", page: 2, size: 10 },
+    });
+  });
+
+  it("uses correct query key with all params", () => {
+    mockApiGet.mockResolvedValue({ data: { deployments: [] } });
+
+    useGetDeployments({
+      provider_id: "prov-1",
+      flow_ids: "f1",
+      page: 3,
+      size: 5,
+    });
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      [
+        "useGetDeployments",
+        { provider_id: "prov-1", flow_ids: "f1", page: 3, size: 5 },
+      ],
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it("returns deployment data from API response", async () => {
+    const responseData = {
+      deployments: [{ id: "d1", name: "Agent 1" }],
+      page: 1,
+      size: 20,
+      total: 1,
+    };
+    mockApiGet.mockResolvedValue({ data: responseData });
+
+    const result = useGetDeployments({ provider_id: "prov-1" });
+    await flushPromises();
+
+    expect(result.data).toBeDefined();
+    if (!result.data) return;
+    expect(result.data).toEqual(responseData);
+    expect(result.data.deployments).toHaveLength(1);
+    expect(result.data.deployments[0].id).toBe("d1");
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-patch-deployment.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-patch-deployment.test.ts
@@ -1,0 +1,98 @@
+const mockApiPatch = jest.fn();
+const mockQueryClient = {
+  refetchQueries: jest.fn(),
+  removeQueries: jest.fn(),
+  invalidateQueries: jest.fn(),
+};
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { patch: mockApiPatch },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mutate: jest.fn((_key: any, fn: any, options: any) => ({
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      mutate: async (payload: any) => {
+        const result = await fn(payload);
+        options?.onSuccess?.(result, payload, undefined);
+        options?.onSettled?.(result);
+        return result;
+      },
+    })),
+    queryClient: mockQueryClient,
+  })),
+}));
+
+import type { DeploymentUpdateRequest } from "../use-patch-deployment";
+import { usePatchDeployment } from "../use-patch-deployment";
+
+describe("usePatchDeployment", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("patches correct URL with deployment_id and sends body without it", async () => {
+    mockApiPatch.mockResolvedValue({ data: { id: "dep-1" } });
+
+    const payload: DeploymentUpdateRequest = {
+      deployment_id: "dep-1",
+      spec: { description: "Updated description" },
+      provider_data: { llm: "new-model" },
+    };
+
+    const mutation = usePatchDeployment();
+    await mutation.mutate(payload);
+
+    expect(mockApiPatch).toHaveBeenCalledWith("/api/v1/deployments/dep-1", {
+      spec: { description: "Updated description" },
+      provider_data: { llm: "new-model" },
+    });
+  });
+
+  it("does not include deployment_id in request body", async () => {
+    mockApiPatch.mockResolvedValue({ data: {} });
+
+    const mutation = usePatchDeployment();
+    await mutation.mutate({
+      deployment_id: "dep-1",
+      spec: { name: "Renamed" },
+    });
+
+    const sentBody = mockApiPatch.mock.calls[0][1];
+    expect(sentBody).not.toHaveProperty("deployment_id");
+  });
+
+  it("refetches deployments and removes stale queries on success", async () => {
+    mockApiPatch.mockResolvedValue({ data: {} });
+
+    const mutation = usePatchDeployment();
+    await mutation.mutate({
+      deployment_id: "dep-1",
+      spec: { description: "x" },
+    });
+
+    expect(mockQueryClient.refetchQueries).toHaveBeenCalledWith({
+      queryKey: ["useGetDeployments"],
+    });
+    expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+      queryKey: ["useGetDeploymentAttachments"],
+    });
+    expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+      queryKey: ["useGetDeployment"],
+    });
+  });
+
+  it("forwards caller onSuccess callback", async () => {
+    mockApiPatch.mockResolvedValue({ data: { id: "dep-1" } });
+
+    const callerOnSuccess = jest.fn();
+    const mutation = usePatchDeployment({ onSuccess: callerOnSuccess });
+    await mutation.mutate({ deployment_id: "dep-1", spec: {} });
+
+    expect(callerOnSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-patch-snapshot.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-patch-snapshot.test.ts
@@ -1,0 +1,101 @@
+const mockApiPatch = jest.fn();
+const mockQueryClient = {
+  refetchQueries: jest.fn(),
+  invalidateQueries: jest.fn(),
+};
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { patch: mockApiPatch },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mutate: jest.fn((_key: any, fn: any, options: any) => ({
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      mutate: async (payload: any) => {
+        const result = await fn(payload);
+        options?.onSuccess?.(result, payload, undefined);
+        options?.onSettled?.(result);
+        return result;
+      },
+    })),
+    queryClient: mockQueryClient,
+  })),
+}));
+
+import { usePatchSnapshot } from "../use-patch-snapshot";
+
+describe("usePatchSnapshot", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("patches snapshot URL with providerSnapshotId", async () => {
+    mockApiPatch.mockResolvedValue({
+      data: { flow_version_id: "fv-1", provider_snapshot_id: "snap-abc" },
+    });
+
+    const mutation = usePatchSnapshot();
+    await mutation.mutate({
+      providerSnapshotId: "snap-abc",
+      flowVersionId: "fv-1",
+    });
+
+    expect(mockApiPatch).toHaveBeenCalledWith(
+      "/api/v1/deployments/snapshots/snap-abc",
+      { flow_version_id: "fv-1" },
+    );
+  });
+
+  it("transforms flowVersionId to flow_version_id in body", async () => {
+    mockApiPatch.mockResolvedValue({
+      data: { flow_version_id: "fv-2", provider_snapshot_id: "snap-xyz" },
+    });
+
+    const mutation = usePatchSnapshot();
+    await mutation.mutate({
+      providerSnapshotId: "snap-xyz",
+      flowVersionId: "fv-2",
+    });
+
+    const sentBody = mockApiPatch.mock.calls[0][1];
+    expect(sentBody).toEqual({ flow_version_id: "fv-2" });
+    expect(sentBody).not.toHaveProperty("flowVersionId");
+    expect(sentBody).not.toHaveProperty("providerSnapshotId");
+  });
+
+  it("refetches useGetDeployments on success", async () => {
+    mockApiPatch.mockResolvedValue({
+      data: { flow_version_id: "fv-1", provider_snapshot_id: "snap-abc" },
+    });
+
+    const mutation = usePatchSnapshot();
+    await mutation.mutate({
+      providerSnapshotId: "snap-abc",
+      flowVersionId: "fv-1",
+    });
+
+    expect(mockQueryClient.refetchQueries).toHaveBeenCalledWith({
+      queryKey: ["useGetDeployments"],
+    });
+  });
+
+  it("returns snapshot update response", async () => {
+    const responseData = {
+      flow_version_id: "fv-1",
+      provider_snapshot_id: "snap-abc",
+    };
+    mockApiPatch.mockResolvedValue({ data: responseData });
+
+    const mutation = usePatchSnapshot();
+    const result = await mutation.mutate({
+      providerSnapshotId: "snap-abc",
+      flowVersionId: "fv-1",
+    });
+
+    expect(result).toEqual(responseData);
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-post-deployment-execution.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-post-deployment-execution.test.ts
@@ -1,0 +1,104 @@
+const mockApiPost = jest.fn();
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { post: mockApiPost },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mutate: jest.fn((_key: any, fn: any, options: any) => ({
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      mutate: async (payload: any) => {
+        const result = await fn(payload);
+        options?.onSettled?.(result);
+        return result;
+      },
+    })),
+  })),
+}));
+
+import type { DeploymentExecutionRequest } from "../use-post-deployment-execution";
+import { usePostDeploymentExecution } from "../use-post-deployment-execution";
+
+describe("usePostDeploymentExecution", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("posts to executions endpoint with correct payload", async () => {
+    const response = {
+      deployment_id: "dep-1",
+      provider_data: {
+        execution_id: "exec-1",
+        status: "running",
+      },
+    };
+    mockApiPost.mockResolvedValue({ data: response });
+
+    const payload: DeploymentExecutionRequest = {
+      provider_id: "prov-1",
+      deployment_id: "dep-1",
+      provider_data: { input: "Hello agent" },
+    };
+
+    const mutation = usePostDeploymentExecution();
+    await mutation.mutate(payload);
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/v1/deployments/executions",
+      payload,
+    );
+  });
+
+  it("includes thread_id for multi-turn conversations", async () => {
+    mockApiPost.mockResolvedValue({
+      data: {
+        deployment_id: "dep-1",
+        provider_data: { execution_id: "exec-2", thread_id: "thread-1" },
+      },
+    });
+
+    const payload: DeploymentExecutionRequest = {
+      provider_id: "prov-1",
+      deployment_id: "dep-1",
+      provider_data: { input: "Follow up", thread_id: "thread-1" },
+    };
+
+    const mutation = usePostDeploymentExecution();
+    await mutation.mutate(payload);
+
+    const sentPayload = mockApiPost.mock.calls[0][1];
+    expect(sentPayload.provider_data.thread_id).toBe("thread-1");
+  });
+
+  it("returns execution response with provider_data", async () => {
+    const response = {
+      deployment_id: "dep-1",
+      provider_data: {
+        execution_id: "exec-1",
+        agent_id: "agent-1",
+        status: "completed",
+        result: { output: "Hello!" },
+        thread_id: "thread-1",
+        started_at: "2026-01-01T00:00:00Z",
+        completed_at: "2026-01-01T00:00:01Z",
+        failed_at: null,
+        cancelled_at: null,
+        last_error: null,
+      },
+    };
+    mockApiPost.mockResolvedValue({ data: response });
+
+    const mutation = usePostDeploymentExecution();
+    const result = await mutation.mutate({
+      provider_id: "prov-1",
+      deployment_id: "dep-1",
+      provider_data: { input: "Hi" },
+    });
+
+    expect(result).toEqual(response);
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-post-deployment-execution.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-post-deployment-execution.test.ts
@@ -39,7 +39,6 @@ describe("usePostDeploymentExecution", () => {
     mockApiPost.mockResolvedValue({ data: response });
 
     const payload: DeploymentExecutionRequest = {
-      provider_id: "prov-1",
       deployment_id: "dep-1",
       provider_data: { input: "Hello agent" },
     };
@@ -48,8 +47,8 @@ describe("usePostDeploymentExecution", () => {
     await mutation.mutate(payload);
 
     expect(mockApiPost).toHaveBeenCalledWith(
-      "/api/v1/deployments/executions",
-      payload,
+      "/api/v1/deployments/dep-1/executions",
+      { provider_data: { input: "Hello agent" } },
     );
   });
 
@@ -62,7 +61,6 @@ describe("usePostDeploymentExecution", () => {
     });
 
     const payload: DeploymentExecutionRequest = {
-      provider_id: "prov-1",
       deployment_id: "dep-1",
       provider_data: { input: "Follow up", thread_id: "thread-1" },
     };
@@ -94,7 +92,6 @@ describe("usePostDeploymentExecution", () => {
 
     const mutation = usePostDeploymentExecution();
     const result = await mutation.mutate({
-      provider_id: "prov-1",
       deployment_id: "dep-1",
       provider_data: { input: "Hi" },
     });

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-post-deployment.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-post-deployment.test.ts
@@ -1,0 +1,104 @@
+const mockApiPost = jest.fn();
+const mockQueryClient = {
+  refetchQueries: jest.fn(),
+  invalidateQueries: jest.fn(),
+};
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { post: mockApiPost },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mutate: jest.fn((_key: any, fn: any, options: any) => ({
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      mutate: async (payload: any) => {
+        const result = await fn(payload);
+        options?.onSuccess?.(result);
+        options?.onSettled?.(result);
+        return result;
+      },
+    })),
+    queryClient: mockQueryClient,
+  })),
+}));
+
+import type { DeploymentCreateRequest } from "../use-post-deployment";
+import { usePostDeployment } from "../use-post-deployment";
+
+describe("usePostDeployment", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const validPayload: DeploymentCreateRequest = {
+    provider_id: "prov-1",
+    spec: { name: "My Agent", description: "A test agent", type: "agent" },
+    provider_data: {
+      llm: "ibm/granite-3-8b-instruct",
+      operations: [
+        {
+          op: "bind",
+          flow_version_id: "fv-1",
+          app_ids: ["app-1"],
+          tool_name: "my_tool",
+        },
+      ],
+      connections: {
+        raw_payloads: [
+          {
+            app_id: "app-1",
+            environment_variables: {
+              API_KEY: { value: "secret", source: "raw" },
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  it("posts to deployments endpoint with full payload", async () => {
+    mockApiPost.mockResolvedValue({ data: { id: "dep-1", name: "My Agent" } });
+
+    const mutation = usePostDeployment();
+    await mutation.mutate(validPayload);
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/v1/deployments",
+      validPayload,
+    );
+  });
+
+  it("refetches useGetDeployments on success", async () => {
+    mockApiPost.mockResolvedValue({ data: { id: "dep-1" } });
+
+    const mutation = usePostDeployment();
+    await mutation.mutate(validPayload);
+
+    expect(mockQueryClient.refetchQueries).toHaveBeenCalledWith({
+      queryKey: ["useGetDeployments"],
+    });
+  });
+
+  it("sends operations without tool_name when not provided", async () => {
+    const payloadNoToolName: DeploymentCreateRequest = {
+      ...validPayload,
+      provider_data: {
+        ...validPayload.provider_data,
+        operations: [
+          { op: "bind", flow_version_id: "fv-1", app_ids: ["app-1"] },
+        ],
+      },
+    };
+    mockApiPost.mockResolvedValue({ data: { id: "dep-1" } });
+
+    const mutation = usePostDeployment();
+    await mutation.mutate(payloadNoToolName);
+
+    const sentPayload = mockApiPost.mock.calls[0][1];
+    expect(sentPayload.provider_data.operations[0].tool_name).toBeUndefined();
+  });
+});

--- a/src/frontend/src/controllers/API/queries/variables/__tests__/use-post-detect-env-vars.test.ts
+++ b/src/frontend/src/controllers/API/queries/variables/__tests__/use-post-detect-env-vars.test.ts
@@ -1,0 +1,81 @@
+const mockApiPost = jest.fn();
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { post: mockApiPost },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/variables"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mutate: jest.fn((_key: any, fn: any, options: any) => ({
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      mutate: async (payload: any) => {
+        const result = await fn(payload);
+        options?.onSettled?.(result);
+        return result;
+      },
+    })),
+  })),
+}));
+
+import type {
+  DetectEnvVarsPayload,
+  DetectEnvVarsResponse,
+} from "../use-post-detect-env-vars";
+import { usePostDetectEnvVars } from "../use-post-detect-env-vars";
+
+describe("usePostDetectEnvVars", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("posts to /variables/detections with flow_version_ids", async () => {
+    const response: DetectEnvVarsResponse = { variables: [] };
+    mockApiPost.mockResolvedValue({ data: response });
+
+    const payload: DetectEnvVarsPayload = {
+      flow_version_ids: ["fv-1", "fv-2"],
+    };
+
+    const mutation = usePostDetectEnvVars();
+    await mutation.mutate(payload);
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/v1/variables/detections",
+      payload,
+    );
+  });
+
+  it("returns detected variables with global_variable_name", async () => {
+    const response: DetectEnvVarsResponse = {
+      variables: [
+        { key: "OPENAI_API_KEY", global_variable_name: "openai_key" },
+        { key: "CUSTOM_VAR", global_variable_name: null },
+      ],
+    };
+    mockApiPost.mockResolvedValue({ data: response });
+
+    const mutation = usePostDetectEnvVars();
+    const result = (await mutation.mutate({
+      flow_version_ids: ["fv-1"],
+    })) as unknown as DetectEnvVarsResponse;
+
+    expect(result).toEqual(response);
+    expect(result.variables).toHaveLength(2);
+    expect(result.variables[0].global_variable_name).toBe("openai_key");
+    expect(result.variables[1].global_variable_name).toBeNull();
+  });
+
+  it("returns empty variables array when no env vars detected", async () => {
+    mockApiPost.mockResolvedValue({ data: { variables: [] } });
+
+    const mutation = usePostDetectEnvVars();
+    const result = (await mutation.mutate({
+      flow_version_ids: ["fv-1"],
+    })) as unknown as DetectEnvVarsResponse;
+
+    expect(result.variables).toEqual([]);
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/add-provider-modal.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/add-provider-modal.test.tsx
@@ -163,7 +163,7 @@ describe("Submit behavior", () => {
       expect(mockMutateAsync).toHaveBeenCalledWith({
         name: "My Env",
         provider_key: "watsonx-orchestrate",
-        provider_url: "https://prod.example.com",
+        url: "https://prod.example.com",
         provider_data: { api_key: "sk-test-123" }, // pragma: allowlist secret
       });
     });

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/add-provider-modal.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/add-provider-modal.test.tsx
@@ -1,0 +1,219 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+const mockMutateAsync = jest.fn();
+
+jest.mock(
+  "@/controllers/API/queries/deployment-provider-accounts/use-post-provider-account",
+  () => ({
+    usePostProviderAccount: () => ({
+      mutateAsync: mockMutateAsync,
+    }),
+  }),
+);
+
+jest.mock("../hooks/use-error-alert", () => ({
+  useErrorAlert: () => jest.fn(),
+}));
+
+jest.mock(
+  "@/components/common/genericIconComponent",
+  () =>
+    function MockIcon({ name }: { name: string }) {
+      return <span data-testid={`icon-${name}`} />;
+    },
+);
+
+import AddProviderModal from "../components/add-provider-modal";
+
+function renderModal(open = true) {
+  const setOpen = jest.fn();
+  const result = render(
+    <TooltipProvider>
+      <AddProviderModal open={open} setOpen={setOpen} />
+    </TooltipProvider>,
+  );
+  return { setOpen, ...result };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe("Rendering", () => {
+  it("renders modal title and description", () => {
+    renderModal();
+    expect(screen.getByText("Add Environment")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Configure your watsonx Orchestrate credentials/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows watsonx Orchestrate provider badge", () => {
+    renderModal();
+    expect(screen.getByText("watsonx Orchestrate")).toBeInTheDocument();
+  });
+
+  it("renders form fields: Name, API Key, Service Environment URL", () => {
+    renderModal();
+    expect(screen.getByPlaceholderText("e.g. Production")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Enter your API key"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("https://api.example.com"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders Cancel and Save buttons", () => {
+    renderModal();
+    expect(screen.getByTestId("add-provider-cancel")).toBeInTheDocument();
+    expect(screen.getByTestId("add-provider-save")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Form validation
+// ---------------------------------------------------------------------------
+
+describe("Form validation", () => {
+  it("Save is disabled when all fields are empty", () => {
+    renderModal();
+    expect(screen.getByTestId("add-provider-save")).toBeDisabled();
+  });
+
+  it("Save is disabled when only name is filled", async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.type(screen.getByPlaceholderText("e.g. Production"), "My Env");
+    expect(screen.getByTestId("add-provider-save")).toBeDisabled();
+  });
+
+  it("Save is disabled when api_key is missing", async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.type(screen.getByPlaceholderText("e.g. Production"), "My Env");
+    await user.type(
+      screen.getByPlaceholderText("https://api.example.com"),
+      "https://prod.example.com",
+    );
+    expect(screen.getByTestId("add-provider-save")).toBeDisabled();
+  });
+
+  it("Save is enabled when all required fields are filled", async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.type(screen.getByPlaceholderText("e.g. Production"), "My Env");
+    await user.type(
+      screen.getByPlaceholderText("Enter your API key"),
+      "sk-test-123", // pragma: allowlist secret
+    );
+    await user.type(
+      screen.getByPlaceholderText("https://api.example.com"),
+      "https://prod.example.com",
+    );
+    expect(screen.getByTestId("add-provider-save")).not.toBeDisabled();
+  });
+
+  it("Save is disabled when fields are whitespace-only", async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.type(screen.getByPlaceholderText("e.g. Production"), "   ");
+    await user.type(screen.getByPlaceholderText("Enter your API key"), "   ");
+    await user.type(
+      screen.getByPlaceholderText("https://api.example.com"),
+      "   ",
+    );
+    expect(screen.getByTestId("add-provider-save")).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Submit behavior
+// ---------------------------------------------------------------------------
+
+describe("Submit behavior", () => {
+  async function fillForm() {
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText("e.g. Production"), " My Env ");
+    await user.type(
+      screen.getByPlaceholderText("Enter your API key"),
+      " sk-test-123 ", // pragma: allowlist secret
+    );
+    await user.type(
+      screen.getByPlaceholderText("https://api.example.com"),
+      " https://prod.example.com ",
+    );
+    return user;
+  }
+
+  it("calls createProviderAccount with trimmed values", async () => {
+    mockMutateAsync.mockResolvedValue({ id: "new-prov" });
+    const { setOpen } = renderModal();
+    const user = await fillForm();
+
+    await user.click(screen.getByTestId("add-provider-save"));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        name: "My Env",
+        provider_key: "watsonx-orchestrate",
+        provider_url: "https://prod.example.com",
+        provider_data: { api_key: "sk-test-123" }, // pragma: allowlist secret
+      });
+    });
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("shows Saving... text during submission", async () => {
+    let resolveCreate!: () => void;
+    mockMutateAsync.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveCreate = resolve;
+      }),
+    );
+    renderModal();
+    const user = await fillForm();
+
+    await user.click(screen.getByTestId("add-provider-save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Saving...")).toBeInTheDocument();
+    });
+
+    resolveCreate();
+  });
+
+  it("does not close modal on API error", async () => {
+    mockMutateAsync.mockRejectedValue(new Error("Network error"));
+    const { setOpen } = renderModal();
+    const user = await fillForm();
+
+    await user.click(screen.getByTestId("add-provider-save"));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalled();
+    });
+    // setOpen(false) should NOT have been called
+    expect(setOpen).not.toHaveBeenCalledWith(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cancel behavior
+// ---------------------------------------------------------------------------
+
+describe("Cancel behavior", () => {
+  it("calls setOpen(false) when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const { setOpen } = renderModal();
+
+    await user.click(screen.getByTestId("add-provider-cancel"));
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/create-mode.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/create-mode.test.tsx
@@ -1,0 +1,924 @@
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import {
+  DeploymentStepperProvider,
+  useDeploymentStepper,
+} from "../contexts/deployment-stepper-context";
+import type {
+  ConnectionItem,
+  DeploymentProvider,
+  ProviderAccount,
+} from "../types";
+
+jest.mock(
+  "@/controllers/API/queries/deployment-provider-accounts/use-post-provider-account",
+  () => ({ usePostProviderAccount: jest.fn() }),
+);
+jest.mock("@/controllers/API/queries/deployments/use-post-deployment", () => ({
+  usePostDeployment: jest.fn(),
+}));
+jest.mock("@/controllers/API/queries/deployments/use-patch-deployment", () => ({
+  usePatchDeployment: jest.fn(),
+}));
+
+const mockProvider: DeploymentProvider = {
+  id: "provider-1",
+  type: "watsonx",
+  name: "watsonx Orchestrate",
+  icon: "watsonx-icon",
+};
+
+const mockInstance: ProviderAccount = {
+  id: "instance-1",
+  name: "My WxO Instance",
+  provider_tenant_id: "tenant-1",
+  provider_key: "watsonx-orchestrate",
+  provider_url: "https://api.example.com",
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+};
+
+function renderCreateHook(
+  initialState?: Parameters<
+    typeof DeploymentStepperProvider
+  >[0]["initialState"],
+) {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <DeploymentStepperProvider initialState={initialState}>
+      {children}
+    </DeploymentStepperProvider>
+  );
+  return renderHook(() => useDeploymentStepper(), { wrapper });
+}
+
+// ---------------------------------------------------------------------------
+// Create mode — basic state
+// ---------------------------------------------------------------------------
+
+describe("Create mode — basic state", () => {
+  it("starts in create mode with 4 steps", () => {
+    const { result } = renderCreateHook();
+    expect(result.current.isEditMode).toBe(false);
+    expect(result.current.totalSteps).toBe(4);
+    expect(result.current.currentStep).toBe(1);
+    expect(result.current.editingDeployment).toBeNull();
+  });
+
+  it("defaults to agent type with empty fields", () => {
+    const { result } = renderCreateHook();
+    expect(result.current.deploymentType).toBe("agent");
+    expect(result.current.deploymentName).toBe("");
+    expect(result.current.deploymentDescription).toBe("");
+    expect(result.current.selectedLlm).toBe("");
+  });
+
+  it("starts with empty flow/connection maps", () => {
+    const { result } = renderCreateHook();
+    expect(result.current.selectedVersionByFlow.size).toBe(0);
+    expect(result.current.attachedConnectionByFlow.size).toBe(0);
+    expect(result.current.toolNameByFlow.size).toBe(0);
+    expect(result.current.connections).toEqual([]);
+  });
+
+  it("starts with no provider/instance selected", () => {
+    const { result } = renderCreateHook();
+    expect(result.current.selectedProvider).toBeNull();
+    expect(result.current.selectedInstance).toBeNull();
+  });
+
+  it("accepts initialProvider and initialInstance", () => {
+    const { result } = renderCreateHook({
+      initialProvider: mockProvider,
+      initialInstance: mockInstance,
+    });
+    expect(result.current.selectedProvider).toEqual(mockProvider);
+    expect(result.current.selectedInstance).toEqual(mockInstance);
+  });
+
+  it("accepts initialFlowId", () => {
+    const { result } = renderCreateHook({ initialFlowId: "flow-abc" });
+    expect(result.current.initialFlowId).toBe("flow-abc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create mode — canGoNext validation per step
+// ---------------------------------------------------------------------------
+
+describe("Create mode — canGoNext validation", () => {
+  describe("Step 1 (Provider)", () => {
+    it("blocks when no provider selected", () => {
+      const { result } = renderCreateHook();
+      expect(result.current.canGoNext).toBe(false);
+    });
+
+    it("blocks when provider selected but no instance or credentials", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+      });
+      expect(result.current.canGoNext).toBe(false);
+    });
+
+    it("allows when provider + existing instance selected", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+        initialInstance: mockInstance,
+      });
+      expect(result.current.canGoNext).toBe(true);
+    });
+
+    it("allows when provider + valid credentials entered", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+      });
+
+      act(() => {
+        result.current.setCredentials({
+          name: "New Account",
+          provider_key: "watsonx-orchestrate",
+          provider_url: "https://api.example.com",
+          api_key: "my-secret-key", // pragma: allowlist secret
+        });
+      });
+
+      expect(result.current.canGoNext).toBe(true);
+    });
+
+    it("blocks when credentials are partially filled", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+      });
+
+      act(() => {
+        result.current.setCredentials({
+          name: "New Account",
+          provider_key: "watsonx-orchestrate",
+          provider_url: "",
+          api_key: "my-secret-key", // pragma: allowlist secret
+        });
+      });
+
+      expect(result.current.canGoNext).toBe(false);
+    });
+  });
+
+  describe("Step 2 (Type)", () => {
+    it("blocks when name is empty", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+        initialInstance: mockInstance,
+      });
+
+      act(() => result.current.handleNext()); // → step 2
+      expect(result.current.currentStep).toBe(2);
+
+      act(() => result.current.setSelectedLlm("gpt-4"));
+      expect(result.current.canGoNext).toBe(false);
+    });
+
+    it("blocks when LLM is empty", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+        initialInstance: mockInstance,
+      });
+
+      act(() => result.current.handleNext()); // → step 2
+
+      act(() => result.current.setDeploymentName("My Agent"));
+      expect(result.current.canGoNext).toBe(false);
+    });
+
+    it("blocks when name is whitespace-only", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+        initialInstance: mockInstance,
+      });
+
+      act(() => result.current.handleNext()); // → step 2
+
+      act(() => {
+        result.current.setDeploymentName("   ");
+        result.current.setSelectedLlm("gpt-4");
+      });
+
+      expect(result.current.canGoNext).toBe(false);
+    });
+
+    it("allows when both name and LLM are set", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+        initialInstance: mockInstance,
+      });
+
+      act(() => result.current.handleNext()); // → step 2
+
+      act(() => {
+        result.current.setDeploymentName("My Agent");
+        result.current.setSelectedLlm("gpt-4");
+      });
+
+      expect(result.current.canGoNext).toBe(true);
+    });
+  });
+
+  describe("Step 3 (Attach Flows)", () => {
+    it("blocks when no flows attached in create mode", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+        initialInstance: mockInstance,
+      });
+
+      // Navigate to step 3
+      act(() => result.current.handleNext()); // → step 2
+      act(() => {
+        result.current.setDeploymentName("My Agent");
+        result.current.setSelectedLlm("gpt-4");
+      });
+      act(() => result.current.handleNext()); // → step 3
+
+      expect(result.current.currentStep).toBe(3);
+      expect(result.current.canGoNext).toBe(false);
+    });
+
+    it("allows when at least one flow is attached", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+        initialInstance: mockInstance,
+      });
+
+      act(() => result.current.handleNext()); // → step 2
+      act(() => {
+        result.current.setDeploymentName("My Agent");
+        result.current.setSelectedLlm("gpt-4");
+      });
+      act(() => result.current.handleNext()); // → step 3
+
+      act(() => {
+        result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      });
+
+      expect(result.current.canGoNext).toBe(true);
+    });
+  });
+
+  describe("Step 4 (Review)", () => {
+    it("always allows proceeding (review is the final step)", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+        initialInstance: mockInstance,
+      });
+
+      act(() => result.current.handleNext()); // → step 2
+      act(() => {
+        result.current.setDeploymentName("My Agent");
+        result.current.setSelectedLlm("gpt-4");
+      });
+      act(() => result.current.handleNext()); // → step 3
+      act(() => {
+        result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      });
+      act(() => result.current.handleNext()); // → step 4
+
+      expect(result.current.currentStep).toBe(4);
+      expect(result.current.canGoNext).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create mode — step navigation
+// ---------------------------------------------------------------------------
+
+describe("Create mode — step navigation", () => {
+  it("handleNext increments step", () => {
+    const { result } = renderCreateHook({
+      initialProvider: mockProvider,
+      initialInstance: mockInstance,
+    });
+
+    act(() => result.current.handleNext());
+    expect(result.current.currentStep).toBe(2);
+  });
+
+  it("handleBack decrements step", () => {
+    const { result } = renderCreateHook({
+      initialProvider: mockProvider,
+      initialInstance: mockInstance,
+    });
+
+    act(() => result.current.handleNext());
+    act(() => result.current.handleBack());
+    expect(result.current.currentStep).toBe(1);
+  });
+
+  it("handleBack does not go below minStep", () => {
+    const { result } = renderCreateHook();
+    act(() => result.current.handleBack());
+    expect(result.current.currentStep).toBe(1);
+  });
+
+  it("handleNext does not exceed totalSteps", () => {
+    const { result } = renderCreateHook({
+      initialProvider: mockProvider,
+      initialInstance: mockInstance,
+    });
+
+    // Navigate all the way to step 4
+    act(() => result.current.handleNext());
+    act(() => result.current.handleNext());
+    act(() => result.current.handleNext());
+    act(() => result.current.handleNext()); // should stay at 4
+
+    expect(result.current.currentStep).toBe(4);
+  });
+
+  it("respects initialStep", () => {
+    const { result } = renderCreateHook({
+      initialProvider: mockProvider,
+      initialInstance: mockInstance,
+      initialStep: 2,
+    });
+
+    expect(result.current.currentStep).toBe(2);
+    expect(result.current.minStep).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create mode — provider selection
+// ---------------------------------------------------------------------------
+
+describe("Create mode — provider selection", () => {
+  it("setSelectedProvider clears instance and credentials", () => {
+    const { result } = renderCreateHook({
+      initialProvider: mockProvider,
+      initialInstance: mockInstance,
+    });
+
+    const newProvider: DeploymentProvider = {
+      id: "provider-2",
+      type: "kubernetes",
+      name: "Kubernetes",
+      icon: "k8s-icon",
+    };
+
+    act(() => result.current.setSelectedProvider(newProvider));
+
+    expect(result.current.selectedProvider).toEqual(newProvider);
+    expect(result.current.selectedInstance).toBeNull();
+    expect(result.current.credentials).toEqual({
+      name: "",
+      provider_key: "",
+      provider_url: "",
+      api_key: "",
+    });
+  });
+
+  it("needsProviderAccountCreation is true when no instance but valid credentials", () => {
+    const { result } = renderCreateHook({
+      initialProvider: mockProvider,
+    });
+
+    act(() => {
+      result.current.setCredentials({
+        name: "New Account",
+        provider_key: "watsonx-orchestrate",
+        provider_url: "https://api.example.com",
+        api_key: "my-secret-key", // pragma: allowlist secret
+      });
+    });
+
+    expect(result.current.needsProviderAccountCreation).toBe(true);
+  });
+
+  it("needsProviderAccountCreation is false when instance is selected", () => {
+    const { result } = renderCreateHook({
+      initialProvider: mockProvider,
+      initialInstance: mockInstance,
+    });
+
+    expect(result.current.needsProviderAccountCreation).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create mode — flow version selection
+// ---------------------------------------------------------------------------
+
+describe("Create mode — flow version selection", () => {
+  it("handleSelectVersion adds a new flow-version mapping", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+    });
+
+    expect(result.current.selectedVersionByFlow.size).toBe(1);
+    expect(result.current.selectedVersionByFlow.get("flow-1")).toEqual({
+      versionId: "ver-1",
+      versionTag: "v1",
+    });
+  });
+
+  it("handleSelectVersion overwrites existing version for same flow", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+    });
+    act(() => {
+      result.current.handleSelectVersion("flow-1", "ver-2", "v2");
+    });
+
+    expect(result.current.selectedVersionByFlow.size).toBe(1);
+    expect(result.current.selectedVersionByFlow.get("flow-1")).toEqual({
+      versionId: "ver-2",
+      versionTag: "v2",
+    });
+  });
+
+  it("handles multiple flows independently", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.handleSelectVersion("flow-2", "ver-2", "v2");
+      result.current.handleSelectVersion("flow-3", "ver-3", "v3");
+    });
+
+    expect(result.current.selectedVersionByFlow.size).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create mode — connection management
+// ---------------------------------------------------------------------------
+
+describe("Create mode — connection management", () => {
+  it("setConnections stores connection items", () => {
+    const { result } = renderCreateHook();
+
+    const conns: ConnectionItem[] = [
+      {
+        id: "conn-1",
+        name: "DB Connection",
+        variableCount: 2,
+        isNew: true,
+        environmentVariables: { DB_HOST: "localhost", DB_PORT: "5432" },
+      },
+    ];
+
+    act(() => result.current.setConnections(conns));
+    expect(result.current.connections).toEqual(conns);
+  });
+
+  it("setAttachedConnectionByFlow maps flows to connections", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setAttachedConnectionByFlow(
+        new Map([
+          ["flow-1", ["conn-1", "conn-2"]],
+          ["flow-2", ["conn-3"]],
+        ]),
+      );
+    });
+
+    expect(result.current.attachedConnectionByFlow.get("flow-1")).toEqual([
+      "conn-1",
+      "conn-2",
+    ]);
+    expect(result.current.attachedConnectionByFlow.get("flow-2")).toEqual([
+      "conn-3",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create mode — buildProviderAccountPayload
+// ---------------------------------------------------------------------------
+
+describe("Create mode — buildProviderAccountPayload", () => {
+  it("returns null when credentials are not valid", () => {
+    const { result } = renderCreateHook();
+    expect(result.current.buildProviderAccountPayload()).toBeNull();
+  });
+
+  it("returns null when credentials are partially filled", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setCredentials({
+        name: "Account",
+        provider_key: "watsonx-orchestrate",
+        provider_url: "",
+        api_key: "key-123", // pragma: allowlist secret
+      });
+    });
+
+    expect(result.current.buildProviderAccountPayload()).toBeNull();
+  });
+
+  it("returns correct payload shape when credentials are valid", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setCredentials({
+        name: "  My Account  ",
+        provider_key: "watsonx-orchestrate",
+        provider_url: "  https://api.example.com  ",
+        api_key: "  secret-key-123  ", // pragma: allowlist secret
+      });
+    });
+
+    const payload = result.current.buildProviderAccountPayload();
+    expect(payload).toEqual({
+      name: "My Account",
+      provider_key: "watsonx-orchestrate",
+      provider_url: "https://api.example.com",
+      provider_data: { api_key: "secret-key-123" }, // pragma: allowlist secret
+    });
+  });
+
+  it("trims whitespace from all credential fields", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setCredentials({
+        name: "  padded  ",
+        provider_key: "watsonx-orchestrate",
+        provider_url: "  https://padded.com  ",
+        api_key: "  padded-key  ", // pragma: allowlist secret
+      });
+    });
+
+    const payload = result.current.buildProviderAccountPayload();
+    expect(payload).toBeDefined();
+    if (!payload) return;
+    expect(payload.name).toBe("padded");
+    expect(payload.provider_url).toBe("https://padded.com");
+    expect(payload.provider_data.api_key).toBe("padded-key"); // pragma: allowlist secret
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create mode — buildDeploymentPayload
+// ---------------------------------------------------------------------------
+
+describe("Create mode — buildDeploymentPayload", () => {
+  it("builds correct spec with name, description, and type", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setDeploymentName("Test Agent");
+      result.current.setDeploymentDescription("Agent description");
+      result.current.setDeploymentType("agent");
+      result.current.setSelectedLlm("gpt-4");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+    });
+
+    const payload = result.current.buildDeploymentPayload("provider-1");
+    expect(payload.provider_id).toBe("provider-1");
+    expect(payload.spec).toEqual({
+      name: "Test Agent",
+      description: "Agent description",
+      type: "agent",
+    });
+  });
+
+  it("includes LLM in provider_data", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setDeploymentName("Agent");
+      result.current.setSelectedLlm("granite-3b");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    expect(payload.provider_data.llm).toBe("granite-3b");
+  });
+
+  it("builds bind operations for each attached flow", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setDeploymentName("Agent");
+      result.current.setSelectedLlm("model-1");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.handleSelectVersion("flow-2", "ver-2", "v2");
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    expect(payload.provider_data.operations).toHaveLength(2);
+    expect(payload.provider_data.operations[0].op).toBe("bind");
+    expect(payload.provider_data.operations[1].op).toBe("bind");
+  });
+
+  it("includes app_ids from attachedConnectionByFlow", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setDeploymentName("Agent");
+      result.current.setSelectedLlm("model-1");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.setAttachedConnectionByFlow(
+        new Map([["flow-1", ["app-1", "app-2"]]]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    const bindOp = payload.provider_data.operations[0];
+    expect(bindOp.app_ids).toEqual(["app-1", "app-2"]);
+  });
+
+  it("includes raw_payloads only for new connections", () => {
+    const { result } = renderCreateHook();
+
+    const newConn: ConnectionItem = {
+      id: "conn-new",
+      name: "New Connection",
+      variableCount: 1,
+      isNew: true,
+      environmentVariables: { API_URL: "https://example.com" },
+    };
+    const existingConn: ConnectionItem = {
+      id: "conn-existing",
+      name: "Existing Connection",
+      variableCount: 0,
+      isNew: false,
+      environmentVariables: {},
+    };
+
+    act(() => {
+      result.current.setDeploymentName("Agent");
+      result.current.setSelectedLlm("model-1");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.setConnections([newConn, existingConn]);
+      result.current.setAttachedConnectionByFlow(
+        new Map([["flow-1", ["conn-new", "conn-existing"]]]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    const rawPayloads = payload.provider_data.connections.raw_payloads;
+    expect(rawPayloads).toHaveLength(1);
+    expect(rawPayloads[0].app_id).toBe("conn-new");
+  });
+
+  it("wraps env vars with source: raw by default", () => {
+    const { result } = renderCreateHook();
+
+    const conn: ConnectionItem = {
+      id: "conn-1",
+      name: "Connection",
+      variableCount: 1,
+      isNew: true,
+      environmentVariables: { DB_HOST: "localhost" },
+    };
+
+    act(() => {
+      result.current.setDeploymentName("Agent");
+      result.current.setSelectedLlm("model-1");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.setConnections([conn]);
+      result.current.setAttachedConnectionByFlow(
+        new Map([["flow-1", ["conn-1"]]]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    const envVars =
+      payload.provider_data.connections.raw_payloads[0].environment_variables;
+    expect(envVars.DB_HOST).toEqual({ value: "localhost", source: "raw" });
+  });
+
+  it("wraps global var keys with source: variable", () => {
+    const { result } = renderCreateHook();
+
+    const conn: ConnectionItem = {
+      id: "conn-1",
+      name: "Connection",
+      variableCount: 2,
+      isNew: true,
+      environmentVariables: {
+        DB_HOST: "localhost",
+        SECRET_KEY: "my-global-var", // pragma: allowlist secret
+      },
+      globalVarKeys: new Set(["SECRET_KEY"]),
+    };
+
+    act(() => {
+      result.current.setDeploymentName("Agent");
+      result.current.setSelectedLlm("model-1");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.setConnections([conn]);
+      result.current.setAttachedConnectionByFlow(
+        new Map([["flow-1", ["conn-1"]]]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    const envVars =
+      payload.provider_data.connections.raw_payloads[0].environment_variables;
+    expect(envVars.DB_HOST).toEqual({ value: "localhost", source: "raw" });
+    expect(envVars.SECRET_KEY).toEqual({
+      value: "my-global-var",
+      source: "variable",
+    });
+  });
+
+  it("returns empty raw_payloads when no new connections", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setDeploymentName("Agent");
+      result.current.setSelectedLlm("model-1");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    expect(payload.provider_data.connections.raw_payloads).toEqual([]);
+  });
+
+  it("returns empty operations when no flows attached", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setDeploymentName("Agent");
+      result.current.setSelectedLlm("model-1");
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    expect(payload.provider_data.operations).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create mode — multi-flow scenarios
+// ---------------------------------------------------------------------------
+
+describe("Create mode — multi-flow scenarios", () => {
+  it("builds payload with 3+ flows, connections, and tool names", () => {
+    const { result } = renderCreateHook();
+
+    const conn1: ConnectionItem = {
+      id: "conn-a",
+      name: "Connection A",
+      variableCount: 1,
+      isNew: true,
+      environmentVariables: { KEY_A: "val-a" },
+    };
+    const conn2: ConnectionItem = {
+      id: "conn-b",
+      name: "Connection B",
+      variableCount: 1,
+      isNew: true,
+      environmentVariables: { KEY_B: "val-b" },
+    };
+
+    act(() => {
+      result.current.setDeploymentName("Multi-Flow Agent");
+      result.current.setSelectedLlm("model-1");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.handleSelectVersion("flow-2", "ver-2", "v2");
+      result.current.handleSelectVersion("flow-3", "ver-3", "v3");
+      result.current.setToolNameByFlow(
+        new Map([
+          ["flow-1", "Tool Alpha"],
+          ["flow-2", "Tool Beta"],
+          // flow-3 intentionally has no custom name
+        ]),
+      );
+      result.current.setConnections([conn1, conn2]);
+      result.current.setAttachedConnectionByFlow(
+        new Map([
+          ["flow-1", ["conn-a"]],
+          ["flow-2", ["conn-b"]],
+          ["flow-3", ["conn-a", "conn-b"]],
+        ]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    const ops = payload.provider_data.operations;
+
+    expect(ops).toHaveLength(3);
+
+    const flow1Op = ops.find((o) => o.flow_version_id === "ver-1");
+    expect(flow1Op?.tool_name).toBe("Tool Alpha");
+    expect(flow1Op?.app_ids).toEqual(["conn-a"]);
+
+    const flow2Op = ops.find((o) => o.flow_version_id === "ver-2");
+    expect(flow2Op?.tool_name).toBe("Tool Beta");
+    expect(flow2Op?.app_ids).toEqual(["conn-b"]);
+
+    const flow3Op = ops.find((o) => o.flow_version_id === "ver-3");
+    expect(flow3Op?.tool_name).toBeUndefined();
+    expect(flow3Op?.app_ids).toEqual(["conn-a", "conn-b"]);
+
+    // Both connections are new, so both appear in raw_payloads
+    const rawPayloads = payload.provider_data.connections.raw_payloads;
+    expect(rawPayloads).toHaveLength(2);
+    const appIds = rawPayloads.map((r) => r.app_id).sort();
+    expect(appIds).toEqual(["conn-a", "conn-b"]);
+  });
+
+  it("deduplicates connections in raw_payloads across flows", () => {
+    const { result } = renderCreateHook();
+
+    const sharedConn: ConnectionItem = {
+      id: "conn-shared",
+      name: "Shared Connection",
+      variableCount: 1,
+      isNew: true,
+      environmentVariables: { SHARED_KEY: "shared-val" },
+    };
+
+    act(() => {
+      result.current.setDeploymentName("Agent");
+      result.current.setSelectedLlm("model-1");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.handleSelectVersion("flow-2", "ver-2", "v2");
+      result.current.setConnections([sharedConn]);
+      result.current.setAttachedConnectionByFlow(
+        new Map([
+          ["flow-1", ["conn-shared"]],
+          ["flow-2", ["conn-shared"]],
+        ]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    // Even though both flows reference the same connection, it should only appear once
+    expect(payload.provider_data.connections.raw_payloads).toHaveLength(1);
+    expect(payload.provider_data.connections.raw_payloads[0].app_id).toBe(
+      "conn-shared",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create mode — edge cases
+// ---------------------------------------------------------------------------
+
+describe("Create mode — edge cases", () => {
+  it("empty description is allowed in payload", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setDeploymentName("Agent");
+      result.current.setSelectedLlm("model-1");
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    expect(payload.spec.description).toBe("");
+  });
+
+  it("buildDeploymentPayload works with MCP deployment type", () => {
+    const { result } = renderCreateHook();
+
+    act(() => {
+      result.current.setDeploymentName("MCP Server");
+      result.current.setDeploymentType("mcp");
+      result.current.setSelectedLlm("model-1");
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    expect(payload.spec.type).toBe("mcp");
+  });
+
+  it("connection with empty environmentVariables produces empty object", () => {
+    const { result } = renderCreateHook();
+
+    const conn: ConnectionItem = {
+      id: "conn-empty",
+      name: "Empty Vars",
+      variableCount: 0,
+      isNew: true,
+      environmentVariables: {},
+    };
+
+    act(() => {
+      result.current.setDeploymentName("Agent");
+      result.current.setSelectedLlm("model-1");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.setConnections([conn]);
+      result.current.setAttachedConnectionByFlow(
+        new Map([["flow-1", ["conn-empty"]]]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentPayload("p-1");
+    expect(
+      payload.provider_data.connections.raw_payloads[0].environment_variables,
+    ).toEqual({});
+  });
+
+  it("buildDeploymentUpdatePayload throws in create mode", () => {
+    const { result } = renderCreateHook();
+    expect(() => result.current.buildDeploymentUpdatePayload()).toThrow(
+      "buildDeploymentUpdatePayload called outside edit mode",
+    );
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/create-mode.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/create-mode.test.tsx
@@ -31,9 +31,8 @@ const mockProvider: DeploymentProvider = {
 const mockInstance: ProviderAccount = {
   id: "instance-1",
   name: "My WxO Instance",
-  provider_tenant_id: "tenant-1",
   provider_key: "watsonx-orchestrate",
-  provider_url: "https://api.example.com",
+  url: "https://api.example.com",
   created_at: "2025-01-01T00:00:00Z",
   updated_at: "2025-01-01T00:00:00Z",
 };
@@ -136,7 +135,7 @@ describe("Create mode — canGoNext validation", () => {
         result.current.setCredentials({
           name: "New Account",
           provider_key: "watsonx-orchestrate",
-          provider_url: "https://api.example.com",
+          url: "https://api.example.com",
           api_key: "my-secret-key", // pragma: allowlist secret
         });
       });
@@ -153,7 +152,7 @@ describe("Create mode — canGoNext validation", () => {
         result.current.setCredentials({
           name: "New Account",
           provider_key: "watsonx-orchestrate",
-          provider_url: "",
+          url: "",
           api_key: "my-secret-key", // pragma: allowlist secret
         });
       });
@@ -369,7 +368,7 @@ describe("Create mode — provider selection", () => {
     expect(result.current.credentials).toEqual({
       name: "",
       provider_key: "",
-      provider_url: "",
+      url: "",
       api_key: "",
     });
   });
@@ -383,7 +382,7 @@ describe("Create mode — provider selection", () => {
       result.current.setCredentials({
         name: "New Account",
         provider_key: "watsonx-orchestrate",
-        provider_url: "https://api.example.com",
+        url: "https://api.example.com",
         api_key: "my-secret-key", // pragma: allowlist secret
       });
     });
@@ -511,7 +510,7 @@ describe("Create mode — buildProviderAccountPayload", () => {
       result.current.setCredentials({
         name: "Account",
         provider_key: "watsonx-orchestrate",
-        provider_url: "",
+        url: "",
         api_key: "key-123", // pragma: allowlist secret
       });
     });
@@ -526,7 +525,7 @@ describe("Create mode — buildProviderAccountPayload", () => {
       result.current.setCredentials({
         name: "  My Account  ",
         provider_key: "watsonx-orchestrate",
-        provider_url: "  https://api.example.com  ",
+        url: "  https://api.example.com  ",
         api_key: "  secret-key-123  ", // pragma: allowlist secret
       });
     });
@@ -535,7 +534,7 @@ describe("Create mode — buildProviderAccountPayload", () => {
     expect(payload).toEqual({
       name: "My Account",
       provider_key: "watsonx-orchestrate",
-      provider_url: "https://api.example.com",
+      url: "https://api.example.com",
       provider_data: { api_key: "secret-key-123" }, // pragma: allowlist secret
     });
   });
@@ -547,7 +546,7 @@ describe("Create mode — buildProviderAccountPayload", () => {
       result.current.setCredentials({
         name: "  padded  ",
         provider_key: "watsonx-orchestrate",
-        provider_url: "  https://padded.com  ",
+        url: "  https://padded.com  ",
         api_key: "  padded-key  ", // pragma: allowlist secret
       });
     });
@@ -556,7 +555,7 @@ describe("Create mode — buildProviderAccountPayload", () => {
     expect(payload).toBeDefined();
     if (!payload) return;
     expect(payload.name).toBe("padded");
-    expect(payload.provider_url).toBe("https://padded.com");
+    expect(payload.url).toBe("https://padded.com");
     expect(payload.provider_data.api_key).toBe("padded-key"); // pragma: allowlist secret
   });
 });
@@ -579,11 +578,9 @@ describe("Create mode — buildDeploymentPayload", () => {
 
     const payload = result.current.buildDeploymentPayload("provider-1");
     expect(payload.provider_id).toBe("provider-1");
-    expect(payload.spec).toEqual({
-      name: "Test Agent",
-      description: "Agent description",
-      type: "agent",
-    });
+    expect(payload.name).toBe("Test Agent");
+    expect(payload.description).toBe("Agent description");
+    expect(payload.type).toBe("agent");
   });
 
   it("includes LLM in provider_data", () => {
@@ -610,9 +607,9 @@ describe("Create mode — buildDeploymentPayload", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("p-1");
-    expect(payload.provider_data.operations).toHaveLength(2);
-    expect(payload.provider_data.operations[0].op).toBe("bind");
-    expect(payload.provider_data.operations[1].op).toBe("bind");
+    expect(payload.provider_data.add_flows).toHaveLength(2);
+    expect(payload.provider_data.add_flows[0].flow_version_id).toBeDefined();
+    expect(payload.provider_data.add_flows[1].flow_version_id).toBeDefined();
   });
 
   it("includes app_ids from attachedConnectionByFlow", () => {
@@ -628,8 +625,8 @@ describe("Create mode — buildDeploymentPayload", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("p-1");
-    const bindOp = payload.provider_data.operations[0];
-    expect(bindOp.app_ids).toEqual(["app-1", "app-2"]);
+    const addFlow = payload.provider_data.add_flows[0];
+    expect(addFlow.app_ids).toEqual(["app-1", "app-2"]);
   });
 
   it("includes raw_payloads only for new connections", () => {
@@ -661,9 +658,9 @@ describe("Create mode — buildDeploymentPayload", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("p-1");
-    const rawPayloads = payload.provider_data.connections.raw_payloads;
-    expect(rawPayloads).toHaveLength(1);
-    expect(rawPayloads[0].app_id).toBe("conn-new");
+    const connections = payload.provider_data.connections;
+    expect(connections).toHaveLength(1);
+    expect(connections[0].app_id).toBe("conn-new");
   });
 
   it("wraps env vars with source: raw by default", () => {
@@ -688,9 +685,13 @@ describe("Create mode — buildDeploymentPayload", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("p-1");
-    const envVars =
-      payload.provider_data.connections.raw_payloads[0].environment_variables;
-    expect(envVars.DB_HOST).toEqual({ value: "localhost", source: "raw" });
+    const credentials = payload.provider_data.connections[0].credentials;
+    const dbHostCred = credentials.find((c) => c.key === "DB_HOST");
+    expect(dbHostCred).toEqual({
+      key: "DB_HOST",
+      value: "localhost",
+      source: "raw",
+    });
   });
 
   it("wraps global var keys with source: variable", () => {
@@ -719,10 +720,16 @@ describe("Create mode — buildDeploymentPayload", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("p-1");
-    const envVars =
-      payload.provider_data.connections.raw_payloads[0].environment_variables;
-    expect(envVars.DB_HOST).toEqual({ value: "localhost", source: "raw" });
-    expect(envVars.SECRET_KEY).toEqual({
+    const credentials = payload.provider_data.connections[0].credentials;
+    const dbHostCred = credentials.find((c) => c.key === "DB_HOST");
+    const secretKeyCred = credentials.find((c) => c.key === "SECRET_KEY");
+    expect(dbHostCred).toEqual({
+      key: "DB_HOST",
+      value: "localhost",
+      source: "raw",
+    });
+    expect(secretKeyCred).toEqual({
+      key: "SECRET_KEY",
       value: "my-global-var",
       source: "variable",
     });
@@ -738,7 +745,7 @@ describe("Create mode — buildDeploymentPayload", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("p-1");
-    expect(payload.provider_data.connections.raw_payloads).toEqual([]);
+    expect(payload.provider_data.connections).toEqual([]);
   });
 
   it("returns empty operations when no flows attached", () => {
@@ -750,7 +757,7 @@ describe("Create mode — buildDeploymentPayload", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("p-1");
-    expect(payload.provider_data.operations).toEqual([]);
+    expect(payload.provider_data.add_flows).toEqual([]);
   });
 });
 
@@ -801,26 +808,26 @@ describe("Create mode — multi-flow scenarios", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("p-1");
-    const ops = payload.provider_data.operations;
+    const addFlows = payload.provider_data.add_flows;
 
-    expect(ops).toHaveLength(3);
+    expect(addFlows).toHaveLength(3);
 
-    const flow1Op = ops.find((o) => o.flow_version_id === "ver-1");
+    const flow1Op = addFlows.find((o) => o.flow_version_id === "ver-1");
     expect(flow1Op?.tool_name).toBe("Tool Alpha");
     expect(flow1Op?.app_ids).toEqual(["conn-a"]);
 
-    const flow2Op = ops.find((o) => o.flow_version_id === "ver-2");
+    const flow2Op = addFlows.find((o) => o.flow_version_id === "ver-2");
     expect(flow2Op?.tool_name).toBe("Tool Beta");
     expect(flow2Op?.app_ids).toEqual(["conn-b"]);
 
-    const flow3Op = ops.find((o) => o.flow_version_id === "ver-3");
+    const flow3Op = addFlows.find((o) => o.flow_version_id === "ver-3");
     expect(flow3Op?.tool_name).toBeUndefined();
     expect(flow3Op?.app_ids).toEqual(["conn-a", "conn-b"]);
 
-    // Both connections are new, so both appear in raw_payloads
-    const rawPayloads = payload.provider_data.connections.raw_payloads;
-    expect(rawPayloads).toHaveLength(2);
-    const appIds = rawPayloads.map((r) => r.app_id).sort();
+    // Both connections are new, so both appear in connections
+    const connections = payload.provider_data.connections;
+    expect(connections).toHaveLength(2);
+    const appIds = connections.map((r) => r.app_id).sort();
     expect(appIds).toEqual(["conn-a", "conn-b"]);
   });
 
@@ -851,10 +858,8 @@ describe("Create mode — multi-flow scenarios", () => {
 
     const payload = result.current.buildDeploymentPayload("p-1");
     // Even though both flows reference the same connection, it should only appear once
-    expect(payload.provider_data.connections.raw_payloads).toHaveLength(1);
-    expect(payload.provider_data.connections.raw_payloads[0].app_id).toBe(
-      "conn-shared",
-    );
+    expect(payload.provider_data.connections).toHaveLength(1);
+    expect(payload.provider_data.connections[0].app_id).toBe("conn-shared");
   });
 });
 
@@ -872,7 +877,7 @@ describe("Create mode — edge cases", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("p-1");
-    expect(payload.spec.description).toBe("");
+    expect(payload.description).toBe("");
   });
 
   it("buildDeploymentPayload works with MCP deployment type", () => {
@@ -885,7 +890,7 @@ describe("Create mode — edge cases", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("p-1");
-    expect(payload.spec.type).toBe("mcp");
+    expect(payload.type).toBe("mcp");
   });
 
   it("connection with empty environmentVariables produces empty object", () => {
@@ -910,9 +915,7 @@ describe("Create mode — edge cases", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("p-1");
-    expect(
-      payload.provider_data.connections.raw_payloads[0].environment_variables,
-    ).toEqual({});
+    expect(payload.provider_data.connections[0].credentials).toEqual([]);
   });
 
   it("buildDeploymentUpdatePayload throws in create mode", () => {

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/custom-tool-naming.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/custom-tool-naming.test.tsx
@@ -79,6 +79,81 @@ describe("Custom tool naming", () => {
     expect(bindOp.tool_name).toBeUndefined();
   });
 
+  it("tool name with special characters is preserved in payload", () => {
+    const { result } = renderStepperHook();
+
+    act(() => {
+      result.current.setDeploymentName("Test Agent");
+      result.current.setSelectedLlm("test-model");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.setToolNameByFlow(
+        new Map([["flow-1", "my-tool_v2.0 (beta) [test]"]]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentPayload("provider-1");
+    expect(payload.provider_data.operations[0].tool_name).toBe(
+      "my-tool_v2.0 (beta) [test]",
+    );
+  });
+
+  it("tool name with unicode characters is preserved", () => {
+    const { result } = renderStepperHook();
+
+    act(() => {
+      result.current.setDeploymentName("Test Agent");
+      result.current.setSelectedLlm("test-model");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.setToolNameByFlow(
+        new Map([["flow-1", "ferramenta_análise"]]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentPayload("provider-1");
+    expect(payload.provider_data.operations[0].tool_name).toBe(
+      "ferramenta_análise",
+    );
+  });
+
+  it("very long tool name is preserved without truncation", () => {
+    const { result } = renderStepperHook();
+    const longName = "A".repeat(500);
+
+    act(() => {
+      result.current.setDeploymentName("Test Agent");
+      result.current.setSelectedLlm("test-model");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.setToolNameByFlow(new Map([["flow-1", longName]]));
+    });
+
+    const payload = result.current.buildDeploymentPayload("provider-1");
+    expect(payload.provider_data.operations[0].tool_name).toBe(longName);
+    expect(payload.provider_data.operations[0].tool_name).toHaveLength(500);
+  });
+
+  it("two flows can have the same tool name (no client-side collision check)", () => {
+    const { result } = renderStepperHook();
+
+    act(() => {
+      result.current.setDeploymentName("Test Agent");
+      result.current.setSelectedLlm("test-model");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+      result.current.handleSelectVersion("flow-2", "ver-2", "v2");
+      result.current.setToolNameByFlow(
+        new Map([
+          ["flow-1", "Same Name"],
+          ["flow-2", "Same Name"],
+        ]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentPayload("provider-1");
+    const ops = payload.provider_data.operations;
+    expect(ops).toHaveLength(2);
+    expect(ops[0].tool_name).toBe("Same Name");
+    expect(ops[1].tool_name).toBe("Same Name");
+  });
+
   it("each flow can have its own tool name", () => {
     const { result } = renderStepperHook();
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/custom-tool-naming.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/custom-tool-naming.test.tsx
@@ -92,7 +92,7 @@ describe("Custom tool naming", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("provider-1");
-    expect(payload.provider_data.operations[0].tool_name).toBe(
+    expect(payload.provider_data.add_flows[0].tool_name).toBe(
       "my-tool_v2.0 (beta) [test]",
     );
   });
@@ -110,7 +110,7 @@ describe("Custom tool naming", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("provider-1");
-    expect(payload.provider_data.operations[0].tool_name).toBe(
+    expect(payload.provider_data.add_flows[0].tool_name).toBe(
       "ferramenta_análise",
     );
   });
@@ -127,8 +127,8 @@ describe("Custom tool naming", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("provider-1");
-    expect(payload.provider_data.operations[0].tool_name).toBe(longName);
-    expect(payload.provider_data.operations[0].tool_name).toHaveLength(500);
+    expect(payload.provider_data.add_flows[0].tool_name).toBe(longName);
+    expect(payload.provider_data.add_flows[0].tool_name).toHaveLength(500);
   });
 
   it("two flows can have the same tool name (no client-side collision check)", () => {
@@ -148,10 +148,10 @@ describe("Custom tool naming", () => {
     });
 
     const payload = result.current.buildDeploymentPayload("provider-1");
-    const ops = payload.provider_data.operations;
-    expect(ops).toHaveLength(2);
-    expect(ops[0].tool_name).toBe("Same Name");
-    expect(ops[1].tool_name).toBe("Same Name");
+    const addFlows = payload.provider_data.add_flows;
+    expect(addFlows).toHaveLength(2);
+    expect(addFlows[0].tool_name).toBe("Same Name");
+    expect(addFlows[1].tool_name).toBe("Same Name");
   });
 
   it("each flow can have its own tool name", () => {

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployment-details-modal.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployment-details-modal.test.tsx
@@ -42,7 +42,7 @@ jest.mock(
 );
 
 let mockConfigsData: {
-  configs: Array<{ id: string; name: string }>;
+  configs: Array<{ app_id: string; connection_id: string }>;
 } | null = null;
 let mockIsFetchingConfigs = false;
 
@@ -76,7 +76,6 @@ const makeDeployment = (overrides: Partial<Deployment> = {}): Deployment => ({
   provider_data: { llm: "granite-13b-chat" },
   resource_key: "rk-1",
   attached_count: 2,
-  matched_attachments: null,
   provider_account_id: "prov-1",
   ...overrides,
 });
@@ -121,8 +120,8 @@ beforeEach(() => {
   mockIsFetchingAttachments = false;
   mockConfigsData = {
     configs: [
-      { id: "cfg-1", name: "Production Config" },
-      { id: "cfg-2", name: "Staging Config" },
+      { app_id: "cfg-1", connection_id: "conn-1" },
+      { app_id: "cfg-2", connection_id: "conn-2" },
     ],
   };
   mockIsFetchingConfigs = false;
@@ -200,8 +199,9 @@ describe("Flow list with versions and connections", () => {
 
   it("maps connection IDs to names via configMap", () => {
     renderModal();
-    expect(screen.getByText("Production Config")).toBeInTheDocument();
-    expect(screen.getByText("Staging Config")).toBeInTheDocument();
+    // Configs matched by app_id — the app_id strings are rendered as connection names
+    expect(screen.getByText("cfg-1")).toBeInTheDocument();
+    expect(screen.getByText("cfg-2")).toBeInTheDocument();
   });
 
   it("shows 'No flows attached' when flow list is empty", () => {
@@ -210,11 +210,11 @@ describe("Flow list with versions and connections", () => {
     expect(screen.getByText("No flows attached")).toBeInTheDocument();
   });
 
-  it("shows flow_id as fallback when config not found", () => {
+  it("shows nothing for connections when config not found", () => {
     mockConfigsData = { configs: [] };
     renderModal();
-    // app_ids that aren't in configMap appear as-is
-    expect(screen.getByText("cfg-1")).toBeInTheDocument();
+    // app_ids not in configMap are filtered out, so no connection labels appear
+    expect(screen.queryByText("cfg-1")).not.toBeInTheDocument();
   });
 });
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployment-details-modal.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployment-details-modal.test.tsx
@@ -1,0 +1,263 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Deployment } from "../types";
+
+// ---------------------------------------------------------------------------
+// Mocks — API hooks
+// ---------------------------------------------------------------------------
+
+let mockDeploymentDetail: Deployment | null = null;
+let mockIsFetchingDetails = false;
+
+jest.mock("@/controllers/API/queries/deployments/use-get-deployment", () => ({
+  useGetDeployment: () => ({
+    data: mockDeploymentDetail,
+    isFetching: mockIsFetchingDetails,
+  }),
+}));
+
+let mockAttachmentsData: {
+  flow_versions: Array<{
+    id: string;
+    flow_id: string;
+    flow_name: string | null;
+    version_number: number;
+    attached_at: string | null;
+    provider_snapshot_id: string | null;
+    tool_name: string | null;
+    provider_data: { app_ids?: string[] } | null;
+  }>;
+} | null = null;
+let mockIsFetchingAttachments = false;
+
+jest.mock(
+  "@/controllers/API/queries/deployments/use-get-deployment-attachments",
+  () => ({
+    useGetDeploymentAttachments: () => ({
+      data: mockAttachmentsData,
+      isFetching: mockIsFetchingAttachments,
+    }),
+  }),
+);
+
+let mockConfigsData: {
+  configs: Array<{ id: string; name: string }>;
+} | null = null;
+let mockIsFetchingConfigs = false;
+
+jest.mock(
+  "@/controllers/API/queries/deployments/use-get-deployment-configs",
+  () => ({
+    useGetDeploymentConfigs: () => ({
+      data: mockConfigsData,
+      isFetching: mockIsFetchingConfigs,
+    }),
+  }),
+);
+
+jest.mock(
+  "@/components/common/genericIconComponent",
+  () =>
+    function MockIcon({ name }: { name: string }) {
+      return <span data-testid={`icon-${name}`} />;
+    },
+);
+
+import DeploymentDetailsModal from "../components/deployment-details-modal/deployment-details-modal";
+
+const makeDeployment = (overrides: Partial<Deployment> = {}): Deployment => ({
+  id: "dep-1",
+  name: "My Agent",
+  description: "A sales agent",
+  type: "agent",
+  created_at: "2025-05-01T00:00:00Z",
+  updated_at: "2025-06-10T00:00:00Z",
+  provider_data: { llm: "granite-13b-chat" },
+  resource_key: "rk-1",
+  attached_count: 2,
+  matched_attachments: null,
+  provider_account_id: "prov-1",
+  ...overrides,
+});
+
+function renderModal(
+  deployment: Deployment | null = makeDeployment(),
+  open = true,
+) {
+  const setOpen = jest.fn();
+  const result = render(
+    <TooltipProvider>
+      <DeploymentDetailsModal
+        open={open}
+        setOpen={setOpen}
+        deployment={deployment}
+        providerName="watsonx Prod"
+      />
+    </TooltipProvider>,
+  );
+  return { setOpen, ...result };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  const dep = makeDeployment();
+  mockDeploymentDetail = dep;
+  mockIsFetchingDetails = false;
+  mockAttachmentsData = {
+    flow_versions: [
+      {
+        id: "fv-1",
+        flow_id: "flow-1",
+        flow_name: "Sales Flow",
+        version_number: 3,
+        attached_at: "2025-06-01T00:00:00Z",
+        provider_snapshot_id: "snap-1",
+        tool_name: "sales_tool",
+        provider_data: { app_ids: ["cfg-1", "cfg-2"] },
+      },
+    ],
+  };
+  mockIsFetchingAttachments = false;
+  mockConfigsData = {
+    configs: [
+      { id: "cfg-1", name: "Production Config" },
+      { id: "cfg-2", name: "Staging Config" },
+    ],
+  };
+  mockIsFetchingConfigs = false;
+});
+
+// ---------------------------------------------------------------------------
+// Basic rendering
+// ---------------------------------------------------------------------------
+
+describe("Basic rendering", () => {
+  it("renders the Deployment Details title", () => {
+    renderModal();
+    expect(screen.getByText("Deployment Details")).toBeInTheDocument();
+  });
+
+  it("renders the description text", () => {
+    renderModal();
+    expect(
+      screen.getByText("View deployment configuration and attached flows."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Close button", () => {
+    renderModal();
+    expect(screen.getByTestId("deployment-details-close")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Info grid rendering
+// ---------------------------------------------------------------------------
+
+describe("Info grid rendering", () => {
+  it("shows deployment type", () => {
+    renderModal();
+    expect(screen.getByText("agent")).toBeInTheDocument();
+  });
+
+  it("shows deployment name", () => {
+    renderModal();
+    expect(screen.getByText("My Agent")).toBeInTheDocument();
+  });
+
+  it("shows description when present", () => {
+    renderModal();
+    expect(screen.getByText("A sales agent")).toBeInTheDocument();
+  });
+
+  it("shows LLM model from provider_data", () => {
+    renderModal();
+    expect(screen.getByText("granite-13b-chat")).toBeInTheDocument();
+  });
+
+  it("shows provider name", () => {
+    renderModal();
+    expect(screen.getByText("watsonx Prod")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flow list with versions and connections
+// ---------------------------------------------------------------------------
+
+describe("Flow list with versions and connections", () => {
+  it("shows attached flows count", () => {
+    renderModal();
+    expect(screen.getByText("Attached Flows (1)")).toBeInTheDocument();
+  });
+
+  it("shows flow name and version number", () => {
+    renderModal();
+    expect(screen.getByText("Sales Flow")).toBeInTheDocument();
+    expect(screen.getByText("v3")).toBeInTheDocument();
+  });
+
+  it("maps connection IDs to names via configMap", () => {
+    renderModal();
+    expect(screen.getByText("Production Config")).toBeInTheDocument();
+    expect(screen.getByText("Staging Config")).toBeInTheDocument();
+  });
+
+  it("shows 'No flows attached' when flow list is empty", () => {
+    mockAttachmentsData = { flow_versions: [] };
+    renderModal();
+    expect(screen.getByText("No flows attached")).toBeInTheDocument();
+  });
+
+  it("shows flow_id as fallback when config not found", () => {
+    mockConfigsData = { configs: [] };
+    renderModal();
+    // app_ids that aren't in configMap appear as-is
+    expect(screen.getByText("cfg-1")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loading state
+// ---------------------------------------------------------------------------
+
+describe("Loading state", () => {
+  it("shows loading indicator when fetching details", () => {
+    mockIsFetchingDetails = true;
+    renderModal();
+    // Loading component is rendered
+    expect(screen.queryByText("Attached Flows")).not.toBeInTheDocument();
+  });
+
+  it("shows loading indicator when fetching attachments", () => {
+    mockIsFetchingAttachments = true;
+    renderModal();
+    expect(screen.queryByText("Attached Flows")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Close behavior
+// ---------------------------------------------------------------------------
+
+describe("Close behavior", () => {
+  it("calls setOpen when Close button is clicked", async () => {
+    const user = userEvent.setup();
+    const { setOpen } = renderModal();
+
+    await user.click(screen.getByTestId("deployment-details-close"));
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Null deployment
+// ---------------------------------------------------------------------------
+
+describe("Null deployment", () => {
+  it("renders without crashing when deployment is null", () => {
+    renderModal(null);
+    expect(screen.getByText("Deployment Details")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployment-stepper-modal.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployment-stepper-modal.test.tsx
@@ -1,0 +1,359 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Deployment, ProviderAccount } from "../types";
+
+// ---------------------------------------------------------------------------
+// Mocks — API hooks
+// ---------------------------------------------------------------------------
+
+let mockAttachmentsData: {
+  flow_versions: Array<{
+    id: string;
+    flow_id: string;
+    flow_name: string | null;
+    version_number: number;
+    attached_at: string | null;
+    provider_snapshot_id: string | null;
+    tool_name: string | null;
+    provider_data: { app_ids?: string[] } | null;
+  }>;
+} | null = null;
+let mockIsLoadingAttachments = false;
+
+jest.mock(
+  "@/controllers/API/queries/deployments/use-get-deployment-attachments",
+  () => ({
+    useGetDeploymentAttachments: () => ({
+      data: mockAttachmentsData,
+      isFetching: mockIsLoadingAttachments,
+      isLoading: mockIsLoadingAttachments,
+    }),
+  }),
+);
+
+let mockDeploymentDetail: Deployment | null = null;
+let mockIsLoadingDetail = false;
+
+jest.mock("@/controllers/API/queries/deployments/use-get-deployment", () => ({
+  useGetDeployment: () => ({
+    data: mockDeploymentDetail,
+    isFetching: mockIsLoadingDetail,
+    isLoading: mockIsLoadingDetail,
+  }),
+}));
+
+const mockCreateProviderAccount = jest.fn();
+jest.mock(
+  "@/controllers/API/queries/deployment-provider-accounts/use-post-provider-account",
+  () => ({
+    usePostProviderAccount: () => ({
+      mutateAsync: mockCreateProviderAccount,
+    }),
+  }),
+);
+
+const mockCreateDeployment = jest.fn();
+jest.mock("@/controllers/API/queries/deployments/use-post-deployment", () => ({
+  usePostDeployment: () => ({
+    mutateAsync: mockCreateDeployment,
+  }),
+}));
+
+const mockUpdateDeployment = jest.fn();
+jest.mock("@/controllers/API/queries/deployments/use-patch-deployment", () => ({
+  usePatchDeployment: () => ({
+    mutateAsync: mockUpdateDeployment,
+  }),
+}));
+
+jest.mock("../hooks/use-error-alert", () => ({
+  useErrorAlert: () => jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks — stepper context internals (the modal provides the context)
+//
+// We need to mock the child step components to keep this test focused on
+// the modal's own behavior (step navigation, deploy flow, edit mode loading).
+// ---------------------------------------------------------------------------
+
+jest.mock("../components/step-provider", () =>
+  jest.fn(() => <div data-testid="step-provider">StepProvider</div>),
+);
+jest.mock("../components/step-type", () =>
+  jest.fn(() => <div data-testid="step-type">StepType</div>),
+);
+jest.mock("../components/step-attach-flows", () =>
+  jest.fn(() => <div data-testid="step-attach-flows">StepAttachFlows</div>),
+);
+jest.mock("../components/step-review", () =>
+  jest.fn(() => <div data-testid="step-review">StepReview</div>),
+);
+jest.mock("../components/step-deploy-status", () =>
+  jest.fn(({ phase }: { phase: string }) => (
+    <div data-testid="step-deploy-status">{phase}</div>
+  )),
+);
+
+jest.mock(
+  "@/components/common/genericIconComponent",
+  () =>
+    function MockIcon({ name }: { name: string }) {
+      return <span data-testid={`icon-${name}`} />;
+    },
+);
+
+jest.mock("@/components/ui/loading", () =>
+  jest.fn(() => <span data-testid="loading-spinner" />),
+);
+
+// Mock hooks that the context depends on internally
+jest.mock(
+  "@/controllers/API/queries/deployment-provider-accounts/use-get-provider-accounts",
+  () => ({
+    useGetProviderAccounts: () => ({ data: undefined }),
+  }),
+);
+
+jest.mock(
+  "@/controllers/API/queries/deployments/use-get-deployment-configs",
+  () => ({
+    useGetDeploymentConfigs: () => ({ data: undefined }),
+  }),
+);
+
+jest.mock(
+  "@/controllers/API/queries/deployments/use-get-deployment-llms",
+  () => ({
+    useGetDeploymentLlms: () => ({ data: undefined, isLoading: false }),
+  }),
+);
+
+jest.mock(
+  "@/controllers/API/queries/flows/use-get-refresh-flows-query",
+  () => ({
+    useGetRefreshFlowsQuery: () => ({ data: [] }),
+  }),
+);
+
+jest.mock(
+  "@/controllers/API/queries/flow-version/use-get-flow-versions",
+  () => ({
+    useGetFlowVersions: () => ({ data: null, isLoading: false }),
+  }),
+);
+
+jest.mock(
+  "@/controllers/API/queries/variables/use-post-detect-env-vars",
+  () => ({
+    usePostDetectEnvVars: () => ({ mutateAsync: jest.fn() }),
+  }),
+);
+
+jest.mock("@/controllers/API/queries/variables", () => ({
+  useGetGlobalVariables: () => ({ data: [] }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  useParams: () => ({ folderId: "folder-1" }),
+}));
+
+jest.mock("@/stores/foldersStore", () => ({
+  useFolderStore: () => "folder-1",
+}));
+
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+import DeploymentStepperModal from "../components/deployment-stepper-modal";
+
+const makeDeployment = (overrides: Partial<Deployment> = {}): Deployment => ({
+  id: "dep-1",
+  name: "My Agent",
+  description: "A sales agent",
+  type: "agent",
+  created_at: "2025-05-01T00:00:00Z",
+  updated_at: "2025-06-10T00:00:00Z",
+  provider_data: { llm: "granite-13b-chat" },
+  resource_key: "rk-1",
+  attached_count: 2,
+  matched_attachments: null,
+  provider_account_id: "prov-1",
+  ...overrides,
+});
+
+const makeInstance = (
+  overrides: Partial<ProviderAccount> = {},
+): ProviderAccount => ({
+  id: "inst-1",
+  name: "Prod Instance",
+  provider_tenant_id: "tenant-1",
+  provider_key: "watsonx-orchestrate",
+  provider_url: "https://api.example.com",
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+  ...overrides,
+});
+
+function renderModal(
+  overrides: Partial<Parameters<typeof DeploymentStepperModal>[0]> = {},
+) {
+  const setOpen = jest.fn();
+  const result = render(
+    <TooltipProvider>
+      <DeploymentStepperModal open={true} setOpen={setOpen} {...overrides} />
+    </TooltipProvider>,
+  );
+  return { setOpen, ...result };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAttachmentsData = null;
+  mockIsLoadingAttachments = false;
+  mockDeploymentDetail = null;
+  mockIsLoadingDetail = false;
+});
+
+// ---------------------------------------------------------------------------
+// Create mode — step navigation
+// ---------------------------------------------------------------------------
+
+describe("Create mode — step navigation", () => {
+  it("renders Create New Deployment title", () => {
+    renderModal();
+    expect(screen.getAllByText("Create New Deployment")[0]).toBeInTheDocument();
+  });
+
+  it("starts on step 1 — StepProvider", () => {
+    renderModal();
+    expect(screen.getByTestId("step-provider")).toBeInTheDocument();
+  });
+
+  it("shows Cancel and Next buttons", () => {
+    renderModal();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    // Next button has data-testid
+    expect(screen.getByTestId("deployment-stepper-next")).toBeInTheDocument();
+  });
+
+  it("shows Back button disabled on first step", () => {
+    renderModal();
+    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+  });
+
+  it("skips to step 2 when initialProvider and initialInstance are provided", () => {
+    renderModal({
+      initialProvider: {
+        id: "watsonx",
+        type: "watsonx",
+        name: "watsonx Orchestrate",
+        icon: "Bot",
+      },
+      initialInstance: makeInstance(),
+    });
+    expect(screen.getByTestId("step-type")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edit mode — loading & pre-population
+// ---------------------------------------------------------------------------
+
+describe("Edit mode — loading", () => {
+  it("shows loading text when fetching edit data", () => {
+    mockIsLoadingAttachments = true;
+    mockIsLoadingDetail = true;
+    renderModal({ editingDeployment: makeDeployment() });
+    expect(screen.getByText("Loading deployment data...")).toBeInTheDocument();
+  });
+
+  it("renders Update Deployment title in edit mode once loaded", () => {
+    mockAttachmentsData = { flow_versions: [] };
+    mockDeploymentDetail = makeDeployment();
+    renderModal({ editingDeployment: makeDeployment() });
+    expect(screen.getAllByText("Update Deployment")[0]).toBeInTheDocument();
+  });
+
+  it("starts on step-type in edit mode (skips provider step)", () => {
+    mockAttachmentsData = { flow_versions: [] };
+    mockDeploymentDetail = makeDeployment();
+    renderModal({ editingDeployment: makeDeployment() });
+    expect(screen.getByTestId("step-type")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edit mode — initial state from attachments
+// ---------------------------------------------------------------------------
+
+describe("Edit mode — initial state from attachments", () => {
+  beforeEach(() => {
+    mockDeploymentDetail = makeDeployment();
+    mockAttachmentsData = {
+      flow_versions: [
+        {
+          id: "fv-1",
+          flow_id: "flow-1",
+          flow_name: "Sales Flow",
+          version_number: 2,
+          attached_at: "2025-06-01T00:00:00Z",
+          provider_snapshot_id: "snap-1",
+          tool_name: "custom_sales_tool",
+          provider_data: { app_ids: ["cfg-1"] },
+        },
+      ],
+    };
+  });
+
+  it("renders without crashing with attachment data", () => {
+    renderModal({ editingDeployment: makeDeployment() });
+    expect(screen.getAllByText("Update Deployment")[0]).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Modal close prevention
+// ---------------------------------------------------------------------------
+
+describe("Modal close prevention during deploy", () => {
+  it("renders the Cancel button", () => {
+    renderModal();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("calls setOpen(false) when Cancel is clicked in idle state", async () => {
+    const user = userEvent.setup();
+    const { setOpen } = renderModal();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step labels
+// ---------------------------------------------------------------------------
+
+describe("Step labels", () => {
+  it("shows all 4 step labels in create mode", () => {
+    renderModal();
+    expect(screen.getByText("Provider")).toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("Attach Flows")).toBeInTheDocument();
+    expect(screen.getByText("Review")).toBeInTheDocument();
+  });
+
+  it("shows 3 step labels in edit mode", () => {
+    mockAttachmentsData = { flow_versions: [] };
+    mockDeploymentDetail = makeDeployment();
+    renderModal({ editingDeployment: makeDeployment() });
+    expect(screen.queryByText("Provider")).not.toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("Attach Flows")).toBeInTheDocument();
+    expect(screen.getByText("Review")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployments-table.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployments-table.test.tsx
@@ -1,0 +1,283 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Deployment } from "../types";
+
+// Mock child components that fetch data or use complex UI
+jest.mock(
+  "@/components/common/genericIconComponent",
+  () =>
+    function MockIcon({ name }: { name: string }) {
+      return <span data-testid={`icon-${name}`} />;
+    },
+);
+jest.mock("../components/deployment-expanded-row", () =>
+  jest.fn(({ deploymentId }: { deploymentId: string }) => (
+    <tr data-testid={`expanded-row-${deploymentId}`}>
+      <td>Expanded</td>
+    </tr>
+  )),
+);
+jest.mock("@/components/ui/loading", () =>
+  jest.fn(() => <span data-testid="loading-spinner" />),
+);
+
+import DeploymentsTable from "../components/deployments-table";
+
+const makeDeployment = (overrides: Partial<Deployment> = {}): Deployment => ({
+  id: "dep-1",
+  name: "My Agent",
+  description: null,
+  type: "agent",
+  created_at: "2025-06-01T00:00:00Z",
+  updated_at: "2025-06-10T12:00:00Z",
+  provider_data: null,
+  resource_key: "rk-1",
+  attached_count: 2,
+  matched_attachments: null,
+  provider_account_id: "prov-1",
+  ...overrides,
+});
+
+const providerMap: Record<string, string> = {
+  "prov-1": "watsonx Prod",
+};
+
+const noop = jest.fn();
+
+function renderTable(
+  deployments: Deployment[] = [makeDeployment()],
+  overrides: Partial<Parameters<typeof DeploymentsTable>[0]> = {},
+) {
+  return render(
+    <DeploymentsTable
+      deployments={deployments}
+      providerMap={providerMap}
+      onTestDeployment={noop}
+      onViewDetails={noop}
+      onUpdateDeployment={noop}
+      onDeleteDeployment={noop}
+      {...overrides}
+    />,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Row rendering
+// ---------------------------------------------------------------------------
+
+describe("Row rendering", () => {
+  it("renders a deployment row with name, type badge, and provider", () => {
+    renderTable();
+    expect(screen.getByTestId("deployment-row-dep-1")).toBeInTheDocument();
+    expect(screen.getByText("My Agent")).toBeInTheDocument();
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("watsonx Prod")).toBeInTheDocument();
+  });
+
+  it("renders description when present", () => {
+    renderTable([makeDeployment({ description: "Handles sales queries" })]);
+    expect(screen.getByText("Handles sales queries")).toBeInTheDocument();
+  });
+
+  it("does not render description when null", () => {
+    renderTable([makeDeployment({ description: null })]);
+    expect(screen.queryByText("Handles sales queries")).not.toBeInTheDocument();
+  });
+
+  it("shows MCP badge for mcp type", () => {
+    renderTable([makeDeployment({ type: "mcp" })]);
+    expect(screen.getByText("MCP")).toBeInTheDocument();
+  });
+
+  it("shows dash when provider is unknown", () => {
+    renderTable([makeDeployment({ provider_account_id: "unknown" })]);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders multiple rows", () => {
+    renderTable([
+      makeDeployment({ id: "dep-1", name: "Agent A" }),
+      makeDeployment({ id: "dep-2", name: "Agent B" }),
+    ]);
+    expect(screen.getByTestId("deployment-row-dep-1")).toBeInTheDocument();
+    expect(screen.getByTestId("deployment-row-dep-2")).toBeInTheDocument();
+  });
+
+  it("formats the last modified date", () => {
+    renderTable([makeDeployment({ updated_at: "2025-06-10T12:00:00Z" })]);
+    // toLocaleDateString output varies, just check the row exists
+    expect(screen.getByTestId("deployment-row-dep-1")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Attachment count & expand/collapse
+// ---------------------------------------------------------------------------
+
+describe("Attachment count & expand/collapse", () => {
+  it("shows attachment count with correct pluralization", () => {
+    renderTable([makeDeployment({ attached_count: 1 })]);
+    expect(screen.getByText(/1 flow$/)).toBeInTheDocument();
+  });
+
+  it("pluralizes for multiple flows", () => {
+    renderTable([makeDeployment({ attached_count: 3 })]);
+    expect(screen.getByText("3 flows")).toBeInTheDocument();
+  });
+
+  it("disables toggle when attached_count is 0", () => {
+    renderTable([makeDeployment({ attached_count: 0 })]);
+    const toggle = screen.getByTestId("toggle-attachments-dep-1");
+    expect(toggle).toBeDisabled();
+  });
+
+  it("expands row on toggle click", async () => {
+    const user = userEvent.setup();
+    renderTable();
+    const toggle = screen.getByTestId("toggle-attachments-dep-1");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("expanded-row-dep-1")).toBeInTheDocument();
+  });
+
+  it("collapses expanded row on second click", async () => {
+    const user = userEvent.setup();
+    renderTable();
+    const toggle = screen.getByTestId("toggle-attachments-dep-1");
+
+    await user.click(toggle);
+    expect(screen.getByTestId("expanded-row-dep-1")).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(screen.queryByTestId("expanded-row-dep-1")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test button
+// ---------------------------------------------------------------------------
+
+describe("Test button", () => {
+  it("calls onTestDeployment with deployment when clicked", async () => {
+    const user = userEvent.setup();
+    const onTest = jest.fn();
+    const dep = makeDeployment();
+    renderTable([dep], { onTestDeployment: onTest });
+
+    await user.click(screen.getByTestId("test-deployment-dep-1"));
+    expect(onTest).toHaveBeenCalledWith(dep);
+  });
+
+  it("has correct aria-label", () => {
+    renderTable();
+    expect(screen.getByTestId("test-deployment-dep-1")).toHaveAttribute(
+      "aria-label",
+      "Test My Agent",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action menu
+// ---------------------------------------------------------------------------
+
+describe("Action menu", () => {
+  it("shows actions button with correct aria-label", () => {
+    renderTable();
+    expect(screen.getByTestId("actions-deployment-dep-1")).toHaveAttribute(
+      "aria-label",
+      "Actions for My Agent",
+    );
+  });
+
+  it("calls onViewDetails when Details is clicked", async () => {
+    const user = userEvent.setup();
+    const onDetails = jest.fn();
+    const dep = makeDeployment();
+    renderTable([dep], { onViewDetails: onDetails });
+
+    await user.click(screen.getByTestId("actions-deployment-dep-1"));
+    await user.click(screen.getByText("Details"));
+    expect(onDetails).toHaveBeenCalledWith(dep);
+  });
+
+  it("calls onUpdateDeployment when Update is clicked", async () => {
+    const user = userEvent.setup();
+    const onUpdate = jest.fn();
+    const dep = makeDeployment();
+    renderTable([dep], { onUpdateDeployment: onUpdate });
+
+    await user.click(screen.getByTestId("actions-deployment-dep-1"));
+    await user.click(screen.getByText("Update"));
+    expect(onUpdate).toHaveBeenCalledWith(dep);
+  });
+
+  it("calls onDeleteDeployment when Delete is clicked", async () => {
+    const user = userEvent.setup();
+    const onDelete = jest.fn();
+    const dep = makeDeployment();
+    renderTable([dep], { onDeleteDeployment: onDelete });
+
+    await user.click(screen.getByTestId("actions-deployment-dep-1"));
+    await user.click(screen.getByText("Delete"));
+    expect(onDelete).toHaveBeenCalledWith(dep);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deleting state
+// ---------------------------------------------------------------------------
+
+describe("Deleting state", () => {
+  it("shows loading spinner instead of actions when deleting", () => {
+    renderTable([makeDeployment()], { deletingId: "dep-1" });
+    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("actions-deployment-dep-1"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("applies opacity to the deleting row", () => {
+    renderTable([makeDeployment()], { deletingId: "dep-1" });
+    const row = screen.getByTestId("deployment-row-dep-1");
+    expect(row.className).toContain("opacity-50");
+  });
+
+  it("does not affect other rows", () => {
+    renderTable(
+      [
+        makeDeployment({ id: "dep-1" }),
+        makeDeployment({ id: "dep-2", name: "Other" }),
+      ],
+      { deletingId: "dep-1" },
+    );
+    const otherRow = screen.getByTestId("deployment-row-dep-2");
+    expect(otherRow.className).not.toContain("opacity-50");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Column headers
+// ---------------------------------------------------------------------------
+
+describe("Column headers", () => {
+  it("renders all expected column headers", () => {
+    renderTable();
+    for (const header of [
+      "Name",
+      "Type",
+      "Attached",
+      "Provider",
+      "Last Modified",
+      "Test",
+    ]) {
+      expect(screen.getByText(header)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
@@ -297,11 +297,11 @@ describe("Edit mode — no-op and partial update payloads", () => {
     act(() => result.current.setDeploymentDescription("New description only"));
 
     const payload = result.current.buildDeploymentUpdatePayload();
-    expect(payload.spec).toEqual({ description: "New description only" });
-    // No operations since no flows changed
-    const ops =
-      (payload.provider_data?.operations as Array<{ op: string }>) ?? [];
-    expect(ops).toHaveLength(0);
+    expect(payload.description).toBe("New description only");
+    // No upsert_flows since no flows changed
+    const upsertFlows =
+      (payload.provider_data?.upsert_flows as Array<unknown>) ?? [];
+    expect(upsertFlows).toHaveLength(0);
   });
 
   it("sends only LLM change without spec when description unchanged", () => {
@@ -311,7 +311,7 @@ describe("Edit mode — no-op and partial update payloads", () => {
 
     const payload = result.current.buildDeploymentUpdatePayload();
     expect(payload.provider_data?.llm).toBe("new-model");
-    expect(payload.spec).toBeUndefined();
+    expect(payload.description).toBeUndefined();
   });
 
   it("sends only flow operations when only flows changed", () => {
@@ -322,16 +322,14 @@ describe("Edit mode — no-op and partial update payloads", () => {
     });
 
     const payload = result.current.buildDeploymentUpdatePayload();
-    const ops =
-      (payload.provider_data?.operations as Array<{
-        op: string;
+    const upsertFlows =
+      (payload.provider_data?.upsert_flows as Array<{
         flow_version_id?: string;
       }>) ?? [];
-    const bindOps = ops.filter((o) => o.op === "bind");
-    expect(bindOps).toHaveLength(1);
-    expect(bindOps[0].flow_version_id).toBe("ver-new");
-    // Description didn't change → no spec
-    expect(payload.spec).toBeUndefined();
+    expect(upsertFlows).toHaveLength(1);
+    expect(upsertFlows[0].flow_version_id).toBe("ver-new");
+    // Description didn't change → no description field
+    expect(payload.description).toBeUndefined();
   });
 });
 
@@ -352,14 +350,17 @@ describe("Edit mode — detach then re-attach same flow", () => {
       versionTag: "v1",
     });
 
-    // Payload should have no remove_tool or bind for flow-1 (it's back to original)
+    // Payload should have no remove_flows or upsert_flows for flow-1 (it's back to original)
     const payload = result.current.buildDeploymentUpdatePayload();
-    const ops =
-      (payload.provider_data?.operations as Array<{
-        op: string;
+    const upsertFlows =
+      (payload.provider_data?.upsert_flows as Array<{
         flow_version_id?: string;
       }>) ?? [];
-    expect(ops.filter((o) => o.flow_version_id === "ver-1")).toHaveLength(0);
+    const removeFlows = (payload.provider_data?.remove_flows as string[]) ?? [];
+    expect(
+      upsertFlows.filter((o) => o.flow_version_id === "ver-1"),
+    ).toHaveLength(0);
+    expect(removeFlows.includes("ver-1")).toBe(false);
   });
 
   it("detaching all flows then re-attaching one produces correct ops", () => {
@@ -376,20 +377,21 @@ describe("Edit mode — detach then re-attach same flow", () => {
     act(() => result.current.handleUndoRemoveFlow("flow-2"));
 
     const payload = result.current.buildDeploymentUpdatePayload();
-    const ops =
-      (payload.provider_data?.operations as Array<{
-        op: string;
+    const removeFlows = (payload.provider_data?.remove_flows as string[]) ?? [];
+    const upsertFlows =
+      (payload.provider_data?.upsert_flows as Array<{
         flow_version_id?: string;
       }>) ?? [];
 
-    // flow-1 should have remove_tool
-    expect(ops.filter((o) => o.op === "remove_tool")).toHaveLength(1);
-    expect(ops.find((o) => o.op === "remove_tool")?.flow_version_id).toBe(
-      "ver-1",
-    );
+    // flow-1 should be in remove_flows
+    expect(removeFlows).toHaveLength(1);
+    expect(removeFlows[0]).toBe("ver-1");
 
-    // flow-2 was undone, so no remove_tool and no bind (it's pre-existing)
-    expect(ops.filter((o) => o.flow_version_id === "ver-2")).toHaveLength(0);
+    // flow-2 was undone, so it should not be in remove_flows or upsert_flows
+    expect(removeFlows.includes("ver-2")).toBe(false);
+    expect(
+      upsertFlows.filter((o) => o.flow_version_id === "ver-2"),
+    ).toHaveLength(0);
   });
 });
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
@@ -271,6 +271,118 @@ describe("Edit mode — throws outside edit mode", () => {
   });
 });
 
+describe("Edit mode — no-op and partial update payloads", () => {
+  it("sends fallback spec when nothing changed at all", () => {
+    const { result } = renderEditHook();
+    const payload = result.current.buildDeploymentUpdatePayload();
+    // LLM is pre-filled so provider_data always has llm
+    expect(payload.deployment_id).toBe("deploy-1");
+    expect(payload.provider_data?.llm).toBe("test-model");
+    // No spec change → no spec field (or fallback if no provider_data either)
+  });
+
+  it("sends only description in spec when only description changed", () => {
+    const { result } = renderEditHook();
+
+    act(() => result.current.setDeploymentDescription("New description only"));
+
+    const payload = result.current.buildDeploymentUpdatePayload();
+    expect(payload.spec).toEqual({ description: "New description only" });
+    // No operations since no flows changed
+    const ops =
+      (payload.provider_data?.operations as Array<{ op: string }>) ?? [];
+    expect(ops).toHaveLength(0);
+  });
+
+  it("sends only LLM change without spec when description unchanged", () => {
+    const { result } = renderEditHook();
+
+    act(() => result.current.setSelectedLlm("new-model"));
+
+    const payload = result.current.buildDeploymentUpdatePayload();
+    expect(payload.provider_data?.llm).toBe("new-model");
+    expect(payload.spec).toBeUndefined();
+  });
+
+  it("sends only flow operations when only flows changed", () => {
+    const { result } = renderEditHook();
+
+    act(() => {
+      result.current.handleSelectVersion("flow-new", "ver-new", "v1");
+    });
+
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const ops =
+      (payload.provider_data?.operations as Array<{
+        op: string;
+        flow_version_id?: string;
+      }>) ?? [];
+    const bindOps = ops.filter((o) => o.op === "bind");
+    expect(bindOps).toHaveLength(1);
+    expect(bindOps[0].flow_version_id).toBe("ver-new");
+    // Description didn't change → no spec
+    expect(payload.spec).toBeUndefined();
+  });
+});
+
+describe("Edit mode — detach then re-attach same flow", () => {
+  it("re-attaching a detached flow restores it to selectedVersionByFlow", () => {
+    const { result } = renderEditHook();
+
+    // Detach flow-1
+    act(() => result.current.handleRemoveAttachedFlow("flow-1"));
+    expect(result.current.removedFlowIds.has("flow-1")).toBe(true);
+    expect(result.current.selectedVersionByFlow.has("flow-1")).toBe(false);
+
+    // Re-attach via undo
+    act(() => result.current.handleUndoRemoveFlow("flow-1"));
+    expect(result.current.removedFlowIds.has("flow-1")).toBe(false);
+    expect(result.current.selectedVersionByFlow.get("flow-1")).toEqual({
+      versionId: "ver-1",
+      versionTag: "v1",
+    });
+
+    // Payload should have no remove_tool or bind for flow-1 (it's back to original)
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const ops =
+      (payload.provider_data?.operations as Array<{
+        op: string;
+        flow_version_id?: string;
+      }>) ?? [];
+    expect(ops.filter((o) => o.flow_version_id === "ver-1")).toHaveLength(0);
+  });
+
+  it("detaching all flows then re-attaching one produces correct ops", () => {
+    const { result } = renderEditHook();
+
+    // Detach both
+    act(() => {
+      result.current.handleRemoveAttachedFlow("flow-1");
+      result.current.handleRemoveAttachedFlow("flow-2");
+    });
+    expect(result.current.removedFlowIds.size).toBe(2);
+
+    // Re-attach only flow-2
+    act(() => result.current.handleUndoRemoveFlow("flow-2"));
+
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const ops =
+      (payload.provider_data?.operations as Array<{
+        op: string;
+        flow_version_id?: string;
+      }>) ?? [];
+
+    // flow-1 should have remove_tool
+    expect(ops.filter((o) => o.op === "remove_tool")).toHaveLength(1);
+    expect(ops.find((o) => o.op === "remove_tool")?.flow_version_id).toBe(
+      "ver-1",
+    );
+
+    // flow-2 was undone, so no remove_tool and no bind (it's pre-existing)
+    expect(ops.filter((o) => o.flow_version_id === "ver-2")).toHaveLength(0);
+  });
+});
+
 describe("Edit mode — pre-populated provider data", () => {
   it("pre-fills toolNameByFlow from initialToolNameByFlow", () => {
     const { result } = renderEditHook();

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/providers-table.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/providers-table.test.tsx
@@ -20,9 +20,8 @@ const makeProvider = (
 ): ProviderAccount => ({
   id: "prov-1",
   name: "Production WxO",
-  provider_tenant_id: "tenant-1",
   provider_key: "watsonx-orchestrate",
-  provider_url: "https://api.example.com",
+  url: "https://api.example.com",
   created_at: "2025-05-01T00:00:00Z",
   updated_at: "2025-05-10T00:00:00Z",
   ...overrides,

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/providers-table.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/providers-table.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ProviderAccount } from "../types";
+
+jest.mock(
+  "@/components/common/genericIconComponent",
+  () =>
+    function MockIcon({ name }: { name: string }) {
+      return <span data-testid={`icon-${name}`} />;
+    },
+);
+jest.mock("@/components/ui/loading", () =>
+  jest.fn(() => <span data-testid="loading-spinner" />),
+);
+
+import ProvidersTable from "../components/providers-table";
+
+const makeProvider = (
+  overrides: Partial<ProviderAccount> = {},
+): ProviderAccount => ({
+  id: "prov-1",
+  name: "Production WxO",
+  provider_tenant_id: "tenant-1",
+  provider_key: "watsonx-orchestrate",
+  provider_url: "https://api.example.com",
+  created_at: "2025-05-01T00:00:00Z",
+  updated_at: "2025-05-10T00:00:00Z",
+  ...overrides,
+});
+
+const noop = jest.fn();
+
+function renderTable(
+  providers: ProviderAccount[] = [makeProvider()],
+  overrides: Partial<Parameters<typeof ProvidersTable>[0]> = {},
+) {
+  return render(
+    <ProvidersTable
+      providers={providers}
+      onDeleteProvider={noop}
+      {...overrides}
+    />,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Row rendering
+// ---------------------------------------------------------------------------
+
+describe("Row rendering", () => {
+  it("renders a provider row with name, URL, and provider key", () => {
+    renderTable();
+    expect(screen.getByTestId("provider-row-prov-1")).toBeInTheDocument();
+    expect(screen.getByText("Production WxO")).toBeInTheDocument();
+    expect(screen.getByText("https://api.example.com")).toBeInTheDocument();
+    expect(screen.getByText("watsonx-orchestrate")).toBeInTheDocument();
+  });
+
+  it("renders multiple provider rows", () => {
+    renderTable([
+      makeProvider({ id: "prov-1", name: "Prod" }),
+      makeProvider({ id: "prov-2", name: "Staging" }),
+    ]);
+    expect(screen.getByTestId("provider-row-prov-1")).toBeInTheDocument();
+    expect(screen.getByTestId("provider-row-prov-2")).toBeInTheDocument();
+  });
+
+  it("shows dash when created_at is null", () => {
+    renderTable([makeProvider({ created_at: null })]);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Column headers
+// ---------------------------------------------------------------------------
+
+describe("Column headers", () => {
+  it("renders all expected column headers", () => {
+    renderTable();
+    for (const header of ["Name", "URL", "Provider Key", "Created"]) {
+      expect(screen.getByText(header)).toBeInTheDocument();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delete action
+// ---------------------------------------------------------------------------
+
+describe("Delete action", () => {
+  it("calls onDeleteProvider when Delete is clicked", async () => {
+    const user = userEvent.setup();
+    const onDelete = jest.fn();
+    const provider = makeProvider();
+    renderTable([provider], { onDeleteProvider: onDelete });
+
+    await user.click(screen.getByTestId("actions-provider-prov-1"));
+    await user.click(screen.getByText("Delete"));
+    expect(onDelete).toHaveBeenCalledWith(provider);
+  });
+
+  it("has correct aria-label on actions button", () => {
+    renderTable();
+    expect(screen.getByTestId("actions-provider-prov-1")).toHaveAttribute(
+      "aria-label",
+      "Actions for Production WxO",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deleting state
+// ---------------------------------------------------------------------------
+
+describe("Deleting state", () => {
+  it("shows loading spinner when deleting", () => {
+    renderTable([makeProvider()], { deletingId: "prov-1" });
+    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("actions-provider-prov-1"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("applies opacity to the deleting row", () => {
+    renderTable([makeProvider()], { deletingId: "prov-1" });
+    const row = screen.getByTestId("provider-row-prov-1");
+    expect(row.className).toContain("opacity-50");
+  });
+
+  it("does not affect other rows", () => {
+    renderTable(
+      [
+        makeProvider({ id: "prov-1" }),
+        makeProvider({ id: "prov-2", name: "Other" }),
+      ],
+      { deletingId: "prov-1" },
+    );
+    const otherRow = screen.getByTestId("provider-row-prov-2");
+    expect(otherRow.className).not.toContain("opacity-50");
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-attach-flows-connection-panel.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-attach-flows-connection-panel.test.tsx
@@ -1,0 +1,405 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ConnectionItem, EnvVarEntry } from "../types";
+
+jest.mock(
+  "@/components/common/genericIconComponent",
+  () =>
+    function MockIcon({ name }: { name: string }) {
+      return <span data-testid={`icon-${name}`} />;
+    },
+);
+
+jest.mock(
+  "@/components/core/parameterRenderComponent/components/inputComponent",
+  () =>
+    function MockInputComponent({
+      id,
+      placeholder,
+      value,
+      onChange,
+      options,
+      selectedOption,
+      setSelectedOption,
+    }: {
+      id: string;
+      placeholder: string;
+      value: string;
+      onChange: (v: string) => void;
+      options?: string[];
+      selectedOption?: string;
+      setSelectedOption?: (v: string) => void;
+    }) {
+      return (
+        <div data-testid={`input-component-${id}`}>
+          <input
+            placeholder={placeholder}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            data-testid={`input-${id}`}
+          />
+          {options && options.length > 0 && (
+            <select
+              data-testid={`select-${id}`}
+              value={selectedOption ?? ""}
+              onChange={(e) => setSelectedOption?.(e.target.value)}
+            >
+              <option value="">Select...</option>
+              {options.map((o) => (
+                <option key={o} value={o}>
+                  {o}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+      );
+    },
+);
+
+import { ConnectionPanel } from "../components/step-attach-flows-connection-panel";
+
+const _noop = jest.fn();
+
+const defaultProps = {
+  connectionTab: "available" as const,
+  onTabChange: jest.fn(),
+  connections: [] as ConnectionItem[],
+  selectedConnections: new Set<string>(),
+  onToggleConnection: jest.fn(),
+  newConnectionName: "",
+  onNameChange: jest.fn(),
+  newConnectionDescription: "",
+  onDescriptionChange: jest.fn(),
+  envVars: [{ id: "ev-1", key: "", value: "" }] as EnvVarEntry[],
+  detectedVarCount: 0,
+  globalVariableOptions: [] as string[],
+  onEnvVarChange: jest.fn(),
+  onEnvVarSelectGlobalVar: jest.fn(),
+  onAddEnvVar: jest.fn(),
+  onChangeFlow: jest.fn(),
+  onSkipConnection: jest.fn(),
+  onAttachConnection: jest.fn(),
+  onCreateConnection: jest.fn(),
+  isDuplicateName: false,
+};
+
+function renderPanel(overrides: Partial<typeof defaultProps> = {}) {
+  const props = { ...defaultProps, ...overrides };
+  return render(<ConnectionPanel {...props} />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tab toggle
+// ---------------------------------------------------------------------------
+
+describe("Tab toggle", () => {
+  it("renders Available Connections and Create Connection tabs", () => {
+    renderPanel();
+    expect(screen.getByText("Available Connections")).toBeInTheDocument();
+    expect(screen.getByText("Create Connection")).toBeInTheDocument();
+  });
+
+  it("calls onTabChange when switching tabs", async () => {
+    const user = userEvent.setup();
+    const onTabChange = jest.fn();
+    renderPanel({ onTabChange });
+
+    await user.click(screen.getByText("Create Connection"));
+    expect(onTabChange).toHaveBeenCalledWith("create");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Available tab — empty state
+// ---------------------------------------------------------------------------
+
+describe("Available tab — empty state", () => {
+  it("shows empty state when no connections exist", () => {
+    renderPanel({ connections: [] });
+    expect(screen.getByText("No connections yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("Create your first connection"),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking 'Create your first connection' switches to create tab", async () => {
+    const user = userEvent.setup();
+    const onTabChange = jest.fn();
+    renderPanel({ connections: [], onTabChange });
+
+    await user.click(screen.getByText("Create your first connection"));
+    expect(onTabChange).toHaveBeenCalledWith("create");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Available tab — with connections
+// ---------------------------------------------------------------------------
+
+describe("Available tab — with connections", () => {
+  const connections: ConnectionItem[] = [
+    {
+      id: "conn-1",
+      name: "Prod Connection",
+      variableCount: 0,
+      isNew: false,
+      environmentVariables: {},
+    },
+    {
+      id: "conn-2",
+      name: "New Connection",
+      variableCount: 1,
+      isNew: true,
+      environmentVariables: { KEY: "val" },
+    },
+  ];
+
+  it("renders connection items", () => {
+    renderPanel({ connections });
+    expect(screen.getByText("Prod Connection")).toBeInTheDocument();
+    expect(screen.getByText("New Connection")).toBeInTheDocument();
+  });
+
+  it("shows search input", () => {
+    renderPanel({ connections });
+    expect(
+      screen.getByPlaceholderText("Search connections..."),
+    ).toBeInTheDocument();
+  });
+
+  it("filters connections by search query", async () => {
+    const user = userEvent.setup();
+    renderPanel({ connections });
+
+    await user.type(
+      screen.getByPlaceholderText("Search connections..."),
+      "Prod",
+    );
+    expect(screen.getByText("Prod Connection")).toBeInTheDocument();
+    expect(screen.queryByText("New Connection")).not.toBeInTheDocument();
+  });
+
+  it("shows no-match message for unmatched search", async () => {
+    const user = userEvent.setup();
+    renderPanel({ connections });
+
+    await user.type(
+      screen.getByPlaceholderText("Search connections..."),
+      "zzz",
+    );
+    expect(screen.getByText(/No connections match/)).toBeInTheDocument();
+  });
+
+  it("calls onToggleConnection when clicking a connection", async () => {
+    const user = userEvent.setup();
+    const onToggle = jest.fn();
+    renderPanel({ connections, onToggleConnection: onToggle });
+
+    await user.click(screen.getByText("Prod Connection"));
+    expect(onToggle).toHaveBeenCalledWith("conn-1");
+  });
+
+  it("sorts new connections to the top", () => {
+    renderPanel({ connections });
+    const items = screen.getAllByText(/Connection/);
+    // "New Connection" (isNew=true) should appear before "Prod Connection"
+    expect(items[0].textContent).toContain("New Connection");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create tab — form
+// ---------------------------------------------------------------------------
+
+describe("Create tab — form", () => {
+  it("renders connection name input", () => {
+    renderPanel({ connectionTab: "create" });
+    expect(
+      screen.getByPlaceholderText("e.g., SALES_BOT_PROD"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders description input", () => {
+    renderPanel({ connectionTab: "create" });
+    expect(
+      screen.getByPlaceholderText("e.g., Production sales bot connection"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders environment variable key/value row", () => {
+    renderPanel({
+      connectionTab: "create",
+      envVars: [{ id: "ev-1", key: "", value: "" }],
+    });
+    expect(screen.getByPlaceholderText("Key")).toBeInTheDocument();
+  });
+
+  it("calls onNameChange on name input", async () => {
+    const user = userEvent.setup();
+    const onNameChange = jest.fn();
+    renderPanel({ connectionTab: "create", onNameChange });
+
+    await user.type(screen.getByPlaceholderText("e.g., SALES_BOT_PROD"), "A");
+    expect(onNameChange).toHaveBeenCalled();
+  });
+
+  it("calls onAddEnvVar when add variable button is clicked", async () => {
+    const user = userEvent.setup();
+    const onAddEnvVar = jest.fn();
+    renderPanel({ connectionTab: "create", onAddEnvVar });
+
+    await user.click(screen.getByText("+ Add variable"));
+    expect(onAddEnvVar).toHaveBeenCalled();
+  });
+
+  it("shows detected variable count message", () => {
+    renderPanel({ connectionTab: "create", detectedVarCount: 3 });
+    expect(
+      screen.getByText(
+        "3 variables auto-detected from the selected flow version.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows singular variable count message for 1 variable", () => {
+    renderPanel({ connectionTab: "create", detectedVarCount: 1 });
+    expect(
+      screen.getByText(
+        "1 variable auto-detected from the selected flow version.",
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Duplicate name detection
+// ---------------------------------------------------------------------------
+
+describe("Duplicate name detection", () => {
+  it("shows duplicate name error", () => {
+    renderPanel({
+      connectionTab: "create",
+      newConnectionName: "Existing",
+      isDuplicateName: true,
+    });
+    expect(
+      screen.getByText("A connection with this name already exists."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show error when name is unique", () => {
+    renderPanel({
+      connectionTab: "create",
+      newConnectionName: "Unique",
+      isDuplicateName: false,
+    });
+    expect(
+      screen.queryByText("A connection with this name already exists."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables Create Connection footer button when name is duplicate", () => {
+    renderPanel({
+      connectionTab: "create",
+      newConnectionName: "Existing",
+      isDuplicateName: true,
+    });
+    expect(screen.getByTestId("connection-create")).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Footer buttons
+// ---------------------------------------------------------------------------
+
+describe("Footer buttons", () => {
+  it("renders all footer buttons via data-testid", () => {
+    renderPanel();
+    expect(screen.getByTestId("connection-change-flow")).toBeInTheDocument();
+    expect(screen.getByTestId("connection-skip")).toBeInTheDocument();
+    expect(screen.getByTestId("connection-attach")).toBeInTheDocument();
+  });
+
+  it("Attach is disabled when no connections selected", () => {
+    renderPanel({ selectedConnections: new Set() });
+    expect(screen.getByTestId("connection-attach")).toBeDisabled();
+  });
+
+  it("Attach is enabled when connections are selected", () => {
+    renderPanel({ selectedConnections: new Set(["conn-1"]) });
+    expect(screen.getByTestId("connection-attach")).not.toBeDisabled();
+  });
+
+  it("Create is disabled when name is empty", () => {
+    renderPanel({ connectionTab: "create", newConnectionName: "" });
+    expect(screen.getByTestId("connection-create")).toBeDisabled();
+  });
+
+  it("Create is enabled when name is provided", () => {
+    renderPanel({ connectionTab: "create", newConnectionName: "MyConn" });
+    expect(screen.getByTestId("connection-create")).not.toBeDisabled();
+  });
+
+  it("calls onChangeFlow when Change Flow is clicked", async () => {
+    const user = userEvent.setup();
+    const onChangeFlow = jest.fn();
+    renderPanel({ onChangeFlow });
+
+    await user.click(screen.getByTestId("connection-change-flow"));
+    expect(onChangeFlow).toHaveBeenCalled();
+  });
+
+  it("calls onSkipConnection when Skip is clicked", async () => {
+    const user = userEvent.setup();
+    const onSkip = jest.fn();
+    renderPanel({ onSkipConnection: onSkip });
+
+    await user.click(screen.getByTestId("connection-skip"));
+    expect(onSkip).toHaveBeenCalled();
+  });
+
+  it("calls onAttachConnection when Attach is clicked", async () => {
+    const user = userEvent.setup();
+    const onAttach = jest.fn();
+    renderPanel({
+      selectedConnections: new Set(["conn-1"]),
+      onAttachConnection: onAttach,
+    });
+
+    await user.click(screen.getByTestId("connection-attach"));
+    expect(onAttach).toHaveBeenCalled();
+  });
+
+  it("calls onCreateConnection when Create is clicked", async () => {
+    const user = userEvent.setup();
+    const onCreate = jest.fn();
+    renderPanel({
+      connectionTab: "create",
+      newConnectionName: "New",
+      onCreateConnection: onCreate,
+    });
+
+    await user.click(screen.getByTestId("connection-create"));
+    expect(onCreate).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Global variable options
+// ---------------------------------------------------------------------------
+
+describe("Global variable options", () => {
+  it("renders global variable dropdown in env var row when options available", () => {
+    renderPanel({
+      connectionTab: "create",
+      globalVariableOptions: ["MY_SECRET", "DB_PASS"],
+      envVars: [{ id: "ev-1", key: "TEST_KEY", value: "" }],
+    });
+    expect(screen.getByTestId("select-env-val-ev-1")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-attach-flows.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-attach-flows.test.tsx
@@ -1,0 +1,434 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ConnectionItem } from "../types";
+
+// ---------------------------------------------------------------------------
+// Mocks — stepper context
+// ---------------------------------------------------------------------------
+
+let mockIsEditMode = false;
+let mockInitialFlowId: string | undefined;
+let mockSelectedInstance: { id: string } | null = { id: "inst-1" };
+let mockConnections: ConnectionItem[] = [];
+const mockSetConnections = jest.fn();
+let mockSelectedVersionByFlow = new Map<
+  string,
+  { versionId: string; versionTag: string }
+>();
+const mockHandleSelectVersion = jest.fn();
+let mockToolNameByFlow = new Map<string, string>();
+const mockSetToolNameByFlow = jest.fn();
+let mockAttachedConnectionByFlow = new Map<string, string[]>();
+const mockSetAttachedConnectionByFlow = jest.fn();
+let mockRemovedFlowIds = new Set<string>();
+const mockHandleRemoveAttachedFlow = jest.fn();
+const mockHandleUndoRemoveFlow = jest.fn();
+
+jest.mock("../contexts/deployment-stepper-context", () => ({
+  useDeploymentStepper: () => ({
+    isEditMode: mockIsEditMode,
+    initialFlowId: mockInitialFlowId,
+    selectedInstance: mockSelectedInstance,
+    connections: mockConnections,
+    setConnections: mockSetConnections,
+    selectedVersionByFlow: mockSelectedVersionByFlow,
+    handleSelectVersion: mockHandleSelectVersion,
+    toolNameByFlow: mockToolNameByFlow,
+    setToolNameByFlow: mockSetToolNameByFlow,
+    attachedConnectionByFlow: mockAttachedConnectionByFlow,
+    setAttachedConnectionByFlow: mockSetAttachedConnectionByFlow,
+    removedFlowIds: mockRemovedFlowIds,
+    handleRemoveAttachedFlow: mockHandleRemoveAttachedFlow,
+    handleUndoRemoveFlow: mockHandleUndoRemoveFlow,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks — route & stores
+// ---------------------------------------------------------------------------
+
+jest.mock("react-router-dom", () => ({
+  useParams: () => ({ folderId: "folder-1" }),
+}));
+
+jest.mock("@/stores/foldersStore", () => ({
+  useFolderStore: () => "folder-1",
+}));
+
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks — API hooks
+// ---------------------------------------------------------------------------
+
+let mockFlowsData: Array<{
+  id: string;
+  name: string;
+  folder_id: string;
+  is_component: boolean;
+  icon?: string;
+}> = [];
+
+jest.mock(
+  "@/controllers/API/queries/flows/use-get-refresh-flows-query",
+  () => ({
+    useGetRefreshFlowsQuery: () => ({
+      data: mockFlowsData,
+    }),
+  }),
+);
+
+let mockConfigsData: {
+  configs: Array<{ id: string; name: string }>;
+} | null = null;
+
+jest.mock(
+  "@/controllers/API/queries/deployments/use-get-deployment-configs",
+  () => ({
+    useGetDeploymentConfigs: () => ({
+      data: mockConfigsData,
+    }),
+  }),
+);
+
+let mockVersionsData: {
+  entries: Array<{
+    id: string;
+    version_tag: string;
+    created_at: string;
+  }>;
+} | null = null;
+let mockIsLoadingVersions = false;
+
+jest.mock(
+  "@/controllers/API/queries/flow-version/use-get-flow-versions",
+  () => ({
+    useGetFlowVersions: () => ({
+      data: mockVersionsData,
+      isLoading: mockIsLoadingVersions,
+    }),
+  }),
+);
+
+const mockDetectEnvVars = jest.fn().mockResolvedValue({ variables: [] });
+
+jest.mock(
+  "@/controllers/API/queries/variables/use-post-detect-env-vars",
+  () => ({
+    usePostDetectEnvVars: () => ({
+      mutateAsync: mockDetectEnvVars,
+    }),
+  }),
+);
+
+jest.mock("@/controllers/API/queries/variables", () => ({
+  useGetGlobalVariables: () => ({
+    data: [{ name: "GLOBAL_SECRET" }, { name: "DB_PASS" }],
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// UI component mocks
+// ---------------------------------------------------------------------------
+
+jest.mock(
+  "@/components/common/genericIconComponent",
+  () =>
+    function MockIcon({ name }: { name: string }) {
+      return <span data-testid={`icon-${name}`} />;
+    },
+);
+
+jest.mock(
+  "@/components/core/parameterRenderComponent/components/inputComponent",
+  () =>
+    function MockInputComponent({
+      id,
+      placeholder,
+      value,
+      onChange,
+    }: {
+      id: string;
+      placeholder: string;
+      value: string;
+      onChange: (v: string) => void;
+    }) {
+      return (
+        <input
+          data-testid={`input-${id}`}
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      );
+    },
+);
+
+import StepAttachFlows from "../components/step-attach-flows";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsEditMode = false;
+  mockInitialFlowId = undefined;
+  mockSelectedInstance = { id: "inst-1" };
+  mockConnections = [];
+  mockSelectedVersionByFlow = new Map();
+  mockToolNameByFlow = new Map();
+  mockAttachedConnectionByFlow = new Map();
+  mockRemovedFlowIds = new Set();
+  mockFlowsData = [
+    {
+      id: "flow-1",
+      name: "Sales Flow",
+      folder_id: "folder-1",
+      is_component: false,
+    },
+    {
+      id: "flow-2",
+      name: "Support Flow",
+      folder_id: "folder-1",
+      is_component: false,
+    },
+  ];
+  mockConfigsData = null;
+  mockVersionsData = {
+    entries: [
+      { id: "ver-1", version_tag: "v1", created_at: "2025-06-01T00:00:00Z" },
+      { id: "ver-2", version_tag: "v2", created_at: "2025-06-02T00:00:00Z" },
+    ],
+  };
+  mockIsLoadingVersions = false;
+});
+
+// ---------------------------------------------------------------------------
+// Three-panel layout rendering
+// ---------------------------------------------------------------------------
+
+describe("Three-panel layout rendering", () => {
+  it("renders the Attach Flows heading", () => {
+    render(<StepAttachFlows />);
+    expect(screen.getByText("Attach Flows")).toBeInTheDocument();
+  });
+
+  it("renders the Available Flows panel header", () => {
+    render(<StepAttachFlows />);
+    expect(screen.getByText("Available Flows")).toBeInTheDocument();
+  });
+
+  it("renders flow items in the list", () => {
+    render(<StepAttachFlows />);
+    expect(screen.getByTestId("flow-item-flow-1")).toBeInTheDocument();
+    expect(screen.getByTestId("flow-item-flow-2")).toBeInTheDocument();
+  });
+
+  it("filters out components from flow list", () => {
+    mockFlowsData = [
+      ...mockFlowsData,
+      {
+        id: "comp-1",
+        name: "My Component",
+        folder_id: "folder-1",
+        is_component: true,
+      },
+    ];
+    render(<StepAttachFlows />);
+    expect(screen.queryByText("My Component")).not.toBeInTheDocument();
+  });
+
+  it("filters out flows from other folders", () => {
+    mockFlowsData = [
+      ...mockFlowsData,
+      {
+        id: "other-flow",
+        name: "Other Folder Flow",
+        folder_id: "folder-2",
+        is_component: false,
+      },
+    ];
+    render(<StepAttachFlows />);
+    expect(screen.queryByText("Other Folder Flow")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Version panel
+// ---------------------------------------------------------------------------
+
+describe("Version panel", () => {
+  it("shows version panel with flow name when flow is selected", () => {
+    render(<StepAttachFlows />);
+    // First flow is selected by default — name appears in both flow list and version panel
+    expect(screen.getAllByText("Sales Flow").length).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getByText("Select a version to attach to this deployment"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders version items", () => {
+    render(<StepAttachFlows />);
+    expect(screen.getByTestId("version-item-ver-1")).toBeInTheDocument();
+    expect(screen.getByTestId("version-item-ver-2")).toBeInTheDocument();
+  });
+
+  it("shows loading state for versions", () => {
+    mockIsLoadingVersions = true;
+    render(<StepAttachFlows />);
+    expect(screen.getByText("Loading versions...")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no versions available", () => {
+    mockVersionsData = { entries: [] };
+    render(<StepAttachFlows />);
+    expect(screen.getByText("No versions found")).toBeInTheDocument();
+  });
+
+  it("shows ATTACHED badge for already-attached versions", () => {
+    mockSelectedVersionByFlow = new Map([
+      ["flow-1", { versionId: "ver-1", versionTag: "v1" }],
+    ]);
+    render(<StepAttachFlows />);
+    expect(screen.getAllByText("ATTACHED").length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flow selection triggers version panel
+// ---------------------------------------------------------------------------
+
+describe("Flow selection", () => {
+  it("selecting a different flow shows its name in the version panel", async () => {
+    const user = userEvent.setup();
+    render(<StepAttachFlows />);
+
+    await user.click(screen.getByTestId("flow-item-flow-2"));
+    // Flow name appears in both the flow list and the version panel header
+    expect(screen.getAllByText("Support Flow").length).toBeGreaterThanOrEqual(
+      1,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Connection panel toggle
+// ---------------------------------------------------------------------------
+
+describe("Connection panel toggle", () => {
+  it("switches to connection panel after clicking a version", async () => {
+    const user = userEvent.setup();
+    render(<StepAttachFlows />);
+
+    await user.click(screen.getByTestId("version-item-ver-1"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Select or Create New Connection"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("detects env vars when a version is selected", async () => {
+    const user = userEvent.setup();
+    render(<StepAttachFlows />);
+
+    await user.click(screen.getByTestId("version-item-ver-1"));
+
+    await waitFor(() => {
+      expect(mockDetectEnvVars).toHaveBeenCalledWith({
+        flow_version_ids: ["ver-1"],
+      });
+    });
+  });
+
+  it("defaults to create tab when no existing connections", async () => {
+    const user = userEvent.setup();
+    mockConnections = [];
+    render(<StepAttachFlows />);
+
+    await user.click(screen.getByTestId("version-item-ver-1"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("e.g., SALES_BOT_PROD"),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Existing connections seeding
+// ---------------------------------------------------------------------------
+
+describe("Existing connections seeding", () => {
+  it("seeds connections from provider configs", () => {
+    mockConfigsData = {
+      configs: [
+        { id: "cfg-1", name: "Production Config" },
+        { id: "cfg-2", name: "Staging Config" },
+      ],
+    };
+    render(<StepAttachFlows />);
+    expect(mockSetConnections).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edit mode features
+// ---------------------------------------------------------------------------
+
+describe("Edit mode features", () => {
+  beforeEach(() => {
+    mockIsEditMode = true;
+    mockSelectedVersionByFlow = new Map([
+      ["flow-1", { versionId: "ver-1", versionTag: "v1" }],
+    ]);
+  });
+
+  it("shows ATTACHED badge for attached flows in flow list", () => {
+    render(<StepAttachFlows />);
+    expect(screen.getAllByText("ATTACHED").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows detach button for attached flows", () => {
+    render(<StepAttachFlows />);
+    expect(screen.getByTestId("detach-flow-flow-1")).toBeInTheDocument();
+  });
+
+  it("calls handleRemoveAttachedFlow when detach is clicked", async () => {
+    const user = userEvent.setup();
+    render(<StepAttachFlows />);
+
+    await user.click(screen.getByTestId("detach-flow-flow-1"));
+    expect(mockHandleRemoveAttachedFlow).toHaveBeenCalledWith("flow-1");
+  });
+
+  it("shows REMOVED badge for removed flows", () => {
+    mockRemovedFlowIds = new Set(["flow-1"]);
+    render(<StepAttachFlows />);
+    expect(screen.getByText("REMOVED")).toBeInTheDocument();
+  });
+
+  it("shows undo button for removed flows", () => {
+    mockRemovedFlowIds = new Set(["flow-1"]);
+    render(<StepAttachFlows />);
+    expect(screen.getByTestId("undo-remove-flow-flow-1")).toBeInTheDocument();
+  });
+
+  it("calls handleUndoRemoveFlow when undo is clicked", async () => {
+    const user = userEvent.setup();
+    mockRemovedFlowIds = new Set(["flow-1"]);
+    render(<StepAttachFlows />);
+
+    await user.click(screen.getByTestId("undo-remove-flow-flow-1"));
+    expect(mockHandleUndoRemoveFlow).toHaveBeenCalledWith("flow-1");
+  });
+
+  it("sorts attached flows to the top", () => {
+    render(<StepAttachFlows />);
+    const flowItems = screen.getAllByTestId(/^flow-item-/);
+    // flow-1 is attached, so it should appear first
+    expect(flowItems[0]).toHaveAttribute("data-testid", "flow-item-flow-1");
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-provider.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-provider.test.tsx
@@ -1,0 +1,204 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ProviderAccount, ProviderCredentials } from "../types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSetSelectedProvider = jest.fn();
+const mockSetSelectedInstance = jest.fn();
+const mockSetCredentials = jest.fn();
+
+let mockProviderAccountsData: { providers: ProviderAccount[] } | undefined;
+
+jest.mock(
+  "@/controllers/API/queries/deployment-provider-accounts/use-get-provider-accounts",
+  () => ({
+    useGetProviderAccounts: () => ({
+      data: mockProviderAccountsData,
+    }),
+  }),
+);
+
+jest.mock("../contexts/deployment-stepper-context", () => ({
+  useDeploymentStepper: () => ({
+    setSelectedProvider: mockSetSelectedProvider,
+    selectedInstance: null,
+    setSelectedInstance: mockSetSelectedInstance,
+    credentials: {
+      name: "",
+      provider_key: "watsonx-orchestrate",
+      provider_url: "",
+      api_key: "",
+    } as ProviderCredentials,
+    setCredentials: mockSetCredentials,
+  }),
+}));
+
+jest.mock(
+  "@/components/common/genericIconComponent",
+  () =>
+    function MockIcon({ name }: { name: string }) {
+      return <span data-testid={`icon-${name}`} />;
+    },
+);
+
+import StepProvider from "../components/step-provider";
+
+const makeEnvironment = (
+  overrides: Partial<ProviderAccount> = {},
+): ProviderAccount => ({
+  id: "env-1",
+  name: "Prod Environment",
+  provider_tenant_id: "tenant-1",
+  provider_key: "watsonx-orchestrate",
+  provider_url: "https://api.prod.example.com",
+  created_at: "2025-05-01T00:00:00Z",
+  updated_at: "2025-05-01T00:00:00Z",
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockProviderAccountsData = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// Basic rendering
+// ---------------------------------------------------------------------------
+
+describe("Basic rendering", () => {
+  it("renders the Provider heading", () => {
+    render(<StepProvider />);
+    expect(screen.getByText("Provider")).toBeInTheDocument();
+  });
+
+  it("displays the watsonx Orchestrate provider card", () => {
+    render(<StepProvider />);
+    expect(screen.getByText("watsonx Orchestrate")).toBeInTheDocument();
+  });
+
+  it("calls setSelectedProvider on mount", () => {
+    render(<StepProvider />);
+    expect(mockSetSelectedProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "watsonx",
+        type: "watsonx",
+        name: "watsonx Orchestrate",
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No existing environments
+// ---------------------------------------------------------------------------
+
+describe("No existing environments", () => {
+  it("shows the credentials form directly", () => {
+    mockProviderAccountsData = { providers: [] };
+    render(<StepProvider />);
+    expect(screen.getByPlaceholderText("e.g. Production")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Enter your API key"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the environment tab toggle", () => {
+    mockProviderAccountsData = { providers: [] };
+    render(<StepProvider />);
+    expect(
+      screen.queryByText("Choose existing environment"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// With existing environments
+// ---------------------------------------------------------------------------
+
+describe("With existing environments", () => {
+  beforeEach(() => {
+    mockProviderAccountsData = {
+      providers: [
+        makeEnvironment({ id: "env-1", name: "Prod Environment" }),
+        makeEnvironment({
+          id: "env-2",
+          name: "Staging",
+          provider_url: "https://api.staging.example.com",
+        }),
+      ],
+    };
+  });
+
+  it("shows environment tab toggle with both tabs", () => {
+    render(<StepProvider />);
+    expect(screen.getByText("Choose existing environment")).toBeInTheDocument();
+    expect(screen.getByText("Add new environment")).toBeInTheDocument();
+  });
+
+  it("auto-switches to existing tab when environments available", async () => {
+    render(<StepProvider />);
+    // The existing tab should be active, showing the environment list
+    await waitFor(() => {
+      expect(
+        screen.getByText("Select from your existing environments"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders environment radio items", async () => {
+    render(<StepProvider />);
+    await waitFor(() => {
+      expect(screen.getByText("Prod Environment")).toBeInTheDocument();
+      expect(screen.getByText("Staging")).toBeInTheDocument();
+    });
+  });
+
+  it("shows environment URLs", async () => {
+    render(<StepProvider />);
+    await waitFor(() => {
+      expect(
+        screen.getByText("https://api.prod.example.com"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("https://api.staging.example.com"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("calls setSelectedInstance when an environment is selected", async () => {
+    const user = userEvent.setup();
+    render(<StepProvider />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Prod Environment")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Prod Environment"));
+    expect(mockSetSelectedInstance).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "env-1", name: "Prod Environment" }),
+    );
+  });
+
+  it("switches to credentials form when 'Add new environment' tab is clicked", async () => {
+    const user = userEvent.setup();
+    render(<StepProvider />);
+
+    await user.click(screen.getByText("Add new environment"));
+    expect(screen.getByPlaceholderText("e.g. Production")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Enter your API key"),
+    ).toBeInTheDocument();
+  });
+
+  it("has radiogroup role for environment selection", async () => {
+    render(<StepProvider />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("radiogroup", { name: "Existing environments" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-provider.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-provider.test.tsx
@@ -10,7 +10,9 @@ const mockSetSelectedProvider = jest.fn();
 const mockSetSelectedInstance = jest.fn();
 const mockSetCredentials = jest.fn();
 
-let mockProviderAccountsData: { providers: ProviderAccount[] } | undefined;
+let mockProviderAccountsData:
+  | { provider_accounts: ProviderAccount[] }
+  | undefined;
 
 jest.mock(
   "@/controllers/API/queries/deployment-provider-accounts/use-get-provider-accounts",
@@ -29,7 +31,7 @@ jest.mock("../contexts/deployment-stepper-context", () => ({
     credentials: {
       name: "",
       provider_key: "watsonx-orchestrate",
-      provider_url: "",
+      url: "",
       api_key: "",
     } as ProviderCredentials,
     setCredentials: mockSetCredentials,
@@ -51,9 +53,8 @@ const makeEnvironment = (
 ): ProviderAccount => ({
   id: "env-1",
   name: "Prod Environment",
-  provider_tenant_id: "tenant-1",
   provider_key: "watsonx-orchestrate",
-  provider_url: "https://api.prod.example.com",
+  url: "https://api.prod.example.com",
   created_at: "2025-05-01T00:00:00Z",
   updated_at: "2025-05-01T00:00:00Z",
   ...overrides,
@@ -97,7 +98,7 @@ describe("Basic rendering", () => {
 
 describe("No existing environments", () => {
   it("shows the credentials form directly", () => {
-    mockProviderAccountsData = { providers: [] };
+    mockProviderAccountsData = { provider_accounts: [] };
     render(<StepProvider />);
     expect(screen.getByPlaceholderText("e.g. Production")).toBeInTheDocument();
     expect(
@@ -106,7 +107,7 @@ describe("No existing environments", () => {
   });
 
   it("does not show the environment tab toggle", () => {
-    mockProviderAccountsData = { providers: [] };
+    mockProviderAccountsData = { provider_accounts: [] };
     render(<StepProvider />);
     expect(
       screen.queryByText("Choose existing environment"),
@@ -121,12 +122,12 @@ describe("No existing environments", () => {
 describe("With existing environments", () => {
   beforeEach(() => {
     mockProviderAccountsData = {
-      providers: [
+      provider_accounts: [
         makeEnvironment({ id: "env-1", name: "Prod Environment" }),
         makeEnvironment({
           id: "env-2",
           name: "Staging",
-          provider_url: "https://api.staging.example.com",
+          url: "https://api.staging.example.com",
         }),
       ],
     };

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-review.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-review.test.tsx
@@ -1,0 +1,351 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ConnectionItem } from "../types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockIsEditMode = false;
+let mockDeploymentType = "agent";
+let mockDeploymentName = "My Agent";
+let mockSelectedLlm = "granite-13b-chat";
+let mockConnections: ConnectionItem[] = [];
+let mockSelectedVersionByFlow = new Map<
+  string,
+  { versionId: string; versionTag: string }
+>();
+let mockToolNameByFlow = new Map<string, string>();
+const mockSetToolNameByFlow = jest.fn();
+let mockAttachedConnectionByFlow = new Map<string, string[]>();
+let mockRemovedFlowIds = new Set<string>();
+
+jest.mock("../contexts/deployment-stepper-context", () => ({
+  useDeploymentStepper: () => ({
+    isEditMode: mockIsEditMode,
+    deploymentType: mockDeploymentType,
+    deploymentName: mockDeploymentName,
+    selectedLlm: mockSelectedLlm,
+    connections: mockConnections,
+    selectedVersionByFlow: mockSelectedVersionByFlow,
+    toolNameByFlow: mockToolNameByFlow,
+    setToolNameByFlow: mockSetToolNameByFlow,
+    attachedConnectionByFlow: mockAttachedConnectionByFlow,
+    removedFlowIds: mockRemovedFlowIds,
+  }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  useParams: () => ({ folderId: "folder-1" }),
+}));
+
+jest.mock("@/stores/foldersStore", () => ({
+  useFolderStore: () => "folder-1",
+}));
+
+let mockFlowsData: Array<{
+  id: string;
+  name: string;
+  folder_id: string;
+  is_component: boolean;
+}> = [];
+
+jest.mock(
+  "@/controllers/API/queries/flows/use-get-refresh-flows-query",
+  () => ({
+    useGetRefreshFlowsQuery: () => ({
+      data: mockFlowsData,
+    }),
+  }),
+);
+
+jest.mock(
+  "@/components/common/genericIconComponent",
+  () =>
+    function MockIcon({ name }: { name: string }) {
+      return <span data-testid={`icon-${name}`} />;
+    },
+);
+
+import StepReview from "../components/step-review";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsEditMode = false;
+  mockDeploymentType = "agent";
+  mockDeploymentName = "My Agent";
+  mockSelectedLlm = "granite-13b-chat";
+  mockConnections = [];
+  mockSelectedVersionByFlow = new Map();
+  mockToolNameByFlow = new Map();
+  mockAttachedConnectionByFlow = new Map();
+  mockRemovedFlowIds = new Set();
+  mockFlowsData = [
+    {
+      id: "flow-1",
+      name: "Sales Flow",
+      folder_id: "folder-1",
+      is_component: false,
+    },
+    {
+      id: "flow-2",
+      name: "Support Flow",
+      folder_id: "folder-1",
+      is_component: false,
+    },
+  ];
+});
+
+// ---------------------------------------------------------------------------
+// Two-column layout
+// ---------------------------------------------------------------------------
+
+describe("Two-column layout", () => {
+  it("renders the Review & Confirm heading", () => {
+    render(<StepReview />);
+    expect(screen.getByText("Review & Confirm")).toBeInTheDocument();
+  });
+
+  it("shows deployment type", () => {
+    render(<StepReview />);
+    expect(screen.getByText("agent")).toBeInTheDocument();
+  });
+
+  it("shows deployment name", () => {
+    render(<StepReview />);
+    expect(screen.getByText("My Agent")).toBeInTheDocument();
+  });
+
+  it("shows selected LLM model", () => {
+    render(<StepReview />);
+    expect(screen.getByText("granite-13b-chat")).toBeInTheDocument();
+  });
+
+  it("shows dash when no flows attached", () => {
+    render(<StepReview />);
+    // The "Attached Flows" column should show "—"
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("shows dash when deployment name is empty", () => {
+    mockDeploymentName = "";
+    render(<StepReview />);
+    // At least one "—" for the empty name
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not show Model row when no LLM is selected", () => {
+    mockSelectedLlm = "";
+    render(<StepReview />);
+    expect(screen.queryByText("granite-13b-chat")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Attached flows display
+// ---------------------------------------------------------------------------
+
+describe("Attached flows display", () => {
+  beforeEach(() => {
+    mockSelectedVersionByFlow = new Map([
+      ["flow-1", { versionId: "v1-id", versionTag: "v1" }],
+    ]);
+  });
+
+  it("shows attached flow name and version badge", () => {
+    render(<StepReview />);
+    // Flow name appears in both Attached Flows column and config section
+    expect(screen.getAllByText("Sales Flow").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("v1").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows multiple attached flows", () => {
+    mockSelectedVersionByFlow = new Map([
+      ["flow-1", { versionId: "v1-id", versionTag: "v1" }],
+      ["flow-2", { versionId: "v2-id", versionTag: "v3" }],
+    ]);
+    render(<StepReview />);
+    // Flow names appear in both the Attached Flows column and the config section
+    expect(screen.getAllByText("Sales Flow").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Support Flow").length).toBeGreaterThanOrEqual(
+      1,
+    );
+  });
+
+  it("shows Unknown for flows not found in flow data", () => {
+    mockSelectedVersionByFlow = new Map([
+      ["flow-missing", { versionId: "v1-id", versionTag: "v1" }],
+    ]);
+    render(<StepReview />);
+    expect(screen.getAllByText("Unknown").length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool name inline editing
+// ---------------------------------------------------------------------------
+
+describe("Tool name inline editing", () => {
+  beforeEach(() => {
+    mockSelectedVersionByFlow = new Map([
+      ["flow-1", { versionId: "v1-id", versionTag: "v1" }],
+    ]);
+  });
+
+  it("shows flow name as tool name when no custom name is set", () => {
+    render(<StepReview />);
+    // The tool name defaults to flowName
+    expect(screen.getAllByText("Sales Flow").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows custom tool name when set", () => {
+    mockToolNameByFlow = new Map([["flow-1", "Custom Tool"]]);
+    render(<StepReview />);
+    expect(screen.getByText("Custom Tool")).toBeInTheDocument();
+  });
+
+  it("renders edit button for tool name", () => {
+    render(<StepReview />);
+    expect(screen.getByTestId("edit-tool-name")).toBeInTheDocument();
+  });
+
+  it("enters editing mode when edit button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<StepReview />);
+
+    await user.click(screen.getByTestId("edit-tool-name"));
+    expect(screen.getByTestId("tool-name-input")).toBeInTheDocument();
+  });
+
+  it("confirms edit on Enter key", async () => {
+    const user = userEvent.setup();
+    render(<StepReview />);
+
+    await user.click(screen.getByTestId("edit-tool-name"));
+    const input = screen.getByTestId("tool-name-input");
+    await user.clear(input);
+    await user.type(input, "New Name{Enter}");
+
+    expect(mockSetToolNameByFlow).toHaveBeenCalled();
+  });
+
+  it("cancels edit on Escape key", async () => {
+    const user = userEvent.setup();
+    mockToolNameByFlow = new Map([["flow-1", "Original"]]);
+    render(<StepReview />);
+
+    await user.click(screen.getByTestId("edit-tool-name"));
+    const input = screen.getByTestId("tool-name-input");
+    await user.clear(input);
+    await user.type(input, "Changed{Escape}");
+
+    // Should revert — no setToolNameByFlow call after Escape
+    expect(screen.queryByTestId("tool-name-input")).not.toBeInTheDocument();
+    expect(screen.getByText("Original")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Connection display with masked env vars
+// ---------------------------------------------------------------------------
+
+describe("Connection display with masked env vars", () => {
+  beforeEach(() => {
+    mockSelectedVersionByFlow = new Map([
+      ["flow-1", { versionId: "v1-id", versionTag: "v1" }],
+    ]);
+    mockConnections = [
+      {
+        id: "conn-1",
+        name: "Prod Connection",
+        variableCount: 2,
+        isNew: true,
+        environmentVariables: {
+          API_KEY: "secret-value", // pragma: allowlist secret
+          DB_URL: "postgres://...",
+        },
+      },
+      {
+        id: "conn-2",
+        name: "Existing Connection",
+        variableCount: 0,
+        isNew: false,
+        environmentVariables: {},
+      },
+    ];
+    mockAttachedConnectionByFlow = new Map([["flow-1", ["conn-1", "conn-2"]]]);
+  });
+
+  it("shows new connections section", () => {
+    render(<StepReview />);
+    expect(screen.getByText("New Connections")).toBeInTheDocument();
+    expect(screen.getByText("Prod Connection")).toBeInTheDocument();
+  });
+
+  it("shows existing connections section", () => {
+    render(<StepReview />);
+    expect(screen.getByText("Existing Connections")).toBeInTheDocument();
+    expect(screen.getByText("Existing Connection")).toBeInTheDocument();
+  });
+
+  it("masks environment variable values", () => {
+    render(<StepReview />);
+    expect(screen.getByText("API_KEY")).toBeInTheDocument();
+    expect(screen.getByText("DB_URL")).toBeInTheDocument();
+    // Values should be masked
+    expect(screen.getAllByText("••••••••").length).toBe(2);
+    // Actual values should NOT appear
+    expect(screen.queryByText("secret-value")).not.toBeInTheDocument();
+    expect(screen.queryByText("postgres://...")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Detaching section (edit mode)
+// ---------------------------------------------------------------------------
+
+describe("Detaching section (edit mode)", () => {
+  it("does not show detaching section in create mode", () => {
+    mockRemovedFlowIds = new Set(["flow-1"]);
+    render(<StepReview />);
+    expect(screen.queryByText("Detaching")).not.toBeInTheDocument();
+  });
+
+  it("shows detaching section in edit mode with removed flows", () => {
+    mockIsEditMode = true;
+    mockRemovedFlowIds = new Set(["flow-1"]);
+    render(<StepReview />);
+    expect(screen.getByText("Detaching")).toBeInTheDocument();
+    expect(screen.getByText("removing")).toBeInTheDocument();
+  });
+
+  it("does not show detaching section when no flows are removed", () => {
+    mockIsEditMode = true;
+    mockRemovedFlowIds = new Set();
+    render(<StepReview />);
+    expect(screen.queryByText("Detaching")).not.toBeInTheDocument();
+  });
+
+  it("shows flow name in detaching section", () => {
+    mockIsEditMode = true;
+    mockRemovedFlowIds = new Set(["flow-1"]);
+    render(<StepReview />);
+    expect(screen.getByText("Sales Flow")).toBeInTheDocument();
+  });
+
+  it("shows Unknown flow for unrecognized flow IDs", () => {
+    mockIsEditMode = true;
+    mockRemovedFlowIds = new Set(["flow-unknown"]);
+    render(<StepReview />);
+    expect(screen.getByText("Unknown flow")).toBeInTheDocument();
+  });
+
+  it("shows help text about detaching", () => {
+    mockIsEditMode = true;
+    mockRemovedFlowIds = new Set(["flow-1"]);
+    render(<StepReview />);
+    expect(
+      screen.getByText(/These tools will be detached from the agent/),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-type.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-type.test.tsx
@@ -1,0 +1,222 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSetDeploymentType = jest.fn();
+const mockSetDeploymentName = jest.fn();
+const mockSetDeploymentDescription = jest.fn();
+const mockSetSelectedLlm = jest.fn();
+
+let mockIsEditMode = false;
+let mockDeploymentType = "agent";
+let mockDeploymentName = "";
+let mockDeploymentDescription = "";
+let mockSelectedLlm = "";
+let mockSelectedInstance: { id: string } | null = { id: "inst-1" };
+let mockLlmModels: Array<{ model_name: string }> = [];
+let mockLlmsLoading = false;
+
+jest.mock("../contexts/deployment-stepper-context", () => ({
+  useDeploymentStepper: () => ({
+    isEditMode: mockIsEditMode,
+    deploymentType: mockDeploymentType,
+    setDeploymentType: mockSetDeploymentType,
+    deploymentName: mockDeploymentName,
+    setDeploymentName: mockSetDeploymentName,
+    deploymentDescription: mockDeploymentDescription,
+    setDeploymentDescription: mockSetDeploymentDescription,
+    selectedLlm: mockSelectedLlm,
+    setSelectedLlm: mockSetSelectedLlm,
+    selectedInstance: mockSelectedInstance,
+  }),
+}));
+
+jest.mock(
+  "@/controllers/API/queries/deployments/use-get-deployment-llms",
+  () => ({
+    useGetDeploymentLlms: () => ({
+      data: {
+        provider_data: { models: mockLlmModels },
+      },
+      isLoading: mockLlmsLoading,
+    }),
+  }),
+);
+
+jest.mock(
+  "@/components/common/genericIconComponent",
+  () =>
+    function MockIcon({ name }: { name: string }) {
+      return <span data-testid={`icon-${name}`} />;
+    },
+);
+
+import StepType from "../components/step-type";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsEditMode = false;
+  mockDeploymentType = "agent";
+  mockDeploymentName = "";
+  mockDeploymentDescription = "";
+  mockSelectedLlm = "";
+  mockSelectedInstance = { id: "inst-1" };
+  mockLlmModels = [];
+  mockLlmsLoading = false;
+});
+
+// ---------------------------------------------------------------------------
+// Basic rendering
+// ---------------------------------------------------------------------------
+
+describe("Basic rendering", () => {
+  it("renders the Deployment Type heading", () => {
+    render(<StepType />);
+    expect(screen.getByText("Deployment Type")).toBeInTheDocument();
+  });
+
+  it("renders type selection with Agent option", () => {
+    render(<StepType />);
+    expect(screen.getByTestId("deployment-type-agent")).toBeInTheDocument();
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Conversational agent with chat interface and tool calling",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders required field indicators", () => {
+    render(<StepType />);
+    expect(screen.getByText("Agent Name")).toBeInTheDocument();
+    expect(screen.getByText("Model")).toBeInTheDocument();
+  });
+
+  it("renders optional description field", () => {
+    render(<StepType />);
+    expect(screen.getByText("Description")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Describe the agent's purpose..."),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Name input
+// ---------------------------------------------------------------------------
+
+describe("Name input", () => {
+  it("renders with placeholder", () => {
+    render(<StepType />);
+    expect(screen.getByPlaceholderText("e.g., Sales Bot")).toBeInTheDocument();
+  });
+
+  it("calls setDeploymentName on input change", async () => {
+    const user = userEvent.setup();
+    render(<StepType />);
+
+    const input = screen.getByPlaceholderText("e.g., Sales Bot");
+    await user.type(input, "A");
+    expect(mockSetDeploymentName).toHaveBeenCalled();
+  });
+
+  it("is disabled in edit mode", () => {
+    mockIsEditMode = true;
+    render(<StepType />);
+    expect(screen.getByPlaceholderText("e.g., Sales Bot")).toBeDisabled();
+  });
+
+  it("shows helper text in edit mode", () => {
+    mockIsEditMode = true;
+    render(<StepType />);
+    expect(
+      screen.getByText("Name cannot be changed after creation."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show helper text in create mode", () => {
+    render(<StepType />);
+    expect(
+      screen.queryByText("Name cannot be changed after creation."),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LLM dropdown
+// ---------------------------------------------------------------------------
+
+describe("LLM dropdown", () => {
+  it("shows loading placeholder when fetching", () => {
+    mockLlmsLoading = true;
+    render(<StepType />);
+    expect(screen.getByText("Loading models...")).toBeInTheDocument();
+  });
+
+  it("shows select placeholder when not loading", () => {
+    mockLlmsLoading = false;
+    render(<StepType />);
+    expect(screen.getByText("Select a model")).toBeInTheDocument();
+  });
+
+  it("shows selected model value when one is set", () => {
+    mockLlmModels = [
+      { model_name: "granite-13b-chat" },
+      { model_name: "llama-3-70b" },
+    ];
+    mockSelectedLlm = "granite-13b-chat";
+    render(<StepType />);
+    // The SelectValue renders the selected model text
+    expect(screen.getByText("granite-13b-chat")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type selection
+// ---------------------------------------------------------------------------
+
+describe("Type selection", () => {
+  it("renders agent type as selected by default", () => {
+    render(<StepType />);
+    const agentLabel = screen.getByTestId("deployment-type-agent");
+    const radio = agentLabel.querySelector('input[type="radio"]');
+    expect(radio).toBeChecked();
+  });
+
+  it("triggers onChange on the radio input", () => {
+    render(<StepType />);
+    const agentLabel = screen.getByTestId("deployment-type-agent");
+    const radio = agentLabel.querySelector(
+      'input[type="radio"]',
+    ) as HTMLInputElement;
+    expect(radio).toBeTruthy();
+    expect(radio.value).toBe("agent");
+  });
+
+  it("has radiogroup role", () => {
+    render(<StepType />);
+    expect(
+      screen.getByRole("radiogroup", { name: "Deployment type" }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Description textarea
+// ---------------------------------------------------------------------------
+
+describe("Description textarea", () => {
+  it("calls setDeploymentDescription on input", async () => {
+    const user = userEvent.setup();
+    render(<StepType />);
+
+    const textarea = screen.getByPlaceholderText(
+      "Describe the agent's purpose...",
+    );
+    await user.type(textarea, "A");
+    expect(mockSetDeploymentDescription).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/add-provider-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/add-provider-modal.tsx
@@ -89,10 +89,19 @@ export default function AddProviderModal({
         </div>
 
         <div className="flex items-center justify-end gap-3 pt-4">
-          <Button variant="outline" onClick={handleClose} disabled={isSaving}>
+          <Button
+            variant="outline"
+            onClick={handleClose}
+            disabled={isSaving}
+            data-testid="add-provider-cancel"
+          >
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={!canSave || isSaving}>
+          <Button
+            onClick={handleSave}
+            disabled={!canSave || isSaving}
+            data-testid="add-provider-save"
+          >
             {isSaving ? "Saving..." : "Save"}
           </Button>
         </div>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/add-provider-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/add-provider-modal.tsx
@@ -68,7 +68,9 @@ export default function AddProviderModal({
   return (
     <Dialog open={open} onOpenChange={(value) => !value && handleClose()}>
       <DialogContent className="sm:max-w-[500px]">
-        <DialogTitle>Add Environment</DialogTitle>
+        <DialogTitle data-testid="add-provider-modal-title">
+          Add Environment
+        </DialogTitle>
         <DialogDescription>
           Configure your watsonx Orchestrate credentials below.
         </DialogDescription>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-details-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-details-modal.tsx
@@ -106,7 +106,11 @@ export default function DeploymentDetailsModal({
         )}
 
         <div className="flex justify-end border-t px-6 py-4">
-          <Button variant="outline" onClick={() => setOpen(false)}>
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            data-testid="deployment-details-close"
+          >
             Close
           </Button>
         </div>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-stepper-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-stepper-modal.tsx
@@ -8,8 +8,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { usePostProviderAccount } from "@/controllers/API/queries/deployment-provider-accounts/use-post-provider-account";
-import { useGetDeploymentAttachments } from "@/controllers/API/queries/deployments/use-get-deployment-attachments";
 import { useGetDeployment } from "@/controllers/API/queries/deployments/use-get-deployment";
+import { useGetDeploymentAttachments } from "@/controllers/API/queries/deployments/use-get-deployment-attachments";
 import { usePatchDeployment } from "@/controllers/API/queries/deployments/use-patch-deployment";
 import { usePostDeployment } from "@/controllers/API/queries/deployments/use-post-deployment";
 import {
@@ -299,7 +299,10 @@ function DeploymentStepperModalContent({
 
       {/* Title + Stepper */}
       <div className="flex flex-col gap-4 px-6 pt-6">
-        <h2 className="text-center text-2xl font-semibold">
+        <h2
+          className="text-center text-2xl font-semibold"
+          data-testid="stepper-modal-title"
+        >
           {isEditMode ? "Update Deployment" : "Create New Deployment"}
         </h2>
         <DeploymentStepper />

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-table.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-table.tsx
@@ -221,6 +221,7 @@ export default function DeploymentsTable({
                         <DropdownMenuSeparator />
                         <DropdownMenuItem
                           className="text-destructive focus:text-destructive"
+                          data-testid={`delete-deployment-${deployment.id}`}
                           onClick={() => onDeleteDeployment?.(deployment)}
                         >
                           <ForwardedIconComponent

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-connection-panel.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-connection-panel.tsx
@@ -244,10 +244,18 @@ export const ConnectionPanel = memo(function ConnectionPanel({
 
         {/* Footer buttons */}
         <div className="flex items-center gap-3 pt-4">
-          <Button variant="outline" onClick={onChangeFlow}>
+          <Button
+            variant="outline"
+            onClick={onChangeFlow}
+            data-testid="connection-change-flow"
+          >
             Change Flow
           </Button>
-          <Button variant="outline" onClick={onSkipConnection}>
+          <Button
+            variant="outline"
+            onClick={onSkipConnection}
+            data-testid="connection-skip"
+          >
             Skip
           </Button>
           {connectionTab === "available" ? (
@@ -255,6 +263,7 @@ export const ConnectionPanel = memo(function ConnectionPanel({
               className="flex-1"
               disabled={selectedConnections.size === 0}
               onClick={onAttachConnection}
+              data-testid="connection-attach"
             >
               Attach Connection to Flow
             </Button>
@@ -263,6 +272,7 @@ export const ConnectionPanel = memo(function ConnectionPanel({
               className="flex-1"
               disabled={newConnectionName.trim() === "" || isDuplicateName}
               onClick={onCreateConnection}
+              data-testid="connection-create"
             >
               Create Connection
             </Button>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-provider.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-provider.tsx
@@ -78,6 +78,7 @@ function EnvironmentList({
               value={environment.id}
               selected={isSelected}
               onChange={() => onSelectEnvironment(environment)}
+              data-testid={`provider-item-${environment.id}`}
             >
               <span className="flex flex-col">
                 <span className="text-sm font-medium leading-tight">

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/__tests__/use-deployment-chat.test.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/__tests__/use-deployment-chat.test.ts
@@ -164,7 +164,6 @@ describe("useDeploymentChat", () => {
 
     expect(mockPostExecution).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider_id: "my-provider",
         deployment_id: "my-dep",
         provider_data: expect.objectContaining({ input: "hello world" }),
       }),
@@ -397,8 +396,8 @@ describe("useDeploymentChat", () => {
     });
 
     expect(mockGetExecution).toHaveBeenCalledWith({
+      deployment_id: "d1",
       execution_id: "my-exec-id",
-      provider_id: "my-provider",
     });
   });
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/__tests__/use-deployment-chat.test.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/__tests__/use-deployment-chat.test.ts
@@ -1,0 +1,829 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPostExecution = jest.fn();
+const mockGetExecution = jest.fn();
+
+jest.mock(
+  "@/controllers/API/queries/deployments/use-post-deployment-execution",
+  () => ({
+    usePostDeploymentExecution: () => ({ mutateAsync: mockPostExecution }),
+  }),
+);
+
+jest.mock(
+  "@/controllers/API/queries/deployments/use-get-deployment-execution",
+  () => ({
+    useGetDeploymentExecution: () => ({ mutateAsync: mockGetExecution }),
+  }),
+);
+
+import { useDeploymentChat } from "../use-deployment-chat";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Make a postExecution response with the given provider_data overrides. */
+const makePostResponse = (
+  providerDataOverrides: Record<string, unknown> = {},
+) => ({
+  provider_data: {
+    execution_id: "exec-1",
+    status: "pending",
+    ...providerDataOverrides,
+  },
+});
+
+/** Make a getExecution response (defaults to completed with text content). */
+const makeGetResponse = (
+  providerDataOverrides: Record<string, unknown> = {},
+) => ({
+  provider_data: {
+    execution_id: "exec-1",
+    status: "completed",
+    result: {
+      data: {
+        message: {
+          content: [{ type: "text", text: "Hello back!" }],
+        },
+      },
+    },
+    ...providerDataOverrides,
+  },
+});
+
+/** Make a completed getExecution response with no result (falls back to status string). */
+const makePendingGetResponse = () =>
+  makeGetResponse({ status: "pending", result: undefined });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useDeploymentChat", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockPostExecution.mockClear();
+    mockGetExecution.mockClear();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+
+  it("initializes with empty messages and not waiting", () => {
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.isWaitingForResponse).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Guard conditions — sendMessage does nothing
+  // -------------------------------------------------------------------------
+
+  it("does not send a whitespace-only message", async () => {
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("   ");
+    });
+
+    expect(mockPostExecution).not.toHaveBeenCalled();
+    expect(result.current.messages).toHaveLength(0);
+  });
+
+  it("does not send an empty string", async () => {
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("");
+    });
+
+    expect(mockPostExecution).not.toHaveBeenCalled();
+  });
+
+  it("does not send a second message while waiting for response from the first", async () => {
+    mockPostExecution.mockResolvedValue(makePostResponse());
+    // Keep getExecution pending forever (never resolves) so isWaitingForResponse stays true
+    mockGetExecution.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    // Start first message
+    act(() => {
+      void result.current.sendMessage("first");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.isWaitingForResponse).toBe(true);
+
+    // Attempt second message
+    await act(async () => {
+      await result.current.sendMessage("second");
+    });
+
+    expect(mockPostExecution).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // postExecution request shape
+  // -------------------------------------------------------------------------
+
+  it("sends the message text and deployment/provider ids to postExecution", async () => {
+    mockPostExecution.mockResolvedValueOnce(
+      makePostResponse({ status: "completed", execution_id: null }),
+    );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "my-provider", deploymentId: "my-dep" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello world");
+    });
+
+    expect(mockPostExecution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider_id: "my-provider",
+        deployment_id: "my-dep",
+        provider_data: expect.objectContaining({ input: "hello world" }),
+      }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Immediate terminal — no polling
+  // -------------------------------------------------------------------------
+
+  it("handles an immediately-completed response (status=completed)", async () => {
+    mockPostExecution.mockResolvedValueOnce(
+      makePostResponse({
+        execution_id: "exec-1",
+        status: "completed",
+        result: {
+          data: {
+            message: { content: [{ type: "text", text: "Immediate reply" }] },
+          },
+        },
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[0]).toMatchObject({
+      role: "user",
+      content: "hello",
+    });
+    expect(result.current.messages[1]).toMatchObject({
+      role: "assistant",
+      content: "Immediate reply",
+      isLoading: false,
+    });
+    expect(result.current.isWaitingForResponse).toBe(false);
+    expect(mockGetExecution).not.toHaveBeenCalled();
+  });
+
+  it("handles an immediately-completed response via completed_at", async () => {
+    mockPostExecution.mockResolvedValueOnce(
+      makePostResponse({
+        completed_at: "2025-01-01T00:00:00Z",
+        result: {
+          data: {
+            message: {
+              content: [{ type: "text", text: "Done via completed_at" }],
+            },
+          },
+        },
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(result.current.messages[1].content).toBe("Done via completed_at");
+    expect(mockGetExecution).not.toHaveBeenCalled();
+  });
+
+  it("falls back to status string when result has no text content", async () => {
+    mockPostExecution.mockResolvedValueOnce(
+      makePostResponse({ status: "success", result: undefined }),
+    );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(result.current.messages[1].content).toBe("success");
+  });
+
+  // -------------------------------------------------------------------------
+  // No execution ID returned
+  // -------------------------------------------------------------------------
+
+  it("shows error when no execution_id is returned and response is not terminal", async () => {
+    mockPostExecution.mockResolvedValueOnce(
+      makePostResponse({ execution_id: null, status: "pending" }),
+    );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(result.current.messages[1]).toMatchObject({
+      role: "assistant",
+      isLoading: false,
+      error: "Execution started but no execution ID was returned.",
+    });
+    expect(result.current.isWaitingForResponse).toBe(false);
+    expect(mockGetExecution).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // postExecution throws
+  // -------------------------------------------------------------------------
+
+  it("shows error message when postExecution throws an Error", async () => {
+    mockPostExecution.mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(result.current.messages[1]).toMatchObject({
+      role: "assistant",
+      isLoading: false,
+      error: "Network error",
+    });
+    expect(result.current.isWaitingForResponse).toBe(false);
+  });
+
+  it("shows generic error when postExecution throws a non-Error value", async () => {
+    mockPostExecution.mockRejectedValueOnce("unexpected string error");
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(result.current.messages[1]).toMatchObject({
+      isLoading: false,
+      error: "Failed to start execution",
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Polling — happy path
+  // -------------------------------------------------------------------------
+
+  it("polls until terminal status then updates assistant message", async () => {
+    mockPostExecution.mockResolvedValueOnce(makePostResponse());
+    mockGetExecution
+      .mockResolvedValueOnce(makePendingGetResponse()) // poll 1: still pending
+      .mockResolvedValueOnce(makeGetResponse()); // poll 2: completed
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    act(() => {
+      void result.current.sendMessage("hello");
+    });
+
+    // Flush postExecution
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Poll 1
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetExecution).toHaveBeenCalledTimes(1);
+    expect(result.current.isWaitingForResponse).toBe(true); // still waiting
+
+    // Poll 2
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isWaitingForResponse).toBe(false);
+    });
+
+    expect(result.current.messages[1]).toMatchObject({
+      role: "assistant",
+      content: "Hello back!",
+      isLoading: false,
+    });
+    expect(mockGetExecution).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes provider_id and execution_id to getExecution during polling", async () => {
+    mockPostExecution.mockResolvedValueOnce(
+      makePostResponse({ execution_id: "my-exec-id" }),
+    );
+    mockGetExecution.mockResolvedValueOnce(makeGetResponse());
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "my-provider", deploymentId: "d1" }),
+    );
+
+    act(() => {
+      void result.current.sendMessage("hello");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetExecution).toHaveBeenCalledWith({
+      execution_id: "my-exec-id",
+      provider_id: "my-provider",
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Polling — failure paths
+  // -------------------------------------------------------------------------
+
+  it("shows timeout error after MAX_POLL_ATTEMPTS (30) polls all return pending", async () => {
+    mockPostExecution.mockResolvedValueOnce(makePostResponse());
+    // All 31 polls return pending (MAX_POLL_ATTEMPTS = 30, timeout fires at attempt 31)
+    mockGetExecution.mockResolvedValue(makePendingGetResponse());
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    act(() => {
+      void result.current.sendMessage("hello");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Advance through all 31 poll ticks
+    for (let i = 0; i < 31; i++) {
+      act(() => {
+        jest.advanceTimersByTime(1500);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    await waitFor(() => {
+      expect(result.current.messages[1].error).toBe(
+        "Execution timed out. Please try again.",
+      );
+    });
+
+    expect(result.current.isWaitingForResponse).toBe(false);
+    expect(result.current.messages[1].isLoading).toBe(false);
+  });
+
+  it("shows error when a poll call throws", async () => {
+    mockPostExecution.mockResolvedValueOnce(makePostResponse());
+    mockGetExecution.mockRejectedValueOnce(new Error("Poll failed"));
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    act(() => {
+      void result.current.sendMessage("hello");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages[1].error).toBe("Poll failed");
+    });
+
+    expect(result.current.isWaitingForResponse).toBe(false);
+  });
+
+  it("shows 'Execution failed.' when execution has failed_at and no last_error", async () => {
+    mockPostExecution.mockResolvedValueOnce(makePostResponse());
+    mockGetExecution.mockResolvedValueOnce(
+      makeGetResponse({
+        failed_at: "2025-01-01T00:00:00Z",
+        status: "failed",
+        result: undefined,
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    act(() => {
+      void result.current.sendMessage("hello");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages[1].error).toBe("Execution failed.");
+    });
+  });
+
+  it("shows last_error when execution has failed_at with a specific error message", async () => {
+    mockPostExecution.mockResolvedValueOnce(makePostResponse());
+    mockGetExecution.mockResolvedValueOnce(
+      makeGetResponse({
+        failed_at: "2025-01-01T00:00:00Z",
+        last_error: "Tool invocation failed: timeout",
+        status: "failed",
+        result: undefined,
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    act(() => {
+      void result.current.sendMessage("hello");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages[1].error).toBe(
+        "Tool invocation failed: timeout",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Thread ID persistence
+  // -------------------------------------------------------------------------
+
+  it("extracts and persists thread_id for subsequent messages", async () => {
+    const terminalResponse = {
+      execution_id: null,
+      thread_id: "thread-abc",
+      status: "completed",
+      result: {
+        data: {
+          message: { content: [{ type: "text", text: "Reply" }] },
+        },
+      },
+    };
+
+    mockPostExecution
+      .mockResolvedValueOnce({ provider_data: terminalResponse })
+      .mockResolvedValueOnce({ provider_data: terminalResponse });
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    // First message
+    await act(async () => {
+      await result.current.sendMessage("first");
+    });
+
+    // Second message — must include thread_id
+    await act(async () => {
+      await result.current.sendMessage("second");
+    });
+
+    expect(mockPostExecution).toHaveBeenCalledTimes(2);
+    expect(mockPostExecution).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        provider_data: expect.objectContaining({ thread_id: "thread-abc" }),
+      }),
+    );
+  });
+
+  it("does not send thread_id on the first message", async () => {
+    mockPostExecution.mockResolvedValueOnce(
+      makePostResponse({ execution_id: null, status: "completed" }),
+    );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(mockPostExecution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider_data: expect.not.objectContaining({
+          thread_id: expect.anything(),
+        }),
+      }),
+    );
+  });
+
+  it("extracts thread_id from nested result.data.message.context.wxo_thread_id", async () => {
+    mockPostExecution
+      .mockResolvedValueOnce({
+        provider_data: {
+          execution_id: null,
+          status: "completed",
+          result: {
+            data: {
+              message: {
+                context: { wxo_thread_id: "wxo-thread-xyz" },
+                content: [{ type: "text", text: "Reply" }],
+              },
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        provider_data: {
+          execution_id: null,
+          status: "completed",
+          result: {
+            data: { message: { content: [{ type: "text", text: "Second" }] } },
+          },
+        },
+      });
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("first");
+    });
+    await act(async () => {
+      await result.current.sendMessage("second");
+    });
+
+    expect(mockPostExecution).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        provider_data: expect.objectContaining({ thread_id: "wxo-thread-xyz" }),
+      }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool traces
+  // -------------------------------------------------------------------------
+
+  it("attaches tool traces to the assistant message when present", async () => {
+    mockPostExecution.mockResolvedValueOnce(
+      makePostResponse({
+        execution_id: null,
+        status: "completed",
+        result: {
+          data: {
+            message: {
+              content: [{ type: "text", text: "Done!" }],
+              step_history: [
+                {
+                  step_details: [
+                    {
+                      type: "tool_calls",
+                      tool_calls: [
+                        { id: "c1", name: "my_tool", args: { x: 1 } },
+                      ],
+                    },
+                    {
+                      type: "tool_response",
+                      tool_call_id: "c1",
+                      content: "tool output",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(result.current.messages[1].toolTraces).toHaveLength(1);
+    expect(result.current.messages[1].toolTraces![0]).toMatchObject({
+      toolName: "my_tool",
+      input: { x: 1 },
+      output: "tool output",
+    });
+  });
+
+  it("does not attach toolTraces when step_history is empty", async () => {
+    mockPostExecution.mockResolvedValueOnce(
+      makePostResponse({
+        execution_id: null,
+        status: "completed",
+        result: {
+          data: { message: { content: [{ type: "text", text: "Reply" }] } },
+        },
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(result.current.messages[1].toolTraces).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // resetChat
+  // -------------------------------------------------------------------------
+
+  it("resetChat clears all messages and resets waiting state", async () => {
+    mockPostExecution.mockResolvedValueOnce(
+      makePostResponse({
+        execution_id: null,
+        status: "completed",
+        result: {
+          data: { message: { content: [{ type: "text", text: "Reply" }] } },
+        },
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+    expect(result.current.messages).toHaveLength(2);
+
+    act(() => {
+      result.current.resetChat();
+    });
+
+    expect(result.current.messages).toHaveLength(0);
+    expect(result.current.isWaitingForResponse).toBe(false);
+  });
+
+  it("resetChat clears thread_id so the next message has no thread_id", async () => {
+    mockPostExecution
+      .mockResolvedValueOnce({
+        provider_data: {
+          execution_id: null,
+          thread_id: "thread-to-clear",
+          status: "completed",
+          result: {
+            data: { message: { content: [{ type: "text", text: "Reply" }] } },
+          },
+        },
+      })
+      .mockResolvedValueOnce(
+        makePostResponse({ execution_id: null, status: "completed" }),
+      );
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage("first");
+    });
+
+    act(() => {
+      result.current.resetChat();
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("new conversation");
+    });
+
+    expect(mockPostExecution).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        provider_data: expect.not.objectContaining({
+          thread_id: expect.anything(),
+        }),
+      }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // User message appearance
+  // -------------------------------------------------------------------------
+
+  it("adds user and assistant (loading) messages immediately on send", async () => {
+    // Use a never-resolving promise to keep the hook in loading state
+    mockPostExecution.mockReturnValueOnce(new Promise(() => {}));
+
+    const { result } = renderHook(() =>
+      useDeploymentChat({ providerId: "p1", deploymentId: "d1" }),
+    );
+
+    act(() => {
+      void result.current.sendMessage("hello");
+    });
+
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[0]).toMatchObject({
+      role: "user",
+      content: "hello",
+    });
+    expect(result.current.messages[1]).toMatchObject({
+      role: "assistant",
+      content: "",
+      isLoading: true,
+    });
+    expect(result.current.isWaitingForResponse).toBe(true);
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/__tests__/watsonx-result-parsers.test.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/__tests__/watsonx-result-parsers.test.ts
@@ -1,0 +1,530 @@
+import {
+  extractTextFromResult,
+  extractThreadId,
+  extractToolTraces,
+} from "../watsonx-result-parsers";
+
+// ---------------------------------------------------------------------------
+// extractTextFromResult
+// ---------------------------------------------------------------------------
+
+describe("extractTextFromResult", () => {
+  it("returns empty string for null input", () => {
+    expect(extractTextFromResult(null)).toBe("");
+  });
+
+  it("returns empty string for undefined input", () => {
+    expect(extractTextFromResult(undefined)).toBe("");
+  });
+
+  it("returns empty string when result has no data", () => {
+    expect(extractTextFromResult({})).toBe("");
+  });
+
+  it("returns empty string when message has no content array", () => {
+    expect(extractTextFromResult({ data: { message: {} } })).toBe("");
+  });
+
+  it("returns empty string when content is not an array", () => {
+    expect(
+      extractTextFromResult({ data: { message: { content: "text" } } }),
+    ).toBe("");
+  });
+
+  it("extracts text from type='text' content items", () => {
+    const result = {
+      data: {
+        message: {
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      },
+    };
+    expect(extractTextFromResult(result)).toBe("Hello world");
+  });
+
+  it("extracts text from response_type='text' content items", () => {
+    const result = {
+      data: {
+        message: {
+          content: [
+            { response_type: "text", text: "Hello from response_type" },
+          ],
+        },
+      },
+    };
+    expect(extractTextFromResult(result)).toBe("Hello from response_type");
+  });
+
+  it("joins multiple text items with newlines", () => {
+    const result = {
+      data: {
+        message: {
+          content: [
+            { type: "text", text: "Line 1" },
+            { type: "text", text: "Line 2" },
+          ],
+        },
+      },
+    };
+    expect(extractTextFromResult(result)).toBe("Line 1\nLine 2");
+  });
+
+  it("ignores non-text content items", () => {
+    const result = {
+      data: {
+        message: {
+          content: [
+            { type: "image", text: "ignored" },
+            { type: "text", text: "kept" },
+          ],
+        },
+      },
+    };
+    expect(extractTextFromResult(result)).toBe("kept");
+  });
+
+  it("returns empty string when content array has no text items", () => {
+    const result = {
+      data: {
+        message: {
+          content: [{ type: "image" }, { type: "video" }],
+        },
+      },
+    };
+    expect(extractTextFromResult(result)).toBe("");
+  });
+
+  it("ignores items where text is not a string", () => {
+    const result = {
+      data: {
+        message: {
+          content: [
+            { type: "text", text: 42 },
+            { type: "text", text: "valid" },
+          ],
+        },
+      },
+    };
+    expect(extractTextFromResult(result)).toBe("valid");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractToolTraces
+// ---------------------------------------------------------------------------
+
+describe("extractToolTraces", () => {
+  it("returns empty array for null input", () => {
+    expect(extractToolTraces(null)).toEqual([]);
+  });
+
+  it("returns empty array for undefined input", () => {
+    expect(extractToolTraces(undefined)).toEqual([]);
+  });
+
+  it("returns empty array when result has no data", () => {
+    expect(extractToolTraces({})).toEqual([]);
+  });
+
+  it("returns empty array when step_history is missing", () => {
+    expect(extractToolTraces({ data: { message: {} } })).toEqual([]);
+  });
+
+  it("returns empty array when step_history is not an array", () => {
+    expect(
+      extractToolTraces({ data: { message: { step_history: "invalid" } } }),
+    ).toEqual([]);
+  });
+
+  it("returns empty array for empty step_history", () => {
+    expect(
+      extractToolTraces({ data: { message: { step_history: [] } } }),
+    ).toEqual([]);
+  });
+
+  it("extracts tool trace from new WxO format (tool_calls + tool_response)", () => {
+    const result = {
+      data: {
+        message: {
+          step_history: [
+            {
+              role: "assistant",
+              step_details: [
+                {
+                  type: "tool_calls",
+                  agent_display_name: "MainAgent",
+                  tool_calls: [
+                    {
+                      id: "call-1",
+                      name: "search_tool",
+                      args: { query: "test" },
+                    },
+                  ],
+                },
+                {
+                  type: "tool_response",
+                  tool_call_id: "call-1",
+                  content: "Search results here",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const traces = extractToolTraces(result);
+    expect(traces).toHaveLength(1);
+    expect(traces[0]).toEqual({
+      toolName: "search_tool",
+      input: { query: "test" },
+      output: "Search results here",
+      agentName: "MainAgent",
+    });
+  });
+
+  it("leaves output undefined when tool_call has no matching tool_response", () => {
+    const result = {
+      data: {
+        message: {
+          step_history: [
+            {
+              step_details: [
+                {
+                  type: "tool_calls",
+                  tool_calls: [{ id: "call-1", name: "my_tool", args: {} }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const traces = extractToolTraces(result);
+    expect(traces).toHaveLength(1);
+    expect(traces[0].output).toBeUndefined();
+  });
+
+  it("uses 'unknown' as toolName when call has no name", () => {
+    const result = {
+      data: {
+        message: {
+          step_history: [
+            {
+              step_details: [
+                {
+                  type: "tool_calls",
+                  tool_calls: [{ id: "call-1", args: {} }], // no name
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const traces = extractToolTraces(result);
+    expect(traces[0].toolName).toBe("unknown");
+  });
+
+  it("skips tool_calls entries without an id", () => {
+    const result = {
+      data: {
+        message: {
+          step_history: [
+            {
+              step_details: [
+                {
+                  type: "tool_calls",
+                  tool_calls: [{ name: "tool_without_id", args: {} }], // no id
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    expect(extractToolTraces(result)).toHaveLength(0);
+  });
+
+  it("extracts multiple tools from a single step", () => {
+    const result = {
+      data: {
+        message: {
+          step_history: [
+            {
+              step_details: [
+                {
+                  type: "tool_calls",
+                  tool_calls: [
+                    { id: "c1", name: "tool_a", args: { x: 1 } },
+                    { id: "c2", name: "tool_b", args: { y: 2 } },
+                  ],
+                },
+                {
+                  type: "tool_response",
+                  tool_call_id: "c1",
+                  content: "a result",
+                },
+                {
+                  type: "tool_response",
+                  tool_call_id: "c2",
+                  content: "b result",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const traces = extractToolTraces(result);
+    expect(traces).toHaveLength(2);
+    const traceA = traces.find((t) => t.toolName === "tool_a");
+    const traceB = traces.find((t) => t.toolName === "tool_b");
+    expect(traceA?.output).toBe("a result");
+    expect(traceB?.output).toBe("b result");
+  });
+
+  it("extracts traces from legacy format (tool_use + tool_result)", () => {
+    const result = {
+      data: {
+        message: {
+          step_history: [
+            {
+              step_details: [
+                {
+                  tool_use: { name: "legacy_tool", input: { param: "value" } },
+                  tool_result: { output: "legacy output" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const traces = extractToolTraces(result);
+    expect(traces).toHaveLength(1);
+    expect(traces[0]).toMatchObject({
+      toolName: "legacy_tool",
+      input: { param: "value" },
+      output: "legacy output",
+    });
+  });
+
+  it("handles legacy tool_use without tool_result", () => {
+    const result = {
+      data: {
+        message: {
+          step_history: [
+            {
+              step_details: [
+                {
+                  tool_use: { name: "legacy_tool", input: {} },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const traces = extractToolTraces(result);
+    expect(traces).toHaveLength(1);
+    expect(traces[0].output).toBeUndefined();
+  });
+
+  it("ignores step_details with type='tool_call' (echo of original call)", () => {
+    const result = {
+      data: {
+        message: {
+          step_history: [
+            {
+              step_details: [{ type: "tool_call", name: "echo_entry" }],
+            },
+          ],
+        },
+      },
+    };
+    expect(extractToolTraces(result)).toHaveLength(0);
+  });
+
+  it("handles steps with no step_details", () => {
+    const result = {
+      data: {
+        message: {
+          step_history: [{ role: "assistant" }], // no step_details
+        },
+      },
+    };
+    expect(extractToolTraces(result)).toEqual([]);
+  });
+
+  it("collects traces across multiple steps", () => {
+    const result = {
+      data: {
+        message: {
+          step_history: [
+            {
+              step_details: [
+                {
+                  type: "tool_calls",
+                  tool_calls: [{ id: "c1", name: "tool_a", args: {} }],
+                },
+                {
+                  type: "tool_response",
+                  tool_call_id: "c1",
+                  content: "result_a",
+                },
+              ],
+            },
+            {
+              step_details: [
+                {
+                  type: "tool_calls",
+                  tool_calls: [{ id: "c2", name: "tool_b", args: {} }],
+                },
+                {
+                  type: "tool_response",
+                  tool_call_id: "c2",
+                  content: "result_b",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const traces = extractToolTraces(result);
+    expect(traces).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractThreadId
+// ---------------------------------------------------------------------------
+
+describe("extractThreadId", () => {
+  it("returns null for null input", () => {
+    expect(extractThreadId(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(extractThreadId(undefined)).toBeNull();
+  });
+
+  it("returns null for empty object", () => {
+    expect(extractThreadId({})).toBeNull();
+  });
+
+  it("extracts thread_id directly from providerData", () => {
+    expect(extractThreadId({ thread_id: "tid-1" })).toBe("tid-1");
+  });
+
+  it("returns null when top-level thread_id is an empty string", () => {
+    expect(extractThreadId({ thread_id: "" })).toBeNull();
+  });
+
+  it("returns null when top-level thread_id is not a string", () => {
+    expect(extractThreadId({ thread_id: 12345 })).toBeNull();
+  });
+
+  it("extracts thread_id from result.data.message.thread_id", () => {
+    const providerData = {
+      result: {
+        data: {
+          message: { thread_id: "msg-thread-1" },
+        },
+      },
+    };
+    expect(extractThreadId(providerData)).toBe("msg-thread-1");
+  });
+
+  it("returns null when message.thread_id is an empty string", () => {
+    const providerData = {
+      result: { data: { message: { thread_id: "" } } },
+    };
+    expect(extractThreadId(providerData)).toBeNull();
+  });
+
+  it("extracts thread_id from result.data.message.context.wxo_thread_id", () => {
+    const providerData = {
+      result: {
+        data: {
+          message: {
+            context: { wxo_thread_id: "wxo-tid-1" },
+          },
+        },
+      },
+    };
+    expect(extractThreadId(providerData)).toBe("wxo-tid-1");
+  });
+
+  it("returns null when wxo_thread_id is an empty string", () => {
+    const providerData = {
+      result: {
+        data: {
+          message: { context: { wxo_thread_id: "" } },
+        },
+      },
+    };
+    expect(extractThreadId(providerData)).toBeNull();
+  });
+
+  it("extracts thread_id from result.data.thread_id", () => {
+    const providerData = {
+      result: {
+        data: { thread_id: "data-tid-1" },
+      },
+    };
+    expect(extractThreadId(providerData)).toBe("data-tid-1");
+  });
+
+  it("prefers top-level thread_id over nested locations", () => {
+    const providerData = {
+      thread_id: "top-level",
+      result: {
+        data: { message: { thread_id: "msg-level" } },
+      },
+    };
+    expect(extractThreadId(providerData)).toBe("top-level");
+  });
+
+  it("prefers message.thread_id over context.wxo_thread_id", () => {
+    const providerData = {
+      result: {
+        data: {
+          message: {
+            thread_id: "msg-level",
+            context: { wxo_thread_id: "wxo-level" },
+          },
+        },
+      },
+    };
+    expect(extractThreadId(providerData)).toBe("msg-level");
+  });
+
+  it("prefers context.wxo_thread_id over data.thread_id", () => {
+    const providerData = {
+      result: {
+        data: {
+          thread_id: "data-level",
+          message: {
+            context: { wxo_thread_id: "wxo-level" },
+          },
+        },
+      },
+    };
+    expect(extractThreadId(providerData)).toBe("wxo-level");
+  });
+
+  it("returns null when no thread_id found anywhere", () => {
+    expect(
+      extractThreadId({ status: "pending", execution_id: "e1" }),
+    ).toBeNull();
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/test-deployment-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/test-deployment-modal.tsx
@@ -44,7 +44,10 @@ export default function TestDeploymentModal({
           Chat interface to test the {deployment?.name ?? "deployment"}
         </DialogDescription>
 
-        <h2 className="text-center text-2xl font-semibold py-5">
+        <h2
+          className="text-center text-2xl font-semibold py-5"
+          data-testid="test-deployment-modal-title"
+        >
           Test Deployment
         </h2>
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-delete-with-confirmation.test.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-delete-with-confirmation.test.ts
@@ -1,0 +1,296 @@
+import { act, renderHook } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockShowError = jest.fn();
+
+jest.mock("../use-error-alert", () => ({
+  useErrorAlert: () => mockShowError,
+}));
+
+import { useDeleteWithConfirmation } from "../use-delete-with-confirmation";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TestItem {
+  id: string;
+  name: string;
+}
+
+type Params = { id: string };
+
+const makeEvent = () =>
+  ({
+    stopPropagation: jest.fn(),
+  }) as unknown as React.MouseEvent<HTMLButtonElement, MouseEvent>;
+
+const renderDeleteHook = (
+  mutateFn: jest.Mock = jest.fn(),
+  buildParams: (id: string) => Params = (id) => ({ id }),
+  errorMessage = "Failed to delete item",
+) =>
+  renderHook(() =>
+    useDeleteWithConfirmation<TestItem, Params>(
+      mutateFn,
+      buildParams,
+      errorMessage,
+    ),
+  );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useDeleteWithConfirmation", () => {
+  beforeEach(() => {
+    mockShowError.mockClear();
+  });
+
+  describe("initial state", () => {
+    it("initializes with null target", () => {
+      const { result } = renderDeleteHook();
+      expect(result.current.target).toBeNull();
+    });
+
+    it("initializes with null deletingId", () => {
+      const { result } = renderDeleteHook();
+      expect(result.current.deletingId).toBeNull();
+    });
+  });
+
+  describe("requestDelete", () => {
+    it("sets the target item", () => {
+      const { result } = renderDeleteHook();
+      const item: TestItem = { id: "item-1", name: "Widget" };
+
+      act(() => {
+        result.current.requestDelete(item);
+      });
+
+      expect(result.current.target).toEqual(item);
+    });
+
+    it("replaces a previous target with the new one", () => {
+      const { result } = renderDeleteHook();
+
+      act(() => {
+        result.current.requestDelete({ id: "item-1", name: "First" });
+      });
+      act(() => {
+        result.current.requestDelete({ id: "item-2", name: "Second" });
+      });
+
+      expect(result.current.target).toEqual({ id: "item-2", name: "Second" });
+    });
+  });
+
+  describe("cancelDelete", () => {
+    it("clears the target", () => {
+      const { result } = renderDeleteHook();
+
+      act(() => {
+        result.current.requestDelete({ id: "item-1", name: "Widget" });
+      });
+      act(() => {
+        result.current.cancelDelete();
+      });
+
+      expect(result.current.target).toBeNull();
+    });
+
+    it("is a no-op when target is already null", () => {
+      const { result } = renderDeleteHook();
+
+      act(() => {
+        result.current.cancelDelete();
+      });
+
+      expect(result.current.target).toBeNull();
+    });
+  });
+
+  describe("setModalOpen", () => {
+    it("clears the target when called with false", () => {
+      const { result } = renderDeleteHook();
+
+      act(() => {
+        result.current.requestDelete({ id: "item-1", name: "Widget" });
+      });
+      act(() => {
+        result.current.setModalOpen(false);
+      });
+
+      expect(result.current.target).toBeNull();
+    });
+
+    it("does not change state when called with true", () => {
+      const { result } = renderDeleteHook();
+      const item: TestItem = { id: "item-1", name: "Widget" };
+
+      act(() => {
+        result.current.requestDelete(item);
+      });
+      act(() => {
+        result.current.setModalOpen(true);
+      });
+
+      expect(result.current.target).toEqual(item);
+    });
+  });
+
+  describe("confirmDelete", () => {
+    it("does nothing when target is null", () => {
+      const mutateFn = jest.fn();
+      const { result } = renderDeleteHook(mutateFn);
+      const event = makeEvent();
+
+      act(() => {
+        result.current.confirmDelete(event);
+      });
+
+      expect(mutateFn).not.toHaveBeenCalled();
+    });
+
+    it("calls stopPropagation on the event", () => {
+      const { result } = renderDeleteHook();
+      const event = makeEvent();
+
+      act(() => {
+        result.current.requestDelete({ id: "item-1", name: "Widget" });
+      });
+      act(() => {
+        result.current.confirmDelete(event);
+      });
+
+      expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
+    it("calls mutateFn with params built from the target id", () => {
+      const mutateFn = jest.fn();
+      const buildParams = jest.fn((id: string) => ({ id, extra: "data" }));
+      const { result } = renderDeleteHook(mutateFn, buildParams);
+      const item: TestItem = { id: "item-1", name: "Widget" };
+
+      act(() => {
+        result.current.requestDelete(item);
+      });
+      act(() => {
+        result.current.confirmDelete(makeEvent());
+      });
+
+      expect(buildParams).toHaveBeenCalledWith("item-1");
+      expect(mutateFn).toHaveBeenCalledWith(
+        { id: "item-1", extra: "data" },
+        expect.objectContaining({
+          onError: expect.any(Function),
+          onSettled: expect.any(Function),
+        }),
+      );
+    });
+
+    it("sets deletingId to the confirmed item's id", () => {
+      const mutateFn = jest.fn();
+      const { result } = renderDeleteHook(mutateFn);
+
+      act(() => {
+        result.current.requestDelete({ id: "item-1", name: "Widget" });
+      });
+      act(() => {
+        result.current.confirmDelete(makeEvent());
+      });
+
+      expect(result.current.deletingId).toBe("item-1");
+    });
+
+    it("clears target after confirming", () => {
+      const { result } = renderDeleteHook();
+
+      act(() => {
+        result.current.requestDelete({ id: "item-1", name: "Widget" });
+      });
+      act(() => {
+        result.current.confirmDelete(makeEvent());
+      });
+
+      expect(result.current.target).toBeNull();
+    });
+  });
+
+  describe("mutation callbacks", () => {
+    it("onSettled clears deletingId", () => {
+      const mutateFn = jest.fn();
+      const { result } = renderDeleteHook(mutateFn);
+
+      act(() => {
+        result.current.requestDelete({ id: "item-1", name: "Widget" });
+      });
+      act(() => {
+        result.current.confirmDelete(makeEvent());
+      });
+      expect(result.current.deletingId).toBe("item-1");
+
+      act(() => {
+        const { onSettled } = mutateFn.mock.calls[0][1] as {
+          onSettled: () => void;
+        };
+        onSettled();
+      });
+
+      expect(result.current.deletingId).toBeNull();
+    });
+
+    it("onError calls showError with the configured error message", () => {
+      const mutateFn = jest.fn();
+      const { result } = renderDeleteHook(
+        mutateFn,
+        (id) => ({ id }),
+        "Cannot delete widget",
+      );
+
+      act(() => {
+        result.current.requestDelete({ id: "item-1", name: "Widget" });
+      });
+      act(() => {
+        result.current.confirmDelete(makeEvent());
+      });
+
+      const error = new Error("server error");
+      act(() => {
+        const { onError } = mutateFn.mock.calls[0][1] as {
+          onError: (err: unknown) => void;
+        };
+        onError(error);
+      });
+
+      expect(mockShowError).toHaveBeenCalledWith("Cannot delete widget", error);
+    });
+
+    it("onError can handle non-Error values", () => {
+      const mutateFn = jest.fn();
+      const { result } = renderDeleteHook(mutateFn);
+
+      act(() => {
+        result.current.requestDelete({ id: "item-1", name: "Widget" });
+      });
+      act(() => {
+        result.current.confirmDelete(makeEvent());
+      });
+
+      act(() => {
+        const { onError } = mutateFn.mock.calls[0][1] as {
+          onError: (err: unknown) => void;
+        };
+        onError("a plain string error");
+      });
+
+      expect(mockShowError).toHaveBeenCalledWith(
+        "Failed to delete item",
+        "a plain string error",
+      );
+    });
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-error-alert.test.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-error-alert.test.ts
@@ -1,0 +1,117 @@
+import { act, renderHook } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSetErrorData = jest.fn();
+
+jest.mock("@/stores/alertStore", () => ({
+  __esModule: true,
+  default: (selector: (s: { setErrorData: jest.Mock }) => unknown) =>
+    selector({ setErrorData: mockSetErrorData }),
+}));
+
+jest.mock("@/controllers/API/helpers/get-axios-error-message", () => ({
+  getAxiosErrorMessage: (
+    err: unknown,
+    fallback = "An unknown error occurred",
+  ) => {
+    if (err instanceof Error) return err.message;
+    return fallback;
+  },
+}));
+
+import { useErrorAlert } from "../use-error-alert";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useErrorAlert", () => {
+  beforeEach(() => {
+    mockSetErrorData.mockClear();
+  });
+
+  it("calls setErrorData with the provided title and extracted error message", () => {
+    const { result } = renderHook(() => useErrorAlert());
+
+    act(() => {
+      result.current("Delete failed", new Error("network failure"));
+    });
+
+    expect(mockSetErrorData).toHaveBeenCalledWith({
+      title: "Delete failed",
+      list: ["network failure"],
+    });
+  });
+
+  it("uses fallback message for non-Error values", () => {
+    const { result } = renderHook(() => useErrorAlert());
+
+    act(() => {
+      result.current("Oops", "just a string");
+    });
+
+    expect(mockSetErrorData).toHaveBeenCalledWith({
+      title: "Oops",
+      list: ["An unknown error occurred"],
+    });
+  });
+
+  it("uses fallback message for null errors", () => {
+    const { result } = renderHook(() => useErrorAlert());
+
+    act(() => {
+      result.current("Error", null);
+    });
+
+    expect(mockSetErrorData).toHaveBeenCalledWith({
+      title: "Error",
+      list: ["An unknown error occurred"],
+    });
+  });
+
+  it("uses fallback message for undefined errors", () => {
+    const { result } = renderHook(() => useErrorAlert());
+
+    act(() => {
+      result.current("Error", undefined);
+    });
+
+    expect(mockSetErrorData).toHaveBeenCalledWith({
+      title: "Error",
+      list: ["An unknown error occurred"],
+    });
+  });
+
+  it("returns a stable callback reference across re-renders", () => {
+    const { result, rerender } = renderHook(() => useErrorAlert());
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it("supports different titles and errors in successive calls", () => {
+    const { result } = renderHook(() => useErrorAlert());
+
+    act(() => {
+      result.current("First error", new Error("error one"));
+    });
+    act(() => {
+      result.current("Second error", new Error("error two"));
+    });
+
+    expect(mockSetErrorData).toHaveBeenCalledTimes(2);
+    expect(mockSetErrorData).toHaveBeenNthCalledWith(1, {
+      title: "First error",
+      list: ["error one"],
+    });
+    expect(mockSetErrorData).toHaveBeenNthCalledWith(2, {
+      title: "Second error",
+      list: ["error two"],
+    });
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-navigate-to-test.test.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-navigate-to-test.test.ts
@@ -1,0 +1,91 @@
+import { renderHook } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockNavigate = jest.fn();
+
+jest.mock("@/customization/hooks/use-custom-navigate", () => ({
+  useCustomNavigate: () => mockNavigate,
+}));
+
+import { useNavigateToTest } from "../use-navigate-to-test";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useNavigateToTest", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it("navigates to /all with flowType, testDeployment, and testProviderId in state", () => {
+    const { result } = renderHook(() => useNavigateToTest());
+
+    result.current({ id: "d1", name: "My Deployment" }, "provider-1");
+
+    expect(mockNavigate).toHaveBeenCalledWith("/all", {
+      state: {
+        flowType: "deployments",
+        testDeployment: { id: "d1", name: "My Deployment" },
+        testProviderId: "provider-1",
+      },
+    });
+  });
+
+  it("passes the correct deployment id and name to state", () => {
+    const { result } = renderHook(() => useNavigateToTest());
+
+    result.current({ id: "abc-123", name: "Production Bot" }, "wxo-prod");
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "/all",
+      expect.objectContaining({
+        state: expect.objectContaining({
+          testDeployment: { id: "abc-123", name: "Production Bot" },
+        }),
+      }),
+    );
+  });
+
+  it("passes the correct provider id to state", () => {
+    const { result } = renderHook(() => useNavigateToTest());
+
+    result.current({ id: "d1", name: "Bot" }, "my-provider-id");
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "/all",
+      expect.objectContaining({
+        state: expect.objectContaining({ testProviderId: "my-provider-id" }),
+      }),
+    );
+  });
+
+  it("always navigates to /all regardless of deployment details", () => {
+    const { result } = renderHook(() => useNavigateToTest());
+
+    result.current({ id: "d2", name: "Another Bot" }, "p2");
+
+    expect(mockNavigate).toHaveBeenCalledWith("/all", expect.anything());
+  });
+
+  it("always sets flowType to 'deployments'", () => {
+    const { result } = renderHook(() => useNavigateToTest());
+
+    result.current({ id: "d1", name: "Bot" }, "p1");
+
+    const [[, options]] = mockNavigate.mock.calls;
+    expect(options.state.flowType).toBe("deployments");
+  });
+
+  it("returns a stable callback reference across re-renders", () => {
+    const { result, rerender } = renderHook(() => useNavigateToTest());
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-provider-filter.test.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-provider-filter.test.ts
@@ -1,0 +1,187 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ProviderAccount } from "../../types";
+import { ALL_PROVIDERS, useProviderFilter } from "../use-provider-filter";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeProvider = (
+  overrides: Partial<ProviderAccount> = {},
+): ProviderAccount => ({
+  id: "p1",
+  name: "Prod Environment",
+  provider_tenant_id: "tenant-1",
+  provider_key: "watsonx-orchestrate",
+  provider_url: "https://api.example.com",
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useProviderFilter", () => {
+  describe("initial state", () => {
+    it("initializes with ALL_PROVIDERS selected", () => {
+      const { result } = renderHook(() => useProviderFilter([]));
+      expect(result.current.selectedProviderId).toBe(ALL_PROVIDERS);
+    });
+
+    it("returns all provider IDs in providerIdsToQuery when all selected", () => {
+      const providers = [
+        makeProvider({ id: "p1" }),
+        makeProvider({ id: "p2" }),
+      ];
+      const { result } = renderHook(() => useProviderFilter(providers));
+      expect(result.current.providerIdsToQuery).toEqual(["p1", "p2"]);
+    });
+
+    it("returns empty providerIdsToQuery for empty provider list", () => {
+      const { result } = renderHook(() => useProviderFilter([]));
+      expect(result.current.providerIdsToQuery).toEqual([]);
+    });
+
+    it("builds providerMap from provider list", () => {
+      const providers = [
+        makeProvider({ id: "p1", name: "Prod" }),
+        makeProvider({ id: "p2", name: "Staging" }),
+      ];
+      const { result } = renderHook(() => useProviderFilter(providers));
+      expect(result.current.providerMap).toEqual({ p1: "Prod", p2: "Staging" });
+    });
+
+    it("returns empty providerMap for empty provider list", () => {
+      const { result } = renderHook(() => useProviderFilter([]));
+      expect(result.current.providerMap).toEqual({});
+    });
+  });
+
+  describe("provider selection", () => {
+    it("returns only the selected provider ID in providerIdsToQuery", () => {
+      const providers = [
+        makeProvider({ id: "p1" }),
+        makeProvider({ id: "p2" }),
+      ];
+      const { result } = renderHook(() => useProviderFilter(providers));
+
+      act(() => {
+        result.current.setSelectedProviderId("p1");
+      });
+
+      expect(result.current.providerIdsToQuery).toEqual(["p1"]);
+      expect(result.current.selectedProviderId).toBe("p1");
+    });
+
+    it("returns all IDs after resetting back to ALL_PROVIDERS", () => {
+      const providers = [
+        makeProvider({ id: "p1" }),
+        makeProvider({ id: "p2" }),
+      ];
+      const { result } = renderHook(() => useProviderFilter(providers));
+
+      act(() => {
+        result.current.setSelectedProviderId("p1");
+      });
+      act(() => {
+        result.current.setSelectedProviderId(ALL_PROVIDERS);
+      });
+
+      expect(result.current.providerIdsToQuery).toEqual(["p1", "p2"]);
+    });
+  });
+
+  describe("reset on provider deletion", () => {
+    it("resets to ALL_PROVIDERS when the selected provider is removed from the list", () => {
+      const providers = [
+        makeProvider({ id: "p1" }),
+        makeProvider({ id: "p2" }),
+      ];
+      const { result, rerender } = renderHook(
+        ({ list }: { list: ProviderAccount[] }) => useProviderFilter(list),
+        { initialProps: { list: providers } },
+      );
+
+      act(() => {
+        result.current.setSelectedProviderId("p2");
+      });
+      expect(result.current.selectedProviderId).toBe("p2");
+
+      rerender({ list: [makeProvider({ id: "p1" })] });
+
+      expect(result.current.selectedProviderId).toBe(ALL_PROVIDERS);
+    });
+
+    it("does not reset when the selected provider still exists", () => {
+      const providers = [
+        makeProvider({ id: "p1" }),
+        makeProvider({ id: "p2" }),
+      ];
+      const { result, rerender } = renderHook(
+        ({ list }: { list: ProviderAccount[] }) => useProviderFilter(list),
+        { initialProps: { list: providers } },
+      );
+
+      act(() => {
+        result.current.setSelectedProviderId("p1");
+      });
+
+      // Remove p2 (not the selected one)
+      rerender({ list: [makeProvider({ id: "p1" })] });
+
+      expect(result.current.selectedProviderId).toBe("p1");
+    });
+
+    it("does not reset when ALL_PROVIDERS is selected and a provider is removed", () => {
+      const providers = [
+        makeProvider({ id: "p1" }),
+        makeProvider({ id: "p2" }),
+      ];
+      const { result, rerender } = renderHook(
+        ({ list }: { list: ProviderAccount[] }) => useProviderFilter(list),
+        { initialProps: { list: providers } },
+      );
+
+      expect(result.current.selectedProviderId).toBe(ALL_PROVIDERS);
+
+      rerender({ list: [makeProvider({ id: "p1" })] });
+
+      expect(result.current.selectedProviderId).toBe(ALL_PROVIDERS);
+    });
+
+    it("does not reset when the provider list is empty and ALL_PROVIDERS is selected", () => {
+      const { result, rerender } = renderHook(
+        ({ list }: { list: ProviderAccount[] }) => useProviderFilter(list),
+        { initialProps: { list: [makeProvider({ id: "p1" })] } },
+      );
+
+      // Don't select a specific provider — stay at ALL_PROVIDERS
+      rerender({ list: [] });
+
+      expect(result.current.selectedProviderId).toBe(ALL_PROVIDERS);
+    });
+  });
+
+  describe("providerMap updates", () => {
+    it("updates providerMap when providers list changes", () => {
+      const initial = [makeProvider({ id: "p1", name: "Prod" })];
+      const { result, rerender } = renderHook(
+        ({ list }: { list: ProviderAccount[] }) => useProviderFilter(list),
+        { initialProps: { list: initial } },
+      );
+
+      expect(result.current.providerMap).toEqual({ p1: "Prod" });
+
+      rerender({
+        list: [
+          makeProvider({ id: "p1", name: "Prod" }),
+          makeProvider({ id: "p2", name: "Staging" }),
+        ],
+      });
+
+      expect(result.current.providerMap).toEqual({ p1: "Prod", p2: "Staging" });
+    });
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-test-deployment-modal.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-test-deployment-modal.test.tsx
@@ -1,0 +1,264 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import type { Deployment } from "../../types";
+import { useTestDeploymentModal } from "../use-test-deployment-modal";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeDeployment = (overrides: Partial<Deployment> = {}): Deployment =>
+  ({
+    id: "dep-1",
+    name: "My Deployment",
+    provider_account_id: "prov-1",
+    ...overrides,
+  }) as Deployment;
+
+const withRouter =
+  (
+    initialEntries: Array<string | { pathname: string; state?: unknown }> = [
+      "/",
+    ],
+  ) =>
+  ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+  );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useTestDeploymentModal", () => {
+  describe("initial state", () => {
+    it("starts with no test target and modal closed", () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter(),
+      });
+
+      expect(result.current.testTarget).toBeNull();
+      expect(result.current.open).toBe(false);
+      expect(result.current.testProviderId).toBe("");
+    });
+  });
+
+  describe("handleTestDeployment", () => {
+    it("sets testTarget from the deployment", () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter(),
+      });
+      const deployment = makeDeployment({
+        id: "d1",
+        name: "Bot",
+        provider_account_id: "p1",
+      });
+
+      act(() => {
+        result.current.handleTestDeployment(deployment);
+      });
+
+      expect(result.current.testTarget).toMatchObject({
+        id: "d1",
+        name: "Bot",
+      });
+    });
+
+    it("sets testProviderId from deployment.provider_account_id", () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter(),
+      });
+
+      act(() => {
+        result.current.handleTestDeployment(
+          makeDeployment({ provider_account_id: "prov-99" }),
+        );
+      });
+
+      expect(result.current.testProviderId).toBe("prov-99");
+    });
+
+    it("uses empty string for testProviderId when provider_account_id is null", () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter(),
+      });
+
+      act(() => {
+        result.current.handleTestDeployment(
+          makeDeployment({ provider_account_id: null as unknown as string }),
+        );
+      });
+
+      expect(result.current.testProviderId).toBe("");
+    });
+
+    it("opens the modal", () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter(),
+      });
+
+      act(() => {
+        result.current.handleTestDeployment(makeDeployment());
+      });
+
+      expect(result.current.open).toBe(true);
+    });
+  });
+
+  describe("handleTestFromStepper", () => {
+    it("sets testTarget and testProviderId from explicit args", () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter(),
+      });
+
+      act(() => {
+        result.current.handleTestFromStepper(
+          { id: "d2", name: "Stepper Bot" },
+          "stepper-provider",
+        );
+      });
+
+      expect(result.current.testTarget).toEqual({
+        id: "d2",
+        name: "Stepper Bot",
+      });
+      expect(result.current.testProviderId).toBe("stepper-provider");
+      expect(result.current.open).toBe(true);
+    });
+  });
+
+  describe("close", () => {
+    it("clears testTarget and testProviderId", () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter(),
+      });
+
+      act(() => {
+        result.current.handleTestDeployment(makeDeployment());
+      });
+      act(() => {
+        result.current.close();
+      });
+
+      expect(result.current.testTarget).toBeNull();
+      expect(result.current.testProviderId).toBe("");
+      expect(result.current.open).toBe(false);
+    });
+  });
+
+  describe("setOpen", () => {
+    it("clears testTarget and testProviderId when called with false", () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter(),
+      });
+
+      act(() => {
+        result.current.handleTestDeployment(makeDeployment());
+      });
+      act(() => {
+        result.current.setOpen(false);
+      });
+
+      expect(result.current.testTarget).toBeNull();
+      expect(result.current.testProviderId).toBe("");
+    });
+
+    it("does not change state when called with true", () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter(),
+      });
+
+      act(() => {
+        result.current.setOpen(true);
+      });
+
+      expect(result.current.testTarget).toBeNull();
+    });
+  });
+
+  describe("auto-open from navigation state", () => {
+    it("opens modal and sets target when navigated from canvas deploy button", async () => {
+      const initialState = {
+        testDeployment: { id: "nav-dep", name: "Nav Bot" },
+        testProviderId: "nav-provider",
+      };
+
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter([{ pathname: "/all", state: initialState }]),
+      });
+
+      await waitFor(() => {
+        expect(result.current.testTarget).toEqual({
+          id: "nav-dep",
+          name: "Nav Bot",
+        });
+      });
+
+      expect(result.current.testProviderId).toBe("nav-provider");
+      expect(result.current.open).toBe(true);
+    });
+
+    it("does not auto-open when navigation state has testDeployment but no testProviderId", async () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter([
+          {
+            pathname: "/all",
+            state: { testDeployment: { id: "d1", name: "Bot" } },
+          },
+        ]),
+      });
+
+      // Give the effect time to run
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.testTarget).toBeNull();
+      expect(result.current.open).toBe(false);
+    });
+
+    it("does not auto-open when navigation state has testProviderId but no testDeployment", async () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter([
+          { pathname: "/all", state: { testProviderId: "p1" } },
+        ]),
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.testTarget).toBeNull();
+      expect(result.current.open).toBe(false);
+    });
+
+    it("does not auto-open when navigation state is empty", () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter([{ pathname: "/all", state: {} }]),
+      });
+
+      expect(result.current.testTarget).toBeNull();
+      expect(result.current.open).toBe(false);
+    });
+  });
+
+  describe("open computed property", () => {
+    it("is true only when testTarget is set", () => {
+      const { result } = renderHook(() => useTestDeploymentModal(), {
+        wrapper: withRouter(),
+      });
+
+      expect(result.current.open).toBe(false);
+
+      act(() => {
+        result.current.handleTestDeployment(makeDeployment());
+      });
+      expect(result.current.open).toBe(true);
+
+      act(() => {
+        result.current.close();
+      });
+      expect(result.current.open).toBe(false);
+    });
+  });
+});

--- a/src/frontend/tests/core/features/deployment-create.spec.ts
+++ b/src/frontend/tests/core/features/deployment-create.spec.ts
@@ -1,0 +1,392 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../fixtures";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import {
+  CONFIGS_MOCK,
+  DEPLOY_RESPONSE,
+  FLOW_VERSIONS_MOCK,
+  FLOWS_MOCK,
+  LLMS_MOCK,
+  PROVIDERS_MOCK,
+} from "../../utils/deployment-mocks";
+
+// ---------------------------------------------------------------------------
+// Helper: set up all required API route mocks
+// ---------------------------------------------------------------------------
+async function setupDeploymentMocks(page: Page, folderId: string) {
+  // Broad catch-all registered FIRST so specific routes (registered after) take priority via LIFO
+  await page.route("**/api/v1/deployments*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ deployments: [] }),
+    });
+  });
+
+  // Provider accounts
+  await page.route("**/api/v1/deployments/providers**", (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PROVIDERS_MOCK),
+      });
+    } else {
+      route.continue();
+    }
+  });
+
+  // LLMs
+  await page.route("**/api/v1/deployments/llms**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(LLMS_MOCK),
+    });
+  });
+
+  // Deployment configs (connections)
+  await page.route("**/api/v1/deployments/configs**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(CONFIGS_MOCK),
+    });
+  });
+
+  // Flows list — inject the captured folderId so the component's folder filter passes
+  await page.route("**/api/v1/flows/**", (route) => {
+    const url = route.request().url();
+    if (url.includes("/versions/")) {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(FLOW_VERSIONS_MOCK),
+      });
+      return;
+    }
+    const flows = FLOWS_MOCK.map((f) => ({ ...f, folder_id: folderId }));
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(flows),
+    });
+  });
+
+  // Global variables (used in attach-flows step)
+  await page.route("**/api/v1/variables**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([]),
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: navigate to the deployments page and open the stepper
+// ---------------------------------------------------------------------------
+async function openDeploymentStepper(page: Page) {
+  // Listen for the folders/projects API response BEFORE bootstrap to capture
+  // the real myCollectionId. The step-attach-flows component filters flows by
+  // folder_id === myCollectionId, so mock flows must carry the same id.
+  const projectsResponsePromise = page.waitForResponse(
+    (resp) => resp.url().includes("/api/v1/projects") && resp.status() === 200,
+    { timeout: 30000 },
+  );
+
+  await awaitBootstrapTest(page, { skipModal: true });
+
+  let myCollectionId = "";
+  try {
+    const projectsResp = await projectsResponsePromise;
+    const folders = await projectsResp.json();
+    const match = Array.isArray(folders)
+      ? (folders.find(
+          (f: { name: string; id: string }) => f.name === "Starter Project",
+        ) ?? folders[0])
+      : null;
+    myCollectionId = (match as { id: string } | null)?.id ?? "";
+  } catch {
+    // proceed with empty id — test will likely fail at flow-item assertion
+  }
+
+  await setupDeploymentMocks(page, myCollectionId);
+  await page.getByTestId("deployments-btn").click();
+  await page.waitForSelector('[data-testid="new-deployment-btn"]');
+  await page.getByTestId("new-deployment-btn").click();
+  // Wait for the stepper dialog to appear
+  await page.waitForSelector('[data-testid="deployment-stepper-next"]');
+}
+
+// ---------------------------------------------------------------------------
+// Helper: select the provider in step 1
+// ---------------------------------------------------------------------------
+async function selectProvider(page: Page) {
+  await page.getByTestId("provider-item-prov-1").click();
+}
+
+// ---------------------------------------------------------------------------
+// Helper: navigate steps 1 → 2 (provider → type)
+// ---------------------------------------------------------------------------
+async function goToStepType(page: Page) {
+  await selectProvider(page);
+  await page.getByTestId("deployment-stepper-next").click();
+  // Wait for the Type step heading
+  await page.waitForSelector("text=Deployment Type");
+}
+
+// ---------------------------------------------------------------------------
+// Helper: navigate steps 1 → 2 → 3 (provider → type → attach flows)
+// ---------------------------------------------------------------------------
+async function goToStepAttachFlows(page: Page) {
+  await goToStepType(page);
+  // Fill required fields: name and type
+  await page.getByPlaceholder("e.g., Sales Bot").fill("My Deployment");
+  await page.getByTestId("deployment-type-agent").click();
+  // Select the LLM model
+  await page.getByRole("combobox").click();
+  await page.getByRole("option", { name: "ibm/granite-13b-chat" }).click();
+  // Advance to attach flows
+  await page.getByTestId("deployment-stepper-next").click();
+  await page.waitForSelector("text=Attach Flows");
+}
+
+// ---------------------------------------------------------------------------
+// Helper: navigate all steps through attach flows and select a flow+version
+// ---------------------------------------------------------------------------
+async function goToStepReview(page: Page) {
+  await goToStepAttachFlows(page);
+  // Click flow item
+  await page.waitForSelector('[data-testid="flow-item-f1"]');
+  await page.getByTestId("flow-item-f1").click();
+  // Click version item
+  await page.waitForSelector('[data-testid="version-item-fv1"]');
+  await page.getByTestId("version-item-fv1").click();
+  // After clicking version, a connection panel may appear - skip it if present
+  const skipBtn = page.getByRole("button", { name: /skip/i });
+  const skipVisible = await skipBtn.isVisible().catch(() => false);
+  if (skipVisible) {
+    await skipBtn.click();
+  }
+  // Advance to review
+  await page.getByTestId("deployment-stepper-next").click();
+  await page.waitForSelector("text=Review & Confirm");
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Opens stepper on New Deployment click
+// ---------------------------------------------------------------------------
+test(
+  "deployment-create: opens stepper on New Deployment click",
+  { tag: ["@deployment", "@workspace"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await awaitBootstrapTest(page, { skipModal: true });
+    await setupDeploymentMocks(page);
+    await page.getByTestId("deployments-btn").click();
+    await page.waitForSelector('[data-testid="new-deployment-btn"]');
+    await page.getByTestId("new-deployment-btn").click();
+
+    await expect(page.getByTestId("stepper-modal-title")).toBeVisible();
+    await expect(page.getByTestId("deployment-stepper-next")).toBeVisible();
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 2: Step 1 (Provider) — Next disabled without selection, enabled after
+// ---------------------------------------------------------------------------
+test(
+  "deployment-create: step 1 provider - Next disabled without selection, enabled after selecting",
+  { tag: ["@deployment", "@workspace"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await openDeploymentStepper(page);
+
+    // Next should be disabled before selection
+    await expect(page.getByTestId("deployment-stepper-next")).toBeDisabled();
+
+    // Select the existing provider
+    await selectProvider(page);
+
+    // Next should now be enabled
+    await expect(page.getByTestId("deployment-stepper-next")).toBeEnabled();
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 3: Step 2 (Type) — fill name, select type, Next becomes enabled
+// ---------------------------------------------------------------------------
+test(
+  "deployment-create: step 2 type - fill name and select type to enable Next",
+  { tag: ["@deployment", "@workspace"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await openDeploymentStepper(page);
+    await selectProvider(page);
+    await page.getByTestId("deployment-stepper-next").click();
+
+    // Type step should be visible
+    await expect(
+      page.getByRole("heading", { name: /Deployment Type/i }),
+    ).toBeVisible();
+
+    // Next should be disabled before filling required fields
+    await expect(page.getByTestId("deployment-stepper-next")).toBeDisabled();
+
+    // Fill in the deployment name
+    await page.getByPlaceholder("e.g., Sales Bot").fill("My Deployment");
+
+    // Select the agent type
+    await page.getByTestId("deployment-type-agent").click();
+
+    // Select the LLM model
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: "ibm/granite-13b-chat" }).click();
+
+    // Next should now be enabled
+    await expect(page.getByTestId("deployment-stepper-next")).toBeEnabled();
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 4: Step 3 (Attach Flows) — select a flow and version, Next enables
+// ---------------------------------------------------------------------------
+test(
+  "deployment-create: step 3 attach flows - select flow and version enables Next",
+  { tag: ["@deployment", "@workspace"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await openDeploymentStepper(page);
+    await goToStepType(page);
+
+    // Fill required type step fields
+    await page.getByPlaceholder("e.g., Sales Bot").fill("My Deployment");
+    await page.getByTestId("deployment-type-agent").click();
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: "ibm/granite-13b-chat" }).click();
+    await page.getByTestId("deployment-stepper-next").click();
+
+    // Attach flows step should be visible
+    await page.waitForSelector('[data-testid="flow-item-f1"]', {
+      timeout: 20000,
+    });
+
+    // Click the flow item
+    await page.waitForSelector('[data-testid="flow-item-f1"]');
+    await page.getByTestId("flow-item-f1").click();
+
+    // Version panel should appear, click the version
+    await page.waitForSelector('[data-testid="version-item-fv1"]');
+    await page.getByTestId("version-item-fv1").click();
+
+    // Skip connection if prompted
+    const skipBtn = page.getByRole("button", { name: /skip/i });
+    const skipVisible = await skipBtn.isVisible().catch(() => false);
+    if (skipVisible) {
+      await skipBtn.click();
+    }
+
+    // Next should be enabled after version selection
+    await expect(page.getByTestId("deployment-stepper-next")).toBeEnabled();
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 5: Step 4 (Review) — shows review content and Deploy button
+// ---------------------------------------------------------------------------
+test(
+  "deployment-create: step 4 review - shows review content and Deploy button text",
+  { tag: ["@deployment", "@workspace"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await openDeploymentStepper(page);
+    await goToStepReview(page);
+
+    // Review heading and content should be visible
+    await expect(
+      page.getByRole("heading", { name: /Review & Confirm/i }),
+    ).toBeVisible();
+
+    // The deployment name should appear in the review
+    await expect(page.getByText("My Deployment")).toBeVisible();
+
+    // The Next/Deploy button text should be "Deploy"
+    await expect(page.getByTestId("deployment-stepper-next")).toContainText(
+      "Deploy",
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 6: Deploy triggers POST, shows deploy status
+// ---------------------------------------------------------------------------
+test(
+  "deployment-create: clicking Deploy triggers POST and shows deploy status",
+  { tag: ["@deployment", "@workspace"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await openDeploymentStepper(page);
+
+    // Set up POST deployments mock (after bootstrap, before deploy click)
+    await page.route("**/api/v1/deployments", (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify(DEPLOY_RESPONSE),
+        });
+      } else {
+        route.continue();
+      }
+    });
+    await goToStepReview(page);
+
+    // Watch for the POST request
+    const postRequestPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/v1/deployments") &&
+        req.method() === "POST" &&
+        !req.url().includes("/providers") &&
+        !req.url().includes("/llms") &&
+        !req.url().includes("/configs"),
+    );
+
+    // Click Deploy
+    await page.getByTestId("deployment-stepper-next").click();
+
+    // Assert the POST request was made
+    await postRequestPromise;
+
+    // Assert deploy status content is shown (either deploying or deployed state)
+    await expect(
+      page.getByRole("heading", {
+        name: /Deploying\.\.\.|Deployment successful/i,
+      }),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);

--- a/src/frontend/tests/core/features/deployment-edit.spec.ts
+++ b/src/frontend/tests/core/features/deployment-edit.spec.ts
@@ -1,0 +1,245 @@
+import { expect, test } from "../../fixtures";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import {
+  ATTACHMENTS_MOCK,
+  DEPLOYMENT_DETAIL_MOCK,
+  DEPLOYMENTS_MOCK,
+  LLMS_MOCK,
+  PROVIDERS_MOCK,
+} from "../../utils/deployment-mocks";
+
+async function setupRoutes(page: Parameters<typeof test>[2]["page"]) {
+  // Register broad catch-all FIRST so specific routes (registered after) take priority via LIFO
+  await page.route("**/api/v1/deployments*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(DEPLOYMENTS_MOCK),
+    });
+  });
+
+  await page.route("**/api/v1/deployments/configs*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ configs: [], page: 1, size: 10000, total: 0 }),
+    });
+  });
+
+  await page.route("**/api/v1/deployments/llms*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(LLMS_MOCK),
+    });
+  });
+
+  await page.route("**/api/v1/deployments/providers*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(PROVIDERS_MOCK),
+    });
+  });
+
+  await page.route("**/api/v1/deployments/dep-1", (route) => {
+    if (route.request().method() === "PATCH") {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(DEPLOYMENT_DETAIL_MOCK),
+      });
+    }
+  });
+
+  await page.route("**/api/v1/deployments/dep-1/flows*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ATTACHMENTS_MOCK),
+    });
+  });
+}
+
+async function navigateToDeployments(page: Parameters<typeof test>[2]["page"]) {
+  await awaitBootstrapTest(page, { skipModal: true });
+  await page.getByTestId("deployments-btn").click();
+  await page.waitForSelector('[data-testid="new-deployment-btn"]');
+}
+
+async function openEditDialog(page: Parameters<typeof test>[2]["page"]) {
+  await page.getByTestId("actions-deployment-dep-1").click();
+  await page.getByRole("menuitem", { name: "Update" }).click();
+  await page.waitForSelector('[data-testid="stepper-modal-title"]');
+}
+
+test(
+  "Opens edit stepper from actions menu",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await setupRoutes(page);
+    await navigateToDeployments(page);
+
+    await page
+      .getByTestId("deployment-row-dep-1")
+      .waitFor({ state: "visible" });
+    await page.getByTestId("actions-deployment-dep-1").click();
+    await page.getByRole("menuitem", { name: "Update" }).click();
+
+    await page.waitForSelector('[data-testid="stepper-modal-title"]');
+
+    await expect(page.getByTestId("stepper-modal-title")).toBeVisible();
+    await expect(page.getByTestId("deployment-stepper-next")).toBeVisible();
+  },
+);
+
+test(
+  "Edit mode skips provider step — starts at Type",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await setupRoutes(page);
+    await navigateToDeployments(page);
+
+    await page
+      .getByTestId("deployment-row-dep-1")
+      .waitFor({ state: "visible" });
+    await openEditDialog(page);
+
+    // Wait for stepper body to render (parallel fetches must complete)
+    await page.waitForSelector('h2:has-text("Deployment Type")');
+
+    await expect(page.getByText("Deployment Type")).toBeVisible();
+
+    // Provider step heading should NOT be visible
+    await expect(page.getByText("Choose Provider")).not.toBeVisible();
+
+    // Navigation buttons should be present
+    await expect(page.getByTestId("deployment-stepper-next")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Back" })).toBeVisible();
+  },
+);
+
+test(
+  "Name field pre-populated in edit mode",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await setupRoutes(page);
+    await navigateToDeployments(page);
+
+    await page
+      .getByTestId("deployment-row-dep-1")
+      .waitFor({ state: "visible" });
+    await openEditDialog(page);
+
+    // Wait for stepper body to render
+    await page.waitForSelector('h2:has-text("Deployment Type")');
+
+    const nameInput = page.getByPlaceholder("e.g., Sales Bot");
+    await expect(nameInput).toHaveValue("Test Deployment");
+  },
+);
+
+test(
+  "Submitting PATCH closes modal",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await setupRoutes(page);
+    await navigateToDeployments(page);
+
+    await page
+      .getByTestId("deployment-row-dep-1")
+      .waitFor({ state: "visible" });
+    await openEditDialog(page);
+
+    // Wait for stepper body to render (parallel fetches must complete)
+    await page.waitForSelector('h2:has-text("Deployment Type")');
+
+    // Navigate through the stepper steps to reach Review
+    // Step: Type → click Next
+    await page.getByTestId("deployment-stepper-next").click();
+
+    // Step: Attach Flows → click Next
+    await page.getByTestId("deployment-stepper-next").click();
+
+    // Step: Review → click Update (final step)
+    const patchRequestPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/v1/deployments/dep-1") &&
+        req.method() === "PATCH",
+    );
+
+    await page.getByTestId("deployment-stepper-next").click();
+
+    await patchRequestPromise;
+
+    // Modal should close after PATCH
+    await expect(page.getByTestId("stepper-modal-title")).not.toBeVisible();
+  },
+);
+
+test(
+  "Cancel during edit closes modal without calling PATCH",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await setupRoutes(page);
+    await navigateToDeployments(page);
+
+    await page
+      .getByTestId("deployment-row-dep-1")
+      .waitFor({ state: "visible" });
+    await openEditDialog(page);
+
+    // Wait for stepper body to render
+    await page.waitForSelector('h2:has-text("Deployment Type")');
+
+    let patchCalled = false;
+    page.on("request", (req) => {
+      if (
+        req.url().includes("/api/v1/deployments/dep-1") &&
+        req.method() === "PATCH"
+      ) {
+        patchCalled = true;
+      }
+    });
+
+    // Click Cancel
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    // Modal should be closed
+    await expect(page.getByTestId("stepper-modal-title")).not.toBeVisible();
+
+    // PATCH must not have been called
+    expect(patchCalled).toBe(false);
+  },
+);

--- a/src/frontend/tests/core/features/deployment-providers.spec.ts
+++ b/src/frontend/tests/core/features/deployment-providers.spec.ts
@@ -147,7 +147,7 @@ test(
         });
       } else {
         const body = postCalled
-          ? { providers: [NEW_PROVIDER] }
+          ? { provider_accounts: [NEW_PROVIDER] }
           : EMPTY_PROVIDERS_MOCK;
         route.fulfill({
           status: 200,

--- a/src/frontend/tests/core/features/deployment-providers.spec.ts
+++ b/src/frontend/tests/core/features/deployment-providers.spec.ts
@@ -1,0 +1,314 @@
+import { expect, test } from "../../fixtures";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import {
+  EMPTY_PROVIDERS_MOCK,
+  NEW_PROVIDER,
+  PROVIDERS_MOCK,
+} from "../../utils/deployment-mocks";
+
+async function navigateToProvidersTab(
+  page: Parameters<typeof test>[2]["page"],
+) {
+  await awaitBootstrapTest(page, { skipModal: true });
+  await page.getByTestId("deployments-btn").click();
+  await page.waitForSelector('[data-testid="new-deployment-btn"]');
+  await page.getByTestId("subtab-providers").click();
+  await page.waitForSelector('[data-testid="new-provider-btn"]');
+}
+
+test(
+  "Empty state shows Add Environment button",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_PROVIDERS_MOCK),
+      });
+    });
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ deployments: [] }),
+      });
+    });
+
+    await navigateToProvidersTab(page);
+
+    await expect(page.getByTestId("add-provider-empty-btn")).toBeVisible();
+  },
+);
+
+test(
+  "New Environment button opens modal with save disabled on empty form",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_PROVIDERS_MOCK),
+      });
+    });
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ deployments: [] }),
+      });
+    });
+
+    await navigateToProvidersTab(page);
+
+    await page.getByTestId("new-provider-btn").click();
+
+    await expect(page.getByTestId("add-provider-modal-title")).toBeVisible();
+    await expect(page.getByTestId("add-provider-save")).toBeDisabled();
+  },
+);
+
+test(
+  "Save button becomes enabled after filling all required fields",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_PROVIDERS_MOCK),
+      });
+    });
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ deployments: [] }),
+      });
+    });
+
+    await navigateToProvidersTab(page);
+
+    await page.getByTestId("new-provider-btn").click();
+
+    await expect(page.getByTestId("add-provider-save")).toBeDisabled();
+
+    await page.getByPlaceholder("e.g. Production").fill("My Env");
+    await page
+      .getByPlaceholder("Enter your API key")
+      .fill("test-api-key-12345");
+    await page
+      .getByPlaceholder("https://api.example.com")
+      .fill("https://example.com");
+
+    await expect(page.getByTestId("add-provider-save")).toBeEnabled();
+  },
+);
+
+test(
+  "Save calls POST and modal closes",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    let postCalled = false;
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      const method = route.request().method();
+
+      if (method === "POST") {
+        postCalled = true;
+        route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify(NEW_PROVIDER),
+        });
+      } else {
+        const body = postCalled
+          ? { providers: [NEW_PROVIDER] }
+          : EMPTY_PROVIDERS_MOCK;
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(body),
+        });
+      }
+    });
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ deployments: [] }),
+      });
+    });
+
+    await navigateToProvidersTab(page);
+
+    await page.getByTestId("new-provider-btn").click();
+
+    await page.getByPlaceholder("e.g. Production").fill("My Env");
+    await page
+      .getByPlaceholder("Enter your API key")
+      .fill("test-api-key-12345");
+    await page
+      .getByPlaceholder("https://api.example.com")
+      .fill("https://example.com");
+
+    const postRequest = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/v1/deployments/providers") &&
+        req.method() === "POST",
+    );
+
+    await page.getByTestId("add-provider-save").click();
+
+    await postRequest;
+
+    await expect(
+      page.getByTestId("add-provider-modal-title"),
+    ).not.toBeVisible();
+  },
+);
+
+test(
+  "Delete triggers confirmation dialog then calls DELETE",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ deployments: [] }),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/providers/prov-1", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      const method = route.request().method();
+      if (method === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(PROVIDERS_MOCK),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await navigateToProvidersTab(page);
+
+    await expect(page.getByTestId("provider-row-prov-1")).toBeVisible();
+
+    await page.getByTestId("actions-provider-prov-1").click();
+    await page.getByText("Delete").click();
+
+    await expect(
+      page.getByTestId("btn_delete_delete_confirmation_modal"),
+    ).toBeVisible();
+
+    const deleteRequest = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/v1/deployments/providers/prov-1") &&
+        req.method() === "DELETE",
+    );
+
+    await page.getByTestId("btn_delete_delete_confirmation_modal").click();
+
+    await deleteRequest;
+  },
+);
+
+test(
+  "Cancel delete dismisses confirmation without calling DELETE",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    let deleteRequestCount = 0;
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ deployments: [] }),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/providers/prov-1", (route) => {
+      deleteRequestCount++;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PROVIDERS_MOCK),
+      });
+    });
+
+    await navigateToProvidersTab(page);
+
+    await expect(page.getByTestId("provider-row-prov-1")).toBeVisible();
+
+    await page.getByTestId("actions-provider-prov-1").click();
+    await page.getByText("Delete").click();
+
+    await expect(
+      page.getByTestId("btn_cancel_delete_confirmation_modal"),
+    ).toBeVisible();
+
+    await page.getByTestId("btn_cancel_delete_confirmation_modal").click();
+
+    await expect(
+      page.getByTestId("btn_cancel_delete_confirmation_modal"),
+    ).not.toBeVisible();
+
+    expect(deleteRequestCount).toBe(0);
+
+    await expect(page.getByTestId("provider-row-prov-1")).toBeVisible();
+  },
+);

--- a/src/frontend/tests/core/features/deployment-test-modal.spec.ts
+++ b/src/frontend/tests/core/features/deployment-test-modal.spec.ts
@@ -1,0 +1,382 @@
+import { type Page } from "@playwright/test";
+import { expect, test } from "../../fixtures";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import {
+  COMPLETED_EXECUTION_RESPONSE,
+  DEPLOYMENTS_MOCK,
+  POST_EXECUTION_RESPONSE,
+  PROVIDERS_MOCK,
+  RUNNING_EXECUTION_RESPONSE,
+} from "../../utils/deployment-mocks";
+
+async function setupBaseRoutes(page: Page) {
+  // Register broad catch-all FIRST so specific routes (registered after) take priority via LIFO
+  await page.route("**/api/v1/deployments*", (route) => {
+    const url = route.request().url();
+    if (url.includes("/executions")) {
+      route.fallback();
+      return;
+    }
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(DEPLOYMENTS_MOCK),
+    });
+  });
+
+  await page.route("**/api/v1/deployments/providers*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(PROVIDERS_MOCK),
+    });
+  });
+}
+
+async function navigateToDeploymentsPage(page: Page) {
+  await awaitBootstrapTest(page, { skipModal: true });
+  await page.getByTestId("deployments-btn").click();
+  await page.waitForSelector('[data-testid="new-deployment-btn"]');
+}
+
+test(
+  "Test button opens modal with chat interface",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await setupBaseRoutes(page);
+    await navigateToDeploymentsPage(page);
+
+    await page.getByTestId("test-deployment-dep-1").click();
+
+    await expect(page.getByTestId("test-deployment-modal-title")).toBeVisible();
+    await expect(page.getByPlaceholder("Message")).toBeVisible();
+  },
+);
+
+test(
+  "Send message calls POST execution with correct body",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    let capturedRequestBody: Record<string, unknown> | null = null;
+    let executionCallCount = 0;
+
+    await setupBaseRoutes(page);
+
+    await page.route("**/api/v1/deployments/executions/exec-1*", (route) => {
+      executionCallCount++;
+      const isCompleted = executionCallCount > 1;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          isCompleted
+            ? COMPLETED_EXECUTION_RESPONSE
+            : RUNNING_EXECUTION_RESPONSE,
+        ),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/executions", async (route) => {
+      if (route.request().method() === "POST") {
+        const body = route.request().postDataJSON() as Record<string, unknown>;
+        capturedRequestBody = body;
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(POST_EXECUTION_RESPONSE),
+        });
+      } else {
+        route.fallback();
+      }
+    });
+
+    await navigateToDeploymentsPage(page);
+
+    await page.getByTestId("test-deployment-dep-1").click();
+    await expect(page.getByPlaceholder("Message")).toBeVisible();
+
+    await page.getByPlaceholder("Message").fill("Hello AI");
+    await page.getByRole("button", { name: /send message/i }).click();
+
+    await expect
+      .poll(() => capturedRequestBody, { timeout: 10_000 })
+      .toMatchObject({
+        deployment_id: "dep-1",
+        provider_data: { input: "Hello AI" },
+      });
+  },
+);
+
+test(
+  "Response appears in chat after polling completes",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    let executionCallCount = 0;
+
+    await setupBaseRoutes(page);
+
+    await page.route("**/api/v1/deployments/executions/exec-1*", (route) => {
+      executionCallCount++;
+      const isCompleted = executionCallCount > 1;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          isCompleted
+            ? COMPLETED_EXECUTION_RESPONSE
+            : RUNNING_EXECUTION_RESPONSE,
+        ),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/executions", async (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(POST_EXECUTION_RESPONSE),
+        });
+      } else {
+        route.fallback();
+      }
+    });
+
+    await navigateToDeploymentsPage(page);
+
+    await page.getByTestId("test-deployment-dep-1").click();
+    await expect(page.getByPlaceholder("Message")).toBeVisible();
+
+    await page.getByPlaceholder("Message").fill("Hello AI");
+    await page.getByRole("button", { name: /send message/i }).click();
+
+    await expect(page.getByText("Hello from AI")).toBeVisible({
+      timeout: 30_000,
+    });
+    expect(executionCallCount).toBeGreaterThanOrEqual(2);
+  },
+);
+
+test(
+  "Input is disabled during polling and re-enabled after response",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    let executionCallCount = 0;
+
+    await setupBaseRoutes(page);
+
+    await page.route("**/api/v1/deployments/executions/exec-1*", (route) => {
+      executionCallCount++;
+      const isCompleted = executionCallCount > 1;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          isCompleted
+            ? COMPLETED_EXECUTION_RESPONSE
+            : RUNNING_EXECUTION_RESPONSE,
+        ),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/executions", async (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(POST_EXECUTION_RESPONSE),
+        });
+      } else {
+        route.fallback();
+      }
+    });
+
+    await navigateToDeploymentsPage(page);
+
+    await page.getByTestId("test-deployment-dep-1").click();
+    await expect(page.getByPlaceholder("Message")).toBeVisible();
+
+    await page.getByPlaceholder("Message").fill("Hello AI");
+    await page.getByRole("button", { name: /send message/i }).click();
+
+    // Textarea should be disabled while waiting for response
+    await expect(page.getByPlaceholder("Message")).toBeDisabled();
+
+    // After response arrives, textarea should be re-enabled
+    await expect(page.getByText("Hello from AI")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByPlaceholder("Message")).toBeEnabled();
+  },
+);
+
+test(
+  "Multi-turn: second message includes thread_id from first response",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    let executionCallCount = 0;
+    const capturedBodies: Array<Record<string, unknown>> = [];
+
+    await setupBaseRoutes(page);
+
+    await page.route("**/api/v1/deployments/executions/exec-1*", (route) => {
+      executionCallCount++;
+      const isCompleted = executionCallCount % 2 === 0;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          isCompleted
+            ? COMPLETED_EXECUTION_RESPONSE
+            : RUNNING_EXECUTION_RESPONSE,
+        ),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/executions", async (route) => {
+      if (route.request().method() === "POST") {
+        const body = route.request().postDataJSON() as Record<string, unknown>;
+        capturedBodies.push(body);
+        // Reset poll counter for each new execution so each returns running then completed
+        executionCallCount = 0;
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(POST_EXECUTION_RESPONSE),
+        });
+      } else {
+        route.fallback();
+      }
+    });
+
+    await navigateToDeploymentsPage(page);
+
+    await page.getByTestId("test-deployment-dep-1").click();
+    await expect(page.getByPlaceholder("Message")).toBeVisible();
+
+    // First message
+    await page.getByPlaceholder("Message").fill("First message");
+    await page.getByRole("button", { name: /send message/i }).click();
+
+    // Wait for first response
+    await expect(page.getByText("Hello from AI")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Second message
+    await page.getByPlaceholder("Message").fill("Second message");
+    await page.getByRole("button", { name: /send message/i }).click();
+
+    // Wait for second response
+    await expect(page.getByText("Hello from AI")).toHaveCount(2, {
+      timeout: 30_000,
+    });
+
+    // Second POST should include thread_id from first response
+    expect(capturedBodies).toHaveLength(2);
+    expect(capturedBodies[1]).toMatchObject({
+      deployment_id: "dep-1",
+      provider_data: {
+        input: "Second message",
+        thread_id: "thread-1",
+      },
+    });
+  },
+);
+
+test(
+  "Close and reopen modal resets chat history",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    let executionCallCount = 0;
+
+    await setupBaseRoutes(page);
+
+    await page.route("**/api/v1/deployments/executions/exec-1*", (route) => {
+      executionCallCount++;
+      const isCompleted = executionCallCount > 1;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          isCompleted
+            ? COMPLETED_EXECUTION_RESPONSE
+            : RUNNING_EXECUTION_RESPONSE,
+        ),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/executions", async (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(POST_EXECUTION_RESPONSE),
+        });
+      } else {
+        route.fallback();
+      }
+    });
+
+    await navigateToDeploymentsPage(page);
+
+    // Open modal and send a message
+    await page.getByTestId("test-deployment-dep-1").click();
+    await expect(page.getByPlaceholder("Message")).toBeVisible();
+
+    await page.getByPlaceholder("Message").fill("Hello AI");
+    await page.getByRole("button", { name: /send message/i }).click();
+
+    // Wait for response to appear
+    await expect(page.getByText("Hello from AI")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Close the modal by pressing Escape
+    await page.keyboard.press("Escape");
+
+    // Verify the modal is closed
+    await expect(page.getByPlaceholder("Message")).not.toBeVisible();
+
+    // Reopen the modal
+    executionCallCount = 0;
+    await page.getByTestId("test-deployment-dep-1").click();
+    await expect(page.getByPlaceholder("Message")).toBeVisible();
+
+    // Chat should be empty — no previous messages visible
+    await expect(page.getByText("Hello AI")).not.toBeVisible();
+    await expect(page.getByText("Hello from AI")).not.toBeVisible();
+
+    // Empty state ("Agent Chat") should be shown
+    await expect(page.getByText("Agent Chat")).toBeVisible();
+  },
+);

--- a/src/frontend/tests/core/features/deployment-test-modal.spec.ts
+++ b/src/frontend/tests/core/features/deployment-test-modal.spec.ts
@@ -13,7 +13,8 @@ async function setupBaseRoutes(page: Page) {
   // Register broad catch-all FIRST so specific routes (registered after) take priority via LIFO
   await page.route("**/api/v1/deployments*", (route) => {
     const url = route.request().url();
-    if (url.includes("/executions")) {
+    // Execution routes are handled per-test; fall through for those
+    if (url.includes("/dep-1/executions") || url.includes("/executions")) {
       route.fallback();
       return;
     }
@@ -72,33 +73,42 @@ test(
 
     await setupBaseRoutes(page);
 
-    await page.route("**/api/v1/deployments/executions/exec-1*", (route) => {
-      executionCallCount++;
-      const isCompleted = executionCallCount > 1;
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(
-          isCompleted
-            ? COMPLETED_EXECUTION_RESPONSE
-            : RUNNING_EXECUTION_RESPONSE,
-        ),
-      });
-    });
-
-    await page.route("**/api/v1/deployments/executions", async (route) => {
-      if (route.request().method() === "POST") {
-        const body = route.request().postDataJSON() as Record<string, unknown>;
-        capturedRequestBody = body;
+    await page.route(
+      "**/api/v1/deployments/dep-1/executions/exec-1",
+      (route) => {
+        executionCallCount++;
+        const isCompleted = executionCallCount > 1;
         route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify(POST_EXECUTION_RESPONSE),
+          body: JSON.stringify(
+            isCompleted
+              ? COMPLETED_EXECUTION_RESPONSE
+              : RUNNING_EXECUTION_RESPONSE,
+          ),
         });
-      } else {
-        route.fallback();
-      }
-    });
+      },
+    );
+
+    await page.route(
+      "**/api/v1/deployments/dep-1/executions",
+      async (route) => {
+        if (route.request().method() === "POST") {
+          const body = route.request().postDataJSON() as Record<
+            string,
+            unknown
+          >;
+          capturedRequestBody = body;
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(POST_EXECUTION_RESPONSE),
+          });
+        } else {
+          route.fallback();
+        }
+      },
+    );
 
     await navigateToDeploymentsPage(page);
 
@@ -111,7 +121,6 @@ test(
     await expect
       .poll(() => capturedRequestBody, { timeout: 10_000 })
       .toMatchObject({
-        deployment_id: "dep-1",
         provider_data: { input: "Hello AI" },
       });
   },
@@ -130,31 +139,37 @@ test(
 
     await setupBaseRoutes(page);
 
-    await page.route("**/api/v1/deployments/executions/exec-1*", (route) => {
-      executionCallCount++;
-      const isCompleted = executionCallCount > 1;
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(
-          isCompleted
-            ? COMPLETED_EXECUTION_RESPONSE
-            : RUNNING_EXECUTION_RESPONSE,
-        ),
-      });
-    });
-
-    await page.route("**/api/v1/deployments/executions", async (route) => {
-      if (route.request().method() === "POST") {
+    await page.route(
+      "**/api/v1/deployments/dep-1/executions/exec-1",
+      (route) => {
+        executionCallCount++;
+        const isCompleted = executionCallCount > 1;
         route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify(POST_EXECUTION_RESPONSE),
+          body: JSON.stringify(
+            isCompleted
+              ? COMPLETED_EXECUTION_RESPONSE
+              : RUNNING_EXECUTION_RESPONSE,
+          ),
         });
-      } else {
-        route.fallback();
-      }
-    });
+      },
+    );
+
+    await page.route(
+      "**/api/v1/deployments/dep-1/executions",
+      async (route) => {
+        if (route.request().method() === "POST") {
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(POST_EXECUTION_RESPONSE),
+          });
+        } else {
+          route.fallback();
+        }
+      },
+    );
 
     await navigateToDeploymentsPage(page);
 
@@ -184,31 +199,37 @@ test(
 
     await setupBaseRoutes(page);
 
-    await page.route("**/api/v1/deployments/executions/exec-1*", (route) => {
-      executionCallCount++;
-      const isCompleted = executionCallCount > 1;
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(
-          isCompleted
-            ? COMPLETED_EXECUTION_RESPONSE
-            : RUNNING_EXECUTION_RESPONSE,
-        ),
-      });
-    });
-
-    await page.route("**/api/v1/deployments/executions", async (route) => {
-      if (route.request().method() === "POST") {
+    await page.route(
+      "**/api/v1/deployments/dep-1/executions/exec-1",
+      (route) => {
+        executionCallCount++;
+        const isCompleted = executionCallCount > 1;
         route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify(POST_EXECUTION_RESPONSE),
+          body: JSON.stringify(
+            isCompleted
+              ? COMPLETED_EXECUTION_RESPONSE
+              : RUNNING_EXECUTION_RESPONSE,
+          ),
         });
-      } else {
-        route.fallback();
-      }
-    });
+      },
+    );
+
+    await page.route(
+      "**/api/v1/deployments/dep-1/executions",
+      async (route) => {
+        if (route.request().method() === "POST") {
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(POST_EXECUTION_RESPONSE),
+          });
+        } else {
+          route.fallback();
+        }
+      },
+    );
 
     await navigateToDeploymentsPage(page);
 
@@ -243,35 +264,44 @@ test(
 
     await setupBaseRoutes(page);
 
-    await page.route("**/api/v1/deployments/executions/exec-1*", (route) => {
-      executionCallCount++;
-      const isCompleted = executionCallCount % 2 === 0;
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(
-          isCompleted
-            ? COMPLETED_EXECUTION_RESPONSE
-            : RUNNING_EXECUTION_RESPONSE,
-        ),
-      });
-    });
-
-    await page.route("**/api/v1/deployments/executions", async (route) => {
-      if (route.request().method() === "POST") {
-        const body = route.request().postDataJSON() as Record<string, unknown>;
-        capturedBodies.push(body);
-        // Reset poll counter for each new execution so each returns running then completed
-        executionCallCount = 0;
+    await page.route(
+      "**/api/v1/deployments/dep-1/executions/exec-1",
+      (route) => {
+        executionCallCount++;
+        const isCompleted = executionCallCount % 2 === 0;
         route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify(POST_EXECUTION_RESPONSE),
+          body: JSON.stringify(
+            isCompleted
+              ? COMPLETED_EXECUTION_RESPONSE
+              : RUNNING_EXECUTION_RESPONSE,
+          ),
         });
-      } else {
-        route.fallback();
-      }
-    });
+      },
+    );
+
+    await page.route(
+      "**/api/v1/deployments/dep-1/executions",
+      async (route) => {
+        if (route.request().method() === "POST") {
+          const body = route.request().postDataJSON() as Record<
+            string,
+            unknown
+          >;
+          capturedBodies.push(body);
+          // Reset poll counter for each new execution so each returns running then completed
+          executionCallCount = 0;
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(POST_EXECUTION_RESPONSE),
+          });
+        } else {
+          route.fallback();
+        }
+      },
+    );
 
     await navigateToDeploymentsPage(page);
 
@@ -299,7 +329,6 @@ test(
     // Second POST should include thread_id from first response
     expect(capturedBodies).toHaveLength(2);
     expect(capturedBodies[1]).toMatchObject({
-      deployment_id: "dep-1",
       provider_data: {
         input: "Second message",
         thread_id: "thread-1",
@@ -321,31 +350,37 @@ test(
 
     await setupBaseRoutes(page);
 
-    await page.route("**/api/v1/deployments/executions/exec-1*", (route) => {
-      executionCallCount++;
-      const isCompleted = executionCallCount > 1;
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(
-          isCompleted
-            ? COMPLETED_EXECUTION_RESPONSE
-            : RUNNING_EXECUTION_RESPONSE,
-        ),
-      });
-    });
-
-    await page.route("**/api/v1/deployments/executions", async (route) => {
-      if (route.request().method() === "POST") {
+    await page.route(
+      "**/api/v1/deployments/dep-1/executions/exec-1",
+      (route) => {
+        executionCallCount++;
+        const isCompleted = executionCallCount > 1;
         route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify(POST_EXECUTION_RESPONSE),
+          body: JSON.stringify(
+            isCompleted
+              ? COMPLETED_EXECUTION_RESPONSE
+              : RUNNING_EXECUTION_RESPONSE,
+          ),
         });
-      } else {
-        route.fallback();
-      }
-    });
+      },
+    );
+
+    await page.route(
+      "**/api/v1/deployments/dep-1/executions",
+      async (route) => {
+        if (route.request().method() === "POST") {
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(POST_EXECUTION_RESPONSE),
+          });
+        } else {
+          route.fallback();
+        }
+      },
+    );
 
     await navigateToDeploymentsPage(page);
 

--- a/src/frontend/tests/core/features/deployments-page.spec.ts
+++ b/src/frontend/tests/core/features/deployments-page.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test } from "../../fixtures";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import { DEPLOYMENTS_MOCK, PROVIDERS_MOCK } from "../../utils/deployment-mocks";
+
+test(
+  "Renders Deployments tab with sub-tab toggles",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ providers: [] }),
+      });
+    });
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ deployments: [] }),
+      });
+    });
+
+    await awaitBootstrapTest(page, { skipModal: true });
+    await page.getByTestId("deployments-btn").click();
+    await page.waitForSelector('[data-testid="new-deployment-btn"]');
+
+    await expect(page.getByTestId("subtab-deployments")).toBeVisible();
+    await expect(page.getByTestId("subtab-providers")).toBeVisible();
+  },
+);
+
+test(
+  "Deployments empty state shows create button when no providers exist",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ providers: [] }),
+      });
+    });
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ deployments: [] }),
+      });
+    });
+
+    await awaitBootstrapTest(page, { skipModal: true });
+    await page.getByTestId("deployments-btn").click();
+    await page.waitForSelector('[data-testid="new-deployment-btn"]');
+
+    await expect(page.getByTestId("create-deployment-empty-btn")).toBeVisible();
+    await expect(page.getByTestId("new-deployment-btn")).toBeVisible();
+  },
+);
+
+test(
+  "Providers empty state shows add provider button when switching to providers tab",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ providers: [] }),
+      });
+    });
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ deployments: [] }),
+      });
+    });
+
+    await awaitBootstrapTest(page, { skipModal: true });
+    await page.getByTestId("deployments-btn").click();
+    await page.waitForSelector('[data-testid="new-deployment-btn"]');
+
+    await page.getByTestId("subtab-providers").click();
+
+    await expect(page.getByTestId("add-provider-empty-btn")).toBeVisible();
+    await expect(page.getByTestId("new-provider-btn")).toBeVisible();
+  },
+);
+
+test(
+  "Deployment list renders a row for each deployment",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(DEPLOYMENTS_MOCK),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PROVIDERS_MOCK),
+      });
+    });
+
+    await awaitBootstrapTest(page, { skipModal: true });
+    await page.getByTestId("deployments-btn").click();
+    await page.waitForSelector('[data-testid="new-deployment-btn"]');
+
+    await expect(page.getByTestId("deployment-row-dep-1")).toBeVisible();
+  },
+);
+
+test(
+  "Provider list renders a row for each provider",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(DEPLOYMENTS_MOCK),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PROVIDERS_MOCK),
+      });
+    });
+
+    await awaitBootstrapTest(page, { skipModal: true });
+    await page.getByTestId("deployments-btn").click();
+    await page.waitForSelector('[data-testid="new-deployment-btn"]');
+
+    await page.getByTestId("subtab-providers").click();
+
+    await expect(page.getByTestId("provider-row-prov-1")).toBeVisible();
+  },
+);

--- a/src/frontend/tests/core/features/deployments-page.spec.ts
+++ b/src/frontend/tests/core/features/deployments-page.spec.ts
@@ -15,7 +15,7 @@ test(
       route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ providers: [] }),
+        body: JSON.stringify({ provider_accounts: [] }),
       });
     });
 
@@ -49,7 +49,7 @@ test(
       route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ providers: [] }),
+        body: JSON.stringify({ provider_accounts: [] }),
       });
     });
 
@@ -83,7 +83,7 @@ test(
       route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ providers: [] }),
+        body: JSON.stringify({ provider_accounts: [] }),
       });
     });
 

--- a/src/frontend/tests/core/features/deployments-page.spec.ts
+++ b/src/frontend/tests/core/features/deployments-page.spec.ts
@@ -1,6 +1,18 @@
 import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
-import { DEPLOYMENTS_MOCK, PROVIDERS_MOCK } from "../../utils/deployment-mocks";
+import {
+  DEPLOYMENT,
+  DEPLOYMENTS_MOCK,
+  PROVIDERS_MOCK,
+} from "../../utils/deployment-mocks";
+
+async function navigateToDeploymentsTab(
+  page: Parameters<typeof test>[2]["page"],
+) {
+  await awaitBootstrapTest(page, { skipModal: true });
+  await page.getByTestId("deployments-btn").click();
+  await page.waitForSelector('[data-testid="new-deployment-btn"]');
+}
 
 test(
   "Renders Deployments tab with sub-tab toggles",
@@ -171,5 +183,196 @@ test(
     await page.getByTestId("subtab-providers").click();
 
     await expect(page.getByTestId("provider-row-prov-1")).toBeVisible();
+  },
+);
+
+test(
+  "Delete deployment opens type-to-confirm dialog",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PROVIDERS_MOCK),
+      });
+    });
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(DEPLOYMENTS_MOCK),
+      });
+    });
+
+    await navigateToDeploymentsTab(page);
+    await expect(page.getByTestId("deployment-row-dep-1")).toBeVisible();
+
+    await page.getByTestId("actions-deployment-dep-1").click();
+    await page.getByTestId("delete-deployment-dep-1").click();
+
+    await expect(
+      page.getByTestId("input-type-to-confirm-delete"),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "Delete deployment button is disabled until deployment name is typed",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PROVIDERS_MOCK),
+      });
+    });
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(DEPLOYMENTS_MOCK),
+      });
+    });
+
+    await navigateToDeploymentsTab(page);
+    await page.getByTestId("actions-deployment-dep-1").click();
+    await page.getByTestId("delete-deployment-dep-1").click();
+
+    const deleteBtn = page.getByTestId("btn-delete-type-to-confirm-delete");
+    await expect(deleteBtn).toBeDisabled();
+
+    await page.getByTestId("input-type-to-confirm-delete").fill("wrong name");
+    await expect(deleteBtn).toBeDisabled();
+
+    await page
+      .getByTestId("input-type-to-confirm-delete")
+      .fill(DEPLOYMENT.name);
+    await expect(deleteBtn).toBeEnabled();
+  },
+);
+
+test(
+  "Delete deployment — typing correct name and confirming calls DELETE",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PROVIDERS_MOCK),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/dep-1", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      });
+    });
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(DEPLOYMENTS_MOCK),
+      });
+    });
+
+    await navigateToDeploymentsTab(page);
+    await page.getByTestId("actions-deployment-dep-1").click();
+    await page.getByTestId("delete-deployment-dep-1").click();
+
+    await page
+      .getByTestId("input-type-to-confirm-delete")
+      .fill(DEPLOYMENT.name);
+
+    const deleteRequest = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/v1/deployments/dep-1") &&
+        req.method() === "DELETE",
+    );
+
+    await page.getByTestId("btn-delete-type-to-confirm-delete").click();
+
+    await deleteRequest;
+  },
+);
+
+test(
+  "Cancel delete deployment dismisses dialog without calling DELETE",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    let deleteRequestCount = 0;
+
+    await page.route("**/api/v1/deployments/providers*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PROVIDERS_MOCK),
+      });
+    });
+
+    await page.route("**/api/v1/deployments/dep-1", (route) => {
+      if (route.request().method() === "DELETE") {
+        deleteRequestCount++;
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: "{}",
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/deployments*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(DEPLOYMENTS_MOCK),
+      });
+    });
+
+    await navigateToDeploymentsTab(page);
+    await page.getByTestId("actions-deployment-dep-1").click();
+    await page.getByTestId("delete-deployment-dep-1").click();
+
+    await expect(
+      page.getByTestId("btn-cancel-type-to-confirm-delete"),
+    ).toBeVisible();
+
+    await page.getByTestId("btn-cancel-type-to-confirm-delete").click();
+
+    await expect(
+      page.getByTestId("btn-cancel-type-to-confirm-delete"),
+    ).not.toBeVisible();
+
+    expect(deleteRequestCount).toBe(0);
+    await expect(page.getByTestId("deployment-row-dep-1")).toBeVisible();
   },
 );

--- a/src/frontend/tests/utils/deployment-mocks.ts
+++ b/src/frontend/tests/utils/deployment-mocks.ts
@@ -1,0 +1,145 @@
+// ---------------------------------------------------------------------------
+// Shared mock data for deployment E2E tests
+// ---------------------------------------------------------------------------
+
+export const PROVIDER = {
+  id: "prov-1",
+  name: "My Env",
+  provider_key: "watsonx-orchestrate",
+  provider_url: "https://example.com",
+  created_at: "2026-04-06T00:00:00Z",
+};
+
+export const PROVIDERS_MOCK = {
+  providers: [PROVIDER],
+  page: 1,
+  size: 20,
+  total: 1,
+};
+
+export const EMPTY_PROVIDERS_MOCK = { providers: [] };
+
+export const NEW_PROVIDER = {
+  id: "prov-new",
+  name: "My Env",
+  provider_key: "watsonx-orchestrate",
+  provider_url: "https://example.com",
+  created_at: "2026-04-06T00:00:00Z",
+};
+
+export const DEPLOYMENT = {
+  id: "dep-1",
+  name: "Test Deployment",
+  type: "agent",
+  provider_account_id: "prov-1",
+  provider_account_name: "My Env",
+  status: "deployed",
+};
+
+export const DEPLOYMENTS_MOCK = { deployments: [DEPLOYMENT] };
+
+export const DEPLOYMENT_DETAIL_MOCK = {
+  ...DEPLOYMENT,
+  provider_data: { llm: "ibm/granite-13b-chat" },
+};
+
+export const ATTACHMENTS_MOCK = {
+  flow_versions: [
+    {
+      id: "fv1",
+      flow_id: "f1",
+      flow_name: "My Flow",
+      version_number: 1,
+      attached_at: "2026-04-06T00:00:00Z",
+      provider_snapshot_id: null,
+      tool_name: "my-flow",
+      provider_data: null,
+    },
+  ],
+  page: 1,
+  size: 50,
+  total: 1,
+};
+
+// Shape returned by GET /api/v1/deployments/llms — used in create stepper
+export const LLMS_MOCK = {
+  provider_data: {
+    models: [{ model_name: "ibm/granite-13b-chat" }],
+  },
+};
+
+export const CONFIGS_MOCK = {
+  configs: [],
+  page: 1,
+  size: 10000,
+  total: 0,
+};
+
+export const FLOWS_MOCK = [
+  {
+    id: "f1",
+    name: "My Flow",
+    is_component: false,
+    folder_id: "my-collection",
+    icon: "Workflow",
+    description: "",
+    data: null,
+  },
+];
+
+export const FLOW_VERSIONS_MOCK = {
+  entries: [
+    {
+      id: "fv1",
+      flow_id: "f1",
+      version_tag: "v1",
+      version_number: 1,
+      created_at: "2026-04-06T00:00:00Z",
+      is_current: true,
+    },
+  ],
+};
+
+export const DEPLOY_RESPONSE = {
+  id: "dep-new",
+  name: "My Deployment",
+  type: "agent",
+  provider_account_id: "prov-1",
+  status: "deploying",
+};
+
+export const POST_EXECUTION_RESPONSE = {
+  deployment_id: "dep-1",
+  provider_data: {
+    execution_id: "exec-1",
+    status: "running",
+    thread_id: null,
+    result: null,
+  },
+};
+
+export const RUNNING_EXECUTION_RESPONSE = {
+  deployment_id: "dep-1",
+  provider_data: {
+    execution_id: "exec-1",
+    status: "running",
+    result: null,
+    thread_id: null,
+  },
+};
+
+export const COMPLETED_EXECUTION_RESPONSE = {
+  deployment_id: "dep-1",
+  provider_data: {
+    execution_id: "exec-1",
+    status: "completed",
+    thread_id: "thread-1",
+    result: {
+      data: {
+        message: {
+          content: [{ type: "text", text: "Hello from AI" }],
+        },
+      },
+    },
+  },
+};

--- a/src/frontend/tests/utils/deployment-mocks.ts
+++ b/src/frontend/tests/utils/deployment-mocks.ts
@@ -6,24 +6,24 @@ export const PROVIDER = {
   id: "prov-1",
   name: "My Env",
   provider_key: "watsonx-orchestrate",
-  provider_url: "https://example.com",
+  url: "https://example.com",
   created_at: "2026-04-06T00:00:00Z",
 };
 
 export const PROVIDERS_MOCK = {
-  providers: [PROVIDER],
+  provider_accounts: [PROVIDER],
   page: 1,
   size: 20,
   total: 1,
 };
 
-export const EMPTY_PROVIDERS_MOCK = { providers: [] };
+export const EMPTY_PROVIDERS_MOCK = { provider_accounts: [] };
 
 export const NEW_PROVIDER = {
   id: "prov-new",
   name: "My Env",
   provider_key: "watsonx-orchestrate",
-  provider_url: "https://example.com",
+  url: "https://example.com",
   created_at: "2026-04-06T00:00:00Z",
 };
 

--- a/src/frontend/vite.config.mts
+++ b/src/frontend/vite.config.mts
@@ -58,7 +58,9 @@ export default defineConfig(({ mode }) => {
         envLangflow.LANGFLOW_MCP_COMPOSER_ENABLED ?? "true",
       ),
       "import.meta.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS": JSON.stringify(
-        envLangflow.LANGFLOW_FEATURE_WXO_DEPLOYMENTS ?? "false",
+        envLangflow.LANGFLOW_FEATURE_WXO_DEPLOYMENTS ??
+          process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS ??
+          "false",
       ),
     },
     plugins: [


### PR DESCRIPTION
## Summary

Adds a comprehensive frontend test suite for the WXO deployments feature covering the full surface area — from API hooks to E2E workflows.

- **43 test files** across unit tests, component tests, and E2E specs
- **~10,500 lines** of new test code
- Adds `data-testid` attributes to 6 components for reliable E2E selector targeting
- Adds shared `deployment-mocks.ts` utility for E2E mock data reuse
- Sets `LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true` in CI workflow env
- Fixes vite config to read feature flags from `process.env` fallback (for CI)

## Test coverage breakdown

### API query & mutation hooks (16 files)
Unit tests for all deployment and provider account React Query hooks:
`useGetDeployments`, `useGetDeployment`, `usePostDeployment`, `usePatchDeployment`, `useDeleteDeployment`, `useGetDeploymentAttachments`, `useGetDeploymentConfigs`, `useGetDeploymentExecution`, `useGetDeploymentLlms`, `useGetDeploymentsByProviders`, `usePatchSnapshot`, `usePostDeploymentExecution`, `useGetProviderAccounts`, `usePostProviderAccount`, `useDeleteProviderAccount`, `usePostDetectEnvVars`

### Stepper context & mode logic (3 files)
Create-mode payload builders, step validation, provider selection, multi-flow scenarios, partial update payloads, detach/re-attach flows, tool naming edge cases, edit-mode pre-population

### Component rendering (14 files)
Deployments table, providers table, stepper steps (type, provider, attach-flows, connection panel), deployment details modal, add-provider modal, deployment stepper modal, deploy button, deploy choice dialog

### Custom hooks (7 files)
`useErrorAlert`, `useProviderFilter`, `useNavigateToTest`, `useDeleteWithConfirmation`, `useTestDeploymentModal`, `useDeploymentChat` (polling, thread_id, timeouts, tool traces), watsonx result parsers (`extractText`, `extractToolTraces`, `extractThreadId`)

### Deploy button & choice dialog (3 files)
Feature-flag gating, disabled states, `handleDeploy` flow, phase transitions (provider → deployments → review → update), auto-select single attachment, `patchSnapshot` args, error flows

### E2E Playwright tests (5 spec files)

| File | Tests | Coverage |
|---|---|---|
| `deployments-page.spec.ts` | 5 | Page nav, empty/loaded states, sub-tab switching |
| `deployment-create.spec.ts` | 6 | Full create wizard, provider selection, attach flows, deploy POST |
| `deployment-edit.spec.ts` | 5 | Edit mode, PATCH update, cancel, name pre-population |
| `deployment-providers.spec.ts` | 6 | Add/delete provider accounts, form validation, confirmation dialog |
| `deployment-test-modal.spec.ts` | 6 | Chat send, polling, multi-turn thread_id, reset on reopen |

Plus 4 additional E2E tests for the type-to-confirm deployment deletion flow.

## Source component changes

Minor additions to enable testability — no behavior changes:

- `deployment-stepper-modal.tsx` — `data-testid="stepper-modal-title"`
- `add-provider-modal.tsx` — `data-testid="add-provider-modal-title"`
- `test-deployment-modal.tsx` — `data-testid="test-deployment-modal-title"`
- `step-provider.tsx` — `data-testid="provider-item-{id}"`
- `deployments-table.tsx` — `data-testid="deployment-delete-action"`
- `deployment-details-modal.tsx` — `data-testid` on detail fields
- `step-attach-flows-connection-panel.tsx` — `data-testid` on connection items

## Infrastructure changes

- `.github/workflows/typescript_test.yml` — add `LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true` env var
- `vite.config.mts` — fall back to `process.env` when `.env` file doesn't define feature flags
- `use-get-provider-accounts.ts` — fix response type to use `provider_accounts` key

## Test plan

- [x] All unit tests pass locally
- [x] All 32 E2E tests pass locally
- [x] No TypeScript errors in modified files
- [x] Biome lint passes
- [x] CI feature flag env var propagates correctly