### PR TITLE
fix: Build the correct oauth callback URL for MCP Composer

### DIFF
--- a/src/lfx/src/lfx/services/mcp_composer/service.py
+++ b/src/lfx/src/lfx/services/mcp_composer/service.py
@@ -1292,7 +1292,7 @@ class MCPComposerService(Service):
                     "oauth_host": "OAUTH_HOST",
                     "oauth_port": "OAUTH_PORT",
                     "oauth_server_url": "OAUTH_SERVER_URL",
-                    "oauth_callback_url": "OAUTH_CALLBACK_URL",
+                    "oauth_callback_url": "OAUTH_CALLBACK_PATH",
                     "oauth_client_id": "OAUTH_CLIENT_ID",
                     "oauth_client_secret": "OAUTH_CLIENT_SECRET",  # pragma: allowlist secret
                     "oauth_auth_url": "OAUTH_AUTH_URL",

--- a/src/lfx/src/lfx/services/mcp_composer/service.py
+++ b/src/lfx/src/lfx/services/mcp_composer/service.py
@@ -1288,11 +1288,13 @@ class MCPComposerService(Service):
                 # Map auth config to environment variables for OAuth
                 # Note: oauth_host and oauth_port are passed both via --host/--port CLI args
                 # (for server binding) and as environment variables (for OAuth flow)
+                # Note: oauth_callback_path must be a callback path (for example: "/oauth/callback"),
+                # not a full URL. Support legacy oauth_callback_url input for backwards compatibility.
                 oauth_env_mapping = {
                     "oauth_host": "OAUTH_HOST",
                     "oauth_port": "OAUTH_PORT",
                     "oauth_server_url": "OAUTH_SERVER_URL",
-                    "oauth_callback_url": "OAUTH_CALLBACK_PATH",
+                    "oauth_callback_path": "OAUTH_CALLBACK_PATH",
                     "oauth_client_id": "OAUTH_CLIENT_ID",
                     "oauth_client_secret": "OAUTH_CLIENT_SECRET",  # pragma: allowlist secret
                     "oauth_auth_url": "OAUTH_AUTH_URL",
@@ -1301,16 +1303,20 @@ class MCPComposerService(Service):
                     "oauth_provider_scope": "OAUTH_PROVIDER_SCOPE",
                 }
 
-                # Backwards compatibility: if oauth_callback_url not set, try oauth_callback_path
-                if ("oauth_callback_url" not in auth_config or not auth_config.get("oauth_callback_url")) and (
-                    "oauth_callback_path" in auth_config and auth_config.get("oauth_callback_path")
-                ):
-                    auth_config["oauth_callback_url"] = auth_config["oauth_callback_path"]
+                normalized_auth_config = dict(auth_config)
+
+                # Backwards compatibility: accept legacy oauth_callback_url input and normalize it
+                # to oauth_callback_path for internal use.
+                if (
+                    "oauth_callback_path" not in normalized_auth_config
+                    or not normalized_auth_config.get("oauth_callback_path")
+                ) and normalized_auth_config.get("oauth_callback_url"):
+                    normalized_auth_config["oauth_callback_path"] = normalized_auth_config["oauth_callback_url"]
 
                 # Add environment variables as command line arguments
                 # Only set non-empty values to avoid Pydantic validation errors
                 for config_key, env_key in oauth_env_mapping.items():
-                    value = auth_config.get(config_key)
+                    value = normalized_auth_config.get(config_key)
                     if value is not None and str(value).strip():
                         cmd.extend(["--env", env_key, str(value)])
 

--- a/src/lfx/src/lfx/services/mcp_composer/service.py
+++ b/src/lfx/src/lfx/services/mcp_composer/service.py
@@ -1313,8 +1313,9 @@ class MCPComposerService(Service):
                 # Map auth config to environment variables for OAuth
                 # Note: oauth_host and oauth_port are passed both via --host/--port CLI args
                 # (for server binding) and as environment variables (for OAuth flow)
