### PR TITLE
fix: follow deployment boundary rules and fail fast (wxo)

### DIFF
--- a/src/backend/base/langflow/api/v1/mappers/deployments/RULES.md
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/RULES.md
@@ -412,6 +412,7 @@ Use this checklist before merge:
 - [ ] Provider-account update logic lives in mapper, not in route conditionals
 - [ ] Provider-specific cross-field rules (e.g. tenant/URL coupling) are implemented as mapper overrides calling `super()`, not as base-class conditionals
 - [ ] Credential extraction uses `resolve_credential_fields`, not route-level assumptions about `provider_data` contents
+- [ ] Non-persisted provider-originated fields are placed in `provider_data` (never top-level)
 - [ ] DB-level consistency validators exist as defense-in-depth for cross-field invariants
 - [ ] Tests cover both base mapper defaults and provider overrides
 - [ ] Failure cases for missing/unexpected bindings are covered
@@ -556,3 +557,14 @@ When adding a new field to an execution or deployment response:
 1. Is Langflow the source of truth for this value? → top level.
 2. Does this value come from the provider and Langflow just relays it? → inside `provider_data`.
 3. Does the provider supply it but Langflow persists and indexes it (like `resource_key`)? → top level is acceptable.
+
+### 14.4 Hard placement rule for non-persisted provider data
+
+If data is not persisted in the Langflow DB and comes directly from the provider,
+it must go into `provider_data`.
+
+Rules:
+
+- Top-level response fields are reserved for values that Langflow persists and controls.
+- Provider-originated data that Langflow only relays must stay in `provider_data` without exception.
+- Examples: provider tool names, execution metadata/status/timestamps, connection types, environments.

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -1244,8 +1244,10 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
         payload["type"] = config_type
         environment = str(item_provider_data.get("environment") or "").strip()
-        if environment:
-            payload["environment"] = environment
+        if not environment:
+            msg = "Invalid config list item provider_data payload: expected non-null and non-empty 'environment'."
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
+        payload["environment"] = environment
         return payload
 
     def _parse_required_payload_slot(

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -1093,8 +1093,10 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 version_number=row.flow_version.version_number,
                 attached_at=row.attachment.created_at,
                 provider_snapshot_id=row.snapshot_id,
-                tool_name=snapshot_name_by_id.get(row.snapshot_id),
-                provider_data=self.shape_deployment_flow_version_item_data(snapshot_data_by_id.get(row.snapshot_id)),
+                provider_data=self.shape_deployment_flow_version_item_data(
+                    snapshot_data=snapshot_data_by_id.get(row.snapshot_id),
+                    tool_name=snapshot_name_by_id.get(row.snapshot_id),
+                ),
             )
             for row in normalized_rows
         ]
@@ -1159,12 +1161,13 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
 
         Edge cases:
         - Provider unreachable / snapshot_result is None: returns ``{}``.
-          The ``tool_name`` field in the response will be ``None`` and the
-          frontend falls back to the Langflow flow name for display.
+          ``provider_data.tool_name`` will be absent/``None`` and the frontend
+          falls back to the Langflow flow name for display.
         - Tool renamed in wxO console: the new name is returned here since
           ``snapshot_result`` is fetched fresh on each request.
         - Tool deleted in wxO: missing from ``snapshot_result.snapshots``,
-          so no entry in the returned dict. ``tool_name`` will be ``None``.
+          so no entry in the returned dict. ``provider_data.tool_name`` will be
+          absent/``None``.
         """
         if not snapshot_result or not snapshot_result.snapshots:
             return {}
@@ -1178,17 +1181,21 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
 
     def shape_deployment_flow_version_item_data(
         self,
+        *,
         snapshot_data: dict[str, Any] | None,
+        tool_name: str | None = None,
     ) -> dict[str, Any] | None:
-        if not snapshot_data:
-            return None
-        raw_connections = snapshot_data.get("connections")
-        if raw_connections is None or not isinstance(raw_connections, dict):
+        raw_connections = snapshot_data.get("connections") if snapshot_data else None
+        app_ids = list(raw_connections.keys()) if isinstance(raw_connections, dict) else []
+        if not app_ids and not tool_name:
             return None
         try:
             return self._validate_slot(
                 self.api_payloads.deployment_item_data,
-                {"app_ids": list(raw_connections.keys())},
+                {
+                    "app_ids": app_ids,
+                    "tool_name": tool_name,
+                },
             )
         except AdapterPayloadValidationError as exc:
             detail = exc.format_first_error()

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -10,7 +10,6 @@ from fastapi import HTTPException, status
 from lfx.services.adapters.deployment.schema import (
     BaseDeploymentData,
     BaseDeploymentDataUpdate,
-    ConfigListItem,
     ConfigListResult,
     DeploymentCreateResult,
     DeploymentListLlmsResult,
@@ -60,6 +59,7 @@ from langflow.api.v1.mappers.deployments.watsonx_orchestrate.payloads import (
     WatsonxApiAddFlowItem,
     WatsonxApiAgentExecutionCreateResultData,
     WatsonxApiAgentExecutionStatusResultData,
+    WatsonxApiConfigListItem,
     WatsonxApiConfigListProviderData,
     WatsonxApiCreatedTool,
     WatsonxApiCreateUpsertToolItem,
@@ -171,6 +171,10 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         ),
         config_list_result=PayloadSlot(
             adapter_model=WatsonxApiConfigListProviderData,
+            policy=PayloadSlotPolicy.VALIDATE_ONLY,
+        ),
+        config_item_data=PayloadSlot(
+            adapter_model=WatsonxApiConfigListItem,
             policy=PayloadSlotPolicy.VALIDATE_ONLY,
         ),
         snapshot_list_result=PayloadSlot(
@@ -1007,11 +1011,26 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             msg = "Watsonx config_list_result payload slot is not configured."
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
 
-        items_all = [self._shape_config_list_item(item) for item in result.configs]
+        items_all: list[WatsonxApiConfigListItem] = []
+        for item in result.configs:
+            if not isinstance(item.provider_data, dict):
+                msg = "Invalid config item provider_data payload: expected non-null object."
+                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
+            items_all.append(
+                self.shape_config_item_data(
+                    {
+                        **item.provider_data,
+                        "connection_id": item.id,
+                        "app_id": item.name,
+                    }
+                )
+            )
         total = len(items_all)
         offset = page_offset(page, size)
         provider_payload = {
-            "connections": items_all[offset : offset + size],
+            "connections": [
+                item.model_dump(mode="json", exclude_none=True) for item in items_all[offset : offset + size]
+            ],
             "page": page,
             "size": size,
             "total": total,
@@ -1232,23 +1251,14 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
                 detail=f"Invalid deployment list item provider_data payload: {detail}",
             ) from exc
 
-    def _shape_config_list_item(self, item: ConfigListItem) -> dict[str, Any]:
-        payload: dict[str, Any] = {
-            "connection_id": str(item.id).strip(),
-            "app_id": str(item.name).strip(),
-        }
-        item_provider_data = item.provider_data if isinstance(item.provider_data, dict) else {}
-        config_type = str(item_provider_data.get("type") or "").strip()
-        if not config_type:
-            msg = "Invalid config list item provider_data payload: expected non-empty 'type'."
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
-        payload["type"] = config_type
-        environment = str(item_provider_data.get("environment") or "").strip()
-        if not environment:
-            msg = "Invalid config list item provider_data payload: expected non-null and non-empty 'environment'."
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
-        payload["environment"] = environment
-        return payload
+    def shape_config_item_data(self, provider_data: dict[str, Any]) -> WatsonxApiConfigListItem:
+        return self._parse_required_payload_slot(
+            slot=self.api_payloads.config_item_data,
+            slot_name="config_item_data",
+            raw=provider_data,
+            missing_payload_detail="Config item provider_data payload is missing.",
+            malformed_payload_detail="Invalid config item provider_data payload:",
+        )
 
     def _parse_required_payload_slot(
         self,

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -1232,8 +1232,13 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         }
         item_provider_data = item.provider_data if isinstance(item.provider_data, dict) else {}
         config_type = str(item_provider_data.get("type") or "").strip()
-        if config_type:
-            payload["type"] = config_type
+        if not config_type:
+            msg = "Invalid config list item provider_data payload: expected non-empty 'type'."
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
+        payload["type"] = config_type
+        environment = str(item_provider_data.get("environment") or "").strip()
+        if environment:
+            payload["environment"] = environment
         return payload
 
     def _parse_required_payload_slot(

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -527,6 +527,7 @@ class WatsonxApiDeploymentFlowVersionItemData(BaseModel):
     model_config = {"extra": "forbid"}
 
     app_ids: list[str] = Field(default_factory=list)
+    tool_name: str | None = None
 
     @field_validator("app_ids", mode="before")
     @classmethod
@@ -534,6 +535,12 @@ class WatsonxApiDeploymentFlowVersionItemData(BaseModel):
         if value is None:
             return []
         return [str(app_id).strip() for app_id in value if str(app_id).strip()]
+
+    @field_validator("tool_name", mode="before")
+    @classmethod
+    def normalize_optional_tool_name(cls, value: Any) -> str | None:
+        normalized = str(value or "").strip()
+        return normalized or None
 
 
 class _WatsonxApiAgentExecutionResultBase(BaseModel):

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -12,7 +12,6 @@ from pydantic import (
     BaseModel,
     Field,
     StringConstraints,
-    ValidationInfo,
     field_validator,
     model_validator,
 )
@@ -20,6 +19,16 @@ from pydantic import (
 from langflow.api.v1.mappers.deployments.contracts import CreateFlowArtifactProviderData
 
 WatsonxApiLlmName = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+    ),
+]
+
+# Keep API-boundary scalar normalization local to this module instead of
+# importing adapter-layer aliases, so mapper contracts can evolve independently.
+NormalizedStr = Annotated[
     str,
     StringConstraints(
         strip_whitespace=True,
@@ -452,32 +461,10 @@ class WatsonxApiConfigListItem(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    connection_id: str = Field(min_length=1)
-    app_id: str = Field(min_length=1)
-    type: str | None = None
-    environment: str | None = None
-
-    @field_validator("connection_id", "app_id", mode="before")
-    @classmethod
-    def normalize_required_strings(cls, value: Any, info: ValidationInfo) -> str:
-        normalized = str(value or "").strip()
-        if not normalized:
-            field_name = str(info.field_name)
-            msg = f"Config list item field '{field_name}' must be a non-empty string."
-            raise ValueError(msg)
-        return normalized
-
-    @field_validator("type", mode="before")
-    @classmethod
-    def normalize_optional_type(cls, value: Any) -> str | None:
-        normalized = str(value or "").strip()
-        return normalized or None
-
-    @field_validator("environment", mode="before")
-    @classmethod
-    def normalize_optional_environment(cls, value: Any) -> str | None:
-        normalized = str(value or "").strip()
-        return normalized or None
+    connection_id: NormalizedStr
+    app_id: NormalizedStr
+    type: NormalizedStr
+    environment: NormalizedStr
 
 
 class WatsonxApiConfigListProviderData(BaseModel):
@@ -541,6 +528,16 @@ class WatsonxApiDeploymentFlowVersionItemData(BaseModel):
     def normalize_optional_tool_name(cls, value: Any) -> str | None:
         normalized = str(value or "").strip()
         return normalized or None
+
+
+class WatsonxApiRenameToolOperation(BaseModel):
+    """API-facing rename-tool operation payload."""
+
+    model_config = {"extra": "forbid"}
+
+    op: Literal["rename_tool"]
+    flow_version_id: str = Field(min_length=1)
+    tool_name: NormalizedStr = Field(min_length=1)
 
 
 class _WatsonxApiAgentExecutionResultBase(BaseModel):

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py
@@ -455,6 +455,7 @@ class WatsonxApiConfigListItem(BaseModel):
     connection_id: str = Field(min_length=1)
     app_id: str = Field(min_length=1)
     type: str | None = None
+    environment: str | None = None
 
     @field_validator("connection_id", "app_id", mode="before")
     @classmethod
@@ -469,6 +470,12 @@ class WatsonxApiConfigListItem(BaseModel):
     @field_validator("type", mode="before")
     @classmethod
     def normalize_optional_type(cls, value: Any) -> str | None:
+        normalized = str(value or "").strip()
+        return normalized or None
+
+    @field_validator("environment", mode="before")
+    @classmethod
+    def normalize_optional_environment(cls, value: Any) -> str | None:
         normalized = str(value or "").strip()
         return normalized or None
 

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -331,15 +331,15 @@ class DeploymentFlowVersionListItem(BaseModel):
     distinguishes the following cases:
 
     * **Tool renamed in provider** — Same ``provider_snapshot_id``, different
-      ``tool_name``.  Langflow picks up the new name on the next fetch.
+      ``provider_data.tool_name``.  Langflow picks up the new name on the next fetch.
     * **Tool deleted in provider** — ``provider_snapshot_id`` no longer
-      resolves.  ``tool_name`` and ``provider_data`` will be ``None``.
+      resolves.  ``provider_data.tool_name`` may be missing/``None``.
     * **Tool deleted + new tool created with same name** — The new tool has
       a different ID.  Langflow's attachment still points to the old
       (missing) ID.  The new tool is invisible to Langflow until explicitly
       attached via an update operation.
 
-    Frontends should use ``tool_name`` for display and
+    Frontends should use ``provider_data.tool_name`` for display and
     ``provider_snapshot_id`` for identity / operations.
     """
 
