### PR TITLE
feat: add policies component for tool protection via ToolGuard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,4 @@ sso-config.yaml
 AGENTS.md
 CLAUDE.local.md
 langflow.log.*
+tmp_toolguard/

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -211,24 +211,6 @@
         "is_secret": false
       }
     ],
-    "SECURITY.md": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "SECURITY.md",
-        "hashed_secret": "d67b0bfe20b56dac12b19258dcfe74b0998d8eeb",
-        "is_verified": false,
-        "line_number": 153,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "SECURITY.md",
-        "hashed_secret": "e57eb248dee276a7a8931d338105a49725dd6ec7",
-        "is_verified": false,
-        "line_number": 154,
-        "is_secret": false
-      }
-    ],
     "deploy/.env.example": [
       {
         "type": "Basic Auth Credentials",
@@ -269,70 +251,121 @@
         "is_secret": false
       }
     ],
-    "docs/docs/API-Reference/api-flows-run.mdx": [
+    "docs/docs/API-Reference/curl-examples/api-monitor/example-request.sh": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/API-Reference/api-flows-run.mdx",
-        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
-        "is_verified": false,
-        "line_number": 433,
-        "is_secret": false
-      }
-    ],
-    "docs/docs/API-Reference/api-monitor.mdx": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/docs/API-Reference/api-monitor.mdx",
+        "filename": "docs/docs/API-Reference/curl-examples/api-monitor/example-request.sh",
         "hashed_secret": "d622736b5a599d5f9798164134b84e1bd96c48fe",
         "is_verified": false,
-        "line_number": 704,
-        "is_secret": false
+        "line_number": 2
       }
     ],
-    "docs/docs/API-Reference/api-openai-responses.mdx": [
+    "docs/docs/API-Reference/curl-examples/api-users/add-user.sh": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/API-Reference/api-openai-responses.mdx",
-        "hashed_secret": "f8f0b44da6dd51f3e5db5129c12a1b95ec71c2d9",
-        "is_verified": false,
-        "line_number": 45,
-        "is_secret": false
-      }
-    ],
-    "docs/docs/API-Reference/api-reference-api-examples.mdx": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/docs/API-Reference/api-reference-api-examples.mdx",
-        "hashed_secret": "7d268ec0fc8a845ff8e1b1af5317ee5dc164808b",
-        "is_verified": false,
-        "line_number": 94,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/docs/API-Reference/api-reference-api-examples.mdx",
-        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
-        "is_verified": false,
-        "line_number": 98,
-        "is_secret": false
-      }
-    ],
-    "docs/docs/API-Reference/api-users.mdx": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/docs/API-Reference/api-users.mdx",
+        "filename": "docs/docs/API-Reference/curl-examples/api-users/add-user.sh",
         "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
         "is_verified": false,
-        "line_number": 21,
-        "is_secret": false
-      },
+        "line_number": 7
+      }
+    ],
+    "docs/docs/API-Reference/curl-examples/api-users/reset-password.sh": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/docs/API-Reference/api-users.mdx",
+        "filename": "docs/docs/API-Reference/curl-examples/api-users/reset-password.sh",
         "hashed_secret": "8f7d56d9f06f8f052a331fedbe14548f0a3305a3",
         "is_verified": false,
-        "line_number": 213,
-        "is_secret": false
+        "line_number": 6
+      }
+    ],
+    "docs/docs/API-Reference/javascript-examples/api-flows-run/pass-global-variables-in-request-headers.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/javascript-examples/api-flows-run/pass-global-variables-in-request-headers.js",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "docs/docs/API-Reference/javascript-examples/api-openai-responses/additional-configuration-for-openai-client-libraries.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/javascript-examples/api-openai-responses/additional-configuration-for-openai-client-libraries.ts",
+        "hashed_secret": "f8f0b44da6dd51f3e5db5129c12a1b95ec71c2d9",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "docs/docs/API-Reference/javascript-examples/api-openai-responses/pass-global-variables-to-your-flows-in-headers.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/javascript-examples/api-openai-responses/pass-global-variables-to-your-flows-in-headers.js",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "docs/docs/API-Reference/javascript-examples/api-users/add-user.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/javascript-examples/api-users/add-user.js",
+        "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "docs/docs/API-Reference/javascript-examples/api-users/reset-password.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/javascript-examples/api-users/reset-password.js",
+        "hashed_secret": "8f7d56d9f06f8f052a331fedbe14548f0a3305a3",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "docs/docs/API-Reference/python-examples/api-openai-responses/additional-configuration-for-openai-client-libraries.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/python-examples/api-openai-responses/additional-configuration-for-openai-client-libraries.py",
+        "hashed_secret": "f8f0b44da6dd51f3e5db5129c12a1b95ec71c2d9",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "docs/docs/API-Reference/python-examples/api-openai-responses/pass-global-variables-to-your-flows-in-headers.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/python-examples/api-openai-responses/pass-global-variables-to-your-flows-in-headers.py",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "docs/docs/API-Reference/python-examples/api-users/add-user.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/python-examples/api-users/add-user.py",
+        "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "docs/docs/API-Reference/python-examples/api-users/delete-user.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/python-examples/api-users/delete-user.py",
+        "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "docs/docs/API-Reference/python-examples/api-users/reset-password.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/API-Reference/python-examples/api-users/reset-password.py",
+        "hashed_secret": "d2dda7662b3f7d6021c82324fd9a5eb04da2c252",
+        "is_verified": false,
+        "line_number": 15
       }
     ],
     "docs/docs/API-Reference/typescript-client.mdx": [
@@ -896,7 +929,7 @@
         "filename": "src/backend/base/langflow/agentic/flows/LangflowAssistant.json",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 583,
+        "line_number": 567,
         "is_secret": false
       },
       {
@@ -904,7 +937,7 @@
         "filename": "src/backend/base/langflow/agentic/flows/LangflowAssistant.json",
         "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
         "is_verified": false,
-        "line_number": 1673,
+        "line_number": 983,
         "is_secret": false
       },
       {
@@ -912,7 +945,7 @@
         "filename": "src/backend/base/langflow/agentic/flows/LangflowAssistant.json",
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 3484,
+        "line_number": 2101,
         "is_secret": false
       },
       {
@@ -920,7 +953,7 @@
         "filename": "src/backend/base/langflow/agentic/flows/LangflowAssistant.json",
         "hashed_secret": "1b9dea00d77ef5f671532b6167d8c6b6482c2dde",
         "is_verified": false,
-        "line_number": 4065,
+        "line_number": 2681,
         "is_secret": false
       }
     ],
@@ -984,24 +1017,55 @@
         "is_secret": false
       }
     ],
-    "src/backend/base/langflow/agentic/flows/langflow_assistant.py": [
+    "src/backend/base/langflow/agentic/flows/TranslationFlow.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/TranslationFlow.json",
+        "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
+        "is_verified": false,
+        "line_number": 121
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/TranslationFlow.json",
+        "hashed_secret": "35be14614e83fe56d9b2ca1c0e2c2a74890b6889",
+        "is_verified": false,
+        "line_number": 650
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/agentic/flows/TranslationFlow.json",
+        "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
+        "is_verified": false,
+        "line_number": 931
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/backend/base/langflow/agentic/flows/langflow_assistant.py",
+        "filename": "src/backend/base/langflow/agentic/flows/TranslationFlow.json",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 123,
-        "is_secret": false
-      }
-    ],
-    "src/backend/base/langflow/agentic/flows/translation_flow.py": [
+        "line_number": 1122
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/backend/base/langflow/agentic/flows/translation_flow.py",
-        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "filename": "src/backend/base/langflow/agentic/flows/TranslationFlow.json",
+        "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
         "is_verified": false,
-        "line_number": 63,
-        "is_secret": false
+        "line_number": 1254
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/agentic/flows/TranslationFlow.json",
+        "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
+        "is_verified": false,
+        "line_number": 1314
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/base/langflow/agentic/flows/TranslationFlow.json",
+        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "is_verified": false,
+        "line_number": 1379
       }
     ],
     "src/backend/base/langflow/alembic/versions/006b3990db50_add_unique_constraints.py": [
@@ -1764,17 +1828,9 @@
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json",
-        "hashed_secret": "b87e1fbb6e7bc22eafe7983b42d1b2bb7e4a60c2",
-        "is_verified": false,
-        "line_number": 1035,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Blog Writer.json",
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
-        "line_number": 1432,
+        "line_number": 1434,
         "is_secret": false
       }
     ],
@@ -1782,9 +1838,16 @@
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json",
+        "hashed_secret": "124b4911c19a9b66b7a7037c77cc27d1e4715719",
+        "is_verified": false,
+        "line_number": 247
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json",
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 1993,
+        "line_number": 2116,
         "is_secret": false
       },
       {
@@ -1792,14 +1855,14 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json",
         "hashed_secret": "d6e6d7b4b115cd3b9d172623199f8c403055fecc",
         "is_verified": false,
-        "line_number": 2271
+        "line_number": 2394
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Custom Component Generator.json",
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
-        "line_number": 2558,
+        "line_number": 2681,
         "is_secret": false
       }
     ],
@@ -1952,14 +2015,14 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json",
         "hashed_secret": "13f728be4fd927580a98667bcd624f511f459de0",
         "is_verified": false,
-        "line_number": 1107
+        "line_number": 1120
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 1254,
+        "line_number": 1267,
         "is_secret": false
       },
       {
@@ -1967,7 +2030,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json",
         "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
         "is_verified": false,
-        "line_number": 1332,
+        "line_number": 1345,
         "is_secret": false
       },
       {
@@ -1975,7 +2038,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Image Sentiment Analysis.json",
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
-        "line_number": 1584,
+        "line_number": 1597,
         "is_secret": false
       }
     ],
@@ -2081,6 +2144,13 @@
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json",
+        "hashed_secret": "124b4911c19a9b66b7a7037c77cc27d1e4715719",
+        "is_verified": false,
+        "line_number": 1737
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json",
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
         "line_number": 2097,
@@ -2091,7 +2161,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Meeting Summary.json",
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
-        "line_number": 3056,
+        "line_number": 3048,
         "is_secret": false
       }
     ],
@@ -2114,6 +2184,13 @@
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json",
+        "hashed_secret": "124b4911c19a9b66b7a7037c77cc27d1e4715719",
+        "is_verified": false,
+        "line_number": 932
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json",
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
         "line_number": 1301,
@@ -2132,10 +2209,16 @@
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json",
-        "hashed_secret": "f1bd76c4aa6a65698214508669f07eb4c000a08b",
+        "hashed_secret": "d6e6d7b4b115cd3b9d172623199f8c403055fecc",
         "is_verified": false,
-        "line_number": 1755,
-        "is_secret": false
+        "line_number": 884
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json",
+        "hashed_secret": "5cbd01eb0c8ebc2f06074b43562328b7676a802e",
+        "is_verified": false,
+        "line_number": 1755
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json": [
@@ -2144,7 +2227,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json",
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 233,
+        "line_number": 234,
         "is_secret": false
       },
       {
@@ -2152,28 +2235,28 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json",
         "hashed_secret": "d6e6d7b4b115cd3b9d172623199f8c403055fecc",
         "is_verified": false,
-        "line_number": 510
+        "line_number": 511
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 1140
+        "line_number": 1141
       },
       {
         "type": "Secret Keyword",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json",
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
-        "line_number": 1285
+        "line_number": 1286
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json",
         "hashed_secret": "7efbf3fa62542d73e5008c319fcd7629017c14b0",
         "is_verified": false,
-        "line_number": 2592
+        "line_number": 2594
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json": [
@@ -2189,7 +2272,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
-        "line_number": 1599,
+        "line_number": 1612,
         "is_secret": false
       },
       {
@@ -2197,7 +2280,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 1790,
+        "line_number": 1803,
         "is_secret": false
       },
       {
@@ -2205,7 +2288,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
         "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
         "is_verified": false,
-        "line_number": 1925,
+        "line_number": 1938,
         "is_secret": false
       },
       {
@@ -2213,7 +2296,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
         "hashed_secret": "d3d6fe3f7d33d0f4aa28c49544a865982a48a00a",
         "is_verified": false,
-        "line_number": 1985,
+        "line_number": 1998,
         "is_secret": false
       },
       {
@@ -2221,7 +2304,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
-        "line_number": 2050,
+        "line_number": 2063,
         "is_secret": false
       },
       {
@@ -2229,7 +2312,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json",
         "hashed_secret": "13f728be4fd927580a98667bcd624f511f459de0",
         "is_verified": false,
-        "line_number": 2320
+        "line_number": 2333
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json": [
@@ -2393,6 +2476,13 @@
         "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json",
+        "hashed_secret": "d6e6d7b4b115cd3b9d172623199f8c403055fecc",
+        "is_verified": false,
+        "line_number": 650
+      },
+      {
         "type": "Secret Keyword",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
@@ -2422,14 +2512,6 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
         "line_number": 1535,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json",
-        "hashed_secret": "b87e1fbb6e7bc22eafe7983b42d1b2bb7e4a60c2",
-        "is_verified": false,
-        "line_number": 1838,
         "is_secret": false
       }
     ],
@@ -2555,15 +2637,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 274,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
-        "hashed_secret": "377e839f86c1529c656c82599fb225b4a1261ed5",
-        "is_verified": false,
-        "line_number": 539,
+        "line_number": 275,
         "is_secret": false
       },
       {
@@ -2571,7 +2645,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
         "hashed_secret": "76d1ef48b3fa8990b7a1aff6a177e5a5b2d018f8",
         "is_verified": false,
-        "line_number": 719,
+        "line_number": 750,
         "is_secret": false
       },
       {
@@ -2579,14 +2653,14 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
         "hashed_secret": "d6e6d7b4b115cd3b9d172623199f8c403055fecc",
         "is_verified": false,
-        "line_number": 1040
+        "line_number": 1071
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
         "hashed_secret": "2317af15ade380e78be36f9ffdc6415d596a8715",
         "is_verified": false,
-        "line_number": 2258,
+        "line_number": 2301,
         "is_secret": false
       },
       {
@@ -2594,7 +2668,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json",
         "hashed_secret": "d2d44958e9ddf0f3c8f9019ce3f56548e801c023",
         "is_verified": false,
-        "line_number": 2653
+        "line_number": 2696
       }
     ],
     "src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json": [
@@ -2626,7 +2700,7 @@
         "filename": "src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json",
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 2210,
+        "line_number": 2223,
         "is_secret": false
       }
     ],
@@ -2768,24 +2842,6 @@
         "is_secret": false
       }
     ],
-    "src/backend/tests/unit/agentic/flows/test_langflow_assistant.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/agentic/flows/test_langflow_assistant.py",
-        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
-        "is_verified": false,
-        "line_number": 29,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/agentic/flows/test_langflow_assistant.py",
-        "hashed_secret": "e5ad10f370283c6276789de684bca60e30306ad5",
-        "is_verified": false,
-        "line_number": 139,
-        "is_secret": false
-      }
-    ],
     "src/backend/tests/unit/agentic/flows/test_translation_flow.py": [
       {
         "type": "Secret Keyword",
@@ -2810,7 +2866,7 @@
         "filename": "src/backend/tests/unit/agentic/services/helpers/test_flow_loader.py",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 237,
+        "line_number": 198,
         "is_secret": false
       },
       {
@@ -2818,7 +2874,7 @@
         "filename": "src/backend/tests/unit/agentic/services/helpers/test_flow_loader.py",
         "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
         "is_verified": false,
-        "line_number": 431,
+        "line_number": 422,
         "is_secret": false
       }
     ],
@@ -2828,7 +2884,7 @@
         "filename": "src/backend/tests/unit/agentic/services/helpers/test_intent_classification.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 221,
         "is_secret": false
       },
       {
@@ -2836,18 +2892,42 @@
         "filename": "src/backend/tests/unit/agentic/services/helpers/test_intent_classification.py",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 169,
+        "line_number": 225,
         "is_secret": false
+      }
+    ],
+    "src/backend/tests/unit/agentic/services/test_assistant_service_streaming.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/services/test_assistant_service_streaming.py",
+        "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
+        "is_verified": false,
+        "line_number": 79
       }
     ],
     "src/backend/tests/unit/agentic/services/test_flow_executor.py": [
       {
         "type": "Secret Keyword",
         "filename": "src/backend/tests/unit/agentic/services/test_flow_executor.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 368
+      }
+    ],
+    "src/backend/tests/unit/agentic/services/test_flow_preparation.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/services/test_flow_preparation.py",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 85,
-        "is_secret": false
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/agentic/services/test_flow_preparation.py",
+        "hashed_secret": "f514a018f63030cf5c50d8e646fbc581111ab9ed",
+        "is_verified": false,
+        "line_number": 82
       }
     ],
     "src/backend/tests/unit/agentic/services/test_provider_service.py": [
@@ -2856,7 +2936,7 @@
         "filename": "src/backend/tests/unit/agentic/services/test_provider_service.py",
         "hashed_secret": "c92b9809dacd9240dc85e86da6388e9b1bfc8a7d",
         "is_verified": false,
-        "line_number": 147,
+        "line_number": 118,
         "is_secret": false
       }
     ],
@@ -2876,15 +2956,6 @@
         "is_verified": false,
         "line_number": 105,
         "is_secret": false
-      }
-    ],
-    "src/backend/tests/unit/api/v1/test_deployment_route_handlers.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/backend/tests/unit/api/v1/test_deployment_route_handlers.py",
-        "hashed_secret": "505032eaf8a3acf9b094a326dfb1cd0537c75a0d",
-        "is_verified": false,
-        "line_number": 291
       }
     ],
     "src/backend/tests/unit/api/v1/test_deployment_schemas.py": [
@@ -2940,6 +3011,24 @@
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
         "line_number": 39
+      }
+    ],
+    "src/backend/tests/unit/api/v1/test_monitor_shared.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_monitor_shared.py",
+        "hashed_secret": "f409ce90a1cd144912d1df8620215b2dc9fda731",
+        "is_verified": false,
+        "line_number": 248
+      }
+    ],
+    "src/backend/tests/unit/api/v1/test_projects.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/backend/tests/unit/api/v1/test_projects.py",
+        "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
+        "is_verified": false,
+        "line_number": 1819
       }
     ],
     "src/backend/tests/unit/api/v1/test_transactions.py": [
@@ -3272,7 +3361,7 @@
         "filename": "src/backend/tests/unit/components/files_and_knowledge/test_file_component.py",
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 592,
         "is_secret": false
       }
     ],
@@ -3813,6 +3902,15 @@
         "is_secret": false
       }
     ],
+    "src/backend/tests/unit/test_flow_validation.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/backend/tests/unit/test_flow_validation.py",
+        "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
+        "is_verified": false,
+        "line_number": 316
+      }
+    ],
     "src/backend/tests/unit/test_get_api_key.py": [
       {
         "type": "Secret Keyword",
@@ -4030,7 +4128,7 @@
         "filename": "src/frontend/src/constants/constants.ts",
         "hashed_secret": "c04f8fbf55c9096907a982750b1c6b0e4c1dd658",
         "is_verified": false,
-        "line_number": 940,
+        "line_number": 936,
         "is_secret": false
       }
     ],
@@ -4042,6 +4140,99 @@
         "is_verified": false,
         "line_number": 7,
         "is_secret": false
+      }
+    ],
+    "src/frontend/src/icons/Agentics/Agentics.jsx": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "64edfe799fc656565698b7fa8f85196dff718f99",
+        "is_verified": false,
+        "line_number": 28
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "87e0250d2588f9c6a054d6686b2b5c7903416e8e",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "df8968f85fb273af031355f9782caa3f4ac7b52a",
+        "is_verified": false,
+        "line_number": 144
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "48f7abc53adb9ef4cc54d10d83892504e08c2245",
+        "is_verified": false,
+        "line_number": 150
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "2e660334911bf0f6dae9268a890f23d9dabeb120",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "819a378ef03728f267eb392e8a9de9e14a70a5bd",
+        "is_verified": false,
+        "line_number": 192
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "67804b2998f2b3404c98a4b6370deb5a0bcc12f3",
+        "is_verified": false,
+        "line_number": 213
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "2e5e560070827acaff97b9bb572cde5ef36385b7",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "d0457be9267a69e6d8650ea62904103b2889a747",
+        "is_verified": false,
+        "line_number": 231
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "0de77228dc0ec35dc635777bdc13a9c63057e106",
+        "is_verified": false,
+        "line_number": 234
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "d0af6b80c1e2fd39150976da4d83240323099628",
+        "is_verified": false,
+        "line_number": 240
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "c641a0469dd38ee51826f882ca1110210827c107",
+        "is_verified": false,
+        "line_number": 252
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/frontend/src/icons/Agentics/Agentics.jsx",
+        "hashed_secret": "5f0d78d561c5e285b8bc3b01c561939edd3e95fe",
+        "is_verified": false,
+        "line_number": 288
       }
     ],
     "src/frontend/src/icons/Azure/Azure.jsx": [
@@ -4090,13 +4281,923 @@
         "is_secret": false
       }
     ],
