### PR TITLE
fix: Sort and check for Phase in migration

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompt Chaining.json
@@ -665,7 +665,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Basic Prompting.json
@@ -626,7 +626,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json
@@ -542,7 +542,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -1037,7 +1037,7 @@
                 "dependencies": [
                   {
                     "name": "requests",
-                    "version": "2.33.0"
+                    "version": "2.33.1"
                   },
                   {
                     "name": "bs4",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json
@@ -925,7 +925,7 @@
                 "dependencies": [
                   {
                     "name": "requests",
-                    "version": "2.33.0"
+                    "version": "2.33.1"
                   },
                   {
                     "name": "bs4",
@@ -1322,7 +1322,7 @@
                 "dependencies": [
                   {
                     "name": "requests",
-                    "version": "2.33.0"
+                    "version": "2.33.1"
                   },
                   {
                     "name": "bs4",
@@ -1725,7 +1725,7 @@
                 "dependencies": [
                   {
                     "name": "requests",
-                    "version": "2.33.0"
+                    "version": "2.33.1"
                   },
                   {
                     "name": "bs4",
@@ -2400,7 +2400,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -420,7 +420,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -1319,7 +1319,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Financial Report Parser.json
@@ -134,7 +134,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -678,7 +678,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -1755,7 +1755,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json
@@ -460,7 +460,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -1128,7 +1128,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -2084,7 +2084,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -346,7 +346,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -1192,7 +1192,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
@@ -263,7 +263,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -541,7 +541,7 @@
                 "dependencies": [
                   {
                     "name": "chromadb",
-                    "version": "1.5.5"
+                    "version": "1.5.6"
                   },
                   {
                     "name": "cryptography",
@@ -585,7 +585,7 @@
                   },
                   {
                     "name": "langchain_ibm",
-                    "version": "1.0.4"
+                    "version": "1.0.6"
                   }
                 ],
                 "total_dependencies": 12

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -456,7 +456,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -1204,7 +1204,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json
@@ -689,7 +689,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -969,7 +969,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -1249,7 +1249,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json
@@ -429,7 +429,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -890,7 +890,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -1186,7 +1186,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3
@@ -1765,7 +1765,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -517,7 +517,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3
@@ -2340,7 +2340,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -400,7 +400,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -781,7 +781,7 @@
                   },
                   {
                     "name": "validators",
-                    "version": "0.34.0"
+                    "version": "0.35.0"
                   },
                   {
                     "name": "lfx",
@@ -1251,7 +1251,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -332,7 +332,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -941,7 +941,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -424,7 +424,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -1772,7 +1772,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -2823,7 +2823,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Translation Loop.json
@@ -376,7 +376,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SEO Keyword Generator.json
@@ -632,7 +632,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -409,7 +409,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -905,7 +905,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -575,7 +575,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -952,7 +952,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3
@@ -958,7 +958,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3
@@ -2403,7 +2403,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3
@@ -2976,7 +2976,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   },
                   {
                     "name": "pydantic",
@@ -3795,7 +3795,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -656,7 +656,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -951,7 +951,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3
@@ -1840,7 +1840,7 @@
                 "dependencies": [
                   {
                     "name": "requests",
-                    "version": "2.33.0"
+                    "version": "2.33.1"
                   },
                   {
                     "name": "bs4",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   },
                   {
                     "name": "pydantic",
@@ -980,7 +980,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -1301,7 +1301,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -830,7 +830,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -1112,7 +1112,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -3581,7 +3581,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -507,7 +507,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -824,7 +824,7 @@
                 "dependencies": [
                   {
                     "name": "requests",
-                    "version": "2.33.0"
+                    "version": "2.33.1"
                   },
                   {
                     "name": "bs4",
@@ -1717,7 +1717,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3
@@ -2300,7 +2300,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3
@@ -2883,7 +2883,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Twitter Thread Generator.json
@@ -710,7 +710,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -1077,7 +1077,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",
@@ -1631,7 +1631,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   },
                   {
                     "name": "pydantic",
@@ -2702,7 +2702,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   },
                   {
                     "name": "lfx",
@@ -3614,7 +3614,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.22"
+                    "version": "1.2.27"
                   }
                 ],
                 "total_dependencies": 3
@@ -1458,7 +1458,7 @@
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.135.1"
+                    "version": "0.135.3"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/tests/unit/alembic/test_existing_migrations.py
+++ b/src/backend/tests/unit/alembic/test_existing_migrations.py
@@ -114,10 +114,16 @@ class TestExistingMigrations:
             pytest.fail(f"Migrations directory not found at {migrations_dir}")
 
         legacy_migration = next(
-            (f for f in migrations_dir.glob("*.py") if not f.name.startswith("00") and f.name != "__init__.py"), None
+            (
+                f
+                for f in sorted(migrations_dir.glob("*.py"))
+                if not f.name.startswith("00") and f.name != "__init__.py" and "Phase:" not in f.read_text()
+            ),
+            None,
         )
 
-        assert legacy_migration is not None, f"No legacy migration files found in {migrations_dir}"
+        if legacy_migration is None:
+            pytest.skip("All migrations already have phase markers")
 
         result = validator.validate_migration_file(legacy_migration)
         assert result["valid"] is False


### PR DESCRIPTION
This pull request updates the `test_legacy_migrations_flagged` test to improve its handling of legacy migration files. The main change is that the test now skips execution if all migration files already contain phase markers, rather than failing in this case.

Test logic improvements:

* Modified the logic to select a legacy migration file by ensuring that files containing "Phase:" are excluded, and sorted the list of candidate files for consistency. If no such file is found, the test is skipped instead of failing, making the test more robust when all migrations are up-to-date.