### PR TITLE
feat: harden /variables/detections to return only global variables

### DIFF
--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -500,26 +500,13 @@ class DetectVarsRequest(BaseModel):
     """Request body for detecting environment variables from flow version IDs."""
 
     flow_version_ids: list[UUID] = Field(
+        min_length=1,
         max_length=50,
         description="Flow version UUIDs to scan for global variable references.",
     )
 
 
-class DetectedEnvVar(BaseModel):
-    """A single detected environment variable reference."""
-
-    key: str = Field(description="The global variable name used as the env var key.")
-    global_variable_name: str | None = Field(
-        default=None,
-        description="The Langflow global variable name, if the field is linked to one.",
-    )
-
-
 class DetectVarsResponse(BaseModel):
-    """Response containing detected environment variable references."""
+    """Response containing detected global variable names."""
 
-    variables: list[DetectedEnvVar] = Field(default_factory=list)
-    unresolved_ids: list[UUID] = Field(
-        default_factory=list,
-        description="Flow version IDs that could not be found or accessed.",
-    )
+    variables: list[str] = Field(default_factory=list, description="Detected global variable names.")

--- a/src/backend/base/langflow/api/v1/schemas/deployments.py
+++ b/src/backend/base/langflow/api/v1/schemas/deployments.py
@@ -122,6 +122,12 @@ FlowIdsQuery = Annotated[list[UUID] | None, AfterValidator(_validate_flow_ids)]
 Max supported length is 1 today.
 """
 
+
+def _validate_detect_vars_request_ids(values: list[UUID]) -> list[UUID]:
+    """AfterValidator for DetectVarsRequest.flow_version_ids."""
+    return _validate_uuid_list(values, field_name="flow_version_ids")
+
+
 # ---------------------------------------------------------------------------
 # Provider sub-resource schemas
 # ---------------------------------------------------------------------------
@@ -499,7 +505,10 @@ class SnapshotUpdateResponse(BaseModel):
 class DetectVarsRequest(BaseModel):
     """Request body for detecting environment variables from flow version IDs."""
 
-    flow_version_ids: list[UUID] = Field(
+    flow_version_ids: Annotated[
+        list[UUID],
+        AfterValidator(_validate_detect_vars_request_ids),
+    ] = Field(
         min_length=1,
         max_length=50,
         description="Flow version UUIDs to scan for global variable references.",

--- a/src/backend/base/langflow/api/v1/variable.py
+++ b/src/backend/base/langflow/api/v1/variable.py
@@ -14,7 +14,7 @@ from langflow.api.v1.models import (
     get_model_names_for_provider,
     get_provider_from_variable_name,
 )
-from langflow.api.v1.schemas.deployments import DetectedEnvVar, DetectVarsRequest, DetectVarsResponse
+from langflow.api.v1.schemas.deployments import DetectVarsRequest, DetectVarsResponse
 from langflow.services.database.models.flow_version.crud import get_flow_version_entry_or_raise
 from langflow.services.database.models.flow_version.exceptions import FlowVersionNotFoundError
 from langflow.services.database.models.variable.model import VariableCreate, VariableRead, VariableUpdate
@@ -272,28 +272,23 @@ async def delete_variable(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-def _derive_env_var_name(field_key: str, template: dict) -> str:
-    """Derive a meaningful env var name for a password field without a global variable.
+def _collect_candidate_variable_keys_from_flow_data(data: dict) -> set[str]:
+    """Collect explicit global-variable keys from flow data."""
+    candidate_keys: set[str] = set()
 
-    Looks for a sibling ``model`` field whose selected value carries a ``category``
-    (e.g. ``"OpenAI"``). When found, returns ``{CATEGORY}_API_KEY`` (e.g.
-    ``OPENAI_API_KEY``).  Falls back to the uppercased field key (``API_KEY``).
-    """
-    model_field = template.get("model")
-    if isinstance(model_field, dict):
-        raw = model_field.get("value")
-        if isinstance(raw, str):
-            try:
-                raw = json.loads(raw)
-            except ValueError:
-                raw = None
-        if isinstance(raw, list) and raw and isinstance(raw[0], dict):
-            category = raw[0].get("category", "")
-            if category:
-                prefix = category.upper().replace(" ", "_").replace("-", "_")
-                return f"{prefix}_{field_key.upper()}"
+    for node in data.get("nodes", []):
+        template = node.get("data", {}).get("node", {}).get("template", {})
+        if not isinstance(template, dict):
+            continue
+        for field in template.values():
+            if not isinstance(field, dict):
+                continue
+            if field.get("load_from_db") is True:
+                var_name = field.get("value")
+                if isinstance(var_name, str) and var_name.strip():
+                    candidate_keys.add(var_name.strip())
 
-    return field_key.upper()
+    return candidate_keys
 
 
 @router.post("/detections", response_model=DetectVarsResponse, include_in_schema=False)
@@ -302,21 +297,24 @@ async def detect_env_vars(
     session: DbSession,
     current_user: CurrentActiveUser,
 ):
-    """Detect credential fields used by the given flow version IDs.
+    """Detect global variable references used by the given flow version IDs.
 
-    Two tiers of detection:
-    1. Fields with ``load_from_db=True``: the ``value`` is a Langflow global
-       variable name — returned with ``global_variable_name`` set.
-    2. Fields with ``password=True`` and no global variable link: the field
-       key is uppercased and returned as a suggested env var name, with
-       ``global_variable_name`` left as ``None``.
+    Candidates are inferred only from ``load_from_db=True`` fields, where
+    the field value is interpreted as the referenced global variable name.
 
-    Results are deduplicated. Global-variable refs take precedence over
-    password-only suggestions when the same key appears in both tiers.
+    Returned values are cross-checked against the user's existing global
+    variable names. This is a security guardrail: it prevents echoing arbitrary
+    template values (including accidental secrets) and ensures results are
+    actual stored global variables.
     """
