### PR TITLE
fix: include connection changes in deployment update payload

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
@@ -417,6 +417,159 @@ describe("Edit mode — pre-populated provider data", () => {
   });
 });
 
+describe("Edit mode — connection updates on pre-existing flows", () => {
+  const upsertFlowType = {} as {
+    upsert_flows?: Array<{
+      flow_version_id?: string;
+      add_app_ids?: string[];
+      remove_app_ids?: string[];
+      tool_name?: string;
+    }>;
+    connections?: Array<unknown>;
+  };
+
+  it("sends add_app_ids when adding a connection to a pre-existing flow", () => {
+    const { result } = renderEditHook();
+
+    act(() => {
+      result.current.setAttachedConnectionByFlow(
+        new Map([["flow-1", ["app-1", "app-2"]]]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const upsertFlows =
+      (payload.provider_data as typeof upsertFlowType)?.upsert_flows ?? [];
+    expect(upsertFlows).toHaveLength(1);
+    expect(upsertFlows[0].flow_version_id).toBe("ver-1");
+    expect(upsertFlows[0].add_app_ids).toEqual(["app-2"]);
+    expect(upsertFlows[0].remove_app_ids).toEqual([]);
+  });
+
+  it("sends remove_app_ids when removing a connection from a pre-existing flow", () => {
+    const { result } = renderEditHook();
+
+    act(() => {
+      result.current.setAttachedConnectionByFlow(
+        new Map([["flow-1", []]]), // removed app-1
+      );
+    });
+
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const upsertFlows =
+      (payload.provider_data as typeof upsertFlowType)?.upsert_flows ?? [];
+    expect(upsertFlows).toHaveLength(1);
+    expect(upsertFlows[0].flow_version_id).toBe("ver-1");
+    expect(upsertFlows[0].add_app_ids).toEqual([]);
+    expect(upsertFlows[0].remove_app_ids).toEqual(["app-1"]);
+  });
+
+  it("sends both add and remove when swapping connections on a pre-existing flow", () => {
+    const { result } = renderEditHook();
+
+    act(() => {
+      result.current.setAttachedConnectionByFlow(
+        new Map([["flow-1", ["app-2", "app-3"]]]), // removed app-1, added app-2 & app-3
+      );
+    });
+
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const upsertFlows =
+      (payload.provider_data as typeof upsertFlowType)?.upsert_flows ?? [];
+    expect(upsertFlows).toHaveLength(1);
+    expect(upsertFlows[0].add_app_ids).toEqual(["app-2", "app-3"]);
+    expect(upsertFlows[0].remove_app_ids).toEqual(["app-1"]);
+  });
+
+  it("does NOT send upsert for pre-existing flow when connections are unchanged", () => {
+    const { result } = renderEditHook();
+    // flow-1 starts with ["app-1"], no changes
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const upsertFlows =
+      (payload.provider_data as typeof upsertFlowType)?.upsert_flows ?? [];
+    // No flows should appear since nothing changed
+    expect(
+      upsertFlows.filter((o) => o.flow_version_id === "ver-1"),
+    ).toHaveLength(0);
+  });
+
+  it("sends connection changes alongside tool_name rename on the same flow", () => {
+    const { result } = renderEditHook();
+
+    act(() => {
+      result.current.setAttachedConnectionByFlow(
+        new Map([["flow-1", ["app-1", "app-2"]]]),
+      );
+      result.current.setToolNameByFlow(
+        new Map([
+          ["flow-1", "renamed_tool"],
+          ["flow-2", "custom_tool_two"],
+        ]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const upsertFlows =
+      (payload.provider_data as typeof upsertFlowType)?.upsert_flows ?? [];
+    expect(upsertFlows).toHaveLength(1);
+    expect(upsertFlows[0].flow_version_id).toBe("ver-1");
+    expect(upsertFlows[0].tool_name).toBe("renamed_tool");
+    expect(upsertFlows[0].add_app_ids).toEqual(["app-2"]);
+    expect(upsertFlows[0].remove_app_ids).toEqual([]);
+  });
+
+  it("includes connections on a newly attached flow with connections", () => {
+    const { result } = renderEditHook();
+
+    act(() => {
+      result.current.handleSelectVersion("flow-new", "ver-new", "v1");
+      result.current.setAttachedConnectionByFlow(
+        new Map([
+          ["flow-1", ["app-1"]], // unchanged
+          ["flow-new", ["app-10", "app-11"]],
+        ]),
+      );
+    });
+
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const upsertFlows =
+      (payload.provider_data as typeof upsertFlowType)?.upsert_flows ?? [];
+    const newFlowEntry = upsertFlows.find(
+      (o) => o.flow_version_id === "ver-new",
+    );
+    expect(newFlowEntry).toBeDefined();
+    expect(newFlowEntry!.add_app_ids).toEqual(["app-10", "app-11"]);
+    expect(newFlowEntry!.remove_app_ids).toEqual([]);
+  });
+});
+
+describe("Edit mode — undo restores connections", () => {
+  it("handleUndoRemoveFlow restores connections from initialConnectionsByFlow", () => {
+    const { result } = renderEditHook();
+
+    // flow-1 starts with connections ["app-1"]
+    act(() => result.current.handleRemoveAttachedFlow("flow-1"));
+    expect(result.current.attachedConnectionByFlow.has("flow-1")).toBe(false);
+
+    act(() => result.current.handleUndoRemoveFlow("flow-1"));
+    expect(result.current.attachedConnectionByFlow.get("flow-1")).toEqual([
+      "app-1",
+    ]);
+
+    // Payload should show no connection diff since it's restored to original
+    const payload = result.current.buildDeploymentUpdatePayload();
+    const upsertFlows =
+      (
+        payload.provider_data as {
+          upsert_flows?: Array<{ flow_version_id?: string }>;
+        }
+      )?.upsert_flows ?? [];
+    expect(
+      upsertFlows.filter((o) => o.flow_version_id === "ver-1"),
+    ).toHaveLength(0);
+  });
+});
+
 describe("Edit mode — tool_name updates", () => {
   it("sends upsert_flows tool_name for renamed pre-existing flow", () => {
     const { result } = renderEditHook();

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
@@ -177,6 +177,11 @@ export function DeploymentStepperProvider({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
+  const initialConnectionsByFlow = useMemo(
+    () => initialState?.initialConnectionsByFlow ?? new Map<string, string[]>(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
 
   const handleRemoveAttachedFlow = useCallback((flowId: string) => {
     setRemovedFlowIds((prev) => new Set([...Array.from(prev), flowId]));
@@ -207,8 +212,16 @@ export function DeploymentStepperProvider({
           return next;
         });
       }
+      const originalConnections = initialConnectionsByFlow.get(flowId);
+      if (originalConnections) {
+        setAttachedConnectionByFlow((prev) => {
+          const next = new Map(prev);
+          next.set(flowId, originalConnections);
+          return next;
+        });
+      }
     },
-    [initialVersionByFlow],
+    [initialVersionByFlow, initialConnectionsByFlow],
   );
 
   const hasValidCredentials =
@@ -406,17 +419,32 @@ export function DeploymentStepperProvider({
         });
       }
 
-      // Renamed tools on pre-existing flows.
+      // Changes on pre-existing flows (tool name and/or connections).
       for (const [flowId, versionEntry] of Array.from(selectedVersionByFlow)) {
         if (!initialVersionByFlow.has(flowId)) continue;
         const currentName = toolNameByFlow.get(flowId)?.trim() ?? "";
         const originalName = initialToolNameByFlow.get(flowId)?.trim() ?? "";
-        if (currentName && currentName !== originalName) {
+        const nameChanged = currentName && currentName !== originalName;
+
+        const currentConnections = attachedConnectionByFlow.get(flowId) ?? [];
+        const originalConnections = initialConnectionsByFlow.get(flowId) ?? [];
+        const originalSet = new Set(originalConnections);
+        const currentSet = new Set(currentConnections);
+        const addAppIds = currentConnections.filter(
+          (id) => !originalSet.has(id),
+        );
+        const removeAppIds = originalConnections.filter(
+          (id) => !currentSet.has(id),
+        );
+        const connectionsChanged =
+          addAppIds.length > 0 || removeAppIds.length > 0;
+
+        if (nameChanged || connectionsChanged) {
           upsertFlows.push({
             flow_version_id: versionEntry.versionId,
-            add_app_ids: [],
-            remove_app_ids: [],
-            tool_name: currentName,
+            add_app_ids: addAppIds,
+            remove_app_ids: removeAppIds,
+            ...(nameChanged && { tool_name: currentName }),
           });
         }
       }
@@ -466,6 +494,7 @@ export function DeploymentStepperProvider({
       selectedLlm,
       initialVersionByFlow,
       initialToolNameByFlow,
+      initialConnectionsByFlow,
       removedFlowIds,
       selectedVersionByFlow,
       toolNameByFlow,

--- a/src/frontend/tests/core/features/deployment-edit.spec.ts
+++ b/src/frontend/tests/core/features/deployment-edit.spec.ts
@@ -2,8 +2,12 @@ import { expect, test } from "../../fixtures";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import {
   ATTACHMENTS_MOCK,
+  ATTACHMENTS_WITH_CONNECTIONS_MOCK,
+  CONFIGS_WITH_CONNECTIONS_MOCK,
   DEPLOYMENT_DETAIL_MOCK,
   DEPLOYMENTS_MOCK,
+  FLOW_VERSIONS_MOCK,
+  FLOWS_MOCK,
   LLMS_MOCK,
   PROVIDERS_MOCK,
 } from "../../utils/deployment-mocks";
@@ -241,5 +245,298 @@ test(
 
     // PATCH must not have been called
     expect(patchCalled).toBe(false);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Helper: set up routes with connection data for edit-mode connection tests
+// ---------------------------------------------------------------------------
+async function setupRoutesWithConnections(
+  page: Parameters<typeof test>[2]["page"],
+  folderId: string,
+) {
+  // Broad catch-all FIRST
+  await page.route("**/api/v1/deployments*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(DEPLOYMENTS_MOCK),
+    });
+  });
+
+  await page.route("**/api/v1/deployments/configs*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(CONFIGS_WITH_CONNECTIONS_MOCK),
+    });
+  });
+
+  await page.route("**/api/v1/deployments/llms*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(LLMS_MOCK),
+    });
+  });
+
+  await page.route("**/api/v1/deployments/providers*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(PROVIDERS_MOCK),
+    });
+  });
+
+  await page.route("**/api/v1/deployments/dep-1", (route) => {
+    if (route.request().method() === "PATCH") {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(DEPLOYMENT_DETAIL_MOCK),
+      });
+    }
+  });
+
+  // Attachments with provider_data containing app_ids
+  await page.route("**/api/v1/deployments/dep-1/flows*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ATTACHMENTS_WITH_CONNECTIONS_MOCK),
+    });
+  });
+
+  // Flows list
+  await page.route("**/api/v1/flows/**", (route) => {
+    const url = route.request().url();
+    if (url.includes("/versions/")) {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(FLOW_VERSIONS_MOCK),
+      });
+      return;
+    }
+    const flows = FLOWS_MOCK.map((f) => ({ ...f, folder_id: folderId }));
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(flows),
+    });
+  });
+
+  // Global variables
+  await page.route("**/api/v1/variables**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([]),
+    });
+  });
+
+  // Env var detection
+  await page.route("**/api/v1/variables/detections**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ variables: [] }),
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test: PATCH includes new connections added to a pre-existing flow
+// ---------------------------------------------------------------------------
+test(
+  "Edit mode includes new connections in PATCH request",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    // Capture folder ID from the projects API before bootstrap
+    const projectsResponsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/v1/projects") && resp.status() === 200,
+      { timeout: 30000 },
+    );
+
+    await awaitBootstrapTest(page, { skipModal: true });
+
+    let folderId = "";
+    try {
+      const projectsResp = await projectsResponsePromise;
+      const folders = await projectsResp.json();
+      const match = Array.isArray(folders)
+        ? (folders.find(
+            (f: { name: string; id: string }) => f.name === "Starter Project",
+          ) ?? folders[0])
+        : null;
+      folderId = (match as { id: string } | null)?.id ?? "";
+    } catch {
+      // proceed
+    }
+
+    await setupRoutesWithConnections(page, folderId);
+    await page.getByTestId("deployments-btn").click();
+    await page.waitForSelector('[data-testid="subtab-deployments"]');
+
+    // Open edit dialog
+    await page
+      .getByTestId("deployment-row-dep-1")
+      .waitFor({ state: "visible" });
+    await page.getByTestId("actions-deployment-dep-1").click();
+    await page.getByRole("menuitem", { name: "Update" }).click();
+    await page.waitForSelector('[data-testid="stepper-modal-title"]');
+
+    // Step 1 (Type) → Next
+    await page.waitForSelector('h2:has-text("Deployment Type")');
+    await page.getByTestId("deployment-stepper-next").click();
+
+    // Step 2 (Attach Flows) — flow "f1" should already be attached
+    await page.waitForSelector("text=Attach Flows");
+    await page.waitForSelector('[data-testid="flow-item-f1"]');
+
+    // Click the pre-attached flow and its version to open the connection panel
+    await page.getByTestId("flow-item-f1").click();
+    await page.waitForSelector('[data-testid="version-item-fv1"]');
+    await page.getByTestId("version-item-fv1").click();
+
+    // Wait for connection panel to appear with available connections
+    await page.waitForSelector('[data-testid="connection-item-existing-app"]');
+    await page.waitForSelector('[data-testid="connection-item-new-app"]');
+
+    // The existing connection should already be checked; select the new one too
+    await page.getByTestId("connection-item-new-app").click();
+
+    // Attach connections
+    await page.getByTestId("connection-attach").click();
+
+    // Step 3 (Review) → click Next
+    await page.getByTestId("deployment-stepper-next").click();
+
+    // Intercept the PATCH request and verify its body
+    const patchRequestPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/v1/deployments/dep-1") &&
+        req.method() === "PATCH",
+    );
+
+    // Click Update
+    await page.getByTestId("deployment-stepper-next").click();
+    const patchRequest = await patchRequestPromise;
+    const body = patchRequest.postDataJSON();
+
+    // Verify the PATCH body includes the new connection
+    const upsertFlows = body?.provider_data?.upsert_flows ?? [];
+    const flowEntry = upsertFlows.find(
+      (f: { flow_version_id: string }) => f.flow_version_id === "fv1",
+    );
+    expect(flowEntry).toBeDefined();
+    expect(flowEntry.add_app_ids).toContain("new-app");
+    // The existing connection should NOT appear in add_app_ids (it was already there)
+    expect(flowEntry.add_app_ids).not.toContain("existing-app");
+    // Nothing was removed
+    expect(flowEntry.remove_app_ids).toEqual([]);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test: PATCH includes removed connections from a pre-existing flow
+// ---------------------------------------------------------------------------
+test(
+  "Edit mode includes removed connections in PATCH request",
+  { tag: ["@release", "@workspace", "@api"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    const projectsResponsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/v1/projects") && resp.status() === 200,
+      { timeout: 30000 },
+    );
+
+    await awaitBootstrapTest(page, { skipModal: true });
+
+    let folderId = "";
+    try {
+      const projectsResp = await projectsResponsePromise;
+      const folders = await projectsResp.json();
+      const match = Array.isArray(folders)
+        ? (folders.find(
+            (f: { name: string; id: string }) => f.name === "Starter Project",
+          ) ?? folders[0])
+        : null;
+      folderId = (match as { id: string } | null)?.id ?? "";
+    } catch {
+      // proceed
+    }
+
+    await setupRoutesWithConnections(page, folderId);
+    await page.getByTestId("deployments-btn").click();
+    await page.waitForSelector('[data-testid="subtab-deployments"]');
+
+    // Open edit dialog
+    await page
+      .getByTestId("deployment-row-dep-1")
+      .waitFor({ state: "visible" });
+    await page.getByTestId("actions-deployment-dep-1").click();
+    await page.getByRole("menuitem", { name: "Update" }).click();
+    await page.waitForSelector('[data-testid="stepper-modal-title"]');
+
+    // Step 1 (Type) → Next
+    await page.waitForSelector('h2:has-text("Deployment Type")');
+    await page.getByTestId("deployment-stepper-next").click();
+
+    // Step 2 (Attach Flows)
+    await page.waitForSelector("text=Attach Flows");
+    await page.waitForSelector('[data-testid="flow-item-f1"]');
+    await page.getByTestId("flow-item-f1").click();
+    await page.waitForSelector('[data-testid="version-item-fv1"]');
+    await page.getByTestId("version-item-fv1").click();
+
+    // Wait for connection panel
+    await page.waitForSelector('[data-testid="connection-item-existing-app"]');
+
+    // Deselect the existing connection (uncheck it)
+    await page.getByTestId("connection-item-existing-app").click();
+
+    // Select only the new connection
+    await page.getByTestId("connection-item-new-app").click();
+    await page.getByTestId("connection-attach").click();
+
+    // Step 3 (Review) → click Next
+    await page.getByTestId("deployment-stepper-next").click();
+
+    const patchRequestPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/v1/deployments/dep-1") &&
+        req.method() === "PATCH",
+    );
+
+    // Click Update
+    await page.getByTestId("deployment-stepper-next").click();
+    const patchRequest = await patchRequestPromise;
+    const body = patchRequest.postDataJSON();
+
+    const upsertFlows = body?.provider_data?.upsert_flows ?? [];
+    const flowEntry = upsertFlows.find(
+      (f: { flow_version_id: string }) => f.flow_version_id === "fv1",
+    );
+    expect(flowEntry).toBeDefined();
+    expect(flowEntry.add_app_ids).toContain("new-app");
+    expect(flowEntry.remove_app_ids).toContain("existing-app");
   },
 );

