### PR TITLE
feat: expose api_key in InspectionPanel, hide from advanced settings edit mode

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/index.tsx
@@ -129,7 +129,7 @@ export default function InputGlobalComponent({
     variableOptions = [...variableOptions, currentValue];
   }
 
-  const selectedOption = loadFromDb || isEnvVarName ? currentValue : "";
+  const selectedOption = loadFromDb ? currentValue : "";
 
   if (!showParameter) {
     return null;

--- a/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelFields.tsx
+++ b/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelFields.tsx
@@ -52,7 +52,8 @@ export default function InspectionPanelFields({
         const template = data.node?.template[templateField];
         if (isInternalField(templateField)) return false;
         if (HIDDEN_FIELDS[data.type]?.includes(templateField)) return false;
-        if (INSPECTION_PANEL_ONLY_FIELDS[data.type]?.includes(templateField)) return false;
+        if (INSPECTION_PANEL_ONLY_FIELDS[data.type]?.includes(templateField))
+          return false;
         if (
           data.type === "APIRequest" &&
           templateField === "body" &&

--- a/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelFields.tsx
+++ b/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelFields.tsx
@@ -14,7 +14,7 @@ import type { NodeDataType, targetHandleType } from "@/types/flow";
 import { scapeJSONParse } from "@/utils/reactflowUtils";
 import InspectionPanelEditField from "./InspectionPanelEditField";
 import InspectionPanelField from "./InspectionPanelField";
-import { HIDDEN_FIELDS } from "./hidden-fields";
+import { HIDDEN_FIELDS, INSPECTION_PANEL_ONLY_FIELDS } from "./hidden-fields";
 
 interface InspectionPanelFieldsProps {
   data: NodeDataType;
@@ -52,6 +52,7 @@ export default function InspectionPanelFields({
         const template = data.node?.template[templateField];
         if (isInternalField(templateField)) return false;
         if (HIDDEN_FIELDS[data.type]?.includes(templateField)) return false;
+        if (INSPECTION_PANEL_ONLY_FIELDS[data.type]?.includes(templateField)) return false;
         if (
           data.type === "APIRequest" &&
           templateField === "body" &&

--- a/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/hidden-fields.ts
+++ b/src/frontend/src/pages/FlowPage/components/InspectionPanel/components/hidden-fields.ts
@@ -14,16 +14,11 @@ export const HIDDEN_FIELDS: Record<string, string[]> = {
     "autoset_encoding",
   ],
   UnifiedWebSearch: ["ceid"],
-  Agent: ["api_key", "format_instructions", "output_schema", "verbose"],
-  EmbeddingModel: ["show_progress_bar", "chunk_size", "api_key"],
-  LanguageModelComponent: ["api_key"],
+  Agent: ["format_instructions", "output_schema", "verbose"],
+  EmbeddingModel: ["show_progress_bar", "chunk_size"],
   Memory: ["sender_type"],
-  BatchRunComponent: ["api_key"],
-  GuardrailValidator: ["api_key"],
-  SmartRouter: ["api_key"],
-  "Smart Transform": ["api_key"],
-  StructuredOutput: ["api_key", "system_prompt", "schema_name"],
-  KnowledgeBase: ["api_key", "include_embeddings"],
+  StructuredOutput: ["system_prompt", "schema_name"],
+  KnowledgeBase: ["include_embeddings"],
   DynamicCreateData: ["include_metadata"],
   SplitText: ["keep_separator"],
   File: [
@@ -37,4 +32,18 @@ export const HIDDEN_FIELDS: Record<string, string[]> = {
     "doc_key",
     "use_multithreading",
   ],
+};
+
+// Fields to show in the InspectionPanel but hide from the advanced settings edit mode.
+// These fields are intentionally surfaced only in the InspectionPanel for a streamlined UX.
+export const INSPECTION_PANEL_ONLY_FIELDS: Record<string, string[]> = {
+  Agent: ["api_key"],
+  EmbeddingModel: ["api_key"],
+  LanguageModelComponent: ["api_key"],
+  BatchRunComponent: ["api_key"],
+  GuardrailValidator: ["api_key"],
+  SmartRouter: ["api_key"],
+  "Smart Transform": ["api_key"],
+  StructuredOutput: ["api_key"],
+  KnowledgeBase: ["api_key"],
 };


### PR DESCRIPTION
## Summary
- Moves `api_key` out of `HIDDEN_FIELDS` into a new `INSPECTION_PANEL_ONLY_FIELDS` constant in `hidden-fields.ts`
- `api_key` now surfaces in the InspectionPanel's normal (read) view for Agent, EmbeddingModel, LanguageModelComponent, BatchRunComponent, GuardrailValidator, SmartRouter, Smart Transform, StructuredOutput, and KnowledgeBase components
- `api_key` remains hidden from the InspectionPanel's canvas-toggle edit mode via the new `INSPECTION_PANEL_ONLY_FIELDS` check in `allEditableFields`

## Test plan
- [ ] Open a flow with an Agent/LanguageModelComponent/EmbeddingModel node and select it — confirm `api_key` appears in the InspectionPanel
- [ ] Click the edit (fields) icon in the InspectionPanel — confirm `api_key` does NOT appear in the canvas-toggle edit mode
- [ ] Verify other fields in `HIDDEN_FIELDS` (e.g. `format_instructions`, `output_schema`) are still hidden from the InspectionPanel