@@ -357,15 +357,6 @@ class DeploymentFlowVersionListItem(BaseModel):
     provider_snapshot_id: str | None = Field(
         default=None,
         description="Provider-owned snapshot/tool identifier linked by the attachment.",
-    )
-    tool_name: str | None = Field(
-        default=None,
-        description=(
-            "Provider tool name for this snapshot. May differ from ``flow_name`` "
-            "if the user set a custom name at deploy time or renamed the tool in "
-            "the provider console. ``None`` when the provider is unreachable or "
-            "the tool has been deleted — frontends should fall back to ``flow_name``."
-        ),
     )
     provider_data: dict[str, Any] | None = Field(
         default=None,

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/config.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/config.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from ibm_watsonx_orchestrate_clients.connections.connections_client import ListConfigsResponse
 from ibm_watsonx_orchestrate_core.types.connections import (
     ConnectionConfiguration,
     ConnectionEnvironment,
@@ -13,20 +14,44 @@ from ibm_watsonx_orchestrate_core.types.connections import (
     ConnectionSecurityScheme,
 )
 from lfx.services.adapters.deployment.exceptions import (
+    DeploymentNotFoundError,
     InvalidContentError,
     InvalidDeploymentOperationError,
 )
-from lfx.services.adapters.deployment.schema import ConfigItem, DeploymentConfig, IdLike
+from lfx.services.adapters.deployment.schema import (
+    ConfigItem,
+    ConfigListItem,
+    ConfigListParams,
+    ConfigListResult,
+    DeploymentConfig,
+    IdLike,
+)
+from lfx.services.adapters.payload import AdapterPayloadMissingError, AdapterPayloadValidationError, PayloadSlot
 
 from langflow.services.adapters.deployment.watsonx_orchestrate.client import resolve_runtime_credentials
-from langflow.services.adapters.deployment.watsonx_orchestrate.utils import validate_wxo_name
+from langflow.services.adapters.deployment.watsonx_orchestrate.constants import ErrorPrefix
+from langflow.services.adapters.deployment.watsonx_orchestrate.core.tools import extract_langflow_connections_binding
+from langflow.services.adapters.deployment.watsonx_orchestrate.utils import (
+    raise_as_deployment_error,
+    require_single_deployment_id,
+    validate_wxo_name,
+)
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from ibm_watsonx_orchestrate_clients.connections.connections_client import ConnectionsClient, GetConnectionResponse
+    from collections.abc import Iterable
+
+    from ibm_watsonx_orchestrate_clients.connections.connections_client import (
+        ConnectionsClient,
+        GetConnectionResponse,
+    )
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import (
+        WatsonxConfigItemProviderData,
+        WatsonxConfigListResultData,
+    )
     from langflow.services.adapters.deployment.watsonx_orchestrate.types import WxOClient
 
 
@@ -127,6 +152,285 @@ def resolve_create_app_id(
 
     normalized_config_name = validate_wxo_name(config.raw_payload.name)
     return f"{deployment_name}_{normalized_config_name}_app_id"
+
+
+def normalize_optional_text(value: str | None) -> str | None:
+    """Strip whitespace and return ``None`` for empty/blank strings."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        msg = f"normalize_optional_text: expected str | None, got {type(value).__name__}: {value!r}"
+        raise TypeError(msg)
+    normalized = value.strip()
+    return normalized or None
+
+
+def build_config_list_item(
+    *,
+    config_item_data_slot: PayloadSlot[WatsonxConfigItemProviderData],
+    connection_id: str,
+    app_id: str,
+    config_type: str | None = None,
+    environment: str | None = None,
+) -> ConfigListItem:
+    """Build a normalized config list item from resolved identifiers."""
+    try:
+        provider_data = config_item_data_slot.apply(
+            {
+                "type": config_type,
+                "environment": environment,
+            }
+        )
+    except (AdapterPayloadMissingError, AdapterPayloadValidationError) as exc:
+        detail = exc.format_first_error() if isinstance(exc, AdapterPayloadValidationError) else str(exc)
+        if normalize_optional_text(config_type) == "key_value_creds" and not normalize_optional_text(environment):
+            msg = (
+                "wxO returned a key_value_creds connection without a required environment: "
+                f"connection_id='{connection_id}', app_id='{app_id}'."
+            )
+        else:
+            msg = (
+                "wxO returned an invalid config item provider_data payload: "
+                f"connection_id='{connection_id}', app_id='{app_id}', detail='{detail}'."
+            )
+        raise InvalidContentError(message=msg) from None
+
+    return ConfigListItem(
+        id=connection_id,
+        name=app_id,
+        provider_data=provider_data,
+    )
+
+
+def warn_if_expected_ids_missing(
+    *,
+    deployment_id: str,
+    resource_name: str,
+    expected_ids: Iterable[object],
+    resolved_ids: set[object],
+) -> None:
+    missing_ids = [resource_id for resource_id in expected_ids if resource_id not in resolved_ids]
+    if missing_ids:
+        logger.warning(
+            "list_configs: deployment '%s' references %s IDs not returned by provider "
+            "(possibly stale/deleted between reads): %s",
+            deployment_id,
+            resource_name,
+            missing_ids,
+        )
+
+
+def _build_tenant_scope_config_items(
+    *,
+    raw_connections: list[ListConfigsResponse] | None,
+    config_item_data_slot: PayloadSlot[WatsonxConfigItemProviderData],
+) -> list[ConfigListItem]:
+    configs: list[ConfigListItem] = []
+    for connection in raw_connections or []:
+        if not isinstance(connection, ListConfigsResponse):
+            msg = f"wxO list_configs returned an unexpected connection entry type: {type(connection).__name__}."
+            raise InvalidContentError(message=msg)
+        config_id = connection.connection_id
+        config_name = connection.app_id
+        config_type = connection.security_scheme
+        if config_type != "key_value_creds":
+            continue
+        environment = getattr(connection, "environment", None)
+        configs.append(
+            build_config_list_item(
+                config_item_data_slot=config_item_data_slot,
+                connection_id=config_id,
+                app_id=config_name,
+                config_type=config_type,
+                environment=environment,
+            )
+        )
+    return configs
+
+
+def _collect_tool_connection_ids(
+    *,
+    tools: list[dict],
+) -> tuple[set[str], set[object]]:
+    all_tool_connection_ids: set[str] = set()
+    resolved_tool_ids: set[object] = set()
+    for tool in tools:
+        tool_id = tool.get("id")
+        resolved_tool_ids.add(tool_id)
+        connections = extract_langflow_connections_binding(tool)
+        all_tool_connection_ids.update(connections.values())
+    return all_tool_connection_ids, resolved_tool_ids
+
+
+def _build_deployment_scope_config_items(
+    *,
+    detailed_connections: list[object],
+    config_item_data_slot: PayloadSlot[WatsonxConfigItemProviderData],
+) -> tuple[list[ConfigListItem], set[object]]:
+    configs: list[ConfigListItem] = []
+    resolved_connection_ids: set[object] = set()
+    for connection in detailed_connections:
+        connection_id = connection.connection_id
+        resolved_connection_ids.add(connection_id)
+        config_type = getattr(connection, "security_scheme", None)
+        if config_type != "key_value_creds":
+            continue
+        configs.append(
+            build_config_list_item(
+                config_item_data_slot=config_item_data_slot,
+                connection_id=connection_id,
+                app_id=getattr(connection, "app_id", None),
+                config_type=config_type,
+                environment=getattr(connection, "environment", None),
+            )
+        )
+    return configs, resolved_connection_ids
+
+
+async def _fetch_deployment_agent_for_configs(
+    *,
+    clients: WxOClient,
+    agent_id: str,
+) -> dict[str, Any]:
+    try:
+        agent = await asyncio.to_thread(clients.agent.get_draft_by_id, agent_id)
+    except Exception as exc:  # noqa: BLE001
+        raise_as_deployment_error(
+            exc,
+            error_prefix=ErrorPrefix.LIST_CONFIGS,
+            log_msg="Unexpected error while listing wxO deployment configs",
+        )
+
+    if not agent:
+        msg = f"Deployment '{agent_id}' not found."
+        raise DeploymentNotFoundError(msg)
+    if not isinstance(agent, dict):
+        msg = f"wxO returned an unexpected deployment payload type for '{agent_id}': {type(agent).__name__}."
+        raise InvalidContentError(message=msg)
+    return agent
+
+
+async def _resolve_deployment_scope_configs(
+    *,
+    clients: WxOClient,
+    config_item_data_slot: PayloadSlot[WatsonxConfigItemProviderData],
+    agent_id: str,
+    tool_ids: object,
+) -> list[ConfigListItem]:
+    tools: list[dict]
+    try:
+        tools = await asyncio.to_thread(clients.tool.get_drafts_by_ids, tool_ids)
+    except Exception as exc:  # noqa: BLE001
+        raise_as_deployment_error(
+            exc,
+            error_prefix=ErrorPrefix.LIST_CONFIGS,
+            log_msg="Unexpected error while listing wxO tools for config extraction",
+        )
+
+    all_tool_connection_ids, resolved_tool_ids = _collect_tool_connection_ids(tools=tools)
+
+    warn_if_expected_ids_missing(
+        deployment_id=agent_id,
+        resource_name="tool",
+        expected_ids=tool_ids,
+        resolved_ids=resolved_tool_ids,
+    )
+
+    configs: list[ConfigListItem] = []
+    # duplication might occur given the list connections api returns
+    # two entries per app id, one for draft and one for live
+    connection_ids = list(all_tool_connection_ids)
+    if connection_ids:
+        try:
+            detailed_connections = await asyncio.to_thread(clients.connections.get_drafts_by_ids, connection_ids)
+        except Exception as exc:  # noqa: BLE001
+            raise_as_deployment_error(
+                exc,
+                error_prefix=ErrorPrefix.LIST_CONFIGS,
+                log_msg="Unexpected error while enriching wxO deployment configs with connection types",
+            )
+        else:
+            configs, resolved_connection_ids = _build_deployment_scope_config_items(
+                detailed_connections=detailed_connections,
+                config_item_data_slot=config_item_data_slot,
+            )
+            warn_if_expected_ids_missing(
+                deployment_id=agent_id,
+                resource_name="connection",
+                expected_ids=connection_ids,
+                resolved_ids=resolved_connection_ids,
+            )
+
+    return configs
+
+
+async def _list_deployment_scope_configs(
+    *,
+    clients: WxOClient,
+    params: ConfigListParams,
+    config_item_data_slot: PayloadSlot[WatsonxConfigItemProviderData],
+    config_list_result_slot: PayloadSlot[WatsonxConfigListResultData],
+) -> ConfigListResult:
+    agent_id = require_single_deployment_id(params, resource_label="config")
+    agent = await _fetch_deployment_agent_for_configs(clients=clients, agent_id=agent_id)
+
+    raw_tool_ids = agent.get("tools", [])
+    if raw_tool_ids is None:
+        raw_tool_ids = []
+    tool_ids = raw_tool_ids
+
+    if not tool_ids:
+        return ConfigListResult(
+            configs=[],
+            provider_result=config_list_result_slot.parse({"deployment_id": agent_id, "tool_ids": []}).model_dump(
+                exclude_none=True
+            ),
+        )
+
+    configs = await _resolve_deployment_scope_configs(
+        clients=clients,
+        config_item_data_slot=config_item_data_slot,
+        agent_id=agent_id,
+        tool_ids=tool_ids,
+    )
+
+    return ConfigListResult(
+        configs=configs,
+        provider_result=config_list_result_slot.parse({"deployment_id": agent_id}).model_dump(exclude_none=True),
+    )
+
+
+async def list_configs(
+    *,
+    clients: WxOClient,
+    params: ConfigListParams | None,
+    config_item_data_slot: PayloadSlot[WatsonxConfigItemProviderData],
+    config_list_result_slot: PayloadSlot[WatsonxConfigListResultData],
+) -> ConfigListResult:
+    if not params or not params.deployment_ids:
+        try:
+            raw_connections = await asyncio.to_thread(clients.connections.list)
+        except Exception as exc:  # noqa: BLE001
+            raise_as_deployment_error(
+                exc,
+                error_prefix=ErrorPrefix.LIST_CONFIGS,
+                log_msg="Unexpected error while listing wxO tenant configs",
+            )
+
+        return ConfigListResult(
+            configs=_build_tenant_scope_config_items(
+                raw_connections=raw_connections,
+                config_item_data_slot=config_item_data_slot,
+            ),
+            provider_result=config_list_result_slot.parse({}).model_dump(exclude_none=True),
+        )
+
+    return await _list_deployment_scope_configs(
+        clients=clients,
+        params=params,
+        config_item_data_slot=config_item_data_slot,
+        config_list_result_slot=config_list_result_slot,
+    )
 
 
 async def validate_connection(connections_client: ConnectionsClient, *, app_id: str) -> GetConnectionResponse:

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/payloads.py
@@ -11,6 +11,7 @@ from lfx.services.adapters.payload import AdapterPayload, PayloadSlot
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator, model_validator
 
 RawToolName = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+NormalizedStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
 class WatsonxFlowArtifactProviderData(BaseModel):
@@ -551,6 +552,7 @@ class WatsonxAgentExecutionResultData(BaseModel):
         default=None,
         description="WXO agent identifier (resource_key in Langflow DB).",
     )
+    thread_id: NormalizedId | None = None
     status: str | None = None
     result: Any | None = None
     started_at: str | None = None
@@ -582,6 +584,15 @@ class WatsonxSnapshotConnectionsProviderData(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     connections: dict[NormalizedId, NormalizedId] = Field(default_factory=dict)
+
+
+class WatsonxConfigItemProviderData(BaseModel):
+    """Provider data contract for config list items."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: NormalizedStr
+    environment: NormalizedStr
 
 
 class WatsonxConfigListResultData(BaseModel):
@@ -656,6 +667,7 @@ PAYLOAD_SCHEMAS = DeploymentPayloadSchemas(
     deployment_create=PayloadSlot(WatsonxDeploymentCreatePayload),
     flow_artifact=PayloadSlot(WatsonxFlowArtifactProviderData),
     snapshot_item_data=PayloadSlot(WatsonxSnapshotConnectionsProviderData),
+    config_item_data=PayloadSlot(WatsonxConfigItemProviderData),
     deployment_create_result=PayloadSlot(WatsonxDeploymentCreateResultData),
     deployment_update=PayloadSlot(WatsonxDeploymentUpdatePayload),
     deployment_update_result=PayloadSlot(WatsonxDeploymentUpdateResultData),

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -146,14 +146,37 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
         connection_id: str,
         app_id: str,
         config_type: str | None = None,
+        environment: str | None = None,
     ) -> ConfigListItem:
         """Build a normalized config list item from resolved identifiers."""
-        provider_data = {"type": config_type} if config_type else None
+        provider_data: dict[str, str] = {}
+        if config_type:
+            provider_data["type"] = config_type
+        if environment:
+            provider_data["environment"] = environment
         return ConfigListItem(
             id=connection_id,
             name=app_id,
-            provider_data=provider_data,
+            provider_data=provider_data or None,
         )
+
+    @staticmethod
+    def _warn_if_expected_ids_missing(
+        *,
+        deployment_id: str,
+        resource_name: str,
+        expected_ids: list[object],
+        resolved_ids: set[object],
+    ) -> None:
+        missing_ids = [resource_id for resource_id in expected_ids if resource_id not in resolved_ids]
+        if missing_ids:
+            logger.warning(
+                "list_configs: deployment '%s' references %s IDs not returned by provider "
+                "(possibly stale/deleted between reads): %s",
+                deployment_id,
+                resource_name,
+                missing_ids,
+            )
 
     @staticmethod
     def _normalize_optional_text(value: object | None) -> str | None:
@@ -747,11 +770,15 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                 config_id = connection.connection_id
                 config_name = connection.app_id
                 config_type = self._normalize_optional_text(connection.security_scheme)
+                if config_type != "key_value_creds":
+                    continue
+                environment = self._normalize_optional_text(getattr(connection, "environment", None))
                 configs.append(
                     self._build_config_list_item(
                         connection_id=config_id,
                         app_id=config_name,
                         config_type=config_type,
+                        environment=environment,
                     )
                 )
             return ConfigListResult(
@@ -772,9 +799,14 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
         if not agent:
             msg = f"Deployment '{agent_id}' not found."
             raise DeploymentNotFoundError(msg)
+        if not isinstance(agent, dict):
+            msg = f"wxO returned an unexpected deployment payload type for '{agent_id}': {type(agent).__name__}."
+            raise InvalidContentError(message=msg)
 
-        tool_ids = agent.get("tools", []) if isinstance(agent, dict) else []
-        tool_ids = dedupe_list(tool_ids)
+        raw_tool_ids = agent.get("tools", [])
+        if raw_tool_ids is None:
+            raw_tool_ids = []
+        tool_ids = raw_tool_ids
 
         if not tool_ids:
             return ConfigListResult(
@@ -796,37 +828,53 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             )
 
         app_to_connection_id: dict[str, str] = {}
-        for tool in tools or []:
-            if not isinstance(tool, dict):
-                continue
+        resolved_tool_ids: set[object] = set()
+        for tool in tools:
+            tool_id = tool.get("id")
+            resolved_tool_ids.add(tool_id)
             connections = extract_langflow_connections_binding(tool)
             if not connections:
                 continue
-            for app_id, connection_id in connections.items():
-                app_to_connection_id.setdefault(app_id, connection_id)
+            app_to_connection_id.update(connections)
 
-        connection_type_by_id: dict[str, str] = {}
-        connection_ids = dedupe_list(
-            [connection_id for connection_id in app_to_connection_id.values() if connection_id]
+        self._warn_if_expected_ids_missing(
+            deployment_id=agent_id,
+            resource_name="tool",
+            expected_ids=tool_ids,
+            resolved_ids=resolved_tool_ids,
         )
+
+        key_value_connection_ids: set[str] = set()
+        key_value_connection_environment_by_id: dict[str, str | None] = {}
+        # duplication might occur given the list connections api returns
+        # two entries per app id, one for draft and one for live
+        connection_ids = list(dict.fromkeys(app_to_connection_id.values()))
         if connection_ids:
             try:
                 detailed_connections = await asyncio.to_thread(clients.connections.get_drafts_by_ids, connection_ids)
             except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "list_configs: failed to enrich deployment configs with connection types",
-                    exc_info=exc,
+                raise_as_deployment_error(
+                    exc,
+                    error_prefix=ErrorPrefix.LIST_CONFIGS,
+                    log_msg="Unexpected error while enriching wxO deployment configs with connection types",
                 )
             else:
-                for connection in detailed_connections or []:
-                    if not isinstance(connection, ListConfigsResponse):
-                        continue
+                resolved_connection_ids: set[object] = set()
+                for connection in detailed_connections:
                     connection_id = connection.connection_id
-                    if not connection_id:
-                        continue
+                    resolved_connection_ids.add(connection_id)
                     config_type = self._normalize_optional_text(connection.security_scheme)
-                    if config_type:
-                        connection_type_by_id[connection_id] = config_type
+                    if config_type == "key_value_creds":
+                        key_value_connection_ids.add(connection_id)
+                        key_value_connection_environment_by_id[connection_id] = self._normalize_optional_text(
+                            getattr(connection, "environment", None)
+                        )
+                self._warn_if_expected_ids_missing(
+                    deployment_id=agent_id,
+                    resource_name="connection",
+                    expected_ids=connection_ids,
+                    resolved_ids=resolved_connection_ids,
+                )
 
         # Preserve first-seen binding order (tool order + per-tool connection order)
         # instead of re-sorting app_ids alphabetically.
@@ -834,9 +882,11 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             self._build_config_list_item(
                 connection_id=connection_id,
                 app_id=app_id,
-                config_type=connection_type_by_id.get(connection_id),
+                config_type="key_value_creds",
+                environment=key_value_connection_environment_by_id.get(connection_id),
             )
             for app_id, connection_id in app_to_connection_id.items()
+            if connection_id in key_value_connection_ids
         ]
 
         return ConfigListResult(

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -179,6 +179,16 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             )
 
     @staticmethod
+    def _require_non_empty_config_environment(*, connection_id: str, app_id: str, environment: str | None) -> str:
+        if environment:
+            return environment
+        msg = (
+            "wxO returned a key_value_creds connection without a required environment: "
+            f"connection_id='{connection_id}', app_id='{app_id}'."
+        )
+        raise InvalidContentError(message=msg)
+
+    @staticmethod
     def _normalize_optional_text(value: object | None) -> str | None:
         """Normalize SDK scalar/enum/tuple values to optional text.
 
@@ -772,7 +782,11 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                 config_type = self._normalize_optional_text(connection.security_scheme)
                 if config_type != "key_value_creds":
                     continue
-                environment = self._normalize_optional_text(getattr(connection, "environment", None))
+                environment = self._require_non_empty_config_environment(
+                    connection_id=config_id,
+                    app_id=config_name,
+                    environment=self._normalize_optional_text(getattr(connection, "environment", None)),
+                )
                 configs.append(
                     self._build_config_list_item(
                         connection_id=config_id,
@@ -865,9 +879,14 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                     resolved_connection_ids.add(connection_id)
                     config_type = self._normalize_optional_text(connection.security_scheme)
                     if config_type == "key_value_creds":
+                        app_id = self._normalize_optional_text(connection.app_id) or "<unknown>"
                         key_value_connection_ids.add(connection_id)
                         key_value_connection_environment_by_id[connection_id] = self._normalize_optional_text(
-                            getattr(connection, "environment", None)
+                            self._require_non_empty_config_environment(
+                                connection_id=connection_id,
+                                app_id=app_id,
+                                environment=self._normalize_optional_text(getattr(connection, "environment", None)),
+                            )
                         )
                 self._warn_if_expected_ids_missing(
                     deployment_id=agent_id,

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
 from ibm_cloud_sdk_core import ApiException
-from ibm_watsonx_orchestrate_clients.connections.connections_client import ListConfigsResponse
 from ibm_watsonx_orchestrate_clients.tools.tool_client import ClientAPIException
 from lfx.services.adapters.deployment.base import BaseDeploymentService
 from lfx.services.adapters.deployment.exceptions import (
@@ -29,7 +28,6 @@ from lfx.services.adapters.deployment.exceptions import (
 from lfx.services.adapters.deployment.schema import (
     BaseDeploymentData,
     BaseFlowArtifact,
-    ConfigListItem,
     ConfigListParams,
     ConfigListResult,
     DeploymentCreate,
@@ -64,6 +62,9 @@ from langflow.services.adapters.deployment.watsonx_orchestrate.client import get
 from langflow.services.adapters.deployment.watsonx_orchestrate.constants import (
     SUPPORTED_ADAPTER_DEPLOYMENT_TYPES,
     ErrorPrefix,
+)
+from langflow.services.adapters.deployment.watsonx_orchestrate.core.config import (
+    list_configs as list_adapter_configs,
 )
 from langflow.services.adapters.deployment.watsonx_orchestrate.core.create import (
     apply_provider_create_plan_with_rollback,
@@ -104,11 +105,11 @@ from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import (
     WatsonxDeploymentUpdateResultData,
 )
 from langflow.services.adapters.deployment.watsonx_orchestrate.utils import (
-    _require_single_deployment_id,
     dedupe_list,
     extract_agent_tool_ids,
     extract_error_detail,
     raise_as_deployment_error,
+    require_single_deployment_id,
 )
 from langflow.services.deps import get_settings_service
 
@@ -139,82 +140,6 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             raise RuntimeError(msg)
         self.settings_service = settings_service
         self.set_ready()
-
-    @staticmethod
-    def _build_config_list_item(
-        *,
-        connection_id: str,
-        app_id: str,
-        config_type: str | None = None,
-        environment: str | None = None,
-    ) -> ConfigListItem:
-        """Build a normalized config list item from resolved identifiers."""
-        provider_data: dict[str, str] = {}
-        if config_type:
-            provider_data["type"] = config_type
-        if environment:
-            provider_data["environment"] = environment
-        return ConfigListItem(
-            id=connection_id,
-            name=app_id,
-            provider_data=provider_data or None,
-        )
-
-    @staticmethod
-    def _warn_if_expected_ids_missing(
-        *,
-        deployment_id: str,
-        resource_name: str,
-        expected_ids: list[object],
-        resolved_ids: set[object],
-    ) -> None:
-        missing_ids = [resource_id for resource_id in expected_ids if resource_id not in resolved_ids]
-        if missing_ids:
-            logger.warning(
-                "list_configs: deployment '%s' references %s IDs not returned by provider "
-                "(possibly stale/deleted between reads): %s",
-                deployment_id,
-                resource_name,
-                missing_ids,
-            )
-
-    @staticmethod
-    def _require_non_empty_config_environment(*, connection_id: str, app_id: str, environment: str | None) -> str:
-        if environment:
-            return environment
-        msg = (
-            "wxO returned a key_value_creds connection without a required environment: "
-            f"connection_id='{connection_id}', app_id='{app_id}'."
-        )
-        raise InvalidContentError(message=msg)
-
-    @staticmethod
-    def _normalize_optional_text(value: object | None) -> str | None:
-        """Normalize SDK scalar/enum/tuple values to optional text.
-
-        Guards against two quirks in the upstream SDK model definitions:
-
-        * **Tuple defaults** - Several ``ListConfigsResponse`` fields are
-          declared with trailing commas (e.g. ``security_scheme: ... = None,``)
-          which makes the Python default ``(None,)`` instead of ``None``.
-          Pydantic coerces this away when the field *is* supplied, but we
-          unwrap single-element tuples defensively in case a future SDK
-          version or edge case surfaces the raw default.
-        * **str-Enum coercion** - ``ConnectionSecurityScheme(str, Enum)``
-          inherits from ``str``, yet ``str()`` returns the class-qualified
-          name (``"ConnectionSecurityScheme.KEY_VALUE"``) in Python 3.11+.
-          Extracting ``.value`` yields the raw string we need.
-        """
-        if isinstance(value, tuple):
-            if len(value) == 1:
-                value = value[0]
-            else:
-                logger.debug("_normalize_optional_text: ignoring multi-element tuple: %s", value)
-                return None
-        if hasattr(value, "value"):
-            value = value.value
-        normalized = str(value or "").strip()
-        return normalized or None
 
     async def _get_provider_clients(self, *, user_id: IdLike, db: AsyncSession) -> WxOClient:
         """Resolve provider clients through a service-level seam.
@@ -762,157 +687,11 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
     ) -> ConfigListResult:
         """List configs visible to this adapter."""
         clients = await self._get_provider_clients(user_id=user_id, db=db)
-        if not params or not params.deployment_ids:
-            try:
-                raw_connections = await asyncio.to_thread(clients.connections.list)
-            except Exception as exc:  # noqa: BLE001
-                raise_as_deployment_error(
-                    exc,
-                    error_prefix=ErrorPrefix.LIST_CONFIGS,
-                    log_msg="Unexpected error while listing wxO tenant configs",
-                )
-
-            configs: list[ConfigListItem] = []
-            for connection in raw_connections or []:
-                if not isinstance(connection, ListConfigsResponse):
-                    msg = f"wxO list_configs returned an unexpected connection entry type: {type(connection).__name__}."
-                    raise InvalidContentError(message=msg)
-                config_id = connection.connection_id
-                config_name = connection.app_id
-                config_type = self._normalize_optional_text(connection.security_scheme)
-                if config_type != "key_value_creds":
-                    continue
-                environment = self._require_non_empty_config_environment(
-                    connection_id=config_id,
-                    app_id=config_name,
-                    environment=self._normalize_optional_text(getattr(connection, "environment", None)),
-                )
-                configs.append(
-                    self._build_config_list_item(
-                        connection_id=config_id,
-                        app_id=config_name,
-                        config_type=config_type,
-                        environment=environment,
-                    )
-                )
-            return ConfigListResult(
-                configs=configs,
-                provider_result=self.payload_schemas.config_list_result.parse({}).model_dump(exclude_none=True),
-            )
-
-        agent_id = _require_single_deployment_id(params, resource_label="config")
-        try:
-            agent = await asyncio.to_thread(clients.agent.get_draft_by_id, agent_id)
-        except Exception as exc:  # noqa: BLE001
-            raise_as_deployment_error(
-                exc,
-                error_prefix=ErrorPrefix.LIST_CONFIGS,
-                log_msg="Unexpected error while listing wxO deployment configs",
-            )
-
-        if not agent:
-            msg = f"Deployment '{agent_id}' not found."
-            raise DeploymentNotFoundError(msg)
-        if not isinstance(agent, dict):
-            msg = f"wxO returned an unexpected deployment payload type for '{agent_id}': {type(agent).__name__}."
-            raise InvalidContentError(message=msg)
-
-        raw_tool_ids = agent.get("tools", [])
-        if raw_tool_ids is None:
-            raw_tool_ids = []
-        tool_ids = raw_tool_ids
-
-        if not tool_ids:
-            return ConfigListResult(
-                configs=[],
-                provider_result=self.payload_schemas.config_list_result.parse(
-                    {"deployment_id": agent_id, "tool_ids": []}
-                ).model_dump(exclude_none=True),
-            )
-
-        tools: list[dict]
-
-        try:
-            tools = await asyncio.to_thread(clients.tool.get_drafts_by_ids, tool_ids)
-        except Exception as exc:  # noqa: BLE001
-            raise_as_deployment_error(
-                exc,
-                error_prefix=ErrorPrefix.LIST_CONFIGS,
-                log_msg="Unexpected error while listing wxO tools for config extraction",
-            )
-
-        app_to_connection_id: dict[str, str] = {}
-        resolved_tool_ids: set[object] = set()
-        for tool in tools:
-            tool_id = tool.get("id")
-            resolved_tool_ids.add(tool_id)
-            connections = extract_langflow_connections_binding(tool)
-            if not connections:
-                continue
-            app_to_connection_id.update(connections)
-
-        self._warn_if_expected_ids_missing(
-            deployment_id=agent_id,
-            resource_name="tool",
-            expected_ids=tool_ids,
-            resolved_ids=resolved_tool_ids,
-        )
-
-        key_value_connection_ids: set[str] = set()
-        key_value_connection_environment_by_id: dict[str, str | None] = {}
-        # duplication might occur given the list connections api returns
-        # two entries per app id, one for draft and one for live
-        connection_ids = list(dict.fromkeys(app_to_connection_id.values()))
-        if connection_ids:
-            try:
-                detailed_connections = await asyncio.to_thread(clients.connections.get_drafts_by_ids, connection_ids)
-            except Exception as exc:  # noqa: BLE001
-                raise_as_deployment_error(
-                    exc,
-                    error_prefix=ErrorPrefix.LIST_CONFIGS,
-                    log_msg="Unexpected error while enriching wxO deployment configs with connection types",
-                )
-            else:
-                resolved_connection_ids: set[object] = set()
-                for connection in detailed_connections:
-                    connection_id = connection.connection_id
-                    resolved_connection_ids.add(connection_id)
-                    config_type = self._normalize_optional_text(connection.security_scheme)
-                    if config_type == "key_value_creds":
-                        app_id = self._normalize_optional_text(connection.app_id) or "<unknown>"
-                        key_value_connection_ids.add(connection_id)
-                        key_value_connection_environment_by_id[connection_id] = self._normalize_optional_text(
-                            self._require_non_empty_config_environment(
-                                connection_id=connection_id,
-                                app_id=app_id,
-                                environment=self._normalize_optional_text(getattr(connection, "environment", None)),
-                            )
-                        )
-                self._warn_if_expected_ids_missing(
-                    deployment_id=agent_id,
-                    resource_name="connection",
-                    expected_ids=connection_ids,
-                    resolved_ids=resolved_connection_ids,
-                )
-
-        # Preserve first-seen binding order (tool order + per-tool connection order)
-        # instead of re-sorting app_ids alphabetically.
-        configs = [
-            self._build_config_list_item(
-                connection_id=connection_id,
-                app_id=app_id,
-                config_type="key_value_creds",
-                environment=key_value_connection_environment_by_id.get(connection_id),
-            )
-            for app_id, connection_id in app_to_connection_id.items()
-            if connection_id in key_value_connection_ids
-        ]
-
-        return ConfigListResult(
-            configs=configs,
-            provider_result=self.payload_schemas.config_list_result.parse({"deployment_id": agent_id}).model_dump(
-                exclude_none=True
-            ),
+        return await list_adapter_configs(
+            clients=clients,
+            params=params,
+            config_item_data_slot=self.payload_schemas.config_item_data,
+            config_list_result_slot=self.payload_schemas.config_list_result,
         )
 
     async def list_snapshots(
@@ -971,7 +750,7 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                 provider_result=self.payload_schemas.snapshot_list_result.parse({}).model_dump(exclude_none=True),
             )
 
-        agent_id = _require_single_deployment_id(params, resource_label="snapshot")
+        agent_id = require_single_deployment_id(params, resource_label="snapshot")
 
         try:
             agent = await asyncio.to_thread(clients.agent.get_draft_by_id, agent_id)

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/utils.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/utils.py
@@ -69,7 +69,7 @@ def normalize_and_dedupe_ids(values: list[Any] | None, *, field_name: str) -> li
     return dedupe_list([_normalize_and_validate_id(str(value), field_name=field_name) for value in values])
 
 
-def _require_single_deployment_id(
+def require_single_deployment_id(
     params: ConfigListParams | SnapshotListParams | None,
     *,
     resource_label: str,

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -387,7 +387,7 @@ def test_watsonx_mapper_shapes_config_list_result_with_full_slot_validation() ->
                 updated_at=now,
                 provider_data={"type": "key_value_creds"},
             ),
-            ConfigListItem(id="conn-2", name="cfg-2"),
+            ConfigListItem(id="conn-2", name="cfg-2", provider_data={"type": "key_value_creds"}),
         ],
         provider_result={"deployment_id": " dep-1 ", "tool_ids": ["tool-1", "  "]},
     )
@@ -414,7 +414,27 @@ def test_watsonx_mapper_shapes_config_list_result_with_full_slot_validation() ->
     }
 
 
-def test_watsonx_mapper_config_list_accepts_items_without_type() -> None:
+def test_watsonx_mapper_shapes_config_list_result_with_environment_metadata() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    result = ConfigListResult(
+        configs=[
+            ConfigListItem(
+                id="conn-1",
+                name="cfg-1",
+                provider_data={"type": "key_value_creds", "environment": "live"},
+            ),
+        ],
+        provider_result={},
+    )
+
+    shaped = mapper.shape_config_list_result(result, page=1, size=10)
+    assert shaped.provider_data is not None
+    assert shaped.provider_data["connections"] == [
+        {"connection_id": "conn-1", "app_id": "cfg-1", "type": "key_value_creds", "environment": "live"}
+    ]
+
+
+def test_watsonx_mapper_config_list_fails_fast_when_type_missing() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     result = ConfigListResult(
         configs=[
@@ -427,16 +447,17 @@ def test_watsonx_mapper_config_list_accepts_items_without_type() -> None:
         provider_result={},
     )
 
-    shaped = mapper.shape_config_list_result(result, page=1, size=10)
-    assert shaped.provider_data is not None
-    assert shaped.provider_data["connections"] == [{"connection_id": "conn-bad", "app_id": "cfg-bad"}]
+    with pytest.raises(HTTPException) as exc_info:
+        mapper.shape_config_list_result(result, page=1, size=10)
+    assert exc_info.value.status_code == 500
+    assert "expected non-empty 'type'" in str(exc_info.value.detail)
 
 
-def test_watsonx_mapper_config_list_exposes_connection_id_and_app_id() -> None:
+def test_watsonx_mapper_config_list_exposes_connection_id_app_id_and_type() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     result = ConfigListResult(
         configs=[
-            ConfigListItem(id="conn-dep", name="cfg-dep"),
+            ConfigListItem(id="conn-dep", name="cfg-dep", provider_data={"type": "key_value_creds"}),
         ],
         provider_result={},
     )
@@ -449,10 +470,11 @@ def test_watsonx_mapper_config_list_exposes_connection_id_and_app_id() -> None:
     assert shaped.provider_data["connections"][0] == {
         "connection_id": "conn-dep",
         "app_id": "cfg-dep",
+        "type": "key_value_creds",
     }
 
 
-def test_watsonx_mapper_config_list_ignores_unexpected_provider_data_keys() -> None:
+def test_watsonx_mapper_config_list_rejects_missing_type_even_with_other_provider_data() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
     result = ConfigListResult(
         configs=[
@@ -465,9 +487,10 @@ def test_watsonx_mapper_config_list_ignores_unexpected_provider_data_keys() -> N
         provider_result={},
     )
 
-    shaped = mapper.shape_config_list_result(result, page=1, size=10)
-    assert shaped.provider_data is not None
-    assert shaped.provider_data["connections"] == [{"connection_id": "conn-1", "app_id": "cfg-1"}]
+    with pytest.raises(HTTPException) as exc_info:
+        mapper.shape_config_list_result(result, page=1, size=10)
+    assert exc_info.value.status_code == 500
+    assert "expected non-empty 'type'" in str(exc_info.value.detail)
 
 
 def test_watsonx_mapper_shapes_snapshot_list_result_without_nested_provider_data() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -392,9 +392,9 @@ def test_watsonx_mapper_shapes_config_list_result_with_full_slot_validation() ->
                 name="cfg-1",
                 created_at=now,
                 updated_at=now,
-                provider_data={"type": "key_value_creds"},
+                provider_data={"type": "key_value_creds", "environment": "draft"},
             ),
-            ConfigListItem(id="conn-2", name="cfg-2", provider_data={"type": "key_value_creds"}),
+            ConfigListItem(id="conn-2", name="cfg-2", provider_data={"type": "key_value_creds", "environment": "live"}),
         ],
         provider_result={"deployment_id": " dep-1 ", "tool_ids": ["tool-1", "  "]},
     )
@@ -414,10 +414,12 @@ def test_watsonx_mapper_shapes_config_list_result_with_full_slot_validation() ->
     assert shaped.provider_data["connections"][0]["app_id"] == "cfg-1"
     assert shaped.provider_data["connections"][0]["connection_id"] == "conn-1"
     assert shaped.provider_data["connections"][0]["type"] == "key_value_creds"
+    assert shaped.provider_data["connections"][0]["environment"] == "draft"
     assert set(shaped.provider_data["connections"][0].keys()) == {
         "app_id",
         "connection_id",
         "type",
+        "environment",
     }
 
 
@@ -464,7 +466,11 @@ def test_watsonx_mapper_config_list_exposes_connection_id_app_id_and_type() -> N
     mapper = WatsonxOrchestrateDeploymentMapper()
     result = ConfigListResult(
         configs=[
-            ConfigListItem(id="conn-dep", name="cfg-dep", provider_data={"type": "key_value_creds"}),
+            ConfigListItem(
+                id="conn-dep",
+                name="cfg-dep",
+                provider_data={"type": "key_value_creds", "environment": "draft"},
+            ),
         ],
         provider_result={},
     )
@@ -478,7 +484,27 @@ def test_watsonx_mapper_config_list_exposes_connection_id_app_id_and_type() -> N
         "connection_id": "conn-dep",
         "app_id": "cfg-dep",
         "type": "key_value_creds",
+        "environment": "draft",
     }