-                # Note: oauth_callback_path must be a callback path (for example: "/oauth/callback"),
-                # not a full URL. Support legacy oauth_callback_url input for backwards compatibility.
+                # Note: mcp-composer expects the env var name OAUTH_CALLBACK_PATH, but the value
+                # is still the full callback URL used as the OAuth redirect_uri. Support legacy
+                # oauth_callback_path input for backwards compatibility.
                 oauth_env_mapping = {
                     "oauth_host": "OAUTH_HOST",
                     "oauth_port": "OAUTH_PORT",

--- a/src/lfx/src/lfx/services/mcp_composer/service.py
+++ b/src/lfx/src/lfx/services/mcp_composer/service.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 from functools import wraps
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from lfx.log.logger import logger
 from lfx.services.base import Service
@@ -1311,7 +1312,15 @@ class MCPComposerService(Service):
                     "oauth_callback_path" not in normalized_auth_config
                     or not normalized_auth_config.get("oauth_callback_path")
                 ) and normalized_auth_config.get("oauth_callback_url"):
-                    normalized_auth_config["oauth_callback_path"] = normalized_auth_config["oauth_callback_url"]
+                    callback_url = str(normalized_auth_config["oauth_callback_url"]).strip()
+                    parsed_callback_url = urlsplit(callback_url)
+                    if parsed_callback_url.scheme or parsed_callback_url.netloc:
+                        callback_path = parsed_callback_url.path or "/"
+                        if parsed_callback_url.query:
+                            callback_path = f"{callback_path}?{parsed_callback_url.query}"
+                        normalized_auth_config["oauth_callback_path"] = callback_path
+                    else:
+                        normalized_auth_config["oauth_callback_path"] = callback_url
 
                 # Add environment variables as command line arguments
                 # Only set non-empty values to avoid Pydantic validation errors

--- a/src/lfx/src/lfx/services/mcp_composer/service.py
+++ b/src/lfx/src/lfx/services/mcp_composer/service.py
@@ -14,7 +14,6 @@ from collections.abc import Callable
 from functools import wraps
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit
 
 from lfx.log.logger import logger
 from lfx.services.base import Service
