### PR TITLE
feat: validate duplicate tool names at deployment review step

### DIFF
--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -866,7 +866,7 @@ async def list_deployment_snapshots(
     deployment_id: DeploymentIdQuery | None = None,
     provider_snapshot_names: Annotated[
         list[str] | None,
-        Query(description="Filter snapshots by provider tool names."),
+        Query(min_length=1, description="Filter snapshots by provider tool names."),
     ] = None,
     page: Annotated[int, Query(ge=1)] = 1,
     size: Annotated[int, Query(ge=1, le=50)] = 20,

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -17,6 +17,7 @@ from lfx.services.adapters.deployment.schema import (
     DeploymentType,
     DeploymentUpdateResult,
 )
+from pydantic import AfterValidator, StringConstraints
 
 from langflow.api.utils import CurrentActiveUser, DbSession, DbSessionReadOnly
 from langflow.api.v1.mappers.deployments import get_deployment_mapper
@@ -129,6 +130,16 @@ DeploymentIdQuery = Annotated[
     UUID,
     Query(description="Langflow DB deployment UUID (`deployment.id`)."),
 ]
+SnapshotNameQueryItem = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+def _dedupe_snapshot_names(values: list[str] | None) -> list[str] | None:
+    if values is None:
+        return None
+    return list(dict.fromkeys(values))
+
+
+SnapshotNamesQuery = Annotated[list[SnapshotNameQueryItem] | None, AfterValidator(_dedupe_snapshot_names)]
 IncludeProviderDeleteQuery = Annotated[
     bool,
     Query(
@@ -864,14 +875,20 @@ async def list_deployment_snapshots(
     session: DbSessionReadOnly,
     current_user: CurrentActiveUser,
     deployment_id: DeploymentIdQuery | None = None,
-    provider_snapshot_names: Annotated[
-        list[str] | None,
-        Query(min_length=1, description="Filter snapshots by provider tool names."),
+    names: Annotated[
+        SnapshotNamesQuery,
+        Query(min_length=1, description="Filter by provider-owned snapshot names."),
     ] = None,
     page: Annotated[int, Query(ge=1)] = 1,
     size: Annotated[int, Query(ge=1, le=50)] = 20,
 ):
     """List deployment snapshots/tools."""
+    if deployment_id is not None and names is not None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="filtering by both deployment_id and names is not supported.",
+        )
+
     provider_account = await get_owned_provider_account_or_404(
         provider_id=provider_id,
         user_id=current_user.id,
@@ -892,7 +909,7 @@ async def list_deployment_snapshots(
     deployment_mapper = get_deployment_mapper(provider_account.provider_key)
     adapter_params = await deployment_mapper.resolve_snapshot_list_adapter_params(
         deployment_resource_key=deployment_row.resource_key if deployment_row is not None else None,
-        snapshot_names=provider_snapshot_names,
+        snapshot_names=names,
         provider_params=None,
         db=session,
     )

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -904,6 +904,46 @@ async def list_deployment_snapshots(
     )
 
 
+@router.get("/snapshots/check-names")
+async def check_snapshot_names(
+    provider_id: DeploymentProviderAccountIdQuery,
+    session: DbSessionReadOnly,
+    current_user: CurrentActiveUser,
+    names: Annotated[list[str], Query(description="Tool names to check for existence.")],
+):
+    """Check which tool names already exist in the provider.
+
+    Returns a mapping of each queried name to a boolean indicating existence.
+    Uses the provider SDK's name-based lookup for efficient server-side filtering.
+    """
+    if not names:
+        return {"existing_names": []}
+
+    provider_account = await get_owned_provider_account_or_404(
+        provider_id=provider_id,
+        user_id=current_user.id,
+        db=session,
+    )
+    deployment_adapter = resolve_deployment_adapter(provider_account.provider_key)
+    with (
+        handle_adapter_errors(mapper=get_deployment_mapper(provider_account.provider_key)),
+        deployment_provider_scope(
+            provider_account.id,
+        ),
+    ):
+        try:
+            existing = await deployment_adapter.check_tool_names_exist(
+                user_id=current_user.id,
+                names=names,
+                db=session,
+            )
+        except Exception:  # noqa: BLE001
+            # If the adapter doesn't support name-check, return empty.
+            existing = []
+
+    return {"existing_names": existing}
+
+
 @router.patch(
     "/snapshots/{provider_snapshot_id}",
     response_model=SnapshotUpdateResponse,

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -864,6 +864,10 @@ async def list_deployment_snapshots(
     session: DbSessionReadOnly,
     current_user: CurrentActiveUser,
     deployment_id: DeploymentIdQuery | None = None,
+    provider_snapshot_names: Annotated[
+        list[str] | None,
+        Query(description="Filter snapshots by provider tool names."),
+    ] = None,
     page: Annotated[int, Query(ge=1)] = 1,
     size: Annotated[int, Query(ge=1, le=50)] = 20,
 ):
@@ -888,6 +892,7 @@ async def list_deployment_snapshots(
     deployment_mapper = get_deployment_mapper(provider_account.provider_key)
     adapter_params = await deployment_mapper.resolve_snapshot_list_adapter_params(
         deployment_resource_key=deployment_row.resource_key if deployment_row is not None else None,
+        snapshot_names=provider_snapshot_names,
         provider_params=None,
         db=session,
     )
@@ -902,46 +907,6 @@ async def list_deployment_snapshots(
         page=page,
         size=size,
     )
-
-
-@router.get("/snapshots/check-names")
-async def check_snapshot_names(
-    provider_id: DeploymentProviderAccountIdQuery,
-    session: DbSessionReadOnly,
-    current_user: CurrentActiveUser,
-    names: Annotated[list[str], Query(description="Tool names to check for existence.")],
-):
-    """Check which tool names already exist in the provider.
-
-    Returns a mapping of each queried name to a boolean indicating existence.
-    Uses the provider SDK's name-based lookup for efficient server-side filtering.
-    """
-    if not names:
-        return {"existing_names": []}
-
-    provider_account = await get_owned_provider_account_or_404(
-        provider_id=provider_id,
-        user_id=current_user.id,
-        db=session,
-    )
-    deployment_adapter = resolve_deployment_adapter(provider_account.provider_key)
-    with (
-        handle_adapter_errors(mapper=get_deployment_mapper(provider_account.provider_key)),
-        deployment_provider_scope(
-            provider_account.id,
-        ),
-    ):
-        try:
-            existing = await deployment_adapter.check_tool_names_exist(
-                user_id=current_user.id,
-                names=names,
-                db=session,
-            )
-        except Exception:  # noqa: BLE001
-            # If the adapter doesn't support name-check, return empty.
-            existing = []
-
-    return {"existing_names": existing}
 
 
 @router.patch(

--- a/src/backend/base/langflow/api/v1/mappers/deployments/base.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/base.py
@@ -296,12 +296,14 @@ class BaseDeploymentMapper:
         self,
         *,
         deployment_resource_key: str | None,
+        snapshot_names: list[str] | None = None,
         provider_params: dict[str, Any] | None,
         db: AsyncSession,
     ) -> SnapshotListParams:
         resolved_provider_params = await self.resolve_snapshot_list_params(provider_params, db)
         return SnapshotListParams(
             deployment_ids=[deployment_resource_key] if deployment_resource_key is not None else None,
+            snapshot_names=snapshot_names or None,
             provider_params=resolved_provider_params,
         )
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -18,6 +18,7 @@ from lfx.services.adapters.deployment.schema import (
     DeploymentUpdateResult,
     ExecutionCreateResult,
     ExecutionStatusResult,
+    SnapshotListParams,
     SnapshotListResult,
     VerifyCredentials,
 )
@@ -312,6 +313,22 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
             raw=provider_data,
         )
         return parsed.model_dump()
+
+    async def resolve_snapshot_list_adapter_params(
+        self,
+        *,
+        deployment_resource_key: str | None,
+        snapshot_names: list[str] | None = None,
+        provider_params: dict[str, Any] | None,
+        db: AsyncSession,
+    ) -> SnapshotListParams:
+        normalized = [name for n in snapshot_names if (name := normalize_wxo_name(n))] if snapshot_names else None
+        return await super().resolve_snapshot_list_adapter_params(
+            deployment_resource_key=deployment_resource_key,
+            snapshot_names=normalized,
+            provider_params=provider_params,
+            db=db,
+        )
 
     def resolve_provider_account_create(
         self,

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -701,17 +701,21 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
     ) -> SnapshotListResult:
         """List snapshots visible to this adapter.
 
-        Supports three modes:
+        Supports four modes:
         - **deployment-scoped**: requires exactly one ``deployment_id`` in params;
           returns tools bound to that agent.
         - **snapshot-ids-only**: when ``snapshot_ids`` is provided and
           ``deployment_ids`` is empty/None, fetches tools directly by ID to
           verify which ones still exist in the provider.
+        - **snapshot-names**: when ``snapshot_names`` is provided and
+          ``deployment_ids`` is empty/None, fetches tools by name to check
+          which ones exist in the provider tenant.
         - **tenant-scoped**: when neither deployment_ids nor snapshot_ids are
           provided, returns all draft tools visible in the provider tenant.
         """
         has_deployment_ids = params and params.deployment_ids
         has_snapshot_ids = params and params.snapshot_ids
+        has_snapshot_names = params and params.snapshot_names
 
         if has_snapshot_ids and has_deployment_ids:
             logger.warning(
@@ -723,6 +727,30 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
 
         if has_snapshot_ids and not has_deployment_ids:
             return await verify_tools_by_ids(clients, params.snapshot_ids)  # type: ignore[union-attr]
+        if has_snapshot_names and not has_deployment_ids:
+            try:
+                raw_tools = await asyncio.to_thread(clients.tool.get_drafts_by_names, params.snapshot_names)  # type: ignore[union-attr]
+            except Exception as exc:  # noqa: BLE001
+                raise_as_deployment_error(
+                    exc,
+                    error_prefix=ErrorPrefix.LIST,
+                    log_msg="Unexpected error while listing wxO snapshots by name",
+                )
+            snapshots = [
+                SnapshotItem(
+                    id=tool["id"],
+                    name=tool.get("name") or tool["id"],
+                    provider_data=self._validate_snapshot_item_provider_data(
+                        {"connections": extract_langflow_connections_binding(tool)}
+                    ),
+                )
+                for tool in (raw_tools or [])
+                if isinstance(tool, dict) and tool.get("id")
+            ]
+            return SnapshotListResult(
+                snapshots=snapshots,
+                provider_result=self.payload_schemas.snapshot_list_result.parse({}).model_dump(exclude_none=True),
+            )
         if not has_deployment_ids:
             try:
                 raw_tools = await asyncio.to_thread(clients.get_tools_raw)
@@ -823,23 +851,6 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
                 log_msg="Unexpected error while verifying wxO tool snapshots by ID",
             )
         return snapshots
-
-    async def check_tool_names_exist(
-        self,
-        *,
-        user_id: IdLike,
-        names: list[str],
-        db: AsyncSession,
-    ) -> list[str]:
-        """Return the subset of *names* that already exist as tools in the provider."""
-        if not names:
-            return []
-        clients = await self._get_provider_clients(user_id=user_id, db=db)
-        try:
-            tools = await asyncio.to_thread(clients.tool.get_drafts_by_names, names)
-        except Exception:  # noqa: BLE001
-            return []
-        return [str(tool.get("name") or "") for tool in (tools or []) if isinstance(tool, dict) and tool.get("name")]
 
     async def verify_credentials(
         self,

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -824,6 +824,23 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             )
         return snapshots
 
+    async def check_tool_names_exist(
+        self,
+        *,
+        user_id: IdLike,
+        names: list[str],
+        db: AsyncSession,
+    ) -> list[str]:
+        """Return the subset of *names* that already exist as tools in the provider."""
+        if not names:
+            return []
+        clients = await self._get_provider_clients(user_id=user_id, db=db)
+        try:
+            tools = await asyncio.to_thread(clients.tool.get_drafts_by_names, names)
+        except Exception:  # noqa: BLE001
+            return []
+        return [str(tool.get("name") or "") for tool in (tools or []) if isinstance(tool, dict) and tool.get("name")]
+
     async def verify_credentials(
         self,
         *,

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -875,6 +875,7 @@ class TestConfigAndSnapshotListRoutes:
         result = await list_deployment_snapshots(
             provider_id=pa.id,
             deployment_id=deployment.id,
+            provider_snapshot_names=None,
             page=1,
             size=10,
             session=AsyncMock(),
@@ -884,6 +885,7 @@ class TestConfigAndSnapshotListRoutes:
         assert result is expected_response
         mapper.resolve_snapshot_list_adapter_params.assert_awaited_once_with(
             deployment_resource_key="dep-key",
+            snapshot_names=None,
             provider_params=None,
             db=ANY,
         )
@@ -893,6 +895,50 @@ class TestConfigAndSnapshotListRoutes:
             adapter.list_snapshots.return_value,
             page=1,
             size=10,
+        )
+
+    @pytest.mark.asyncio
+    @patch(f"{ROUTES_MODULE}.resolve_deployment_adapter")
+    @patch(f"{ROUTES_MODULE}.get_deployment_mapper")
+    @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
+    async def test_list_snapshots_passes_provider_snapshot_names_to_mapper(
+        self,
+        mock_get_pa,
+        mock_get_mapper,
+        mock_resolve_adapter,
+    ):
+        from langflow.api.v1.deployments import list_deployment_snapshots
+
+        pa = _fake_provider_account()
+        mock_get_pa.return_value = pa
+        adapter = AsyncMock()
+        adapter.list_snapshots.return_value = SnapshotListResult(
+            snapshots=[SnapshotItem(id="tool-1", name="my_tool")],
+        )
+        mock_resolve_adapter.return_value = adapter
+        mapper = MagicMock()
+        adapter_params = MagicMock()
+        expected_response = MagicMock()
+        mapper.resolve_snapshot_list_adapter_params = AsyncMock(return_value=adapter_params)
+        mapper.shape_snapshot_list_result.return_value = expected_response
+        mock_get_mapper.return_value = mapper
+
+        result = await list_deployment_snapshots(
+            provider_id=pa.id,
+            deployment_id=None,
+            provider_snapshot_names=["my_tool", "other_tool"],
+            page=1,
+            size=10,
+            session=AsyncMock(),
+            current_user=_fake_user(),
+        )
+
+        assert result is expected_response
+        mapper.resolve_snapshot_list_adapter_params.assert_awaited_once_with(
+            deployment_resource_key=None,
+            snapshot_names=["my_tool", "other_tool"],
+            provider_params=None,
+            db=ANY,
         )
 
 

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -90,6 +90,27 @@ def _fake_attachment(*, provider_snapshot_id: str | None = None) -> SimpleNamesp
 
 
 # ---------------------------------------------------------------------------
+# query parameter validators
+# ---------------------------------------------------------------------------
+
+
+class TestQueryParameterValidators:
+    def test_dedupe_snapshot_names_preserves_order(self):
+        from langflow.api.v1.deployments import _dedupe_snapshot_names
+
+        assert _dedupe_snapshot_names(["my_tool", "other_tool", "my_tool", "third_tool"]) == [
+            "my_tool",
+            "other_tool",
+            "third_tool",
+        ]
+
+    def test_dedupe_snapshot_names_keeps_none(self):
+        from langflow.api.v1.deployments import _dedupe_snapshot_names
+
+        assert _dedupe_snapshot_names(None) is None
+
+
+# ---------------------------------------------------------------------------
 # create_deployment: rollback on commit failure
 # ---------------------------------------------------------------------------
 
@@ -875,7 +896,7 @@ class TestConfigAndSnapshotListRoutes:
         result = await list_deployment_snapshots(
             provider_id=pa.id,
             deployment_id=deployment.id,
-            provider_snapshot_names=None,
+            names=None,
             page=1,
             size=10,
             session=AsyncMock(),
@@ -898,10 +919,33 @@ class TestConfigAndSnapshotListRoutes:
         )
 
     @pytest.mark.asyncio
+    @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
+    async def test_list_snapshots_rejects_deployment_id_with_names(
+        self,
+        mock_get_pa,
+    ):
+        from langflow.api.v1.deployments import list_deployment_snapshots
+
+        with pytest.raises(HTTPException) as exc_info:
+            await list_deployment_snapshots(
+                provider_id=uuid4(),
+                deployment_id=uuid4(),
+                names=["my_tool"],
+                page=1,
+                size=10,
+                session=AsyncMock(),
+                current_user=_fake_user(),
+            )
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail == "filtering by both deployment_id and names is not supported."
+        mock_get_pa.assert_not_awaited()
+
+    @pytest.mark.asyncio
     @patch(f"{ROUTES_MODULE}.resolve_deployment_adapter")
     @patch(f"{ROUTES_MODULE}.get_deployment_mapper")
     @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
-    async def test_list_snapshots_passes_provider_snapshot_names_to_mapper(
+    async def test_list_snapshots_passes_names_to_mapper(
         self,
         mock_get_pa,
         mock_get_mapper,
@@ -926,7 +970,7 @@ class TestConfigAndSnapshotListRoutes:
         result = await list_deployment_snapshots(
             provider_id=pa.id,
             deployment_id=None,
-            provider_snapshot_names=["my_tool", "other_tool"],
+            names=["my_tool", "other_tool"],
             page=1,
             size=10,
             session=AsyncMock(),

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -186,6 +186,9 @@ class FakeToolClient:
             return [{"name": tool_name}]
         return []
 
+    def get_drafts_by_names(self, names: list[str]):
+        return [dict(tool) for tool in self._tools_by_id.values() if tool.get("name") in names]
+
     def update(self, tool_id: str, payload: dict):
         self.update_calls.append((tool_id, payload))
         current = self._tools_by_id.get(tool_id, {"id": tool_id})
@@ -4227,6 +4230,121 @@ async def test_list_snapshots_snapshot_ids_trusts_verified_results_without_reval
     )
 
     assert result.snapshots[0].provider_data == {"unexpected": "value"}
+
+
+def test_snapshot_list_params_snapshot_names_strips_whitespace():
+    params = SnapshotListParams(snapshot_names=["  my_tool  ", "other "])
+    assert params.snapshot_names == ["my_tool", "other"]
+
+
+def test_snapshot_list_params_snapshot_names_rejects_empty_strings():
+    with pytest.raises(ValidationError):
+        SnapshotListParams(snapshot_names=[""])
+
+
+def test_snapshot_list_params_snapshot_names_rejects_whitespace_only():
+    with pytest.raises(ValidationError):
+        SnapshotListParams(snapshot_names=["  "])
+
+
+def test_snapshot_list_params_snapshot_names_rejects_empty_list():
+    with pytest.raises(ValidationError):
+        SnapshotListParams(snapshot_names=[])
+
+
+def test_snapshot_list_params_snapshot_names_none_is_valid():
+    params = SnapshotListParams(snapshot_names=None)
+    assert params.snapshot_names is None
+
+
+@pytest.mark.anyio
+async def test_list_snapshots_snapshot_names_returns_matching_tools(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": []}),
+        tool=FakeToolClient(
+            [
+                {"id": "tool-1", "name": "my_tool", "binding": {"langflow": {"connections": {"cfg-1": "conn-1"}}}},
+                {"id": "tool-2", "name": "other_tool"},
+            ]
+        ),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_snapshots(
+        user_id="user-1",
+        db=object(),
+        params=SnapshotListParams(snapshot_names=["my_tool"]),
+    )
+
+    assert len(result.snapshots) == 1
+    assert result.snapshots[0].id == "tool-1"
+    assert result.snapshots[0].name == "my_tool"
+    assert result.snapshots[0].provider_data == {"connections": {"cfg-1": "conn-1"}}
+
+
+@pytest.mark.anyio
+async def test_list_snapshots_snapshot_names_returns_empty_when_no_match(monkeypatch):
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": []}),
+        tool=FakeToolClient(
+            [
+                {"id": "tool-1", "name": "existing_tool"},
+            ]
+        ),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_snapshots(
+        user_id="user-1",
+        db=object(),
+        params=SnapshotListParams(snapshot_names=["nonexistent_tool"]),
+    )
+
+    assert len(result.snapshots) == 0
+
+
+@pytest.mark.anyio
+async def test_list_snapshots_snapshot_names_ignored_when_deployment_ids_present(monkeypatch):
+    """When deployment_ids present, snapshot_names should be ignored and deployment-scoped path used."""
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": ["tool-1"]}),
+        tool=FakeToolClient(
+            [
+                {"id": "tool-1", "name": "agent_tool", "binding": {"langflow": {"connections": {}}}},
+                {"id": "tool-2", "name": "my_tool"},
+            ]
+        ),
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    result = await service.list_snapshots(
+        user_id="user-1",
+        db=object(),
+        params=SnapshotListParams(deployment_ids=["dep-1"], snapshot_names=["my_tool"]),
+    )
+
+    # Should return agent's tools (deployment-scoped), not name-filtered results
+    assert len(result.snapshots) == 1
+    assert result.snapshots[0].id == "tool-1"
+    assert result.snapshots[0].name == "agent_tool"
 
 
 @pytest.mark.anyio

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -4348,6 +4348,37 @@ async def test_list_snapshots_snapshot_names_ignored_when_deployment_ids_present
 
 
 @pytest.mark.anyio
+async def test_list_snapshots_snapshot_names_wraps_provider_error(monkeypatch):
+    """get_drafts_by_names failure is wrapped via raise_as_deployment_error."""
+    service = WatsonxOrchestrateDeploymentService(DummySettingsService())
+    fake_tool = FakeToolClient([])
+
+    def get_drafts_by_names_raises(names):  # noqa: ARG001
+        msg = "provider timeout"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(fake_tool, "get_drafts_by_names", get_drafts_by_names_raises)
+
+    fake_clients = SimpleNamespace(
+        agent=FakeAgentClient({"id": "dep-1", "tools": []}),
+        tool=fake_tool,
+        connections=FakeConnectionsClient(),
+    )
+
+    async def mock_get_provider_clients(*, user_id, db):  # noqa: ARG001
+        return fake_clients
+
+    monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
+
+    with pytest.raises(DeploymentError, match="listing"):
+        await service.list_snapshots(
+            user_id="user-1",
+            db=object(),
+            params=SnapshotListParams(snapshot_names=["my_tool"]),
+        )
+
+
+@pytest.mark.anyio
 async def test_verify_tools_by_ids_returns_only_connections_provider_data():
     fake_clients = SimpleNamespace(
         tool=FakeToolClient(

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -216,7 +216,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1082,7 +1081,6 @@
       "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
       "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5",
         "csstype": "^3.1.2",
@@ -1094,7 +1092,6 @@
       "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.2.tgz",
       "integrity": "sha512-EGtpoEjLrUu4W1fHD+a62XR+hzC5YfsWm+6lO0Kybcga3yYEij9beegO0jZgug27V+Rf7vns95VPVP6mFd/DEQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@chakra-ui/color-mode": "2.2.0",
         "@chakra-ui/object-utils": "2.1.0",
@@ -1201,7 +1198,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
       "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -1238,7 +1234,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
       "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -1248,7 +1243,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
       "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1344,7 +1338,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1368,7 +1361,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6046,7 +6038,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.26"
@@ -6453,7 +6444,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -7165,7 +7155,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7176,7 +7165,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7192,8 +7180,7 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.9.tgz",
       "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -7825,7 +7812,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8567,7 +8553,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8960,7 +8945,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -9394,7 +9378,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9971,7 +9954,6 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10250,7 +10232,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -11377,7 +11358,6 @@
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11530,7 +11510,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -12089,7 +12068,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -13675,7 +13653,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -13725,7 +13702,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -13765,7 +13741,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -16261,7 +16236,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16684,7 +16658,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16757,7 +16730,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16788,7 +16760,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -17451,7 +17422,6 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -17970,8 +17940,7 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
       "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -18150,7 +18119,6 @@
       "integrity": "sha512-uBSZu/GZa9aEIW3QMGvdQPMZWhGxSe4dyRWU8B3/Vd47Gy/XLC7tsBxRr13txmmPOEDHZR94uLuq0H50fvuqBw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -18521,7 +18489,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -19104,7 +19071,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19617,7 +19583,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -20602,7 +20567,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -216,6 +216,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1081,6 +1082,7 @@
       "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
       "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5",
         "csstype": "^3.1.2",
@@ -1092,6 +1094,7 @@
       "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.2.tgz",
       "integrity": "sha512-EGtpoEjLrUu4W1fHD+a62XR+hzC5YfsWm+6lO0Kybcga3yYEij9beegO0jZgug27V+Rf7vns95VPVP6mFd/DEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@chakra-ui/color-mode": "2.2.0",
         "@chakra-ui/object-utils": "2.1.0",
@@ -1198,6 +1201,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
       "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -1234,6 +1238,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
       "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -1243,6 +1248,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
       "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1338,6 +1344,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1361,6 +1368,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6038,6 +6046,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.26"
@@ -6444,6 +6453,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -7155,6 +7165,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7165,6 +7176,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7180,7 +7192,8 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.9.tgz",
       "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -7812,6 +7825,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8553,6 +8567,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8945,6 +8960,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -9378,6 +9394,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9954,6 +9971,7 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10232,6 +10250,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -11358,6 +11377,7 @@
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11510,6 +11530,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -12068,6 +12089,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -13653,6 +13675,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -13702,6 +13725,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -13741,6 +13765,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -16236,6 +16261,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16658,6 +16684,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16730,6 +16757,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16760,6 +16788,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -17422,6 +17451,7 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -17940,7 +17970,8 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
       "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -18119,6 +18150,7 @@
       "integrity": "sha512-uBSZu/GZa9aEIW3QMGvdQPMZWhGxSe4dyRWU8B3/Vd47Gy/XLC7tsBxRr13txmmPOEDHZR94uLuq0H50fvuqBw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -18489,6 +18521,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -19071,6 +19104,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19583,6 +19617,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -20567,6 +20602,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-check-tool-names.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-check-tool-names.test.ts
@@ -1,0 +1,120 @@
+const mockApiGet = jest.fn();
+const mockQueryClient = {
+  refetchQueries: jest.fn(),
+  invalidateQueries: jest.fn(),
+};
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { get: mockApiGet },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v1/deployments"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    query: jest.fn((_key: any, fn: any, _options: any) => {
+      // Immediately invoke the query function for testing
+      fn();
+      return { data: undefined, isLoading: true };
+    }),
+    queryClient: mockQueryClient,
+  })),
+}));
+
+import { useCheckToolNames } from "../use-check-tool-names";
+
+describe("useCheckToolNames", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("calls snapshots endpoint with provider_snapshot_names param", () => {
+    mockApiGet.mockResolvedValue({
+      data: {
+        provider_data: {
+          tools: [{ id: "tool-1", name: "my_tool" }],
+          total: 1,
+        },
+      },
+    });
+
+    useCheckToolNames(
+      { providerId: "prov-1", names: ["my_tool", "other_tool"] },
+      {},
+    );
+
+    expect(mockApiGet).toHaveBeenCalledWith("/api/v1/deployments/snapshots", {
+      params: {
+        provider_id: "prov-1",
+        provider_snapshot_names: ["my_tool", "other_tool"],
+        size: 50,
+      },
+      paramsSerializer: { indexes: null },
+    });
+  });
+
+  it("extracts tool names from snapshot list response", async () => {
+    mockApiGet.mockResolvedValue({
+      data: {
+        provider_data: {
+          tools: [
+            { id: "tool-1", name: "my_tool" },
+            { id: "tool-2", name: "another_tool" },
+          ],
+          total: 2,
+        },
+      },
+    });
+
+    // Call the hook to trigger the query function
+    useCheckToolNames(
+      { providerId: "prov-1", names: ["my_tool", "another_tool"] },
+      {},
+    );
+
+    // Wait for the async fn to resolve
+    await new Promise(process.nextTick);
+
+    // Verify the API was called with correct endpoint
+    expect(mockApiGet).toHaveBeenCalledWith(
+      "/api/v1/deployments/snapshots",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          provider_snapshot_names: ["my_tool", "another_tool"],
+        }),
+      }),
+    );
+  });
+
+  it("returns empty existing_names when provider_data has no tools", async () => {
+    mockApiGet.mockResolvedValue({
+      data: { provider_data: {} },
+    });
+
+    useCheckToolNames({ providerId: "prov-1", names: ["nonexistent"] }, {});
+
+    await new Promise(process.nextTick);
+
+    expect(mockApiGet).toHaveBeenCalledWith(
+      "/api/v1/deployments/snapshots",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          provider_snapshot_names: ["nonexistent"],
+        }),
+      }),
+    );
+  });
+
+  it("does not call old check-names endpoint", () => {
+    mockApiGet.mockResolvedValue({
+      data: { provider_data: { tools: [] } },
+    });
+
+    useCheckToolNames({ providerId: "prov-1", names: ["test"] }, {});
+
+    const calledUrl = mockApiGet.mock.calls[0][0];
+    expect(calledUrl).not.toContain("check-names");
+    expect(calledUrl).toBe("/api/v1/deployments/snapshots");
+  });
+});

