### PR TITLE
 fix: allow spacebar in chat input textarea

### DIFF
--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/components/input-wrapper.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/components/input-wrapper.tsx
@@ -68,6 +68,11 @@ const InputWrapper = ({
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    // Don't handle keyboard events that originate from the textarea
+    if (target.closest("textarea")) {
+      return;
+    }
     if (e.key !== "Enter" && e.key !== " ") {
       return;
     }


### PR DESCRIPTION
Description

Fixes a bug where pressing the spacebar in the Playground chat input field did not insert space characters. The key press was being captured and blocked by the input wrapper's keyboard event handler.

Problem
The onKeyDown handler attached to the input wrapper div was calling preventDefault() for both Enter and Space keys without first checking if the event originated from the textarea element itself. This caused the spacebar to be blocked when users were typing in the textarea, preventing multi-word inputs during flow testing.

Solution
Added a target check at the beginning of the onKeyDown handler to detect if keyboard events originate from the textarea. If they do, the handler returns early without preventing default behavior, allowing normal text input including spaces.

The handler now only prevents default behavior when Space or Enter keys are pressed on the wrapper div itself (not the textarea), which is the intended behavior for focusing the input field.

Testing
✅ Spacebar now works correctly in Playground input field
✅ Multi-word messages can be typed without issues

