### PR TITLE
fix: gracefully handle pyperclip failure in headless/remote environments

### DIFF
--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -1069,8 +1069,10 @@ def api_key_banner(unmasked_api_key) -> None:
         clipboard_msg = (
             f"\nThe API key has been copied to your clipboard. [bold]{['Ctrl', 'Cmd'][is_mac]} + V[/bold] to paste it."
         )
-    except Exception:  # noqa: BLE001
-        pass
+    except Exception as exc:  # noqa: BLE001
+        # Clipboard access is best-effort: pyperclip raises in headless/Docker/SSH environments
+        # where no clipboard mechanism is available. Log and continue so the key is still displayed.
+        logger.debug(f"Could not copy API key to clipboard: {exc}")
     panel = Panel(
         f"[bold]API Key Created Successfully:[/bold]\n\n"
         f"[bold blue]{unmasked_api_key.api_key}[/bold blue]\n\n"

--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -1066,7 +1066,9 @@ def api_key_banner(unmasked_api_key) -> None:
         import pyperclip
 
         pyperclip.copy(unmasked_api_key.api_key)
-        clipboard_msg = f"\nThe API key has been copied to your clipboard. [bold]{['Ctrl', 'Cmd'][is_mac]} + V[/bold] to paste it."
+        clipboard_msg = (
+            f"\nThe API key has been copied to your clipboard. [bold]{['Ctrl', 'Cmd'][is_mac]} + V[/bold] to paste it."
+        )
     except Exception:  # noqa: BLE001
         pass
     panel = Panel(

--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -1061,15 +1061,19 @@ def version_option(
 
 def api_key_banner(unmasked_api_key) -> None:
     is_mac = platform.system() == "Darwin"
-    import pyperclip
+    clipboard_msg = ""
+    try:
+        import pyperclip
 
-    pyperclip.copy(unmasked_api_key.api_key)
+        pyperclip.copy(unmasked_api_key.api_key)
+        clipboard_msg = f"\nThe API key has been copied to your clipboard. [bold]{['Ctrl', 'Cmd'][is_mac]} + V[/bold] to paste it."
+    except Exception:  # noqa: BLE001
+        pass
     panel = Panel(
         f"[bold]API Key Created Successfully:[/bold]\n\n"
         f"[bold blue]{unmasked_api_key.api_key}[/bold blue]\n\n"
         "This is the only time the API key will be displayed. \n"
-        "Make sure to store it in a secure location. \n\n"
-        f"The API key has been copied to your clipboard. [bold]{['Ctrl', 'Cmd'][is_mac]} + V[/bold] to paste it.",
+        f"Make sure to store it in a secure location.{clipboard_msg}",
         box=box.ROUNDED,
         border_style="blue",
         expand=False,

--- a/src/backend/tests/unit/test_cli.py
+++ b/src/backend/tests/unit/test_cli.py
@@ -1,6 +1,7 @@
 import socket
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -8,6 +9,7 @@ import typer
 from langflow.__main__ import (
     DIRECT_UVICORN_PLATFORMS,
     _create_superuser,
+    api_key_banner,
     app,
     build_direct_uvicorn_kwargs,
     clamp_uvicorn_workers,
@@ -277,6 +279,40 @@ def test_build_direct_uvicorn_kwargs_does_not_clamp_on_linux():
     # if it ever gets reused on Linux the clamp must remain a no-op there.
     result = build_direct_uvicorn_kwargs(**_kwargs(workers=4, system="Linux"))
     assert result["workers"] == 4
+
+
+# ---------------------------------------------------------------------------
+# api_key_banner: clipboard must be best-effort.
+#
+# Regression guard for #12341: pyperclip raises in headless/Docker/SSH
+# environments because no clipboard mechanism is available. The banner must
+# still print the API key (the only time it's ever shown) instead of crashing.
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_banner_survives_pyperclip_failure(capsys):
+    """Clipboard failure must not crash the banner — the key is the user's only copy."""
+    api_key_obj = SimpleNamespace(api_key="lf-test-12341")
+
+    with patch("pyperclip.copy", side_effect=Exception("Pyperclip could not find a copy/paste mechanism")):
+        api_key_banner(api_key_obj)
+
+    output = capsys.readouterr().out
+    assert "lf-test-12341" in output, "API key must still be displayed when clipboard fails"
+    assert "clipboard" not in output.lower(), "no clipboard hint should appear when copy failed"
+
+
+def test_api_key_banner_shows_clipboard_hint_on_success(capsys):
+    """Happy path: when clipboard copy succeeds, the paste hint is shown."""
+    api_key_obj = SimpleNamespace(api_key="lf-test-ok")
+
+    with patch("pyperclip.copy") as mock_copy:
+        api_key_banner(api_key_obj)
+
+    mock_copy.assert_called_once_with("lf-test-ok")
+    output = capsys.readouterr().out
+    assert "lf-test-ok" in output
+    assert "clipboard" in output.lower()
 
 
 def test_build_direct_uvicorn_kwargs_pins_full_shape():


### PR DESCRIPTION
Fixes #12341

## Problem
The `langflow api-key` command fails in Docker/SSH with PyperclipException because there is no clipboard mechanism in headless environments.

## Solution
Wrap the pyperclip import and copy() call in try/except. If clipboard access fails, the API key panel is still displayed without the clipboard hint message.

## Testing
Verified API key panel displays correctly when pyperclip is unavailable.