+
+
+def test_watsonx_mapper_config_list_fails_fast_when_environment_missing() -> None:
+    mapper = WatsonxOrchestrateDeploymentMapper()
+    result = ConfigListResult(
+        configs=[
+            ConfigListItem(
+                id="conn-no-env",
+                name="cfg-no-env",
+                provider_data={"type": "key_value_creds"},
+            ),
+        ],
+        provider_result={},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        mapper.shape_config_list_result(result, page=1, size=10)
+    assert exc_info.value.status_code == 500
+    assert "expected non-null and non-empty 'environment'" in str(exc_info.value.detail)
 
 
 def test_watsonx_mapper_config_list_rejects_missing_type_even_with_other_provider_data() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -229,18 +229,25 @@ def test_watsonx_mapper_formats_conflict_detail(raw_message: str, expected: str)
 def test_watsonx_mapper_shapes_flow_version_item_data_from_connections() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
 
-    shaped = mapper.shape_deployment_flow_version_item_data({"connections": {"cfg-1": "conn-1", "cfg-2": "conn-2"}})
+    shaped = mapper.shape_deployment_flow_version_item_data(
+        snapshot_data={"connections": {"cfg-1": "conn-1", "cfg-2": "conn-2"}},
+        tool_name="Tool 1",
+    )
 
-    assert shaped == {"app_ids": ["cfg-1", "cfg-2"]}
+    assert shaped == {"app_ids": ["cfg-1", "cfg-2"], "tool_name": "Tool 1"}
 
 
 def test_watsonx_mapper_flow_version_item_data_handles_missing_invalid_and_empty_connections() -> None:
     mapper = WatsonxOrchestrateDeploymentMapper()
 
-    assert mapper.shape_deployment_flow_version_item_data(None) is None
-    assert mapper.shape_deployment_flow_version_item_data({}) is None
-    assert mapper.shape_deployment_flow_version_item_data({"connections": []}) is None
-    assert mapper.shape_deployment_flow_version_item_data({"connections": {}}) == {"app_ids": []}
+    assert mapper.shape_deployment_flow_version_item_data(snapshot_data=None) is None
+    assert mapper.shape_deployment_flow_version_item_data(snapshot_data={}) is None
+    assert mapper.shape_deployment_flow_version_item_data(snapshot_data={"connections": []}) is None
+    assert mapper.shape_deployment_flow_version_item_data(snapshot_data={"connections": {}}) is None
+    assert mapper.shape_deployment_flow_version_item_data(snapshot_data=None, tool_name="Tool 1") == {
+        "app_ids": [],
+        "tool_name": "Tool 1",
+    }
 
 
 def test_watsonx_mapper_shapes_flow_version_list_result_with_enrichment() -> None:
@@ -282,7 +289,7 @@ def test_watsonx_mapper_shapes_flow_version_list_result_with_enrichment() -> Non
     assert shaped.flow_versions[0].version_number == 3
     assert shaped.flow_versions[0].attached_at == attached_at
     assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
-    assert shaped.flow_versions[0].provider_data == {"app_ids": ["cfg-1"]}
+    assert shaped.flow_versions[0].provider_data == {"app_ids": ["cfg-1"], "tool_name": "Tool 1"}
 
 
 def test_watsonx_mapper_flow_version_list_result_returns_empty_app_ids_when_snapshot_has_no_connections() -> None:
@@ -315,7 +322,7 @@ def test_watsonx_mapper_flow_version_list_result_returns_empty_app_ids_when_snap
     assert shaped.total == 1
     assert len(shaped.flow_versions) == 1
     assert shaped.flow_versions[0].provider_snapshot_id == "tool-1"
-    assert shaped.flow_versions[0].provider_data == {"app_ids": []}
+    assert shaped.flow_versions[0].provider_data == {"app_ids": [], "tool_name": "Tool 1"}
 
 
 def test_watsonx_mapper_flow_version_list_result_degrades_when_snapshot_result_missing() -> None:

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -82,6 +82,7 @@ def test_watsonx_mapper_is_registered() -> None:
     assert mapper.api_payloads.deployment_update is not None
     assert mapper.api_payloads.deployment_update_result is not None
     assert mapper.api_payloads.config_list_result is not None
+    assert mapper.api_payloads.config_item_data is not None
     assert mapper.api_payloads.snapshot_list_result is not None
 
 
@@ -459,7 +460,9 @@ def test_watsonx_mapper_config_list_fails_fast_when_type_missing() -> None:
     with pytest.raises(HTTPException) as exc_info:
         mapper.shape_config_list_result(result, page=1, size=10)
     assert exc_info.value.status_code == 500
-    assert "expected non-empty 'type'" in str(exc_info.value.detail)
+    detail = str(exc_info.value.detail)
+    assert "Invalid config item provider_data payload:" in detail
+    assert "'type'" in detail
 
 
 def test_watsonx_mapper_config_list_exposes_connection_id_app_id_and_type() -> None:
@@ -504,7 +507,9 @@ def test_watsonx_mapper_config_list_fails_fast_when_environment_missing() -> Non
     with pytest.raises(HTTPException) as exc_info:
         mapper.shape_config_list_result(result, page=1, size=10)
     assert exc_info.value.status_code == 500
-    assert "expected non-null and non-empty 'environment'" in str(exc_info.value.detail)
+    detail = str(exc_info.value.detail)
+    assert "Invalid config item provider_data payload:" in detail
+    assert "'environment'" in detail
 
 
 def test_watsonx_mapper_config_list_rejects_missing_type_even_with_other_provider_data() -> None:
@@ -523,7 +528,9 @@ def test_watsonx_mapper_config_list_rejects_missing_type_even_with_other_provide
     with pytest.raises(HTTPException) as exc_info:
         mapper.shape_config_list_result(result, page=1, size=10)
     assert exc_info.value.status_code == 500
-    assert "expected non-empty 'type'" in str(exc_info.value.detail)
+    detail = str(exc_info.value.detail)
+    assert "Invalid config item provider_data payload:" in detail
+    assert "'type'" in detail
 
 
 def test_watsonx_mapper_shapes_snapshot_list_result_without_nested_provider_data() -> None:

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -2904,7 +2904,7 @@ async def test_create_execution_posts_runs_payload(monkeypatch):
 
     assert result.deployment_id == "dep-1"
     assert result.execution_id == "run-1"
-    assert result.provider_result == {"status": "accepted", "execution_id": "run-1"}
+    assert result.provider_result == {"status": "accepted", "execution_id": "run-1", "thread_id": "thread-1"}
     assert fake_base.post_calls
     path, payload = fake_base.post_calls[0]
     assert path == "/runs"
@@ -5443,6 +5443,124 @@ def test_extract_agent_tool_ids():
 
 
 # ---------------------------------------------------------------------------
+# Config helper unit tests (core/config.py standalone functions)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_optional_text_strips_and_returns_none_for_empty():
+    from langflow.services.adapters.deployment.watsonx_orchestrate.core.config import normalize_optional_text
+
+    assert normalize_optional_text(None) is None
+    assert normalize_optional_text("") is None
+    assert normalize_optional_text("  ") is None
+    assert normalize_optional_text("hello") == "hello"
+    assert normalize_optional_text("  spaced  ") == "spaced"
+
+
+def test_normalize_optional_text_rejects_non_str():
+    from langflow.services.adapters.deployment.watsonx_orchestrate.core.config import normalize_optional_text
+
+    with pytest.raises(TypeError, match=r"expected str \| None"):
+        normalize_optional_text(("value",))
+    with pytest.raises(TypeError, match=r"expected str \| None"):
+        normalize_optional_text(42)
+
+
+def test_normalize_optional_text_handles_str_enum():
+    from enum import Enum
+
+    from langflow.services.adapters.deployment.watsonx_orchestrate.core.config import normalize_optional_text
+
+    class FakeEnum(str, Enum):
+        KEY_VALUE = "key_value_creds"
+
+    assert normalize_optional_text(FakeEnum.KEY_VALUE) == "key_value_creds"
+
+
+def test_build_config_list_item_valid():
+    from langflow.services.adapters.deployment.watsonx_orchestrate.core.config import build_config_list_item
+    from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import WatsonxConfigItemProviderData
+    from lfx.services.adapters.payload import PayloadSlot
+
+    slot = PayloadSlot(WatsonxConfigItemProviderData)
+    item = build_config_list_item(
+        config_item_data_slot=slot,
+        connection_id="conn-1",
+        app_id="app-1",
+        config_type="key_value_creds",
+        environment="draft",
+    )
+    assert item.id == "conn-1"
+    assert item.name == "app-1"
+    assert isinstance(item.provider_data, dict)
+    assert item.provider_data["type"] == "key_value_creds"
+    assert item.provider_data["environment"] == "draft"
+
+
+def test_build_config_list_item_missing_environment_for_key_value_creds():
+    from langflow.services.adapters.deployment.watsonx_orchestrate.core.config import build_config_list_item
+    from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import WatsonxConfigItemProviderData
+    from lfx.services.adapters.payload import PayloadSlot
+
+    slot = PayloadSlot(WatsonxConfigItemProviderData)
+    with pytest.raises(InvalidContentError, match="key_value_creds connection without a required environment"):
+        build_config_list_item(
+            config_item_data_slot=slot,
+            connection_id="conn-1",
+            app_id="app-1",
+            config_type="key_value_creds",
+            environment=None,
+        )
+
+
+def test_build_config_list_item_invalid_payload():
+    from langflow.services.adapters.deployment.watsonx_orchestrate.core.config import build_config_list_item
+    from langflow.services.adapters.deployment.watsonx_orchestrate.payloads import WatsonxConfigItemProviderData
+    from lfx.services.adapters.payload import PayloadSlot
+
+    slot = PayloadSlot(WatsonxConfigItemProviderData)
+    with pytest.raises(InvalidContentError, match="invalid config item provider_data payload"):
+        build_config_list_item(
+            config_item_data_slot=slot,
+            connection_id="conn-1",
+            app_id="app-1",
+            config_type="unknown_type",
+            environment=None,
+        )
+
+
+def test_warn_if_expected_ids_missing_logs_warning(caplog):
+    import logging
+
+    from langflow.services.adapters.deployment.watsonx_orchestrate.core.config import warn_if_expected_ids_missing
+
+    with caplog.at_level(logging.WARNING):
+        warn_if_expected_ids_missing(
+            deployment_id="dep-1",
+            resource_name="tool",
+            expected_ids=["t1", "t2", "t3"],
+            resolved_ids={"t1"},
+        )
+    assert "t2" in caplog.text
+    assert "t3" in caplog.text
+
+
+def test_warn_if_expected_ids_missing_no_warning_when_all_resolved(caplog):
+    import logging
+
+    from langflow.services.adapters.deployment.watsonx_orchestrate.core.config import warn_if_expected_ids_missing
+
+    with caplog.at_level(logging.WARNING):
+        warn_if_expected_ids_missing(
+            deployment_id="dep-1",
+            resource_name="tool",
+            expected_ids=["t1", "t2"],
+            resolved_ids={"t1", "t2"},
+        )
+    assert "list_configs" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
 # Execution helper tests
 # ---------------------------------------------------------------------------
 
@@ -5795,7 +5913,7 @@ async def test_create_maps_409_conflict_to_deployment_conflict_error():
                 response=SimpleNamespace(status_code=409, text='{"detail":"already exists"}')
             ),
         ),
