### PR TITLE
fix: Remove ddl_if from session_metadata indexes in MessageTable

### DIFF
--- a/src/backend/base/langflow/services/database/models/message/model.py
+++ b/src/backend/base/langflow/services/database/models/message/model.py
@@ -139,12 +139,12 @@ class MessageTable(MessageBase, table=True):  # type: ignore[call-arg]
             "ix_message_session_metadata_tenant",
             text("(session_metadata->>'tenant_id')"),
             postgresql_using="btree",
-        ).ddl_if(dialect="postgresql"),
+        ),
         Index(
             "ix_message_session_metadata_user",
             text("(session_metadata->>'user_id')"),
             postgresql_using="btree",
-        ).ddl_if(dialect="postgresql"),
+        ),
     )
 
     id: UUID = Field(default_factory=uuid4, primary_key=True)


### PR DESCRIPTION
## Summary

- Remove `.ddl_if(dialect="postgresql")` from the two session_metadata indexes in `MessageTable`
- `.ddl_if()` hides the indexes from alembic's autogenerate comparison, so `command.check()` sees indexes in the database that aren't in the model metadata and reports `remove_index` operations, crashing on startup
- The `postgresql_using="btree"` parameter already ensures they're only created on PostgreSQL
- Verified with Docker: 1.8.1 -> 1.9.0 upgrade on PostgreSQL now works; SQLite is unaffected