### PR TITLE
fix: skip missing server file when delete_after_processing=True to avoid race condition

### DIFF
--- a/src/lfx/src/lfx/base/data/base_file.py
+++ b/src/lfx/src/lfx/base/data/base_file.py
@@ -646,6 +646,14 @@ class BaseFileComponent(Component, ABC):
                     resolved_path = Path(self.resolve_path(path_str))
 
                 if not resolved_path.exists():
+                    if delete_after_processing:
+                        # File may have already been processed and deleted by a concurrent output call.
+                        # Silently skip to avoid a false error in this race condition.
+                        self.log(
+                            f"Server file '{path}' not found - skipping as it may have been "
+                            "already processed and deleted by a concurrent call."
+                        )
+                        return
                     msg = f"File not found: '{path}' (resolved to: '{resolved_path}'). Please upload the file again."
                     self.log(msg)
                     if not self.silent_errors:

--- a/src/lfx/src/lfx/base/data/base_file.py
+++ b/src/lfx/src/lfx/base/data/base_file.py
@@ -214,6 +214,20 @@ class BaseFileComponent(Component, ABC):
             # Step 1: Validate the provided paths
             files = self._validate_and_resolve_paths()
 
+            # Race-condition recovery: when a server file is configured with
+            # ``delete_server_file_after_processing=True`` and another output
+            # method on the same component already processed and deleted it,
+            # ``_validate_and_resolve_paths`` returns an empty list. Without
+            # recovery the call would silently produce empty data. Reuse the
+            # processed result cached from the first call so every connected
+            # output sees the same parsed file content.
+            if not files and getattr(self, "_load_files_base_processed_cache", None) is not None:
+                self.log(
+                    "Server file already processed and deleted by a prior call on this "
+                    "component instance; returning cached parsed data to avoid data loss."
+                )
+                return self._load_files_base_processed_cache
+
             # Step 2: Handle bundles recursively
             all_files = self._unpack_and_collect_files(files)
 
@@ -224,7 +238,11 @@ class BaseFileComponent(Component, ABC):
             processed_files = self.process_files(final_files)
 
             # Extract and flatten Data objects to return
-            return [data for file in processed_files for data in file.data if file.data]
+            result = [data for file in processed_files for data in file.data if file.data]
+            # Cache the processed result so concurrent output methods can recover
+            # it when the server file gets deleted between calls.
+            self._load_files_base_processed_cache = result
+            return result
 
         finally:
             # Delete temporary directories

--- a/src/lfx/src/lfx/base/data/base_file.py
+++ b/src/lfx/src/lfx/base/data/base_file.py
@@ -1,6 +1,7 @@
 import ast
 import shutil
 import tarfile
+import threading
 from abc import ABC, abstractmethod
 from io import BytesIO
 from pathlib import Path
@@ -202,59 +203,115 @@ class BaseFileComponent(Component, ABC):
             list[BaseFile]: A list of BaseFile objects with updated `data`.
         """
 
+    def _load_files_paths_cache_key(self) -> tuple:
+        """Build a stable cache key for ``load_files_base`` from the current inputs.
+
+        The key includes both the local ``path`` input and any server file paths from
+        ``file_path``, plus the ``markdown`` flag (which can change which content
+        ``process_files`` produces). It is paths-keyed by design so different
+        component executions or input changes never reuse another call's cache.
+        """
+        path_value = getattr(self, "path", None)
+        if isinstance(path_value, list):
+            paths_part: tuple[str, ...] = tuple(str(p) for p in path_value)
+        elif path_value:
+            paths_part = (str(path_value),)
+        else:
+            paths_part = ()
+
+        file_path_part: tuple[str, ...] = ()
+        try:
+            server_data = self._file_path_as_list()
+        except (ValueError, AttributeError):
+            server_data = []
+        for d in server_data:
+            sp = d.data.get(self.SERVER_FILE_PATH_FIELDNAME) if isinstance(d.data, dict) else None
+            if sp:
+                file_path_part = (*file_path_part, str(sp))
+
+        markdown_flag = getattr(self, "markdown", False)
+        return (paths_part, file_path_part, markdown_flag)
+
     def load_files_base(self) -> list[Data]:
         """Loads and parses file(s), including unpacked file bundles.