@@ -835,6 +834,28 @@ class MCPComposerService(Service):
         """
         return None if (value is None or value == "") else value
 
+    @classmethod
+    def _normalize_oauth_callback_aliases(cls, auth_config: dict[str, Any] | None) -> dict[str, Any]:
+        """Normalize OAuth callback aliases to a canonical full callback URL value.
+
+        `oauth_callback_url` is the canonical field name in Langflow. For compatibility,
+        we also accept `oauth_callback_path` and mirror the effective value to both keys so
+        comparisons and subprocess env var mapping stay consistent.
+        """
+        if not auth_config:
+            return {}
+
+        normalized_auth_config = dict(auth_config)
+        callback_url = cls._normalize_config_value(normalized_auth_config.get("oauth_callback_url"))
+        callback_path = cls._normalize_config_value(normalized_auth_config.get("oauth_callback_path"))
+        effective_callback = callback_url or callback_path
+
+        if effective_callback is not None:
+            normalized_auth_config["oauth_callback_url"] = effective_callback
+            normalized_auth_config["oauth_callback_path"] = effective_callback
+
+        return normalized_auth_config
+
     def _has_auth_config_changed(self, existing_auth: dict[str, Any] | None, new_auth: dict[str, Any] | None) -> bool:
         """Check if auth configuration has changed in a way that requires restart."""
         if not existing_auth and not new_auth:
@@ -842,6 +863,9 @@ class MCPComposerService(Service):
 
         if not existing_auth or not new_auth:
             return True
+
+        existing_auth = self._normalize_oauth_callback_aliases(existing_auth)
+        new_auth = self._normalize_oauth_callback_aliases(new_auth)
 
         auth_type = new_auth.get("auth_type", "")
 
@@ -1304,23 +1328,7 @@ class MCPComposerService(Service):
                     "oauth_provider_scope": "OAUTH_PROVIDER_SCOPE",
                 }
 
-                normalized_auth_config = dict(auth_config)
-
-                # Backwards compatibility: accept legacy oauth_callback_url input and normalize it
-                # to oauth_callback_path for internal use.
-                if (
-                    "oauth_callback_path" not in normalized_auth_config
-                    or not normalized_auth_config.get("oauth_callback_path")
-                ) and normalized_auth_config.get("oauth_callback_url"):
-                    callback_url = str(normalized_auth_config["oauth_callback_url"]).strip()
-                    parsed_callback_url = urlsplit(callback_url)
-                    if parsed_callback_url.scheme or parsed_callback_url.netloc:
-                        callback_path = parsed_callback_url.path or "/"
-                        if parsed_callback_url.query:
-                            callback_path = f"{callback_path}?{parsed_callback_url.query}"
-                        normalized_auth_config["oauth_callback_path"] = callback_path
-                    else:
-                        normalized_auth_config["oauth_callback_path"] = callback_url
+                normalized_auth_config = self._normalize_oauth_callback_aliases(auth_config)
 
                 # Add environment variables as command line arguments
                 # Only set non-empty values to avoid Pydantic validation errors

--- a/src/lfx/tests/unit/services/settings/test_mcp_composer.py
+++ b/src/lfx/tests/unit/services/settings/test_mcp_composer.py
@@ -405,3 +405,160 @@ class TestPortChangeHandling:
         mock_start.assert_awaited()
         kwargs = mock_start.call_args.kwargs
         assert kwargs["legacy_sse_url"] == f"{streamable_url}/sse"
+
+
+class TestOAuthCallbackEnvMapping:
+    """Test that OAuth callback URL is mapped to the correct env var for mcp-composer."""
+
+    @pytest.mark.asyncio
+    async def test_callback_url_mapped_to_oauth_callback_path(self, mcp_service):
+        """Verify oauth_callback_url is sent as OAUTH_CALLBACK_PATH, not OAUTH_CALLBACK_URL.
+
+        mcp-composer's ServerSettings model expects a 'callback_path' field
+        (populated via OAUTH_CALLBACK_PATH env var). Sending OAUTH_CALLBACK_URL
+        produces an 'Extra inputs are not permitted' Pydantic validation error.
+        """
+        project_id = "callback-test"
+        callback = "http://localhost:9000/auth/idaas/callback"
+        auth_config = {
+            "auth_type": "oauth",
+            "oauth_host": "localhost",
+            "oauth_port": "9000",
+            "oauth_server_url": "http://localhost:9000",
+            "oauth_callback_url": callback,
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "csecret",  # pragma: allowlist secret
+            "oauth_auth_url": "http://auth",
+            "oauth_token_url": "http://token",
+            "oauth_mcp_scope": "mcp",
+            "oauth_provider_scope": "openid",
+        }
+
+        mcp_service._start_locks[project_id] = asyncio.Lock()
+
+        mock_process = MagicMock(pid=1111)
+        with (
+            patch.object(mcp_service, "_is_port_available", return_value=True),
+            patch.object(
+                mcp_service,
+                "_start_project_composer_process",
+                new=AsyncMock(return_value=mock_process),
+            ) as mock_start,
+        ):
+            await mcp_service._do_start_project_composer(
+                project_id=project_id,
+                streamable_http_url="http://test/mcp",
+                auth_config=auth_config,
+                max_retries=1,
+                max_startup_checks=1,
+                startup_delay=0.1,
+            )
+
+        mock_start.assert_awaited()
+        # auth_config is the 5th positional arg (index 4)
+        passed_auth = mock_start.call_args[0][4]
+
+        # The auth_config should still carry the value under oauth_callback_url
+        assert passed_auth["oauth_callback_url"] == callback
+
+    @pytest.mark.asyncio
+    async def test_callback_path_backwards_compat(self, mcp_service):
+        """Verify legacy oauth_callback_path is promoted and sent as OAUTH_CALLBACK_PATH."""
+        project_id = "compat-test"
+        callback = "http://localhost:9000/auth/callback"
+        auth_config = {
+            "auth_type": "oauth",
+            "oauth_host": "localhost",
+            "oauth_port": "9000",
+            "oauth_server_url": "http://localhost:9000",
+            "oauth_callback_path": callback,
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "csecret",  # pragma: allowlist secret
+            "oauth_auth_url": "http://auth",
+            "oauth_token_url": "http://token",
+        }
+
+        mock_settings = MagicMock()
+        mock_settings.settings.mcp_composer_version = "==0.1.0.8.10"
+
+        mock_process = MagicMock(pid=2222, poll=MagicMock(return_value=None))
+
+        with (
+            patch("lfx.services.mcp_composer.service.get_settings_service", return_value=mock_settings),
+            patch("subprocess.Popen", return_value=mock_process) as mock_popen,
+            patch.object(mcp_service, "_is_port_available", return_value=False),
+        ):
+            await mcp_service._start_project_composer_process(
+                project_id=project_id,
+                host="localhost",
+                port=9000,
+                streamable_http_url="http://test/mcp",
+                auth_config=auth_config,
+                max_startup_checks=1,
+                startup_delay=0.01,
+            )
+
+        cmd = mock_popen.call_args[0][0]
+
+        # Legacy oauth_callback_path should be promoted and sent as OAUTH_CALLBACK_PATH
+        assert "OAUTH_CALLBACK_PATH" in cmd, f"Expected OAUTH_CALLBACK_PATH in command but got: {cmd}"
+        idx = cmd.index("OAUTH_CALLBACK_PATH")
+        assert cmd[idx + 1] == callback
+
+    @pytest.mark.asyncio
+    async def test_subprocess_receives_callback_path_env_var(self, mcp_service):
+        """Verify the subprocess command uses OAUTH_CALLBACK_PATH, not OAUTH_CALLBACK_URL.
+
+        This is the core regression test: mcp-composer's ServerSettings has a
+        'callback_path' field (env_prefix='OAUTH_'), so the env var must be
+        OAUTH_CALLBACK_PATH.  Sending OAUTH_CALLBACK_URL causes a Pydantic
+        'extra_forbidden' validation error.
+        """
+        project_id = "env-var-test"
+        callback = "http://localhost:9000/auth/idaas/callback"
+        auth_config = {
+            "auth_type": "oauth",
+            "oauth_host": "localhost",
+            "oauth_port": "9000",
+            "oauth_server_url": "http://localhost:9000",
+            "oauth_callback_url": callback,
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "csecret",  # pragma: allowlist secret
+            "oauth_auth_url": "http://auth",
+            "oauth_token_url": "http://token",
+            "oauth_mcp_scope": "mcp",
+            "oauth_provider_scope": "openid",
+        }
+
+        mock_settings = MagicMock()
+        mock_settings.settings.mcp_composer_version = "==0.1.0.8.10"
+
+        mock_process = MagicMock(pid=3333, poll=MagicMock(return_value=None))
+
+        with (
+            patch("lfx.services.mcp_composer.service.get_settings_service", return_value=mock_settings),
+            patch("subprocess.Popen", return_value=mock_process) as mock_popen,
+            patch.object(mcp_service, "_is_port_available", return_value=False),
+        ):
+            await mcp_service._start_project_composer_process(
+                project_id=project_id,
+                host="localhost",
+                port=9000,
+                streamable_http_url="http://test/mcp",
+                auth_config=auth_config,
+                max_startup_checks=1,
+                startup_delay=0.01,
+            )
+
+        cmd = mock_popen.call_args[0][0]
+
+        # OAUTH_CALLBACK_PATH must appear in the command
+        assert "OAUTH_CALLBACK_PATH" in cmd, f"Expected OAUTH_CALLBACK_PATH in command but got: {cmd}"
+        # The callback value should follow the env key
+        idx = cmd.index("OAUTH_CALLBACK_PATH")
+        assert cmd[idx + 1] == callback
+
+        # OAUTH_CALLBACK_URL must NOT appear (would cause extra_forbidden error)
+        assert "OAUTH_CALLBACK_URL" not in cmd, (
+            f"OAUTH_CALLBACK_URL should not be in command (mcp-composer rejects it): {cmd}"
+        )

--- a/src/lfx/tests/unit/services/settings/test_mcp_composer.py
+++ b/src/lfx/tests/unit/services/settings/test_mcp_composer.py
@@ -507,6 +507,49 @@ class TestOAuthCallbackConfigForwarding:
         assert cmd[idx + 1] == callback_url
 
     @pytest.mark.asyncio
+    async def test_callback_url_wins_when_both_callback_fields_are_present(self, mcp_service):
+        """Verify canonical oauth_callback_url takes precedence over deprecated oauth_callback_path."""
+        project_id = "canonical-callback-test"
+        callback_url = "http://localhost:9000/auth/idaas/callback"
+        stale_callback_path = "http://localhost:9999/stale/callback"
+        auth_config = {
+            "auth_type": "oauth",
+            "oauth_host": "localhost",
+            "oauth_port": "9000",
+            "oauth_server_url": "http://localhost:9000",
+            "oauth_callback_url": callback_url,
+            "oauth_callback_path": stale_callback_path,
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "csecret",  # pragma: allowlist secret
+            "oauth_auth_url": "http://auth",
+            "oauth_token_url": "http://token",
+        }
+
+        mock_settings = MagicMock()
+        mock_settings.settings.mcp_composer_version = "==0.1.0.8.10"
+
+        mock_process = MagicMock(pid=4444, poll=MagicMock(return_value=None))
+
+        with (
+            patch("lfx.services.mcp_composer.service.get_settings_service", return_value=mock_settings),
+            patch("subprocess.Popen", return_value=mock_process) as mock_popen,
+            patch.object(mcp_service, "_is_port_available", return_value=False),
+        ):
+            await mcp_service._start_project_composer_process(
+                project_id=project_id,
+                host="localhost",
+                port=9000,
+                streamable_http_url="http://test/mcp",
+                auth_config=auth_config,
+                max_startup_checks=1,
+                startup_delay=0.01,
+            )
+
+        cmd = mock_popen.call_args[0][0]
+        idx = cmd.index("OAUTH_CALLBACK_PATH")
+        assert cmd[idx + 1] == callback_url
+
+    @pytest.mark.asyncio
     async def test_subprocess_receives_callback_path_env_var(self, mcp_service):
         """Verify the subprocess command uses OAUTH_CALLBACK_PATH, not OAUTH_CALLBACK_URL.
 
