### PR TITLE
fix(deployments): remove unused description field from connection panel

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-attach-flows-connection-panel.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-attach-flows-connection-panel.test.tsx
@@ -69,8 +69,6 @@ const defaultProps = {
   onToggleConnection: jest.fn(),
   newConnectionName: "",
   onNameChange: jest.fn(),
-  newConnectionDescription: "",
-  onDescriptionChange: jest.fn(),
   envVars: [{ id: "ev-1", key: "", value: "" }] as EnvVarEntry[],
   detectedVarCount: 0,
   globalVariableOptions: [] as string[],
@@ -221,13 +219,6 @@ describe("Create tab — form", () => {
     renderPanel({ connectionTab: "create" });
     expect(
       screen.getByPlaceholderText("e.g., SALES_BOT_PROD"),
-    ).toBeInTheDocument();
-  });
-
-  it("renders description input", () => {
-    renderPanel({ connectionTab: "create" });
-    expect(
-      screen.getByPlaceholderText("e.g., Production sales bot connection"),
     ).toBeInTheDocument();
   });
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-connection-panel.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-connection-panel.tsx
@@ -17,8 +17,6 @@ export const ConnectionPanel = memo(function ConnectionPanel({
   onToggleConnection,
   newConnectionName,
   onNameChange,
-  newConnectionDescription,
-  onDescriptionChange,
   envVars,
   detectedVarCount,
   globalVariableOptions,
@@ -38,8 +36,6 @@ export const ConnectionPanel = memo(function ConnectionPanel({
   onToggleConnection: (id: string) => void;
   newConnectionName: string;
   onNameChange: (v: string) => void;
-  newConnectionDescription: string;
-  onDescriptionChange: (v: string) => void;
   envVars: EnvVarEntry[];
   detectedVarCount: number;
   globalVariableOptions: string[];
@@ -179,15 +175,6 @@ export const ConnectionPanel = memo(function ConnectionPanel({
                     A connection with this name already exists.
                   </span>
                 )}
-              </div>
-              <div className="flex flex-col">
-                <span className="pb-2 text-sm font-medium">Description</span>
-                <Input
-                  placeholder="e.g., Production sales bot connection"
-                  className="bg-muted"
-                  value={newConnectionDescription}
-                  onChange={(e) => onDescriptionChange(e.target.value)}
-                />
               </div>
               <div className="flex flex-col">
                 <span className="pb-2 text-sm font-medium">

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
@@ -112,7 +112,6 @@ export default function StepAttachFlows() {
     new Set(),
   );
   const [newConnectionName, setNewConnectionName] = useState("");
-  const [newConnectionDescription, setNewConnectionDescription] = useState("");
   const [envVars, setEnvVars] = useState<EnvVarEntry[]>(() => [
     { id: crypto.randomUUID(), key: "", value: "" },
   ]);
@@ -295,7 +294,6 @@ export default function StepAttachFlows() {
     );
     setConnectionTab("available");
     setNewConnectionName("");
-    setNewConnectionDescription("");
     setEnvVars([{ id: crypto.randomUUID(), key: "", value: "" }]);
   }, [envVars, newConnectionName, setConnections]);
 
@@ -425,8 +423,6 @@ export default function StepAttachFlows() {
               }
               newConnectionName={newConnectionName}
               onNameChange={setNewConnectionName}
-              newConnectionDescription={newConnectionDescription}
-              onDescriptionChange={setNewConnectionDescription}
               envVars={envVars}
               detectedVarCount={detectedVarCount}
               globalVariableOptions={globalVariableOptions}


### PR DESCRIPTION
## Summary
- Removes the Description input from the Create Connection tab in the deploy stepper modal
- The field was never persisted — `ConnectionItem` has no `description` field and the value was never sent to any API
- Cleans up associated state, props, and test references

<img width="929" height="1057" alt="Screenshot 2026-04-07 at 3 30 58 PM" src="https://github.com/user-attachments/assets/9fb57275-4087-4a8f-8722-6568a4aeea64" />