+
+        Concurrent output methods on the same component instance are serialized so
+        that only one performs the actual file read/process/delete; the others see
+        the cached parsed result. This prevents both the spurious ``ValueError``
+        from a deleted server file and the silent data-loss interleaving where a
+        second caller would otherwise pass validation, then find the file gone in
+        ``_filter_and_mark_files`` and produce empty data.
 
         Returns:
             list[Data]: Parsed data from the processed files.
         """
-        self._temp_dirs: list[TemporaryDirectory] = []
-        final_files = []  # Initialize to avoid UnboundLocalError
-        try:
-            # Step 1: Validate the provided paths
-            files = self._validate_and_resolve_paths()
+        if not hasattr(self, "_load_files_base_lock"):
+            # Lazily attach a per-instance lock so we don't need to override __init__.
+            # First-touch lock-creation is itself racy in theory, but in practice
+            # every call goes through the same Python attribute write, and the lock
+            # only needs to exist before the next entry — see test
+            # ``test_concurrent_output_calls_are_serialized``.
+            self._load_files_base_lock = threading.Lock()
 
-            # Race-condition recovery: when a server file is configured with
-            # ``delete_server_file_after_processing=True`` and another output
-            # method on the same component already processed and deleted it,
-            # ``_validate_and_resolve_paths`` returns an empty list. Without
-            # recovery the call would silently produce empty data. Reuse the
-            # processed result cached from the first call so every connected
-            # output sees the same parsed file content.
-            if not files and getattr(self, "_load_files_base_processed_cache", None) is not None:
-                self.log(
-                    "Server file already processed and deleted by a prior call on this "
-                    "component instance; returning cached parsed data to avoid data loss."
-                )
-                return self._load_files_base_processed_cache
+        cache_key = self._load_files_paths_cache_key()
+        paths_subkey = cache_key[:-1]  # paths only, ignoring markdown flag
 
-            # Step 2: Handle bundles recursively
-            all_files = self._unpack_and_collect_files(files)
+        with self._load_files_base_lock:
+            cache: dict = getattr(self, "_load_files_base_processed_cache", None) or {}
 
-            # Step 3: Final validation of file types
-            final_files = self._filter_and_mark_files(all_files)
+            # Exact-key fast path: same inputs already processed once on this
+            # instance — return the cached parsed data and avoid reprocessing
+            # (and re-attempting to read a possibly-deleted server file).
+            if cache_key in cache:
+                return cache[cache_key]
 
-            # Step 4: Process files
-            processed_files = self.process_files(final_files)
+            self._temp_dirs: list[TemporaryDirectory] = []
+            self._validate_skipped_due_to_delete_race = False
+            final_files: list = []
+            try:
+                files = self._validate_and_resolve_paths()
 
-            # Extract and flatten Data objects to return
-            result = [data for file in processed_files for data in file.data if file.data]
-            # Cache the processed result so concurrent output methods can recover
-            # it when the server file gets deleted between calls.
-            self._load_files_base_processed_cache = result
-            return result
+                # Recovery path: validation skipped a missing server file marked
+                # ``delete_after_processing=True`` (i.e. a prior output call on
+                # this same instance already processed and deleted it). If we
+                # have any cached parsed result for the same source paths, reuse
+                # it so connected outputs see the same content instead of empty
+                # data. We accept that the cached entry may have been produced
+                # under a different ``markdown`` flag; preserving content is
+                # better than silently dropping it.
+                if self._validate_skipped_due_to_delete_race and not files and cache:
+                    for cached_key, cached_value in cache.items():
+                        if cached_key[:-1] == paths_subkey:
+                            self.log(
+                                "Server file already processed and deleted by a prior call "
+                                "on this component instance; reusing cached parsed data."
+                            )
+                            return cached_value
 
-        finally:
-            # Delete temporary directories
-            for temp_dir in self._temp_dirs:
-                temp_dir.cleanup()
-            # Delete files marked for deletion
-            for file in final_files:
-                if file.delete_after_processing and file.path.exists():
-                    if file.path.is_dir():
-                        shutil.rmtree(file.path)
-                    else:
-                        file.path.unlink()
+                all_files = self._unpack_and_collect_files(files)
+                final_files = self._filter_and_mark_files(all_files)
+                processed_files = self.process_files(final_files)
+                result = [data for file in processed_files for data in file.data if file.data]
+
+                # Only cache successful, non-empty results so a legitimate empty
+                # input on a later call cannot be misread as a race-recovery hit.
+                if result:
+                    cache[cache_key] = result
+                    self._load_files_base_processed_cache = cache
+
+                return result
+
+            finally:
+                # Delete temporary directories
+                for temp_dir in self._temp_dirs:
+                    temp_dir.cleanup()
+                # Delete files marked for deletion
+                for file in final_files:
+                    if file.delete_after_processing and file.path.exists():
+                        if file.path.is_dir():
+                            shutil.rmtree(file.path)
+                        else:
+                            file.path.unlink()
 
     def load_files_core(self) -> list[Data]:
         """Load files and return as Data objects, with per-instance caching.
