### PR TITLE
fix: pass session_id as thread_id in LangSmith tracer

### DIFF
--- a/src/backend/base/langflow/services/tracing/langsmith.py
+++ b/src/backend/base/langflow/services/tracing/langsmith.py
@@ -25,7 +25,9 @@ if TYPE_CHECKING:
 
 
 class LangSmithTracer(BaseTracer):
-    def __init__(self, trace_name: str, trace_type: str, project_name: str, trace_id: UUID, session_id: str | None = None):
+    def __init__(
+        self, trace_name: str, trace_type: str, project_name: str, trace_id: UUID, session_id: str | None = None
+    ):
         try:
             self._ready = self.setup_langsmith()
             if not self._ready:

--- a/src/backend/base/langflow/services/tracing/langsmith.py
+++ b/src/backend/base/langflow/services/tracing/langsmith.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 class LangSmithTracer(BaseTracer):
-    def __init__(self, trace_name: str, trace_type: str, project_name: str, trace_id: UUID):
+    def __init__(self, trace_name: str, trace_type: str, project_name: str, trace_id: UUID, session_id: str | None = None):
         try:
             self._ready = self.setup_langsmith()
             if not self._ready:
@@ -34,6 +34,7 @@ class LangSmithTracer(BaseTracer):
             self.trace_type = trace_type
             self.project_name = project_name
             self.trace_id = trace_id
+            self.session_id = session_id
             from langsmith import get_current_run_tree
             from langsmith.run_helpers import trace
 
@@ -41,6 +42,9 @@ class LangSmithTracer(BaseTracer):
             self._children: dict[str, RunTree] = {}
             self._children_traces: dict[str, trace] = {}
             self._child_link: dict[str, str] = {}
+            metadata = {}
+            if self.session_id:
+                metadata["thread_id"] = self.session_id
             parent = get_current_run_tree()
             if parent is not None and (parent.id == trace_id or parent.name == trace_name):
                 # duplicate init of LangSmithTracer with same trace_id\\trace_name, using current run tree
@@ -52,6 +56,7 @@ class LangSmithTracer(BaseTracer):
                     run_type=self.get_run_type(self.trace_type),
                     run_id=self.trace_id if parent is None else None,
                     parent=parent,
+                    metadata=metadata or None,
                 )
                 self._run_tree = self._trace.__enter__()
             self._run_tree.add_event({"name": "Start", "time": datetime.now(timezone.utc).isoformat()})

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -167,6 +167,7 @@ class TracingService(Service):
             trace_type="chain",
             project_name=trace_context.project_name,
             trace_id=trace_context.run_id,
+            session_id=trace_context.session_id,
         )
 
     def _initialize_langwatch_tracer(self, trace_context: TraceContext) -> None:


### PR DESCRIPTION
## Summary

- The LangSmith tracer was the only tracer not receiving `session_id` from the tracing service, so traces sent to LangSmith had no `thread_id` metadata and LangSmith's Threads view couldn't group conversations
- Pass `session_id` through to the LangSmith tracer and set it as `thread_id` in the trace metadata, consistent with how Langfuse, Opik, Traceloop, and other tracers already handle it

## Test plan

- [x] Ran Langflow 1.8.4 with LangSmith tracing enabled
- [x] Verified `thread_id` appears in trace metadata in LangSmith
- [x] Verified LangSmith Threads view groups conversations correctly
- [x] Confirmed no regression — traces without a session still work (metadata passed as `None`)

Threads working below
<img width="2002" height="1205" alt="image" src="https://github.com/user-attachments/assets/6b739058-48ca-423d-a016-201178e60009" />