-    global_var_keys: dict[str, str] = {}
-    password_keys: dict[str, str] = {}
-    unresolved_ids: list[UUID] = []
+    variable_service = get_variable_service()
+    existing_variable_names = {
+        name
+        for name in await variable_service.list_variables(user_id=current_user.id, session=session)
+        if isinstance(name, str) and name
+    }
+
+    candidate_keys: set[str] = set()
 
     for version_id in payload.flow_version_ids:
         try:
@@ -325,33 +323,18 @@ async def detect_env_vars(
                 version_id=version_id,
                 user_id=current_user.id,
             )
-        except FlowVersionNotFoundError:
-            unresolved_ids.append(version_id)
-            continue
+        except FlowVersionNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=f"Flow version {version_id} not found") from exc
 
         data = version.data
         if not isinstance(data, dict):
-            continue
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Flow version {version_id} data must be a JSON object with a 'nodes' list "
+                    "containing node templates."
+                ),
+            )
+        candidate_keys.update(_collect_candidate_variable_keys_from_flow_data(data))
 
-        for node in data.get("nodes", []):
-            template = node.get("data", {}).get("node", {}).get("template", {})
-            if not isinstance(template, dict):
-                continue
-            for field_key, field in template.items():
-                if not isinstance(field, dict):
-                    continue
-                if field.get("load_from_db") is True:
-                    var_name = field.get("value")
-                    if isinstance(var_name, str) and var_name.strip():
-                        global_var_keys[var_name.strip()] = var_name.strip()
-                elif field.get("password") is True:
-                    suggested = _derive_env_var_name(field_key, template)
-                    if suggested not in global_var_keys:
-                        password_keys[suggested] = suggested
-
-    merged: list[DetectedEnvVar] = [DetectedEnvVar(key=k, global_variable_name=k) for k in sorted(global_var_keys)]
-    merged.extend(
-        DetectedEnvVar(key=k, global_variable_name=None) for k in sorted(password_keys) if k not in global_var_keys
-    )
-
-    return DetectVarsResponse(variables=merged, unresolved_ids=unresolved_ids)
+    return DetectVarsResponse(variables=sorted(existing_variable_names.intersection(candidate_keys)))

--- a/src/backend/base/langflow/api/v1/variable.py
+++ b/src/backend/base/langflow/api/v1/variable.py
@@ -15,8 +15,7 @@ from langflow.api.v1.models import (
     get_provider_from_variable_name,
 )
 from langflow.api.v1.schemas.deployments import DetectVarsRequest, DetectVarsResponse
-from langflow.services.database.models.flow_version.crud import get_flow_version_entry_or_raise
-from langflow.services.database.models.flow_version.exceptions import FlowVersionNotFoundError
+from langflow.services.database.models.flow_version.crud import get_flow_version_entries_by_ids
 from langflow.services.database.models.variable.model import VariableCreate, VariableRead, VariableUpdate
 from langflow.services.deps import get_variable_service
 from langflow.services.variable.constants import CREDENTIAL_TYPE, GENERIC_TYPE
@@ -285,10 +284,23 @@ def _collect_candidate_variable_keys_from_flow_data(data: dict) -> set[str]:
                 continue
             if field.get("load_from_db") is True:
                 var_name = field.get("value")
-                if isinstance(var_name, str) and var_name.strip():
-                    candidate_keys.add(var_name.strip())
+                normalized_var_name = var_name.strip() if isinstance(var_name, str) else None
+                if normalized_var_name:
+                    candidate_keys.add(normalized_var_name)
 
     return candidate_keys