@@ -563,3 +606,30 @@ class TestOAuthCallbackConfigForwarding:
         assert "OAUTH_CALLBACK_URL" not in cmd, (
             f"OAUTH_CALLBACK_URL should not be in command (mcp-composer rejects it): {cmd}"
         )
+
+    def test_callback_aliases_do_not_trigger_restart_when_effective_value_matches(self, mcp_service):
+        """Alias-only callback field changes should not force composer restarts."""
+        existing_auth = {
+            "auth_type": "oauth",
+            "oauth_host": "localhost",
+            "oauth_port": "9000",
+            "oauth_server_url": "http://localhost:9000",
+            "oauth_callback_path": "http://localhost:9000/auth/idaas/callback",
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "csecret",  # pragma: allowlist secret
+            "oauth_auth_url": "http://auth",
+            "oauth_token_url": "http://token",
+        }
+        new_auth = {
+            "auth_type": "oauth",
+            "oauth_host": "localhost",
+            "oauth_port": "9000",
+            "oauth_server_url": "http://localhost:9000",
+            "oauth_callback_url": "http://localhost:9000/auth/idaas/callback",
+            "oauth_client_id": "cid",
+            "oauth_client_secret": "csecret",  # pragma: allowlist secret
+            "oauth_auth_url": "http://auth",
+            "oauth_token_url": "http://token",
+        }
+
+        assert mcp_service._has_auth_config_changed(existing_auth, new_auth) is False

