### PR TITLE
feat(deployments): type-to-confirm dialog for deployment deletion

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/type-to-confirm-delete-dialog.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/type-to-confirm-delete-dialog.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import TypeToConfirmDeleteDialog from "../components/type-to-confirm-delete-dialog";
+
+function renderDialog(
+  props: React.ComponentProps<typeof TypeToConfirmDeleteDialog>,
+) {
+  return render(
+    <TooltipProvider>
+      <TypeToConfirmDeleteDialog {...props} />
+    </TooltipProvider>,
+  );
+}
+
+function rerenderDialog(
+  rerender: ReturnType<typeof render>["rerender"],
+  props: React.ComponentProps<typeof TypeToConfirmDeleteDialog>,
+) {
+  return rerender(
+    <TooltipProvider>
+      <TypeToConfirmDeleteDialog {...props} />
+    </TooltipProvider>,
+  );
+}
+
+const defaultProps = {
+  open: true,
+  onOpenChange: jest.fn(),
+  deploymentName: "My Agent",
+  onConfirm: jest.fn(),
+};
+
+describe("TypeToConfirmDeleteDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders deployment name in the body", () => {
+    renderDialog(defaultProps);
+
+    expect(
+      screen.getByText(/Permanently delete the deployment/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("code")).toHaveTextContent("My Agent");
+  });
+
+  it("Delete button is disabled when input is empty", () => {
+    renderDialog(defaultProps);
+
+    const deleteBtn = screen.getByTestId("btn-delete-type-to-confirm-delete");
+    expect(deleteBtn).toBeDisabled();
+  });
+
+  it("Delete button is disabled when input does not match deployment name", () => {
+    renderDialog(defaultProps);
+
+    const input = screen.getByTestId("input-type-to-confirm-delete");
+    fireEvent.change(input, { target: { value: "wrong-value" } });
+
+    const deleteBtn = screen.getByTestId("btn-delete-type-to-confirm-delete");
+    expect(deleteBtn).toBeDisabled();
+  });
+
+  it("Delete button is enabled when input matches deployment name exactly", () => {
+    renderDialog(defaultProps);
+
+    const input = screen.getByTestId("input-type-to-confirm-delete");
+    fireEvent.change(input, { target: { value: "My Agent" } });
+
+    const deleteBtn = screen.getByTestId("btn-delete-type-to-confirm-delete");
+    expect(deleteBtn).toBeEnabled();
+  });
+
+  it("calls onConfirm when Delete button is clicked with correct input", () => {
+    const onConfirm = jest.fn();
+    renderDialog({ ...defaultProps, onConfirm });
+
+    const input = screen.getByTestId("input-type-to-confirm-delete");
+    fireEvent.change(input, { target: { value: "My Agent" } });
+
+    const deleteBtn = screen.getByTestId("btn-delete-type-to-confirm-delete");
+    fireEvent.click(deleteBtn);
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("input resets to empty when dialog is closed (open becomes false)", () => {
+    const { rerender } = renderDialog({ ...defaultProps, open: true });
+
+    const input = screen.getByTestId("input-type-to-confirm-delete");
+    fireEvent.change(input, { target: { value: "My Agent" } });
+    expect(input).toHaveValue("My Agent");
+
+    rerenderDialog(rerender, { ...defaultProps, open: false });
+
+    // Input should be reset; since dialog is closed, query the component's
+    // internal state by reopening it
+    rerenderDialog(rerender, { ...defaultProps, open: true });
+
+    const resetInput = screen.getByTestId("input-type-to-confirm-delete");
+    expect(resetInput).toHaveValue("");
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/type-to-confirm-delete-dialog.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/type-to-confirm-delete-dialog.test.tsx
@@ -84,6 +84,16 @@ describe("TypeToConfirmDeleteDialog", () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
+  it("Delete button is disabled when input matches deployment name with different casing", () => {
+    renderDialog(defaultProps);
+
+    const input = screen.getByTestId("input-type-to-confirm-delete");
+    fireEvent.change(input, { target: { value: "my agent" } });
+
+    const deleteBtn = screen.getByTestId("btn-delete-type-to-confirm-delete");
+    expect(deleteBtn).toBeDisabled();
+  });
+
   it("input resets to empty when dialog is closed (open becomes false)", () => {
     const { rerender } = renderDialog({ ...defaultProps, open: true });
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-content.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-content.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/components/ui/select";
 import { useDeleteDeployment } from "@/controllers/API/queries/deployments/use-delete-deployment";
 import { useGetDeploymentsByProviders } from "@/controllers/API/queries/deployments/use-get-deployments-by-providers";
-import DeleteConfirmationModal from "@/modals/deleteConfirmationModal";
 import { useDeleteWithConfirmation } from "../hooks/use-delete-with-confirmation";
 import { ALL_PROVIDERS, useProviderFilter } from "../hooks/use-provider-filter";
 import { useTestDeploymentModal } from "../hooks/use-test-deployment-modal";
@@ -19,6 +18,7 @@ import DeploymentsEmptyState from "./deployments-empty-state";
 import DeploymentsLoadingSkeleton from "./deployments-loading-skeleton";
 import DeploymentsTable from "./deployments-table";
 import TestDeploymentModal from "./test-deployment-modal/test-deployment-modal";
+import TypeToConfirmDeleteDialog from "./type-to-confirm-delete-dialog";
 
 const buildDeploymentDeleteParams = (id: string) => ({ deployment_id: id });
 
@@ -49,11 +49,10 @@ export default function DeploymentsContent({
 
   const { mutate: deleteDeployment } = useDeleteDeployment();
 
-  const deploymentDelete = useDeleteWithConfirmation(
-    deleteDeployment,
-    buildDeploymentDeleteParams,
-    "Error deleting deployment",
-  );
+  const deploymentDelete = useDeleteWithConfirmation<
+    Deployment,
+    { deployment_id: string }
+  >(deleteDeployment, buildDeploymentDeleteParams, "Error deleting deployment");
 
   const [editingDeployment, setEditingDeployment] = useState<Deployment | null>(
     null,
@@ -154,10 +153,10 @@ export default function DeploymentsContent({
         }
       />
 
-      <DeleteConfirmationModal
+      <TypeToConfirmDeleteDialog
         open={!!deploymentDelete.target}
-        setOpen={deploymentDelete.setModalOpen}
-        description={`deployment "${deploymentDelete.target?.name}"`}
+        onOpenChange={deploymentDelete.setModalOpen}
+        deploymentName={deploymentDelete.target?.name ?? ""}
         onConfirm={deploymentDelete.confirmDelete}
       />
     </>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/type-to-confirm-delete-dialog.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/type-to-confirm-delete-dialog.tsx
@@ -41,7 +41,7 @@ export default function TypeToConfirmDeleteDialog({
           <DialogTitle>
             <div className="flex items-center">
               <AlertTriangle
-                className="h-6 w-6 pr-1 text-destructive"
+                className="mr-2 h-6 w-6 text-destructive"
                 strokeWidth={1.5}
               />
               <span className="pl-2">Delete</span>
@@ -54,7 +54,7 @@ export default function TypeToConfirmDeleteDialog({
             in Langflow and Watsonx Orchestrate.
           </p>
           <label htmlFor="confirm-delete-input" className="text-sm">
-            Type the agent name to confirm:{" "}
+            Type the deployment name to confirm:{" "}
             <code className="font-mono bg-muted px-1 rounded text-sm">
               {deploymentName}
             </code>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/type-to-confirm-delete-dialog.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/type-to-confirm-delete-dialog.tsx
@@ -1,0 +1,96 @@
+import { DialogClose } from "@radix-ui/react-dialog";
+import { AlertTriangle } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+interface TypeToConfirmDeleteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  deploymentName: string;
+  onConfirm: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export default function TypeToConfirmDeleteDialog({
+  open,
+  onOpenChange,
+  deploymentName,
+  onConfirm,
+}: TypeToConfirmDeleteDialogProps) {
+  const [inputValue, setInputValue] = useState("");
+
+  useEffect(() => {
+    if (!open) {
+      setInputValue("");
+    }
+  }, [open]);
+
+  const isConfirmDisabled = inputValue !== deploymentName;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            <div className="flex items-center">
+              <AlertTriangle
+                className="h-6 w-6 pr-1 text-destructive"
+                strokeWidth={1.5}
+              />
+              <span className="pl-2">Delete</span>
+            </div>
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 pb-3 text-sm">
+          <p>
+            Permanently delete the deployment <strong>{deploymentName}</strong>{" "}
+            in Langflow and Watsonx Orchestrate.
+          </p>
+          <label htmlFor="confirm-delete-input" className="text-sm">
+            Type the agent name to confirm:{" "}
+            <code className="font-mono bg-muted px-1 rounded text-sm">
+              {deploymentName}
+            </code>
+          </label>
+          <Input
+            id="confirm-delete-input"
+            autoFocus
+            placeholder={deploymentName}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            data-testid="input-type-to-confirm-delete"
+          />
+          <p>This can't be undone.</p>
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button
+              onClick={(e) => e.stopPropagation()}
+              className="mr-1"
+              variant="outline"
+              data-testid="btn-cancel-type-to-confirm-delete"
+            >
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            type="submit"
+            variant="destructive"
+            disabled={isConfirmDisabled}
+            onClick={onConfirm}
+            data-testid="btn-delete-type-to-confirm-delete"
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-delete-with-confirmation.test.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-delete-with-confirmation.test.ts
@@ -1,0 +1,182 @@
+import { act, renderHook } from "@testing-library/react";
+import { useDeleteWithConfirmation } from "../use-delete-with-confirmation";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockShowError = jest.fn();
+jest.mock("../use-error-alert", () => ({
+  useErrorAlert: () => mockShowError,
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+type Item = { id: string; name: string };
+
+const makeItem = (overrides: Partial<Item> = {}): Item => ({
+  id: "dep-1",
+  name: "My Deployment",
+  ...overrides,
+});
+
+const buildParams = (id: string) => ({ deployment_id: id });
+
+function makeMouseEvent() {
+  return { stopPropagation: jest.fn() } as unknown as React.MouseEvent<
+    HTMLButtonElement,
+    MouseEvent
+  >;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("useDeleteWithConfirmation", () => {
+  let mutateFn: jest.Mock;
+
+  beforeEach(() => {
+    mutateFn = jest.fn();
+    mockShowError.mockClear();
+  });
+
+  it("starts with target and deletingId as null", () => {
+    const { result } = renderHook(() =>
+      useDeleteWithConfirmation(mutateFn, buildParams, "Error"),
+    );
+
+    expect(result.current.target).toBeNull();
+    expect(result.current.deletingId).toBeNull();
+  });
+
+  it("requestDelete sets the target item", () => {
+    const { result } = renderHook(() =>
+      useDeleteWithConfirmation(mutateFn, buildParams, "Error"),
+    );
+    const item = makeItem();
+
+    act(() => {
+      result.current.requestDelete(item);
+    });
+
+    expect(result.current.target).toEqual(item);
+  });
+
+  it("confirmDelete calls mutateFn with built params and clears target", () => {
+    const { result } = renderHook(() =>
+      useDeleteWithConfirmation(mutateFn, buildParams, "Error"),
+    );
+    const item = makeItem();
+
+    act(() => {
+      result.current.requestDelete(item);
+    });
+
+    act(() => {
+      result.current.confirmDelete(makeMouseEvent());
+    });
+
+    expect(mutateFn).toHaveBeenCalledWith(
+      { deployment_id: "dep-1" },
+      expect.objectContaining({
+        onError: expect.any(Function),
+        onSettled: expect.any(Function),
+      }),
+    );
+    expect(result.current.target).toBeNull();
+    expect(result.current.deletingId).toBe("dep-1");
+  });
+
+  it("confirmDelete is a no-op when target is null", () => {
+    const { result } = renderHook(() =>
+      useDeleteWithConfirmation(mutateFn, buildParams, "Error"),
+    );
+
+    act(() => {
+      result.current.confirmDelete(makeMouseEvent());
+    });
+
+    expect(mutateFn).not.toHaveBeenCalled();
+  });
+
+  it("onSettled clears deletingId", () => {
+    const { result } = renderHook(() =>
+      useDeleteWithConfirmation(mutateFn, buildParams, "Error"),
+    );
+
+    act(() => {
+      result.current.requestDelete(makeItem());
+    });
+    act(() => {
+      result.current.confirmDelete(makeMouseEvent());
+    });
+
+    expect(result.current.deletingId).toBe("dep-1");
+
+    // Simulate mutateFn calling onSettled
+    const { onSettled } = mutateFn.mock.calls[0][1];
+    act(() => {
+      onSettled();
+    });
+
+    expect(result.current.deletingId).toBeNull();
+  });
+
+  it("onError calls showError with the configured message", () => {
+    const { result } = renderHook(() =>
+      useDeleteWithConfirmation(
+        mutateFn,
+        buildParams,
+        "Error deleting deployment",
+      ),
+    );
+
+    act(() => {
+      result.current.requestDelete(makeItem());
+    });
+    act(() => {
+      result.current.confirmDelete(makeMouseEvent());
+    });
+
+    const { onError } = mutateFn.mock.calls[0][1];
+    const fakeError = new Error("network failure");
+    act(() => {
+      onError(fakeError);
+    });
+
+    expect(mockShowError).toHaveBeenCalledWith(
+      "Error deleting deployment",
+      fakeError,
+    );
+  });
+
+  it("setModalOpen(false) clears the target", () => {
+    const { result } = renderHook(() =>
+      useDeleteWithConfirmation(mutateFn, buildParams, "Error"),
+    );
+
+    act(() => {
+      result.current.requestDelete(makeItem());
+    });
+    expect(result.current.target).not.toBeNull();
+
+    act(() => {
+      result.current.setModalOpen(false);
+    });
+
+    expect(result.current.target).toBeNull();
+  });
+
+  it("setModalOpen(true) does not change target", () => {
+    const { result } = renderHook(() =>
+      useDeleteWithConfirmation(mutateFn, buildParams, "Error"),
+    );
+
+    act(() => {
+      result.current.requestDelete(makeItem());
+    });
+
+    act(() => {
+      result.current.setModalOpen(true);
+    });
+
+    expect(result.current.target).toEqual(makeItem());
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/use-delete-with-confirmation.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/use-delete-with-confirmation.ts
@@ -6,7 +6,6 @@ interface DeleteWithConfirmation<T extends { id: string; name: string }> {
   deletingId: string | null;
   requestDelete: (item: T) => void;
   confirmDelete: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-  cancelDelete: () => void;
   setModalOpen: (open: boolean) => void;
 }
 
@@ -46,10 +45,6 @@ export function useDeleteWithConfirmation<
     [target, mutateFn, buildParams, errorMessage, showError],
   );
 
-  const cancelDelete = useCallback(() => {
-    setTarget(null);
-  }, []);
-
   const setModalOpen = useCallback((open: boolean) => {
     if (!open) setTarget(null);
   }, []);
@@ -59,7 +54,6 @@ export function useDeleteWithConfirmation<
     deletingId,
     requestDelete,
     confirmDelete,
-    cancelDelete,
     setModalOpen,
   };
 }


### PR DESCRIPTION
## Summary

- Replaces the generic `DeleteConfirmationModal` for deployment deletion with a deployment-specific `TypeToConfirmDeleteDialog`
- User must type the deployment name exactly before the Delete button activates — prevents accidental destruction of production agents in both Langflow and Watsonx Orchestrate
- Follows industry-standard patterns (GitHub repo deletion, AWS resource deletion)

## Changes

- **New:** `type-to-confirm-delete-dialog.tsx` — deployment-specific dialog with accessible label, placeholder, and exact-match validation
- **Updated:** `deployments-content.tsx` — wires up the new dialog; `DeleteConfirmationModal` removed from this flow
- **New:** `type-to-confirm-delete-dialog.test.tsx` — 6 unit tests covering all confirmation behaviours


https://github.com/user-attachments/assets/dc9391df-8bab-460e-8dc9-5ce4ce904aeb

