### PR TITLE
chore(i18n): disable automatic browser language detection

### DIFF
--- a/src/frontend/src/i18n.ts
+++ b/src/frontend/src/i18n.ts
@@ -2,16 +2,11 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import en from "./locales/en.json";
 
-const detectedLang =
-  localStorage.getItem("languagePreference") ||
-  navigator.language.split("-")[0] ||
-  "en";
-
 i18n.use(initReactI18next).init({
   resources: {
     en: { translation: en },
   },
-  lng: detectedLang,
+  lng: "en",
   fallbackLng: "en",
   interpolation: {
     escapeValue: false,

--- a/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx
@@ -21,7 +21,6 @@ import type {
 } from "../../../../types/components";
 import useScrollToElement from "../hooks/use-scroll-to-element";
 import GeneralPageHeaderComponent from "./components/GeneralPageHeader";
-import LanguageFormComponent from "./components/LanguageForm";
 import PasswordFormComponent from "./components/PasswordForm";
 import ProfilePictureFormComponent from "./components/ProfilePictureForm";
 
@@ -139,8 +138,6 @@ export const GeneralPage = () => {
       <GeneralPageHeaderComponent />
 
       <div className="flex w-full flex-col gap-6">
-        <LanguageFormComponent />
-
         {ENABLE_PROFILE_ICONS && (
           <ProfilePictureFormComponent
             profilePicture={profilePicture}


### PR DESCRIPTION
## Summary
- Removes automatic browser language detection via `navigator.language`
- Removes `localStorage` language preference lookup
- Hardcodes `lng: "en"` until full i18n language selection is implemented

## Test plan
- [ ] Verify app loads in English regardless of browser language setting
- [ ] Verify no language switching occurs on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)