### PR TITLE
fix: Make sure we don't toggle models on hover

### DIFF
--- a/src/frontend/src/components/ui/switch.tsx
+++ b/src/frontend/src/components/ui/switch.tsx
@@ -4,25 +4,47 @@ import * as SwitchPrimitives from "@radix-ui/react-switch";
 import * as React from "react";
 import { cn } from "@/utils/utils";
 
+interface SwitchProps
+  extends React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> {
+  stopPropagation?: boolean;
+}
+
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent px-0.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
-      className,
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb
+  SwitchProps
+>(
+  (
+    { className, stopPropagation = false, onClick, onPointerDown, ...props },
+    ref,
+  ) => (
+    <SwitchPrimitives.Root
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+        "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent px-0.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+        className,
       )}
-    />
-  </SwitchPrimitives.Root>
-));
+      onClick={(event) => {
+        onClick?.(event);
+        if (stopPropagation) {
+          event.stopPropagation();
+        }
+      }}
+      onPointerDown={(event) => {
+        onPointerDown?.(event);
+        if (stopPropagation) {
+          event.stopPropagation();
+        }
+      }}
+      {...props}
+      ref={ref}
+    >
+      <SwitchPrimitives.Thumb
+        className={cn(
+          "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+        )}
+      />
+    </SwitchPrimitives.Root>
+  ),
+);
 Switch.displayName = SwitchPrimitives.Root.displayName;
 
 export { Switch };

--- a/src/frontend/src/modals/modelProviderModal/__tests__/ModelSelection.test.tsx
+++ b/src/frontend/src/modals/modelProviderModal/__tests__/ModelSelection.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ModelSelection from "../components/ModelSelection";
 import { Model } from "../components/types";
@@ -148,21 +148,27 @@ describe("ModelSelection", () => {
       expect(onModelToggle).toHaveBeenCalledWith("gpt-4", expect.any(Boolean));
     });
 
-    it("should not call onModelToggle when a toggle is hovered", () => {
+    it("should not bubble toggle clicks to parent containers", async () => {
       const onModelToggle = jest.fn();
+      const onParentClick = jest.fn();
+      const user = userEvent.setup();
 
       render(
-        <ModelSelection {...defaultProps} onModelToggle={onModelToggle} />,
+        <div onClick={onParentClick}>
+          <ModelSelection {...defaultProps} onModelToggle={onModelToggle} />
+        </div>,
       );
 
       const toggle = screen.getByTestId(
         "embeddings-toggle-text-embedding-ada-002",
       );
+      await user.click(toggle);
 
-      fireEvent.mouseEnter(toggle);
-      fireEvent.mouseMove(toggle);
-
-      expect(onModelToggle).not.toHaveBeenCalled();
+      expect(onModelToggle).toHaveBeenCalledWith(
+        "text-embedding-ada-002",
+        expect.any(Boolean),
+      );
+      expect(onParentClick).not.toHaveBeenCalled();
     });
   });
 

--- a/src/frontend/src/modals/modelProviderModal/__tests__/ModelSelection.test.tsx
+++ b/src/frontend/src/modals/modelProviderModal/__tests__/ModelSelection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ModelSelection from "../components/ModelSelection";
 import { Model } from "../components/types";
@@ -146,6 +146,23 @@ describe("ModelSelection", () => {
       await user.click(toggle);
 
       expect(onModelToggle).toHaveBeenCalledWith("gpt-4", expect.any(Boolean));
+    });
+
+    it("should not call onModelToggle when a toggle is hovered", () => {
+      const onModelToggle = jest.fn();
+
+      render(
+        <ModelSelection {...defaultProps} onModelToggle={onModelToggle} />,
+      );
+
+      const toggle = screen.getByTestId(
+        "embeddings-toggle-text-embedding-ada-002",
+      );
+
+      fireEvent.mouseEnter(toggle);
+      fireEvent.mouseMove(toggle);
+
+      expect(onModelToggle).not.toHaveBeenCalled();
     });
   });
 

--- a/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
@@ -1,4 +1,5 @@
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Switch } from "@/components/ui/switch";
 import { useGetEnabledModels } from "@/controllers/API/queries/models/use-get-enabled-models";
 
 import { Model } from "@/modals/modelProviderModal/components/types";
@@ -19,46 +20,6 @@ interface ModelRowProps {
   testIdPrefix: string;
   isEnabledModel?: boolean;
 }