+    "src/frontend/src/locales/de.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "696e6809b4c7a037e3bfeea796bfbf1e89ce5fbd",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "071241279b1ee9edc0e265315fba2833f3c6e1d9",
+        "is_verified": false,
+        "line_number": 41
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "4d67e279837e369ee293a323066ef4a05f30ef40",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "97f7ca718a0013593c7a0a914474182107af35d0",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "40a6165fa766809c4d5cc31c9d69bf592b2e930e",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "029a9cd4161ece9fcf5eda09f07874d228daa9e6",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "e71719056a00aeb51887b49912f107d7075e3953",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "33401d90fa17dd65aeb2468f398353281be85596",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "e686334c3bec530179fc0d6f81b75005b8a3541f",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "cfd32aee63f6617c1aa367ff901f9f16abc25ccc",
+        "is_verified": false,
+        "line_number": 104
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "7f9b4ce8fafe27fd7f28e30503ff90be2c51f6f1",
+        "is_verified": false,
+        "line_number": 109
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "a6b7fa3036809eeab8bb104d9c93e8acff5ea081",
+        "is_verified": false,
+        "line_number": 110
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "02eed8625057933776c899e6e60175a552231af3",
+        "is_verified": false,
+        "line_number": 113
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "7af90a388f3f51da50bd0ccfc074ac83a5e77abf",
+        "is_verified": false,
+        "line_number": 194
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "06e10503631d5b1680e4a08e3a5e0ab109812c48",
+        "is_verified": false,
+        "line_number": 245
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "de70a102ac9fe37a0714c25453e50afb4f078359",
+        "is_verified": false,
+        "line_number": 247
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "2a24f50d36559883d2bc391e4e99f9a7afd56ef9",
+        "is_verified": false,
+        "line_number": 266
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "a24f75c63a48219c05df0f39831e66aa1faa6189",
+        "is_verified": false,
+        "line_number": 343
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "fa4b98297401af5e6ab7a402330a12715e891325",
+        "is_verified": false,
+        "line_number": 345
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "9c46c22e7a8ff423706b990fc02c85e0d324f134",
+        "is_verified": false,
+        "line_number": 356
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "91cde4236a3754b4b57733682edfc50571d954c6",
+        "is_verified": false,
+        "line_number": 357
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "9625c6b66710b648d27ee284940849a6b5abf3f0",
+        "is_verified": false,
+        "line_number": 358
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/de.json",
+        "hashed_secret": "cc57a2140542893b4c9396b6a7186b26351c6fe5",
+        "is_verified": false,
+        "line_number": 372
+      }
+    ],
+    "src/frontend/src/locales/en.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "2c3e84f9a984dfb630b908d617069ef33e1fac5b",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "d2c98a3ccd3706c8e941300f1ac53c8ae293b69e",
+        "is_verified": false,
+        "line_number": 26
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "d69c3b1ac54be7da3666d9937b9c78e7c309d6e8",
+        "is_verified": false,
+        "line_number": 27
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "af58392e77ee336caf0d1aad15057ad0745985e5",
+        "is_verified": false,
+        "line_number": 31
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "5faf5025b1a06d16ab0763d128e25b138166792c",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "def70f3dcbf1bcbe925c6d838543917bfc924064",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "4a81761c117cf80ada43fdf5237bbc9e61222651",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "19a2fbd0dd38b4097f419c962342ef5e109eab07",
+        "is_verified": false,
+        "line_number": 94
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "cb88e78a13f07467c3e44000869553e709ecd44f",
+        "is_verified": false,
+        "line_number": 95
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "c04f8fbf55c9096907a982750b1c6b0e4c1dd658",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
+        "is_verified": false,
+        "line_number": 152
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "29333d2356d5dd3aafb45a8614c6d825b6f58424",
+        "is_verified": false,
+        "line_number": 154
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "198b73ffd1a6d9c83101382c6df255edac0d3625",
+        "is_verified": false,
+        "line_number": 160
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "51d69ae6046d2a3be245449d5b38165d5d78def5",
+        "is_verified": false,
+        "line_number": 162
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "2e19560960addfd442570c5b2830afc1115cd3f0",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "ad0cb64bb04fb2dd4e7072fca59f7f23eb025df9",
+        "is_verified": false,
+        "line_number": 170
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "c2d404cb7bad34de0af2136b8efa809ea96170fa",
+        "is_verified": false,
+        "line_number": 172
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "1abaf3f0bb2d459a0fdefe08084901710603a6be",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "47acd2028cf81b5da88ddeedb2aea4eca4b71fbd",
+        "is_verified": false,
+        "line_number": 227
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/en.json",
+        "hashed_secret": "c23d0f85d66cef95852d6a63811ab919de76b02a",
+        "is_verified": false,
+        "line_number": 259
+      }
+    ],
+    "src/frontend/src/locales/es.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "fce2533c38ef22f06740a61818d9f399856b45ad",
+        "is_verified": false,
+        "line_number": 41
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "6776e8e8ad87a11f849d602165885c18b7ffd9c2",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "5a6d1c612954979ea99ee33dbb2d231b00f6ac0a",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "e0bb5d3509b1c0a528192ba194fd358e7cf68aa1",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "641e0eab068bccd95b4b55a4c361e4115c418a5f",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "192b20f92ccd805d527886bed6301b7b371fe348",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "765294f5f2dd1748dbd78e9b59afc3a1787697a2",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "9b230eabf26be3b9d702c89641b984f98d206061",
+        "is_verified": false,
+        "line_number": 104
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "dbfcc263a0fdacc0d688abea5294c8c4968f6dcb",
+        "is_verified": false,
+        "line_number": 109
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "d4c5cdf17c6b6a46dd939ad3f9304e726e60384f",
+        "is_verified": false,
+        "line_number": 110
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "8014424f8694a36a30603e437661446e2eb8c299",
+        "is_verified": false,
+        "line_number": 113
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "0f89cb19175c596fc2ae829f5c09d4d04512cc0d",
+        "is_verified": false,
+        "line_number": 194
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "d35e35ce246c917e0d30a073363f12eb6b412d5e",
+        "is_verified": false,
+        "line_number": 245
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "1cf31e02bf7c19d36f7fd85ca673beb6ab075457",
+        "is_verified": false,
+        "line_number": 247
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "5c324bbf8f0a15d640a2ca93b4bb0183d106edd8",
+        "is_verified": false,
+        "line_number": 266
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "fc4cb17d803c31094c9d646d708e73a8f618f1f3",
+        "is_verified": false,
+        "line_number": 343
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "bdd17febdd742a928650952ec63b0ab0d7eeddac",
+        "is_verified": false,
+        "line_number": 356
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "15e4f8d5f1d2759b1e83f9082a8ce8e194eb5600",
+        "is_verified": false,
+        "line_number": 357
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "c8700cb4716f270e7c37191104366e7b1cadc9de",
+        "is_verified": false,
+        "line_number": 358
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/es.json",
+        "hashed_secret": "0147f29ee8d8343d8d70f94b71b0053b268461e3",
+        "is_verified": false,
+        "line_number": 372
+      }
+    ],
+    "src/frontend/src/locales/fr.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "8972f0dab3b53b35a68dd4bb860647825d2fd366",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "f4cde692d8841bc82500a858c0b039b87d5aac25",
+        "is_verified": false,
+        "line_number": 41
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "75a674a3626e87c539a2518afb33931a57598116",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "394f48d2520c7e41c4e4913d77d03a84fb6cc356",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "94e2f3ee14b92e2e675a8f6118d28738dbf5c6ba",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "bd03c54cd14fd738c7cea7add3ae43058b612392",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "6a4a9f5fd35aba4316eae8fecd22b6520130d3bb",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "cb3228774ef442aa34e93da66e3c2ebbac09a3b6",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "d3a999088e8965ab9ce5c092d636171c69665666",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "c1a3d196da57a31bc8f209f520d7b1453bf18313",
+        "is_verified": false,
+        "line_number": 110
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "d3f815b74ab709a72cf9cdce437053fa0dce6287",
+        "is_verified": false,
+        "line_number": 194
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "7f49bb36f7d78041a9c8e79fdead35277249f701",
+        "is_verified": false,
+        "line_number": 245
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "88362d0d044cf4144e78f646e101110e3f44a9e5",
+        "is_verified": false,
+        "line_number": 247
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "b1df0ac48f734b370fc58c591ef0772266f88bb4",
+        "is_verified": false,
+        "line_number": 266
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/fr.json",
+        "hashed_secret": "ff959bbe348ba1b8176852cd2e3d6ba8dbf4062d",
+        "is_verified": false,
+        "line_number": 356
+      }
+    ],
+    "src/frontend/src/locales/ja.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "2177120edbf5e594d72fdcb9b8fe2183adfc1782",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "ad309c2e61dfa1a5c0dc9896da7fd830af70b8f6",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "4479d5f53df4c7c7bf5e956086be99f06a1de389",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "6dbe389b0fad2a6c97e803c3b6b5a2d8d22522b5",
+        "is_verified": false,
+        "line_number": 104
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "8ce3126ccfb3229f34fe26a2d087ec4e4e159b9d",
+        "is_verified": false,
+        "line_number": 109
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "de6f8e3f2efe3d1041ea12f5151130da05447df8",
+        "is_verified": false,
+        "line_number": 113
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "3cf78799d5f2ac03456fc62edd2ad65120b64f05",
+        "is_verified": false,
+        "line_number": 194
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "d46f0990d79bb487d60ff3a855f6916f3e4e6a1a",
+        "is_verified": false,
+        "line_number": 245
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "20cff9da46719805d7fe563353ad67624227b054",
+        "is_verified": false,
+        "line_number": 343
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "5e8bcadfaab440649c70e43a015503e9109a7bfa",
+        "is_verified": false,
+        "line_number": 345
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "44ed46c9ee10a3a7308c6d1a5df4cb082c57b9e0",
+        "is_verified": false,
+        "line_number": 356
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "20e6aa34a3dd984dd602c294ee85714b53a0a872",
+        "is_verified": false,
+        "line_number": 357
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "b5426a913c9da60eff621ee15e0b195bf6aaa8da",
+        "is_verified": false,
+        "line_number": 358
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/ja.json",
+        "hashed_secret": "9e7ba6c71dc246eee615e88e31861a563e33b42d",
+        "is_verified": false,
+        "line_number": 372
+      }
+    ],
+    "src/frontend/src/locales/pt.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "88f195fbbbbeb256d8efac5b6b20e24d319725ee",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "6d9129298ef5058bb568a75df1daa3171d2f6233",
+        "is_verified": false,
+        "line_number": 41
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "38a814286845e0bf7c437e2f0238e6aa127916b9",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "deba0172511d5701d964202f4e5de698d5e07c67",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "f5256124567ff538827b07cd38077b4d2f0ff4cd",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "30ec8da443543f88f3717d8198a3ea4c07734e5f",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "42f1178697edfac6f6b2532587187fdd33accaf0",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "60743e0ecf39ab99f572bb2f4358ce144499395c",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "1422160d3d897876d721df10805d9fe293add09d",
+        "is_verified": false,
+        "line_number": 104
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "cc0bedebf2fadcc1bfbfa9daf41bba27a2d9aad0",
+        "is_verified": false,
+        "line_number": 109
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "7caaac3befa935700513d4123b881c383af03452",
+        "is_verified": false,
+        "line_number": 110
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "792615431c8645d5df08db0bf84f5db8014f4a17",
+        "is_verified": false,
+        "line_number": 113
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "8610717164ef598531238326ede1ac540dd7a74c",
+        "is_verified": false,
+        "line_number": 194
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "29022bd1c2181fbd36940c13cc3fa70041b48ab6",
+        "is_verified": false,
+        "line_number": 245
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "9c469e53fd34bd270037c7e3309345e0383f7331",
+        "is_verified": false,
+        "line_number": 247
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "e5de519e1707a85ae531c311d440ee66c9d92013",
+        "is_verified": false,
+        "line_number": 266
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "8390eaf853b58ba7ac38db1b8a2cc0808e701547",
+        "is_verified": false,
+        "line_number": 343
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "0f0b397ea447a3fa2ad71bf2275fef3c57c19ced",
+        "is_verified": false,
+        "line_number": 345
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "9a36a9b7c6bfc059b4f02372fff29d59a7d28956",
+        "is_verified": false,
+        "line_number": 356
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "d041f1238574c9fda80f329a69df103dd0362201",
+        "is_verified": false,
+        "line_number": 357
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "cb9c85cb748ddd0400375630f5ec0206759ddb89",
+        "is_verified": false,
+        "line_number": 358
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/pt.json",
+        "hashed_secret": "01817544892d96dedca2ad884fa493fea87ba133",
+        "is_verified": false,
+        "line_number": 372
+      }
+    ],
+    "src/frontend/src/locales/zh-Hans.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "c2c9099cb20503082b8973cbe38e7ba4712379d8",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "7d4449172fe7f8214f3b91655c013aa2de3fc8aa",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "15017ab3ec0dda97b754524421ed4dcff8bc2252",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "d9bbe5c31c394c33128697ada5ad6bb2386b2d50",
+        "is_verified": false,
+        "line_number": 104
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "47d79393f1549ed6bc311a334cda7f88bea287cc",
+        "is_verified": false,
+        "line_number": 109
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "596d019fb62944b96319dc89f44d017cd8fb7152",
+        "is_verified": false,
+        "line_number": 113
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "925ec0cb3d802b1c10bd74612833338e38f123e9",
+        "is_verified": false,
+        "line_number": 194
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "00e66990421091c8a0f9084a1997c317ffe34000",
+        "is_verified": false,
+        "line_number": 245
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "5df1d83e18c6e5903e3f4805f0af1415fd050ef7",
+        "is_verified": false,
+        "line_number": 343
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "c10e8dbe79654ae8ed496c4c50f5e188b7924a4e",
+        "is_verified": false,
+        "line_number": 345
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "7223cfc50b72fe9b091b46275f561526aba9e705",
+        "is_verified": false,
+        "line_number": 356
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "4aa9a3231780af9a37413cb7034ecdf72d43cfec",
+        "is_verified": false,
+        "line_number": 357
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "68af7627d36cc6b923f5928a198165857f1ba5f1",
+        "is_verified": false,
+        "line_number": 358
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/frontend/src/locales/zh-Hans.json",
+        "hashed_secret": "7443c6e0ef4c013461140fb1aa2a7a60b40a0b89",
+        "is_verified": false,
+        "line_number": 372
+      }
+    ],
     "src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx": [
       {
         "type": "Secret Keyword",
         "filename": "src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 312,
+        "line_number": 314,
         "is_secret": false
       },
       {
@@ -4104,7 +5205,7 @@
         "filename": "src/frontend/src/modals/IOModal/components/chatView/chatInput/components/voice-assistant/voice-assistant.tsx",
         "hashed_secret": "1b447eca6f69c26354668f050d0c2cc893605aa5",
         "is_verified": false,
-        "line_number": 314,
+        "line_number": 316,
         "is_secret": false
       }
     ],
@@ -4344,56 +5445,56 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "46df7d934ead26ee1c954d5e997acc3b157d56c4",
         "is_verified": false,
-        "line_number": 302
+        "line_number": 303
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "30a2a8335760cb94085e13994c660605216798b4",
         "is_verified": false,
-        "line_number": 479
+        "line_number": 480
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ae599515f76955f80e617e5094977bc3e34ad6ee",
         "is_verified": false,
-        "line_number": 620
+        "line_number": 621
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "29864a43636a47b564bcb813c6b274a94b974e58",
         "is_verified": false,
-        "line_number": 930
+        "line_number": 931
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "790f32ea451dcd1b0439e5039709769d582fbfe3",
         "is_verified": false,
-        "line_number": 1271
+        "line_number": 1272
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9469330d1ca2f99e4a225fe4cac886ea0b96b7e1",
         "is_verified": false,
-        "line_number": 1464
+        "line_number": 1465
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "697ccfba2c15c7cd8cf6307fd83a491b5c2c9e3e",
+        "hashed_secret": "6ec4fa9c659c1a8f406814e5482dee2e6588d335",
         "is_verified": false,
-        "line_number": 1986
+        "line_number": 2007
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "42a810efde880424b1aec6d80360d8befa6c6521",
         "is_verified": false,
