### PR TITLE
fix: deployment UX improvements — error toast, tool name, refetch, runtime feature flag

### DIFF
--- a/src/frontend/src/components/core/flowToolbarComponent/components/__tests__/deploy-button.test.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/__tests__/deploy-button.test.tsx
@@ -13,8 +13,10 @@ const mockHandleDeploy = jest.fn();
 const mockSetChoiceDialogOpen = jest.fn();
 const mockSetDeployModalOpen = jest.fn();
 
-jest.mock("@/customization/feature-flags", () => ({
-  ENABLE_DEPLOYMENTS: true,
+jest.mock("@/stores/utilityStore", () => ({
+  useUtilityStore: (
+    selector: (s: { featureFlags: Record<string, unknown> }) => unknown,
+  ) => selector({ featureFlags: { wxo_deployments: true } }),
 }));
 
 jest.mock("../deploy-choice-dialog/hooks/use-prepare-deploy", () => ({

--- a/src/frontend/src/components/core/flowToolbarComponent/components/deploy-button.tsx
+++ b/src/frontend/src/components/core/flowToolbarComponent/components/deploy-button.tsx
@@ -1,7 +1,7 @@
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
-import { ENABLE_DEPLOYMENTS } from "@/customization/feature-flags";
 import DeploymentStepperModal from "@/pages/MainPage/pages/deploymentsPage/components/deployment-stepper-modal";
 import { useNavigateToTest } from "@/pages/MainPage/pages/deploymentsPage/hooks/use-navigate-to-test";
+import { useUtilityStore } from "@/stores/utilityStore";
 import DeployChoiceDialog from "./deploy-choice-dialog";
 import { usePrepareDeploy } from "./deploy-choice-dialog/hooks/use-prepare-deploy";
 
@@ -79,6 +79,9 @@ function DeployButtonInner() {
 }
 
 export default function DeployButton() {
-  if (!ENABLE_DEPLOYMENTS) return null;
+  const deploymentsEnabled = useUtilityStore(
+    (s) => s.featureFlags.wxo_deployments === true,
+  );
+  if (!deploymentsEnabled) return null;
   return <DeployButtonInner />;
 }

--- a/src/frontend/src/controllers/API/helpers/__tests__/get-axios-error-message.test.ts
+++ b/src/frontend/src/controllers/API/helpers/__tests__/get-axios-error-message.test.ts
@@ -1,0 +1,72 @@
+import { AxiosError, AxiosHeaders } from "axios";
+import { getAxiosErrorMessage } from "../get-axios-error-message";
+
+function makeAxiosError(data: unknown, message = "Request failed"): AxiosError {
+  const error = new AxiosError(message);
+  error.response = {
+    data,
+    status: 422,
+    statusText: "Unprocessable Entity",
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
+
+describe("getAxiosErrorMessage", () => {
+  it("returns string detail from Axios error response", () => {
+    const err = makeAxiosError({ detail: "Not found" });
+    expect(getAxiosErrorMessage(err)).toBe("Not found");
+  });
+
+  it("returns joined msg fields when detail is a Pydantic validation error array", () => {
+    const err = makeAxiosError({
+      detail: [
+        {
+          type: "value_error",
+          loc: ["body", "url"],
+          msg: "Value error, URL hostname 'evil.com' is not allowed for provider 'watsonx-orchestrate'",
+        },
+      ],
+    });
+    expect(getAxiosErrorMessage(err)).toBe(
+      "Value error, URL hostname 'evil.com' is not allowed for provider 'watsonx-orchestrate'",
+    );
+  });
+
+  it("joins multiple validation errors with semicolons", () => {
+    const err = makeAxiosError({
+      detail: [
+        { msg: "Field required", loc: ["body", "name"] },
+        { msg: "Invalid URL", loc: ["body", "url"] },
+      ],
+    });
+    expect(getAxiosErrorMessage(err)).toBe("Field required; Invalid URL");
+  });
+
+  it("falls back to err.message when detail is missing", () => {
+    const err = makeAxiosError({});
+    expect(getAxiosErrorMessage(err)).toBe("Request failed");
+  });
+
+  it("falls back to default message for non-Axios, non-Error values", () => {
+    expect(getAxiosErrorMessage("random string")).toBe(
+      "An unknown error occurred",
+    );
+  });
+
+  it("returns Error.message for plain Error instances", () => {
+    expect(getAxiosErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("uses custom fallback when provided", () => {
+    expect(getAxiosErrorMessage(null, "custom fallback")).toBe(
+      "custom fallback",
+    );
+  });
+
+  it("handles detail as an array of plain strings", () => {
+    const err = makeAxiosError({ detail: ["error one", "error two"] });
+    expect(getAxiosErrorMessage(err)).toBe("error one; error two");
+  });
+});

--- a/src/frontend/src/controllers/API/helpers/get-axios-error-message.ts
+++ b/src/frontend/src/controllers/API/helpers/get-axios-error-message.ts
@@ -1,6 +1,36 @@
 import axios from "axios";
 
 /**
+ * Extract a string from the `detail` field of an Axios error response.
+ *
+ * FastAPI returns `detail` as a plain string for most HTTP errors, but
+ * Pydantic validation errors (422) return an array of objects with a `msg`
+ * property.  This helper handles both shapes.
+ */
+function extractDetail(data: unknown): string | undefined {
+  if (data == null || typeof data !== "object") return undefined;
+
+  const detail = (data as Record<string, unknown>).detail;
+
+  if (typeof detail === "string") return detail;
+
+  if (Array.isArray(detail) && detail.length > 0) {
+    return detail
+      .map((entry: unknown) => {
+        if (typeof entry === "string") return entry;
+        if (entry != null && typeof entry === "object") {
+          const msg = (entry as Record<string, unknown>).msg;
+          if (typeof msg === "string") return msg;
+        }
+        return String(entry);
+      })
+      .join("; ");
+  }
+
+  return undefined;
+}
+
+/**
  * Extracts a user-friendly error message from an unknown catch value.
  * Prefers `response.data.detail` for Axios errors, then `.message`, then a fallback.
  */
@@ -9,11 +39,7 @@ export function getAxiosErrorMessage(
   fallback = "An unknown error occurred",
 ): string {
   if (axios.isAxiosError(err)) {
-    return (
-      (err.response?.data as { detail?: string })?.detail ||
-      err.message ||
-      fallback
-    );
+    return extractDetail(err.response?.data) || err.message || fallback;
   }
   if (err instanceof Error) {
     return err.message;

--- a/src/frontend/src/controllers/API/queries/config/use-get-config.ts
+++ b/src/frontend/src/controllers/API/queries/config/use-get-config.ts
@@ -114,7 +114,7 @@ export const useGetConfig: useQueryFunctionType<
         setAutoSaving(data.auto_saving);
         setAutoSavingInterval(data.auto_saving_interval);
         setHealthCheckMaxRetries(data.health_check_max_retries);
-        setFeatureFlags(data.feature_flags);
+        setFeatureFlags(data.feature_flags ?? {});
         setSerializationMaxItemsLength(data.serialization_max_items_length);
         setWebhookPollingInterval(
           data.webhook_polling_interval ?? DEFAULT_POLLING_INTERVAL,

--- a/src/frontend/src/customization/feature-flags.ts
+++ b/src/frontend/src/customization/feature-flags.ts
@@ -16,9 +16,6 @@ export const ENABLE_FILES_ON_PLAYGROUND = true;
 export const ENABLE_MCP = true;
 export const ENABLE_MCP_NOTICE = false;
 export const ENABLE_KNOWLEDGE_BASES = true;
-/** @deprecated Use `useFeatureFlags().deploymentsEnabled` from the utility store instead. */
-export const ENABLE_DEPLOYMENTS =
-  import.meta.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS === "true";
 export const ENABLE_INSPECTION_PANEL = true;
 
 export const ENABLE_MCP_COMPOSER =

--- a/src/frontend/src/customization/feature-flags.ts
+++ b/src/frontend/src/customization/feature-flags.ts
@@ -16,6 +16,7 @@ export const ENABLE_FILES_ON_PLAYGROUND = true;
 export const ENABLE_MCP = true;
 export const ENABLE_MCP_NOTICE = false;
 export const ENABLE_KNOWLEDGE_BASES = true;
+/** @deprecated Use `useFeatureFlags().deploymentsEnabled` from the utility store instead. */
 export const ENABLE_DEPLOYMENTS =
   import.meta.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS === "true";
 export const ENABLE_INSPECTION_PANEL = true;

--- a/src/frontend/src/pages/MainPage/components/header/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/index.tsx
@@ -8,10 +8,11 @@ import { Input } from "@/components/ui/input";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { useDeleteDeleteFlows } from "@/controllers/API/queries/flows/use-delete-delete-flows";
 import { useGetDownloadFlows } from "@/controllers/API/queries/flows/use-get-download-flows";
-import { ENABLE_DEPLOYMENTS, ENABLE_MCP } from "@/customization/feature-flags";
+import { ENABLE_MCP } from "@/customization/feature-flags";
 import DeleteConfirmationModal from "@/modals/deleteConfirmationModal";
 import useAlertStore from "@/stores/alertStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
+import { useUtilityStore } from "@/stores/utilityStore";
 import { cn } from "@/utils/utils";
 
 import type { FlowTabType } from "../../types";
@@ -77,7 +78,9 @@ const HeaderComponent = ({
     setDebouncedSearch(e.target.value);
   };
 
-  const isDeploymentsEnabled = ENABLE_DEPLOYMENTS;
+  const isDeploymentsEnabled = useUtilityStore(
+    (s) => s.featureFlags.wxo_deployments === true,
+  );
 
   // Determine which tabs to show based on feature flags
   const tabTypes = [

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployment-details-modal.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployment-details-modal.test.tsx
@@ -25,8 +25,7 @@ let mockAttachmentsData: {
     version_number: number;
     attached_at: string | null;
     provider_snapshot_id: string | null;
-    tool_name: string | null;
-    provider_data: { app_ids?: string[] } | null;
+    provider_data: { app_ids?: string[]; tool_name?: string | null } | null;
   }>;
 } | null = null;
 let mockIsFetchingAttachments = false;
@@ -112,8 +111,7 @@ beforeEach(() => {
         version_number: 3,
         attached_at: "2025-06-01T00:00:00Z",
         provider_snapshot_id: "snap-1",
-        tool_name: "sales_tool",
-        provider_data: { app_ids: ["cfg-1", "cfg-2"] },
+        provider_data: { app_ids: ["cfg-1", "cfg-2"], tool_name: "sales_tool" },
       },
     ],
   };
@@ -195,6 +193,29 @@ describe("Flow list with versions and connections", () => {
     renderModal();
     expect(screen.getByText("Sales Flow")).toBeInTheDocument();
     expect(screen.getByText("v3")).toBeInTheDocument();
+  });
+
+  it("shows tool name from provider_data", () => {
+    renderModal();
+    expect(screen.getByText("sales_tool")).toBeInTheDocument();
+  });
+
+  it("does not render tool section when tool_name is null", () => {
+    mockAttachmentsData = {
+      flow_versions: [
+        {
+          id: "fv-1",
+          flow_id: "flow-1",
+          flow_name: "Sales Flow",
+          version_number: 3,
+          attached_at: null,
+          provider_snapshot_id: null,
+          provider_data: { app_ids: [] },
+        },
+      ],
+    };
+    renderModal();
+    expect(screen.queryByTestId("icon-Wrench")).not.toBeInTheDocument();
   });
 
   it("maps connection IDs to names via configMap", () => {

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-details-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-details-modal.tsx
@@ -34,19 +34,22 @@ export default function DeploymentDetailsModal({
 
   const { data: details, isFetching: isFetchingDetails } = useGetDeployment(
     { deploymentId },
-    { enabled: open && !!deploymentId },
+    { enabled: open && !!deploymentId, refetchOnWindowFocus: false },
   );
 
   const { data: attachmentsData, isFetching: isFetchingAttachments } =
     useGetDeploymentAttachments(
       { deploymentId },
-      { enabled: open && !!deploymentId },
+      { enabled: open && !!deploymentId, refetchOnWindowFocus: false },
     );
 
   const providerId = deployment?.provider_account_id ?? "";
 
   const { data: configsData, isFetching: isFetchingConfigs } =
-    useGetDeploymentConfigs({ providerId }, { enabled: open && !!providerId });
+    useGetDeploymentConfigs(
+      { providerId },
+      { enabled: open && !!providerId, refetchOnWindowFocus: false },
+    );
 
   const isLoading =
     isFetchingDetails || isFetchingAttachments || isFetchingConfigs;

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-flow-list.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-flow-list.tsx
@@ -24,6 +24,7 @@ export default function DeploymentFlowList({
               key={fv.id}
               flowName={fv.flow_name}
               versionNumber={fv.version_number}
+              toolName={fv.provider_data?.tool_name ?? null}
               connectionNames={getConnectionNames(fv)}
             />
           ))}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/flow-version-item.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/flow-version-item.tsx
@@ -5,12 +5,14 @@ import ConnectionItem from "./connection-item";
 interface FlowVersionItemProps {
   flowName: string | null;
   versionNumber: number;
+  toolName: string | null;
   connectionNames: string[];
 }
 
 export default function FlowVersionItem({
   flowName,
   versionNumber,
+  toolName,
   connectionNames,
 }: FlowVersionItemProps) {
   return (
@@ -31,6 +33,16 @@ export default function FlowVersionItem({
           v{versionNumber}
         </Badge>
       </div>
+
+      {toolName && (
+        <div className="flex items-center gap-2 pl-5">
+          <ForwardedIconComponent
+            name="Wrench"
+            className="h-3 w-3 shrink-0 text-muted-foreground"
+          />
+          <span className="text-xs text-muted-foreground">{toolName}</span>
+        </div>
+      )}
 
       {connectionNames.length > 0 && (
         <div className="flex flex-col gap-1 pl-5">

--- a/src/frontend/vite.config.mts
+++ b/src/frontend/vite.config.mts
@@ -57,11 +57,6 @@ export default defineConfig(({ mode }) => {
       "import.meta.env.LANGFLOW_MCP_COMPOSER_ENABLED": JSON.stringify(
         envLangflow.LANGFLOW_MCP_COMPOSER_ENABLED ?? "true",
       ),
-      "import.meta.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS": JSON.stringify(
-        envLangflow.LANGFLOW_FEATURE_WXO_DEPLOYMENTS ??
-          process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS ??
-          "false",
-      ),
     },
     plugins: [
       react(),


### PR DESCRIPTION
## Summary
- **Fix: error toast shows `[object Object]`** — `getAxiosErrorMessage` assumed `response.data.detail` is always a string, but FastAPI/Pydantic 422 responses return an array of objects. Added `extractDetail` helper that handles both shapes.
- **Feat: show tool name in Deployment Details modal** — `provider_data.tool_name` was already returned by the API but not displayed. Each attached flow version now shows the tool name.
- **Fix: deployment details modal refetching on tab switch** — Added `refetchOnWindowFocus: false` to the three queries in the modal.
- **Refactor: runtime feature flag for deployments** — `ENABLE_DEPLOYMENTS` was baked in at Vite build time. Both consumers now read from `useUtilityStore.featureFlags.wxo_deployments` at runtime via the `/config` endpoint, making it toggleable without rebuilding. Removed the unused constant and vite define.