### PR TITLE
fix: Change the order of deps for re parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
-    "click>=8.3.2",
     "langflow-base[complete]~=0.9.0",
+    "click>=8.3.2",
 ]
 
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the order of dependencies in the `pyproject.toml` file. The `click` dependency is now listed after `langflow-base[complete]`.

- [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L20-R21): Reordered the `dependencies` list so that `"click"` appears after `"langflow-base[complete]"`.