-
-interface ModelToggleSwitchProps {
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-  testId: string;
-  modelName: string;
-}
-
-const ModelToggleSwitch = ({
-  checked,
-  onCheckedChange,
-  testId,
-  modelName,
-}: ModelToggleSwitchProps) => (
-  <button
-    type="button"
-    role="switch"
-    aria-checked={checked}
-    aria-label={`${checked ? "Disable" : "Enable"} ${modelName}`}
-    data-testid={testId}
-    className={cn(
-      "inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent px-0.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
-      checked ? "bg-primary" : "bg-input",
-    )}
-    onPointerDown={(event) => {
-      event.stopPropagation();
-    }}
-    onClick={(event) => {
-      event.stopPropagation();
-      onCheckedChange(!checked);
-    }}
-  >
-    <span
-      className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform",
-        checked ? "translate-x-5" : "translate-x-0",
-      )}
-    />
-  </button>
-);
 
 /** Single row displaying a model with its toggle switch */
 const ModelRow = ({
@@ -81,12 +42,27 @@ const ModelRow = ({
       </span>
     </div>
     {isEnabledModel && (
-      <ModelToggleSwitch
-        checked={enabled}
-        onCheckedChange={(checked) => onToggle(model.model_name, checked)}
-        testId={`${testIdPrefix}-toggle-${model.model_name}`}
-        modelName={model.model_name}
-      />
+      <div
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+        onPointerDown={(event) => {
+          event.stopPropagation();
+        }}
+      >
+        <Switch
+          checked={enabled}
+          onCheckedChange={(checked) => onToggle(model.model_name, checked)}
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          onPointerDown={(event) => {
+            event.stopPropagation();
+          }}
+          data-testid={`${testIdPrefix}-toggle-${model.model_name}`}
+          aria-label={`${enabled ? "Disable" : "Enable"} ${model.model_name}`}
+        />
+      </div>
     )}
   </div>
 );

--- a/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
@@ -42,27 +42,13 @@ const ModelRow = ({
       </span>
     </div>
     {isEnabledModel && (
-      <div
-        onClick={(event) => {
-          event.stopPropagation();
-        }}
-        onPointerDown={(event) => {
-          event.stopPropagation();
-        }}
-      >
-        <Switch
-          checked={enabled}
-          onCheckedChange={(checked) => onToggle(model.model_name, checked)}
-          onClick={(event) => {
-            event.stopPropagation();
-          }}
-          onPointerDown={(event) => {
-            event.stopPropagation();
-          }}
-          data-testid={`${testIdPrefix}-toggle-${model.model_name}`}
-          aria-label={`${enabled ? "Disable" : "Enable"} ${model.model_name}`}
-        />
-      </div>
+      <Switch
+        checked={enabled}
+        onCheckedChange={(checked) => onToggle(model.model_name, checked)}
+        data-testid={`${testIdPrefix}-toggle-${model.model_name}`}
+        aria-label={`${enabled ? "Disable" : "Enable"} ${model.model_name}`}
+        stopPropagation
+      />
     )}
   </div>
 );

--- a/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
@@ -1,5 +1,4 @@
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
-import { Switch } from "@/components/ui/switch";
 import { useGetEnabledModels } from "@/controllers/API/queries/models/use-get-enabled-models";
 
 import { Model } from "@/modals/modelProviderModal/components/types";
@@ -20,6 +19,46 @@ interface ModelRowProps {
   testIdPrefix: string;
   isEnabledModel?: boolean;
 }
+
+interface ModelToggleSwitchProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  testId: string;
+  modelName: string;
+}
+
+const ModelToggleSwitch = ({
+  checked,
+  onCheckedChange,
+  testId,
+  modelName,
+}: ModelToggleSwitchProps) => (
+  <button
+    type="button"
+    role="switch"
+    aria-checked={checked}
+    aria-label={`${checked ? "Disable" : "Enable"} ${modelName}`}
+    data-testid={testId}
+    className={cn(
+      "inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent px-0.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+      checked ? "bg-primary" : "bg-input",
+    )}
+    onPointerDown={(event) => {
+      event.stopPropagation();
+    }}
+    onClick={(event) => {
+      event.stopPropagation();
+      onCheckedChange(!checked);
+    }}
+  >
+    <span
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform",
+        checked ? "translate-x-5" : "translate-x-0",
+      )}
+    />
+  </button>
+);
 
 /** Single row displaying a model with its toggle switch */
 const ModelRow = ({
@@ -42,10 +81,11 @@ const ModelRow = ({
       </span>
     </div>
     {isEnabledModel && (
-      <Switch
+      <ModelToggleSwitch
         checked={enabled}
         onCheckedChange={(checked) => onToggle(model.model_name, checked)}
-        data-testid={`${testIdPrefix}-toggle-${model.model_name}`}
+        testId={`${testIdPrefix}-toggle-${model.model_name}`}
+        modelName={model.model_name}
       />
     )}
   </div>


### PR DESCRIPTION
This pull request improves the `Switch` UI component to allow optional prevention of event bubbling, and ensures that toggle actions within the `ModelSelection` modal do not trigger parent container click handlers. It also adds a test to verify this behavior.

**Switch component enhancements:**

* Added a `stopPropagation` prop to the `Switch` component in `switch.tsx`, allowing consumers to prevent click and pointer down events from bubbling up the DOM tree. [[1]](diffhunk://#diff-a51079d4b8dc3162840f2017ddba872cf0745d105f62e1027c7f83751171e2adR7-R36) [[2]](diffhunk://#diff-a51079d4b8dc3162840f2017ddba872cf0745d105f62e1027c7f83751171e2adL25-R47)

**ModelSelection modal improvements:**

* Updated the `ModelSelection` modal to use the new `stopPropagation` prop on toggle switches, preventing parent container click handlers from being triggered during toggle interactions.
* Added a test to ensure that toggle clicks do not bubble up to parent containers, verifying correct event handling.