@@ -666,7 +723,9 @@ class BaseFileComponent(Component, ABC):
                 if not resolved_path.exists():
                     if delete_after_processing:
                         # File may have already been processed and deleted by a concurrent output call.
-                        # Silently skip to avoid a false error in this race condition.
+                        # Flag the skip so ``load_files_base`` can recover from any cached
+                        # parsed result for these paths instead of returning empty data.
+                        self._validate_skipped_due_to_delete_race = True
                         self.log(
                             f"Server file '{path}' not found - skipping as it may have been "
                             "already processed and deleted by a concurrent call."

--- a/src/lfx/src/lfx/base/data/base_file.py
+++ b/src/lfx/src/lfx/base/data/base_file.py
@@ -116,6 +116,11 @@ class BaseFileComponent(Component, ABC):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Eagerly create the per-instance lock used to serialize load_files_base.
+        # Lazy creation inside load_files_base would itself be racy on the very
+        # first concurrent entry — two threads could each create their own Lock
+        # and bypass serialization on the call this PR is meant to fix.
+        self._load_files_base_lock = threading.Lock()
         # Dynamically update FileInput to include valid extensions and bundles
         self.get_base_inputs()[0].file_types = [
             *self.valid_extensions,
@@ -245,14 +250,6 @@ class BaseFileComponent(Component, ABC):
         Returns:
             list[Data]: Parsed data from the processed files.
         """
-        if not hasattr(self, "_load_files_base_lock"):
-            # Lazily attach a per-instance lock so we don't need to override __init__.
-            # First-touch lock-creation is itself racy in theory, but in practice
-            # every call goes through the same Python attribute write, and the lock
-            # only needs to exist before the next entry — see test
-            # ``test_concurrent_output_calls_are_serialized``.
-            self._load_files_base_lock = threading.Lock()
-
         cache_key = self._load_files_paths_cache_key()
         paths_subkey = cache_key[:-1]  # paths only, ignoring markdown flag
 

--- a/src/lfx/tests/unit/base/data/test_base_file.py
+++ b/src/lfx/tests/unit/base/data/test_base_file.py
@@ -249,3 +249,54 @@ class TestLoadFilesMessage:
         assert "Field extraction" in result_text
         # JSON content should be present in some form
         assert "parsed" in result_text or "Dict content" in result_text
+
+
+class TestDeleteAfterProcessingRaceCondition:
+    """Tests for race condition when delete_server_file_after_processing=True."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.component = TestFileComponent()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_path = Path(self.temp_dir.name)
+
+    def teardown_method(self):
+        """Clean up test fixtures."""
+        self.temp_dir.cleanup()
+
+    def test_validate_and_resolve_paths_skips_missing_file_when_delete_after_processing(self):
+        """When delete_after_processing=True, a missing server file should be silently skipped.
+
+        This covers the race condition where multiple concurrent output calls both invoke
+        load_files_base(). The first call processes and deletes the server file; the second
+        call must not raise ValueError when it finds the file already gone.
+        """
+        # Create a real file, then delete it to simulate the race condition
+        server_file = self.temp_path / "server_file.txt"
+        server_file.write_text("content", encoding="utf-8")
+
+        # Set up the component with the server file path via file_path Data input
+        file_data = Data(data={"file_path": str(server_file)})
+        self.component.file_path = file_data
+        self.component.delete_server_file_after_processing = True
+        self.component.silent_errors = False  # Ensure errors would normally propagate
+
+        # First call: processes and deletes the file
+        self.component.load_files_base()
+        assert not server_file.exists(), "File should have been deleted after first call"
+
+        # Second call: file is already gone; should NOT raise ValueError
+        result = self.component.load_files_base()
+        assert result == [], "Second call on deleted server file should return empty list"
+
+    def test_validate_raises_for_missing_file_when_not_delete_after_processing(self):
+        """When delete_after_processing=False, a missing file should still raise ValueError."""
+        missing_path = self.temp_path / "nonexistent.txt"
+
+        self.component.path = [str(missing_path)]
+        self.component.delete_server_file_after_processing = False
+        self.component.silent_errors = False
+
+        import pytest
+        with pytest.raises(ValueError, match="File not found"):
+            self.component.load_files_base()

--- a/src/lfx/tests/unit/base/data/test_base_file.py
+++ b/src/lfx/tests/unit/base/data/test_base_file.py
@@ -2,6 +2,7 @@
 
 import json
 import tempfile
+import threading
 from pathlib import Path
 
 from lfx.base.data.base_file import BaseFileComponent
@@ -315,3 +316,73 @@ class TestDeleteAfterProcessingRaceCondition:
 
         with pytest.raises(ValueError, match="File not found"):
             self.component.load_files_base()
+
+    def test_concurrent_output_calls_are_serialized(self):
+        """Concurrent load_files_base() calls on the same instance must share parsed data.
+
+        Exercises the lock + keyed cache path: two threads enter load_files_base at the
+        same time. Only one should execute the read+process+delete cycle; the other must
+        observe the cached parsed result rather than racing past validation and producing
+        empty output.
+        """
+        server_file = self.temp_path / "concurrent_file.txt"
+        server_file.write_text("concurrent-content", encoding="utf-8")
+
+        self.component.file_path = Data(data={"file_path": str(server_file)})
+        self.component.delete_server_file_after_processing = True
+        self.component.silent_errors = False
+
+        results: list[list[Data]] = []
+        errors: list[BaseException] = []
+        barrier = threading.Barrier(2)
+
+        def worker():
+            try:
+                barrier.wait(timeout=5)
+                results.append(self.component.load_files_base())
+            except BaseException as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Concurrent load_files_base() raised: {errors!r}"
+        assert len(results) == 2
+        assert results[0], "First completed call should return non-empty parsed data"
+        assert results[0] == results[1], (
+            "Concurrent calls must return identical parsed data — neither caller should "
+            "silently fall through to empty output when the other deletes the server file."
+        )
+        assert not server_file.exists(), "Server file should have been deleted exactly once"
+
+    def test_cache_does_not_pollute_legitimate_empty_input(self):
+        """An empty validation result (no input configured) must not return stale cached data.
+
+        Covers the secondary blocker: race-recovery should only activate when validation
+        actually skipped a missing ``delete_after_processing=True`` server file, not for
+        every empty validation result.
+        """
+        # Configure a fresh component with no inputs at all.
+        self.component.file_path = None
+        self.component.path = []
+        self.component.delete_server_file_after_processing = True
+
+        # First call has no input → returns empty without populating recovery cache.
+        first = self.component.load_files_base()
+        assert first == [], "Empty input should yield empty output, not stale cache"
+
+        # Now simulate that a *different* prior call did populate the cache for some
+        # other set of paths. The empty-input call must not pick that up.
+        cached_data = [Data(data={"text": "stale", "file_path": "/tmp/old.txt"})]
+        self.component._load_files_base_processed_cache = {  # type: ignore[attr-defined]
+            ((), ("/tmp/old.txt",), False): cached_data,
+        }
+
+        second = self.component.load_files_base()
+        assert second == [], (
+            "Race-recovery must be keyed to the current paths and gated on the "
+            "validation-skip flag; an empty input must not return a stale cached result."
+        )

--- a/src/lfx/tests/unit/base/data/test_base_file.py
+++ b/src/lfx/tests/unit/base/data/test_base_file.py
@@ -290,10 +290,14 @@ class TestDeleteAfterProcessingRaceCondition:
         assert result == [], "Second call on deleted server file should return empty list"
 
     def test_validate_raises_for_missing_file_when_not_delete_after_processing(self):
-        """When delete_after_processing=False, a missing file should still raise ValueError."""
+        """When delete_after_processing=False, a missing file should still raise ValueError.
+
+        Exercises the ``file_path`` decision branch in load_files_base (not the ``self.path``
+        branch) so the non-race-condition error path is covered for server-file inputs.
+        """
         missing_path = self.temp_path / "nonexistent.txt"
 
-        self.component.path = [str(missing_path)]
+        self.component.file_path = Data(data={"file_path": str(missing_path)})
         self.component.delete_server_file_after_processing = False
         self.component.silent_errors = False
 

--- a/src/lfx/tests/unit/base/data/test_base_file.py
+++ b/src/lfx/tests/unit/base/data/test_base_file.py
@@ -298,5 +298,6 @@ class TestDeleteAfterProcessingRaceCondition:
         self.component.silent_errors = False
 
         import pytest
+
         with pytest.raises(ValueError, match="File not found"):
             self.component.load_files_base()

--- a/src/lfx/tests/unit/base/data/test_base_file.py
+++ b/src/lfx/tests/unit/base/data/test_base_file.py
@@ -264,14 +264,18 @@ class TestDeleteAfterProcessingRaceCondition:
         """Clean up test fixtures."""
         self.temp_dir.cleanup()
 
-    def test_validate_and_resolve_paths_skips_missing_file_when_delete_after_processing(self):
-        """When delete_after_processing=True, a missing server file should be silently skipped.
+    def test_concurrent_output_calls_share_processed_result_when_delete_after_processing(self):
+        """Concurrent output calls share the cached parsed result after the server file is gone.
 
-        This covers the race condition where multiple concurrent output calls both invoke
-        load_files_base(). The first call processes and deletes the server file; the second
-        call must not raise ValueError when it finds the file already gone.
+        When delete_after_processing=True and the server file has already been deleted by a
+        prior output call on the same component instance, load_files_base must return the cached
+        processed result so downstream outputs receive the same parsed data instead of empty Data.
+
+        This covers the race condition where a File component with multiple connected outputs
+        invokes load_files_base() more than once: the first call processes and deletes the
+        server file; the second call must neither raise nor silently drop output data.
         """
-        # Create a real file, then delete it to simulate the race condition
+        # Create a real file with known content
         server_file = self.temp_path / "server_file.txt"
         server_file.write_text("content", encoding="utf-8")
 
@@ -282,12 +286,18 @@ class TestDeleteAfterProcessingRaceCondition:
         self.component.silent_errors = False  # Ensure errors would normally propagate
 
         # First call: processes and deletes the file
-        self.component.load_files_base()
+        first_result = self.component.load_files_base()
         assert not server_file.exists(), "File should have been deleted after first call"
+        assert first_result, "First call should return non-empty parsed data"
 
-        # Second call: file is already gone; should NOT raise ValueError
-        result = self.component.load_files_base()
-        assert result == [], "Second call on deleted server file should return empty list"
+        # Second call: file is already gone; should NOT raise and must NOT drop the data.
+        # The cached processed result from the first call should be returned so a second
+        # downstream output sees the same content rather than an empty Data wrapper.
+        second_result = self.component.load_files_base()
+        assert second_result == first_result, (
+            "Second call on deleted server file must return the cached processed data "
+            "(not an empty list), to preserve output correctness for concurrent outputs."
+        )
 
     def test_validate_raises_for_missing_file_when_not_delete_after_processing(self):
         """When delete_after_processing=False, a missing file should still raise ValueError.


### PR DESCRIPTION
Fixes #8887

## Problem

When a `FileComponent` has multiple outputs connected to downstream nodes, Langflow executes `load_files_base()` concurrently for each output. The first call processes the server file and deletes it (in the `finally` block of `load_files_base`). The second concurrent call then fails at `_validate_and_resolve_paths()` with a `ValueError` because the file is already gone.

The key path:
- `_validate_and_resolve_paths` → `add_file(delete_after_processing=True)` → file not found → `ValueError`

## Solution

In `add_file` inside `_validate_and_resolve_paths`, when `delete_after_processing=True` and the resolved path does not exist, silently skip the file (log a diagnostic message and `return`) instead of raising. This gracefully handles the race condition where the file was already processed and deleted by a concurrent call.

The existing error path (`delete_after_processing=False`) is unaffected — missing files still raise `ValueError` when `silent_errors=False`.

## Testing

- Added `TestDeleteAfterProcessingRaceCondition` with two tests:
  1. Verifies that calling `load_files_base()` after the server file is already deleted does **not** raise when `delete_after_processing=True`
  2. Verifies that missing files **still raise** `ValueError` when `delete_after_processing=False`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of concurrent file deletion scenarios: when a server file is deleted during processing and deletion-after-processing is enabled, the system now logs a message and gracefully skips the file instead of raising an error.

* **Tests**
  * Added test coverage for race condition handling in file deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->