+
+
+def _validate_flow_or_422(*, version_id: UUID, data: object) -> dict:
+    """Validate flow version data structure and raise HTTP 422 on malformed input."""
+    if not (isinstance(data, dict) and "nodes" in data and isinstance(data["nodes"], list)):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Flow version {version_id} data must be a JSON object with a 'nodes' list containing node templates."
+            ),
+        )
+    return data
 
 
 @router.post("/detections", response_model=DetectVarsResponse, include_in_schema=False)
@@ -315,26 +327,18 @@ async def detect_env_vars(
     }
 
     candidate_keys: set[str] = set()
+    versions_by_id = await get_flow_version_entries_by_ids(
+        session,
+        version_ids=payload.flow_version_ids,
+        user_id=current_user.id,
+    )
 
     for version_id in payload.flow_version_ids:
-        try:
-            version = await get_flow_version_entry_or_raise(
-                session,
-                version_id=version_id,
-                user_id=current_user.id,
-            )
-        except FlowVersionNotFoundError as exc:
-            raise HTTPException(status_code=404, detail=f"Flow version {version_id} not found") from exc
+        version = versions_by_id.get(version_id)
+        if version is None:
+            raise HTTPException(status_code=404, detail=f"Flow version {version_id} not found")
 
-        data = version.data
-        if not isinstance(data, dict):
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    f"Flow version {version_id} data must be a JSON object with a 'nodes' list "
-                    "containing node templates."
-                ),
-            )
+        data = _validate_flow_or_422(version_id=version_id, data=version.data)
         candidate_keys.update(_collect_candidate_variable_keys_from_flow_data(data))
 
     return DetectVarsResponse(variables=sorted(existing_variable_names.intersection(candidate_keys)))

--- a/src/backend/base/langflow/services/database/models/flow_version/crud.py
+++ b/src/backend/base/langflow/services/database/models/flow_version/crud.py
@@ -25,6 +25,7 @@ from langflow.services.database.models.flow_version_deployment_attachment.model 
 from langflow.services.deps import get_settings_service
 
 MAX_VERSION_RETRIES = 3
+MAX_VERSION_ID_FILTER_SIZE = 50
 
 
 async def get_next_version_number(session: AsyncSession, flow_id: UUID) -> int:
@@ -214,6 +215,30 @@ async def get_flow_version_entry(
 ) -> FlowVersion | None:
     result = await session.exec(select(FlowVersion).where(FlowVersion.id == version_id, FlowVersion.user_id == user_id))
     return result.first()
+
+
+async def get_flow_version_entries_by_ids(
+    session: AsyncSession,
+    version_ids: list[UUID],
+    user_id: UUID,
+) -> dict[UUID, FlowVersion]:
+    """Get flow-version entries for a user using a single query.
+
+    Returns a mapping of ``version_id -> FlowVersion`` for all found ids.
+    Missing ids are omitted from the returned mapping.
+    """
+    if not version_ids:
+        return {}
+    if len(version_ids) > MAX_VERSION_ID_FILTER_SIZE:
+        msg = f"version_ids supports at most {MAX_VERSION_ID_FILTER_SIZE} values."
+        raise ValueError(msg)
+
+    stmt = select(FlowVersion).where(
+        col(FlowVersion.id).in_(version_ids),
+        FlowVersion.user_id == user_id,
+    )
+    rows = (await session.exec(stmt)).all()
+    return {row.id: row for row in rows}
 
 
 async def get_flow_version_entry_or_raise(

--- a/src/backend/tests/unit/api/v1/test_detect_env_vars.py
+++ b/src/backend/tests/unit/api/v1/test_detect_env_vars.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 from langflow.api.v1.schemas.deployments import DetectVarsRequest
-from langflow.api.v1.variable import _derive_env_var_name, detect_env_vars
+from langflow.api.v1.variable import detect_env_vars
 from langflow.services.database.models.flow_version.exceptions import FlowVersionNotFoundError
+from pydantic import ValidationError
 
 MODULE = "langflow.api.v1.variable"
 
@@ -23,37 +24,8 @@ def _node(template: dict) -> dict:
     return {"data": {"node": {"template": template}}}
 
 
-# ---------------------------------------------------------------------------
-# _derive_env_var_name
-# ---------------------------------------------------------------------------
-
-
-class TestDeriveEnvVarName:
-    def test_falls_back_to_uppercased_field_key(self):
-        assert _derive_env_var_name("api_key", {}) == "API_KEY"
-
-    def test_uses_category_from_model_field_when_value_is_list(self):
-        template = {"model": {"value": [{"category": "OpenAI"}]}}
-        assert _derive_env_var_name("api_key", template) == "OPENAI_API_KEY"
-
-    def test_uses_category_from_json_encoded_model_value(self):
-        template = {"model": {"value": json.dumps([{"category": "Anthropic"}])}}
-        assert _derive_env_var_name("api_key", template) == "ANTHROPIC_API_KEY"
-
-    def test_normalizes_spaces_and_hyphens_in_category(self):
-        template = {"model": {"value": [{"category": "My-Custom Provider"}]}}
-        assert _derive_env_var_name("secret", template) == "MY_CUSTOM_PROVIDER_SECRET"
-
-    def test_ignores_empty_category(self):
-        template = {"model": {"value": [{"category": ""}]}}
-        assert _derive_env_var_name("token", template) == "TOKEN"
-
-    def test_ignores_non_dict_model_field(self):
-        assert _derive_env_var_name("key", {"model": "not-a-dict"}) == "KEY"
-
-    def test_ignores_malformed_json_in_model_value(self):
-        template = {"model": {"value": "{not valid json"}}
-        assert _derive_env_var_name("key", template) == "KEY"
+def _variable_service_with_names(names: list[str] | None = None) -> SimpleNamespace:
+    return SimpleNamespace(list_variables=AsyncMock(return_value=names or []))
 
 
 # ---------------------------------------------------------------------------
@@ -79,37 +51,40 @@ class TestDetectEnvVars:
                 ]
             }
         )
