### PR TITLE
fix: resolve race condition in test_component_logging for Python 3.13

### DIFF
--- a/src/lfx/tests/unit/custom/custom_component/test_component_events.py
+++ b/src/lfx/tests/unit/custom/custom_component/test_component_events.py
@@ -200,8 +200,12 @@ async def test_component_logging():
     # Log a message
     await asyncio.to_thread(component.log, "Test log message")
 
-    # Get the event from the queue
-    event_id, event_data, _ = queue.get_nowait()
+    # Get the event from the queue with timeout to avoid race conditions
+    try:
+        event_id, event_data, _ = await asyncio.wait_for(queue.get(), timeout=5.0)
+    except asyncio.TimeoutError:
+        pytest.fail("Timeout waiting for log event in queue")
+
     event = event_data.decode("utf-8")
 
     assert "Test log message" in event


### PR DESCRIPTION
Replace queue.get_nowait() with asyncio.wait_for(queue.get(), timeout=5.0) to properly wait for async events in the queue, preventing QueueEmpty errors in Python 3.13.

Fixes flaky test failure in release workflow.