-        "line_number": 3106,
+        "line_number": 3107,
         "is_secret": false
       },
       {
@@ -4401,7 +5502,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7014798bb60656a38da4a856545a06c773976112",
         "is_verified": false,
-        "line_number": 5047,
+        "line_number": 5048,
         "is_secret": false
       },
       {
@@ -4409,7 +5510,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "36ec1308f12e9f599e3845a6ad07d6591fb0c301",
         "is_verified": false,
-        "line_number": 5470,
+        "line_number": 5471,
         "is_secret": false
       },
       {
@@ -4417,14 +5518,14 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ef44ace2f949ed2f7fe71ef6441c1053a73cc004",
         "is_verified": false,
-        "line_number": 5710
+        "line_number": 5711
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "59d43c509612f89c187f862266890ae0dd5fbb9a",
         "is_verified": false,
-        "line_number": 6052,
+        "line_number": 6053,
         "is_secret": false
       },
       {
@@ -4432,7 +5533,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "597868714ac401a26b57be0f857457eeb984be18",
         "is_verified": false,
-        "line_number": 9287,
+        "line_number": 9289,
         "is_secret": false
       },
       {
@@ -4440,7 +5541,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a178830480afc434270a7a53512d97758ec6d139",
         "is_verified": false,
-        "line_number": 9547,
+        "line_number": 9549,
         "is_secret": false
       },
       {
@@ -4448,7 +5549,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "6c7724fbb114bfc616ee7bbbb3214e58907abaf1",
         "is_verified": false,
-        "line_number": 10027,
+        "line_number": 10030,
         "is_secret": false
       },
       {
@@ -4456,7 +5557,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "794ae8fea8a51838b63423486552f5398a47e6fc",
         "is_verified": false,
-        "line_number": 10462,
+        "line_number": 10466,
         "is_secret": false
       },
       {
@@ -4464,7 +5565,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "97e68220b094141268772b8b601fa6cd7432de92",
         "is_verified": false,
-        "line_number": 10750,
+        "line_number": 10754,
         "is_secret": false
       },
       {
@@ -4472,7 +5573,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a5af47522dc8a08746c380da81917bdd6eda057a",
         "is_verified": false,
-        "line_number": 11390,
+        "line_number": 11394,
         "is_secret": false
       },
       {
@@ -4480,7 +5581,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9f66cbc518bb79dc6f0a78af0aa52bbadefe2399",
         "is_verified": false,
-        "line_number": 11866,
+        "line_number": 11871,
         "is_secret": false
       },
       {
@@ -4488,7 +5589,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "b3c2f9fda15f2d3816c7edc667bb24267be41a58",
         "is_verified": false,
-        "line_number": 12112,
+        "line_number": 12117,
         "is_secret": false
       },
       {
@@ -4496,7 +5597,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "72be8a21dd766c795332576419e6864eddc5db4e",
         "is_verified": false,
-        "line_number": 12343,
+        "line_number": 12348,
         "is_secret": false
       },
       {
@@ -4504,7 +5605,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1659f95bebec345a9e20e32fa71e8eac4f32f6a2",
         "is_verified": false,
-        "line_number": 14663,
+        "line_number": 14668,
         "is_secret": false
       },
       {
@@ -4512,7 +5613,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "15e5f792860e53987a756bed19fba1204a671e19",
         "is_verified": false,
-        "line_number": 15316,
+        "line_number": 15321,
         "is_secret": false
       },
       {
@@ -4520,7 +5621,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "91700b2378ff5d682d1d57cff40818586609015d",
         "is_verified": false,
-        "line_number": 16622,
+        "line_number": 16627,
         "is_secret": false
       },
       {
@@ -4528,7 +5629,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4b9838e8ff9ae89c3d23d3c853e0d07935618f00",
         "is_verified": false,
-        "line_number": 18581,
+        "line_number": 18586,
         "is_secret": false
       },
       {
@@ -4536,7 +5637,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1aa0d90add98cf00965a327eed79bf65d589e3ce",
         "is_verified": false,
-        "line_number": 19234,
+        "line_number": 19239,
         "is_secret": false
       },
       {
@@ -4544,7 +5645,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3698dc86868353e8ff5ed4564f78d45f1e6c08b7",
         "is_verified": false,
-        "line_number": 19887,
+        "line_number": 19892,
         "is_secret": false
       },
       {
@@ -4552,7 +5653,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "def35d315dd1ab5b0b4a05fc66847f6b73d0d853",
         "is_verified": false,
-        "line_number": 23152,
+        "line_number": 23157,
         "is_secret": false
       },
       {
@@ -4560,7 +5661,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "932fd84fba062a90506c3086945b53d4a6a3f169",
         "is_verified": false,
-        "line_number": 24458,
+        "line_number": 24463,
         "is_secret": false
       },
       {
@@ -4568,7 +5669,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d1a66c6f4de1b56cc6e24cb0a9c78f5ba0230f56",
         "is_verified": false,
-        "line_number": 25111,
+        "line_number": 25116,
         "is_secret": false
       },
       {
@@ -4576,7 +5677,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ddd35c43ce79e9b7ffc5f2894a1a92ad4da3297d",
         "is_verified": false,
-        "line_number": 25764,
+        "line_number": 25769,
         "is_secret": false
       },
       {
@@ -4584,7 +5685,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "bfa2c52c96d82a086f93287e90c3c889e292989e",
         "is_verified": false,
-        "line_number": 26417,
+        "line_number": 26422,
         "is_secret": false
       },
       {
@@ -4592,7 +5693,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ac40271e91c0d84c26bf3613a94545872a801998",
         "is_verified": false,
-        "line_number": 29682,
+        "line_number": 29687,
         "is_secret": false
       },
       {
@@ -4600,7 +5701,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "691ee8aa156c92e8ae67859d9463020d1d5bec11",
         "is_verified": false,
-        "line_number": 32294,
+        "line_number": 32299,
         "is_secret": false
       },
       {
@@ -4608,7 +5709,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "5c33c0e3b39aa99ab095bf885b5f0688a9332b95",
         "is_verified": false,
-        "line_number": 32947,
+        "line_number": 32952,
         "is_secret": false
       },
       {
@@ -4616,7 +5717,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7bfbc3a0161bb7553a4e14c1eb459d30cf104fdf",
         "is_verified": false,
-        "line_number": 33600,
+        "line_number": 33605,
         "is_secret": false
       },
       {
@@ -4624,7 +5725,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "da7592fd328658e5e783f4d16c62d1d6f9d3acd4",
         "is_verified": false,
-        "line_number": 34253,
+        "line_number": 34258,
         "is_secret": false
       },
       {
@@ -4632,7 +5733,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f0e0ec0ff365d37b4fe860d63a9625ae529d3079",
         "is_verified": false,
-        "line_number": 34906,
+        "line_number": 34911,
         "is_secret": false
       },
       {
@@ -4640,7 +5741,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "23ce66526235ae0035cd8da3920a63c12c1c137a",
         "is_verified": false,
-        "line_number": 36865,
+        "line_number": 36870,
         "is_secret": false
       },
       {
@@ -4648,7 +5749,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a75703e0eb9d3a13d977bf04fa3cc42e9d3c94a2",
         "is_verified": false,
-        "line_number": 40130,
+        "line_number": 40135,
         "is_secret": false
       },
       {
@@ -4656,7 +5757,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "2efc38920659af83e871e71004839171d3eaeba4",
         "is_verified": false,
-        "line_number": 42089,
+        "line_number": 42094,
         "is_secret": false
       },
       {
@@ -4664,7 +5765,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4f514a159d49488561a2efe8585871ce25141548",
         "is_verified": false,
-        "line_number": 42742,
+        "line_number": 42747,
         "is_secret": false
       },
       {
@@ -4672,7 +5773,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "adb1d675969fb13f1d752232026b9872475aca4b",
         "is_verified": false,
-        "line_number": 46007,
+        "line_number": 46012,
         "is_secret": false
       },
       {
@@ -4680,7 +5781,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "99b6e13d3c63e4f323776aec40dda0551bc0aa56",
         "is_verified": false,
-        "line_number": 46660,
+        "line_number": 46665,
         "is_secret": false
       },
       {
@@ -4688,7 +5789,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "914bd29a063d63f5cda65b9193612041bf1b04e9",
         "is_verified": false,
-        "line_number": 49272,
+        "line_number": 49277,
         "is_secret": false
       },
       {
@@ -4696,7 +5797,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "dca20b45dc15f99f985e0f87aacf5569b014ede8",
         "is_verified": false,
-        "line_number": 49925,
+        "line_number": 49930,
         "is_secret": false
       },
       {
@@ -4704,7 +5805,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9d48b00c8700d1dcab9108609465af7112840243",
         "is_verified": false,
-        "line_number": 50578,
+        "line_number": 50583,
         "is_secret": false
       },
       {
@@ -4712,7 +5813,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "e72cb4e0e589831cbbd71514f5b6db7f0d09fd37",
         "is_verified": false,
-        "line_number": 53190,
+        "line_number": 53195,
         "is_secret": false
       },
       {
@@ -4720,7 +5821,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "753c0fdfc1e518b8c44cd464fb28080f3f94a9f4",
         "is_verified": false,
-        "line_number": 54075,
+        "line_number": 54080,
         "is_secret": false
       },
       {
@@ -4728,7 +5829,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ab9b46808af9e1164b7a21d946a2cefcbfa9b769",
         "is_verified": false,
-        "line_number": 54753,
+        "line_number": 54759,
         "is_secret": false
       },
       {
@@ -4736,7 +5837,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f4a6791157ee757125b9f46c2cf72ea19cdfb50e",
         "is_verified": false,
-        "line_number": 55201,
+        "line_number": 55207,
         "is_secret": false
       },
       {
@@ -4744,7 +5845,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "23a1f3524f7b992e6a225072ec63fc780f21da34",
         "is_verified": false,
-        "line_number": 55435,
+        "line_number": 55441,
         "is_secret": false
       },
       {
@@ -4752,7 +5853,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ed86f90a2d697ce47e0cff9b805f9761c4390048",
         "is_verified": false,
-        "line_number": 56894,
+        "line_number": 56900,
         "is_secret": false
       },
       {
@@ -4760,7 +5861,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9a96eb0a8598688b358bdb4b37cdd0019f9934c7",
         "is_verified": false,
-        "line_number": 57622,
+        "line_number": 57628,
         "is_secret": false
       },
       {
@@ -4768,7 +5869,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f846d79058594083280ddae8a1dbce083aaf6427",
         "is_verified": false,
-        "line_number": 57978,
+        "line_number": 57984,
         "is_secret": false
       },
       {
@@ -4776,47 +5877,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "fb0e32db4013340e8e096da4d7cba00c099d9542",
         "is_verified": false,
-        "line_number": 58111,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "b87e1fbb6e7bc22eafe7983b42d1b2bb7e4a60c2",
-        "is_verified": false,
-        "line_number": 58303,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "d33546b1bd9d0542435f0f0946a6231edc175701",
-        "is_verified": false,
-        "line_number": 59119,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "f9ca36cde6942f27b76eac83290189854ff3acd5",
-        "is_verified": false,
-        "line_number": 59341,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "cf2179b851fcddc8328e4f40e46bec14a56747f8",
-        "is_verified": false,
-        "line_number": 59416,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "cc008700c5e02d5c9a7ca24219677922a3f82f17",
-        "is_verified": false,
-        "line_number": 59615,
+        "line_number": 58117,
         "is_secret": false
       },
       {
@@ -4824,14 +5885,14 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d2d44958e9ddf0f3c8f9019ce3f56548e801c023",
         "is_verified": false,
-        "line_number": 60039
+        "line_number": 58984
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7863a3a0eb2ed4e19329374549df3cef1ab7ed16",
         "is_verified": false,
-        "line_number": 60918,
+        "line_number": 59864,
         "is_secret": false
       },
       {
@@ -4839,7 +5900,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "41da17b522aa582bfb292d52e8dd307bada14400",
         "is_verified": false,
-        "line_number": 62118,
+        "line_number": 61064,
         "is_secret": false
       },
       {
@@ -4847,7 +5908,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3632913dea26578a835e7c77ab7f4293d6ec1fe6",
         "is_verified": false,
-        "line_number": 62780,
+        "line_number": 61727,
         "is_secret": false
       },
       {
@@ -4855,7 +5916,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "0321ad34ab13e2dee03faa30b7645b932f24c4d6",
         "is_verified": false,
-        "line_number": 63970,
+        "line_number": 62917,
         "is_secret": false
       },
       {
@@ -4863,7 +5924,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "cb2623c527dbce4b4e4ac56407979cad7149ea9a",
         "is_verified": false,
-        "line_number": 64232,
+        "line_number": 63179,
         "is_secret": false
       },
       {
@@ -4871,23 +5932,37 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "427a8b3d029b9d8020cf1648330b5b0a01eb7e65",
         "is_verified": false,
-        "line_number": 65947,
+        "line_number": 64895,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "87d712244041d657ff8a9655050879f99a3fb359",
+        "is_verified": false,
+        "line_number": 65284
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "2fd7f5b7d8a18e5143661e9f7b51a5d9d36a917a",
         "is_verified": false,
-        "line_number": 67161,
+        "line_number": 66110,
         "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "100955eed8ccc46c514985ee3e53a31e4dbf0cb9",
+        "is_verified": false,
+        "line_number": 66773
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "5bc62a0f48f3bd1f4c9aa548fba2a0b0234fbbd8",
         "is_verified": false,
-        "line_number": 68663,
+        "line_number": 67615,
         "is_secret": false
       },
       {
@@ -4895,15 +5970,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "af246ca4758a5700d172533c40ff71522ae42d99",
         "is_verified": false,
-        "line_number": 68793,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "8c21d79a6f6a5080d3521470b90b316c89080f83",
-        "is_verified": false,
-        "line_number": 69250,
+        "line_number": 67745,
         "is_secret": false
       },
       {
@@ -4911,30 +5978,22 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1f01a7c11bde62eaf153d74394c282aa11574f2a",
         "is_verified": false,
-        "line_number": 69938,
+        "line_number": 68890,
         "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "c1e78fbca179cfef4bcedc4b01c055a5018cb4e0",
+        "hashed_secret": "5cbd01eb0c8ebc2f06074b43562328b7676a802e",
         "is_verified": false,
-        "line_number": 70189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "f1bd76c4aa6a65698214508669f07eb4c000a08b",
-        "is_verified": false,
-        "line_number": 70553,
-        "is_secret": false
+        "line_number": 69513
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a0378f1e9fbdee2f5792824f32acc16f95534180",
         "is_verified": false,
-        "line_number": 71007,
+        "line_number": 69967,
         "is_secret": false
       },
       {
@@ -4942,7 +6001,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "38245225908230e946fe961530d7b9bceca0d939",
         "is_verified": false,
-        "line_number": 71613,
+        "line_number": 70573,
         "is_secret": false
       },
       {
@@ -4950,7 +6009,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1d3051aec8271f45991f72a68fc9be099d3e92c1",
         "is_verified": false,
-        "line_number": 71819,
+        "line_number": 70779,
         "is_secret": false
       },
       {
@@ -4958,7 +6017,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "fb5c8ecafee0b2788e395c40f95b13eb45b464d8",
         "is_verified": false,
-        "line_number": 72686,
+        "line_number": 71646,
         "is_secret": false
       },
       {
@@ -4966,7 +6025,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d377ef5b36367a118f28c20eb126e6ec376e02ea",
         "is_verified": false,
-        "line_number": 72952,
+        "line_number": 71912,
         "is_secret": false
       },
       {
@@ -4974,7 +6033,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f0b2022fc412b5599ddcb48c6f8f87c5a53c26af",
         "is_verified": false,
-        "line_number": 73815,
+        "line_number": 72775,
         "is_secret": false
       },
       {
@@ -4982,7 +6041,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "78f473648929d4b9dd716a3874df23eca9a2d9ed",
         "is_verified": false,
-        "line_number": 73963,
+        "line_number": 72923,
         "is_secret": false
       },
       {
@@ -4990,7 +6049,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "446fa65c4cc6c235fabac8cb7d9241fb018514b8",
         "is_verified": false,
-        "line_number": 75330,
+        "line_number": 74290,
         "is_secret": false
       },
       {
@@ -4998,7 +6057,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "54be28b91891ca9ef7b85502a59b32a2a03a5cb9",
         "is_verified": false,
-        "line_number": 76186,
+        "line_number": 75146,
         "is_secret": false
       },
       {
@@ -5006,7 +6065,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "60f948a394e2811370ba0bb6849777f217ab5274",
         "is_verified": false,
-        "line_number": 76359,
+        "line_number": 75319,
         "is_secret": false
       },
       {
@@ -5014,7 +6073,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "54ed260e3bc31bc77ee06754dff850981d39a66c",
         "is_verified": false,
-        "line_number": 77873,
+        "line_number": 76833,
         "is_secret": false
       },
       {
@@ -5022,14 +6081,14 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d6e6d7b4b115cd3b9d172623199f8c403055fecc",
         "is_verified": false,
-        "line_number": 78148
+        "line_number": 77108
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "8b7be7f7fae86960989b939578d36ce617b498c6",
         "is_verified": false,
-        "line_number": 78810,
+        "line_number": 77770,
         "is_secret": false
       },
       {
@@ -5037,7 +6096,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a6c79dfeb177d34d195c2be48cc62800e629f115",
         "is_verified": false,
-        "line_number": 79333,
+        "line_number": 78293,
         "is_secret": false
       },
       {
@@ -5045,7 +6104,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ef417aa1e71aee527bd6fa12f4490f7d960ec54f",
         "is_verified": false,
-        "line_number": 79533,
+        "line_number": 78493,
         "is_secret": false
       },
       {
@@ -5053,7 +6112,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a356ce34c2d87126e0170adbec7077e4421af5a5",
         "is_verified": false,
-        "line_number": 80389,
+        "line_number": 79349,
         "is_secret": false
       },
       {
@@ -5061,7 +6120,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ccc2dbe82ed3362b249ba70e1bb009cebe0896da",
         "is_verified": false,
-        "line_number": 81339,
+        "line_number": 80299,
         "is_secret": false
       },
       {
@@ -5069,14 +6128,14 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "38e0a75d25980732f3822d2dbe70100bb45f7776",
         "is_verified": false,
-        "line_number": 81508
+        "line_number": 80468
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "6adc7a1a0903ddb6445918094b91181d7a0ad97b",
         "is_verified": false,
-        "line_number": 81659,
+        "line_number": 80619,
         "is_secret": false
       },
       {
@@ -5084,21 +6143,21 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "05d0ff0999b7811f8ff071b6f5dc32f5ae247761",
         "is_verified": false,
-        "line_number": 81812
+        "line_number": 80772
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1479a9069ddd49f42039efa05395334ad689b340",
         "is_verified": false,
-        "line_number": 82074
+        "line_number": 81034
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "aa89465172bb84c366111aeeac493739fa195482",
         "is_verified": false,
-        "line_number": 82749,
+        "line_number": 81709,
         "is_secret": false
       },
       {
@@ -5106,21 +6165,21 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ff086e8fd35b9e537814cb5ac04d10ec05c94f02",
         "is_verified": false,
-        "line_number": 83388
+        "line_number": 82348
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "b6614a286d3c09a4d6f972ed0e3b1a55681291d2",
         "is_verified": false,
-        "line_number": 84156
+        "line_number": 83116
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9373f1ccd9980640fbcec9c685d34eac3c4b9867",
         "is_verified": false,
-        "line_number": 84728,
+        "line_number": 83688,
         "is_secret": false
       },
       {
@@ -5128,70 +6187,70 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "e7d81734cc31a30009dfe21648a9b451db20b26c",
         "is_verified": false,
-        "line_number": 84833
+        "line_number": 83793
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "e9e7e5965c4c11af0b9a7f7a9ac475b1035d8dfa",
         "is_verified": false,
-        "line_number": 85039
+        "line_number": 83999
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "c6a8f64789fbf7f87ab31562cae511b75b12a9de",
         "is_verified": false,
-        "line_number": 85235
+        "line_number": 84195
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1a6049bfe4e287d8b253d70a298ac6c120a009e8",
         "is_verified": false,
-        "line_number": 86191
+        "line_number": 85151
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "60bbe883679e9c5ffdd59dbe0f648ab932d43894",
         "is_verified": false,
-        "line_number": 86349
+        "line_number": 85309
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d055c1cb1713ebd8761a419fc69f22251cba60c1",
         "is_verified": false,
-        "line_number": 86610
+        "line_number": 85570
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "c9ce51e50c6ffd3b77ff3903f8ccb33f079edb93",
         "is_verified": false,
-        "line_number": 88261
+        "line_number": 87221
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7fe6e271898f4d9d4790d69df9b6f04b75cd1a9d",
         "is_verified": false,
-        "line_number": 88793
+        "line_number": 87753
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "13f728be4fd927580a98667bcd624f511f459de0",
         "is_verified": false,
-        "line_number": 89077
+        "line_number": 88037
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3b991cdd2510d7fd1de8b025f0c7cbb9ac84b931",
         "is_verified": false,
-        "line_number": 89394,
+        "line_number": 88354,
         "is_secret": false
       },
       {
@@ -5199,7 +6258,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "573b6322edd45ab8e47491791f0909764e4a2f37",
         "is_verified": false,
-        "line_number": 89915,
+        "line_number": 88875,
         "is_secret": false
       },
       {
@@ -5207,7 +6266,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "8712dea5a30e8180a3f3cfb94b94dd2dce7db414",
         "is_verified": false,
-        "line_number": 90192,
+        "line_number": 89152,
         "is_secret": false
       },
       {
@@ -5215,22 +6274,28 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7efbf3fa62542d73e5008c319fcd7629017c14b0",
         "is_verified": false,
-        "line_number": 92181
+        "line_number": 91142
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "47ce443fa2c6d2894c896af5bf215e058b9211a7",
+        "hashed_secret": "124b4911c19a9b66b7a7037c77cc27d1e4715719",
         "is_verified": false,
-        "line_number": 93524,
-        "is_secret": false
+        "line_number": 92124
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/component_index.json",
+        "hashed_secret": "e2405116ae103458ee88d415e5b1ea9bcdd2f512",
+        "is_verified": false,
+        "line_number": 92630
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4676cd86733e19676c0704d55f548833f5273643",
         "is_verified": false,
-        "line_number": 93684,
+        "line_number": 92905,
         "is_secret": false
       },
       {
@@ -5238,7 +6303,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 93763,
+        "line_number": 92984,
         "is_secret": false
       },
       {
@@ -5246,7 +6311,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f16b56e2e46c4df6bf412a7a9b90c86957016575",
         "is_verified": false,
-        "line_number": 94168,
+        "line_number": 93390,
         "is_secret": false
       },
       {
@@ -5254,14 +6319,14 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "362e18a5d235523febf382bcf21836e271c435c3",
         "is_verified": false,
-        "line_number": 95207
+        "line_number": 94429
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "dede8930d7418d092a12d114de08e444bf0dd82e",
         "is_verified": false,
-        "line_number": 96194,
+        "line_number": 95416,
         "is_secret": false
       },
       {
@@ -5269,7 +6334,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "2a6863fb102cdb7c5f83b6afd00a794efb701566",
         "is_verified": false,
-        "line_number": 96522,
+        "line_number": 95744,
         "is_secret": false
       },
       {
@@ -5277,7 +6342,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4048123bacfc4d262ce85016a54ae55c8063edeb",
         "is_verified": false,
-        "line_number": 96755,
+        "line_number": 95977,
         "is_secret": false
       },
       {
@@ -5285,7 +6350,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "89a477e59f5dec443fcb5e0487bc4816bba70cad",
         "is_verified": false,
-        "line_number": 96938,
+        "line_number": 96160,
         "is_secret": false
       },
       {
@@ -5293,7 +6358,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3de7722ca43ab9676c384eb479950083fb2385bb",
         "is_verified": false,
-        "line_number": 97772,
+        "line_number": 96994,
         "is_secret": false
       },
       {
@@ -5301,7 +6366,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "5ab5903f6c15a46a71c8db55e70119352304cc15",
         "is_verified": false,
-        "line_number": 99094,
+        "line_number": 98316,
         "is_secret": false
       },
       {
@@ -5309,7 +6374,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4311a7e1eaf728d4f31467084f690eff7493a9e4",
         "is_verified": false,
-        "line_number": 99676,
+        "line_number": 98899,
         "is_secret": false
       },
       {
@@ -5317,7 +6382,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "778447ca63a67ae59fea8307b5c436abe9ebeb4f",
         "is_verified": false,
-        "line_number": 100003,
+        "line_number": 99227,
         "is_secret": false
       },
       {
@@ -5325,7 +6390,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a229317aa176166d90f06d566b71932cff018638",
         "is_verified": false,
-        "line_number": 100189,
+        "line_number": 99413,
         "is_secret": false
       },
       {
@@ -5333,14 +6398,14 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "3f3646f2abbfff91cf6323ae334975615368d647",
         "is_verified": false,
-        "line_number": 101146
+        "line_number": 100370
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "f11f7e5870cc432ebcfeeca740aa4d4c351a3d95",
         "is_verified": false,
-        "line_number": 101967,
+        "line_number": 101191,
         "is_secret": false
       },
       {
@@ -5348,7 +6413,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "39a0fb1555a8bcd605b65b7b76dc3af2652d1bb8",
         "is_verified": false,
-        "line_number": 102095,
+        "line_number": 101319,
         "is_secret": false
       },
       {
@@ -5356,7 +6421,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "6516fc2579d674314a52e49462a84159df8479d9",
         "is_verified": false,
-        "line_number": 102280,
+        "line_number": 101504,
         "is_secret": false
       },
       {
@@ -5364,7 +6429,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "9d8a13c0d939f6b5790c6cb248c86f0a4aecc3e1",
         "is_verified": false,
-        "line_number": 102445,
+        "line_number": 101669,
         "is_secret": false
       },
       {
@@ -5372,7 +6437,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "c89fdd11b805574e2ba8910cf63c4273044b887c",
         "is_verified": false,
-        "line_number": 102675,
+        "line_number": 101899,
         "is_secret": false
       },
       {
@@ -5380,15 +6445,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d7b281574944c11832ceba7860689cc5a6606a56",
         "is_verified": false,
-        "line_number": 102798,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "29f233f1b444c5844c32773ad0e4db968a2e60ae",
-        "is_verified": false,
-        "line_number": 103118,
+        "line_number": 102022,
         "is_secret": false
       },
       {
@@ -5396,7 +6453,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7f06239cd274b6930ed82b15c617c6bee4e455aa",
         "is_verified": false,
-        "line_number": 103429,
+        "line_number": 102653,
         "is_secret": false
       },
       {
@@ -5404,7 +6461,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "162232a42f9158e82bb9cd3bac15ff2b2d7efc59",
         "is_verified": false,
-        "line_number": 103569,
+        "line_number": 102793,
         "is_secret": false
       },
       {
@@ -5412,7 +6469,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "76d1ef48b3fa8990b7a1aff6a177e5a5b2d018f8",
         "is_verified": false,
-        "line_number": 103701,
+        "line_number": 102925,
         "is_secret": false
       },
       {
@@ -5420,7 +6477,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "efa90513d8e6348d4005c33485f2981bb2cc3411",
         "is_verified": false,
-        "line_number": 103946,
+        "line_number": 103170,
         "is_secret": false
       },
       {
@@ -5428,7 +6485,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "df722750079d5f4eafa6946825f9dbc2dbb50330",
         "is_verified": false,
-        "line_number": 104162,
+        "line_number": 103386,
         "is_secret": false
       },
       {
@@ -5436,7 +6493,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "cb9c3fb93bf299a1eeaa8085a06e791f72d1c245",
         "is_verified": false,
-        "line_number": 104920,
+        "line_number": 104144,
         "is_secret": false
       },
       {
@@ -5444,7 +6501,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "cd50293b35634a61add9cbfeb9e48fbd44e78bc3",
         "is_verified": false,
-        "line_number": 105988,
+        "line_number": 105214,
         "is_secret": false
       },
       {
@@ -5452,7 +6509,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "b016c72dac43dd6eec034d8b49aa1ded1cc0c6fa",
         "is_verified": false,
-        "line_number": 106230,
+        "line_number": 105456,
         "is_secret": false
       },
       {
@@ -5460,7 +6517,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "72979300428bd6d483243f5d1cb7430ed1ebf6d3",
         "is_verified": false,
-        "line_number": 106568,
+        "line_number": 105794,
         "is_secret": false
       },
       {
@@ -5468,7 +6525,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "08509f7cd25c76dc5ca97e64d21478a617fa193b",
         "is_verified": false,
-        "line_number": 106810,
+        "line_number": 106036,
         "is_secret": false
       },
       {
@@ -5476,7 +6533,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "2dd96ae1cb8802018fb2f6a27926bb5f78957fb0",
         "is_verified": false,
-        "line_number": 108388,
+        "line_number": 107615,
         "is_secret": false
       },
       {
@@ -5484,49 +6541,49 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "d2f0ff9062fd675b53ed11c8f0bdced20c9ca2da",
         "is_verified": false,
-        "line_number": 108574
+        "line_number": 107801
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "5e470d5f88efb21f038e1dc7235e574b3786494c",
         "is_verified": false,
-        "line_number": 108797
+        "line_number": 108024
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "2d693a7a1c790c58b5b95735fcd83326b331dd58",
         "is_verified": false,
-        "line_number": 109092
+        "line_number": 108319
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "711ebff4ea0d7c18d03b813853cda7a8eb32f484",
         "is_verified": false,
-        "line_number": 109258
+        "line_number": 108485
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "827eb24988be42f09d74f7b6fbe9196f9c48ed95",
         "is_verified": false,
-        "line_number": 109445
+        "line_number": 108672
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "2371d9dfeea6253b30d1affa457d5be6ec5f61bc",
         "is_verified": false,
-        "line_number": 109684
+        "line_number": 108911
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "76377d63ef7d864c0cefc5b38c762e16d3ab39b5",
         "is_verified": false,
-        "line_number": 110304,
+        "line_number": 109531,
         "is_secret": false
       },
       {
@@ -5534,7 +6591,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "562c0bc758bca6446fabf1aacf71f63d47bc62ed",
         "is_verified": false,
-        "line_number": 110439,
+        "line_number": 109666,
         "is_secret": false
       },
       {
@@ -5542,7 +6599,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "8c8c106382a84413372980d0991df3e2a20c3797",
         "is_verified": false,
-        "line_number": 110850,
+        "line_number": 110077,
         "is_secret": false
       },
       {
@@ -5550,7 +6607,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "1fd6ae619425c7c342273faad31539a8d2f61787",
         "is_verified": false,
-        "line_number": 111434,
+        "line_number": 110661,
         "is_secret": false
       },
       {
@@ -5558,7 +6615,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4ffc5d8cd514be957c9b87ac84c66205ab6d08d3",
         "is_verified": false,
-        "line_number": 112439,
+        "line_number": 111666,
         "is_secret": false
       },
       {
@@ -5566,7 +6623,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "c0576697d180e97695dd29883a4e1ccb01b2f653",
         "is_verified": false,
-        "line_number": 112852,
+        "line_number": 112080,
         "is_secret": false
       },
       {
@@ -5574,7 +6631,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "497af5dcf573db44fc30ac071ebb008e7ac37669",
         "is_verified": false,
-        "line_number": 113191,
+        "line_number": 112419,
         "is_secret": false
       },
       {
@@ -5582,7 +6639,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "6a5f46048b547457e72572c2d38fb1046591ca71",
         "is_verified": false,
-        "line_number": 114238,
+        "line_number": 113467,
         "is_secret": false
       },
       {
@@ -5590,7 +6647,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "7d770d0728208206c486b536b06077c9953d21f2",
         "is_verified": false,
-        "line_number": 114622,
+        "line_number": 113851,
         "is_secret": false
       },
       {
@@ -5598,7 +6655,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "6fb5a96582d72c338a3f3a7d8144190630d64133",
         "is_verified": false,
-        "line_number": 115024,
+        "line_number": 114253,
         "is_secret": false
       },
       {
@@ -5606,7 +6663,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "270c9abba84329e1be2fa7130b44134c23891f1f",
         "is_verified": false,
-        "line_number": 115362,
+        "line_number": 114591,
         "is_secret": false
       },
       {
@@ -5614,7 +6671,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "a781a6064ef5e2cb085282bb1912e65232fb55d1",
         "is_verified": false,
-        "line_number": 115767,
+        "line_number": 114996,
         "is_secret": false
       },
       {
@@ -5622,7 +6679,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "4943819ce50b5209882a4b91dd4b6140260ec428",
         "is_verified": false,
-        "line_number": 116329,
+        "line_number": 115559,
         "is_secret": false
       },
       {
@@ -5630,7 +6687,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "12690ce26e17773a811f28f4ce4fc91b7e42a747",
         "is_verified": false,
-        "line_number": 116638,
+        "line_number": 115868,
         "is_secret": false
       },
       {
@@ -5638,7 +6695,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "b8e5d31cffa4e410fe6b03a0855c592bceb48d82",
         "is_verified": false,
-        "line_number": 117158,
+        "line_number": 116388,
         "is_secret": false
       },
       {
@@ -5646,7 +6703,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "ef3435e29e3a2c5dcbbb633856c85561848cd995",
         "is_verified": false,
-        "line_number": 117535,
+        "line_number": 116765,
         "is_secret": false
       },
       {
@@ -5654,7 +6711,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "be1df677c309419f4efa0ac48afb2a573beeb95d",
         "is_verified": false,
-        "line_number": 118250,
+        "line_number": 117480,
         "is_secret": false
       },
       {
@@ -5662,7 +6719,7 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "5d65cf087adec89fb18354508030304fc3809586",
         "is_verified": false,
-        "line_number": 118517,
+        "line_number": 117747,
         "is_secret": false
       },
       {
@@ -5670,15 +6727,15 @@
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
         "hashed_secret": "76913f65d6da6c5660de587c8a3e807aafa039dd",
         "is_verified": false,
-        "line_number": 118729,
+        "line_number": 117959,
         "is_secret": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/lfx/src/lfx/_assets/component_index.json",
-        "hashed_secret": "3e9d6fdd4c207f91bf46f62ef4ab12cafd4ed562",
+        "hashed_secret": "ed224b8f1c44b858494a404c3da56528e30723f1",
         "is_verified": false,
-        "line_number": 118893
+        "line_number": 118123
       }
     ],
     "src/lfx/src/lfx/_assets/stable_hash_history.json": [
@@ -6878,6 +7935,13 @@
         "hashed_secret": "1f01a7c11bde62eaf153d74394c282aa11574f2a",
         "is_verified": false,
         "line_number": 2163
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/lfx/src/lfx/_assets/stable_hash_history.json",
+        "hashed_secret": "6940b5e009fe93ed7225e683b5412568c283de99",
+        "is_verified": false,
+        "line_number": 2174
       }
     ],
     "src/lfx/src/lfx/base/models/unified_models/model_catalog.py": [
@@ -6909,7 +7973,7 @@
         "filename": "src/lfx/src/lfx/cli/serve_app.py",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 41,
         "is_secret": false
       }
     ],