-        with patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version):
+        with (
+            patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names(["MY_OPENAI_KEY"]),
+            ),
+        ):
             result = await detect_env_vars(
                 payload=DetectVarsRequest(flow_version_ids=[fv_id]),
                 session=AsyncMock(),
                 current_user=SimpleNamespace(id=uuid4()),
             )
-        assert len(result.variables) == 1
-        assert result.variables[0].key == "MY_OPENAI_KEY"
-        assert result.variables[0].global_variable_name == "MY_OPENAI_KEY"
+        assert result.variables == ["MY_OPENAI_KEY"]
 
     @pytest.mark.asyncio
-    async def test_returns_password_field_suggestions(self):
+    async def test_ignores_password_only_fields(self):
         fv_id = uuid4()
         version = _flow_version_with_data({"nodes": [_node({"api_key": {"password": True}})]})
-        with patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version):
+        with (
+            patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names(["API_KEY"]),
+            ),
+        ):
             result = await detect_env_vars(
                 payload=DetectVarsRequest(flow_version_ids=[fv_id]),
                 session=AsyncMock(),
                 current_user=SimpleNamespace(id=uuid4()),
             )
-        assert len(result.variables) == 1
-        assert result.variables[0].key == "API_KEY"
-        assert result.variables[0].global_variable_name is None
+        assert result.variables == []
 
     @pytest.mark.asyncio
-    async def test_global_var_takes_precedence_over_password(self):
-        """Global var takes precedence over password suggestion.
-
-        When the same key appears as both a global var ref and a password
-        suggestion, only the global var entry is returned.
-        """
+    async def test_load_from_db_is_used_even_when_password_fields_exist(self):
         fv_id = uuid4()
         version = _flow_version_with_data(
             {
@@ -124,16 +99,19 @@ class TestDetectEnvVars:
                 ]
             }
         )
-        with patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version):
+        with (
+            patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names(["API_KEY"]),
+            ),
+        ):
             result = await detect_env_vars(
                 payload=DetectVarsRequest(flow_version_ids=[fv_id]),
                 session=AsyncMock(),
                 current_user=SimpleNamespace(id=uuid4()),
             )
-        keys = {v.key for v in result.variables}
-        assert "API_KEY" in keys
-        api_key_var = next(v for v in result.variables if v.key == "API_KEY")
-        assert api_key_var.global_variable_name == "API_KEY"
+        assert result.variables == ["API_KEY"]
 
     @pytest.mark.asyncio
     async def test_deduplicates_across_versions(self):
@@ -144,71 +122,95 @@ class TestDetectEnvVars:
         async def mock_get(session, *, version_id, user_id):  # noqa: ARG001
             return version1 if version_id == fv1 else version2
 
-        with patch(f"{MODULE}.get_flow_version_entry_or_raise", side_effect=mock_get):
+        with (
+            patch(f"{MODULE}.get_flow_version_entry_or_raise", side_effect=mock_get),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names(["MY_KEY"]),
+            ),
+        ):
             result = await detect_env_vars(
                 payload=DetectVarsRequest(flow_version_ids=[fv1, fv2]),
                 session=AsyncMock(),
                 current_user=SimpleNamespace(id=uuid4()),
             )
-        assert len(result.variables) == 1
+        assert result.variables == ["MY_KEY"]
 
     @pytest.mark.asyncio
-    async def test_skips_missing_flow_versions(self):
+    async def test_fails_fast_for_missing_flow_versions(self):
         fv_id = uuid4()
 
         async def mock_get(session, *, version_id, user_id):  # noqa: ARG001
             raise FlowVersionNotFoundError(version_id)
 
