### PR TITLE
fix: use stable UUIDs for Qdrant document IDs to prevent duplicate ingestion

### DIFF
--- a/src/backend/tests/unit/components/vectorstores/test_qdrant_vector_store_component.py
+++ b/src/backend/tests/unit/components/vectorstores/test_qdrant_vector_store_component.py
@@ -1,0 +1,87 @@
+"""Unit tests for the Qdrant vector store component.
+
+Focuses on the stable, deterministic ID generation introduced for #12641
+so re-ingesting the same content does not create duplicates.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+from lfx.components.qdrant import QdrantVectorStoreComponent
+from lfx.schema.data import Data
+
+
+def _make_component(documents: list[Document]) -> QdrantVectorStoreComponent:
+    return QdrantVectorStoreComponent().set(
+        collection_name="test_collection",
+        embedding=MagicMock(spec=Embeddings),
+        ingest_data=[Data(text=doc.page_content, data=doc.metadata) for doc in documents],
+    )
+
+
+def _captured_ids(documents: list[Document]) -> list[str]:
+    """Run build_vector_store with Qdrant.from_documents patched and return the ids passed in."""
+    component = _make_component(documents)
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_from_documents(_docs, *, embedding, ids, **_kwargs):  # noqa: ARG001
+        captured["ids"] = ids
+        return MagicMock()
+
+    with patch("lfx.components.qdrant.qdrant.Qdrant.from_documents", side_effect=fake_from_documents):
+        component.build_vector_store()
+
+    return captured["ids"]
+
+
+def test_qdrant_ids_are_deterministic_uuid5() -> None:
+    """Same content + metadata must always produce the same UUID."""
+    docs = [Document(page_content="hello world", metadata={"source": "a.txt", "page": 1})]
+
+    first = _captured_ids(docs)
+    second = _captured_ids(docs)
+
+    assert first == second
+    # UUID5 strings: 36 chars including hyphens, version nibble == '5'.
+    parsed = uuid.UUID(first[0])
+    assert parsed.version == 5
+
+
+def test_qdrant_ids_are_metadata_order_independent() -> None:
+    """Two docs with identical content and metadata in different insertion order share an ID."""
+    doc_a = Document(page_content="same text", metadata={"a": 1, "b": 2, "nested": {"x": 1, "y": 2}})
+    doc_b = Document(page_content="same text", metadata={"nested": {"y": 2, "x": 1}, "b": 2, "a": 1})
+
+    ids = _captured_ids([doc_a, doc_b])
+
+    assert ids[0] == ids[1]
+
+
+def test_qdrant_ids_differ_for_different_content() -> None:
+    docs = [
+        Document(page_content="first", metadata={"source": "a"}),
+        Document(page_content="second", metadata={"source": "a"}),
+    ]
+
+    ids = _captured_ids(docs)
+
+    assert ids[0] != ids[1]
+
+
+def test_qdrant_ids_handle_non_primitive_metadata() -> None:
+    """Non-primitive metadata (datetime, Decimal) must serialize without raising and stay deterministic."""
+    ts = datetime(2026, 5, 11, 12, 0, tzinfo=timezone.utc)
+    docs = [Document(page_content="payload", metadata={"ts": ts, "price": Decimal("9.99")})]
+
+    first = _captured_ids(docs)
+    second = _captured_ids(docs)
+
+    assert first == second
+    uuid.UUID(first[0])  # raises if not a valid UUID

--- a/src/lfx/src/lfx/components/qdrant/qdrant.py
+++ b/src/lfx/src/lfx/components/qdrant/qdrant.py
@@ -1,3 +1,5 @@
+import uuid
+
 from langchain_community.vectorstores import Qdrant
 from langchain_core.embeddings import Embeddings
 
@@ -85,7 +87,13 @@ class QdrantVectorStoreComponent(LCVectorStoreComponent):
             raise TypeError(msg)
 
         if documents:
-            qdrant = Qdrant.from_documents(documents, embedding=self.embedding, **qdrant_kwargs, **server_kwargs)
+            ids = [
+                str(uuid.uuid5(uuid.NAMESPACE_X500, f"{doc.page_content}{sorted(doc.metadata.items())}"))
+                for doc in documents
+            ]
+            qdrant = Qdrant.from_documents(
+                documents, embedding=self.embedding, ids=ids, **qdrant_kwargs, **server_kwargs
+            )
         else:
             from qdrant_client import QdrantClient
 

--- a/src/lfx/src/lfx/components/qdrant/qdrant.py
+++ b/src/lfx/src/lfx/components/qdrant/qdrant.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 
 from langchain_community.vectorstores import Qdrant
@@ -12,7 +13,7 @@ from lfx.io import (
     SecretStrInput,
     StrInput,
 )
-from lfx.schema.data import Data
+from lfx.schema.data import Data, custom_serializer
 
 
 class QdrantVectorStoreComponent(LCVectorStoreComponent):
@@ -88,7 +89,12 @@ class QdrantVectorStoreComponent(LCVectorStoreComponent):
 
         if documents:
             ids = [
-                str(uuid.uuid5(uuid.NAMESPACE_X500, f"{doc.page_content}{sorted(doc.metadata.items())}"))
+                str(
+                    uuid.uuid5(
+                        uuid.NAMESPACE_X500,
+                        f"{doc.page_content}{json.dumps(doc.metadata, sort_keys=True, default=custom_serializer)}",
+                    )
+                )
                 for doc in documents
             ]
             qdrant = Qdrant.from_documents(


### PR DESCRIPTION
Fixes #12641

## Problem

The Qdrant vector store component used `Qdrant.from_documents()` without providing document IDs, causing Qdrant to generate random point IDs on every call. This made ingestion non-idempotent: re-running the same flow with identical documents created duplicate points in the collection, leading to growing collection size, degraded search quality, and wasted storage.

## Solution

Generate deterministic UUID5 IDs from each document's content (`page_content` + sorted `metadata`). UUID5 is a name-based UUID that always produces the same output for the same input, making repeated ingestion of identical documents idempotent — Qdrant will upsert rather than insert new duplicates.

```python
ids = [
    str(uuid.uuid5(uuid.NAMESPACE_X500, f"{doc.page_content}{sorted(doc.metadata.items())}"))
    for doc in documents
]
qdrant = Qdrant.from_documents(documents, embedding=self.embedding, ids=ids, ...)
```

## Testing

- Manually verified that `uuid.uuid5` produces consistent IDs for the same document content
- The `Qdrant.from_documents` method passes `ids` through to `from_texts`, which sends them to Qdrant as point IDs — Qdrant uses these for upsert semantics
- Existing flows are unaffected since the fix only changes how IDs are generated internally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated dependency versions across starter projects.

* **Refactor**
  - Extended data type compatibility in workflow components to handle JSON and Table formats alongside existing DataFrame and Data types.

* **Bug Fixes**
  - Improved vector store document identification with deterministic ID generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->