### PR TITLE
fix: handle read-only filesystem when updating starter project files

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -675,10 +675,30 @@ def get_project_data(project):
 
 
 async def update_project_file(project_path: anyio.Path, project: dict, updated_project_data) -> None:
+    """Update starter project JSON file with new data.
+
+    This function attempts to write updated project data back to the source file.
+    In containerized environments with read-only filesystems (e.g., Kubernetes with
+    readOnlyRootFilesystem: true), the write will fail gracefully since the database
+    is the source of truth for project data.
+
+    Args:
+        project_path: Path to the project JSON file
+        project: Project dictionary to update
+        updated_project_data: New project data to write
+    """
     project["data"] = updated_project_data
-    async with aiofiles.open(str(project_path), "w", encoding="utf-8") as f:
-        await f.write(orjson.dumps(project, option=ORJSON_OPTIONS).decode())
-    await logger.adebug(f"Updated starter project {project['name']} file")
+    try:
+        async with aiofiles.open(str(project_path), "w", encoding="utf-8") as f:
+            await f.write(orjson.dumps(project, option=ORJSON_OPTIONS).decode())
+        await logger.adebug(f"Updated starter project {project['name']} file")
+    except OSError as e:
+        # Handle read-only filesystem (common in containerized environments)
+        # The database update is the important part - file updates are optional
+        await logger.adebug(
+            f"Could not update starter project file {project['name']} (read-only filesystem): {e}. "
+            "This is expected in containerized environments with read-only root filesystem."
+        )
 
 
 def update_existing_project(

--- a/src/backend/tests/unit/test_initial_setup.py
+++ b/src/backend/tests/unit/test_initial_setup.py
@@ -714,3 +714,77 @@ def test_update_projects_resolves_parser_via_component_type_alias():
     updated_project = update_projects_components_with_latest_component_versions(project_data, all_types_dict)
     updated_code = updated_project["nodes"][0]["data"]["node"]["template"]["code"]["value"]
     assert updated_code == "new_parser_code_v2"
+
+
+# ==================== Update Project File Tests ====================
+
+
+async def test_update_project_file_success():
+    """Test that update_project_file successfully writes to a writable path."""
+    from langflow.initial_setup.setup import update_project_file
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        project_path = Path(temp_dir) / "test_project.json"
+        project = {"name": "Test Project", "data": {"old": "data"}}
+        updated_data = {"new": "data"}
+
+        await update_project_file(project_path, project, updated_data)
+
+        # Verify the file was written
+        assert await project_path.exists()
+        content = await project_path.read_text(encoding="utf-8")
+        import orjson
+
+        written_project = orjson.loads(content)
+        assert written_project["data"] == updated_data
+        assert written_project["name"] == "Test Project"
+
+
+async def test_update_project_file_readonly_filesystem():
+    """Test that update_project_file handles read-only filesystem gracefully."""
+    from langflow.initial_setup.setup import update_project_file
+
+    project_path = Path("/nonexistent/readonly/path/test_project.json")
+    project = {"name": "Test Project", "data": {"old": "data"}}
+    updated_data = {"new": "data"}
+
+    # This should NOT raise an exception - it should handle the error gracefully
+    await update_project_file(project_path, project, updated_data)
+
+    # Verify the project dict was still updated (in-memory)
+    assert project["data"] == updated_data
+
+
+async def test_update_project_file_permission_denied():
+    """Test that update_project_file handles permission denied gracefully."""
+    from langflow.initial_setup.setup import update_project_file
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        project_path = Path(temp_dir) / "test_project.json"
+        project = {"name": "Test Project", "data": {"old": "data"}}
+        updated_data = {"new": "data"}
+
+        # Mock aiofiles.open to raise OSError (permission denied)
+        with patch("langflow.initial_setup.setup.aiofiles.open") as mock_open:
+            mock_open.side_effect = OSError(13, "Permission denied")
+
+            # Should not raise
+            await update_project_file(project_path, project, updated_data)
+
+            # Verify the project dict was still updated (in-memory)
+            assert project["data"] == updated_data
+
+
+async def test_update_project_file_logs_debug_on_oserror():
+    """Test that update_project_file logs a debug message on OSError."""
+    from langflow.initial_setup.setup import update_project_file
+
+    project_path = Path("/nonexistent/readonly/path/test_project.json")
+    project = {"name": "Test Project", "data": {"old": "data"}}
+    updated_data = {"new": "data"}
+
+    with patch("langflow.initial_setup.setup.logger") as mock_logger:
+        mock_logger.adebug = AsyncMock()
+        await update_project_file(project_path, project, updated_data)
+        # Verify debug log was called (either success or error path)
+        assert mock_logger.adebug.called

--- a/src/backend/tests/unit/test_security_cors.py
+++ b/src/backend/tests/unit/test_security_cors.py
@@ -280,7 +280,6 @@ class TestRefreshTokenSecurity:
         """Test that valid refresh tokens work correctly."""
         from uuid import uuid4
 
-        from langflow.services.auth.service import AuthService
         from langflow.services.auth.utils import create_refresh_token
 
         mock_db = AsyncMock()
@@ -289,14 +288,7 @@ class TestRefreshTokenSecurity:
         user_id = uuid4()
         mock_user.id = user_id
 
-        # Create a langflow AuthService instance (not lfx) with mocked settings
-        mock_settings_service = MagicMock()
-        auth_service = AuthService(mock_settings_service)
-
-        with (
-            patch("langflow.services.auth.utils._auth_service", return_value=auth_service),
-            patch("langflow.services.auth.service.jwt.decode") as mock_decode,
-        ):
+        with patch("langflow.services.auth.service.jwt.decode") as mock_decode:
             mock_decode.return_value = {"sub": str(user_id), "type": "refresh"}  # Correct type
 
             with patch("langflow.services.auth.utils.get_jwt_verification_key") as mock_verification_key:
@@ -305,7 +297,9 @@ class TestRefreshTokenSecurity:
                 with patch("langflow.services.auth.service.get_user_by_id", new_callable=AsyncMock) as mock_get_user:
                     mock_get_user.return_value = mock_user
 
-                    with patch.object(auth_service, "create_user_tokens", new_callable=AsyncMock) as mock_create_tokens:
+                    with patch(
+                        "langflow.services.auth.service.AuthService.create_user_tokens", new_callable=AsyncMock
+                    ) as mock_create_tokens:
                         expected_access = "new-access-token"
                         expected_refresh = "new-refresh-token"
                         mock_create_tokens.return_value = {

--- a/src/backend/tests/unit/test_security_cors.py
+++ b/src/backend/tests/unit/test_security_cors.py
@@ -280,6 +280,7 @@ class TestRefreshTokenSecurity:
         """Test that valid refresh tokens work correctly."""
         from uuid import uuid4
 
+        from langflow.services.auth.service import AuthService
         from langflow.services.auth.utils import create_refresh_token
 
         mock_db = AsyncMock()
@@ -288,7 +289,14 @@ class TestRefreshTokenSecurity:
         user_id = uuid4()
         mock_user.id = user_id
 
-        with patch("langflow.services.auth.service.jwt.decode") as mock_decode:
+        # Create a langflow AuthService instance (not lfx) with mocked settings
+        mock_settings_service = MagicMock()
+        auth_service = AuthService(mock_settings_service)
+
+        with (
+            patch("langflow.services.auth.utils._auth_service", return_value=auth_service),
+            patch("langflow.services.auth.service.jwt.decode") as mock_decode,
+        ):
             mock_decode.return_value = {"sub": str(user_id), "type": "refresh"}  # Correct type
 
             with patch("langflow.services.auth.utils.get_jwt_verification_key") as mock_verification_key:
@@ -297,9 +305,7 @@ class TestRefreshTokenSecurity:
                 with patch("langflow.services.auth.service.get_user_by_id", new_callable=AsyncMock) as mock_get_user:
                     mock_get_user.return_value = mock_user
 
-                    with patch(
-                        "langflow.services.auth.service.AuthService.create_user_tokens", new_callable=AsyncMock
-                    ) as mock_create_tokens:
+                    with patch.object(auth_service, "create_user_tokens", new_callable=AsyncMock) as mock_create_tokens:
                         expected_access = "new-access-token"
                         expected_refresh = "new-refresh-token"
                         mock_create_tokens.return_value = {


### PR DESCRIPTION
## Summary
- Backport of #11163 to `release-1.9.0`
- Fixes #11145 — Starter projects fail to load on Kubernetes when `readOnlyRootFilesystem: true`
- Wraps `update_project_file()` file write in try-except for `OSError`, logging gracefully instead of crashing
- The database is the source of truth for project data — file updates are optional convenience for development environments
- Adds unit tests for writable, read-only, and permission-denied scenarios

## Test plan
- [x] `test_update_project_file_success` — verifies normal write path works
- [x] `test_update_project_file_readonly_filesystem` — verifies no exception on read-only path
- [x] `test_update_project_file_permission_denied` — verifies graceful handling of permission denied
- [x] `test_update_project_file_logs_debug_on_oserror` — verifies debug logging on error

Original PR by @devbyteai