### PR TITLE
fix(ci): add missing SDK build step to cross-platform workflow_dispatch

### DIFF
--- a/.github/workflows/cross-platform-test.yml
+++ b/.github/workflows/cross-platform-test.yml
@@ -41,6 +41,7 @@ jobs:
       base-artifact-name: ${{ steps.set-names.outputs.base-artifact-name }}
       main-artifact-name: ${{ steps.set-names.outputs.main-artifact-name }}
       lfx-artifact-name: ${{ steps.set-names.outputs.lfx-artifact-name }}
+      sdk-artifact-name: ${{ steps.set-names.outputs.sdk-artifact-name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -67,6 +68,10 @@ jobs:
         run: |
           cd src/lfx
           uv build --wheel --out-dir dist
+      - name: Build SDK package
+        run: |
+          cd src/sdk
+          uv build --wheel --out-dir dist
       - name: Build main package
         run: make build_langflow args="--wheel"
       - name: Upload lfx artifact
@@ -74,6 +79,11 @@ jobs:
         with:
           name: adhoc-dist-lfx
           path: src/lfx/dist
+      - name: Upload SDK artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: adhoc-dist-sdk
+          path: src/sdk/dist
       - name: Upload base artifact
         uses: actions/upload-artifact@v6
         with:
@@ -90,6 +100,7 @@ jobs:
           echo "base-artifact-name=adhoc-dist-base" >> $GITHUB_OUTPUT
           echo "main-artifact-name=adhoc-dist-main" >> $GITHUB_OUTPUT
           echo "lfx-artifact-name=adhoc-dist-lfx" >> $GITHUB_OUTPUT
+          echo "sdk-artifact-name=adhoc-dist-sdk" >> $GITHUB_OUTPUT
 
   test-installation-stable:
     name: Install & Run - ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.python-version }}
@@ -177,10 +188,10 @@ jobs:
 
       # Download artifacts for wheel installation
       - name: Download langflow-sdk package artifact
-        if: steps.install-method.outputs.method == 'wheel' && inputs.sdk-artifact-name != ''
+        if: steps.install-method.outputs.method == 'wheel' && (inputs.sdk-artifact-name != '' || needs.build-if-needed.outputs.sdk-artifact-name != '')
         uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.sdk-artifact-name }}
+          name: ${{ inputs.sdk-artifact-name || needs.build-if-needed.outputs.sdk-artifact-name || 'adhoc-dist-sdk' }}
           path: ./sdk-dist
 
       - name: Download LFX package artifact
@@ -211,7 +222,7 @@ jobs:
 
       # Wheel installation steps — install SDK and LFX together when both are present.
       - name: Install SDK and LFX packages from wheel (Windows)
-        if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows' && inputs.sdk-artifact-name != '' && inputs.lfx-artifact-name != ''
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows' && (inputs.sdk-artifact-name != '' || needs.build-if-needed.outputs.sdk-artifact-name != '') && (inputs.lfx-artifact-name != '' || needs.build-if-needed.outputs.lfx-artifact-name != '')
         run: |
           ls -la ./sdk-dist/
           find ./sdk-dist -name "*.whl" -type f
@@ -228,7 +239,7 @@ jobs:
         shell: bash
 
       - name: Install SDK package from wheel (Windows)
-        if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows' && inputs.sdk-artifact-name != '' && inputs.lfx-artifact-name == ''
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows' && (inputs.sdk-artifact-name != '' || needs.build-if-needed.outputs.sdk-artifact-name != '') && (inputs.lfx-artifact-name == '' && needs.build-if-needed.outputs.lfx-artifact-name == '')
         run: |
           WHEEL_FILE=$(find ./sdk-dist -name "*.whl" -type f | head -1)
           if [ -n "$WHEEL_FILE" ]; then
@@ -240,7 +251,7 @@ jobs:
         shell: bash
 
       - name: Install LFX package from wheel (Windows)
-        if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows' && (inputs.lfx-artifact-name != '' || needs.build-if-needed.outputs.lfx-artifact-name != '') && inputs.sdk-artifact-name == ''
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows' && (inputs.lfx-artifact-name != '' || needs.build-if-needed.outputs.lfx-artifact-name != '') && (inputs.sdk-artifact-name == '' && needs.build-if-needed.outputs.sdk-artifact-name == '')
         run: |
           ls -la ./lfx-dist/
           find ./lfx-dist -name "*.whl" -type f
@@ -282,7 +293,7 @@ jobs:
         shell: bash
 
       - name: Install SDK and LFX packages from wheel (Unix)