@@ -6951,6 +8015,31 @@
         "is_verified": false,
         "line_number": 114,
         "is_secret": false
+      }
+    ],
+    "src/lfx/src/lfx/templates/shell/ci-push.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/templates/shell/ci-push.sh",
+        "hashed_secret": "9ae536c0eb83307aa3b94c341829b7e2be39c2ea",
+        "is_verified": false,
+        "line_number": 32
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/templates/shell/ci-push.sh",
+        "hashed_secret": "51a3d375cd085b9c856551ae3e6f5fbcab909382",
+        "is_verified": false,
+        "line_number": 36
+      }
+    ],
+    "src/lfx/src/lfx/templates/shell/ci-test.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/src/lfx/templates/shell/ci-test.sh",
+        "hashed_secret": "9ae536c0eb83307aa3b94c341829b7e2be39c2ea",
+        "is_verified": false,
+        "line_number": 31
       }
     ],
     "src/lfx/tests/data/starter_projects_1_6_0/Basic Prompting.json": [
@@ -7139,6 +8228,24 @@
         "is_secret": false
       }
     ],
+    "src/lfx/tests/unit/components/agentics/test_llm_factory.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/tests/unit/components/agentics/test_llm_factory.py",
+        "hashed_secret": "d58f8c42247f1cf100bf63f196d93d7d302e8ca9",
+        "is_verified": false,
+        "line_number": 23
+      }
+    ],
+    "src/lfx/tests/unit/components/agentics/test_llm_setup.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lfx/tests/unit/components/agentics/test_llm_setup.py",
+        "hashed_secret": "543bc16afa0bada3dac147c8df8d361065149f0b",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
     "src/lfx/tests/unit/components/langchain_utilities/test_csv_agent.py": [
       {
         "type": "Secret Keyword",
@@ -7190,7 +8297,7 @@
         "filename": "src/lfx/tests/unit/run/test_base.py",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 326,
+        "line_number": 372,
         "is_secret": false
       }
     ],
@@ -7307,5 +8414,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-06T16:25:47Z"
+  "generated_at": "2026-04-09T14:26:21Z"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,9 @@
         "--reload-include",
         "./src/lfx/*",
         "--reload-exclude",
-        "*.db*"
+        "*.db*",
+        "--reload-exclude",
+        "./tmp_toolguard/*"
       ],
       "jinja": true,
       "justMyCode": false,

