### PR TITLE
fix: Update WXO tests for handling none keys

### DIFF
--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -2907,7 +2907,9 @@ async def test_create_execution_posts_runs_payload(monkeypatch):
 
     assert result.deployment_id == "dep-1"
     assert result.execution_id == "run-1"
-    assert result.provider_result == {"status": "accepted", "execution_id": "run-1", "thread_id": "thread-1"}
+    assert result.provider_result["status"] == "accepted"
+    assert result.provider_result["execution_id"] == "run-1"
+    assert result.provider_result["thread_id"] == "thread-1"
     assert fake_base.post_calls
     path, payload = fake_base.post_calls[0]
     assert path == "/runs"
@@ -6675,7 +6677,7 @@ def test_shape_execution_status_result_maps_all_fields():
 
 
 def test_shape_execution_status_result_none_execution_id():
-    """When adapter has no execution_id, provider_data omits the key (exclude_none)."""
+    """When adapter has no execution_id, provider_data includes it as None."""
     from langflow.api.v1.mappers.deployments.watsonx_orchestrate.mapper import WatsonxOrchestrateDeploymentMapper
 
     mapper = WatsonxOrchestrateDeploymentMapper()
@@ -6694,7 +6696,7 @@ def test_shape_execution_status_result_none_execution_id():
         adapter_result,
         deployment_id=deployment_id,
     )
-    assert "execution_id" not in response.provider_data
+    assert response.provider_data["execution_id"] is None
     assert response.provider_data["status"] == "in_progress"
 
 


### PR DESCRIPTION
This pull request updates tests in `test_watsonx_orchestrate.py` to reflect changes in how `execution_id` is handled in provider results. The main focus is on ensuring that when `execution_id` is missing, it is now included as `None` instead of being omitted, and on making the test assertions more robust.

Test behavior updates:

* Updated assertions in `mock_get_provider_clients` to check individual keys in `provider_result` instead of comparing the whole dictionary, making the test less brittle to unrelated changes.

* Changed the expectation in `test_shape_execution_status_result_none_execution_id` so that `provider_data` now includes `"execution_id": None` rather than omitting the key, and updated the docstring to match this new behavior. [[1]](diffhunk://#diff-e636483090aa2a5a7cf0eac03364883d643f647aed4aadc58118c083a275b90bL6678-R6680) [[2]](diffhunk://#diff-e636483090aa2a5a7cf0eac03364883d643f647aed4aadc58118c083a275b90bL6697-R6699)