### PR TITLE
fix(frontend): show global variable dropdown only for password inputs

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/__tests__/index.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/__tests__/index.test.tsx
@@ -90,7 +90,10 @@ const buildTemplateData = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-const buildProps = (templateDataOverrides = {}, propOverrides: Record<string, unknown> = {}) => ({
+const buildProps = (
+  templateDataOverrides = {},
+  propOverrides: Record<string, unknown> = {},
+) => ({
   templateData: buildTemplateData(templateDataOverrides),
   name: "test_field",
   display_name: "Test Field",
@@ -164,13 +167,19 @@ describe("StrRenderComponent", () => {
     });
 
     it("renders CopyFieldAreaComponent for a multiline copy_field", () => {
-      render(<StrRenderComponent {...buildProps({ multiline: true, copy_field: true })} />);
+      render(
+        <StrRenderComponent
+          {...buildProps({ multiline: true, copy_field: true })}
+        />,
+      );
       expect(mockCopyFieldAreaComponent).toHaveBeenCalled();
       expect(mockTextAreaComponent).not.toHaveBeenCalled();
     });
 
     it("renders DropdownComponent when options are present", () => {
-      render(<StrRenderComponent {...buildProps({ options: ["a", "b", "c"] })} />);
+      render(
+        <StrRenderComponent {...buildProps({ options: ["a", "b", "c"] })} />,
+      );
       expect(mockDropdownComponent).toHaveBeenCalled();
       expect(mockInputComponent).not.toHaveBeenCalled();
     });
@@ -181,14 +190,20 @@ describe("StrRenderComponent", () => {
   describe("hasRefreshButton forwarding", () => {
     it("forwards hasRefreshButton=true to InputGlobalComponent", () => {
       render(
-        <StrRenderComponent {...buildProps({ type: "SecretStr", refresh_button: true })} />,
+        <StrRenderComponent
+          {...buildProps({ type: "SecretStr", refresh_button: true })}
+        />,
       );
       const receivedProps = mockInputGlobalComponent.mock.calls[0][0];
       expect(receivedProps.hasRefreshButton).toBe(true);
     });
 
     it("forwards hasRefreshButton=false to InputGlobalComponent when refresh_button is absent", () => {
-      render(<StrRenderComponent {...buildProps({ type: "SecretStr", refresh_button: false })} />);
+      render(
+        <StrRenderComponent
+          {...buildProps({ type: "SecretStr", refresh_button: false })}
+        />,
+      );
       const receivedProps = mockInputGlobalComponent.mock.calls[0][0];
       expect(receivedProps.hasRefreshButton).toBe(false);
     });

--- a/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/__tests__/index.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/__tests__/index.test.tsx
@@ -1,0 +1,317 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { StrRenderComponent } from "..";
+
+// ── child component mocks ────────────────────────────────────────────────────
+
+const mockInputGlobalComponent = jest.fn().mockReturnValue(null);
+const mockInputComponent = jest.fn().mockReturnValue(null);
+const mockTextAreaComponent = jest.fn().mockReturnValue(null);
+const mockDropdownComponent = jest.fn().mockReturnValue(null);
+const mockWebhookFieldComponent = jest.fn().mockReturnValue(null);
+const mockCopyFieldAreaComponent = jest.fn().mockReturnValue(null);
+
+jest.mock(
+  "@/components/core/parameterRenderComponent/components/inputGlobalComponent",
+  () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+      mockInputGlobalComponent(props);
+      return null;
+    },
+  }),
+);
+
+jest.mock(
+  "@/components/core/parameterRenderComponent/components/inputComponent",
+  () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+      mockInputComponent(props);
+      return null;
+    },
+  }),
+);
+
+jest.mock(
+  "@/components/core/parameterRenderComponent/components/textAreaComponent",
+  () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+      mockTextAreaComponent(props);
+      return null;
+    },
+  }),
+);
+
+jest.mock(
+  "@/components/core/parameterRenderComponent/components/dropdownComponent",
+  () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+      mockDropdownComponent(props);
+      return null;
+    },
+  }),
+);
+
+jest.mock(
+  "@/components/core/parameterRenderComponent/components/webhookFieldComponent",
+  () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+      mockWebhookFieldComponent(props);
+      return null;
+    },
+  }),
+);
+
+jest.mock(
+  "@/components/core/parameterRenderComponent/components/copyFieldAreaComponent",
+  () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+      mockCopyFieldAreaComponent(props);
+      return null;
+    },
+  }),
+);
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const buildTemplateData = (overrides: Record<string, unknown> = {}) => ({
+  type: "str",
+  password: false,
+  multiline: false,
+  copy_field: false,
+  load_from_db: false,
+  refresh_button: false,
+  options: undefined,
+  combobox: false,
+  ...overrides,
+});
+
+const buildProps = (templateDataOverrides = {}, propOverrides: Record<string, unknown> = {}) => ({
+  templateData: buildTemplateData(templateDataOverrides),
+  name: "test_field",
+  display_name: "Test Field",
+  placeholder: "Enter value",
+  nodeId: "node-1",
+  nodeClass: {} as any,
+  handleNodeClass: jest.fn(),
+  id: "test-field-id",
+  value: "",
+  editNode: false,
+  handleOnNewValue: jest.fn(),
+  disabled: false,
+  isToolMode: false,
+  nodeInformationMetadata: undefined,
+  ...propOverrides,
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("StrRenderComponent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── component selection ──────────────────────────────────────────────────
+
+  describe("component selection", () => {
+    it("renders InputGlobalComponent for SecretStr type", () => {
+      render(<StrRenderComponent {...buildProps({ type: "SecretStr" })} />);
+      expect(mockInputGlobalComponent).toHaveBeenCalled();
+      expect(mockInputComponent).not.toHaveBeenCalled();
+    });
+
+    it("renders InputGlobalComponent when password is true", () => {
+      render(<StrRenderComponent {...buildProps({ password: true })} />);
+      expect(mockInputGlobalComponent).toHaveBeenCalled();
+      expect(mockInputComponent).not.toHaveBeenCalled();
+    });
+
+    it("renders plain InputComponent for a non-secret, non-password field", () => {
+      render(<StrRenderComponent {...buildProps()} />);
+      expect(mockInputComponent).toHaveBeenCalled();
+      expect(mockInputGlobalComponent).not.toHaveBeenCalled();
+    });
+
+    it("renders TextAreaComponent for a multiline field", () => {
+      render(<StrRenderComponent {...buildProps({ multiline: true })} />);
+      expect(mockTextAreaComponent).toHaveBeenCalled();
+      expect(mockInputComponent).not.toHaveBeenCalled();
+    });
+
+    it("renders WebhookFieldComponent for a multiline webhook node", () => {
+      render(
+        <StrRenderComponent
+          {...buildProps(
+            { multiline: true },
+            {
+              nodeInformationMetadata: {
+                nodeType: "webhook",
+                flowId: "flow-1",
+                flowName: "Flow",
+                isAuth: false,
+                variableName: "",
+              },
+            },
+          )}
+        />,
+      );
+      expect(mockWebhookFieldComponent).toHaveBeenCalled();
+      expect(mockTextAreaComponent).not.toHaveBeenCalled();
+    });
+
+    it("renders CopyFieldAreaComponent for a multiline copy_field", () => {
+      render(<StrRenderComponent {...buildProps({ multiline: true, copy_field: true })} />);
+      expect(mockCopyFieldAreaComponent).toHaveBeenCalled();
+      expect(mockTextAreaComponent).not.toHaveBeenCalled();
+    });
+
+    it("renders DropdownComponent when options are present", () => {
+      render(<StrRenderComponent {...buildProps({ options: ["a", "b", "c"] })} />);
+      expect(mockDropdownComponent).toHaveBeenCalled();
+      expect(mockInputComponent).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── hasRefreshButton forwarding ──────────────────────────────────────────
+
+  describe("hasRefreshButton forwarding", () => {
+    it("forwards hasRefreshButton=true to InputGlobalComponent", () => {
+      render(
+        <StrRenderComponent {...buildProps({ type: "SecretStr", refresh_button: true })} />,
+      );
+      const receivedProps = mockInputGlobalComponent.mock.calls[0][0];
+      expect(receivedProps.hasRefreshButton).toBe(true);
+    });
+
+    it("forwards hasRefreshButton=false to InputGlobalComponent when refresh_button is absent", () => {
+      render(<StrRenderComponent {...buildProps({ type: "SecretStr", refresh_button: false })} />);
+      const receivedProps = mockInputGlobalComponent.mock.calls[0][0];
+      expect(receivedProps.hasRefreshButton).toBe(false);
+    });
+
+    it("forwards hasRefreshButton=true to plain InputComponent", () => {
+      render(<StrRenderComponent {...buildProps({ refresh_button: true })} />);
+      const receivedProps = mockInputComponent.mock.calls[0][0];
+      expect(receivedProps.hasRefreshButton).toBe(true);
+    });
+
+    it("forwards hasRefreshButton=false to plain InputComponent when refresh_button is absent", () => {
+      render(<StrRenderComponent {...buildProps({ refresh_button: false })} />);
+      const receivedProps = mockInputComponent.mock.calls[0][0];
+      expect(receivedProps.hasRefreshButton).toBe(false);
+    });
+  });
+
+  // ── load_from_db cleanup effect ──────────────────────────────────────────
+
+  describe("load_from_db cleanup effect", () => {
+    it("clears load_from_db when the field is not a global-variable field and load_from_db is true", async () => {
+      const handleOnNewValue = jest.fn();
+      render(
+        <StrRenderComponent
+          {...buildProps(
+            { type: "str", password: false, load_from_db: true },
+            { handleOnNewValue },
+          )}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(handleOnNewValue).toHaveBeenCalledWith(
+          { load_from_db: false },
+          { skipSnapshot: true },
+        );
+      });
+    });
+
+    it("does not clear load_from_db for a SecretStr field", async () => {
+      const handleOnNewValue = jest.fn();
+      render(
+        <StrRenderComponent
+          {...buildProps(
+            { type: "SecretStr", load_from_db: true },
+            { handleOnNewValue },
+          )}
+        />,
+      );
+
+      // Give the effect time to potentially fire
+      await act(async () => {});
+
+      expect(handleOnNewValue).not.toHaveBeenCalled();
+    });
+
+    it("does not clear load_from_db for a password=true field", async () => {
+      const handleOnNewValue = jest.fn();
+      render(
+        <StrRenderComponent
+          {...buildProps(
+            { type: "str", password: true, load_from_db: true },
+            { handleOnNewValue },
+          )}
+        />,
+      );
+
+      await act(async () => {});
+
+      expect(handleOnNewValue).not.toHaveBeenCalled();
+    });
+
+    it("does not call handleOnNewValue when load_from_db is already false", async () => {
+      const handleOnNewValue = jest.fn();
+      render(
+        <StrRenderComponent
+          {...buildProps(
+            { type: "str", password: false, load_from_db: false },
+            { handleOnNewValue },
+          )}
+        />,
+      );
+
+      await act(async () => {});
+
+      expect(handleOnNewValue).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── InputComponent onChange behaviour ────────────────────────────────────
+
+  describe("plain InputComponent onChange", () => {
+    it("always passes load_from_db: false when the user types", () => {
+      const handleOnNewValue = jest.fn();
+      render(<StrRenderComponent {...buildProps({}, { handleOnNewValue })} />);
+
+      // Extract the onChange prop forwarded to InputComponent
+      const { onChange } = mockInputComponent.mock.calls[0][0] as {
+        onChange: (value: string, skipSnapshot?: boolean) => void;
+      };
+
+      onChange("hello");
+
+      expect(handleOnNewValue).toHaveBeenCalledWith(
+        { value: "hello", load_from_db: false },
+        { skipSnapshot: undefined },
+      );
+    });
+
+    it("forwards the skipSnapshot flag through to handleOnNewValue", () => {
+      const handleOnNewValue = jest.fn();
+      render(<StrRenderComponent {...buildProps({}, { handleOnNewValue })} />);
+
+      const { onChange } = mockInputComponent.mock.calls[0][0] as {
+        onChange: (value: string, skipSnapshot?: boolean) => void;
+      };
+
+      onChange("world", true);
+
+      expect(handleOnNewValue).toHaveBeenCalledWith(
+        { value: "world", load_from_db: false },
+        { skipSnapshot: true },
+      );
+    });
+  });
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx
@@ -1,6 +1,9 @@
+import { useEffect } from "react";
 import type { InputProps, StrRenderComponentType } from "../../types";
 import CopyFieldAreaComponent from "../copyFieldAreaComponent";
 import DropdownComponent from "../dropdownComponent";
+import { getPlaceholder } from "../../helpers/get-placeholder-disabled";
+import InputComponent from "../inputComponent";
 import InputGlobalComponent from "../inputGlobalComponent";
 import TextAreaComponent from "../textAreaComponent";
 import WebhookFieldComponent from "../webhookFieldComponent";
@@ -17,6 +20,15 @@ export function StrRenderComponent({
 }: InputProps<string, StrRenderComponentType>) {
   const { handleOnNewValue, id, isToolMode, nodeInformationMetadata } =
     baseInputProps;
+
+  const allowGlobalVariables =
+    templateData.type === "SecretStr" || templateData.password === true;
+
+  useEffect(() => {
+    if (!allowGlobalVariables && templateData.load_from_db) {
+      handleOnNewValue({ load_from_db: false }, { skipSnapshot: true });
+    }
+  }, [allowGlobalVariables, templateData.load_from_db, handleOnNewValue]);
 
   const noOptions = !templateData.options;
   const isMultiline = templateData.multiline;
@@ -51,15 +63,39 @@ export function StrRenderComponent({
       );
     }
 
+    if (allowGlobalVariables) {
+      return (
+        <InputGlobalComponent
+          {...baseInputProps}
+          password={templateData.password}
+          load_from_db={templateData.load_from_db}
+          placeholder={placeholder}
+          display_name={display_name}
+          id={`input-${name}`}
+          isToolMode={isToolMode}
+          hasRefreshButton={!!templateData.refresh_button}
+        />
+      );
+    }
+
     return (
-      <InputGlobalComponent
-        {...baseInputProps}
-        password={templateData.password}
-        load_from_db={templateData.load_from_db}
-        placeholder={placeholder}
-        display_name={display_name}
+      <InputComponent
+        nodeStyle
+        placeholder={getPlaceholder(!!baseInputProps.disabled, placeholder)}
         id={`input-${name}`}
+        editNode={baseInputProps.editNode}
+        disabled={baseInputProps.disabled}
+        password={templateData.password ?? false}
+        value={baseInputProps.value ?? ""}
+        onChange={(inputValue: string, skipSnapshot?: boolean) => {
+          handleOnNewValue(
+            { value: inputValue, load_from_db: false },
+            { skipSnapshot },
+          );
+        }}
         isToolMode={isToolMode}
+        hasRefreshButton={!!templateData.refresh_button}
+        inspectionPanel={baseInputProps.inspectionPanel}
       />
     );
   }

--- a/src/frontend/tests/core/features/globalVariables.spec.ts
+++ b/src/frontend/tests/core/features/globalVariables.spec.ts
@@ -3,7 +3,6 @@ import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 
 import { initialGPTsetup } from "../../utils/initialGPTsetup";
-import { zoomOut } from "../../utils/zoom-out";
 
 test(
   "user must be able to save or delete a global variable",
@@ -42,6 +41,8 @@ test(
     const credentialName = Math.random().toString();
 
     await page.getByText("OpenAI", { exact: true }).last().click();
+
+    await page.getByTestId("remove-icon-badge").click();
 
     await page.getByTestId("icon-Globe").nth(0).click();
     await page.getByText("Add New Variable", { exact: true }).click();


### PR DESCRIPTION
Description

The global variable component was available for all input fields, for all components. I made sure it is available alone for SecretStr and if templateData.password is true

Screenshot

Before

https://github.com/user-attachments/assets/903d3c8d-6415-453f-9e16-1f36840c6dca


After
https://github.com/user-attachments/assets/436a70a5-06f6-4ee6-bb9f-f00af1fe14f1

