### PR TITLE
fix(celery): honor LANGFLOW_REDIS_DB to match Pydantic Settings default

### DIFF
--- a/src/backend/base/langflow/core/celeryconfig.py
+++ b/src/backend/base/langflow/core/celeryconfig.py
@@ -3,11 +3,15 @@ import os
 
 langflow_redis_host = os.environ.get("LANGFLOW_REDIS_HOST")
 langflow_redis_port = os.environ.get("LANGFLOW_REDIS_PORT")
+# Match the Pydantic Settings default (redis_db: int = 0) so that the Celery
+# worker and the main application operate on the same Redis database when the
+# user overrides LANGFLOW_REDIS_DB.
+langflow_redis_db = os.environ.get("LANGFLOW_REDIS_DB", "0")
 # broker default user
 
 if langflow_redis_host and langflow_redis_port:
-    broker_url = f"redis://{langflow_redis_host}:{langflow_redis_port}/0"
-    result_backend = f"redis://{langflow_redis_host}:{langflow_redis_port}/0"
+    broker_url = f"redis://{langflow_redis_host}:{langflow_redis_port}/{langflow_redis_db}"
+    result_backend = f"redis://{langflow_redis_host}:{langflow_redis_port}/{langflow_redis_db}"
 else:
     # RabbitMQ
     mq_user = os.environ.get("RABBITMQ_DEFAULT_USER", "langflow")


### PR DESCRIPTION
## Problem

The Pydantic `Settings` class defines `redis_db: int = 0`
(`src/lfx/src/lfx/services/settings/base.py:179`), which users can override via
`LANGFLOW_REDIS_DB`. The main application honors this setting, but the Celery
worker config (`src/backend/base/langflow/core/celeryconfig.py`) hardcodes
database `/0` in both `broker_url` and `result_backend`.

As a result, setting `LANGFLOW_REDIS_DB=2` causes the app and the Celery
worker to operate on different Redis databases — a silent split-brain between
the API process and background workers. The app writes to DB 2, the worker
reads/writes DB 0.

## Fix

Read `LANGFLOW_REDIS_DB` in `celeryconfig.py` with a default of `"0"` and use
it when building the Redis URLs. `celeryconfig.py` intentionally uses raw
`os.environ` (it is loaded by the Celery CLI before the Langflow app
bootstraps and cannot import Pydantic Settings), so this mirror of the default
is the minimal safe alignment.

## Compatibility

- When `LANGFLOW_REDIS_DB` is **not** set, the default `\"0\"` preserves the
  current behavior exactly — URLs still end in `/0`.
- Only affects users who explicitly set `LANGFLOW_REDIS_DB`; for them it fixes
  the divergence between the API process and the Celery workers.
- No change to the RabbitMQ fallback branch.
- No change to `BROKER_URL` / `RESULT_BACKEND` overrides.

## Test plan

- [ ] Unset `LANGFLOW_REDIS_DB`, set `LANGFLOW_REDIS_HOST=redis` and
      `LANGFLOW_REDIS_PORT=6379` → URLs end in `/0` (unchanged).
- [ ] Set `LANGFLOW_REDIS_DB=2` along with host/port → URLs end in `/2`.
- [ ] Unset all Redis env vars → RabbitMQ fallback unchanged.