### PR TITLE
fix: restore webhook SSE authentication using FastAPI dependency injection

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -681,6 +681,7 @@ async def simplified_run_flow_session(
 async def webhook_events_stream(
     flow_id_or_name: str,  # noqa: ARG001 - Used by get_flow_by_id_or_endpoint_name dependency
     flow: Annotated[Flow, Depends(get_flow_by_id_or_endpoint_name)],
+    user: Annotated[User | UserRead, Depends(get_current_user_for_sse)],
     request: Request,
 ):
     """Server-Sent Events (SSE) endpoint for real-time webhook build updates.
@@ -691,9 +692,6 @@ async def webhook_events_stream(
     Authentication: Requires user to be logged in (via cookie) or provide API key.
     The user must own the flow to subscribe to its events.
     """
-    # Authenticate user via cookie or API key
-    user = await get_current_user_for_sse(request)
-
     # Verify user owns the flow
     if str(flow.user_id) != str(user.id):
         raise HTTPException(

--- a/src/backend/tests/unit/test_webhook.py
+++ b/src/backend/tests/unit/test_webhook.py
@@ -812,69 +812,9 @@ class TestSimpleRunFlowTask:
 class TestWebhookEventsStreamAuth:
     """Unit tests for webhook_events_stream authentication."""
 
-    async def test_calls_get_current_user_for_sse_for_authentication(self):
-        """Should call get_current_user_for_sse to validate authentication."""
-        from unittest.mock import AsyncMock, Mock, patch
-
-        from langflow.api.v1.endpoints import webhook_events_stream
-
-        user_id = "user-123"
-        flow = Mock()
-        flow.id = "test-flow-id"
-        flow.name = "Test Flow"
-        flow.user_id = user_id
-
-        request = Mock()
-        request.is_disconnected = AsyncMock(return_value=True)  # Disconnect immediately
-
-        mock_user = Mock()
-        mock_user.id = user_id
-
-        with (
-            patch("langflow.api.v1.endpoints.get_current_user_for_sse", new_callable=AsyncMock) as mock_auth,
-            patch("langflow.api.v1.endpoints.webhook_event_manager") as mock_manager,
-        ):
-            mock_auth.return_value = mock_user
-            mock_manager.subscribe = AsyncMock(return_value=asyncio.Queue())
-            mock_manager.unsubscribe = AsyncMock()
-
-            await webhook_events_stream(
-                flow_id_or_name="test-flow-id",
-                flow=flow,
-                request=request,
-            )
-
-            # Should call get_current_user_for_sse with request
-            mock_auth.assert_called_once_with(request)
-
-    async def test_raises_403_when_auth_fails(self):
-        """Should propagate 403 error when authentication fails."""
-        from unittest.mock import AsyncMock, Mock, patch
-
-        from fastapi import HTTPException
-        from langflow.api.v1.endpoints import webhook_events_stream
-
-        flow = Mock()
-        flow.id = "test-flow-id"
-
-        request = Mock()
-
-        with patch("langflow.api.v1.endpoints.get_current_user_for_sse", new_callable=AsyncMock) as mock_auth:
-            mock_auth.side_effect = HTTPException(status_code=403, detail="Missing or invalid credentials")
-
-            with pytest.raises(HTTPException) as exc_info:
-                await webhook_events_stream(
-                    flow_id_or_name="test-flow-id",
-                    flow=flow,
-                    request=request,
-                )
-
-            assert exc_info.value.status_code == 403
-            assert "Missing or invalid credentials" in exc_info.value.detail
-
     async def test_raises_403_when_user_does_not_own_flow(self):
         """Should raise 403 when authenticated user doesn't own the flow."""
-        from unittest.mock import AsyncMock, Mock, patch
+        from unittest.mock import Mock
 
         from fastapi import HTTPException
         from langflow.api.v1.endpoints import webhook_events_stream
@@ -888,15 +828,13 @@ class TestWebhookEventsStreamAuth:
 
         request = Mock()
 
-        with patch("langflow.api.v1.endpoints.get_current_user_for_sse", new_callable=AsyncMock) as mock_auth:
-            mock_auth.return_value = mock_user
+        with pytest.raises(HTTPException) as exc_info:
+            await webhook_events_stream(
+                flow_id_or_name="test-flow-id",
+                flow=flow,
+                user=mock_user,
+                request=request,
+            )
 
-            with pytest.raises(HTTPException) as exc_info:
-                await webhook_events_stream(
-                    flow_id_or_name="test-flow-id",
-                    flow=flow,
-                    request=request,
-                )
-
-            assert exc_info.value.status_code == 403
-            assert "Access denied" in exc_info.value.detail
+        assert exc_info.value.status_code == 403
+        assert "Access denied" in exc_info.value.detail

--- a/src/backend/tests/unit/test_webhook_sse_regression.py
+++ b/src/backend/tests/unit/test_webhook_sse_regression.py
@@ -1,0 +1,110 @@
+"""Regression test for webhook SSE real-time event delivery.
+
+Bug: After POST /api/v1/webhook/{flow_id}, the UI's Inspect Output panel never shows
+the Webhook build because the SSE endpoint `/api/v1/webhook-events/{flow_id}` was
+returning 403 to the frontend subscriber. As a result the frontend `flowPool` stayed
+empty and the Inspect Output panel showed "Please build the component first".
+
+Root cause: `get_current_user_for_sse` takes `db: AsyncSession = Depends(...)` as a
+default parameter — it is supposed to be invoked as a FastAPI dependency.
+`webhook_events_stream` was calling it as a plain function
+(`user = await get_current_user_for_sse(request)`), so the `db` argument was the
+unresolved `Depends(...)` object instead of an `AsyncSession`. Every auth attempt then
+blew up inside the auth service, was wrapped as `InvalidCredentialsError`, and the SSE
+endpoint raised 403 for every request.
+
+The regression was introduced in PR #11654 (Pluggable AuthService) when
+`get_current_user_for_sse` was refactored from using `async with session_scope() as db`
+internally to receiving `db` via FastAPI `Depends(...)`.
+
+Fix: make `webhook_events_stream` resolve `get_current_user_for_sse` through FastAPI
+dependency injection so the `db` session is properly provided.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+async def _assert_sse_not_forbidden(client, url: str) -> None:
+    """Send a GET with a tight timeout and assert the endpoint does not return 403.
+
+    SSE responses are long-lived, so we can't read the body; instead:
+      * 403 response → regression is present (fails fast, before the timeout)
+      * TimeoutError → the SSE stream opened (200) and is idle waiting for events
+    """
+    try:
+        response = await asyncio.wait_for(client.get(url), timeout=3.0)
+    except asyncio.TimeoutError:
+        return
+
+    assert response.status_code != 403, (
+        f"SSE endpoint returned 403. Regression: get_current_user_for_sse was "
+        "called directly instead of via FastAPI DI, so its `db` parameter was "
+        f"a Depends(...) object. Body: {response.text}"
+    )
+
+
+async def test_should_not_return_403_when_accessing_webhook_sse_endpoint_with_valid_api_key(
+    client,
+    added_webhook_test,
+    created_api_key,
+):
+    """Direct reproduction: SSE must accept `x-api-key` query param."""
+    flow_id = added_webhook_test["id"]
+    sse_url = f"api/v1/webhook-events/{flow_id}?x-api-key={created_api_key.api_key}"
+
+    await _assert_sse_not_forbidden(client, sse_url)
+
+
+async def test_should_not_return_403_when_accessing_webhook_sse_endpoint_with_valid_cookie(
+    client,
+    added_webhook_test,
+    active_user,
+):
+    """SSE must accept `access_token_lf` cookie — the real path used by the browser.
+
+    The frontend's EventSource relies on cookies (not headers or query params) for
+    authentication. This test mirrors that exact flow to make sure the fix holds for
+    the real end-user scenario.
+    """
+    login_response = await client.post(
+        "api/v1/login",
+        data={"username": active_user.username, "password": "testpassword"},
+    )
+    assert login_response.status_code == 200
+    # httpx AsyncClient automatically persists Set-Cookie headers into client.cookies,
+    # so subsequent requests will carry access_token_lf.
+    assert "access_token_lf" in client.cookies
+
+    flow_id = added_webhook_test["id"]
+    sse_url = f"api/v1/webhook-events/{flow_id}"
+
+    await _assert_sse_not_forbidden(client, sse_url)
+
+
+async def test_should_not_return_403_on_sse_endpoint_when_webhook_auth_enable_is_true(
+    client,
+    added_webhook_test,
+    created_api_key,
+):
+    """SSE auth is independent of LANGFLOW_WEBHOOK_AUTH_ENABLE.
+
+    `WEBHOOK_AUTH_ENABLE` controls the POST /webhook endpoint (allow/deny public
+    execution). It must not interfere with SSE subscription: the SSE endpoint always
+    requires a logged-in user who owns the flow, regardless of the flag.
+    """
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    original = settings_service.auth_settings.WEBHOOK_AUTH_ENABLE
+
+    try:
+        settings_service.auth_settings.WEBHOOK_AUTH_ENABLE = True
+
+        flow_id = added_webhook_test["id"]
+        sse_url = f"api/v1/webhook-events/{flow_id}?x-api-key={created_api_key.api_key}"
+
+        await _assert_sse_not_forbidden(client, sse_url)
+    finally:
+        settings_service.auth_settings.WEBHOOK_AUTH_ENABLE = original


### PR DESCRIPTION
This pull request fixes a regression in the authentication flow for the webhook SSE endpoint, ensuring that user authentication is properly handled via FastAPI dependency injection. This resolves an issue where the frontend was unable to receive real-time webhook updates due to persistent 403 errors. The PR also removes outdated unit tests and adds new regression tests to prevent similar issues in the future.

**Authentication and Dependency Injection Fixes:**

* The `webhook_events_stream` endpoint now receives the `user` parameter via FastAPI dependency injection (`Depends(get_current_user_for_sse)`), ensuring the database session is correctly provided and authentication works as intended. [[1]](diffhunk://#diff-2cc70b3b7a7be90cba6b85c839b082b0cc844c917644fdc2c9fafba56ba8b607R684) [[2]](diffhunk://#diff-2cc70b3b7a7be90cba6b85c839b082b0cc844c917644fdc2c9fafba56ba8b607L694-L696)

**Test Suite Updates:**

* Removed unit tests that directly patched or called `get_current_user_for_sse`, which are no longer relevant due to the new dependency injection approach.
* Updated the remaining test to inject the `user` parameter directly, aligning with the new function signature.
* Added a comprehensive regression test module (`test_webhook_sse_regression.py`) that verifies the SSE endpoint does not return 403 for valid API key or cookie authentication and that the fix is robust against configuration changes.