-        tool=FakeToolClient([{"id": "tool-existing-1"}]),
+        tool=FakeToolClient([{"id": "tool-existing-1", "binding": {"langflow": {}}}]),
         connections=FakeConnectionsClient(existing_app_id="app-existing-1"),
     )
     _attach_provider_clients(service, clients)
@@ -5828,7 +5946,7 @@ async def test_create_maps_422_to_invalid_content_error():
                 response=SimpleNamespace(status_code=422, text='{"detail":"validation error"}')
             ),
         ),
-        tool=FakeToolClient([{"id": "tool-existing-1"}]),
+        tool=FakeToolClient([{"id": "tool-existing-1", "binding": {"langflow": {}}}]),
         connections=FakeConnectionsClient(existing_app_id="app-existing-1"),
     )
     _attach_provider_clients(service, clients)
@@ -6083,17 +6201,17 @@ def test_create_agent_run_result_falls_back_to_id_field():
 
 
 # ---------------------------------------------------------------------------
-# Additional coverage: _require_single_deployment_id — multiple IDs
+# Additional coverage: require_single_deployment_id — multiple IDs
 # ---------------------------------------------------------------------------
 
 
 def test_require_single_deployment_id_rejects_multiple_ids():
-    """_require_single_deployment_id raises InvalidContentError for multiple IDs."""
-    from langflow.services.adapters.deployment.watsonx_orchestrate.utils import _require_single_deployment_id
+    """require_single_deployment_id raises InvalidContentError for multiple IDs."""
+    from langflow.services.adapters.deployment.watsonx_orchestrate.utils import require_single_deployment_id
 
     params = ConfigListParams(deployment_ids=["id-1", "id-2"])
     with pytest.raises(InvalidContentError, match="exactly one deployment_id"):