-        with patch(f"{MODULE}.get_flow_version_entry_or_raise", side_effect=mock_get):
-            result = await detect_env_vars(
+        with (
+            patch(f"{MODULE}.get_flow_version_entry_or_raise", side_effect=mock_get),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names(["ANY_KEY"]),
+            ),
+            pytest.raises(HTTPException, match=f"Flow version {fv_id} not found"),
+        ):
+            await detect_env_vars(
                 payload=DetectVarsRequest(flow_version_ids=[fv_id]),
                 session=AsyncMock(),
                 current_user=SimpleNamespace(id=uuid4()),
             )
-        assert result.variables == []
 
     @pytest.mark.asyncio
-    async def test_handles_non_dict_data(self):
+    async def test_fails_fast_for_non_dict_data(self):
         fv_id = uuid4()
         version = _flow_version_with_data(None)
-        with patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version):
-            result = await detect_env_vars(
+        with (
+            patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names(["ANY_KEY"]),
+            ),
+            pytest.raises(
+                HTTPException,
+                match=(
+                    f"Flow version {fv_id} data must be a JSON object with a 'nodes' list containing node templates."
+                ),
+            ),
+        ):
+            await detect_env_vars(
                 payload=DetectVarsRequest(flow_version_ids=[fv_id]),
                 session=AsyncMock(),
                 current_user=SimpleNamespace(id=uuid4()),
             )
-        assert result.variables == []
 
     @pytest.mark.asyncio
-    async def test_empty_flow_version_ids(self):
-        result = await detect_env_vars(
-            payload=DetectVarsRequest(flow_version_ids=[]),
-            session=AsyncMock(),
-            current_user=SimpleNamespace(id=uuid4()),
-        )
-        assert result.variables == []
+    async def test_rejects_empty_flow_version_ids(self):
+        with pytest.raises(ValidationError):
+            DetectVarsRequest(flow_version_ids=[])
 
     @pytest.mark.asyncio
-    async def test_password_with_model_category(self):
+    async def test_filters_out_non_existing_variable_names(self):
         fv_id = uuid4()
         version = _flow_version_with_data(
             {
                 "nodes": [
                     _node(
                         {
-                            "api_key": {"password": True},
-                            "model": {"value": [{"category": "OpenAI"}]},
+                            "api_key": {"load_from_db": True, "value": "sk-live-secret"},
+                            "other_key": {"password": True},
                         }
                     )
                 ]
             }
         )
-        with patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version):
+        with (
+            patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names([]),
+            ),
+        ):
             result = await detect_env_vars(
                 payload=DetectVarsRequest(flow_version_ids=[fv_id]),
                 session=AsyncMock(),
                 current_user=SimpleNamespace(id=uuid4()),
             )
-        assert len(result.variables) == 1
-        assert result.variables[0].key == "OPENAI_API_KEY"
-        assert result.variables[0].global_variable_name is None
+
+        assert result.variables == []

--- a/src/backend/tests/unit/api/v1/test_detect_env_vars.py
+++ b/src/backend/tests/unit/api/v1/test_detect_env_vars.py
@@ -10,13 +10,12 @@ import pytest
 from fastapi import HTTPException
 from langflow.api.v1.schemas.deployments import DetectVarsRequest
 from langflow.api.v1.variable import detect_env_vars
-from langflow.services.database.models.flow_version.exceptions import FlowVersionNotFoundError
 from pydantic import ValidationError
 
 MODULE = "langflow.api.v1.variable"
 
 
-def _flow_version_with_data(data: dict) -> SimpleNamespace:
+def _flow_version_with_data(data: object) -> SimpleNamespace:
     return SimpleNamespace(data=data)
 
 
