### PR TITLE
feat(i18n): sync canvas node translations on language change

### DIFF
--- a/src/frontend/src/controllers/API/queries/flows/use-get-types.ts
+++ b/src/frontend/src/controllers/API/queries/flows/use-get-types.ts
@@ -1,5 +1,8 @@
 import { ENABLE_KNOWLEDGE_BASES } from "@/customization/feature-flags";
-import { recomputeComponentsToUpdateIfNeeded } from "@/stores/flowStore";
+import {
+  recomputeComponentsToUpdateIfNeeded,
+  syncNodeTranslations,
+} from "@/stores/flowStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { useTypesStore } from "@/stores/typesStore";
 import type {
@@ -38,6 +41,7 @@ export const useGetTypes: useQueryFunctionType<
       }
 
       setTypes(data);
+      syncNodeTranslations();
       recomputeComponentsToUpdateIfNeeded();
       return data;
     } catch (error) {

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -314,6 +314,8 @@ const useFlowStore = create<FlowStoreType>((set, get) => ({
       positionDictionary: {},
       rightClickedNodeId: null,
     });
+    // Patch translatable fields if types are already loaded in the new language
+    syncNodeTranslations();
   },
   setIsBuilding: (isBuilding) => {
     const current = get();
@@ -1294,6 +1296,57 @@ export function recomputeComponentsToUpdateIfNeeded(): void {
   if (nodes.length > 0) {
     updateComponentsToUpdate(nodes);
   }
+}
+
+export function syncNodeTranslations(): void {
+  const { nodes } = useFlowStore.getState();
+  if (nodes.length === 0) return;
+
+  const { data: typesData, types } = useTypesStore.getState();
+
+  const updatedNodes = nodes.map((node) => {
+    const nodeType = node.data.type;
+    const category = types[nodeType];
+
+    // Skip custom/group nodes not in the types catalog
+    if (!category || !typesData[category]?.[nodeType]) return node;
+
+    const freshDef = typesData[category][nodeType];
+
+    // Update input field display_names
+    const updatedTemplate = { ...node.data.node!.template };
+    for (const fieldName of Object.keys(updatedTemplate)) {
+      if (freshDef.template?.[fieldName]?.display_name !== undefined) {
+        updatedTemplate[fieldName] = {
+          ...updatedTemplate[fieldName],
+          display_name: freshDef.template[fieldName].display_name,
+        };
+      }
+    }
+
+    // Update output display_names
+    const updatedOutputs = node.data.node!.outputs?.map((output, i) =>
+      freshDef.outputs?.[i]?.display_name !== undefined
+        ? { ...output, display_name: freshDef.outputs[i].display_name }
+        : output,
+    );
+
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        node: {
+          ...node.data.node!,
+          display_name: freshDef.display_name,
+          description: freshDef.description,
+          template: updatedTemplate,
+          ...(updatedOutputs && { outputs: updatedOutputs }),
+        },
+      },
+    };
+  });
+
+  useFlowStore.setState({ nodes: updatedNodes });
 }
 
 export default useFlowStore;


### PR DESCRIPTION
## Summary

- Adds `syncNodeTranslations()` to `flowStore` that patches all canvas nodes with fresh translated strings (display_name, description, template field labels, output labels) whenever the types catalog is refreshed
- Calls it in two places to handle the race between flow loading and types fetching:
  - **`use-get-types.ts`** — covers: nodes already on canvas when translations arrive
  - **`resetFlow`** — covers: translations already loaded when the flow mounts
- Nodes not in the types catalog (custom-code, group nodes) are skipped
- User field values are never touched, only metadata labels

## Test plan

- [ ] Open a flow with nodes on the canvas
- [ ] Navigate to Settings → change language to French (or any non-English)
- [ ] Navigate back to the flow page
- [ ] Verify canvas node titles, descriptions, and inspection panel field labels are in the new language
- [ ] Switch back to English — verify everything reverts
- [ ] Verify custom-code and group nodes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)