-        _require_single_deployment_id(params, resource_label="config")
+        require_single_deployment_id(params, resource_label="config")
 
 
 # ---------------------------------------------------------------------------
@@ -6109,7 +6227,7 @@ async def test_create_preserves_exception_chain_on_unexpected_error():
     original_error = RuntimeError("unexpected db error")
     clients = FakeWXOClients(
         agent=FakeAgentClient({"id": "dep-1", "tools": []}, create_exception=original_error),
-        tool=FakeToolClient([{"id": "tool-existing-1"}]),
+        tool=FakeToolClient([{"id": "tool-existing-1", "binding": {"langflow": {}}}]),
         connections=FakeConnectionsClient(existing_app_id="app-existing-1"),
     )
     _attach_provider_clients(service, clients)

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -7112,12 +7112,12 @@ def test_rename_tool_provider_payload_parses():
 
 
 # ---------------------------------------------------------------------------
-# DeploymentFlowVersionListItem includes tool_name
+# DeploymentFlowVersionListItem carries provider tool_name under provider_data
 # ---------------------------------------------------------------------------
 
 
-def test_flow_version_list_item_includes_tool_name():
-    """DeploymentFlowVersionListItem accepts and serializes tool_name."""
+def test_flow_version_list_item_includes_tool_name_in_provider_data():
+    """DeploymentFlowVersionListItem serializes provider tool_name under provider_data."""
     from langflow.api.v1.schemas.deployments import DeploymentFlowVersionListItem
 
     item = DeploymentFlowVersionListItem(
@@ -7125,15 +7125,14 @@ def test_flow_version_list_item_includes_tool_name():
         flow_id="00000000-0000-0000-0000-000000000002",
         flow_name="My Flow",
         version_number=1,
-        tool_name="my_custom_tool",
+        provider_data={"tool_name": "my_custom_tool"},
     )