-        if: steps.install-method.outputs.method == 'wheel' && matrix.os != 'windows' && inputs.sdk-artifact-name != '' && inputs.lfx-artifact-name != ''
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os != 'windows' && (inputs.sdk-artifact-name != '' || needs.build-if-needed.outputs.sdk-artifact-name != '') && (inputs.lfx-artifact-name != '' || needs.build-if-needed.outputs.lfx-artifact-name != '')
         run: |
           ls -la ./sdk-dist/
           find ./sdk-dist -name "*.whl" -type f
@@ -299,7 +310,7 @@ jobs:
         shell: bash
 
       - name: Install SDK package from wheel (Unix)
-        if: steps.install-method.outputs.method == 'wheel' && matrix.os != 'windows' && inputs.sdk-artifact-name != '' && inputs.lfx-artifact-name == ''
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os != 'windows' && (inputs.sdk-artifact-name != '' || needs.build-if-needed.outputs.sdk-artifact-name != '') && (inputs.lfx-artifact-name == '' && needs.build-if-needed.outputs.lfx-artifact-name == '')
         run: |
           WHEEL_FILE=$(find ./sdk-dist -name "*.whl" -type f | head -1)
           if [ -n "$WHEEL_FILE" ]; then
@@ -311,7 +322,7 @@ jobs:
         shell: bash
 
       - name: Install LFX package from wheel (Unix)
-        if: steps.install-method.outputs.method == 'wheel' && matrix.os != 'windows' && (inputs.lfx-artifact-name != '' || needs.build-if-needed.outputs.lfx-artifact-name != '') && inputs.sdk-artifact-name == ''
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os != 'windows' && (inputs.lfx-artifact-name != '' || needs.build-if-needed.outputs.lfx-artifact-name != '') && (inputs.sdk-artifact-name == '' && needs.build-if-needed.outputs.sdk-artifact-name == '')
         run: |
           ls -la ./lfx-dist/
           find ./lfx-dist -name "*.whl" -type f
@@ -541,10 +552,10 @@ jobs:
 
       # Download artifacts for wheel installation
       - name: Download langflow-sdk package artifact
-        if: steps.install-method.outputs.method == 'wheel' && inputs.sdk-artifact-name != ''
+        if: steps.install-method.outputs.method == 'wheel' && (inputs.sdk-artifact-name != '' || needs.build-if-needed.outputs.sdk-artifact-name != '')
         uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.sdk-artifact-name }}
+          name: ${{ inputs.sdk-artifact-name || needs.build-if-needed.outputs.sdk-artifact-name || 'adhoc-dist-sdk' }}
           path: ./sdk-dist
 
       - name: Download LFX package artifact
@@ -575,7 +586,7 @@ jobs:
 
       # Wheel installation steps — install langflow-sdk before LFX (sdk is not yet on PyPI)
       - name: Install langflow-sdk from wheel (Windows)
-        if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows' && inputs.sdk-artifact-name != ''
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os == 'windows' && (inputs.sdk-artifact-name != '' || needs.build-if-needed.outputs.sdk-artifact-name != '')
         run: |
           WHEEL_FILE=$(find ./sdk-dist -name "*.whl" -type f | head -1)
           if [ -n "$WHEEL_FILE" ]; then
@@ -587,7 +598,7 @@ jobs:
         shell: bash
 
       - name: Install langflow-sdk from wheel (Unix)
-        if: steps.install-method.outputs.method == 'wheel' && matrix.os != 'windows' && inputs.sdk-artifact-name != ''
+        if: steps.install-method.outputs.method == 'wheel' && matrix.os != 'windows' && (inputs.sdk-artifact-name != '' || needs.build-if-needed.outputs.sdk-artifact-name != '')
         run: |
           WHEEL_FILE=$(find ./sdk-dist -name "*.whl" -type f | head -1)
           if [ -n "$WHEEL_FILE" ]; then


### PR DESCRIPTION
Problem: The build-if-needed job was not building the langflow-sdk package. Since lfx depends on langflow-sdk>=0.1.0 and it's not yet on PyPI, all test jobs fail during lfx installation with "No solution found".

Failing run: [https://github.com/langflow-ai/langflow/actions/runs/24050788103](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Fix (same pattern as #12524):

Build langflow-sdk wheel in build-if-needed (cd src/sdk && uv build --wheel)
Upload SDK artifact (adhoc-dist-sdk) and output sdk-artifact-name
Update all SDK download/install conditions with build-if-needed fallback
Fix routing so combined SDK+LFX installer triggers when both come from build-if-needed