--- a/docs/docs/Components/policies.mdx
+++ b/docs/docs/Components/policies.mdx
@@ -1,0 +1,50 @@
+# Policies Component
+
+## Overview
+
+The **Policies Component** is a powerful tool for building tool protection code from textual business policies and instructions. It leverages [ToolGuard](https://github.com/AgentToolkit/toolguard) to automatically generate guard code that validates tool execution against defined business policies.
+
+This component enables developers to:
+- Define business policies in natural language and seamlessly integrate policy enforcement into agent workflows
+- Automatically generate validation code for tools based on these policies
+- Protect tool execution by enforcing policy compliance at runtime
+- Cache generated guard code for improved performance
+
+The component operates in two modes:
+1. **Generate Mode**: Invokes ToolGuard's buildtime process to generate new guard code from policies
+2. **Use Cache Mode**: Uses previously generated guard code for faster execution
+
+## Input Parameters
+
+| Parameter Name | Type | Description | Required In Mode |
+|----------------|------|-------------|------------------|
+| `Active` | `bool` | If `true`, invokes ToolGuard code prior to tool execution. If `false`, skips policy validation. | Both |
+| `Build Mode` | `Generate` or `Use Cache` | Indicates whether to invoke buildtime (Generate) or use cached code (Use Cache). | Both |
+| `ToolGuard Project` | `str` | Name for the ToolGuard project. Used to organize automatically generated ToolGuards code. Default: "my_project" | Both |
+| `Tools` | `List[Tool]` | List of tools that the agent can use. These tools will be wrapped with policy guards. | Both |
+| `Policies` | `List[str]` | One or more clear, well-defined and self-contained business policies. Accepts multiple policy strings. | Generate |
+| `Language Model` | `Model` | Language model provider selection for policy processing. We recommend using Anthropic Claude-Sonnet series for this task: high-performance models designed for code (among others).",| Generate |
+| `API key` | `str` | API key for the selected model provider. | Generate |
+
+## Output
+
+| Output Name | Type | Description |
+|-------------|------|-------------|
+| `Guarded Tools` | `List[Tool]` | List of guarded tools with policy enforcement applied. Returns the original tools if policies are not activated. |
+
+## Usage Notes
+
+- The component requires at least one policy to be defined when `active` is `true`
+- Generated guard code is stored in a working directory structure: `tmp_toolguard/{project_name}/Step_1/` and `tmp_toolguard/{project_name}/Step_2/`
+- The component performs a two-step process:
+  1. **Step 1**: Generate guard specifications from policies (stored in `Step_1/`)
+  2. **Step 2**: Generate executable guard code from specifications (stored in `Step_2/`)
+- When switching between `Generate` and `Use Cache` modes, ensure the cache directory contains valid guard code
+- The component automatically handles module caching and cleanup
+
+## Technical Details
+
+- **Display Name**: Policies
+- **Documentation**: [ToolGuard GitHub](https://github.com/AgentToolkit/toolguard)
+- **Status**: Beta
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
+    "click>=8.3.2",
     "langflow-base[complete]~=0.9.0",
 ]
 
@@ -145,6 +146,7 @@ override-dependencies = [
     "dynaconf>=3.2.13",
     "pillow>=12.0.0",  # Force Pillow 12+ to prevent CVE-vulnerable 11.x versions
     "aiohttp>=3.13.4",
+    "click>=8.3.2",  # Override transitive dependency constraint. from toolguard>mellea>click
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
-    "click>=8.3.2",
     "langflow-base[complete]~=0.9.0",
 ]
 
@@ -146,7 +145,6 @@ override-dependencies = [
     "dynaconf>=3.2.13",
     "pillow>=12.0.0",  # Force Pillow 12+ to prevent CVE-vulnerable 11.x versions
     "aiohttp>=3.13.4",
-    "click>=8.3.2",  # Override transitive dependency constraint. from toolguard>mellea>click
 ]
 
 [project.scripts]

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -290,6 +290,9 @@ spider = ["spider-client>=0.0.27,<1.0.0"]
 # Excluded on macOS x86_64: PyTorch dropped Intel Mac wheel builds after v2.2.2 (see LE-172)
 altk = ["agent-lifecycle-toolkit>=0.10.1,<1.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"]
 
+# Toolguard Integration
+toolguard = ["toolguard>=0.2.14,<1.0.0"]
+
 # Additional LangChain integrations
 # Excluded on macOS x86_64: transitive torch dependency (via sentence-transformers) has no Intel Mac wheels (see LE-172)
 langchain-huggingface = ["langchain-huggingface~=1.2.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"]
@@ -427,6 +430,8 @@ complete = [
     "langflow-base[spider]",
     # ALTK
     "langflow-base[altk]",
+    # Toolguard
+    "langflow-base[toolguard]",
     # Additional LangChain integrations
     "langflow-base[langchain-huggingface]",
     "langflow-base[langchain-unstructured]",

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -291,7 +291,7 @@ spider = ["spider-client>=0.0.27,<1.0.0"]
 altk = ["agent-lifecycle-toolkit>=0.10.1,<1.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"]
 
 # Toolguard Integration
-toolguard = ["toolguard>=0.2.14,<1.0.0"]
+toolguard = ["toolguard>=0.2.15,<1.0.0"]
 
 # Additional LangChain integrations
 # Excluded on macOS x86_64: transitive torch dependency (via sentence-transformers) has no Intel Mac wheels (see LE-172)

--- a/src/backend/tests/unit/components/models_and_agents/policies/__init__.py
+++ b/src/backend/tests/unit/components/models_and_agents/policies/__init__.py
@@ -1,0 +1,3 @@
+"""Unit tests for policies components."""
+
+# Made with Bob

--- a/src/backend/tests/unit/components/models_and_agents/policies/test_guarded_tool.py
+++ b/src/backend/tests/unit/components/models_and_agents/policies/test_guarded_tool.py
@@ -1,0 +1,130 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.tools import StructuredTool
+from lfx.components.models_and_agents.policies.guarded_tool import GuardedTool
+from pydantic import BaseModel
+from toolguard.runtime import PolicyViolationException
+
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+
+def my_function(person: Person) -> str:
+    """Format a person's information as a string.
+
+    Args:
+        person: A Person object containing name and age.
+
+    Returns:
+        A formatted string with the person's name and age.
+    """
+    return f"{person.name} is {person.age} years old"
+
+
+@pytest.mark.asyncio
+async def test_guarded_tool_successful_execution():
+    """Test GuardedTool with successful policy validation."""
+    lc_tool = StructuredTool.from_function(my_function)
+
+    # Mock the toolguard context manager and guard_toolcall
+    mock_toolguard = MagicMock()
+    mock_toolguard.guard_toolcall = AsyncMock()
+    mock_toolguard.__enter__ = MagicMock(return_value=mock_toolguard)
+    mock_toolguard.__exit__ = MagicMock(return_value=None)
+
+    guarded_tool = GuardedTool(lc_tool, [lc_tool], mock_toolguard)
+
+    # Test with dict input
+    result = await guarded_tool.arun({"person": {"name": "Alice", "age": 30}})
+
+    # Verify guard_toolcall was called
+    mock_toolguard.guard_toolcall.assert_called_once()
+    assert "Alice is 30 years old" in result
+
+
+@pytest.mark.asyncio
+async def test_guarded_tool_policy_violation():
+    """Test GuardedTool when policy is violated."""
+    lc_tool = StructuredTool.from_function(my_function)
+
+    # Mock the toolguard to raise PolicyViolationException
+    mock_toolguard = MagicMock()
+    mock_toolguard.guard_toolcall = AsyncMock(side_effect=PolicyViolationException("Age must be under 25"))
+    mock_toolguard.__enter__ = MagicMock(return_value=mock_toolguard)
+    mock_toolguard.__exit__ = MagicMock(return_value=None)
+
+    guarded_tool = GuardedTool(lc_tool, [lc_tool], mock_toolguard)
+
+    # Test with dict input that violates policy
+    result = await guarded_tool.arun({"person": {"name": "Bob", "age": 30}})
+
+    # Verify the error response structure
+    assert result["ok"] is False
+    assert result["error"]["type"] == "PolicyViolationException"
+    assert result["error"]["code"] == "FAILURE"
+    assert "Age must be under 25" in result["error"]["message"]
+    assert result["error"]["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_guarded_tool_parse_input_string():
+    """Test parse_input with string input."""
+    lc_tool = StructuredTool.from_function(my_function)
+
+    # Mock the toolguard
+    mock_toolguard = MagicMock()
+    mock_toolguard.__enter__ = MagicMock(return_value=mock_toolguard)
+    mock_toolguard.__exit__ = MagicMock(return_value=None)
+
+    guarded_tool = GuardedTool(lc_tool, [lc_tool], mock_toolguard)
+
+    # Test JSON string
+    result = guarded_tool.parse_input('{"name": "Charlie", "age": 25}')
+    assert result == {"name": "Charlie", "age": 25}
+
+    # Test non-JSON string (should wrap in dict)
+    result = guarded_tool.parse_input("plain text")
+    assert result == {"input": "plain text"}
+
+
+@pytest.mark.asyncio
+async def test_guarded_tool_parse_input_toolcall():
+    """Test parse_input with ToolCall dict format."""
+    lc_tool = StructuredTool.from_function(my_function)
+
+    # Mock the toolguard
+    mock_toolguard = MagicMock()
+    mock_toolguard.__enter__ = MagicMock(return_value=mock_toolguard)
+    mock_toolguard.__exit__ = MagicMock(return_value=None)
+
+    guarded_tool = GuardedTool(lc_tool, [lc_tool], mock_toolguard)
+
+    # Test with args as JSON string
+    result = guarded_tool.parse_input({"args": '{"name": "Dave", "age": 35}'})
+    assert result == {"name": "Dave", "age": 35}
+
+    # Test with args as dict
+    result = guarded_tool.parse_input({"args": {"name": "Eve", "age": 40}})
+    assert result == {"name": "Eve", "age": 40}
+
+    # Test with args as non-JSON string
+    result = guarded_tool.parse_input({"args": "invalid json"})
+    assert result == {"input": "invalid json"}
+
+
+def test_guarded_tool_run_not_implemented():
+    """Test that sync run() raises NotImplementedError."""
+    lc_tool = StructuredTool.from_function(my_function)
+
+    # Mock the toolguard
+    mock_toolguard = MagicMock()
+    mock_toolguard.__enter__ = MagicMock(return_value=mock_toolguard)
+    mock_toolguard.__exit__ = MagicMock(return_value=None)
+
+    guarded_tool = GuardedTool(lc_tool, [lc_tool], mock_toolguard)
+
+    with pytest.raises(NotImplementedError):
+        guarded_tool.run({"person": {"name": "Test", "age": 20}})

--- a/src/backend/tests/unit/components/models_and_agents/policies/test_llm_wrapper.py
+++ b/src/backend/tests/unit/components/models_and_agents/policies/test_llm_wrapper.py
@@ -1,0 +1,300 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
+from lfx.components.models_and_agents.policies.llm_wrapper import LangchainModelWrapper
+
+
+@pytest.fixture
+def mock_langchain_model():
+    """Create a mock BaseChatModel for testing."""
+    model = MagicMock()
+    model.max_tokens = None
+    model.agenerate = AsyncMock()
+    return model
+
+
+@pytest.fixture
+def wrapper(mock_langchain_model):
+    """Create a LangchainModelWrapper instance with mocked model."""
+    return LangchainModelWrapper(mock_langchain_model)
+
+
+def create_llm_result(content: str, finish_reason: str = "stop") -> LLMResult:
+    """Helper to create a mock LLMResult."""
+    message = AIMessage(content=content)
+    generation = ChatGeneration(message=message, generation_info={"finish_reason": finish_reason})
+    return LLMResult(generations=[[generation]])
+
+
+class TestInitialization:
+    """Tests for LangchainModelWrapper initialization."""
+
+    @pytest.mark.asyncio
+    async def test_init_sets_max_tokens(self, mock_langchain_model):
+        """Test that __init__ sets max_tokens to DEFAULT_MAX_TOKENS if it's None."""
+        assert mock_langchain_model.max_tokens is None
+
+        wrapper = LangchainModelWrapper(mock_langchain_model)
+
+        assert getattr(wrapper.langchain_model, "max_tokens", None) == LangchainModelWrapper.DEFAULT_MAX_OUT_TOKENS
+
+    @pytest.mark.asyncio
+    async def test_init_preserves_existing_max_tokens(self):
+        """Test that __init__ doesn't override existing max_tokens."""
+        model = MagicMock()
+        model.max_tokens = 5000
+        model.agenerate = AsyncMock()
+
+        wrapper = LangchainModelWrapper(model)
+
+        assert getattr(wrapper.langchain_model, "max_tokens", None) == 5000
+
+    @pytest.mark.asyncio
+    async def test_init_without_max_tokens_attribute(self):
+        """Test that __init__ handles models without max_tokens attribute."""
+        model = MagicMock(spec=["agenerate"])  # No max_tokens attribute
+        model.agenerate = AsyncMock()
+
+        # Should not raise an error
+        wrapper = LangchainModelWrapper(model)
+
+        assert wrapper.langchain_model == model
+
+
+class TestRoleConversion:
+    """Tests for role conversion logic."""
+
+    def test_convert_role_user_to_human(self, wrapper):
+        """Test that 'user' role converts to 'human'."""
+        assert wrapper._convert_role("user") == "human"
+
+    def test_convert_role_assistant_to_ai(self, wrapper):
+        """Test that 'assistant' role converts to 'ai'."""
+        assert wrapper._convert_role("assistant") == "ai"
+
+    def test_convert_role_system_to_system(self, wrapper):
+        """Test that 'system' role stays as 'system'."""
+        assert wrapper._convert_role("system") == "system"
+
+    def test_convert_role_unknown_defaults_to_system(self, wrapper):
+        """Test that unknown roles default to 'system'."""
+        assert wrapper._convert_role("unknown") == "system"
+        assert wrapper._convert_role("") == "system"
+
+
+class TestMessageValidation:
+    """Tests for message validation."""
+
+    def test_validate_messages_valid(self, wrapper):
+        """Test validation passes for valid messages."""
+        messages = [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi there"}]
+        # Should not raise
+        wrapper._validate_messages(messages)
+
+    def test_validate_messages_not_list(self, wrapper):
+        """Test validation fails if messages is not a list."""
+        with pytest.raises(TypeError, match="Messages must be a list"):
+            wrapper._validate_messages("not a list")
+
+    def test_validate_messages_item_not_dict(self, wrapper):
+        """Test validation fails if message item is not a dict."""
+        messages = [{"role": "user", "content": "Hello"}, "not a dict"]
+        with pytest.raises(TypeError, match="Message at index 1 must be a dict"):
+            wrapper._validate_messages(messages)
+
+    def test_validate_messages_missing_role(self, wrapper):
+        """Test validation fails if message missing 'role'."""
+        messages = [{"content": "Hello"}]
+        with pytest.raises(ValueError, match="missing 'role' field"):
+            wrapper._validate_messages(messages)
+
+    def test_validate_messages_missing_content(self, wrapper):
+        """Test validation fails if message missing 'content'."""
+        messages = [{"role": "user"}]
+        with pytest.raises(ValueError, match="missing 'content' field"):
+            wrapper._validate_messages(messages)
+
+
+class TestContentExtraction:
+    """Tests for content extraction logic."""
+
+    def test_extract_content_string(self, wrapper):
+        """Test extracting string content."""
+        assert wrapper._extract_content("Hello") == "Hello"
+
+    def test_extract_content_none(self, wrapper):
+        """Test extracting None returns empty string."""
+        assert wrapper._extract_content(None) == ""
+
+    def test_extract_content_list(self, wrapper):
+        """Test extracting list joins with space."""
+        assert wrapper._extract_content(["Hello", "world"]) == "Hello world"
+
+    def test_extract_content_tuple(self, wrapper):
+        """Test extracting tuple joins with space."""
+        assert wrapper._extract_content(("Hello", "world")) == "Hello world"
+
+    def test_extract_content_number(self, wrapper):
+        """Test extracting number converts to string."""
+        assert wrapper._extract_content(42) == "42"
+
+    def test_extract_content_mixed_list(self, wrapper):
+        """Test extracting list with mixed types."""
+        assert wrapper._extract_content(["Hello", 42, None]) == "Hello 42 None"
+
+
+class TestGenerate:
+    """Tests for the generate method."""
+
+    @pytest.mark.asyncio
+    async def test_generate_simple_message(self, wrapper, mock_langchain_model):
+        """Test generate with a simple message that completes successfully."""
+        messages = [{"role": "user", "content": "Hello, how are you?"}]
+
+        mock_langchain_model.agenerate.return_value = create_llm_result("I'm doing well, thank you!")
+
+        result = await wrapper.generate(messages)
+
+        assert result == "I'm doing well, thank you!"
+        assert mock_langchain_model.agenerate.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_generate_multiple_messages(self, wrapper, mock_langchain_model):
+        """Test generate with multiple messages."""
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+            {"role": "user", "content": "How are you?"},
+        ]
+
+        mock_langchain_model.agenerate.return_value = create_llm_result("I'm good!")
+
+        result = await wrapper.generate(messages)
+
+        assert result == "I'm good!"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_max_tokens_reached(self, wrapper, mock_langchain_model):
+        """Test generate handles max tokens reached by continuing generation."""
+        messages = [{"role": "user", "content": "Write a long story"}]
+
+        # First call: max tokens reached
+        first_result = create_llm_result("Once upon a time, there was", finish_reason="length")
+
+        # Second call: completion
+        second_result = create_llm_result(" a brave knight who saved the kingdom.", finish_reason="stop")
+
+        mock_langchain_model.agenerate.side_effect = [first_result, second_result]
+
+        result = await wrapper.generate(messages)
+
+        assert result == "Once upon a time, there was a brave knight who saved the kingdom."
+        assert mock_langchain_model.agenerate.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_generate_max_continuations_exceeded(self, wrapper, mock_langchain_model):
+        """Test that max continuations limit prevents infinite recursion."""
+        messages = [{"role": "user", "content": "Test"}]
+
+        # Always return length finish reason
+        mock_langchain_model.agenerate.return_value = create_llm_result("Part", finish_reason="length")
+
+        with pytest.raises(RuntimeError, match="Maximum continuation depth"):
+            await wrapper.generate(messages)
+
+    @pytest.mark.asyncio
+    async def test_generate_invalid_messages(self, wrapper):
+        """Test generate fails with invalid messages."""
+        with pytest.raises(TypeError, match="Messages must be a list"):
+            await wrapper.generate("not a list")
+
+    @pytest.mark.asyncio
+    async def test_generate_api_failure(self, wrapper, mock_langchain_model):
+        """Test generate handles API failures gracefully."""
+        messages = [{"role": "user", "content": "Test"}]
+
+        mock_langchain_model.agenerate.side_effect = Exception("API Error")
+
+        with pytest.raises(RuntimeError, match="Language model API call failed"):
+            await wrapper.generate(messages)
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_response(self, wrapper, mock_langchain_model):
+        """Test generate handles empty response."""
+        messages = [{"role": "user", "content": "Test"}]
+
+        mock_langchain_model.agenerate.return_value = LLMResult(generations=[[]])
+
+        with pytest.raises(ValueError, match="Empty response from language model"):
+            await wrapper.generate(messages)
+
+    @pytest.mark.asyncio
+    async def test_generate_with_tuple_content(self, wrapper, mock_langchain_model):
+        """Test generate handles tuple content correctly."""
+        messages = [{"role": "user", "content": ("Line 1", "Line 2")}]
+
+        mock_langchain_model.agenerate.return_value = create_llm_result("Response")
+
+        result = await wrapper.generate(messages)
+
+        assert result == "Response"
+        # Verify the tuple was converted to string
+        call_args = mock_langchain_model.agenerate.call_args
+        called_messages = call_args.kwargs["messages"][0]
+        assert "Line 1 Line 2" in str(called_messages[0].content)
+
+    @pytest.mark.asyncio
+    async def test_generate_with_none_content(self, wrapper, mock_langchain_model):
+        """Test generate handles None content."""
+        messages = [{"role": "user", "content": None}]
+
+        mock_langchain_model.agenerate.return_value = create_llm_result("Response")
+
+        result = await wrapper.generate(messages)
+
+        assert result == "Response"
+
+    @pytest.mark.asyncio
+    async def test_generate_preserves_message_order(self, wrapper, mock_langchain_model):
+        """Test that message order is preserved during conversion."""
+        messages = [
+            {"role": "system", "content": "First"},
+            {"role": "user", "content": "Second"},
+            {"role": "assistant", "content": "Third"},
+        ]
+
+        mock_langchain_model.agenerate.return_value = create_llm_result("Response")
+
+        await wrapper.generate(messages)
+
+        call_args = mock_langchain_model.agenerate.call_args
+        called_messages = call_args.kwargs["messages"][0]
+
+        assert called_messages[0].content == "First"
+        assert called_messages[1].content == "Second"
+        assert called_messages[2].content == "Third"
+
+    @pytest.mark.asyncio
+    async def test_generate_continuation_includes_previous_messages(self, wrapper, mock_langchain_model):
+        """Test that continuation includes all previous messages."""
+        messages = [{"role": "user", "content": "Original message"}]
+
+        first_result = create_llm_result("Incomplete", finish_reason="length")
+        second_result = create_llm_result(" Complete", finish_reason="stop")
+
+        mock_langchain_model.agenerate.side_effect = [first_result, second_result]
+
+        await wrapper.generate(messages)
+
+        # Check second call includes original message + response + continuation prompt
+        second_call_args = mock_langchain_model.agenerate.call_args_list[1]
+        called_messages = second_call_args.kwargs["messages"][0]
+
+        # Should have at least 3 messages: original + assistant response + continuation
+        assert len(called_messages) >= 3
+
+
+# Made with Bob

--- a/src/backend/tests/unit/components/models_and_agents/policies/test_policies_component.py
+++ b/src/backend/tests/unit/components/models_and_agents/policies/test_policies_component.py
@@ -1,0 +1,286 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from lfx.components.models_and_agents.policies_component import (
+    MODE_GENERATE,
+    MODE_GUARD,
+    STEP2,
+    PoliciesComponent,
+)
+
+
+@pytest.fixture
+def mock_tool():
+    """Create a mock tool for testing."""
+    tool = MagicMock()
+    tool.name = "test_tool"
+    tool.description = "A test tool"
+    tool.tags = []
+    tool.metadata = {}
+    return tool
+
+
+@pytest.fixture
+def mock_component(mock_tool):
+    """Create a PoliciesComponent instance with mocked dependencies."""
+    with patch.object(PoliciesComponent, "user_id", new_callable=lambda: property(lambda _: "test_user_123")):
+        component = PoliciesComponent()
+        component.project = "test_project"
+        component.in_tools = [mock_tool]
+        component.policies = ["Policy 1: Do not allow negative numbers", "Policy 2: Validate input"]
+        component.model = [{"name": "gpt-5.1", "provider": "OpenAI"}]
+        component.api_key = "test_api_key"  # pragma: allowlist secret
+        component.enabled = True
+        component.mode = MODE_GUARD
+        return component
+
+
+@pytest.mark.asyncio
+async def test_cache_mode_success(mock_component, mock_tool):
+    """Test PoliciesComponent in cache mode with valid cached guards."""
+    code_dir = mock_component.work_dir / STEP2
+
+    # Mock the cache directory exists and toolguard loading
+    with (
+        patch.object(Path, "exists", return_value=True),
+        patch("lfx.components.models_and_agents.policies_component.load_toolguards") as mock_load_guards,
+        patch.object(mock_component, "make_toolguard_result") as mock_make_result,
+        patch("lfx.components.models_and_agents.policies_component.load_toolguards_from_memory") as mock_load_memory,
+        patch("lfx.components.models_and_agents.policies_component.GuardedTool") as mock_guarded_tool,
+    ):
+        mock_tg_result = MagicMock()
+        mock_make_result.return_value = mock_tg_result
+        mock_tg_runtime = MagicMock()
+        mock_load_memory.return_value = mock_tg_runtime
+        mock_guarded_instance = MagicMock()
+        mock_guarded_tool.return_value = mock_guarded_instance
+
+        result = await mock_component.guard_tools()
+
+        # Verify load_toolguards was called during validation
+        mock_load_guards.assert_called_once_with(code_dir)
+
+        # Verify make_toolguard_result was called
+        mock_make_result.assert_called_once()
+
+        # Verify load_toolguards_from_memory was called with the result
+        mock_load_memory.assert_called_once_with(mock_tg_result)
+
+        # Verify GuardedTool was created for each tool
+        assert mock_guarded_tool.call_count == len(mock_component.in_tools)
+        mock_guarded_tool.assert_called_with(mock_tool, mock_component.in_tools, mock_tg_runtime)
+
+        # Verify result contains guarded tools
+        assert len(result) == 1
+        assert result[0] == mock_guarded_instance
+
+
+@pytest.mark.asyncio
+async def test_cache_mode_directory_not_found(mock_component):
+    """Test PoliciesComponent in cache mode when cache directory doesn't exist."""
+    # Mock the cache directory does not exist
+    with (
+        patch.object(Path, "exists", return_value=False),
+        pytest.raises(ValueError, match="Cache directory not found"),
+    ):
+        await mock_component.guard_tools()
+
+
+@pytest.mark.asyncio
+async def test_cache_mode_file_not_found(mock_component):
+    """Test PoliciesComponent in cache mode when required files are missing."""
+    # Mock the cache directory exists but files are missing
+    with (
+        patch.object(Path, "exists", return_value=True),
+        patch("lfx.components.models_and_agents.policies_component.load_toolguards") as mock_load_guards,
+    ):
+        mock_load_guards.side_effect = FileNotFoundError("Guard file not found")
+
+        with pytest.raises(ValueError, match="Required guard code files missing"):
+            await mock_component.guard_tools()
+
+
+@pytest.mark.asyncio
+async def test_cache_mode_corrupted_cache(mock_component):
+    """Test PoliciesComponent in cache mode when cached code is corrupted."""
+    # Mock the cache directory exists but code is corrupted
+    with (
+        patch.object(Path, "exists", return_value=True),
+        patch("lfx.components.models_and_agents.policies_component.load_toolguards") as mock_load_guards,
+    ):
+        mock_load_guards.side_effect = Exception("Invalid Python syntax")
+
+        with pytest.raises(ValueError, match="Failed to load guard code"):
+            await mock_component.guard_tools()
+
+
+# @pytest.mark.asyncio
+# async def test_cache_mode_multiple_tools(mock_component):
+#     """Test PoliciesComponent in cache mode with multiple tools."""
+#     # Add more tools
+#     tool2 = MagicMock()
+#     tool2.name = "tool2"
+#     tool3 = MagicMock()
+#     tool3.name = "tool3"
+#     mock_component.in_tools = [mock_component.in_tools[0], tool2, tool3]
+
+#     with (
+#         patch.object(Path, "exists", return_value=True),
+#         patch.object(mock_component, "make_toolguard_result") as mock_make_result,
+#         patch("lfx.components.models_and_agents.policies_component.load_toolguards_from_memory") as mock_load_memory,
+#         patch("lfx.components.models_and_agents.policies_component.GuardedTool") as mock_guarded_tool,
+#     ):
+#         mock_tg_result = MagicMock()
+#         mock_make_result.return_value = mock_tg_result
+#         mock_tg_runtime = MagicMock()
+#         mock_load_memory.return_value = mock_tg_runtime
+#         mock_guarded_instances = [MagicMock(), MagicMock(), MagicMock()]
+#         mock_guarded_tool.side_effect = mock_guarded_instances
+
+#         result = await mock_component.guard_tools()
+
+#         # Verify GuardedTool was created for each tool
+#         assert mock_guarded_tool.call_count == 3
+#         assert len(result) == 3
+#         assert result == mock_guarded_instances
+
+
+@pytest.mark.asyncio
+async def test_inenabled_returns_original_tools(mock_component, mock_tool):
+    """Test PoliciesComponent when enabled=False returns original tools."""
+    mock_component.enabled = False
+
+    result = await mock_component.guard_tools()
+
+    # Should return original tools without wrapping
+    assert result == mock_component.in_tools
+    assert len(result) == 1
+    assert result[0] == mock_tool
+
+
+@pytest.mark.asyncio
+async def test_generate_mode_validation_errors(mock_component):
+    """Test PoliciesComponent in generate mode with validation errors."""
+    mock_component.mode = MODE_GENERATE
+
+    # Test empty project
+    mock_component.project = ""
+    with pytest.raises(ValueError):  # noqa: PT011
+        await mock_component.guard_tools()
+
+    # Test empty policies
+    mock_component.project = "test_project"
+    mock_component.policies = []
+    with pytest.raises(ValueError, match="policies cannot be empty"):
+        await mock_component.guard_tools()
+
+    # Test empty tools
+    mock_component.policies = ["Policy 1"]
+    mock_component.in_tools = []
+    with pytest.raises(ValueError, match="in_tools cannot be empty"):
+        await mock_component.guard_tools()
+
+    # Test missing model
+    mock_component.in_tools = [MagicMock()]
+    mock_component.model = None
+    with pytest.raises(ValueError, match="model or api_key cannot be empty"):
+        await mock_component.guard_tools()
+
+    # # Test non-recommended model
+    # mock_component.model = [{"name": "gpt-3.5-turbo", "provider": "OpenAI"}]
+    # mock_component.api_key = "test_key"  # pragma: allowlist secret
+    # with pytest.raises(ValueError, match="is not in recommended models"):
+    #     await mock_component.guard_tools()
+
+
+def test_work_dir_property():
+    """Test work_dir property generates correct path."""
+    component = PoliciesComponent()
+    component.project = "test project"
+    work_dir = component.work_dir
+
+    assert "test_project" in str(work_dir)
+    assert work_dir.name == "test_project"
+
+
+def test_to_snake_case():
+    """Test _to_snake_case static method."""
+    assert PoliciesComponent._to_snake_case("My Project") == "my_project"
+    assert PoliciesComponent._to_snake_case("Test-Project") == "test_project"
+    assert PoliciesComponent._to_snake_case("User's Project") == "user_s_project"
+    assert PoliciesComponent._to_snake_case("Project, Name") == "project_name"
+    assert PoliciesComponent._to_snake_case("UPPERCASE") == "uppercase"
+    assert PoliciesComponent._to_snake_case("Mixed-Case Project's Name") == "mixed_case_project_s_name"
+
+    # Test path traversal prevention
+    assert PoliciesComponent._to_snake_case("../../etc/passwd") == "etc_passwd"
+    assert PoliciesComponent._to_snake_case("../../../root") == "root"
+    assert PoliciesComponent._to_snake_case("./hidden") == "hidden"
+    assert PoliciesComponent._to_snake_case("path/to/file") == "path_to_file"
+    assert PoliciesComponent._to_snake_case("back\\slash\\path") == "back_slash_path"
+
+    # Test special characters are sanitized
+    assert PoliciesComponent._to_snake_case("test@#$%project") == "test_project"
+    assert PoliciesComponent._to_snake_case("___multiple___underscores___") == "multiple_underscores"
+
+    # Test empty/invalid input
+    with pytest.raises(ValueError, match="must contain at least one alphanumeric character"):
+        PoliciesComponent._to_snake_case("...")
+    with pytest.raises(ValueError, match="must contain at least one alphanumeric character"):
+        PoliciesComponent._to_snake_case("___")
+    with pytest.raises(ValueError, match="must contain at least one alphanumeric character"):
+        PoliciesComponent._to_snake_case("@#$%")
+
+
+def test_in_recommended_models(mock_component):
+    """Test in_recommended_models method."""
+    assert mock_component.in_recommended_models("gpt-5.1") is True
+    assert mock_component.in_recommended_models("claude-sonnet-4") is True
+    assert mock_component.in_recommended_models("gpt-5.1-turbo") is True
+    assert mock_component.in_recommended_models("claude-sonnet-4-preview") is True
+    assert mock_component.in_recommended_models("gpt-4") is False
+    assert mock_component.in_recommended_models("gpt-3.5-turbo") is False
+    assert mock_component.in_recommended_models("claude-3") is False
+
+
+@pytest.mark.asyncio
+async def test_verify_cached_guards_error_messages(mock_component):
+    """Test that _verify_cached_guards provides helpful error messages."""
+    code_dir = mock_component.work_dir / STEP2
+
+    # Test directory not found error message
+    with patch.object(Path, "exists", return_value=False):
+        with pytest.raises(ValueError, match="Cache directory not found") as exc_info:
+            mock_component._verify_cached_guards(code_dir)
+
+        assert "Generate" in str(exc_info.value)
+        assert str(code_dir) in str(exc_info.value)
+
+    # Test file not found error message
+    with (
+        patch.object(Path, "exists", return_value=True),
+        patch("lfx.components.models_and_agents.policies_component.load_toolguards") as mock_load,
+    ):
+        mock_load.side_effect = FileNotFoundError("Missing file")
+
+        with pytest.raises(ValueError, match="Required guard code files missing") as exc_info:
+            mock_component._verify_cached_guards(code_dir)
+
+        assert "Generate" in str(exc_info.value)
+
+    # Test general error message
+    with (
+        patch.object(Path, "exists", return_value=True),
+        patch("lfx.components.models_and_agents.policies_component.load_toolguards") as mock_load,
+    ):
+        mock_load.side_effect = RuntimeError("Unexpected error")
+
+        with pytest.raises(ValueError, match="Failed to load guard code") as exc_info:
+            mock_component._verify_cached_guards(code_dir)
+
+        assert "corrupted" in str(exc_info.value)
+        assert "Unexpected error" in str(exc_info.value)
+
+
+# Made with Bob

--- a/src/backend/tests/unit/components/models_and_agents/policies/test_tool_invoker.py
+++ b/src/backend/tests/unit/components/models_and_agents/policies/test_tool_invoker.py
@@ -1,0 +1,271 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from lfx.components.models_and_agents.policies.tool_invoker import ToolInvoker
+from mcp.types import CallToolResult
+from pydantic import BaseModel
+
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+    zip_code: str
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_dict_result():
+    """Test invoking a tool that returns a plain dict."""
+    tool = MagicMock()
+    tool.name = "test_tool"
+    tool.ainvoke = AsyncMock(return_value={"result": {"result": "success", "data": 42}})
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("test_tool", {"arg1": "value1"}, dict)
+
+    assert result == {"result": "success", "data": 42}
+    tool.ainvoke.assert_called_once_with(input={"arg1": "value1"})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_value_dict():
+    """Test invoking a tool that returns a dict with 'value' key."""
+    tool = MagicMock()
+    tool.name = "test_tool"
+    tool.ainvoke = AsyncMock(return_value={"value": {"name": "Alice", "age": 30}})
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("test_tool", {"query": "person"}, dict)
+
+    assert result == {"name": "Alice", "age": 30}
+    tool.ainvoke.assert_called_once_with(input={"query": "person"})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_call_tool_result():
+    """Test invoking a tool that returns CallToolResult."""
+    tool = MagicMock()
+    tool.name = "test_tool"
+
+    # Create a mock CallToolResult
+    mock_result = MagicMock(spec=CallToolResult)
+    mock_result.structuredContent = {"status": "ok", "count": 5}
+    tool.ainvoke = AsyncMock(return_value=mock_result)
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("test_tool", {"action": "count"}, dict)
+
+    assert result == {"status": "ok", "count": 5}
+    tool.ainvoke.assert_called_once_with(input={"action": "count"})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_basemodel_return_type():
+    """Test invoking a tool with BaseModel return type."""
+    tool = MagicMock()
+    tool.name = "get_person"
+    tool.ainvoke = AsyncMock(return_value={"name": "Bob", "age": 25})
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("get_person", {"id": 123}, Person)
+
+    assert isinstance(result, Person)
+    assert result.name == "Bob"
+    assert result.age == 25
+    tool.ainvoke.assert_called_once_with(input={"id": 123})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_basemodel_result():
+    """Test invoking a tool that returns a BaseModel instance."""
+    tool = MagicMock()
+    tool.name = "get_address"
+
+    # Tool returns a BaseModel instance
+    address = Address(street="123 Main St", city="Springfield", zip_code="12345")
+    tool.ainvoke = AsyncMock(return_value=address)
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("get_address", {"user_id": 456}, Address)
+
+    assert isinstance(result, Address)
+    assert result.street == "123 Main St"
+    assert result.city == "Springfield"
+    assert result.zip_code == "12345"
+    tool.ainvoke.assert_called_once_with(input={"user_id": 456})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_int_return_type():
+    """Test invoking a tool with int return type."""
+    tool = MagicMock()
+    tool.name = "count_items"
+    tool.ainvoke = AsyncMock(return_value=42)
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("count_items", {"category": "books"}, int)
+
+    assert result == 42
+    assert isinstance(result, int)
+    tool.ainvoke.assert_called_once_with(input={"category": "books"})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_float_return_type():
+    """Test invoking a tool with float return type."""
+    tool = MagicMock()
+    tool.name = "calculate_price"
+    tool.ainvoke = AsyncMock(return_value=99.99)
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("calculate_price", {"item": "widget"}, float)
+
+    assert result == 99.99
+    assert isinstance(result, float)
+    tool.ainvoke.assert_called_once_with(input={"item": "widget"})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_str_return_type():
+    """Test invoking a tool with str return type."""
+    tool = MagicMock()
+    tool.name = "get_message"
+    tool.ainvoke = AsyncMock(return_value="Hello, World!")
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("get_message", {"lang": "en"}, str)
+
+    assert result == "Hello, World!"
+    assert isinstance(result, str)
+    tool.ainvoke.assert_called_once_with(input={"lang": "en"})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_bool_return_type():
+    """Test invoking a tool with bool return type."""
+    tool = MagicMock()
+    tool.name = "is_valid"
+    tool.ainvoke = AsyncMock(return_value=True)
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("is_valid", {"data": "test"}, bool)
+
+    assert result is True
+    assert isinstance(result, bool)
+    tool.ainvoke.assert_called_once_with(input={"data": "test"})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_unknown_tool():
+    """Test invoking a tool that doesn't exist."""
+    tool = MagicMock()
+    tool.name = "existing_tool"
+
+    invoker = ToolInvoker([tool])
+
+    with pytest.raises(ValueError, match="unknown tool nonexistent_tool"):
+        await invoker.invoke("nonexistent_tool", {"arg": "value"}, dict)
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_empty_arguments():
+    """Test invoking a tool with empty arguments."""
+    tool = MagicMock()
+    tool.name = "no_args_tool"
+    tool.ainvoke = AsyncMock(return_value={"status": "ok"})
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("no_args_tool", {}, dict)
+
+    assert result == {"status": "ok"}
+    tool.ainvoke.assert_called_once_with(input={})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_complex_arguments():
+    """Test invoking a tool with complex nested arguments."""
+    tool = MagicMock()
+    tool.name = "complex_tool"
+    complex_args = {
+        "user": {"name": "Charlie", "age": 35},
+        "settings": {"theme": "dark", "notifications": True},
+        "items": [1, 2, 3, 4, 5],
+    }
+    tool.ainvoke = AsyncMock(return_value={"processed": True})
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("complex_tool", complex_args, dict)
+
+    assert result == {"processed": True}
+    tool.ainvoke.assert_called_once_with(input=complex_args)
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_multiple_tools():
+    """Test ToolInvoker with multiple tools and invoking different ones."""
+    tool1 = MagicMock()
+    tool1.name = "tool1"
+    tool1.ainvoke = AsyncMock(return_value={"result": "from_tool1"})
+
+    tool2 = MagicMock()
+    tool2.name = "tool2"
+    tool2.ainvoke = AsyncMock(return_value={"result": "from_tool2"})
+
+    tool3 = MagicMock()
+    tool3.name = "tool3"
+    tool3.ainvoke = AsyncMock(return_value={"result": "from_tool3"})
+
+    invoker = ToolInvoker([tool1, tool2, tool3])
+
+    # Invoke each tool
+    result1 = await invoker.invoke("tool1", {}, dict)
+    result2 = await invoker.invoke("tool2", {}, dict)
+    result3 = await invoker.invoke("tool3", {}, dict)
+
+    assert result1 == "from_tool1"
+    assert result2 == "from_tool2"
+    assert result3 == "from_tool3"
+
+    tool1.ainvoke.assert_called_once()
+    tool2.ainvoke.assert_called_once()
+    tool3.ainvoke.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_with_basemodel_in_value_dict():
+    """Test invoking a tool that returns BaseModel wrapped in value dict."""
+    tool = MagicMock()
+    tool.name = "get_person_wrapped"
+
+    # Tool returns a dict with 'value' containing a BaseModel
+    person = Person(name="Diana", age=28)
+    tool.ainvoke = AsyncMock(return_value={"value": person})
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("get_person_wrapped", {"id": 789}, Person)
+
+    assert isinstance(result, Person)
+    assert result.name == "Diana"
+    assert result.age == 28
+    tool.ainvoke.assert_called_once_with(input={"id": 789})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoker_invoke_primitive_type_conversion():
+    """Test that primitive types are properly converted from string results."""
+    tool = MagicMock()
+    tool.name = "string_number"
+    tool.ainvoke = AsyncMock(return_value="123")
+
+    invoker = ToolInvoker([tool])
+    result = await invoker.invoke("string_number", {}, int)
+
+    assert result == 123
+    assert isinstance(result, int)
+
+
+# Made with Bob

--- a/src/lfx/src/lfx/_assets/stable_hash_history.json
+++ b/src/lfx/src/lfx/_assets/stable_hash_history.json
@@ -2163,5 +2163,15 @@
       "0.3.0": "8b5ca1f38f6e",
       "0.3.1": "8b5ca1f38f6e"
     }
+  },
+  "policies": {
+    "versions": {
+      "0.3.0": "fe3303671fea"
+    }
+  },
+  "policies": {
+    "versions": {
+      "0.3.0": "9bf5e6f39e2d"
+    }
   }
 }

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1935,7 +1935,7 @@ async def update_tools(
                 func=create_tool_func(tool.name, args_schema, client),
                 coroutine=create_tool_coroutine(tool.name, args_schema, client),
                 tags=[tool.name],
-                metadata={"server_name": server_name},
+                metadata={"server_name": server_name, "output_schema": getattr(tool, "outputSchema", None)},
             )
 
             tool_list.append(tool_obj)