-    assert item.tool_name == "my_custom_tool"
     data = item.model_dump()
-    assert data["tool_name"] == "my_custom_tool"
+    assert data["provider_data"]["tool_name"] == "my_custom_tool"
 
 
-def test_flow_version_list_item_tool_name_defaults_to_none():
-    """DeploymentFlowVersionListItem defaults tool_name to None."""
+def test_flow_version_list_item_provider_data_defaults_to_none():
+    """DeploymentFlowVersionListItem defaults provider_data to None."""
     from langflow.api.v1.schemas.deployments import DeploymentFlowVersionListItem
 
     item = DeploymentFlowVersionListItem(
@@ -7141,4 +7140,4 @@ def test_flow_version_list_item_tool_name_defaults_to_none():
         flow_id="00000000-0000-0000-0000-000000000002",
         version_number=1,
     )
-    assert item.tool_name is None
+    assert item.provider_data is None

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -3121,7 +3121,12 @@ async def test_list_configs_deployment_scope_filters_to_key_value_creds(monkeypa
     connections_client = FakeConnectionsClient()
     connections_client._draft_entries_by_id = [
         ListConfigsResponse.model_validate(
-            {"connection_id": "conn-1", "app_id": "cfg-1", "security_scheme": "key_value_creds"}
+            {
+                "connection_id": "conn-1",
+                "app_id": "cfg-1",
+                "security_scheme": "key_value_creds",
+                "environment": "draft",
+            }
         ),
         ListConfigsResponse.model_validate({"connection_id": "conn-2", "app_id": "cfg-2", "security_scheme": "oauth2"}),
     ]
@@ -3144,7 +3149,7 @@ async def test_list_configs_deployment_scope_filters_to_key_value_creds(monkeypa
 
     assert [config.id for config in result.configs] == ["conn-1"]
     assert [config.name for config in result.configs] == ["cfg-1"]
-    assert [config.provider_data for config in result.configs] == [{"type": "key_value_creds"}]
+    assert [config.provider_data for config in result.configs] == [{"type": "key_value_creds", "environment": "draft"}]
 
 
 @pytest.mark.anyio
@@ -3168,6 +3173,7 @@ async def test_list_configs_deployment_scope_warns_on_stale_tool_ids(monkeypatch
                 "connection_id": "conn-1",
                 "app_id": "cfg-1",
                 "security_scheme": "key_value_creds",
+                "environment": "live",
             }
         )
     ]
@@ -3250,7 +3256,7 @@ async def test_list_configs_deployment_scope_accepts_schema_compatible_detailed_
     )
     connections_client = FakeConnectionsClient()
     connections_client._draft_entries_by_id = [
-        SimpleNamespace(connection_id="conn-1", app_id="cfg-1", security_scheme="key_value_creds")
+        SimpleNamespace(connection_id="conn-1", app_id="cfg-1", security_scheme="key_value_creds", environment="draft")
     ]
     fake_clients = SimpleNamespace(
         agent=fake_agent,
@@ -3271,7 +3277,45 @@ async def test_list_configs_deployment_scope_accepts_schema_compatible_detailed_
     assert len(result.configs) == 1
     assert result.configs[0].id == "conn-1"
     assert result.configs[0].name == "cfg-1"
-    assert result.configs[0].provider_data == {"type": "key_value_creds"}
+    assert result.configs[0].provider_data == {"type": "key_value_creds", "environment": "draft"}
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_fails_fast_when_environment_missing(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_agent = FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]})
+    fake_tool = FakeToolClient(
+        [
+            {
+                "id": "tool-1",
+                "name": "tool-one",
+                "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}},
+            }
+        ]
+    )
+    connections_client = FakeConnectionsClient()
+    connections_client._draft_entries_by_id = [
+        ListConfigsResponse.model_validate(
+            {"connection_id": "conn-1", "app_id": "cfg-1", "security_scheme": "key_value_creds"}
+        )
+    ]
+    fake_clients = SimpleNamespace(
+        agent=fake_agent,
+        tool=fake_tool,
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    with pytest.raises(InvalidContentError, match="required environment"):
+        await service.list_configs(
+            user_id="user-1",
+            db=object(),
+            params=ConfigListParams(deployment_ids=["dep-1"]),
+        )
 
 
 @pytest.mark.anyio
@@ -3442,6 +3486,7 @@ async def test_list_configs_deployment_scope_trusts_non_list_tools_payload(monke
                 "connection_id": "conn-1",
                 "app_id": "cfg-1",
                 "security_scheme": "key_value_creds",
+                "environment": "draft",
             }
         )
     ]
@@ -3557,6 +3602,7 @@ async def test_list_configs_deployment_scope_uses_latest_binding_for_same_app(mo
                 "connection_id": "conn-2",
                 "app_id": "cfg-1",
                 "security_scheme": "key_value_creds",
+                "environment": "draft",
             }
         )
     ]
@@ -3652,12 +3698,23 @@ async def test_list_configs_scopes_return_same_normalized_item_shape(monkeypatch
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
         ListConfigsResponse.model_validate(
-            {"connection_id": "conn-1", "app_id": "cfg-1", "name": "Config One", "security_scheme": "key_value_creds"}
+            {
+                "connection_id": "conn-1",
+                "app_id": "cfg-1",
+                "name": "Config One",
+                "security_scheme": "key_value_creds",
+                "environment": "draft",
+            }
         )
     ]
     connections_client._draft_entries_by_id = [
         ListConfigsResponse.model_validate(
-            {"connection_id": "conn-1", "app_id": "cfg-1", "security_scheme": "key_value_creds"}
+            {
+                "connection_id": "conn-1",
+                "app_id": "cfg-1",
+                "security_scheme": "key_value_creds",
+                "environment": "draft",
+            }
         )
     ]
     fake_clients = SimpleNamespace(
@@ -3686,7 +3743,7 @@ async def test_list_configs_scopes_return_same_normalized_item_shape(monkeypatch
         params=ConfigListParams(deployment_ids=["dep-1"]),
     )
 
-    expected = {"id": "conn-1", "name": "cfg-1", "provider_data": {"type": "key_value_creds"}}
+    expected = {"id": "conn-1", "name": "cfg-1", "provider_data": {"type": "key_value_creds", "environment": "draft"}}
     assert len(tenant_result.configs) == 1
     assert len(deployment_result.configs) == 1
     assert tenant_result.configs[0].model_dump(exclude_none=True) == expected
@@ -3813,10 +3870,22 @@ async def test_list_configs_without_deployment_id_lists_tenant_scope(monkeypatch
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
         ListConfigsResponse.model_validate(
-            {"connection_id": "conn-1", "app_id": "cfg-1", "name": "Config One", "security_scheme": "key_value_creds"}
+            {
+                "connection_id": "conn-1",
+                "app_id": "cfg-1",
+                "name": "Config One",
+                "security_scheme": "key_value_creds",
+                "environment": "draft",
+            }
         ),
         ListConfigsResponse.model_validate(
-            {"connection_id": "conn-2", "app_id": "cfg-2", "name": "Config Two", "security_scheme": "key_value_creds"}
+            {
+                "connection_id": "conn-2",
+                "app_id": "cfg-2",
+                "name": "Config Two",
+                "security_scheme": "key_value_creds",
+                "environment": "live",
+            }
         ),
     ]
     fake_clients = SimpleNamespace(
@@ -3848,6 +3917,7 @@ async def test_list_configs_tenant_scope_handles_sdk_models(monkeypatch):
                 "app_id": "cfg-pydantic-1",
                 "name": "Pydantic One",
                 "security_scheme": "key_value_creds",
+                "environment": "draft",
             }
         ),
         ListConfigsResponse.model_validate(
@@ -3856,6 +3926,7 @@ async def test_list_configs_tenant_scope_handles_sdk_models(monkeypatch):
                 "app_id": "cfg-pydantic-2",
                 "name": "Pydantic Two",
                 "security_scheme": "key_value_creds",
+                "environment": "live",
             }
         ),
     ]
@@ -3918,6 +3989,35 @@ async def test_list_configs_tenant_scope_filters_to_key_value_creds(monkeypatch)
 
 
 @pytest.mark.anyio
+async def test_list_configs_tenant_scope_fails_fast_when_environment_missing(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    connections_client = FakeConnectionsClient()
+    connections_client._list_entries = [
+        ListConfigsResponse.model_validate(
+            {
+                "connection_id": "conn-auth",
+                "app_id": "cfg-auth",
+                "name": "Auth Config",
+                "security_scheme": "key_value_creds",
+            }
+        )
+    ]
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": []}),
+        tool=FakeToolClient([]),
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    with pytest.raises(InvalidContentError, match="required environment"):
+        await service.list_configs(user_id="user-1", db=object(), params=None)
+
+
+@pytest.mark.anyio
 async def test_list_configs_tenant_scope_fails_fast_on_dict_entries(monkeypatch):
     """Tenant-scope list_configs raises when wxO returns unexpected entry types."""
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
@@ -3948,10 +4048,22 @@ async def test_list_configs_tenant_scope_preserves_duplicates(monkeypatch):
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
         ListConfigsResponse.model_validate(
-            {"connection_id": "conn-dup", "app_id": "cfg-dup", "name": "First", "security_scheme": "key_value_creds"}
+            {
+                "connection_id": "conn-dup",
+                "app_id": "cfg-dup",
+                "name": "First",
+                "security_scheme": "key_value_creds",
+                "environment": "draft",
+            }
         ),
         ListConfigsResponse.model_validate(
-            {"connection_id": "conn-dup", "app_id": "cfg-dup", "name": "Second", "security_scheme": "key_value_creds"}
+            {
+                "connection_id": "conn-dup",
+                "app_id": "cfg-dup",
+                "name": "Second",
+                "security_scheme": "key_value_creds",
+                "environment": "live",
+            }
         ),
         ListConfigsResponse.model_validate(
             {
@@ -3959,6 +4071,7 @@ async def test_list_configs_tenant_scope_preserves_duplicates(monkeypatch):
                 "app_id": "cfg-unique",
                 "name": "Unique",
                 "security_scheme": "key_value_creds",
+                "environment": "draft",
             }
         ),
     ]

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -3081,6 +3081,7 @@ async def test_list_configs_single_deployment_scope(monkeypatch):
                 "connection_id": "conn-1",
                 "app_id": "cfg-1",
                 "security_scheme": "key_value_creds",
+                "environment": "live",
             }
         )
     ]
@@ -3104,12 +3105,549 @@ async def test_list_configs_single_deployment_scope(monkeypatch):
     assert len(result.configs) == 1
     assert result.configs[0].id == "conn-1"
     assert result.configs[0].name == "cfg-1"
