### PR TITLE
fix: handle missing lfx package metadata in Docker

### DIFF
--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -154,10 +154,17 @@ def _read_component_index(custom_path: str | None = None) -> dict | None:
             return None
 
         # Version check: ensure index matches installed lfx version
-        from importlib.metadata import version
+        from importlib.metadata import PackageNotFoundError, version
 
-        installed_version = version("lfx")
-        if blob.get("version") != installed_version:
+        try:
+            installed_version = version("lfx")
+        except PackageNotFoundError:
+            # In some deployment environments (e.g. Docker with workspace installs),
+            # lfx may be importable but lack dist-info metadata. Skip version check.
+            logger.debug("Could not determine installed lfx version (no package metadata); skipping version check")
+            installed_version = None
+
+        if installed_version is not None and blob.get("version") != installed_version:
             logger.debug(
                 f"Component index version mismatch: index={blob.get('version')}, installed={installed_version}"
             )

--- a/src/lfx/tests/unit/test_component_index.py
+++ b/src/lfx/tests/unit/test_component_index.py
@@ -207,6 +207,36 @@ class TestReadComponentIndex:
 
         assert result is None
 
+    def test_read_index_package_not_found(self, tmp_path):
+        """Test reading index when lfx package metadata is unavailable (e.g. Docker workspace install)."""
+        from importlib.metadata import PackageNotFoundError
+
+        index = {
+            "version": "0.4.0",
+            "entries": [["category1", {"comp1": {"template": {}}}]],
+        }
+        payload = orjson.dumps(index, option=orjson.OPT_SORT_KEYS)
+        index["sha256"] = hashlib.sha256(payload).hexdigest()
+
+        with (
+            patch("lfx.interface.components.inspect.getfile") as mock_getfile,
+            patch("importlib.metadata.version") as mock_version,
+        ):
+            mock_getfile.return_value = str(tmp_path / "lfx" / "__init__.py")
+            mock_version.side_effect = PackageNotFoundError("lfx")
+
+            (tmp_path / "lfx" / "_assets").mkdir(parents=True)
+            (tmp_path / "lfx" / "_assets" / "component_index.json").write_bytes(
+                orjson.dumps(index, option=orjson.OPT_SORT_KEYS | orjson.OPT_INDENT_2)
+            )
+
+            result = _read_component_index()
+
+        # Should succeed - version check skipped when metadata unavailable
+        assert result is not None
+        assert result["version"] == "0.4.0"
+        assert "entries" in result
+
     def test_read_index_custom_path_file(self, tmp_path):
         """Test reading index from custom file path."""
         index = {


### PR DESCRIPTION
## Summary
- Fixes the `PackageNotFoundError: No package metadata was found for lfx` warning that appears on every startup in nightly Docker images
- The root cause is that `uv sync --no-editable` (used in the Docker build) installs `lfx` as a workspace member without proper `.dist-info` metadata, so `importlib.metadata.version("lfx")` fails
- Now catches `PackageNotFoundError` specifically and skips the version check when metadata is unavailable — the SHA256 integrity check already validates the index content
- Adds a unit test covering the `PackageNotFoundError` scenario

## Test plan
- [x] New unit test `test_read_index_package_not_found` passes
- [x] All 27 existing `test_component_index.py` tests still pass
- [ ] Verify nightly Docker image no longer shows the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)