### PR TITLE
fix: Remove test that doesnt test anything

### DIFF
--- a/src/backend/tests/unit/api/v1/test_deployment_sync.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_sync.py
@@ -689,13 +689,6 @@ class TestUpdateSnapshotMapping:
             )
 
 
-def test_as_uuid_accepts_uuid_instances():
-    from langflow.api.v1.mappers.deployments.helpers import as_uuid
-
-    value = uuid4()
-    assert as_uuid(value) == value
-
-
 def test_watsonx_mapper_util_created_snapshot_ids_uses_adapter_slot():
     created = WatsonxOrchestrateDeploymentMapper().util_created_snapshot_ids(
         result=DeploymentUpdateResult(


### PR DESCRIPTION
This pull request removes an unused or unnecessary test from the codebase, specifically targeting the `as_uuid` helper function (which does not exist). No other changes are included.

* Removed the `test_as_uuid_accepts_uuid_instances` test from `src/backend/tests/unit/api/v1/test_deployment_sync.py`, likely because the test was redundant or the function is no longer in use.