### PR TITLE
fix: use project upload error detail

### DIFF
--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -167,7 +167,11 @@ const SideBarFoldersButtonsComponent = ({
                     console.error(err);
                     setErrorData({
                       title: `Error on uploading your project, try dragging it into an existing project.`,
-                      list: [err?.response?.data?.detail || err?.message || "Unknown error"],
+                      list: [
+                        err?.response?.data?.detail ||
+                          err?.message ||
+                          "Unknown error",
+                      ],
                     });
                   },
                 },

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -167,7 +167,7 @@ const SideBarFoldersButtonsComponent = ({
                     console.error(err);
                     setErrorData({
                       title: `Error on uploading your project, try dragging it into an existing project.`,
-                      list: [err["response"]["data"]["message"]],
+                      list: [err["response"]["data"]["detail"]],
                     });
                   },
                 },

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -167,7 +167,7 @@ const SideBarFoldersButtonsComponent = ({
                     console.error(err);
                     setErrorData({
                       title: `Error on uploading your project, try dragging it into an existing project.`,
-                      list: [err["response"]["data"]["detail"]],
+                      list: [err?.response?.data?.detail || err?.message || "Unknown error"],
                     });
                   },
                 },


### PR DESCRIPTION
Fixes #11293

## Summary
- Read project upload failure details from the backend `detail` field.
- Fall back to the error message or `Unknown error` when an upload failure does not include an API response body.
- Keep the existing project upload error alert title unchanged.

## Verification
- Ran `git diff --check`.
- Confirmed the project upload endpoint returns errors through `detail`.
- Confirmed the PR only updates project upload error handling in the sidebar.