--- a/src/lfx/tests/unit/services/settings/test_mcp_composer.py
+++ b/src/lfx/tests/unit/services/settings/test_mcp_composer.py
@@ -407,16 +407,17 @@ class TestPortChangeHandling:
         assert kwargs["legacy_sse_url"] == f"{streamable_url}/sse"
 
 
-class TestOAuthCallbackEnvMapping:
-    """Test that OAuth callback URL is mapped to the correct env var for mcp-composer."""
+class TestOAuthCallbackConfigForwarding:
+    """Test that OAuth callback config is forwarded to process startup unchanged."""
 
     @pytest.mark.asyncio
-    async def test_callback_url_mapped_to_oauth_callback_path(self, mcp_service):
-        """Verify oauth_callback_url is sent as OAUTH_CALLBACK_PATH, not OAUTH_CALLBACK_URL.
+    async def test_callback_url_forwarded_to_start_process_auth_config(self, mcp_service):
+        """Verify oauth_callback_url is preserved when passed to process startup.
 
-        mcp-composer's ServerSettings model expects a 'callback_path' field
-        (populated via OAUTH_CALLBACK_PATH env var). Sending OAUTH_CALLBACK_URL
-        produces an 'Extra inputs are not permitted' Pydantic validation error.
+        This test patches _start_project_composer_process, so it does not verify
+        env-var mapping such as OAUTH_CALLBACK_PATH vs OAUTH_CALLBACK_URL. It
+        only verifies that _do_start_project_composer forwards the callback URL
+        in auth_config to the process-start method unchanged.
         """
         project_id = "callback-test"
         callback = "http://localhost:9000/auth/idaas/callback"
@@ -458,7 +459,7 @@ class TestOAuthCallbackEnvMapping:
         # auth_config is the 5th positional arg (index 4)
         passed_auth = mock_start.call_args[0][4]
 
-        # The auth_config should still carry the value under oauth_callback_url
+        # The auth_config should still carry the value under oauth_callback_url.
         assert passed_auth["oauth_callback_url"] == callback
 
     @pytest.mark.asyncio

--- a/src/lfx/tests/unit/services/settings/test_mcp_composer.py
+++ b/src/lfx/tests/unit/services/settings/test_mcp_composer.py
@@ -463,16 +463,16 @@ class TestOAuthCallbackConfigForwarding:
         assert passed_auth["oauth_callback_url"] == callback
 
     @pytest.mark.asyncio
-    async def test_callback_path_backwards_compat(self, mcp_service):
-        """Verify legacy oauth_callback_path is promoted and sent as OAUTH_CALLBACK_PATH."""
+    async def test_callback_url_backwards_compat(self, mcp_service):
+        """Verify legacy oauth_callback_url is promoted and sent as OAUTH_CALLBACK_PATH."""
         project_id = "compat-test"
-        callback = "http://localhost:9000/auth/callback"
+        callback_url = "http://localhost:9000/auth/callback"
         auth_config = {
             "auth_type": "oauth",
             "oauth_host": "localhost",
             "oauth_port": "9000",
             "oauth_server_url": "http://localhost:9000",
-            "oauth_callback_path": callback,
+            "oauth_callback_url": callback_url,
             "oauth_client_id": "cid",
             "oauth_client_secret": "csecret",  # pragma: allowlist secret
             "oauth_auth_url": "http://auth",
@@ -501,10 +501,10 @@ class TestOAuthCallbackConfigForwarding:
 
         cmd = mock_popen.call_args[0][0]
 
-        # Legacy oauth_callback_path should be promoted and sent as OAUTH_CALLBACK_PATH
+        # Legacy oauth_callback_url should be promoted and sent as OAUTH_CALLBACK_PATH
         assert "OAUTH_CALLBACK_PATH" in cmd, f"Expected OAUTH_CALLBACK_PATH in command but got: {cmd}"
         idx = cmd.index("OAUTH_CALLBACK_PATH")
-        assert cmd[idx + 1] == callback
+        assert cmd[idx + 1] == callback_url
 
     @pytest.mark.asyncio
     async def test_subprocess_receives_callback_path_env_var(self, mcp_service):


### PR DESCRIPTION
This pull request updates the environment variable mapping for the OAuth callback in the `mcp-composer` service to ensure compatibility with its expected configuration, and adds comprehensive tests to prevent regressions related to this mapping. The most important changes are:

**OAuth Callback Environment Variable Mapping:**

* The mapping for the OAuth callback environment variable in `_start_project_composer_process` was changed from `OAUTH_CALLBACK_URL` to `OAUTH_CALLBACK_PATH` to match the expectations of the `mcp-composer`'s `ServerSettings` model and avoid Pydantic validation errors.

**Testing and Validation:**

* Added a new test class `TestOAuthCallbackEnvMapping` in `test_mcp_composer.py` with tests to:
  - Ensure that `oauth_callback_url` is mapped to `OAUTH_CALLBACK_PATH` and not `OAUTH_CALLBACK_URL` when starting the subprocess.
  - Verify backwards compatibility by promoting legacy `oauth_callback_path` to `OAUTH_CALLBACK_PATH`.
  - Assert that the subprocess command receives `OAUTH_CALLBACK_PATH` and does not include `OAUTH_CALLBACK_URL`, preventing validation errors in `mcp-composer`.