### PR TITLE
feat: allow users to name flow snapshots when saving

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveSnapshotButton.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveSnapshotButton.tsx
@@ -58,7 +58,11 @@ export default function SaveSnapshotButton({
       description="Capture the current state as a restore point"
       actionSlot={
         <div className="flex items-center gap-2">
+          <label htmlFor="snapshot-description" className="sr-only">
+            Version name (optional)
+          </label>
           <input
+            id="snapshot-description"
             type="text"
             placeholder="Version name (optional)"
             value={description}

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveSnapshotButton.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveSnapshotButton.tsx
@@ -63,6 +63,7 @@ export default function SaveSnapshotButton({
             placeholder="Version name (optional)"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
+            maxLength={500}
             onKeyDown={(e) => {
               if (
                 e.key === "Enter" &&

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveSnapshotButton.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveSnapshotButton.tsx
@@ -19,6 +19,7 @@ export default function SaveSnapshotButton({
     usePostCreateSnapshot();
   const [isSavingDisplay, setIsSavingDisplay] = useState(false);
   const [savedSuccess, setSavedSuccess] = useState(false);
+  const [description, setDescription] = useState("");
 
   const handleDismiss = () => {
     // Switching the section unmounts the version sidebar, whose cleanup
@@ -31,7 +32,7 @@ export default function SaveSnapshotButton({
   const handleSave = () => {
     setIsSavingDisplay(true);
     createSnapshot(
-      { flowId, description: null },
+      { flowId, description: description.trim() || null },
       {
         onSuccess: () => {
           setSuccessData({ title: "Version saved" });
@@ -57,6 +58,19 @@ export default function SaveSnapshotButton({
       description="Capture the current state as a restore point"
       actionSlot={
         <div className="flex items-center gap-2">
+          <input
+            type="text"
+            placeholder="Version name (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !isSavingDisplay && !isCreating && !savedSuccess) {
+                handleSave();
+              }
+            }}
+            disabled={isSavingDisplay || isCreating || savedSuccess}
+            className="h-8 w-48 rounded-md border border-input bg-background px-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          />
           <CanvasBannerButton variant="outline" onClick={handleDismiss}>
             Keep Building
           </CanvasBannerButton>

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveSnapshotButton.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveSnapshotButton.tsx
@@ -64,7 +64,13 @@ export default function SaveSnapshotButton({
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter" && !isSavingDisplay && !isCreating && !savedSuccess) {
+              if (
+                e.key === "Enter" &&
+                !e.nativeEvent.isComposing &&
+                !isSavingDisplay &&
+                !isCreating &&
+                !savedSuccess
+              ) {
                 handleSave();
               }
             }}

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/FlowVersionSidebar/components/VersionListItem.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/FlowVersionSidebar/components/VersionListItem.tsx
@@ -43,7 +43,15 @@ export default function VersionListItem({
         )}
       >
         <div className="flex flex-col items-start">
-          <span className="font-medium text-sm pb-1">{entry.version_tag}</span>
+          <span className="font-medium text-sm pb-1">
+            {entry.version_tag}
+            {entry.description && (
+              <span className="font-normal text-muted-foreground">
+                {" "}
+                — {entry.description}
+              </span>
+            )}
+          </span>
           <span className="text-xs text-muted-foreground">
             {formatTimestamp(entry.created_at)}
           </span>


### PR DESCRIPTION
## Summary
- Added an optional text input to the "Save version" banner so users can name their snapshots (e.g. "Fixed prompt", "Added search tool")
- Version names are displayed in the version list 
- The field is optional (leaving it empty works exactly as before)
- No backend changes needed ( the `description` field already exists in the API and database)
- Works well with long names as they are being wrapped in the menu:

<img width="269" height="361" alt="image" src="https://github.com/user-attachments/assets/db626ce4-e48b-4c36-a6c3-e16cc7bd9e00" />


## Test plan
- Save a snapshot with a name 
- Save a snapshot without a name
- Press Enter in the text field and saves the snapshot

This PR fixes issue [#12511](https://github.com/langflow-ai/langflow/issues/12511)

**Before:**
<img width="1277" height="987" alt="image" src="https://github.com/user-attachments/assets/6b521b76-3199-4f84-af8c-06d2a74c5d41" />


**After:**

https://github.com/user-attachments/assets/9db150d2-be89-4e7f-b8b3-6164a2860817



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Snapshots can now be named with optional descriptions during creation
  * Snapshot descriptions display in the version history sidebar alongside version identifiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->