--- a/src/lfx/src/lfx/components/models_and_agents/__init__.py
+++ b/src/lfx/src/lfx/components/models_and_agents/__init__.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from lfx.components.models_and_agents.language_model import LanguageModelComponent
     from lfx.components.models_and_agents.mcp_component import MCPToolsComponent
     from lfx.components.models_and_agents.memory import MemoryComponent
+    from lfx.components.models_and_agents.policies_component import PoliciesComponent
     from lfx.components.models_and_agents.prompt import PromptComponent
 
 _dynamic_imports = {
@@ -19,6 +20,7 @@ _dynamic_imports = {
     "MCPToolsComponent": "mcp_component",
     "MemoryComponent": "memory",
     "PromptComponent": "prompt",
+    "PoliciesComponent": "policies_component",
 }
 
 __all__ = [
@@ -27,6 +29,7 @@ __all__ = [
     "LanguageModelComponent",
     "MCPToolsComponent",
     "MemoryComponent",
+    "PoliciesComponent",
     "PromptComponent",
 ]
 

--- a/src/lfx/src/lfx/components/models_and_agents/policies/__init__.py
+++ b/src/lfx/src/lfx/components/models_and_agents/policies/__init__.py
@@ -1,0 +1,4 @@
+# PoliciesComponent has been moved to lfx.components.models_and_agents
+# Supporting utilities remain here for the component to use
+
+__all__ = []

--- a/src/lfx/src/lfx/components/models_and_agents/policies/guard_sync_utils.py
+++ b/src/lfx/src/lfx/components/models_and_agents/policies/guard_sync_utils.py
@@ -1,0 +1,99 @@
+"""Utility functions for synchronizing generated guard code with component inputs."""
+
+from pathlib import Path
+
+from toolguard.runtime.runtime import RESULTS_FILENAME
+
+from lfx.io import CodeInput
+from lfx.log.logger import logger
+
+GENERATED_GUARD_INFO_PREFIX = "Auto-generated ToolGuard code for "
+
+
+def is_generated_guard_field(field: dict) -> bool:
+    """Check if a field represents a generated guard code input.
+
+    Args:
+        field: Dictionary representing a component field/input
+
+    Returns:
+        True if the field is a generated guard code field, False otherwise
+    """
+    if not isinstance(field, dict):
+        return False
+    return (
+        field.get("type") == "code"
+        and field.get("dynamic") is True
+        and isinstance(field.get("info"), str)
+        and field.get("info", "").startswith(GENERATED_GUARD_INFO_PREFIX)
+    )
+
+
+def sync_generated_guard_code_inputs(
+    build_config: dict,
+    work_dir: Path,
+    step2_subdir: str,
+    project_name: str,
+) -> dict:
+    """Synchronize generated guard code files with component code inputs.
+
+    Scans the generated guard code directory and creates/updates CodeInput fields
+    in the build config for each Python file found. Removes stale fields for files
+    that no longer exist.
+
+    Args:
+        build_config: The component's build configuration dictionary
+        work_dir: Base working directory for the toolguard project
+        step2_subdir: Subdirectory name containing generated code (e.g., "Step_2")
+        project_name: Name of the project in snake_case format
+
+    Returns:
+        Updated build_config dictionary with synchronized code inputs
+    """
+    logger.debug("Syncing generated guard code files...")
+    generated_field_names = {key for key, value in build_config.items() if is_generated_guard_field(value)}
+
+    step2_dir = work_dir / step2_subdir
+    logger.debug(f"step2_dir = {step2_dir}")
+    logger.debug(f"step2_dir.exists() = {step2_dir.exists()}")
+    logger.debug(f"step2_dir.is_dir() = {step2_dir.is_dir()}")
+    if not step2_dir.exists() or not step2_dir.is_dir():
+        for field_name in generated_field_names:
+            build_config.pop(field_name, None)
+        return build_config
+
+    files = sorted(path for path in step2_dir.rglob("*") if path.is_file())
+
+    def include_file(relative_name) -> bool:
+        if relative_name.startswith(project_name) and relative_name.endswith(".py"):
+            return True
+        return relative_name == str(RESULTS_FILENAME)
+
+    next_generated_names: set[str] = set()
+
+    for file_path in files:
+        relative_name = file_path.relative_to(step2_dir).as_posix()
+        if not include_file(relative_name):
+            continue
+        logger.debug(f"Processing generated file: {relative_name}")
+        next_generated_names.add(relative_name)
+        try:
+            code_value = file_path.read_text(encoding="utf-8")
+        except OSError:
+            code_value = ""
+
+        code_input = CodeInput(
+            name=relative_name,
+            display_name=relative_name,
+            value=code_value,
+            info=f"{GENERATED_GUARD_INFO_PREFIX}{relative_name}",
+            dynamic=True,
+            advanced=True,
+        )
+        build_config[relative_name] = code_input.to_dict()
+
+    stale_field_names = generated_field_names - next_generated_names
+    for field_name in stale_field_names:
+        build_config.pop(field_name, None)
+
+    return build_config

--- a/src/lfx/src/lfx/components/models_and_agents/policies/guarded_tool.py
+++ b/src/lfx/src/lfx/components/models_and_agents/policies/guarded_tool.py
@@ -1,0 +1,104 @@
+import json
+
+from langchain_core.messages import ToolCall
+from toolguard.runtime import PolicyViolationException
+from toolguard.runtime.runtime import ToolguardRuntime
+
+from lfx.components.models_and_agents.policies.tool_invoker import ToolInvoker
+from lfx.field_typing import Tool
+from lfx.log.logger import logger
+
+
+class GuardedTool(Tool):
+    """A tool wrapper that applies ToolGuard policy validation before execution.
+
+    This component requires async execution as ToolGuard operates asynchronously.
+    The synchronous `run()` method is not supported and will raise NotImplementedError.
+    Always use `arun()` or async invocation methods.
+    """
+
+    _orig_tool: Tool
+    _tool_invoker: ToolInvoker
+    _toolguard: ToolguardRuntime
+
+    def __init__(self, tool: Tool, all_tools: list[Tool], toolguard: ToolguardRuntime):
+        super().__init__(
+            name=tool.name,
+            description=tool.description,
+            args_schema=getattr(tool, "args_schema", None),
+            return_direct=getattr(tool, "return_direct", False),
+            func=self.run,
+            coroutine=self.arun,
+            tags=tool.tags,
+            metadata=tool.metadata,
+            verbose=True,
+        )
+        self._orig_tool = tool
+        self._tool_invoker = ToolInvoker(all_tools)
+        self._toolguard = toolguard
+
+    @property
+    def args(self) -> dict:
+        return self._orig_tool.args
+
+    def _parse_string_to_dict(self, value: str) -> dict:
+        """Parse a string as JSON, or wrap it in a dict if parsing fails."""
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return {"input": value}
+
+    def parse_input(self, tool_input: str | dict | ToolCall) -> dict:
+        # Handle string input - try to parse as JSON, fallback to wrapped input
+        if isinstance(tool_input, str):
+            return self._parse_string_to_dict(tool_input)
+
+        # Handle ToolCall dict format - extract and parse args
+        if isinstance(tool_input, dict) and "args" in tool_input:
+            args = tool_input["args"]
+            if isinstance(args, str):
+                return self._parse_string_to_dict(args)
+            return args if isinstance(args, dict) else {}
+
+        # Return dict as-is or empty dict for None/other types
+        return tool_input if isinstance(tool_input, dict) else {}
+
+    def run(self, tool_input: str | dict | ToolCall, config=None, **kwargs):
+        """Synchronous execution is not supported for GuardedTool.
+
+        ToolGuard requires async execution for policy validation. Please use the
+        async version `arun()` instead, or ensure your execution context supports
+        async tool invocation.
+
+        Raises:
+            NotImplementedError: Always raised as sync execution is not supported.
+        """
+        msg = (
+            "GuardedTool does not support synchronous execution. "
+            "ToolGuard requires async execution for policy validation. "
+            "Please use `arun()` instead or ensure your execution context supports async tool invocation."
+        )
+        raise NotImplementedError(msg)
+
+    async def arun(self, tool_input: str | dict | ToolCall, config=None, **kwargs):
+        args = self.parse_input(tool_input)
+        logger.debug(f"running toolguard for {self.name}")
+
+        with self._toolguard:
+            try:
+                await self._toolguard.guard_toolcall(self.name, args=args, delegate=self._tool_invoker)
+                return await self._orig_tool.arun(tool_input=args, config=config, **kwargs)
+            except PolicyViolationException as ex:
+                logger.debug(f"exception: {ex.message}")
+                return {
+                    "ok": False,
+                    "error": {
+                        "type": "PolicyViolationException",
+                        "code": "FAILURE",
+                        "message": ex.message,
+                        "retryable": True,
+                    },
+                }
+            except Exception:
+                logger.exception("Unhandled exception in class GuardedTool.arun()")
+                raise

--- a/src/lfx/src/lfx/components/models_and_agents/policies/llm_wrapper.py
+++ b/src/lfx/src/lfx/components/models_and_agents/policies/llm_wrapper.py
@@ -1,0 +1,182 @@
+from typing import Any
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import messages_from_dict
+from toolguard.buildtime.llm import LanguageModelBase
+
+
+class LangchainModelWrapper(LanguageModelBase):
+    """Wrapper for Langchain chat models to work with ToolGuard.
+
+    This wrapper handles:
+    - Message format conversion between ToolGuard and Langchain
+    - Automatic continuation when max tokens are reached
+    - Safe error handling and validation
+    """
+
+    MAX_CONTINUATIONS = 5  # Prevent infinite recursion
+    DEFAULT_MAX_OUT_TOKENS = 16000
+
+    def __init__(self, langchain_model: BaseChatModel):
+        """Initialize the wrapper with a Langchain chat model.
+
+        Args:
+            langchain_model: A Langchain BaseChatModel instance
+        """
+        self.langchain_model = langchain_model
+        if hasattr(self.langchain_model, "max_tokens") and getattr(self.langchain_model, "max_tokens", None) is None:
+            self.langchain_model.max_tokens = self.DEFAULT_MAX_OUT_TOKENS
+
+    def _convert_role(self, role: str) -> str:
+        """Convert ToolGuard role to Langchain message type.
+
+        Args:
+            role: The role from ToolGuard format ("user", "assistant", "system")
+
+        Returns:
+            Langchain message type ("human", "ai", "system")
+        """
+        role_mapping = {
+            "user": "human",
+            "assistant": "ai",
+            "system": "system",
+        }
+        return role_mapping.get(role, "system")
+
+    def _validate_messages(self, messages: list[dict]) -> None:
+        """Validate message format.
+
+        Args:
+            messages: List of message dictionaries
+
+        Raises:
+            ValueError: If messages are invalid
+        """
+        if not isinstance(messages, list):
+            msg = f"Messages must be a list, got {type(messages)}"
+            raise TypeError(msg)
+
+        for i, msg in enumerate(messages):
+            if not isinstance(msg, dict):
+                error_msg = f"Message at index {i} must be a dict, got {type(msg)}"
+                raise TypeError(error_msg)
+
+            if "role" not in msg:
+                error_msg = f"Message at index {i} missing 'role' field"
+                raise ValueError(error_msg)
+
+            if "content" not in msg:
+                error_msg = f"Message at index {i} missing 'content' field"
+                raise ValueError(error_msg)
+
+    def _extract_content(self, content: Any) -> str:
+        """Safely extract string content from various types.
+
+        Args:
+            content: Content that could be str, list, tuple, or None
+
+        Returns:
+            String representation of the content
+        """
+        if content is None:
+            return ""
+
+        if isinstance(content, str):
+            return content
+
+        if isinstance(content, (list, tuple)):
+            # Join list/tuple elements with space
+            return " ".join(str(item) for item in content)
+
+        return str(content)
+
+    async def generate(self, messages: list[dict], _recursion_depth: int = 0) -> str:
+        """Generate a response from the language model.
+
+        Args:
+            messages: List of message dicts with 'role' and 'content' keys
+            _recursion_depth: Internal counter to prevent infinite recursion
+
+        Returns:
+            Generated text response
+
+        Raises:
+            ValueError: If messages are invalid or response is malformed
+            RuntimeError: If max continuations exceeded or API call fails
+        """
+        # Validate inputs
+        self._validate_messages(messages)
+
+        # Check recursion depth
+        if _recursion_depth >= self.MAX_CONTINUATIONS:
+            msg = f"Maximum continuation depth ({self.MAX_CONTINUATIONS}) exceeded"
+            raise RuntimeError(msg)
+
+        # Convert messages to Langchain format
+        converted_messages = [
+            {
+                "type": self._convert_role(msg.get("role", "system")),
+                "data": {"content": self._extract_content(msg.get("content"))},
+            }
+            for msg in messages
+        ]
+
+        try:
+            lc_messages = messages_from_dict(converted_messages)
+        except Exception as exc:
+            msg = f"Failed to convert messages to Langchain format: {exc}"
+            raise ValueError(msg) from exc
+
+        # Call the language model
+        try:
+            response = await self.langchain_model.agenerate(
+                messages=[lc_messages],
+            )
+        except Exception as exc:
+            msg = f"Language model API call failed: {exc}"
+            raise RuntimeError(msg) from exc
+
+        # Safely extract response
+        if not response.generations or not response.generations[0]:
+            msg = "Empty response from language model"
+            raise ValueError(msg)
+
+        choice0 = response.generations[0][0]
+
+        if not hasattr(choice0, "message") or not hasattr(choice0.message, "content"):
+            msg = "Malformed response from language model"
+            raise ValueError(msg)
+
+        chunk = self._extract_content(choice0.text)
+
+        # Check if we need to continue due to max tokens
+        generation_info = getattr(choice0, "generation_info", None)
+        if generation_info and isinstance(generation_info, dict):
+            finish_reason = generation_info.get("finish_reason")
+
+            if finish_reason == "length":  # max tokens reached
+                resp_msg = {
+                    "role": "assistant",
+                    "content": chunk,
+                }
+                continue_msg = {
+                    "role": "user",
+                    "content": (
+                        "Continue the previous answer starting exactly from the last incomplete sentence. "
+                        "Do not repeat anything. Do not add any prefix."
+                    ),
+                }
+                next_messages = [
+                    *messages,
+                    resp_msg,
+                    continue_msg,
+                ]
+
+                # Recursive call with depth tracking
+                continuation = await self.generate(next_messages, _recursion_depth + 1)
+                return chunk + continuation
+
+        return chunk
+
+
+# Made with Bob

--- a/src/lfx/src/lfx/components/models_and_agents/policies/module_utils.py
+++ b/src/lfx/src/lfx/components/models_and_agents/policies/module_utils.py
@@ -1,0 +1,22 @@
+"""Utility functions for module management in the policies component."""
+
+import sys
+
+
+def unload_module(name: str) -> None:
+    """Remove a module and all its submodules from sys.modules.
+
+    This ensures complete cleanup of dynamically generated modules,
+    including any nested imports that may have been created.
+
+    Args:
+        name: The name of the module to unload
+    """
+    # Remove the main module
+    if name in sys.modules:
+        del sys.modules[name]
+
+    # Remove all submodules (e.g., module.submodule)
+    modules_to_remove = [mod_name for mod_name in sys.modules if mod_name.startswith(f"{name}.")]
+    for mod_name in modules_to_remove:
+        del sys.modules[mod_name]

--- a/src/lfx/src/lfx/components/models_and_agents/policies/tool_invoker.py
+++ b/src/lfx/src/lfx/components/models_and_agents/policies/tool_invoker.py
@@ -1,0 +1,49 @@
+from typing import Any, TypeVar
+
+from mcp.types import CallToolResult
+from pydantic import BaseModel
+from toolguard.runtime import IToolInvoker
+
+from lfx.field_typing.constants import BaseTool
+from lfx.log.logger import logger
+
+T = TypeVar("T")
+
+
+class ToolInvoker(IToolInvoker):
+    _tools: dict[str, BaseTool]
+
+    def __init__(self, tools: list[BaseTool]) -> None:
+        self._tools = {tool.name: tool for tool in tools}
+
+    async def invoke(self, toolname: str, arguments: dict[str, Any], return_type: type[T]) -> T:
+        tool = self._tools.get(toolname)
+        if tool:
+            logger.info(f"invoking {toolname} internally")
+            res = await tool.ainvoke(input=arguments)
+
+            if isinstance(res, CallToolResult):
+                res_dict = res.structuredContent
+            elif isinstance(res, dict) and "value" in res:
+                res_dict = res["value"]
+            else:
+                res_dict = res
+
+            # Only try to extract "result" key if res_dict is a dictionary
+            if isinstance(res_dict, dict):
+                res_dict = res_dict.get("result", res_dict)
+
+            if isinstance(res_dict, BaseModel):
+                res_dict = res_dict.model_dump()
+
+            if issubclass(return_type, BaseModel):
+                return return_type.model_validate(res_dict)
+            if return_type in (int, float, str, bool):
+                return return_type(res_dict)
+            return res_dict
+
+        msg = f"unknown tool {toolname}"
+        raise ValueError(msg)
+
+
+# Made with Bob

--- a/src/lfx/src/lfx/components/models_and_agents/policies_component.py
+++ b/src/lfx/src/lfx/components/models_and_agents/policies_component.py
@@ -1,0 +1,339 @@
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from toolguard.buildtime import (
+    PolicySpecOptions,
+    ToolGuardsCodeGenerationResult,
+    ToolGuardSpec,
+    generate_guard_specs,
+    generate_guards_code,
+)
+from toolguard.extra.langchain_to_oas import langchain_tools_to_openapi
+from toolguard.runtime import load_toolguards, load_toolguards_from_memory
+from toolguard.runtime.runtime import RESULTS_FILENAME
+
+from lfx.base.models import LCModelComponent
+from lfx.base.models.unified_models import (
+    get_language_model_options,
+    get_llm,
+    update_model_options_in_build_config,
+)
+from lfx.components.models_and_agents.policies.guard_sync_utils import sync_generated_guard_code_inputs
+from lfx.components.models_and_agents.policies.guarded_tool import GuardedTool
+from lfx.components.models_and_agents.policies.llm_wrapper import LangchainModelWrapper
+from lfx.components.models_and_agents.policies.module_utils import unload_module
+from lfx.field_typing import LanguageModel, Tool
+from lfx.io import (
+    BoolInput,
+    HandleInput,
+    ModelInput,
+    MultilineInput,
+    Output,
+    SecretStrInput,
+    StrInput,
+    TabInput,
+)
+from lfx.log.logger import logger
+
+if TYPE_CHECKING:
+    from lfx.inputs.inputs import InputTypes
+
+
+TOOLGUARD_WORK_DIR = Path(os.getenv("TOOLGUARD_WORK_DIR") or "tmp_toolguard")
+BUILDTIME_MODELS = ["gpt-5", "claude-sonnet"]  # currently inactive, we recommend but do not enforce
+STEP1 = "Step_1"
+STEP2 = "Step_2"
+MODE_GENERATE = "🛠️ Generate"
+MODE_GUARD = "🛡️ Guard"
+GENERATED_GUARD_INFO_PREFIX = "Auto-generated ToolGuard code for "
+
+
+class PoliciesComponent(LCModelComponent):
+    """Component for building tool protection code from textual business policies and instructions.
+
+    This component uses ToolGuard to generate and apply policy-based guards to tools,
+    ensuring that tool execution complies with defined business policies.
+    Powered by ALTK ToolGuard (https://github.com/AgentToolkit/toolguard).
+    """
+
+    display_name = "Policies"
+    description = """Component for building tool protection code from textual business policies and instructions.
+Powered by [ALTK ToolGuard](https://github.com/AgentToolkit/toolguard )"""
+    documentation: str = "https://github.com/AgentToolkit/toolguard"
+    icon = "shield-check"
+    name = "policies"
+    beta = True
+
+    inputs = cast(
+        "list[InputTypes]",
+        [
+            BoolInput(
+                name="enabled",
+                display_name="Enabled",
+                info="If `true` - guards tool calls. If `false`, skip policy validation.",
+                value=True,
+            ),
+            TabInput(
+                name="mode",
+                display_name="Activity",
+                options=[MODE_GENERATE, MODE_GUARD],
+                info=(
+                    "Generate new guard code or apply existing guard. "
+                    "Review generated files in the details panel on the right."
+                ),
+                value=MODE_GENERATE,
+                real_time_refresh=True,
+                tool_mode=True,
+            ),
+            MultilineInput(
+                name="project",
+                display_name="Policies Project",
+                info="Folder name of the generated code",
+                value="my_project",
+                # required=True,
+            ),
+            HandleInput(
+                name="in_tools",
+                display_name="Tools",
+                input_types=["Tool"],
+                is_list=True,
+                required=True,
+                info="These are the tools that the agent can use to help with tasks.",
+            ),
+            StrInput(
+                name="policies",
+                display_name="Policies",
+                info="One or more clear, well-defined and self-contained business policies",
+                is_list=True,
+                tool_mode=True,
+                placeholder="Add business policy...",
+                list_add_label="Add Policy",
+                # input_types=[],
+            ),
+            ModelInput(
+                name="model",
+                display_name="Language Model",
+                info=(
+                    "Select LLM for Policies buildtime. We recommend using "
+                    "Anthropic Claude-Sonnet series for this task."
+                ),
+                real_time_refresh=True,
+                required=True,
+            ),
+            SecretStrInput(
+                name="api_key",
+                display_name="API Key",
+                info="Model Provider API key",
+                required=False,
+                advanced=True,
+            ),
+        ],
+    )
+    outputs = [
+        Output(
+            display_name="Guarded Tools",
+            type_=Tool,
+            name="guarded_tools",
+            method="guard_tools",
+            # group_outputs=True,
+        ),
+    ]
+
+    @property
+    def work_dir(self) -> Path:
+        return TOOLGUARD_WORK_DIR / self._to_snake_case(self.project)
+
+    def build_model(self) -> LanguageModel:
+        llm_model = get_llm(
+            model=self.model,
+            user_id=self.user_id,
+            api_key=self.api_key,
+            stream=False,
+        )
+        if llm_model is None:
+            msg = "No language model selected. Please choose a model to proceed."
+            raise ValueError(msg)
+        return llm_model
+
+    def update_build_config(self, build_config: dict, field_value: str, field_name: str | None = None):
+        """Dynamically update build config with user-filtered model options."""
+        updated_build_config = update_model_options_in_build_config(
+            component=self,
+            build_config=build_config,
+            cache_key_prefix="language_model_options",
+            get_options_func=get_language_model_options,
+            field_name=field_name,
+            field_value=field_value,
+        )
+        py_module = self._to_snake_case(self.project)
+        return sync_generated_guard_code_inputs(
+            build_config=updated_build_config,
+            work_dir=self.work_dir,
+            step2_subdir=STEP2,
+            project_name=py_module,
+        )
+
+    async def _generate_guard_specs(self) -> list[ToolGuardSpec]:
+        logger.debug("Starting step 1")
+        logger.debug(f"model = {self.model}")
+        llm = LangchainModelWrapper(self.build_model())
+        out_dir = self.work_dir / STEP1
+        if out_dir.exists():
+            shutil.rmtree(out_dir)
+        policy_text = "\n * ".join(self.policies)
+        open_api = langchain_tools_to_openapi(self.in_tools)
+
+        options = PolicySpecOptions(example_number=4)
+        specs = await generate_guard_specs(
+            policy_text=policy_text, tools=open_api, llm=llm, work_dir=out_dir, options=options
+        )
+        logger.debug("Step 1 Done")
+        return specs
+
+    async def _generate_guard_code(self, specs: list[ToolGuardSpec]) -> ToolGuardsCodeGenerationResult:
+        logger.debug("Starting step 2")
+        out_dir = self.work_dir / STEP2
+        if out_dir.exists():
+            shutil.rmtree(out_dir)
+        llm = LangchainModelWrapper(self.build_model())
+        app_name = self._to_snake_case(self.project)
+        open_api = langchain_tools_to_openapi(self.in_tools)
+
+        gen_result = await generate_guards_code(
+            tools=open_api, tool_specs=specs, work_dir=out_dir, llm=llm, app_name=app_name
+        )
+        logger.debug("Step 2 Done")
+        return gen_result
+
+    def in_recommended_models(self, model_name: str):
+        return any(recommended in model_name for recommended in BUILDTIME_MODELS)
+
+    def validate_before_generate(self) -> None:
+        """Validate required inputs before generating guard code."""
+        if not self.project:
+            msg = "Policies: project cannot be empty!"
+            raise ValueError(msg)
+
+        if not any(self.policies):
+            msg = "Policies: policies cannot be empty!"
+            raise ValueError(msg)
+
+        if not self.in_tools:
+            msg = "Policies: in_tools cannot be empty!"
+            raise ValueError(msg)
+
+        if not self.model or not self.api_key:
+            msg = "Policies: model or api_key cannot be empty!"
+            raise ValueError(msg)
+
+        # uncomment if willing to enforce certain models for buildtime
+        # if not self.in_recommended_models(self.model[0]["name"]):
+        #     msg = f"Policies: model {self.model[0]['name']} is not in recommended models: {BUILDTIME_MODELS}"
+        #     raise ValueError(msg)
+
+    async def generate(self):
+        specs = await self._generate_guard_specs()
+        res = await self._generate_guard_code(specs)
+
+        # if there was a previous version of the guard, remove it from python cache
+        unload_module(res.domain.app_name)
+
+    def _verify_cached_guards(self, code_dir: Path) -> None:
+        # Validate cache exists before attempting to load
+        if not code_dir.exists():
+            msg = (
+                f"Policies: Cache directory not found at '{code_dir}'. "
+                f"Please run in 'Generate' mode first to create the guard code, "
+                f"or verify the project name is correct."
+            )
+            raise ValueError(msg)
+
+        try:
+            load_toolguards(code_dir)
+        except FileNotFoundError as exc:
+            msg = (
+                f"Policies: Required guard code files missing in '{code_dir}'. "
+                f"Please run in 'Generate' mode to create the guard code."
+            )
+            raise ValueError(msg) from exc
+        except Exception as exc:
+            msg = (
+                f"Policies: Failed to load guard code from '{code_dir}'. "
+                f"The cached code may be invalid or corrupted. "
+                f"Try running in 'Generate' mode to rebuild the guard code. "
+                f"Error: {exc!s}"
+            )
+            raise ValueError(msg) from exc
+
+    def _validate_before_using_cache(self, code_dir: Path) -> None:
+        if not self.in_tools:
+            msg = "Policies: in_tools cannot be empty!"
+            raise ValueError(msg)
+
+        self._verify_cached_guards(code_dir)
+
+    def make_toolguard_result(self) -> ToolGuardsCodeGenerationResult:
+        attrs = self.get_vertex().data["node"]["template"]
+        if not attrs:
+            raise ValueError
+
+        result_str = attrs[str(RESULTS_FILENAME)]["value"]
+        result = ToolGuardsCodeGenerationResult.model_validate_json(result_str)
+
+        result.domain.app_types.content = attrs.get(str(result.domain.app_types.file_name))["value"]
+        result.domain.app_api.content = attrs.get(str(result.domain.app_api.file_name))["value"]
+        result.domain.app_api_impl.content = attrs.get(str(result.domain.app_api_impl.file_name))["value"]
+
+        for tool in result.tools.values():
+            tool.guard_file.content = attrs.get(str(tool.guard_file.file_name))["value"]
+            for tool_item in tool.item_guard_files:
+                tool_item.content = attrs.get(str(tool_item.file_name))["value"]
+
+        return result
+
+    async def guard_tools(self) -> list[Tool]:
+        if self.enabled:
+            mode = getattr(self, "mode", MODE_GENERATE)
+            if mode == MODE_GENERATE:
+                self.log(f"Start generating guard code at {self.work_dir}", name="info")
+                self.validate_before_generate()
+                await self.generate()
+                self.log(f"Policies code generation saved to {self.work_dir}", name="info")
+                self.log("Review the generated files in the details panel on the right.", name="info")
+
+            else:  # mode == "guard"
+                self.log(f"using cache from {self.work_dir}", name="info")
+                code_dir = self.work_dir / STEP2
+                self._validate_before_using_cache(code_dir)
+                try:
+                    tg_result = self.make_toolguard_result()
+                    tg_runtime = load_toolguards_from_memory(tg_result)
+                    guarded_tools = [GuardedTool(tool, self.in_tools, tg_runtime) for tool in self.in_tools]
+                    return cast("list[Tool]", guarded_tools)
+                except Exception as e:
+                    logger.exception(e)
+                    raise
+
+        return self.in_tools
+
+    @staticmethod
+    def _to_snake_case(human_name: str) -> str:
+        """Convert human-readable name to snake_case, sanitizing path traversal attempts."""
+        # Convert to lowercase
+        result = human_name.lower()
+
+        # Replace any non-alphanumeric character (including path traversal chars) with underscore
+        result = re.sub(r"[^a-z0-9]+", "_", result)
+
+        # Strip leading/trailing underscores
+        result = result.strip("_")
+
+        # Ensure the result contains at least one alphanumeric character
+        if not result or not re.search(r"[a-z0-9]", result):
+            msg = "Project name must contain at least one alphanumeric character"
+            raise ValueError(msg)
+
+        return result

--- a/uv.lock
+++ b/uv.lock
@@ -1408,14 +1408,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -29,7 +29,6 @@ members = [
 ]
 overrides = [
     { name = "aiohttp", specifier = ">=3.13.4" },
-    { name = "click", specifier = ">=8.3.2" },
     { name = "dynaconf", specifier = ">=3.2.13" },
     { name = "gunicorn", specifier = ">=25.3.0" },
     { name = "markdown", specifier = ">=3.8.0" },
@@ -62,15 +61,6 @@ http-server = [
     { name = "fastapi", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
     { name = "sse-starlette", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
     { name = "starlette", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
-]
-
-[[package]]
-name = "absl-py"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
 ]
 
 [[package]]
@@ -398,15 +388,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "ansicolors"
-version = "1.1.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/31/7faed52088732704523c259e24c26ce6f2f33fbeff2ff59274560c27628e/ansicolors-1.1.8.zip", hash = "sha256:99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0", size = 23027, upload-time = "2017-06-02T21:22:10.729Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/18/a56e2fe47b259bb52201093a3a9d4a32014f9d85071ad07e9d60600890ca/ansicolors-1.1.8-py2.py3-none-any.whl", hash = "sha256:00d2dde5a675579325902536738dd27e4fac1fd68f773fe36c21044eb559e187", size = 13847, upload-time = "2017-06-02T21:22:12.67Z" },
 ]
 
 [[package]]
@@ -1427,14 +1408,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
@@ -3993,19 +3974,6 @@ wheels = [
 ]
 
 [[package]]
-name = "granite-common"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonschema" },
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/10/ca8f59c644a3574a443bb85ff807f1ebbe726a6ad75bd471e092ab002f37/granite_common-0.4.1.tar.gz", hash = "sha256:5290e03d43e2962218aaf13c9c43877af6fb7869332a4ea35983c4f6a206d801", size = 714066, upload-time = "2026-02-25T01:10:45.253Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/ee/c52f5ddb073c111c19f15889646fd65e0be2b4e0b01764237d1ecbcd5bfe/granite_common-0.4.1-py3-none-any.whl", hash = "sha256:e82df48f69a98b46dbff8a36c10a64a13d4400fed2425f2ad9a6981031544062", size = 86633, upload-time = "2026-02-25T01:10:43.845Z" },
-]
-
-[[package]]
 name = "graph-retriever"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5192,15 +5160,6 @@ wheels = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/4b/6f8906aaf67d501e259b0adab4d312945bb7211e8b8d4dcc77c92320edaa/json5-0.14.0.tar.gz", hash = "sha256:b3f492fad9f6cdbced8b7d40b28b9b1c9701c5f561bef0d33b81c2ff433fefcb", size = 52656, upload-time = "2026-03-27T22:50:48.108Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/42/cf027b4ac873b076189d935b135397675dac80cb29acb13e1ab86ad6c631/json5-0.14.0-py3-none-any.whl", hash = "sha256:56cf861bab076b1178eb8c92e1311d273a9b9acea2ccc82c276abf839ebaef3a", size = 36271, upload-time = "2026-03-27T22:50:47.073Z" },
-]
-
-[[package]]
 name = "jsonlines"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5953,7 +5912,6 @@ name = "langflow"
 version = "1.9.0"
 source = { editable = "." }
 dependencies = [
-    { name = "click" },
     { name = "langflow-base", extra = ["complete"] },
 ]
 
@@ -6034,7 +5992,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cassio", marker = "extra == 'cassio'", specifier = ">=0.1.7" },
-    { name = "click", specifier = ">=8.3.2" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse-connect'", specifier = "==0.7.19" },
     { name = "couchbase", marker = "extra == 'couchbase'", specifier = ">=4.2.1" },
     { name = "ctransformers", marker = "extra == 'local'", specifier = ">=0.2.10" },
@@ -7066,7 +7023,7 @@ requires-dist = [
     { name = "sseclient-py", marker = "extra == 'sseclient'", specifier = "==1.8.0" },
     { name = "structlog", specifier = ">=25.4.0,<26.0.0" },
     { name = "supabase", marker = "extra == 'supabase'", specifier = ">=2.6.0,<3.0.0" },
-    { name = "toolguard", marker = "extra == 'toolguard'", specifier = ">=0.2.14,<1.0.0" },
+    { name = "toolguard", marker = "extra == 'toolguard'", specifier = ">=0.2.15,<1.0.0" },
     { name = "traceloop-sdk", marker = "extra == 'traceloop'", specifier = ">=0.43.1,<1.0.0" },
     { name = "trustcall", specifier = ">=0.0.38,<1.0.0" },
     { name = "twelvelabs", marker = "extra == 'twelvelabs'", specifier = ">=0.4.7,<1.0.0" },
@@ -7303,19 +7260,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/dd/8d/2161f46485d9c36c0fa0e1c997faf08bb7843027e59b549598e49f55f8bf/latex2mathml-3.79.0.tar.gz", hash = "sha256:11bde318c2d2d6fcdd105a07509d867cee2208f653278eb80243dec7ea77a0ce", size = 151103, upload-time = "2026-03-12T23:25:08.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/92/56a954dd59637dd2ee013581fa3beea0821f17f2c07f818fc51dcc11fd10/latex2mathml-3.79.0-py3-none-any.whl", hash = "sha256:9f10720d4fcf6b22d1b81f6628237832419a7a29783c13aa92fa8d680165e63d", size = 73945, upload-time = "2026-03-12T23:25:09.466Z" },
-]
-
-[[package]]
-name = "latex2sympy2-extended"
-version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "antlr4-python3-runtime" },
-    { name = "sympy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/75/456da2da05f6380ea96e6ea804ab2c03e41fc3ed80052307fe8efe6ea20e/latex2sympy2_extended-1.11.0.tar.gz", hash = "sha256:9695657c81b50abba2636638638618db59f4663ed2a4a12d62cef74a40e28fec", size = 207023, upload-time = "2026-01-10T01:43:21.319Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/61/f75cd1fa54d8434276126034aed54dd120747de9a8fa013cdd79545ccbeb/latex2sympy2_extended-1.11.0-py3-none-any.whl", hash = "sha256:aebb77d52ce269e25028e4bea89ddb14d242ba36bcf7b636496fb5fd9728d234", size = 209050, upload-time = "2026-01-10T01:43:19.458Z" },
 ]
 
 [[package]]