--- a/src/frontend/tests/utils/deployment-mocks.ts
+++ b/src/frontend/tests/utils/deployment-mocks.ts
@@ -108,6 +108,42 @@ export const DEPLOY_RESPONSE = {
   status: "deploying",
 };
 
+// Attachments with provider_data for edit-mode connection tests.
+// flow "f1" is already attached with connection "existing-app".
+export const ATTACHMENTS_WITH_CONNECTIONS_MOCK = {
+  flow_versions: [
+    {
+      id: "fv1",
+      flow_id: "f1",
+      flow_name: "My Flow",
+      version_number: 1,
+      attached_at: "2026-04-06T00:00:00Z",
+      provider_snapshot_id: null,
+      tool_name: "my-flow",
+      provider_data: {
+        tool_name: "my-flow",
+        app_ids: ["existing-app"],
+      },
+    },
+  ],
+  page: 1,
+  size: 50,
+  total: 1,
+};
+
+// Configs (available connections) returned by the provider.
+export const CONFIGS_WITH_CONNECTIONS_MOCK = {
+  provider_data: {
+    connections: [
+      { connection_id: "conn-1", app_id: "existing-app" },
+      { connection_id: "conn-2", app_id: "new-app" },
+    ],
+    page: 1,
+    size: 10000,
+    total: 2,
+  },
+};
+
 export const POST_EXECUTION_RESPONSE = {
   deployment_id: "dep-1",
   provider_data: {


### PR DESCRIPTION
## Summary
- The update deployment flow was silently dropping connection changes (add/remove) for pre-existing flows. The payload builder only handled tool name renames, hardcoding empty `add_app_ids` and `remove_app_ids`.
- Now diffs current vs initial connections to compute the correct add/remove arrays, and restores connections on undo-remove so re-attached flows match original state.
- Adds unit tests (7 new) and e2e tests (2 new) covering connection update scenarios.