--- a/src/frontend/src/controllers/API/queries/deployments/__tests__/use-check-tool-names.test.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/__tests__/use-check-tool-names.test.ts
@@ -29,7 +29,7 @@ import { useCheckToolNames } from "../use-check-tool-names";
 describe("useCheckToolNames", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("calls snapshots endpoint with provider_snapshot_names param", () => {
+  it("calls snapshots endpoint with names param", () => {
     mockApiGet.mockResolvedValue({
       data: {
         provider_data: {
@@ -47,7 +47,7 @@ describe("useCheckToolNames", () => {
     expect(mockApiGet).toHaveBeenCalledWith("/api/v1/deployments/snapshots", {
       params: {
         provider_id: "prov-1",
-        provider_snapshot_names: ["my_tool", "other_tool"],
+        names: ["my_tool", "other_tool"],
         size: 50,
       },
       paramsSerializer: { indexes: null },
@@ -81,7 +81,7 @@ describe("useCheckToolNames", () => {
       "/api/v1/deployments/snapshots",
       expect.objectContaining({
         params: expect.objectContaining({
-          provider_snapshot_names: ["my_tool", "another_tool"],
+          names: ["my_tool", "another_tool"],
         }),
       }),
     );
@@ -100,7 +100,7 @@ describe("useCheckToolNames", () => {
       "/api/v1/deployments/snapshots",
       expect.objectContaining({
         params: expect.objectContaining({
-          provider_snapshot_names: ["nonexistent"],
+          names: ["nonexistent"],
         }),
       }),
     );

--- a/src/frontend/src/controllers/API/queries/deployments/index.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/index.ts
@@ -1,3 +1,4 @@
+export * from "./use-check-tool-names";
 export * from "./use-delete-deployment";
 export * from "./use-get-deployment";
 export * from "./use-get-deployment-attachments";

--- a/src/frontend/src/controllers/API/queries/deployments/use-check-tool-names.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-check-tool-names.ts
@@ -1,0 +1,38 @@
+import type { useQueryFunctionType } from "@/types/api";
+import { api } from "../../api";
+import { getURL } from "../../helpers/constants";
+import { UseRequestProcessor } from "../../services/request-processor";
+
+interface CheckToolNamesResponse {
+  existing_names: string[];
+}
+
+interface CheckToolNamesParams {
+  providerId: string;
+  names: string[];
+}
+
+export const useCheckToolNames: useQueryFunctionType<
+  CheckToolNamesParams,
+  CheckToolNamesResponse
+> = ({ providerId, names }, options) => {
+  const { query } = UseRequestProcessor();
+
+  const fn = async (): Promise<CheckToolNamesResponse> => {
+    const { data } = await api.get<CheckToolNamesResponse>(
+      `${getURL("DEPLOYMENTS")}/snapshots/check-names`,
+      {
+        params: { provider_id: providerId, names },
+        paramsSerializer: { indexes: null },
+      },
+    );
+    return data;
+  };
+
+  const sortedNames = [...names].sort();
+  return query(
+    ["useCheckToolNames", { providerId, names: sortedNames }],
+    fn,
+    options,
+  );
+};

--- a/src/frontend/src/controllers/API/queries/deployments/use-check-tool-names.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-check-tool-names.ts
@@ -31,7 +31,7 @@ export const useCheckToolNames: useQueryFunctionType<
       {
         params: {
           provider_id: providerId,
-          provider_snapshot_names: names,
+          names,
           size: 50,
         },
         paramsSerializer: { indexes: null },

--- a/src/frontend/src/controllers/API/queries/deployments/use-check-tool-names.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-check-tool-names.ts
@@ -3,6 +3,13 @@ import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
 
+interface SnapshotListResponse {
+  provider_data?: {
+    tools?: Array<{ id: string; name: string }>;
+    total?: number;
+  };
+}
+
 interface CheckToolNamesResponse {
   existing_names: string[];
 }
@@ -19,14 +26,21 @@ export const useCheckToolNames: useQueryFunctionType<
   const { query } = UseRequestProcessor();
 
   const fn = async (): Promise<CheckToolNamesResponse> => {
-    const { data } = await api.get<CheckToolNamesResponse>(
-      `${getURL("DEPLOYMENTS")}/snapshots/check-names`,
+    const { data } = await api.get<SnapshotListResponse>(
+      `${getURL("DEPLOYMENTS")}/snapshots`,
       {
-        params: { provider_id: providerId, names },
+        params: {
+          provider_id: providerId,
+          provider_snapshot_names: names,
+          size: 50,
+        },
         paramsSerializer: { indexes: null },
       },
     );
-    return data;
+    const existingNames = (data.provider_data?.tools ?? [])
+      .map((t) => t.name)
+      .filter(Boolean);
+    return { existing_names: existingNames };
   };
 
   const sortedNames = [...names].sort();

--- a/src/frontend/src/controllers/API/queries/deployments/use-post-deployment.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-post-deployment.ts
@@ -55,6 +55,7 @@ export const usePostDeployment: useMutationFunctionType<
 
   return mutate(["usePostDeployment"], fn, {
     ...options,
+    retry: 1,
     onSuccess: () => {
       return queryClient.refetchQueries({ queryKey: ["useGetDeployments"] });
     },

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-review.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-review.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { useCheckToolNames } from "@/controllers/API/queries/deployments";
 import { useGetRefreshFlowsQuery } from "@/controllers/API/queries/flows/use-get-refresh-flows-query";
 import { useFolderStore } from "@/stores/foldersStore";
 import StepReview from "../components/step-review";
@@ -11,6 +12,10 @@ jest.mock("../contexts/deployment-stepper-context", () => ({
 jest.mock("@/controllers/API/queries/deployments", () => ({
   useCheckToolNames: jest.fn(() => ({ data: undefined })),
 }));
+
+const mockedUseCheckToolNames = useCheckToolNames as jest.MockedFunction<
+  typeof useCheckToolNames
+>;
 
 jest.mock(
   "@/controllers/API/queries/flows/use-get-refresh-flows-query",
@@ -38,33 +43,47 @@ const mockedUseFolderStore = useFolderStore as jest.MockedFunction<
   typeof useFolderStore
 >;
 
-describe("StepReview tool name editing", () => {
-  it("persists tool name edits when input loses focus", () => {
-    const setToolNameByFlow = jest.fn();
+function buildBaseStepper(overrides: Record<string, unknown> = {}) {
+  return {
+    isEditMode: false,
+    deploymentType: "agent",
+    deploymentName: "Agent One",
+    selectedLlm: "meta-llama/llama-3-3-70b-instruct",
+    connections: [],
+    selectedVersionByFlow: new Map([
+      ["flow-1", { versionId: "ver-1", versionTag: "v1" }],
+    ]),
+    toolNameByFlow: new Map<string, string>(),
+    setToolNameByFlow: jest.fn(),
+    attachedConnectionByFlow: new Map(),
+    removedFlowIds: new Set(),
+    selectedInstance: null,
+    preExistingFlowIds: new Set<string>(),
+    initialToolNameByFlow: new Map<string, string>(),
+    setHasToolNameErrors: jest.fn(),
+    ...overrides,
+  } as never;
+}
 
+describe("StepReview tool name editing", () => {
+  beforeEach(() => {
     mockedUseFolderStore.mockImplementation((selector) =>
       selector({ myCollectionId: "folder-1" } as never),
     );
     mockedUseGetRefreshFlowsQuery.mockReturnValue({
-      data: [{ id: "flow-1", name: "New Flow", folder_id: "folder-1" }],
+      data: [
+        { id: "flow-1", name: "New Flow", folder_id: "folder-1" },
+        { id: "flow-2", name: "Other Flow", folder_id: "folder-1" },
+      ],
     } as never);
-    mockedUseDeploymentStepper.mockReturnValue({
-      isEditMode: false,
-      deploymentType: "agent",
-      deploymentName: "Agent One",
-      selectedLlm: "meta-llama/llama-3-3-70b-instruct",
-      connections: [],
-      selectedVersionByFlow: new Map([
-        ["flow-1", { versionId: "ver-1", versionTag: "v1" }],
-      ]),
-      toolNameByFlow: new Map(),
-      setToolNameByFlow,
-      attachedConnectionByFlow: new Map(),
-      removedFlowIds: new Set(),
-      selectedInstance: null,
-      preExistingFlowIds: new Set(),
-      setHasToolNameErrors: jest.fn(),
-    } as never);
+    mockedUseCheckToolNames.mockReturnValue({ data: undefined } as never);
+  });
+
+  it("persists tool name edits when input loses focus", () => {
+    const setToolNameByFlow = jest.fn();
+    mockedUseDeploymentStepper.mockReturnValue(
+      buildBaseStepper({ setToolNameByFlow }),
+    );
 
     render(<StepReview />);
 
@@ -79,5 +98,96 @@ describe("StepReview tool name editing", () => {
     ) => Map<string, string>;
     const updated = updater(new Map());
     expect(updated.get("flow-1")).toBe("My Tool Name");
+  });
+});
+
+describe("StepReview duplicate tool name detection in edit mode", () => {
+  beforeEach(() => {
+    mockedUseFolderStore.mockImplementation((selector) =>
+      selector({ myCollectionId: "folder-1" } as never),
+    );
+    mockedUseGetRefreshFlowsQuery.mockReturnValue({
+      data: [
+        { id: "flow-1", name: "New Flow", folder_id: "folder-1" },
+        { id: "flow-2", name: "Other Flow", folder_id: "folder-1" },
+      ],
+    } as never);
+  });
+
+  it("shows provider duplicate error when pre-existing flow tool name is changed to an existing name", () => {
+    const setHasToolNameErrors = jest.fn();
+    mockedUseCheckToolNames.mockReturnValue({
+      data: { existing_names: ["taken_tool"] },
+    } as never);
+    mockedUseDeploymentStepper.mockReturnValue(
+      buildBaseStepper({
+        isEditMode: true,
+        preExistingFlowIds: new Set(["flow-1"]),
+        initialToolNameByFlow: new Map([["flow-1", "original_tool"]]),
+        toolNameByFlow: new Map([["flow-1", "taken_tool"]]),
+        selectedInstance: { id: "inst-1" },
+        setHasToolNameErrors,
+      }),
+    );
+
+    render(<StepReview />);
+
+    expect(
+      screen.getByText("Edit tool name (already exists in provider)"),
+    ).toBeInTheDocument();
+    expect(setHasToolNameErrors).toHaveBeenCalledWith(true);
+  });
+
+  it("does not show error when pre-existing flow tool name is unchanged", () => {
+    const setHasToolNameErrors = jest.fn();
+    mockedUseCheckToolNames.mockReturnValue({
+      data: { existing_names: ["original_tool"] },
+    } as never);
+    mockedUseDeploymentStepper.mockReturnValue(
+      buildBaseStepper({
+        isEditMode: true,
+        preExistingFlowIds: new Set(["flow-1"]),
+        initialToolNameByFlow: new Map([["flow-1", "original_tool"]]),
+        toolNameByFlow: new Map([["flow-1", "original_tool"]]),
+        selectedInstance: { id: "inst-1" },
+        setHasToolNameErrors,
+      }),
+    );
+
+    render(<StepReview />);
+
+    expect(
+      screen.queryByText("Edit tool name (already exists in provider)"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows batch duplicate error when two flows have the same renamed tool name", () => {
+    const setHasToolNameErrors = jest.fn();
+    mockedUseCheckToolNames.mockReturnValue({ data: undefined } as never);
+    mockedUseDeploymentStepper.mockReturnValue(
+      buildBaseStepper({
+        isEditMode: true,
+        selectedVersionByFlow: new Map([
+          ["flow-1", { versionId: "ver-1", versionTag: "v1" }],
+          ["flow-2", { versionId: "ver-2", versionTag: "v2" }],
+        ]),
+        preExistingFlowIds: new Set(["flow-1"]),
+        initialToolNameByFlow: new Map([["flow-1", "original_tool"]]),
+        toolNameByFlow: new Map([
+          ["flow-1", "same_name"],
+          ["flow-2", "same_name"],
+        ]),
+        selectedInstance: { id: "inst-1" },
+        setHasToolNameErrors,
+      }),
+    );
+
+    render(<StepReview />);
+
+    const errors = screen.getAllByText(
+      "Duplicate tool name within this deployment",
+    );
+    expect(errors.length).toBe(2);
+    expect(setHasToolNameErrors).toHaveBeenCalledWith(true);
   });
 });

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-review.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-review.test.tsx
@@ -8,6 +8,10 @@ jest.mock("../contexts/deployment-stepper-context", () => ({
   useDeploymentStepper: jest.fn(),
 }));
 
+jest.mock("@/controllers/API/queries/deployments", () => ({
+  useCheckToolNames: jest.fn(() => ({ data: undefined })),
+}));
+
 jest.mock(
   "@/controllers/API/queries/flows/use-get-refresh-flows-query",
   () => ({
@@ -57,6 +61,9 @@ describe("StepReview tool name editing", () => {
       setToolNameByFlow,
       attachedConnectionByFlow: new Map(),
       removedFlowIds: new Set(),
+      selectedInstance: null,
+      preExistingFlowIds: new Set(),
+      setHasToolNameErrors: jest.fn(),
     } as never);
 
     render(<StepReview />);

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-flow-list-panel.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-flow-list-panel.tsx
@@ -42,13 +42,20 @@ export const FlowListPanel = memo(function FlowListPanel({
             .map((cid) => connections.find((c) => c.id === cid)?.name)
             .filter(Boolean);
           return (
-            <button
+            <div
               key={flow.id}
-              type="button"
+              role="button"
+              tabIndex={0}
               data-testid={`flow-item-${flow.id}`}
               onClick={() => onSelectFlow(flow.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onSelectFlow(flow.id);
+                }
+              }}
               className={cn(
-                "flex w-full items-center gap-3 rounded-lg p-3 text-left transition-colors",
+                "flex w-full cursor-pointer items-center gap-3 rounded-lg p-3 text-left transition-colors",
                 isRemoved && "opacity-50",
                 selectedFlowId === flow.id ? "bg-muted" : "hover:bg-muted/60",
               )}
@@ -129,7 +136,7 @@ export const FlowListPanel = memo(function FlowListPanel({
                   />
                 </button>
               )}
-            </button>
+            </div>
           );
         })}
       </div>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review.tsx
@@ -106,6 +106,7 @@ export default function StepReview() {
     removedFlowIds,
     selectedInstance,
     preExistingFlowIds,
+    initialToolNameByFlow,
     setHasToolNameErrors,
   } = useDeploymentStepper();
 
@@ -157,13 +158,24 @@ export default function StepReview() {
   const toolNamesToCheck = useMemo(() => {
     const names: string[] = [];
     for (const item of reviewFlows) {
-      // Skip pre-existing flows in edit mode — those already have tools in provider.
-      if (isEditMode && preExistingFlowIds.has(item.flowId)) continue;
       const normalized = normalizeWxoName(item.toolName);
-      if (normalized) names.push(normalized);
+      if (!normalized) continue;
+      // Skip pre-existing flows only if their tool name hasn't changed.
+      if (isEditMode && preExistingFlowIds.has(item.flowId)) {
+        const original = normalizeWxoName(
+          initialToolNameByFlow.get(item.flowId) ?? "",
+        );
+        if (
+          normalized.toLowerCase() === original.toLowerCase() ||
+          normalized.toLowerCase() ===
+            normalizeWxoName(item.flowName).toLowerCase()
+        )
+          continue;
+      }
+      names.push(normalized);
     }
     return names;
-  }, [reviewFlows, isEditMode, preExistingFlowIds]);
+  }, [reviewFlows, isEditMode, preExistingFlowIds, initialToolNameByFlow]);
 
   const { data: checkNamesData } = useCheckToolNames(
     { providerId: selectedInstance?.id ?? "", names: toolNamesToCheck },
@@ -197,9 +209,18 @@ export default function StepReview() {
         batchNames.set(normalized, item.flowId);
       }
 
-      // Check against existing provider tools (skip for pre-existing flows in edit mode)
+      // Check against existing provider tools (skip for pre-existing flows only if name unchanged)
       if (!errors.has(item.flowId) && existingToolNames.has(normalized)) {
-        if (!(isEditMode && preExistingFlowIds.has(item.flowId))) {
+        let skipProviderCheck = false;
+        if (isEditMode && preExistingFlowIds.has(item.flowId)) {
+          const original = normalizeWxoName(
+            initialToolNameByFlow.get(item.flowId) ?? "",
+          ).toLowerCase();
+          skipProviderCheck =
+            normalized === original ||
+            normalized === normalizeWxoName(item.flowName).toLowerCase();
+        }
+        if (!skipProviderCheck) {
           errors.set(
             item.flowId,
             "Edit tool name (already exists in provider)",
@@ -209,7 +230,13 @@ export default function StepReview() {
     }
 
     return errors;
-  }, [reviewFlows, existingToolNames, isEditMode, preExistingFlowIds]);
+  }, [
+    reviewFlows,
+    existingToolNames,
+    isEditMode,
+    preExistingFlowIds,
+    initialToolNameByFlow,
+  ]);
 
   useEffect(() => {
     setHasToolNameErrors(toolNameErrors.size > 0);

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review.tsx
@@ -1,11 +1,17 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { keepPreviousData } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { useCheckToolNames } from "@/controllers/API/queries/deployments";
 import { useGetRefreshFlowsQuery } from "@/controllers/API/queries/flows/use-get-refresh-flows-query";
 import { useFolderStore } from "@/stores/foldersStore";
 import { useDeploymentStepper } from "../contexts/deployment-stepper-context";
+
+function normalizeWxoName(s: string): string {
+  return s.replace(/[\s-]/g, "_").replace(/[^a-zA-Z0-9_]/g, "");
+}
 
 function EditableToolName({
   value,
@@ -98,6 +104,9 @@ export default function StepReview() {
     setToolNameByFlow,
     attachedConnectionByFlow,
     removedFlowIds,
+    selectedInstance,
+    preExistingFlowIds,
+    setHasToolNameErrors,
   } = useDeploymentStepper();
 
   const { folderId } = useParams();
@@ -143,6 +152,69 @@ export default function StepReview() {
       };
     },
   );
+
+  // Collect normalized tool names to check against the provider.
+  const toolNamesToCheck = useMemo(() => {
+    const names: string[] = [];
+    for (const item of reviewFlows) {
+      // Skip pre-existing flows in edit mode — those already have tools in provider.
+      if (isEditMode && preExistingFlowIds.has(item.flowId)) continue;
+      const normalized = normalizeWxoName(item.toolName);
+      if (normalized) names.push(normalized);
+    }
+    return names;
+  }, [reviewFlows, isEditMode, preExistingFlowIds]);
+
+  const { data: checkNamesData } = useCheckToolNames(
+    { providerId: selectedInstance?.id ?? "", names: toolNamesToCheck },
+    {
+      enabled: !!selectedInstance?.id && toolNamesToCheck.length > 0,
+      placeholderData: keepPreviousData,
+    },
+  );
+
+  const existingToolNames = useMemo(() => {
+    if (!checkNamesData?.existing_names) return new Set<string>();
+    return new Set(checkNamesData.existing_names.map((n) => n.toLowerCase()));
+  }, [checkNamesData]);
+
+  const toolNameErrors = useMemo(() => {
+    const errors = new Map<string, string>();
+    const batchNames = new Map<string, string>(); // normalized -> flowId (first seen)
+
+    for (const item of reviewFlows) {
+      const normalized = normalizeWxoName(item.toolName).toLowerCase();
+      if (!normalized) continue;
+
+      // Check batch duplicates (two flows with same tool name in this deployment)
+      const firstFlowId = batchNames.get(normalized);
+      if (firstFlowId) {
+        errors.set(item.flowId, "Duplicate tool name within this deployment");
+        if (!errors.has(firstFlowId)) {
+          errors.set(firstFlowId, "Duplicate tool name within this deployment");
+        }
+      } else {
+        batchNames.set(normalized, item.flowId);
+      }
+
+      // Check against existing provider tools (skip for pre-existing flows in edit mode)
+      if (!errors.has(item.flowId) && existingToolNames.has(normalized)) {
+        if (!(isEditMode && preExistingFlowIds.has(item.flowId))) {
+          errors.set(item.flowId, "Tool name already exists in the provider");
+        }
+      }
+    }
+
+    return errors;
+  }, [reviewFlows, existingToolNames, isEditMode, preExistingFlowIds]);
+
+  useEffect(() => {
+    setHasToolNameErrors(toolNameErrors.size > 0);
+  }, [toolNameErrors, setHasToolNameErrors]);
+
+  useEffect(() => {
+    return () => setHasToolNameErrors(false);
+  }, [setHasToolNameErrors]);
 
   return (
     <div className="flex flex-col gap-4 py-3">
@@ -226,122 +298,137 @@ export default function StepReview() {
       {/* Configuration section – scoped per flow */}
       {reviewFlows.length > 0 && (
         <div className="flex flex-col gap-3">
-          {reviewFlows.map((item) => (
-            <div
-              key={item.flowId}
-              className="rounded-xl border border-border bg-background p-4"
-            >
-              <div className="flex flex-col gap-3">
-                <div className="flex flex-col gap-1">
-                  <div className="flex items-center gap-2">
-                    <ForwardedIconComponent
-                      name="Wrench"
-                      className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
-                    />
-                    <EditableToolName
-                      value={toolNameByFlow.get(item.flowId)?.trim() ?? ""}
-                      placeholder={item.flowName}
-                      onSave={(name) => {
-                        setToolNameByFlow((prev) => {
-                          const next = new Map(prev);
-                          if (name.trim()) {
-                            next.set(item.flowId, name.trim());
-                          } else {
-                            next.delete(item.flowId);
-                          }
-                          return next;
-                        });
-                      }}
-                    />
+          {reviewFlows.map((item) => {
+            const toolError = toolNameErrors.get(item.flowId);
+            return (
+              <div
+                key={item.flowId}
+                className={`rounded-xl border bg-background p-4 ${toolError ? "border-destructive/50" : "border-border"}`}
+              >
+                <div className="flex flex-col gap-3">
+                  <div className="flex flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                      <ForwardedIconComponent
+                        name="Wrench"
+                        className={`h-3.5 w-3.5 shrink-0 ${toolError ? "text-destructive" : "text-muted-foreground"}`}
+                      />
+                      <EditableToolName
+                        value={toolNameByFlow.get(item.flowId)?.trim() ?? ""}
+                        placeholder={item.flowName}
+                        onSave={(name) => {
+                          setToolNameByFlow((prev) => {
+                            const next = new Map(prev);
+                            if (name.trim()) {
+                              next.set(item.flowId, name.trim());
+                            } else {
+                              next.delete(item.flowId);
+                            }
+                            return next;
+                          });
+                        }}
+                      />
+                    </div>
+                    <div className="flex items-center gap-2 pl-5">
+                      <ForwardedIconComponent
+                        name="Workflow"
+                        className="h-3 w-3 shrink-0 text-muted-foreground"
+                      />
+                      <span className="text-xs text-muted-foreground">
+                        {item.flowName}
+                      </span>
+                      <Badge
+                        variant="secondaryStatic"
+                        size="tag"
+                        className="bg-accent-purple-muted text-accent-purple-muted-foreground"
+                      >
+                        {item.versionLabel}
+                      </Badge>
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2 pl-5">
-                    <ForwardedIconComponent
-                      name="Workflow"
-                      className="h-3 w-3 shrink-0 text-muted-foreground"
-                    />
-                    <span className="text-xs text-muted-foreground">
-                      {item.flowName}
-                    </span>
-                    <Badge
-                      variant="secondaryStatic"
-                      size="tag"
-                      className="bg-accent-purple-muted text-accent-purple-muted-foreground"
-                    >
-                      {item.versionLabel}
-                    </Badge>
-                  </div>
-                </div>
 
-                {item.connectionDetails.length > 0 &&
-                  (() => {
-                    const newConns = item.connectionDetails.filter(
-                      (c) => c.isNew,
-                    );
-                    const existingConns = item.connectionDetails.filter(
-                      (c) => !c.isNew,
-                    );
-                    return (
-                      <div className="flex flex-col gap-4">
-                        {existingConns.length > 0 && (
-                          <div className="flex flex-col gap-2">
-                            <span className="text-xs font-medium text-muted-foreground">
-                              Existing Connections
-                            </span>
-                            {existingConns.map((conn) => (
-                              <span
-                                key={conn.name}
-                                className="text-xs font-medium text-foreground"
-                              >
-                                {conn.name}
+                  {item.connectionDetails.length > 0 &&
+                    (() => {
+                      const newConns = item.connectionDetails.filter(
+                        (c) => c.isNew,
+                      );
+                      const existingConns = item.connectionDetails.filter(
+                        (c) => !c.isNew,
+                      );
+                      return (
+                        <div className="flex flex-col gap-4">
+                          {existingConns.length > 0 && (
+                            <div className="flex flex-col gap-2">
+                              <span className="text-xs font-medium text-muted-foreground">
+                                Existing Connections
                               </span>
-                            ))}
-                          </div>
-                        )}
-                        {newConns.length > 0 && (
-                          <div className="flex flex-col gap-2">
-                            <span className="text-xs font-medium text-muted-foreground">
-                              New Connections
-                            </span>
-                            {newConns.map((conn) => (
-                              <div
-                                key={conn.name}
-                                className="flex flex-col gap-1.5"
-                              >
-                                <span className="text-xs font-medium text-foreground">
+                              {existingConns.map((conn) => (
+                                <span
+                                  key={conn.name}
+                                  className="text-xs font-medium text-foreground"
+                                >
                                   {conn.name}
                                 </span>
-                                {conn.envVars.length > 0 && (
-                                  <div className="flex flex-col divide-y divide-border overflow-hidden rounded-md border border-border">
-                                    {conn.envVars.map(({ key, masked }) => (
-                                      <div
-                                        key={key}
-                                        className="flex items-center justify-between bg-muted/40 px-3 py-1.5"
-                                      >
-                                        <span className="font-mono text-xs text-foreground">
-                                          {key}
-                                        </span>
-                                        <div className="flex items-center gap-2">
-                                          <span className="text-muted-foreground">
-                                            =
+                              ))}
+                            </div>
+                          )}
+                          {newConns.length > 0 && (
+                            <div className="flex flex-col gap-2">
+                              <span className="text-xs font-medium text-muted-foreground">
+                                New Connections
+                              </span>
+                              {newConns.map((conn) => (
+                                <div
+                                  key={conn.name}
+                                  className="flex flex-col gap-1.5"
+                                >
+                                  <span className="text-xs font-medium text-foreground">
+                                    {conn.name}
+                                  </span>
+                                  {conn.envVars.length > 0 && (
+                                    <div className="flex flex-col divide-y divide-border overflow-hidden rounded-md border border-border">
+                                      {conn.envVars.map(({ key, masked }) => (
+                                        <div
+                                          key={key}
+                                          className="flex items-center justify-between bg-muted/40 px-3 py-1.5"
+                                        >
+                                          <span className="font-mono text-xs text-foreground">
+                                            {key}
                                           </span>
-                                          <span className="font-mono text-xs text-muted-foreground">
-                                            {masked}
-                                          </span>
+                                          <div className="flex items-center gap-2">
+                                            <span className="text-muted-foreground">
+                                              =
+                                            </span>
+                                            <span className="font-mono text-xs text-muted-foreground">
+                                              {masked}
+                                            </span>
+                                          </div>
                                         </div>
-                                      </div>
-                                    ))}
-                                  </div>
-                                )}
-                              </div>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })()}
+                                      ))}
+                                    </div>
+                                  )}
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })()}
+
+                  {toolError && (
+                    <div className="flex items-center gap-2 rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2">
+                      <ForwardedIconComponent
+                        name="AlertTriangle"
+                        className="h-3.5 w-3.5 shrink-0 text-destructive"
+                      />
+                      <span className="text-xs text-destructive">
+                        {toolError}
+                      </span>
+                    </div>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-review.tsx
@@ -200,7 +200,10 @@ export default function StepReview() {
       // Check against existing provider tools (skip for pre-existing flows in edit mode)
       if (!errors.has(item.flowId) && existingToolNames.has(normalized)) {
         if (!(isEditMode && preExistingFlowIds.has(item.flowId))) {
-          errors.set(item.flowId, "Tool name already exists in the provider");
+          errors.set(
+            item.flowId,
+            "Edit tool name (already exists in provider)",
+          );
         }
       }
     }

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
@@ -100,6 +100,10 @@ interface DeploymentStepperContextType {
   handleRemoveAttachedFlow: (flowId: string) => void;
   handleUndoRemoveFlow: (flowId: string) => void;
 
+  // Tool name validation
+  hasToolNameErrors: boolean;
+  setHasToolNameErrors: Dispatch<SetStateAction<boolean>>;
+
   // Deploy / Update
   needsProviderAccountCreation: boolean;
   buildProviderAccountPayload: () => ProviderAccountCreateRequest | null;
@@ -160,6 +164,8 @@ export function DeploymentStepperProvider({
   const [attachedConnectionByFlow, setAttachedConnectionByFlow] = useState<
     Map<string, string[]>
   >(initialState?.initialConnectionsByFlow ?? new Map());
+
+  const [hasToolNameErrors, setHasToolNameErrors] = useState(false);
 
   // Edit mode: track which pre-existing flows the user wants to detach.
   const [removedFlowIds, setRemovedFlowIds] = useState<Set<string>>(new Set());
@@ -251,6 +257,9 @@ export function DeploymentStepperProvider({
       // In edit mode, user can proceed without new attachments (may just change desc/LLM).
       return isEditMode || selectedVersionByFlow.size > 0;
     }
+    if (logical === 4) {
+      return !hasToolNameErrors;
+    }
     return true;
   }, [
     currentStep,
@@ -262,6 +271,7 @@ export function DeploymentStepperProvider({
     selectedLlm,
     selectedVersionByFlow,
     isEditMode,
+    hasToolNameErrors,
   ]);
 
   const handleNext = useCallback(() => {
@@ -546,6 +556,8 @@ export function DeploymentStepperProvider({
       removedFlowIds,
       handleRemoveAttachedFlow,
       handleUndoRemoveFlow,
+      hasToolNameErrors,
+      setHasToolNameErrors,
       needsProviderAccountCreation,
       buildProviderAccountPayload,
       buildDeploymentPayload,
@@ -577,6 +589,7 @@ export function DeploymentStepperProvider({
       removedFlowIds,
       handleRemoveAttachedFlow,
       handleUndoRemoveFlow,
+      hasToolNameErrors,
       needsProviderAccountCreation,
       buildProviderAccountPayload,
       buildDeploymentPayload,

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
@@ -93,6 +93,8 @@ interface DeploymentStepperContextType {
   /** User-provided tool names per flow. Key = flowId. */
   toolNameByFlow: Map<string, string>;
   setToolNameByFlow: Dispatch<SetStateAction<Map<string, string>>>;
+  /** Original tool names from provider before this edit session (edit mode). Key = flowId. */
+  initialToolNameByFlow: Map<string, string>;
   /** Flow IDs that were already attached before this edit session (edit mode). */
   preExistingFlowIds: Set<string>;
   /** Flow IDs that were originally attached but the user chose to detach (edit mode). */
@@ -550,6 +552,7 @@ export function DeploymentStepperProvider({
       handleSelectVersion,
       toolNameByFlow,
       setToolNameByFlow,
+      initialToolNameByFlow,
       attachedConnectionByFlow,
       setAttachedConnectionByFlow,
       preExistingFlowIds,
@@ -584,6 +587,7 @@ export function DeploymentStepperProvider({
       selectedVersionByFlow,
       handleSelectVersion,
       toolNameByFlow,
+      initialToolNameByFlow,
       attachedConnectionByFlow,
       preExistingFlowIds,
       removedFlowIds,

--- a/src/frontend/tests/core/features/deployment-create.spec.ts
+++ b/src/frontend/tests/core/features/deployment-create.spec.ts
@@ -8,18 +8,33 @@ import {
   FLOWS_MOCK,
   LLMS_MOCK,
   PROVIDERS_MOCK,
+  SNAPSHOTS_DUPLICATE_MOCK,
+  SNAPSHOTS_EMPTY_MOCK,
 } from "../../utils/deployment-mocks";
 
 // ---------------------------------------------------------------------------
 // Helper: set up all required API route mocks
 // ---------------------------------------------------------------------------
-async function setupDeploymentMocks(page: Page, folderId: string) {
+async function setupDeploymentMocks(
+  page: Page,
+  folderId: string,
+  snapshotsMock: object = SNAPSHOTS_EMPTY_MOCK,
+) {
   // Broad catch-all registered FIRST so specific routes (registered after) take priority via LIFO
   await page.route("**/api/v1/deployments*", (route) => {
     route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({ deployments: [] }),
+    });
+  });
+
+  // Snapshots (used for duplicate tool name check on review step)
+  await page.route("**/api/v1/deployments/snapshots**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(snapshotsMock),
     });
   });
 
@@ -86,7 +101,10 @@ async function setupDeploymentMocks(page: Page, folderId: string) {
 // ---------------------------------------------------------------------------
 // Helper: navigate to the deployments page and open the stepper
 // ---------------------------------------------------------------------------
-async function openDeploymentStepper(page: Page) {
+async function openDeploymentStepper(
+  page: Page,
+  snapshotsMock: object = SNAPSHOTS_EMPTY_MOCK,
+) {
   // Listen for the folders/projects API response BEFORE bootstrap to capture
   // the real myCollectionId. The step-attach-flows component filters flows by
   // folder_id === myCollectionId, so mock flows must carry the same id.
@@ -111,7 +129,7 @@ async function openDeploymentStepper(page: Page) {
     // proceed with empty id — test will likely fail at flow-item assertion
   }
 
-  await setupDeploymentMocks(page, myCollectionId);
+  await setupDeploymentMocks(page, myCollectionId, snapshotsMock);
   await page.getByTestId("deployments-btn").click();
   await page.waitForSelector('[data-testid="subtab-deployments"]');
   await page.getByTestId("create-deployment-empty-btn").click();
@@ -425,5 +443,99 @@ test(
     // The input should disappear and the new name should be visible
     await expect(toolNameInput).not.toBeVisible();
     await expect(page.getByText("Custom Tool Name")).toBeVisible();
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 8: Review step — shows duplicate tool name error when provider has existing tool
+// ---------------------------------------------------------------------------
+test(
+  "deployment-create: review step shows error when tool name already exists in provider",
+  { tag: ["@deployment", "@workspace"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await openDeploymentStepper(page, SNAPSHOTS_DUPLICATE_MOCK);
+    await goToStepReview(page);
+
+    // The duplicate tool name error should appear
+    await expect(
+      page.getByText("Edit tool name (already exists in provider)"),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Deploy button should be disabled while there are tool name errors
+    await expect(page.getByTestId("deployment-stepper-next")).toBeDisabled();
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 9: Review step — no error when tool name does not exist in provider
+// ---------------------------------------------------------------------------
+test(
+  "deployment-create: review step shows no error when tool name is unique",
+  { tag: ["@deployment", "@workspace"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await openDeploymentStepper(page, SNAPSHOTS_EMPTY_MOCK);
+    await goToStepReview(page);
+
+    // No duplicate error should be present
+    await expect(
+      page.getByText("Edit tool name (already exists in provider)"),
+    ).not.toBeVisible();
+
+    // Deploy button should be enabled
+    await expect(page.getByTestId("deployment-stepper-next")).toBeEnabled();
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 10: Review step — fixing duplicate tool name clears error
+// ---------------------------------------------------------------------------
+test(
+  "deployment-create: editing tool name to unique value clears duplicate error",
+  { tag: ["@deployment", "@workspace"] },
+  async ({ page }) => {
+    test.skip(
+      process.env.LANGFLOW_FEATURE_WXO_DEPLOYMENTS !== "true",
+      "Requires LANGFLOW_FEATURE_WXO_DEPLOYMENTS=true",
+    );
+
+    await openDeploymentStepper(page, SNAPSHOTS_DUPLICATE_MOCK);
+    await goToStepReview(page);
+
+    // Error should be visible initially
+    await expect(
+      page.getByText("Edit tool name (already exists in provider)"),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId("deployment-stepper-next")).toBeDisabled();
+
+    // Override the snapshots mock to return empty (unique name) for the next check
+    await page.route("**/api/v1/deployments/snapshots**", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(SNAPSHOTS_EMPTY_MOCK),
+      });
+    });
+
+    // Edit the tool name to something unique
+    await page.getByTestId("edit-tool-name").click();
+    const toolNameInput = page.getByTestId("tool-name-input");
+    await toolNameInput.fill("Unique Tool Name");
+    await toolNameInput.press("Enter");
+
+    // Error should clear and deploy button should re-enable
+    await expect(
+      page.getByText("Edit tool name (already exists in provider)"),
+    ).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId("deployment-stepper-next")).toBeEnabled();
   },
 );

--- a/src/frontend/tests/utils/deployment-mocks.ts
+++ b/src/frontend/tests/utils/deployment-mocks.ts
@@ -153,6 +153,20 @@ export const CONFIGS_WITH_CONNECTIONS_MOCK = {
   },
 };
 
+// Snapshot list response — used to check duplicate tool names on review step.
+export const SNAPSHOTS_EMPTY_MOCK = {
+  provider_data: { tools: [], page: 1, size: 50, total: 0 },
+};
+
+export const SNAPSHOTS_DUPLICATE_MOCK = {
+  provider_data: {
+    tools: [{ id: "tool-existing", name: "My_Flow", connections: {} }],
+    page: 1,
+    size: 50,
+    total: 1,
+  },
+};
+
 export const POST_EXECUTION_RESPONSE = {
   deployment_id: "dep-1",
   provider_data: {

--- a/src/lfx/src/lfx/services/adapters/deployment/schema.py
+++ b/src/lfx/src/lfx/services/adapters/deployment/schema.py
@@ -507,6 +507,10 @@ class SnapshotListParams(_BaseListParams[T_SnapshotListParams]):
         None,
         description="Snapshot ids to filter by.",
     )
+    snapshot_names: list[str] | None = Field(
+        None,
+        description="Snapshot names to filter by.",
+    )
 
     @field_validator("snapshot_ids")
     @classmethod

--- a/src/lfx/src/lfx/services/adapters/deployment/schema.py
+++ b/src/lfx/src/lfx/services/adapters/deployment/schema.py
@@ -509,6 +509,7 @@ class SnapshotListParams(_BaseListParams[T_SnapshotListParams]):
     )
     snapshot_names: list[str] | None = Field(
         None,
+        min_length=1,
         description="Snapshot names to filter by.",
     )
 
@@ -516,6 +517,17 @@ class SnapshotListParams(_BaseListParams[T_SnapshotListParams]):
     @classmethod
     def validate_snapshot_ids(cls, value: list[IdLike] | None, info) -> list[str] | None:
         return cls._normalize_filter_id_values(value, field_name=info.field_name)
+
+    @field_validator("snapshot_names")
+    @classmethod
+    def validate_snapshot_names(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        stripped = [name.strip() for name in value]
+        if any(not name for name in stripped):
+            msg = "snapshot_names must not contain empty or whitespace-only entries."
+            raise ValueError(msg)
+        return stripped
 
 
 class DeploymentCreate(BaseModel):


### PR DESCRIPTION
## Summary
- Add `provider_snapshot_names` query parameter to the existing `GET /deployments/snapshots` endpoint for name-based filtering (avoids fetching all 18k+ tools)
- Add name-filtered mode to WXO `list_snapshots` using the SDK's `get_drafts_by_names()`
- Show alert banner with red border on the review step card when a tool name already exists in the provider
- Block the deploy button while any duplicate tool names exist
- Detect batch duplicates (same tool name on multiple flows in the same deployment)
- Use `keepPreviousData` to prevent error indicator flicker during re-validation

<img width="1484" height="1026" alt="image" src="https://github.com/user-attachments/assets/561dd8ab-9fe2-4cf5-a0e4-78edaf2b4f09" />