@@ -7926,18 +7870,6 @@ wheels = [
 ]
 
 [[package]]
-name = "math-verify"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "latex2sympy2-extended" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/12/b8d13b581e110ac2f724a2351a8361a70fa36d057eb945d6379e8747c256/math_verify-0.9.0.tar.gz", hash = "sha256:45ac6c61344ba056b9e99a660a4bc8d044ed408f730aed68c60435aa5eec4645", size = 60329, upload-time = "2026-01-10T01:48:33.056Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/76/6b4969bccc842b6567f7e6ee015684b9428a9b7fcbdf479e73716f43597f/math_verify-0.9.0-py3-none-any.whl", hash = "sha256:3703e7c4885354027fa84409d762a596a2906d1fd4deb78361876bd905a76194", size = 29967, upload-time = "2026-01-10T01:48:31.674Z" },
-]
-
-[[package]]
 name = "matplotlib-inline"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -8007,37 +7939,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mellea"
-version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ansicolors" },
-    { name = "click" },
-    { name = "fastapi" },
-    { name = "granite-common" },
-    { name = "huggingface-hub" },
-    { name = "jinja2" },
-    { name = "json5" },
-    { name = "llm-sandbox", extra = ["docker"] },
-    { name = "math-verify" },
-    { name = "mistletoe" },
-    { name = "ollama" },
-    { name = "openai" },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "rouge-score" },
-    { name = "typer" },
-    { name = "types-requests" },
-    { name = "types-tqdm" },
-    { name = "uvicorn" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/e9/25d87d92064b9781ef3e15d032f6f50deb2ff70b35d3c27f21ff595666ca/mellea-0.3.2.tar.gz", hash = "sha256:b73c5c1da473891e85005042a8e1ac26eae4026f448306884de3c8ba56df1965", size = 3583161, upload-time = "2026-02-26T13:43:30.979Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/d8/4bcf1174810518d7f9fb27ae8d77a9001bd975ef26d24f734f89df051ddc/mellea-0.3.2-py3-none-any.whl", hash = "sha256:ef9beb4b5b3f8c2099d17df592067646ecac2bc47b8f7f8b19951c3acbe37174", size = 3864719, upload-time = "2026-02-26T13:43:29.118Z" },
-]
-
-[[package]]
 name = "mem0ai"
 version = "0.1.34"
 source = { registry = "https://pypi.org/simple" }
@@ -8090,15 +7991,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2e/746f5bb1d6facd1e73eb4af6dd5efda11125b0f29d7908a097485ca6cad9/milvus_lite-2.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2e031088bf308afe5f8567850412d618cfb05a65238ed1a6117f60decccc95a", size = 24421451, upload-time = "2025-06-30T04:23:51.747Z" },
     { url = "https://files.pythonhosted.org/packages/2e/cf/3d1fee5c16c7661cf53977067a34820f7269ed8ba99fe9cf35efc1700866/milvus_lite-2.5.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:a13277e9bacc6933dea172e42231f7e6135bd3bdb073dd2688ee180418abd8d9", size = 45337093, upload-time = "2025-06-30T04:24:06.706Z" },
     { url = "https://files.pythonhosted.org/packages/d3/82/41d9b80f09b82e066894d9b508af07b7b0fa325ce0322980674de49106a0/milvus_lite-2.5.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25ce13f4b8d46876dd2b7ac8563d7d8306da7ff3999bb0d14b116b30f71d706c", size = 55263911, upload-time = "2025-06-30T04:24:19.434Z" },
-]
-
-[[package]]
-name = "mistletoe"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/ae/d33647e2a26a8899224f36afc5e7b7a670af30f1fd87231e9f07ca19d673/mistletoe-1.5.1.tar.gz", hash = "sha256:c5571ce6ca9cfdc7ce9151c3ae79acb418e067812000907616427197648030a3", size = 111769, upload-time = "2025-12-07T16:19:01.066Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/60/0980fefdc4d12c18c1bbab9d62852f27aded8839233c7b0a9827aaf395f5/mistletoe-1.5.1-py3-none-any.whl", hash = "sha256:d3e97664798261503f685f6a6281b092628367cf3128fc68a015a993b0c4feb3", size = 55331, upload-time = "2025-12-07T16:18:59.65Z" },
 ]
 
 [[package]]
