### PR TITLE
fix: Exclude the none values when checking the result

### DIFF
--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -1008,9 +1008,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         )
         return ExecutionCreateResponse(
             deployment_id=deployment_id,
-            provider_data=api_provider_result.model_dump(),
-            # includes None intentionally, simply passes through
-            # wxo api response, which can contain null values
+            provider_data=api_provider_result.model_dump(exclude_none=True),
         )
 
     def shape_execution_status_result(
@@ -1039,9 +1037,7 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         )
         return ExecutionStatusResponse(
             deployment_id=deployment_id,
-            provider_data=api_provider_result.model_dump(),
-            # includes None intentionally, simply passes through
-            # wxo api response, which can contain null values
+            provider_data=api_provider_result.model_dump(exclude_none=True),
         )
 
     def shape_deployment_list_result(

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -639,7 +639,9 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
         return ExecutionCreateResult(
             execution_id=agent_run_result.get("execution_id"),
             deployment_id=agent_id,
-            provider_result=self.payload_schemas.execution_create_result.parse(agent_run_result).model_dump(),
+            provider_result=self.payload_schemas.execution_create_result.parse(agent_run_result).model_dump(
+                exclude_none=True
+            ),
         )
 
     async def get_execution(
@@ -670,7 +672,9 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
         return ExecutionStatusResult(
             execution_id=run_id,
             deployment_id=agent_run_result.get("agent_id"),
-            provider_result=self.payload_schemas.execution_status_result.parse(agent_run_result).model_dump(),
+            provider_result=self.payload_schemas.execution_status_result.parse(agent_run_result).model_dump(
+                exclude_none=True
+            ),
         )
 
     # TODO: allow listing all configs without filtering by deployment_id


### PR DESCRIPTION
This pull request improves how API responses are serialized by excluding fields with `None` values from the provider result data. This change ensures that the returned data structures are cleaner and do not include unnecessary `null` values, which can simplify downstream processing and reduce payload size.

**API response serialization improvements:**

* Updated `shape_execution_create_result` and `shape_execution_status_result` in `mapper.py` to call `model_dump(exclude_none=True)`, ensuring `None` values are excluded from the `provider_data` field. [[1]](diffhunk://#diff-799dfa986c51cdc660a5342e14b75f3703bef72dad122dabd13cb3ba9001cc7dL1011-R1011) [[2]](diffhunk://#diff-799dfa986c51cdc660a5342e14b75f3703bef72dad122dabd13cb3ba9001cc7dL1042-R1040)
* Updated `create_execution` and `get_execution` in `service.py` to call `model_dump(exclude_none=True)` when serializing the `provider_result`, so `None` values are omitted. [[1]](diffhunk://#diff-9b71e42d770980046e8318131d60db40549b395d7cc5a6b240f88f4155d29a8aL642-R644) [[2]](diffhunk://#diff-9b71e42d770980046e8318131d60db40549b395d7cc5a6b240f88f4155d29a8aL673-R677)