+    assert result.configs[0].provider_data == {"type": "key_value_creds", "environment": "live"}
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_filters_to_key_value_creds(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_agent = FakeAgentClient({"id": "dep-1", "tools": ["tool-1", "tool-2"]})
+    fake_tool = FakeToolClient(
+        [
+            {"id": "tool-1", "name": "tool-one", "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}}},
+            {"id": "tool-2", "name": "tool-two", "binding": {"langflow": {"connections": {"cfg-2": "conn-2"}}}},
+        ]
+    )
+    connections_client = FakeConnectionsClient()
+    connections_client._draft_entries_by_id = [
+        ListConfigsResponse.model_validate(
+            {"connection_id": "conn-1", "app_id": "cfg-1", "security_scheme": "key_value_creds"}
+        ),
+        ListConfigsResponse.model_validate({"connection_id": "conn-2", "app_id": "cfg-2", "security_scheme": "oauth2"}),
+    ]
+    fake_clients = SimpleNamespace(
+        agent=fake_agent,
+        tool=fake_tool,
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_configs(
+        user_id="user-1",
+        db=object(),
+        params=ConfigListParams(deployment_ids=["dep-1"]),
+    )
+
+    assert [config.id for config in result.configs] == ["conn-1"]
+    assert [config.name for config in result.configs] == ["cfg-1"]
+    assert [config.provider_data for config in result.configs] == [{"type": "key_value_creds"}]
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_warns_on_stale_tool_ids(monkeypatch, caplog):
+    """Stale tool IDs can be deleted between reads; keep resolved configs and warn."""
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_agent = FakeAgentClient({"id": "dep-1", "tools": ["tool-1", "deleted-tool"]})
+    fake_tool = FakeToolClient(
+        [
+            {
+                "id": "tool-1",
+                "name": "tool-one",
+                "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}},
+            }
+        ]
+    )
+    connections_client = FakeConnectionsClient()
+    connections_client._draft_entries_by_id = [
+        ListConfigsResponse.model_validate(
+            {
+                "connection_id": "conn-1",
+                "app_id": "cfg-1",
+                "security_scheme": "key_value_creds",
+            }
+        )
+    ]
+    fake_clients = SimpleNamespace(
+        agent=fake_agent,
+        tool=fake_tool,
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        result = await service.list_configs(
+            user_id="user-1",
+            db=object(),
+            params=ConfigListParams(deployment_ids=["dep-1"]),
+        )
+
+    assert [config.id for config in result.configs] == ["conn-1"]
+    assert "tool IDs not returned by provider" in caplog.text
+    assert "deleted-tool" in caplog.text
+    assert "dep-1" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_fails_fast_when_type_enrichment_fails(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_agent = FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]})
+    fake_tool = FakeToolClient(
+        [
+            {
+                "id": "tool-1",
+                "name": "tool-one",
+                "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}},
+            }
+        ]
+    )
+    connections_client = FakeConnectionsClient()
+    fake_clients = SimpleNamespace(
+        agent=fake_agent,
+        tool=fake_tool,
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    def get_drafts_by_ids_raises(conn_ids):  # noqa: ARG001
+        msg = "provider timeout"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+    monkeypatch.setattr(connections_client, "get_drafts_by_ids", get_drafts_by_ids_raises)
+
+    with pytest.raises(DeploymentError, match="listing deployment configs"):
+        await service.list_configs(
+            user_id="user-1",
+            db=object(),
+            params=ConfigListParams(deployment_ids=["dep-1"]),
+        )
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_accepts_schema_compatible_detailed_connection(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_agent = FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]})
+    fake_tool = FakeToolClient(
+        [
+            {
+                "id": "tool-1",
+                "name": "tool-one",
+                "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}},
+            }
+        ]
+    )
+    connections_client = FakeConnectionsClient()
+    connections_client._draft_entries_by_id = [
+        SimpleNamespace(connection_id="conn-1", app_id="cfg-1", security_scheme="key_value_creds")
+    ]
+    fake_clients = SimpleNamespace(
+        agent=fake_agent,
+        tool=fake_tool,
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_configs(
+        user_id="user-1",
+        db=object(),
+        params=ConfigListParams(deployment_ids=["dep-1"]),
+    )
+    assert len(result.configs) == 1
+    assert result.configs[0].id == "conn-1"
+    assert result.configs[0].name == "cfg-1"
     assert result.configs[0].provider_data == {"type": "key_value_creds"}
 
 
 @pytest.mark.anyio
+async def test_list_configs_deployment_scope_warns_when_referenced_connection_missing(monkeypatch, caplog):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_agent = FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]})
+    fake_tool = FakeToolClient(
+        [
+            {
+                "id": "tool-1",
+                "name": "tool-one",
+                "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}},
+            }
+        ]
+    )
+    connections_client = FakeConnectionsClient()
+    connections_client._draft_entries_by_id = []
+    fake_clients = SimpleNamespace(
+        agent=fake_agent,
+        tool=fake_tool,
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        result = await service.list_configs(
+            user_id="user-1",
+            db=object(),
+            params=ConfigListParams(deployment_ids=["dep-1"]),
+        )
+    assert result.configs == []
+    assert "connection IDs not returned by provider" in caplog.text
+    assert "conn-1" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_list_configs_tenant_scope_raises_on_provider_list_failure(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    connections_client = FakeConnectionsClient()
+
+    def list_raises():
+        msg = "provider list failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(connections_client, "list", list_raises)
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": []}),
+        tool=FakeToolClient([]),
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    with pytest.raises(DeploymentError, match="listing deployment configs"):
+        await service.list_configs(user_id="user-1", db=object(), params=None)
+
+
+@pytest.mark.anyio
+async def test_list_configs_tenant_scope_handles_none_response(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    connections_client = FakeConnectionsClient()
+    connections_client._list_entries = None
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": []}),
+        tool=FakeToolClient([]),
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_configs(user_id="user-1", db=object(), params=None)
+    assert result.configs == []
+    assert result.provider_result == {}
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_raises_on_agent_fetch_failure(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_agent = FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]})
+    fake_clients = SimpleNamespace(
+        agent=fake_agent,
+        tool=FakeToolClient([]),
+        connections=FakeConnectionsClient(),
+    )
+
+    def get_draft_by_id_raises(deployment_id):  # noqa: ARG001
+        msg = "provider agent fetch failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(fake_agent, "get_draft_by_id", get_draft_by_id_raises)
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    with pytest.raises(DeploymentError, match="listing deployment configs"):
+        await service.list_configs(
+            user_id="user-1",
+            db=object(),
+            params=ConfigListParams(deployment_ids=["dep-1"]),
+        )
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_raises_when_agent_not_found(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient(None),
+        tool=FakeToolClient([]),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    with pytest.raises(DeploymentNotFoundError, match="Deployment 'dep-1' not found"):
+        await service.list_configs(
+            user_id="user-1",
+            db=object(),
+            params=ConfigListParams(deployment_ids=["dep-1"]),
+        )
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_raises_on_non_dict_agent_payload(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient(["dep-1"]),
+        tool=FakeToolClient([]),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    with pytest.raises(InvalidContentError, match="unexpected deployment payload type"):
+        await service.list_configs(
+            user_id="user-1",
+            db=object(),
+            params=ConfigListParams(deployment_ids=["dep-1"]),
+        )
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_trusts_non_list_tools_payload(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    connections_client = FakeConnectionsClient()
+    connections_client._draft_entries_by_id = [
+        ListConfigsResponse.model_validate(
+            {
+                "connection_id": "conn-1",
+                "app_id": "cfg-1",
+                "security_scheme": "key_value_creds",
+            }
+        )
+    ]
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": ("tool-1",)}),
+        tool=FakeToolClient(
+            [
+                {
+                    "id": "tool-1",
+                    "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}},
+                }
+            ]
+        ),
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_configs(
+        user_id="user-1",
+        db=object(),
+        params=ConfigListParams(deployment_ids=["dep-1"]),
+    )
+    assert [config.id for config in result.configs] == ["conn-1"]
+    assert [config.name for config in result.configs] == ["cfg-1"]
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_returns_early_when_no_tools(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": []}),
+        tool=FakeToolClient([]),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_configs(
+        user_id="user-1",
+        db=object(),
+        params=ConfigListParams(deployment_ids=["dep-1"]),
+    )
+    assert result.configs == []
+    assert result.provider_result == {"deployment_id": "dep-1", "tool_ids": []}
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_handles_none_tools_payload(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": None}),
+        tool=FakeToolClient([]),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_configs(
+        user_id="user-1",
+        db=object(),
+        params=ConfigListParams(deployment_ids=["dep-1"]),
+    )
+    assert result.configs == []
+    assert result.provider_result == {"deployment_id": "dep-1", "tool_ids": []}
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_raises_on_tool_fetch_failure(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_tool = FakeToolClient([])
+
+    def get_drafts_by_ids_raises(tool_ids):  # noqa: ARG001
+        msg = "provider tool fetch failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(fake_tool, "get_drafts_by_ids", get_drafts_by_ids_raises)
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]}),
+        tool=fake_tool,
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    with pytest.raises(DeploymentError, match="listing deployment configs"):
+        await service.list_configs(
+            user_id="user-1",
+            db=object(),
+            params=ConfigListParams(deployment_ids=["dep-1"]),
+        )
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_uses_latest_binding_for_same_app(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    connections_client = FakeConnectionsClient()
+    connections_client._draft_entries_by_id = [
+        ListConfigsResponse.model_validate(
+            {
+                "connection_id": "conn-2",
+                "app_id": "cfg-1",
+                "security_scheme": "key_value_creds",
+            }
+        )
+    ]
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": ["tool-1", "tool-2"]}),
+        tool=FakeToolClient(
+            [
+                {"id": "tool-1", "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}}},
+                {"id": "tool-2", "binding": {"langflow": {"connections": {"cfg-1": "conn-2"}}}},
+            ]
+        ),
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_configs(
+        user_id="user-1",
+        db=object(),
+        params=ConfigListParams(deployment_ids=["dep-1"]),
+    )
+    assert len(result.configs) == 1
+    assert result.configs[0].id == "conn-2"
+    assert result.configs[0].name == "cfg-1"
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_skips_enrichment_when_no_connections(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_tool = FakeToolClient([{"id": "tool-1", "name": "tool-without-connections"}])
+    connections_client = FakeConnectionsClient()
+
+    def fail_if_called(conn_ids):  # noqa: ARG001
+        msg = "connection enrichment should not be called"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(connections_client, "get_drafts_by_ids", fail_if_called)
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]}),
+        tool=fake_tool,
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_configs(
+        user_id="user-1",
+        db=object(),
+        params=ConfigListParams(deployment_ids=["dep-1"]),
+    )
+    assert result.configs == []
+
+
+@pytest.mark.anyio
+async def test_list_configs_deployment_scope_raises_on_malformed_detailed_connection(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_tool = FakeToolClient([{"id": "tool-1", "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}}}])
+    connections_client = FakeConnectionsClient()
+    monkeypatch.setattr(
+        connections_client,
+        "get_drafts_by_ids",
+        lambda conn_ids: [SimpleNamespace(security_scheme="key_value_creds")],  # noqa: ARG005
+    )
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]}),
+        tool=fake_tool,
+        connections=connections_client,
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    with pytest.raises(AttributeError):
+        await service.list_configs(
+            user_id="user-1",
+            db=object(),
+            params=ConfigListParams(deployment_ids=["dep-1"]),
+        )
+
+
+@pytest.mark.anyio
 async def test_list_configs_scopes_return_same_normalized_item_shape(monkeypatch):
-    """Tenant-scope and deployment-scope must return the same ConfigListItem shape, including type metadata."""
+    """Tenant-scope and deployment-scope must return the same ConfigListItem shape."""
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
@@ -3274,8 +3812,12 @@ async def test_list_configs_without_deployment_id_lists_tenant_scope(monkeypatch
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
-        ListConfigsResponse.model_validate({"connection_id": "conn-1", "app_id": "cfg-1", "name": "Config One"}),
-        ListConfigsResponse.model_validate({"connection_id": "conn-2", "app_id": "cfg-2", "name": "Config Two"}),
+        ListConfigsResponse.model_validate(
+            {"connection_id": "conn-1", "app_id": "cfg-1", "name": "Config One", "security_scheme": "key_value_creds"}
+        ),
+        ListConfigsResponse.model_validate(
+            {"connection_id": "conn-2", "app_id": "cfg-2", "name": "Config Two", "security_scheme": "key_value_creds"}
+        ),
     ]
     fake_clients = SimpleNamespace(
         agent=FakeAgentClient({"id": "dep-1", "tools": []}),
@@ -3301,10 +3843,20 @@ async def test_list_configs_tenant_scope_handles_sdk_models(monkeypatch):
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
         ListConfigsResponse.model_validate(
-            {"connection_id": "conn-pydantic-1", "app_id": "cfg-pydantic-1", "name": "Pydantic One"}
+            {
+                "connection_id": "conn-pydantic-1",
+                "app_id": "cfg-pydantic-1",
+                "name": "Pydantic One",
+                "security_scheme": "key_value_creds",
+            }
         ),
         ListConfigsResponse.model_validate(
-            {"connection_id": "conn-pydantic-2", "app_id": "cfg-pydantic-2", "name": "Pydantic Two"}
+            {
+                "connection_id": "conn-pydantic-2",
+                "app_id": "cfg-pydantic-2",
+                "name": "Pydantic Two",
+                "security_scheme": "key_value_creds",
+            }
         ),
     ]
     fake_clients = SimpleNamespace(
@@ -3325,18 +3877,27 @@ async def test_list_configs_tenant_scope_handles_sdk_models(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_list_configs_tenant_scope_preserves_type_metadata(monkeypatch):
+async def test_list_configs_tenant_scope_filters_to_key_value_creds(monkeypatch):
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
+        ListConfigsResponse.model_validate(
+            {
+                "connection_id": "conn-oauth",
+                "app_id": "cfg-oauth",
+                "name": "Oauth Config",
+                "security_scheme": "oauth2",
+            }
+        ),
         ListConfigsResponse.model_validate(
             {
                 "connection_id": "conn-auth",
                 "app_id": "cfg-auth",
                 "name": "Auth Config",
                 "security_scheme": "key_value_creds",
+                "environment": "draft",
             }
-        )
+        ),
     ]
     fake_clients = SimpleNamespace(
         agent=FakeAgentClient({"id": "dep-1", "tools": []}),
@@ -3353,7 +3914,7 @@ async def test_list_configs_tenant_scope_preserves_type_metadata(monkeypatch):
     assert len(result.configs) == 1
     assert result.configs[0].id == "conn-auth"
     assert result.configs[0].name == "cfg-auth"
-    assert result.configs[0].provider_data == {"type": "key_value_creds"}
+    assert result.configs[0].provider_data == {"type": "key_value_creds", "environment": "draft"}
 
 
 @pytest.mark.anyio
@@ -3386,9 +3947,20 @@ async def test_list_configs_tenant_scope_preserves_duplicates(monkeypatch):
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     connections_client = FakeConnectionsClient()
     connections_client._list_entries = [
-        ListConfigsResponse.model_validate({"connection_id": "conn-dup", "app_id": "cfg-dup", "name": "First"}),
-        ListConfigsResponse.model_validate({"connection_id": "conn-dup", "app_id": "cfg-dup", "name": "Second"}),
-        ListConfigsResponse.model_validate({"connection_id": "conn-unique", "app_id": "cfg-unique", "name": "Unique"}),
+        ListConfigsResponse.model_validate(
+            {"connection_id": "conn-dup", "app_id": "cfg-dup", "name": "First", "security_scheme": "key_value_creds"}
+        ),
+        ListConfigsResponse.model_validate(
+            {"connection_id": "conn-dup", "app_id": "cfg-dup", "name": "Second", "security_scheme": "key_value_creds"}
+        ),
+        ListConfigsResponse.model_validate(
+            {
+                "connection_id": "conn-unique",
+                "app_id": "cfg-unique",
+                "name": "Unique",
+                "security_scheme": "key_value_creds",
+            }
+        ),
     ]
     fake_clients = SimpleNamespace(
         agent=FakeAgentClient({"id": "dep-1", "tools": []}),

--- a/src/frontend/src/controllers/API/queries/deployments/use-get-deployment-attachments.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-get-deployment-attachments.ts
@@ -8,13 +8,13 @@ import { UseRequestProcessor } from "../../services/request-processor";
  *
  * Identity contract: Langflow tracks provider tools by their immutable
  * `provider_snapshot_id` (wxO tool_id), never by name.
- * - Tool renamed in provider → same snapshot ID, new `tool_name`.
- * - Tool deleted in provider → snapshot ID unresolvable, `tool_name` is null.
+ * - Tool renamed in provider → same snapshot ID, new `provider_data.tool_name`.
+ * - Tool deleted in provider → snapshot ID unresolvable, `provider_data.tool_name` is null/missing.
  * - Tool deleted + new tool created with same name → different ID, our
  *   attachment still points to the old (missing) ID. The new tool is
  *   invisible to Langflow until explicitly attached.
  *
- * Use `tool_name` for display, fall back to `flow_name` when null.
+ * Use `provider_data.tool_name` for display, fall back to `flow_name` when null.
  * Use `provider_snapshot_id` for operations.
  */
 export interface DeploymentFlowVersionItem {
@@ -24,10 +24,10 @@ export interface DeploymentFlowVersionItem {
   version_number: number;
   attached_at: string | null;
   provider_snapshot_id: string | null;
-  /** Provider tool name — null when the tool was deleted or provider is unreachable. */
-  tool_name: string | null;
   provider_data: {
     app_ids?: string[];
+    /** Provider tool name — null/missing when the tool was deleted or provider is unreachable. */
+    tool_name?: string | null;
   } | null;
 }
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-stepper-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-stepper-modal.tsx
@@ -8,8 +8,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { usePostProviderAccount } from "@/controllers/API/queries/deployment-provider-accounts/use-post-provider-account";
-import { useGetDeploymentAttachments } from "@/controllers/API/queries/deployments/use-get-deployment-attachments";
 import { useGetDeployment } from "@/controllers/API/queries/deployments/use-get-deployment";
+import { useGetDeploymentAttachments } from "@/controllers/API/queries/deployments/use-get-deployment-attachments";
 import { usePatchDeployment } from "@/controllers/API/queries/deployments/use-patch-deployment";
 import { usePostDeployment } from "@/controllers/API/queries/deployments/use-post-deployment";
 import {
@@ -71,7 +71,7 @@ export default function DeploymentStepperModal({
   //
   // - If a user renames a tool in the wxO console, the new name appears
   //   here on the next edit. Langflow doesn't cache tool names locally.
-  // - If a tool is deleted in wxO, its tool_name will be null and the
+  // - If a tool is deleted in wxO, provider_data.tool_name will be null and the
   //   review page falls back to the Langflow flow name.
   // - If a connection is deleted in wxO but the tool still references it,
   //   the app_id will appear in connectionsByFlow. The backend will fail
@@ -93,8 +93,9 @@ export default function DeploymentStepperModal({
         versionTag: `v${fv.version_number}`,
       });
       // Pre-populate tool names from the provider (may differ from flow name).
-      if (fv.tool_name) {
-        toolNames.set(fv.flow_id, fv.tool_name);
+      const providerToolName = fv.provider_data?.tool_name;
+      if (providerToolName) {
+        toolNames.set(fv.flow_id, providerToolName);
       }
       // Pre-populate attached connections from existing tool bindings.
       const appIds = fv.provider_data?.app_ids;

--- a/src/lfx/src/lfx/services/adapters/deployment/payloads.py
+++ b/src/lfx/src/lfx/services/adapters/deployment/payloads.py
@@ -52,6 +52,8 @@ T_FlowProviderData = TypeVar("T_FlowProviderData", default=AdapterPayload)
 T_FlowProviderDataModel = TypeVar("T_FlowProviderDataModel", bound=BaseModel, default=BaseModel)
 T_SnapshotItemData = TypeVar("T_SnapshotItemData", default=AdapterPayload)
 T_SnapshotItemDataModel = TypeVar("T_SnapshotItemDataModel", bound=BaseModel, default=BaseModel)
+T_ConfigItemData = TypeVar("T_ConfigItemData", default=AdapterPayload)
+T_ConfigItemDataModel = TypeVar("T_ConfigItemDataModel", bound=BaseModel, default=BaseModel)
 
 # Outbound payload pairs
 T_DeploymentCreateResult = TypeVar("T_DeploymentCreateResult", default=AdapterPayload)
@@ -131,6 +133,7 @@ class DeploymentPayloadFields(ProviderPayloadSchemas):
     deployment_list_result: PayloadSlot[T_DeploymentListResultModel] | None = None
     deployment_llm_list_result: PayloadSlot[T_DeploymentLlmListResultModel] | None = None
     config_list_result: PayloadSlot[T_ConfigListResultModel] | None = None
+    config_item_data: PayloadSlot[T_ConfigItemDataModel] | None = None
     snapshot_list_result: PayloadSlot[T_SnapshotListResultModel] | None = None
     snapshot_item_data: PayloadSlot[T_SnapshotItemDataModel] | None = None
     execution_create_result: PayloadSlot[T_ExecutionCreateResultModel] | None = None

--- a/src/lfx/src/lfx/services/adapters/deployment/schema.py
+++ b/src/lfx/src/lfx/services/adapters/deployment/schema.py
@@ -2,12 +2,13 @@ import datetime
 import json
 from enum import Enum
 from functools import lru_cache
-from typing import Annotated, Any, Generic
+from typing import Annotated, Generic
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator, model_validator
 
 from lfx.services.adapters.deployment.payloads import (
+    T_ConfigItemData,
     T_ConfigListParams,
     T_ConfigListResult,
     T_DeploymentConfig,
@@ -314,14 +315,14 @@ class ConfigDeploymentBindingUpdate(BaseModel):
         return self
 
 
-class ConfigListItem(BaseModel):
+class ConfigListItem(BaseModel, Generic[T_ConfigItemData]):
     """Model representing a result for a config list item."""
 
     id: IdLike = Field(description="The id of the config item")
     name: str = Field(description="The name of the config item")
     created_at: datetime.datetime | None = Field(None, description="The created timestamp of the config item")
     updated_at: datetime.datetime | None = Field(None, description="The last updated timestamp of the config item")
-    provider_data: dict[str, Any] | None = Field(None, description="Provider-specific data for the config item")
+    provider_data: T_ConfigItemData | None = Field(None, description="Provider-specific data for the config item")
 
 
 class ProviderDataModel(BaseModel, Generic[T_ProviderData]):
@@ -402,10 +403,13 @@ class DeploymentListLlmsResult(ProviderResultModel[T_DeploymentLlmListResult]):
     """Provider payload container for listing available deployment LLM metadata."""
 
 
-class ConfigListResult(ProviderResultModel[T_ConfigListResult]):
+class ConfigListResult(
+    ProviderResultModel[T_ConfigListResult],
+    Generic[T_ConfigListResult, T_ConfigItemData],
+):
     """Model representing a result for a config list operation."""
 
-    configs: list[ConfigListItem] = Field(description="The list of configs")
+    configs: list[ConfigListItem[T_ConfigItemData]] = Field(description="The list of configs")
 
 
 class SnapshotListResult(


### PR DESCRIPTION
## Summary

This PR tightens Watsonx deployment config semantics and clarifies API response ownership boundaries for provider-originated fields.

### 1) Config listing hardening + filtering (`list_configs`)
- Filter config list responses to only include `security_scheme == "key_value_creds"` in both tenant and deployment scopes.
- Surface explicit metadata for returned configs:
  - `type` (required for shaped mapper output)
  - `environment` (when available)
- Add fail-fast behavior in mapper when config `type` is missing/empty.
- Keep provider trust model for cross-fetch races (warn on stale references instead of hard-failing).
- Consolidate stale ID warning logic and dedupe connection IDs before enrichment calls.

### 2) Move provider-specific `tool_name` into `provider_data`
- Remove top-level `tool_name` from `DeploymentFlowVersionListItem`.
- Move provider tool name to `provider_data.tool_name` (WXO-specific, non-persisted provider field).
- Update WXO mapper shaping and payload contracts to emit/validate `tool_name` under `provider_data`.
- Update frontend attachments typing + consumer logic to read `provider_data.tool_name`.

### 3) Rules codification
- Extend deployment mapper boundary rules to explicitly require:
  - non-persisted provider-originated data must live in `provider_data`
  - top-level fields remain Langflow-owned/persisted boundary fields.

## Why

- Enforces clear API ownership boundaries (Langflow-owned top-level vs provider-owned `provider_data`).
- Prevents ambiguous expansion of top-level fields with provider-only metadata.
- Reduces noisy/unsupported config entries by returning only actionable `key_value_creds` configs.
- Improves caller clarity by including `environment` and strict `type` semantics.

## Files changed

- `src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py`
- `src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py`
- `src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/payloads.py`
- `src/backend/base/langflow/api/v1/schemas/deployments.py`
- `src/backend/base/langflow/api/v1/mappers/deployments/RULES.md`
- `src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py`
- `src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py`
- `src/frontend/src/controllers/API/queries/deployments/use-get-deployment-attachments.ts`
- `src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-stepper-modal.tsx`

(`deployments api.md` intentionally excluded from commit)

## Behavior changes to call out

- `GET /deployments/configs` now returns only `key_value_creds` connections for WXO.
- Config list items now include `type` and may include `environment`.
- Mapper now returns HTTP 500 for malformed config list entries missing truthy `type`.
- Flow version list no longer exposes top-level `tool_name`; use `provider_data.tool_name` instead.

## Test plan

- [x] `uv run pytest src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py -q`
- [x] `uv run pytest src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py -q -k "list_configs"`
- [x] `uv run pytest src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py -q -k "flow_version_list_item"`
- [x] Focused lint checks on touched files (no new lint errors)