@@ -12920,19 +12812,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rouge-score"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "absl-py" },
-    { name = "nltk" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/c5/9136736c37022a6ad27fea38f3111eb8f02fe75d067f9a985cc358653102/rouge_score-0.1.2.tar.gz", hash = "sha256:c7d4da2683e68c9abf0135ef915d63a46643666f848e558a1b9f7ead17ff0f04", size = 17400, upload-time = "2022-07-22T22:46:22.909Z" }
-
-[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -14366,7 +14245,7 @@ wheels = [
 
 [[package]]
 name = "toolguard"
-version = "0.2.14"
+version = "0.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datamodel-code-generator" },
@@ -14375,7 +14254,6 @@ dependencies = [
     { name = "litellm" },
     { name = "loguru" },
     { name = "markdown" },
-    { name = "mellea" },
     { name = "pydantic" },
     { name = "pyright" },
     { name = "pytest" },
@@ -14383,9 +14261,9 @@ dependencies = [
     { name = "pytest-json-report" },
     { name = "smolagents" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/b0/7c05b63fb8879bae9eb21ed22812c453ffa899dabd12f381cf527fb86600/toolguard-0.2.14.tar.gz", hash = "sha256:ab11c99693c7a599902221de9df3c429b1e40817e65797713b0b2c09cf754af4", size = 65706, upload-time = "2026-04-08T05:09:44.762Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/54/4e864ebc9dd9a2ac38611d92c38a624125a975d1cf71169b0374d5dbee33/toolguard-0.2.15.tar.gz", hash = "sha256:cb7d944aab949264ab81045fa5bdecb822fe3a96d2530337b0b3399acdab2f8c", size = 66931, upload-time = "2026-04-09T08:16:02.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/5f/dd2492ea4e9f32899730a2fcb9f17b4150d794b0dee245f3e27f4da0b8be/toolguard-0.2.14-py3-none-any.whl", hash = "sha256:4ecf926169d00ab5a8a5e4c9d5e3e4e6b48b57e11b49fffdab9052d0c71715c5", size = 96176, upload-time = "2026-04-08T05:09:43.477Z" },
+    { url = "https://files.pythonhosted.org/packages/68/14/759ef24d980d44f11f8b1f52d90b983b9371e6f99d336731d99639964df5/toolguard-0.2.15-py3-none-any.whl", hash = "sha256:2fdac26a15cf6b894ececace30c6a545b68305e3f23028d09d697e60d592f963", size = 97660, upload-time = "2026-04-09T08:16:01.376Z" },
 ]
 
 [[package]]
@@ -14869,18 +14747,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
-]
-
-[[package]]
-name = "types-tqdm"
-version = "4.67.3.20260408"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "types-requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/42/2e2968e68a694d3dac3a47aa0df06e46be1a6eef498e5bd15f4c54674eb9/types_tqdm-4.67.3.20260408.tar.gz", hash = "sha256:fd849a79891ae7136ed47541aface15c35bd9a13160fa8a93e42e10f60cf4c8d", size = 18119, upload-time = "2026-04-08T04:36:52.488Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/5d/7dedddc32ab7bc2344ece772b5e0f03ec63a1d47ad259696689713c1cf50/types_tqdm-4.67.3.20260408-py3-none-any.whl", hash = "sha256:3b9ed74ebef04df8f53d470ffdc84348e93496d8acafa08bf79fafce0f2f5b5d", size = 24561, upload-time = "2026-04-08T04:36:51.538Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ members = [
 ]
 overrides = [
     { name = "aiohttp", specifier = ">=3.13.4" },
+    { name = "click", specifier = ">=8.3.2" },
     { name = "dynaconf", specifier = ">=3.2.13" },
     { name = "gunicorn", specifier = ">=25.3.0" },
     { name = "markdown", specifier = ">=3.8.0" },
@@ -61,6 +62,15 @@ http-server = [
     { name = "fastapi", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
     { name = "sse-starlette", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
     { name = "starlette", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
+]
+
+[[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
 ]
 
 [[package]]
@@ -388,6 +398,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "ansicolors"
+version = "1.1.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/31/7faed52088732704523c259e24c26ce6f2f33fbeff2ff59274560c27628e/ansicolors-1.1.8.zip", hash = "sha256:99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0", size = 23027, upload-time = "2017-06-02T21:22:10.729Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/18/a56e2fe47b259bb52201093a3a9d4a32014f9d85071ad07e9d60600890ca/ansicolors-1.1.8-py2.py3-none-any.whl", hash = "sha256:00d2dde5a675579325902536738dd27e4fac1fd68f773fe36c21044eb559e187", size = 13847, upload-time = "2017-06-02T21:22:12.67Z" },
 ]
 
 [[package]]
@@ -2088,7 +2107,7 @@ wheels = [
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.39.0"
+version = "0.56.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -2097,14 +2116,13 @@ dependencies = [
     { name = "inflect" },
     { name = "isort" },
     { name = "jinja2" },
-    { name = "packaging" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/d8/9c633eafb1cb7f9ccb607bdbda0601d65fe3441954f2998e4222338a0a17/datamodel_code_generator-0.39.0.tar.gz", hash = "sha256:d08b5f9cce8fff2b57784c8f1d737fa91ad22ac621a6a732946307730f24f887", size = 447299, upload-time = "2025-12-02T19:29:58.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/7d/7fc2bb3d8946ca45851da3f23497a2c6e252e92558ccbd89d609cf1e13d4/datamodel_code_generator-0.56.0.tar.gz", hash = "sha256:e7c003fb5421b890aabe12f66ae65b57198b04cfe1da7c40810798020835b3a8", size = 837708, upload-time = "2026-04-04T09:46:19.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/74/aef4da1b08d5c3a70eb25a1fc2c6499cc8588c803c2ebe770f2e5fb77dce/datamodel_code_generator-0.39.0-py3-none-any.whl", hash = "sha256:f08cd8cf826d3556f638989af4851037026a93cfb846aa6429b13cd622714775", size = 151348, upload-time = "2025-12-02T19:29:56.632Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/3a/7f169ffc7a2d69a4f9158b1ac083f685b7f4a1a8a1db5d1e4abbb4e741b7/datamodel_code_generator-0.56.0-py3-none-any.whl", hash = "sha256:a0559683fbe90cdf2ce9b6637e3adae3e3a8056a8d0516df581d486e2834ead2", size = 256545, upload-time = "2026-04-04T09:46:17.582Z" },
 ]
 
 [[package]]
@@ -3975,6 +3993,19 @@ wheels = [
 ]
 
 [[package]]
+name = "granite-common"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/10/ca8f59c644a3574a443bb85ff807f1ebbe726a6ad75bd471e092ab002f37/granite_common-0.4.1.tar.gz", hash = "sha256:5290e03d43e2962218aaf13c9c43877af6fb7869332a4ea35983c4f6a206d801", size = 714066, upload-time = "2026-02-25T01:10:45.253Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ee/c52f5ddb073c111c19f15889646fd65e0be2b4e0b01764237d1ecbcd5bfe/granite_common-0.4.1-py3-none-any.whl", hash = "sha256:e82df48f69a98b46dbff8a36c10a64a13d4400fed2425f2ad9a6981031544062", size = 86633, upload-time = "2026-02-25T01:10:43.845Z" },
+]
+
+[[package]]
 name = "graph-retriever"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5161,6 +5192,15 @@ wheels = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/4b/6f8906aaf67d501e259b0adab4d312945bb7211e8b8d4dcc77c92320edaa/json5-0.14.0.tar.gz", hash = "sha256:b3f492fad9f6cdbced8b7d40b28b9b1c9701c5f561bef0d33b81c2ff433fefcb", size = 52656, upload-time = "2026-03-27T22:50:48.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/42/cf027b4ac873b076189d935b135397675dac80cb29acb13e1ab86ad6c631/json5-0.14.0-py3-none-any.whl", hash = "sha256:56cf861bab076b1178eb8c92e1311d273a9b9acea2ccc82c276abf839ebaef3a", size = 36271, upload-time = "2026-03-27T22:50:47.073Z" },
+]
+
+[[package]]
 name = "jsonlines"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5913,6 +5953,7 @@ name = "langflow"
 version = "1.9.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "langflow-base", extra = ["complete"] },
 ]
 
@@ -5993,6 +6034,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cassio", marker = "extra == 'cassio'", specifier = ">=0.1.7" },
+    { name = "click", specifier = ">=8.3.2" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse-connect'", specifier = "==0.7.19" },
     { name = "couchbase", marker = "extra == 'couchbase'", specifier = ">=4.2.1" },
     { name = "ctransformers", marker = "extra == 'local'", specifier = ">=0.2.10" },
@@ -6254,6 +6296,7 @@ all = [
     { name = "spider-client" },
     { name = "sseclient-py" },
     { name = "supabase" },
+    { name = "toolguard" },
     { name = "traceloop-sdk" },
     { name = "twelvelabs" },
     { name = "upstash-vector" },
@@ -6418,6 +6461,7 @@ complete = [
     { name = "spider-client" },
     { name = "sseclient-py" },
     { name = "supabase" },
+    { name = "toolguard" },
     { name = "traceloop-sdk" },
     { name = "twelvelabs" },
     { name = "upstash-vector" },
@@ -6671,6 +6715,9 @@ sseclient = [
 ]
 supabase = [
     { name = "supabase" },
+]
+toolguard = [
+    { name = "toolguard" },
 ]
 traceloop = [
     { name = "traceloop-sdk" },
@@ -6929,6 +6976,7 @@ requires-dist = [
     { name = "langflow-base", extras = ["spider"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["sseclient"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["supabase"], marker = "extra == 'complete'", editable = "src/backend/base" },
+    { name = "langflow-base", extras = ["toolguard"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["traceloop"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["twelvelabs"], marker = "extra == 'complete'", editable = "src/backend/base" },
     { name = "langflow-base", extras = ["upstash"], marker = "extra == 'complete'", editable = "src/backend/base" },
@@ -7018,6 +7066,7 @@ requires-dist = [
     { name = "sseclient-py", marker = "extra == 'sseclient'", specifier = "==1.8.0" },
     { name = "structlog", specifier = ">=25.4.0,<26.0.0" },
     { name = "supabase", marker = "extra == 'supabase'", specifier = ">=2.6.0,<3.0.0" },
+    { name = "toolguard", marker = "extra == 'toolguard'", specifier = ">=0.2.14,<1.0.0" },
     { name = "traceloop-sdk", marker = "extra == 'traceloop'", specifier = ">=0.43.1,<1.0.0" },
     { name = "trustcall", specifier = ">=0.0.38,<1.0.0" },
     { name = "twelvelabs", marker = "extra == 'twelvelabs'", specifier = ">=0.4.7,<1.0.0" },
@@ -7036,7 +7085,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = ">=1.0.0,<2.0.0" },
     { name = "zep-python", marker = "extra == 'zep'", specifier = "==2.0.2" },
 ]
-provides-extras = ["audio", "postgresql", "local", "couchbase", "cassandra", "clickhouse", "mongodb", "supabase", "redis", "elasticsearch", "faiss", "qdrant", "weaviate", "chroma", "upstash", "pinecone", "milvus", "mongodb-vectors", "astradb", "openai", "anthropic", "cohere", "google", "ollama", "nvidia", "mistral", "sambanova", "groq", "llama-cpp", "sentence-transformers", "ctransformers", "langfuse", "langwatch", "langsmith", "arize", "pypdf", "docx", "pytube", "dspy", "smolagents", "beautifulsoup", "serpapi", "google-api", "wikipedia", "fake-useragent", "duckduckgo", "yfinance", "wolframalpha", "pyarrow", "fastavro", "gitpython", "nltk", "lark", "huggingface", "metaphor", "metal", "markup", "aws", "numexpr", "qianfan", "pgvector", "litellm", "zep", "youtube", "markdown", "kubernetes", "json-repair", "composio", "ragstack", "opensearch", "atlassian", "mem0", "needle", "sseclient", "openinference", "mcp", "ag2", "scrapegraph", "apify", "spider", "altk", "langchain-huggingface", "langchain-unstructured", "graph-retriever", "langchain-mcp-adapters", "opik", "traceloop", "openlayer", "docling", "easyocr", "cleanlab", "twelvelabs", "jigsawstack", "assemblyai", "datasets", "fastparquet", "vlmrun", "cuga", "mlx", "fastmcp", "aioboto3", "astrapy", "gassist", "ibm-watsonx-clients", "complete", "all"]
+provides-extras = ["audio", "postgresql", "local", "couchbase", "cassandra", "clickhouse", "mongodb", "supabase", "redis", "elasticsearch", "faiss", "qdrant", "weaviate", "chroma", "upstash", "pinecone", "milvus", "mongodb-vectors", "astradb", "openai", "anthropic", "cohere", "google", "ollama", "nvidia", "mistral", "sambanova", "groq", "llama-cpp", "sentence-transformers", "ctransformers", "langfuse", "langwatch", "langsmith", "arize", "pypdf", "docx", "pytube", "dspy", "smolagents", "beautifulsoup", "serpapi", "google-api", "wikipedia", "fake-useragent", "duckduckgo", "yfinance", "wolframalpha", "pyarrow", "fastavro", "gitpython", "nltk", "lark", "huggingface", "metaphor", "metal", "markup", "aws", "numexpr", "qianfan", "pgvector", "litellm", "zep", "youtube", "markdown", "kubernetes", "json-repair", "composio", "ragstack", "opensearch", "atlassian", "mem0", "needle", "sseclient", "openinference", "mcp", "ag2", "scrapegraph", "apify", "spider", "altk", "toolguard", "langchain-huggingface", "langchain-unstructured", "graph-retriever", "langchain-mcp-adapters", "opik", "traceloop", "openlayer", "docling", "easyocr", "cleanlab", "twelvelabs", "jigsawstack", "assemblyai", "datasets", "fastparquet", "vlmrun", "cuga", "mlx", "fastmcp", "aioboto3", "astrapy", "gassist", "ibm-watsonx-clients", "complete", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -7254,6 +7303,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/dd/8d/2161f46485d9c36c0fa0e1c997faf08bb7843027e59b549598e49f55f8bf/latex2mathml-3.79.0.tar.gz", hash = "sha256:11bde318c2d2d6fcdd105a07509d867cee2208f653278eb80243dec7ea77a0ce", size = 151103, upload-time = "2026-03-12T23:25:08.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/92/56a954dd59637dd2ee013581fa3beea0821f17f2c07f818fc51dcc11fd10/latex2mathml-3.79.0-py3-none-any.whl", hash = "sha256:9f10720d4fcf6b22d1b81f6628237832419a7a29783c13aa92fa8d680165e63d", size = 73945, upload-time = "2026-03-12T23:25:09.466Z" },
+]
+
+[[package]]
+name = "latex2sympy2-extended"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "sympy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/75/456da2da05f6380ea96e6ea804ab2c03e41fc3ed80052307fe8efe6ea20e/latex2sympy2_extended-1.11.0.tar.gz", hash = "sha256:9695657c81b50abba2636638638618db59f4663ed2a4a12d62cef74a40e28fec", size = 207023, upload-time = "2026-01-10T01:43:21.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/61/f75cd1fa54d8434276126034aed54dd120747de9a8fa013cdd79545ccbeb/latex2sympy2_extended-1.11.0-py3-none-any.whl", hash = "sha256:aebb77d52ce269e25028e4bea89ddb14d242ba36bcf7b636496fb5fd9728d234", size = 209050, upload-time = "2026-01-10T01:43:19.458Z" },
 ]
 
 [[package]]
@@ -7864,6 +7926,18 @@ wheels = [
 ]
 
 [[package]]
+name = "math-verify"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "latex2sympy2-extended" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/12/b8d13b581e110ac2f724a2351a8361a70fa36d057eb945d6379e8747c256/math_verify-0.9.0.tar.gz", hash = "sha256:45ac6c61344ba056b9e99a660a4bc8d044ed408f730aed68c60435aa5eec4645", size = 60329, upload-time = "2026-01-10T01:48:33.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/76/6b4969bccc842b6567f7e6ee015684b9428a9b7fcbdf479e73716f43597f/math_verify-0.9.0-py3-none-any.whl", hash = "sha256:3703e7c4885354027fa84409d762a596a2906d1fd4deb78361876bd905a76194", size = 29967, upload-time = "2026-01-10T01:48:31.674Z" },
+]
+
+[[package]]
 name = "matplotlib-inline"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7933,6 +8007,37 @@ wheels = [
 ]
 
 [[package]]
+name = "mellea"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ansicolors" },
+    { name = "click" },
+    { name = "fastapi" },
+    { name = "granite-common" },
+    { name = "huggingface-hub" },
+    { name = "jinja2" },
+    { name = "json5" },
+    { name = "llm-sandbox", extra = ["docker"] },
+    { name = "math-verify" },
+    { name = "mistletoe" },
+    { name = "ollama" },
+    { name = "openai" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "rouge-score" },
+    { name = "typer" },
+    { name = "types-requests" },
+    { name = "types-tqdm" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/e9/25d87d92064b9781ef3e15d032f6f50deb2ff70b35d3c27f21ff595666ca/mellea-0.3.2.tar.gz", hash = "sha256:b73c5c1da473891e85005042a8e1ac26eae4026f448306884de3c8ba56df1965", size = 3583161, upload-time = "2026-02-26T13:43:30.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/d8/4bcf1174810518d7f9fb27ae8d77a9001bd975ef26d24f734f89df051ddc/mellea-0.3.2-py3-none-any.whl", hash = "sha256:ef9beb4b5b3f8c2099d17df592067646ecac2bc47b8f7f8b19951c3acbe37174", size = 3864719, upload-time = "2026-02-26T13:43:29.118Z" },
+]
+
+[[package]]
 name = "mem0ai"
 version = "0.1.34"
 source = { registry = "https://pypi.org/simple" }
@@ -7985,6 +8090,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2e/746f5bb1d6facd1e73eb4af6dd5efda11125b0f29d7908a097485ca6cad9/milvus_lite-2.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2e031088bf308afe5f8567850412d618cfb05a65238ed1a6117f60decccc95a", size = 24421451, upload-time = "2025-06-30T04:23:51.747Z" },
     { url = "https://files.pythonhosted.org/packages/2e/cf/3d1fee5c16c7661cf53977067a34820f7269ed8ba99fe9cf35efc1700866/milvus_lite-2.5.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:a13277e9bacc6933dea172e42231f7e6135bd3bdb073dd2688ee180418abd8d9", size = 45337093, upload-time = "2025-06-30T04:24:06.706Z" },
     { url = "https://files.pythonhosted.org/packages/d3/82/41d9b80f09b82e066894d9b508af07b7b0fa325ce0322980674de49106a0/milvus_lite-2.5.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25ce13f4b8d46876dd2b7ac8563d7d8306da7ff3999bb0d14b116b30f71d706c", size = 55263911, upload-time = "2025-06-30T04:24:19.434Z" },
+]
+
+[[package]]
+name = "mistletoe"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/ae/d33647e2a26a8899224f36afc5e7b7a670af30f1fd87231e9f07ca19d673/mistletoe-1.5.1.tar.gz", hash = "sha256:c5571ce6ca9cfdc7ce9151c3ae79acb418e067812000907616427197648030a3", size = 111769, upload-time = "2025-12-07T16:19:01.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/60/0980fefdc4d12c18c1bbab9d62852f27aded8839233c7b0a9827aaf395f5/mistletoe-1.5.1-py3-none-any.whl", hash = "sha256:d3e97664798261503f685f6a6281b092628367cf3128fc68a015a993b0c4feb3", size = 55331, upload-time = "2025-12-07T16:18:59.65Z" },
 ]
 
 [[package]]
@@ -11594,6 +11708,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+]
+
+[[package]]
 name = "pysher"
 version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
@@ -11718,6 +11845,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/bd/e0ba6c3cd20b9aa445f0af229f3a9582cce589f083537978a23e6f14e310/pytest-instafail-0.5.0.tar.gz", hash = "sha256:33a606f7e0c8e646dc3bfee0d5e3a4b7b78ef7c36168cfa1f3d93af7ca706c9e", size = 5849, upload-time = "2023-03-31T17:17:32.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/c0/c32dc39fc172e684fdb3d30169843efb65c067be1e12689af4345731126e/pytest_instafail-0.5.0-py3-none-any.whl", hash = "sha256:6855414487e9e4bb76a118ce952c3c27d3866af15487506c4ded92eb72387819", size = 4176, upload-time = "2023-03-31T17:17:30.065Z" },
+]
+
+[[package]]
+name = "pytest-json-report"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "pytest-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/d3/765dae9712fcd68d820338908c1337e077d5fdadccd5cacf95b9b0bea278/pytest-json-report-1.5.0.tar.gz", hash = "sha256:2dde3c647851a19b5f3700729e8310a6e66efb2077d674f27ddea3d34dc615de", size = 21241, upload-time = "2022-03-15T21:03:10.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/35/d07400c715bf8a88aa0c1ee9c9eb6050ca7fe5b39981f0eea773feeb0681/pytest_json_report-1.5.0-py3-none-any.whl", hash = "sha256:9897b68c910b12a2e48dd849f9a284b2c79a732a8a9cb398452ddd23d3c8c325", size = 13222, upload-time = "2022-03-15T21:03:08.65Z" },
+]
+
+[[package]]
+name = "pytest-metadata"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/85/8c969f8bec4e559f8f2b958a15229a35495f5b4ce499f6b865eac54b878d/pytest_metadata-3.1.1.tar.gz", hash = "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8", size = 9952, upload-time = "2024-02-12T19:38:44.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl", hash = "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b", size = 11428, upload-time = "2024-02-12T19:38:42.531Z" },
 ]
 
 [[package]]
@@ -12766,6 +12918,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/5b/bb4f9420802bf73678033a4a55ab1bede36ce2e9b41fec5f966d83d932b3/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:57e8327aacc27f921968cb2a174f9e47b084ce9a7dd0122c8132d22358f6bd79", size = 1120308, upload-time = "2025-11-05T21:40:59.402Z" },
     { url = "https://files.pythonhosted.org/packages/ce/8b/a1299085b28a2f6135e30370b126e3c5055b61908622f2488ade67641479/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:d8955b57e42f2a5434670d5aa7b75eaf6e74602ccd8955dddf7045379cd762fb", size = 1129444, upload-time = "2025-11-05T21:41:17.906Z" },
 ]
+
+[[package]]
+name = "rouge-score"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "nltk" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/c5/9136736c37022a6ad27fea38f3111eb8f02fe75d067f9a985cc358653102/rouge_score-0.1.2.tar.gz", hash = "sha256:c7d4da2683e68c9abf0135ef915d63a46643666f848e558a1b9f7ead17ff0f04", size = 17400, upload-time = "2022-07-22T22:46:22.909Z" }
 
 [[package]]
 name = "rpds-py"
@@ -14200,6 +14365,30 @@ wheels = [
 ]
 
 [[package]]
+name = "toolguard"
+version = "0.2.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "datamodel-code-generator" },
+    { name = "fastmcp" },
+    { name = "langchain-core" },
+    { name = "litellm" },
+    { name = "loguru" },
+    { name = "markdown" },
+    { name = "mellea" },
+    { name = "pydantic" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-json-report" },
+    { name = "smolagents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/b0/7c05b63fb8879bae9eb21ed22812c453ffa899dabd12f381cf527fb86600/toolguard-0.2.14.tar.gz", hash = "sha256:ab11c99693c7a599902221de9df3c429b1e40817e65797713b0b2c09cf754af4", size = 65706, upload-time = "2026-04-08T05:09:44.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/5f/dd2492ea4e9f32899730a2fcb9f17b4150d794b0dee245f3e27f4da0b8be/toolguard-0.2.14-py3-none-any.whl", hash = "sha256:4ecf926169d00ab5a8a5e4c9d5e3e4e6b48b57e11b49fffdab9052d0c71715c5", size = 96176, upload-time = "2026-04-08T05:09:43.477Z" },
+]
+
+[[package]]
 name = "toonify"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -14683,6 +14872,18 @@ wheels = [
 ]
 
 [[package]]
+name = "types-tqdm"
+version = "4.67.3.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/42/2e2968e68a694d3dac3a47aa0df06e46be1a6eef498e5bd15f4c54674eb9/types_tqdm-4.67.3.20260408.tar.gz", hash = "sha256:fd849a79891ae7136ed47541aface15c35bd9a13160fa8a93e42e10f60cf4c8d", size = 18119, upload-time = "2026-04-08T04:36:52.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/5d/7dedddc32ab7bc2344ece772b5e0f03ec63a1d47ad259696689713c1cf50/types_tqdm-4.67.3.20260408-py3-none-any.whl", hash = "sha256:3b9ed74ebef04df8f53d470ffdc84348e93496d8acafa08bf79fafce0f2f5b5d", size = 24561, upload-time = "2026-04-08T04:36:51.538Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -14981,7 +15182,7 @@ all = [
 
 [[package]]
 name = "vlmrun-hub"
-version = "0.1.35"
+version = "0.1.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -14993,9 +15194,9 @@ dependencies = [
     { name = "pydantic-yaml" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/ad/df0f9f4c93aa30c7fe6818c5152054cde2ad5dc606892313b55dfa3c5860/vlmrun_hub-0.1.35.tar.gz", hash = "sha256:a15b0a7b6d1c32f752f65aadb51148c3d69791db9b7e30e69e6cbdc82a067f65", size = 65092, upload-time = "2025-12-15T22:41:51.969Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/58/f71034ef6d8e4d29cf372fdca6c12d373e98b131cba7ab3a22c2fa897042/vlmrun_hub-0.1.34.tar.gz", hash = "sha256:1bb1b356e51555eb542e3ffd35f28fe6e3d2f5755e5df5cbf3809062e5a44c7c", size = 58974, upload-time = "2025-04-07T16:48:37.316Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/42/cf00ae0daf18b7d30ca48e84bf1b492c644df5ba7afa24c0c0417c78eb9f/vlmrun_hub-0.1.35-py3-none-any.whl", hash = "sha256:d8759ec2ba698ac43cd217fb7ffd2b79f214d998339236e8f37fe9a9e7642e9c", size = 65999, upload-time = "2025-12-15T22:41:50.658Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/15/a7ac48035d739b12b396dbebeef73b034d9a8a199808673046c71fe2fd03/vlmrun_hub-0.1.34-py3-none-any.whl", hash = "sha256:79c897dad972e2cce610b788346a7826db4fbabde613e2a0d28d46242a52a9bf", size = 58799, upload-time = "2025-04-07T16:48:35.836Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Reintroduces the policies component from #12564 (originally by @boazdavid), which was reverted in #12585
- Adds policy-based tool protection system using [ToolGuard](https://github.com/AgentToolkit/toolguard) for business policy enforcement
- Includes guard code generation from policy definitions, support for multiple language models (GPT-4o, Claude), and enhanced tool metadata with output schemas
- Adds `toolguard>=0.2.15` dependency

## Test plan
- [ ] Verify unit tests pass for policies component (`src/backend/tests/unit/components/models_and_agents/policies/`)
- [ ] Verify `uv.lock` resolves correctly with `toolguard>=0.2.15`
- [ ] Test Generate and Use Cache modes with ToolGuard
- [ ] Verify no regression in existing components