@@ -52,7 +51,11 @@ class TestDetectEnvVars:
             }
         )
         with (
-            patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version),
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={fv_id: version},
+            ),
             patch(
                 f"{MODULE}.get_variable_service",
                 return_value=_variable_service_with_names(["MY_OPENAI_KEY"]),
@@ -70,7 +73,11 @@ class TestDetectEnvVars:
         fv_id = uuid4()
         version = _flow_version_with_data({"nodes": [_node({"api_key": {"password": True}})]})
         with (
-            patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version),
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={fv_id: version},
+            ),
             patch(
                 f"{MODULE}.get_variable_service",
                 return_value=_variable_service_with_names(["API_KEY"]),
@@ -100,7 +107,11 @@ class TestDetectEnvVars:
             }
         )
         with (
-            patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version),
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={fv_id: version},
+            ),
             patch(
                 f"{MODULE}.get_variable_service",
                 return_value=_variable_service_with_names(["API_KEY"]),
@@ -119,11 +130,12 @@ class TestDetectEnvVars:
         version1 = _flow_version_with_data({"nodes": [_node({"api_key": {"load_from_db": True, "value": "MY_KEY"}})]})
         version2 = _flow_version_with_data({"nodes": [_node({"api_key": {"load_from_db": True, "value": "MY_KEY"}})]})
 
-        async def mock_get(session, *, version_id, user_id):  # noqa: ARG001
-            return version1 if version_id == fv1 else version2
-
         with (
-            patch(f"{MODULE}.get_flow_version_entry_or_raise", side_effect=mock_get),
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={fv1: version1, fv2: version2},
+            ),
             patch(
                 f"{MODULE}.get_variable_service",
                 return_value=_variable_service_with_names(["MY_KEY"]),
@@ -140,11 +152,12 @@ class TestDetectEnvVars:
     async def test_fails_fast_for_missing_flow_versions(self):
         fv_id = uuid4()
 
-        async def mock_get(session, *, version_id, user_id):  # noqa: ARG001
-            raise FlowVersionNotFoundError(version_id)
-
         with (
-            patch(f"{MODULE}.get_flow_version_entry_or_raise", side_effect=mock_get),
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
             patch(
                 f"{MODULE}.get_variable_service",
                 return_value=_variable_service_with_names(["ANY_KEY"]),
@@ -162,7 +175,65 @@ class TestDetectEnvVars:
         fv_id = uuid4()
         version = _flow_version_with_data(None)
         with (
-            patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version),
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={fv_id: version},
+            ),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names(["ANY_KEY"]),
+            ),
+            pytest.raises(
+                HTTPException,
+                match=(
+                    f"Flow version {fv_id} data must be a JSON object with a 'nodes' list containing node templates."
+                ),
+            ),
+        ):
+            await detect_env_vars(
+                payload=DetectVarsRequest(flow_version_ids=[fv_id]),
+                session=AsyncMock(),
+                current_user=SimpleNamespace(id=uuid4()),
+            )
+
+    @pytest.mark.asyncio
+    async def test_fails_fast_for_missing_nodes_list(self):
+        fv_id = uuid4()
+        version = _flow_version_with_data({})
+        with (
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={fv_id: version},
+            ),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names(["ANY_KEY"]),
+            ),
+            pytest.raises(
+                HTTPException,
+                match=(
+                    f"Flow version {fv_id} data must be a JSON object with a 'nodes' list containing node templates."
+                ),
+            ),
+        ):
+            await detect_env_vars(
+                payload=DetectVarsRequest(flow_version_ids=[fv_id]),
+                session=AsyncMock(),
+                current_user=SimpleNamespace(id=uuid4()),
+            )
+
+    @pytest.mark.asyncio
+    async def test_fails_fast_for_non_list_nodes(self):
+        fv_id = uuid4()
+        version = _flow_version_with_data({"nodes": {"template": {}}})
+        with (
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={fv_id: version},
+            ),
             patch(
                 f"{MODULE}.get_variable_service",
                 return_value=_variable_service_with_names(["ANY_KEY"]),
@@ -186,6 +257,87 @@ class TestDetectEnvVars:
             DetectVarsRequest(flow_version_ids=[])
 
     @pytest.mark.asyncio
+    async def test_deduplicates_flow_version_ids_in_request(self):
+        flow_version_id = uuid4()
+        request = DetectVarsRequest(flow_version_ids=[flow_version_id, flow_version_id])
+        assert request.flow_version_ids == [flow_version_id]
+
+    @pytest.mark.asyncio
+    async def test_rejects_more_than_50_flow_version_ids(self):
+        with pytest.raises(ValidationError):
+            DetectVarsRequest(flow_version_ids=[uuid4() for _ in range(51)])
+
+    @pytest.mark.asyncio
+    async def test_strips_whitespace_from_detected_variable_name(self):
+        fv_id = uuid4()
+        version = _flow_version_with_data(
+            {
+                "nodes": [
+                    _node(
+                        {
+                            "api_key": {
+                                "load_from_db": True,
+                                "value": "  MY_OPENAI_KEY  ",
+                            }
+                        }
+                    )
+                ]
+            }
+        )
+        with (
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={fv_id: version},
+            ),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names(["MY_OPENAI_KEY"]),
+            ),
+        ):
+            result = await detect_env_vars(
+                payload=DetectVarsRequest(flow_version_ids=[fv_id]),
+                session=AsyncMock(),
+                current_user=SimpleNamespace(id=uuid4()),
+            )
+        assert result.variables == ["MY_OPENAI_KEY"]
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_string_and_blank_variable_values(self):
+        fv_id = uuid4()
+        version = _flow_version_with_data(
+            {
+                "nodes": [
+                    _node(
+                        {
+                            "null_value": {"load_from_db": True, "value": None},
+                            "int_value": {"load_from_db": True, "value": 123},
+                            "blank_value": {"load_from_db": True, "value": "   "},
+                            "valid_value": {"load_from_db": True, "value": "VALID_KEY"},
+                        }
+                    )
+                ]
+            }
+        )
+        with (
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={fv_id: version},
+            ),
+            patch(
+                f"{MODULE}.get_variable_service",
+                return_value=_variable_service_with_names(["VALID_KEY"]),
+            ),
+        ):
+            result = await detect_env_vars(
+                payload=DetectVarsRequest(flow_version_ids=[fv_id]),
+                session=AsyncMock(),
+                current_user=SimpleNamespace(id=uuid4()),
+            )
+        assert result.variables == ["VALID_KEY"]
+
+    @pytest.mark.asyncio
     async def test_filters_out_non_existing_variable_names(self):
         fv_id = uuid4()
         version = _flow_version_with_data(
@@ -201,7 +353,11 @@ class TestDetectEnvVars:
             }
         )
         with (
-            patch(f"{MODULE}.get_flow_version_entry_or_raise", new_callable=AsyncMock, return_value=version),
+            patch(
+                f"{MODULE}.get_flow_version_entries_by_ids",
+                new_callable=AsyncMock,
+                return_value={fv_id: version},
+            ),
             patch(
                 f"{MODULE}.get_variable_service",
                 return_value=_variable_service_with_names([]),

--- a/src/backend/tests/unit/api/v1/test_flow_version.py
+++ b/src/backend/tests/unit/api/v1/test_flow_version.py
@@ -1433,3 +1433,22 @@ async def test_get_single_version_sync_prunes_stale_attachment(client: AsyncClie
         resp = await client.get(f"api/v1/flows/{flow['id']}/versions/{snap['id']}", headers=logged_in_headers)
         assert resp.status_code == status.HTTP_200_OK
         assert resp.json()["is_deployed"] is False
+
+
+async def test_get_flow_version_entries_by_ids_rejects_oversized_batch():
+    from unittest.mock import AsyncMock
+    from uuid import uuid4
+
+    from langflow.services.database.models.flow_version.crud import get_flow_version_entries_by_ids
+
+    session = AsyncMock()
+    version_ids = [uuid4() for _ in range(51)]
+
+    with pytest.raises(ValueError, match="version_ids supports at most 50 values"):
+        await get_flow_version_entries_by_ids(
+            session=session,
+            version_ids=version_ids,
+            user_id=uuid4(),
+        )
+
+    session.exec.assert_not_called()

--- a/src/backend/tests/unit/api/v1/test_variable.py
+++ b/src/backend/tests/unit/api/v1/test_variable.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest import mock
 from uuid import uuid4
 
@@ -564,3 +565,65 @@ async def test_delete_non_provider_credential_does_not_cleanup_models(client: As
     # Delete the variable - should not trigger any cleanup
     delete_response = await client.delete(f"api/v1/variables/{created_var['id']}", headers=logged_in_headers)
     assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_detect_env_vars_endpoint__returns_detected_names(client: AsyncClient, logged_in_headers):
+    flow_version_id = uuid4()
+    flow_version = SimpleNamespace(
+        data={
+            "nodes": [
+                {
+                    "data": {
+                        "node": {
+                            "template": {
+                                "api_key": {"load_from_db": True, "value": "  MY_OPENAI_KEY  "},
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    variable_service = SimpleNamespace(list_variables=mock.AsyncMock(return_value=["MY_OPENAI_KEY"]))
+
+    with (
+        mock.patch(
+            "langflow.api.v1.variable.get_flow_version_entries_by_ids",
+            new_callable=mock.AsyncMock,
+            return_value={flow_version_id: flow_version},
+        ),
+        mock.patch("langflow.api.v1.variable.get_variable_service", return_value=variable_service),
+    ):
+        response = await client.post(
+            "api/v1/variables/detections",
+            json={"flow_version_ids": [str(flow_version_id)]},
+            headers=logged_in_headers,
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"variables": ["MY_OPENAI_KEY"]}
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_detect_env_vars_endpoint__rejects_missing_nodes(client: AsyncClient, logged_in_headers):
+    flow_version_id = uuid4()
+    flow_version = SimpleNamespace(data={})
+    variable_service = SimpleNamespace(list_variables=mock.AsyncMock(return_value=["ANY_KEY"]))
+
+    with (
+        mock.patch(
+            "langflow.api.v1.variable.get_flow_version_entries_by_ids",
+            new_callable=mock.AsyncMock,
+            return_value={flow_version_id: flow_version},
+        ),
+        mock.patch("langflow.api.v1.variable.get_variable_service", return_value=variable_service),
+    ):
+        response = await client.post(
+            "api/v1/variables/detections",
+            json={"flow_version_ids": [str(flow_version_id)]},
+            headers=logged_in_headers,
+        )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "must be a JSON object with a 'nodes' list" in response.json()["detail"]

--- a/src/frontend/src/controllers/API/queries/variables/__tests__/use-post-detect-env-vars.test.ts
+++ b/src/frontend/src/controllers/API/queries/variables/__tests__/use-post-detect-env-vars.test.ts
@@ -48,12 +48,9 @@ describe("usePostDetectEnvVars", () => {
     );
   });
 
-  it("returns detected variables with global_variable_name", async () => {
+  it("returns detected global variable names", async () => {
     const response: DetectEnvVarsResponse = {
-      variables: [
-        { key: "OPENAI_API_KEY", global_variable_name: "openai_key" },
-        { key: "CUSTOM_VAR", global_variable_name: null },
-      ],
+      variables: ["OPENAI_API_KEY", "CUSTOM_VAR"],
     };
     mockApiPost.mockResolvedValue({ data: response });
 
@@ -64,8 +61,8 @@ describe("usePostDetectEnvVars", () => {
 
     expect(result).toEqual(response);
     expect(result.variables).toHaveLength(2);
-    expect(result.variables[0].global_variable_name).toBe("openai_key");
-    expect(result.variables[1].global_variable_name).toBeNull();
+    expect(result.variables[0]).toBe("OPENAI_API_KEY");
+    expect(result.variables[1]).toBe("CUSTOM_VAR");
   });
 
   it("returns empty variables array when no env vars detected", async () => {

--- a/src/frontend/src/controllers/API/queries/variables/use-post-detect-env-vars.ts
+++ b/src/frontend/src/controllers/API/queries/variables/use-post-detect-env-vars.ts
@@ -7,13 +7,8 @@ export type DetectEnvVarsPayload = {
   flow_version_ids: string[];
 };
 
-export type DetectedEnvVar = {
-  key: string;
-  global_variable_name?: string | null;
-};
-
 export type DetectEnvVarsResponse = {
-  variables: DetectedEnvVar[];
+  variables: string[];
 };
 
 export const usePostDetectEnvVars: useMutationFunctionType<

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
@@ -116,6 +116,11 @@ export default function StepAttachFlows() {
     { id: crypto.randomUUID(), key: "", value: "" },
   ]);
   const [detectedVarCount, setDetectedVarCount] = useState(0);
+
+  const { mutateAsync: detectEnvVars } = usePostDetectEnvVars();
+  const { data: globalVariables } = useGetGlobalVariables();
+  const globalVariableOptions = (globalVariables ?? []).map((v) => v.name);
+
   // When a flow+version are pre-selected from outside (e.g., canvas deploy button),
   // auto-advance to the connections panel and detect env vars for the pre-selected version.
   useEffect(() => {
@@ -135,11 +140,11 @@ export default function StepAttachFlows() {
         if (detected.length > 0) {
           setDetectedVarCount(detected.length);
           setEnvVars(
-            detected.map((v) => ({
+            detected.map((variableName) => ({
               id: crypto.randomUUID(),
-              key: v.key,
-              value: v.global_variable_name ?? "",
-              globalVar: Boolean(v.global_variable_name),
+              key: variableName,
+              value: variableName,
+              globalVar: true,
             })),
           );
         }
@@ -153,10 +158,6 @@ export default function StepAttachFlows() {
     detect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const { mutateAsync: detectEnvVars } = usePostDetectEnvVars();
-  const { data: globalVariables } = useGetGlobalVariables();
-  const globalVariableOptions = (globalVariables ?? []).map((v) => v.name);
 
   const isDuplicateConnectionName = useMemo(() => {
     const trimmed = newConnectionName.trim().toLowerCase();
@@ -203,11 +204,11 @@ export default function StepAttachFlows() {
         if (detected.length > 0) {
           setDetectedVarCount(detected.length);
           setEnvVars(
-            detected.map((v) => ({
+            detected.map((variableName) => ({
               id: crypto.randomUUID(),
-              key: v.key,
-              value: v.global_variable_name ?? "",
-              globalVar: Boolean(v.global_variable_name),
+              key: variableName,
+              value: variableName,
+              globalVar: true,
             })),
           );
         } else {


### PR DESCRIPTION


Drop the two-tier detection model (load_from_db + password-field heuristics) in favor of a single source: fields with load_from_db=True. Candidates are cross-checked against the user's existing global variables before being returned, preventing accidental secret leakage via template values.
- Remove DetectedEnvVar model and unresolved_ids from the response
- Flatten response to list[str] of verified global variable names (breaking API change, but this endpoint is new in 1.9.0)
- Fail fast (404/422) on missing or malformed flow versions
- Add min_length=1 validation on flow_version_ids
- Update frontend types and consumers to match simplified response