### PR TITLE
fix(deployments): enforce single-environment filter on deployments page

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-content.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-content.tsx
@@ -9,7 +9,7 @@ import {
 import { useDeleteDeployment } from "@/controllers/API/queries/deployments/use-delete-deployment";
 import { useGetDeploymentsByProviders } from "@/controllers/API/queries/deployments/use-get-deployments-by-providers";
 import { useDeleteWithConfirmation } from "../hooks/use-delete-with-confirmation";
-import { ALL_PROVIDERS, useProviderFilter } from "../hooks/use-provider-filter";
+import { useProviderFilter } from "../hooks/use-provider-filter";
 import { useTestDeploymentModal } from "../hooks/use-test-deployment-modal";
 import type { Deployment, ProviderAccount } from "../types";
 import DeploymentDetailsModal from "./deployment-details-modal/deployment-details-modal";
@@ -27,6 +27,7 @@ interface DeploymentsContentProps {
   providers: ProviderAccount[];
   stepperOpen: boolean;
   setStepperOpen: (open: boolean) => void;
+  onGoToProviders: () => void;
 }
 
 export default function DeploymentsContent({
@@ -34,6 +35,7 @@ export default function DeploymentsContent({
   providers,
   stepperOpen,
   setStepperOpen,
+  onGoToProviders,
 }: DeploymentsContentProps) {
   const {
     selectedProviderId,
@@ -64,14 +66,21 @@ export default function DeploymentsContent({
 
   const isLoading = isLoadingProviders || isLoadingDeployments;
   const hasProviders = providers.length > 0;
-  const isEmpty = !hasProviders || deployments.length === 0;
 
   const content = (() => {
     if (isLoading) return <DeploymentsLoadingSkeleton />;
-    if (isEmpty)
+    if (!hasProviders)
       return (
         <DeploymentsEmptyState
-          onCreateDeployment={() => setStepperOpen(true)}
+          variant="no-providers"
+          onAction={onGoToProviders}
+        />
+      );
+    if (deployments.length === 0)
+      return (
+        <DeploymentsEmptyState
+          variant="no-deployments"
+          onAction={() => setStepperOpen(true)}
         />
       );
     return (
@@ -92,7 +101,7 @@ export default function DeploymentsContent({
 
   return (
     <>
-      {providers.length > 1 && (
+      {providers.length >= 1 && (
         <div className="flex items-center gap-2">
           <span className="text-sm text-muted-foreground">Environment:</span>
           <Select
@@ -103,7 +112,6 @@ export default function DeploymentsContent({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={ALL_PROVIDERS}>All environments</SelectItem>
               {providers.map((p) => (
                 <SelectItem key={p.id} value={p.id}>
                   {p.name}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-empty-state.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-empty-state.tsx
@@ -2,26 +2,46 @@ import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Button } from "@/components/ui/button";
 
 interface DeploymentsEmptyStateProps {
-  onCreateDeployment: () => void;
+  variant: "no-providers" | "no-deployments";
+  onAction: () => void;
 }
 
+const copy = {
+  "no-providers": {
+    title: "No Environments",
+    description: "Add an environment before creating deployments.",
+    button: "Add Environment",
+    icon: "Plus" as const,
+    testId: "add-environment-empty-btn",
+  },
+  "no-deployments": {
+    title: "No Deployments",
+    description:
+      "Create your first deployment to run your flows in production.",
+    button: "Create Deployment",
+    icon: "Plus" as const,
+    testId: "create-deployment-empty-btn",
+  },
+};
+
 export default function DeploymentsEmptyState({
-  onCreateDeployment,
+  variant,
+  onAction,
 }: DeploymentsEmptyStateProps) {
+  const { title, description, button, icon, testId } = copy[variant];
+
   return (
     <div className="flex flex-col items-center justify-center py-24">
-      <h3 className="text-lg font-semibold">No Deployments</h3>
-      <p className="mt-1 text-sm text-muted-foreground">
-        Create your first deployment to run your flows in production.
-      </p>
+      <h3 className="text-lg font-semibold">{title}</h3>
+      <p className="mt-1 text-sm text-muted-foreground">{description}</p>
       <Button
         variant="outline"
         className="mt-4"
-        data-testid="create-deployment-empty-btn"
-        onClick={onCreateDeployment}
+        data-testid={testId}
+        onClick={onAction}
       >
-        <ForwardedIconComponent name="Plus" className="h-4 w-4" />
-        Create Deployment
+        <ForwardedIconComponent name={icon} className="h-4 w-4" />
+        {button}
       </Button>
     </div>
   );

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/provider-credentials-form.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/provider-credentials-form.tsx
@@ -16,8 +16,25 @@ export default function ProviderCredentialsForm({
 }: ProviderCredentialsFormProps) {
   const [showApiKey, setShowApiKey] = useState(false);
 
-  const apiKeyAndUrlFields = (
+  const urlAndApiKeyFields = (
     <>
+      <div className="flex flex-col">
+        <span className="pb-2 text-sm font-medium">
+          Service Environment URL <span className="text-destructive">*</span>
+        </span>
+        <Input
+          type="url"
+          placeholder="https://api.example.com"
+          className="bg-muted"
+          value={credentials.url}
+          onChange={(e) =>
+            onCredentialsChange({
+              ...credentials,
+              url: e.target.value,
+            })
+          }
+        />
+      </div>
       <div className="flex flex-col">
         <span className="pb-2 text-sm font-medium">
           API Key <span className="text-destructive">*</span>
@@ -48,23 +65,6 @@ export default function ProviderCredentialsForm({
           </button>
         </div>
       </div>
-      <div className="flex flex-col">
-        <span className="pb-2 text-sm font-medium">
-          Service Environment URL <span className="text-destructive">*</span>
-        </span>
-        <Input
-          type="url"
-          placeholder="https://api.example.com"
-          className="bg-muted"
-          value={credentials.url}
-          onChange={(e) =>
-            onCredentialsChange({
-              ...credentials,
-              url: e.target.value,
-            })
-          }
-        />
-      </div>
     </>
   );
 
@@ -88,9 +88,9 @@ export default function ProviderCredentialsForm({
         />
       </div>
       {layout === "two-column" ? (
-        <div className="grid grid-cols-2 gap-4">{apiKeyAndUrlFields}</div>
+        <div className="grid grid-cols-2 gap-4">{urlAndApiKeyFields}</div>
       ) : (
-        apiKeyAndUrlFields
+        urlAndApiKeyFields
       )}
     </div>
   );

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/deployments-page.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/deployments-page.tsx
@@ -45,6 +45,10 @@ export default function DeploymentsPage() {
           providers={providers}
           stepperOpen={stepperOpen}
           setStepperOpen={setStepperOpen}
+          onGoToProviders={() => {
+            setActiveSubTab("providers");
+            setAddProviderOpen(true);
+          }}
         />
       )}
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-provider-filter.test.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-provider-filter.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import type { ProviderAccount } from "../../types";
-import { ALL_PROVIDERS, useProviderFilter } from "../use-provider-filter";
+import { useProviderFilter } from "../use-provider-filter";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -25,18 +25,27 @@ const makeProvider = (
 
 describe("useProviderFilter", () => {
   describe("initial state", () => {
-    it("initializes with ALL_PROVIDERS selected", () => {
-      const { result } = renderHook(() => useProviderFilter([]));
-      expect(result.current.selectedProviderId).toBe(ALL_PROVIDERS);
-    });
-
-    it("returns all provider IDs in providerIdsToQuery when all selected", () => {
+    it("initializes with first provider selected", () => {
       const providers = [
         makeProvider({ id: "p1" }),
         makeProvider({ id: "p2" }),
       ];
       const { result } = renderHook(() => useProviderFilter(providers));
-      expect(result.current.providerIdsToQuery).toEqual(["p1", "p2"]);
+      expect(result.current.selectedProviderId).toBe("p1");
+    });
+
+    it("initializes with empty string when no providers given", () => {
+      const { result } = renderHook(() => useProviderFilter([]));
+      expect(result.current.selectedProviderId).toBe("");
+    });
+
+    it("returns only the first provider ID in providerIdsToQuery", () => {
+      const providers = [
+        makeProvider({ id: "p1" }),
+        makeProvider({ id: "p2" }),
+      ];
+      const { result } = renderHook(() => useProviderFilter(providers));
+      expect(result.current.providerIdsToQuery).toEqual(["p1"]);
     });
 
     it("returns empty providerIdsToQuery for empty provider list", () => {
@@ -68,33 +77,52 @@ describe("useProviderFilter", () => {
       const { result } = renderHook(() => useProviderFilter(providers));
 
       act(() => {
-        result.current.setSelectedProviderId("p1");
+        result.current.setSelectedProviderId("p2");
       });
 
-      expect(result.current.providerIdsToQuery).toEqual(["p1"]);
-      expect(result.current.selectedProviderId).toBe("p1");
+      expect(result.current.providerIdsToQuery).toEqual(["p2"]);
+      expect(result.current.selectedProviderId).toBe("p2");
     });
 
-    it("returns all IDs after resetting back to ALL_PROVIDERS", () => {
+    it("providerIdsToQuery is always a single-element array", () => {
       const providers = [
         makeProvider({ id: "p1" }),
         makeProvider({ id: "p2" }),
+        makeProvider({ id: "p3" }),
       ];
       const { result } = renderHook(() => useProviderFilter(providers));
 
+      // Initially selects first provider — single element
+      expect(result.current.providerIdsToQuery).toHaveLength(1);
+
       act(() => {
-        result.current.setSelectedProviderId("p1");
-      });
-      act(() => {
-        result.current.setSelectedProviderId(ALL_PROVIDERS);
+        result.current.setSelectedProviderId("p3");
       });
 
-      expect(result.current.providerIdsToQuery).toEqual(["p1", "p2"]);
+      expect(result.current.providerIdsToQuery).toHaveLength(1);
+      expect(result.current.providerIdsToQuery).toEqual(["p3"]);
+    });
+  });
+
+  describe("selects first provider once providers load", () => {
+    it("updates selection when providers arrive after mount", () => {
+      const { result, rerender } = renderHook(
+        ({ list }: { list: ProviderAccount[] }) => useProviderFilter(list),
+        { initialProps: { list: [] } },
+      );
+
+      expect(result.current.selectedProviderId).toBe("");
+
+      rerender({
+        list: [makeProvider({ id: "p1" }), makeProvider({ id: "p2" })],
+      });
+
+      expect(result.current.selectedProviderId).toBe("p1");
     });
   });
 
   describe("reset on provider deletion", () => {
-    it("resets to ALL_PROVIDERS when the selected provider is removed from the list", () => {
+    it("selects next available provider when selected provider is removed", () => {
       const providers = [
         makeProvider({ id: "p1" }),
         makeProvider({ id: "p2" }),
@@ -111,7 +139,7 @@ describe("useProviderFilter", () => {
 
       rerender({ list: [makeProvider({ id: "p1" })] });
 
-      expect(result.current.selectedProviderId).toBe(ALL_PROVIDERS);
+      expect(result.current.selectedProviderId).toBe("p1");
     });
 
     it("does not reset when the selected provider still exists", () => {
@@ -132,35 +160,6 @@ describe("useProviderFilter", () => {
       rerender({ list: [makeProvider({ id: "p1" })] });
 
       expect(result.current.selectedProviderId).toBe("p1");
-    });
-
-    it("does not reset when ALL_PROVIDERS is selected and a provider is removed", () => {
-      const providers = [
-        makeProvider({ id: "p1" }),
-        makeProvider({ id: "p2" }),
-      ];
-      const { result, rerender } = renderHook(
-        ({ list }: { list: ProviderAccount[] }) => useProviderFilter(list),
-        { initialProps: { list: providers } },
-      );
-
-      expect(result.current.selectedProviderId).toBe(ALL_PROVIDERS);
-
-      rerender({ list: [makeProvider({ id: "p1" })] });
-
-      expect(result.current.selectedProviderId).toBe(ALL_PROVIDERS);
-    });
-
-    it("does not reset when the provider list is empty and ALL_PROVIDERS is selected", () => {
-      const { result, rerender } = renderHook(
-        ({ list }: { list: ProviderAccount[] }) => useProviderFilter(list),
-        { initialProps: { list: [makeProvider({ id: "p1" })] } },
-      );
-
-      // Don't select a specific provider — stay at ALL_PROVIDERS
-      rerender({ list: [] });
-
-      expect(result.current.selectedProviderId).toBe(ALL_PROVIDERS);
     });
   });
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/use-provider-filter.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/use-provider-filter.ts
@@ -1,8 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ProviderAccount } from "../types";
 
-const ALL_PROVIDERS = "all";
-
 interface ProviderFilter {
   selectedProviderId: string;
   setSelectedProviderId: (id: string) => void;
@@ -13,23 +11,26 @@ interface ProviderFilter {
 export function useProviderFilter(
   providers: ProviderAccount[],
 ): ProviderFilter {
-  const [selectedProviderId, setSelectedProviderId] = useState(ALL_PROVIDERS);
+  const [selectedProviderId, setSelectedProviderId] = useState(
+    () => providers[0]?.id ?? "",
+  );
 
-  // Reset filter when the selected provider no longer exists
+  // Select first provider once providers load, or reset when selected is removed
   useEffect(() => {
+    if (providers.length === 0) return;
+
     if (
-      selectedProviderId !== ALL_PROVIDERS &&
-      providers.length > 0 &&
+      !selectedProviderId ||
       !providers.some((p) => p.id === selectedProviderId)
     ) {
-      setSelectedProviderId(ALL_PROVIDERS);
+      setSelectedProviderId(providers[0].id);
     }
   }, [providers, selectedProviderId]);
 
   const providerIdsToQuery = useMemo(() => {
-    if (selectedProviderId !== ALL_PROVIDERS) return [selectedProviderId];
-    return providers.map((p) => p.id);
-  }, [selectedProviderId, providers]);
+    if (!selectedProviderId) return [];
+    return [selectedProviderId];
+  }, [selectedProviderId]);
 
   const providerMap = useMemo(
     () =>
@@ -47,5 +48,3 @@ export function useProviderFilter(
     providerMap,
   };
 }
-
-export { ALL_PROVIDERS };


### PR DESCRIPTION
## Summary
- Remove the "All environments" global listing mode — deployments are now always fetched for a single selected environment, avoiding N parallel API calls that each trigger a backend sync
- Differentiate empty states: "No Environments" (with CTA to add one) vs "No Deployments" (with CTA to create one)
- Always show the environment selector dropdown (even with a single provider)
- Reorder provider credentials form: URL before API Key

<img width="489" height="294" alt="image" src="https://github.com/user-attachments/assets/1ad933d0-32bd-46e1-944b-c416ada10f49" />
<img width="878" height="236" alt="image" src="https://github.com/user-attachments/assets/c7b8d6df-52b8-412b-9b67-77dffceae1f9" />
