### PR TITLE
feat: enforce unique snapshot to flow version relationship

### DIFF
--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -524,7 +524,7 @@ async def create_deployment(
         )
 
         await session.commit()
-    except Exception:
+    except Exception as exc:
         # Compensate: delete the provider resource so it doesn't become orphaned.
         # Only the deployment resource itself is deleted (e.g. the WXO agent).
         # Secondary resources (snapshots/tools, configs) may remain orphaned --
@@ -550,6 +550,8 @@ async def create_deployment(
                 user_id=current_user.id,
                 db=session,
             )
+        if isinstance(exc, ValueError):
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
         raise
     return deployment_mapper.shape_deployment_create_result(
         provider_create_result, deployment_row, provider_key=provider_account.provider_key
@@ -1243,7 +1245,7 @@ async def update_deployment(
             )
 
         await session.commit()
-    except Exception:
+    except Exception as exc:
         # Provider was already mutated by deployment_adapter.update above.
         # Roll back the session to discard any pending DB changes (or reset
         # it from the "inactive" state after a failed commit) so the mapper
@@ -1259,6 +1261,8 @@ async def update_deployment(
             user_id=current_user.id,
             db=session,
         )
+        if isinstance(exc, ValueError):
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
         raise
 
     return deployment_mapper.shape_deployment_update_result(

--- a/src/backend/base/langflow/api/v1/deployments.py
+++ b/src/backend/base/langflow/api/v1/deployments.py
@@ -102,9 +102,11 @@ from langflow.services.database.models.deployment_provider_account.crud import (
     update_provider_account as update_provider_account_row,
 )
 from langflow.services.database.models.flow_version_deployment_attachment.crud import (
+    AttachmentConflictError,
     get_attachment_by_provider_snapshot_id,
     list_deployment_attachments,
     list_deployment_attachments_for_flow_version_ids,
+    update_flow_version_by_provider_snapshot_id,
 )
 
 router = APIRouter(prefix="/deployments", tags=["Deployments"], include_in_schema=False)
@@ -550,7 +552,7 @@ async def create_deployment(
                 user_id=current_user.id,
                 db=session,
             )
-        if isinstance(exc, ValueError):
+        if isinstance(exc, AttachmentConflictError):
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
         raise
     return deployment_mapper.shape_deployment_create_result(
@@ -998,17 +1000,40 @@ async def update_snapshot(
             flow_artifact=flow_artifact,
         )
 
-    # Provider mutation succeeded — update the local attachment record.
+    # Provider mutation succeeded — update all local attachment rows that share
+    # this provider snapshot id.
     # If the DB flush fails, attempt a best-effort compensating re-upload
     # of the previous flow version's artifact.
+    # Concurrency note: rollback uses a single previously-read flow_version_id.
+    # This assumes the snapshot->flow_version invariant held before this call.
+    # Because the invariant is enforced in app logic (not a DB constraint),
+    # concurrent writers can still race and violate that assumption.
     previous_flow_version_id = attachment.flow_version_id
-    attachment.flow_version_id = body.flow_version_id
-    session.add(attachment)
     try:
-        await session.flush()
-        await session.refresh(attachment)
+        updated_rows = await update_flow_version_by_provider_snapshot_id(
+            session,
+            user_id=current_user.id,
+            provider_snapshot_id=snapshot_id,
+            flow_version_id=body.flow_version_id,
+        )
+        if updated_rows == 0:
+            logger.warning(
+                "Snapshot '%s' update changed zero attachment rows after provider mutation "
+                "(user_id=%s, requested_flow_version_id=%s). Possible concurrent modification.",
+                snapshot_id,
+                current_user.id,
+                body.flow_version_id,
+            )
+        await session.commit()
     except Exception:
         await session.rollback()
+        logger.warning(
+            "DB update/commit failed after provider snapshot update for snapshot '%s' "
+            "(requested_flow_version_id=%s). Attempting compensating provider rollback.",
+            snapshot_id,
+            body.flow_version_id,
+            exc_info=True,
+        )
         try:
             prev_version = await get_flow_version_entry(
                 session,
@@ -1037,7 +1062,7 @@ async def update_snapshot(
             logger.warning(
                 "Best-effort rollback failed for snapshot '%s'. "
                 "Provider content reflects flow_version_id=%s but attachment "
-                "record points to flow_version_id=%s. Manual reconciliation may be needed.",
+                "records point to flow_version_id=%s. Manual reconciliation may be needed.",
                 snapshot_id,
                 body.flow_version_id,
                 previous_flow_version_id,
@@ -1261,7 +1286,7 @@ async def update_deployment(
             user_id=current_user.id,
             db=session,
         )
-        if isinstance(exc, ValueError):
+        if isinstance(exc, AttachmentConflictError):
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
         raise
 

--- a/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
+++ b/src/backend/base/langflow/api/v1/mappers/deployments/watsonx_orchestrate/mapper.py
@@ -265,18 +265,17 @@ class WatsonxOrchestrateDeploymentMapper(BaseDeploymentMapper):
         if resource == "connection":
             return (
                 f"A connection with app_id '{normalized_resource_name}' already exists in the provider. "
-                "Reference it as an existing connection instead of creating a new one."
+                "Please choose a different name."
                 if normalized_resource_name
                 else "A connection referenced in this request already exists in the provider. "
-                "Reference it as an existing connection instead of creating a new one."
+                "Please choose a different name."
             )
         if resource == "agent":
             return (
                 f"An agent with name '{normalized_resource_name}' already exists in the provider. "
-                "Please choose a different name or delete the existing agent first."
+                "Please choose a different name."
                 if normalized_resource_name
-                else "An agent with this name already exists in the provider. "
-                "Please choose a different name or delete the existing agent first."
+                else "An agent with this name already exists in the provider. Please choose a different name."
             )
 
         return super().format_conflict_detail(

--- a/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
+++ b/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
@@ -18,6 +18,38 @@ if TYPE_CHECKING:
     from langflow.services.database.models.flow_version.model import FlowVersion
 
 
+async def _check_snapshot_flow_version_conflict(
+    db: AsyncSession,
+    *,
+    provider_snapshot_id: str | None,
+    flow_version_id: UUID,
+) -> None:
+    """Ensure a provider_snapshot_id is only ever linked to one flow version.
+
+    A tool can appear in multiple deployments, but every row with the same
+    provider_snapshot_id must point to the same flow_version_id.  For example:
+
+        (FV=1, tool=A, deploy=X)  ✓  — first use of tool A
+        (FV=1, tool=A, deploy=Y)  ✓  — same FV, different deployment, OK
+        (FV=2, tool=A, deploy=Z)  ✗  — different FV for tool A, rejected
+
+    This cannot be expressed as a DB unique constraint, so we enforce it here.
+    """
+    if not provider_snapshot_id:
+        return
+    stmt = select(FlowVersionDeploymentAttachment.flow_version_id).where(
+        FlowVersionDeploymentAttachment.provider_snapshot_id == provider_snapshot_id,
+        FlowVersionDeploymentAttachment.flow_version_id != flow_version_id,
+    ).limit(1)
+    conflict = (await db.exec(stmt)).first()
+    if conflict is not None:
+        msg = (
+            f"Tool '{provider_snapshot_id}' is already attached to a different flow version. "
+            f"Each tool can only be linked to one flow version."
+        )
+        raise ValueError(msg)
+
+
 async def create_deployment_attachment(
     db: AsyncSession,
     *,
@@ -26,6 +58,9 @@ async def create_deployment_attachment(
     deployment_id: UUID,
     provider_snapshot_id: str | None = None,
 ) -> FlowVersionDeploymentAttachment:
+    await _check_snapshot_flow_version_conflict(
+        db, provider_snapshot_id=provider_snapshot_id, flow_version_id=flow_version_id,
+    )
     row = FlowVersionDeploymentAttachment(
         user_id=user_id,
         flow_version_id=flow_version_id,
@@ -164,6 +199,9 @@ async def update_deployment_attachment_provider_snapshot_id(
     attachment: FlowVersionDeploymentAttachment,
     provider_snapshot_id: str | None,
 ) -> FlowVersionDeploymentAttachment:
+    await _check_snapshot_flow_version_conflict(
+        db, provider_snapshot_id=provider_snapshot_id, flow_version_id=attachment.flow_version_id,
+    )
     attachment.provider_snapshot_id = provider_snapshot_id
     db.add(attachment)
     await db.flush()

--- a/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
+++ b/src/backend/base/langflow/services/database/models/flow_version_deployment_attachment/crud.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from lfx.log.logger import logger
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import col, delete, func, select
+from sqlmodel import col, delete, func, select, update
 
 from langflow.services.database.models.flow_version_deployment_attachment.model import (
     FlowVersionDeploymentAttachment,
@@ -16,6 +16,18 @@ if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
     from langflow.services.database.models.flow_version.model import FlowVersion
+
+
+class AttachmentConflictError(ValueError):
+    """Base exception for flow-version attachment conflicts."""
+
+
+class SnapshotFlowVersionConflictError(AttachmentConflictError):
+    """Raised when one provider snapshot is linked to multiple flow versions."""
+
+
+class DeploymentAttachmentConflictError(AttachmentConflictError):
+    """Raised when a deployment attachment violates DB uniqueness constraints."""
 
 
 async def _check_snapshot_flow_version_conflict(
@@ -34,20 +46,34 @@ async def _check_snapshot_flow_version_conflict(
         (FV=2, tool=A, deploy=Z)  ✗  — different FV for tool A, rejected
 
     This cannot be expressed as a DB unique constraint, so we enforce it here.
+
+    Concurrency note: this is a read-before-write guard with no DB-level lock
+    or uniqueness guarantee on provider_snapshot_id. Concurrent transactions
+    can still both pass this check before either commit.
     """
     if not provider_snapshot_id:
         return
-    stmt = select(FlowVersionDeploymentAttachment.flow_version_id).where(
-        FlowVersionDeploymentAttachment.provider_snapshot_id == provider_snapshot_id,
-        FlowVersionDeploymentAttachment.flow_version_id != flow_version_id,
-    ).limit(1)
+    stmt = (
+        select(FlowVersionDeploymentAttachment.flow_version_id)
+        .where(
+            FlowVersionDeploymentAttachment.provider_snapshot_id == provider_snapshot_id,
+            FlowVersionDeploymentAttachment.flow_version_id != flow_version_id,
+        )
+        .limit(1)
+    )
     conflict = (await db.exec(stmt)).first()
     if conflict is not None:
+        logger.info(
+            "Snapshot flow-version conflict detected for provider_snapshot_id=%s (requested=%s existing=%s).",
+            provider_snapshot_id,
+            flow_version_id,
+            conflict,
+        )
         msg = (
             f"Tool '{provider_snapshot_id}' is already attached to a different flow version. "
             f"Each tool can only be linked to one flow version."
         )
-        raise ValueError(msg)
+        raise SnapshotFlowVersionConflictError(msg)
 
 
 async def create_deployment_attachment(
@@ -59,7 +85,9 @@ async def create_deployment_attachment(
     provider_snapshot_id: str | None = None,
 ) -> FlowVersionDeploymentAttachment:
     await _check_snapshot_flow_version_conflict(
-        db, provider_snapshot_id=provider_snapshot_id, flow_version_id=flow_version_id,
+        db,
+        provider_snapshot_id=provider_snapshot_id,
+        flow_version_id=flow_version_id,
     )
     row = FlowVersionDeploymentAttachment(
         user_id=user_id,
@@ -81,7 +109,7 @@ async def create_deployment_attachment(
         msg = (
             f"Attachment conflicts with an existing record (flow_version={flow_version_id}, deployment={deployment_id})"
         )
-        raise ValueError(msg) from exc
+        raise DeploymentAttachmentConflictError(msg) from exc
     await db.refresh(row)
     return row
 
@@ -200,7 +228,9 @@ async def update_deployment_attachment_provider_snapshot_id(
     provider_snapshot_id: str | None,
 ) -> FlowVersionDeploymentAttachment:
     await _check_snapshot_flow_version_conflict(
-        db, provider_snapshot_id=provider_snapshot_id, flow_version_id=attachment.flow_version_id,
+        db,
+        provider_snapshot_id=provider_snapshot_id,
+        flow_version_id=attachment.flow_version_id,
     )
     attachment.provider_snapshot_id = provider_snapshot_id
     db.add(attachment)
@@ -343,6 +373,33 @@ async def get_attachment_by_provider_snapshot_id(
         FlowVersionDeploymentAttachment.provider_snapshot_id == provider_snapshot_id,
     )
     return (await db.exec(stmt)).first()
+
+
+async def update_flow_version_by_provider_snapshot_id(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    provider_snapshot_id: str,
+    flow_version_id: UUID,
+) -> int:
+    """Update all attachment rows that share a provider_snapshot_id.
+
+    A single provider snapshot can be attached to multiple deployments, so
+    route handlers must update every matching row together.
+
+    Concurrency note: this is a set-based UPDATE without an explicit lock/read
+    phase. If concurrent writers touch the same snapshot id, last commit wins.
+    """
+    stmt = (
+        update(FlowVersionDeploymentAttachment)
+        .where(
+            FlowVersionDeploymentAttachment.user_id == user_id,
+            FlowVersionDeploymentAttachment.provider_snapshot_id == provider_snapshot_id,
+        )
+        .values(flow_version_id=flow_version_id)
+    )
+    result = await db.exec(stmt)
+    return int(result.rowcount or 0)
 
 
 async def count_attachments_by_deployment_ids(

--- a/src/backend/base/langflow/tests/services/database/models/flow_version_deployment_attachment/test_crud.py
+++ b/src/backend/base/langflow/tests/services/database/models/flow_version_deployment_attachment/test_crud.py
@@ -11,6 +11,8 @@ from langflow.services.database.models.deployment_provider_account.model import 
 from langflow.services.database.models.flow.model import Flow
 from langflow.services.database.models.flow_version.model import FlowVersion
 from langflow.services.database.models.flow_version_deployment_attachment.crud import (
+    DeploymentAttachmentConflictError,
+    SnapshotFlowVersionConflictError,
     count_attachments_by_deployment_ids,
     create_deployment_attachment,
     delete_deployment_attachment,
@@ -21,6 +23,7 @@ from langflow.services.database.models.flow_version_deployment_attachment.crud i
     list_deployment_attachments,
     list_deployment_attachments_for_flow_version_ids,
     update_deployment_attachment_provider_snapshot_id,
+    update_flow_version_by_provider_snapshot_id,
 )
 from langflow.services.database.models.flow_version_deployment_attachment.model import (
     FlowVersionDeploymentAttachment,
@@ -194,7 +197,7 @@ class TestCreateDeploymentAttachment:
         )
         await db.commit()
 
-        with pytest.raises(ValueError, match="Attachment conflicts with an existing record"):
+        with pytest.raises(DeploymentAttachmentConflictError, match="Attachment conflicts with an existing record"):
             await create_deployment_attachment(
                 db,
                 user_id=user.id,
@@ -385,6 +388,79 @@ class TestUpdateDeploymentAttachmentProviderSnapshotId:
         await db.commit()
 
         assert updated.provider_snapshot_id is None
+
+
+@pytest.mark.asyncio
+class TestUpdateFlowVersionByProviderSnapshotId:
+    async def test_updates_all_rows_for_snapshot_id(
+        self,
+        db: AsyncSession,
+        user: User,
+        flow: Flow,
+        flow_version: FlowVersion,
+        deployment: Deployment,
+        folder: Folder,
+        provider_account: DeploymentProviderAccount,
+    ):
+        flow_version_2 = FlowVersion(flow_id=flow.id, user_id=user.id, version_number=2, data={})
+        deployment_2 = Deployment(
+            user_id=user.id,
+            project_id=folder.id,
+            deployment_provider_account_id=provider_account.id,
+            resource_key="rk-2",
+            name="test-deployment-2",
+            deployment_type=DeploymentType.AGENT,
+        )
+        db.add_all([flow_version_2, deployment_2])
+        await db.commit()
+        await db.refresh(flow_version_2)
+        await db.refresh(deployment_2)
+
+        await create_deployment_attachment(
+            db,
+            user_id=user.id,
+            flow_version_id=flow_version.id,
+            deployment_id=deployment.id,
+            provider_snapshot_id="tool-A",
+        )
+        await create_deployment_attachment(
+            db,
+            user_id=user.id,
+            flow_version_id=flow_version.id,
+            deployment_id=deployment_2.id,
+            provider_snapshot_id="tool-A",
+        )
+        await db.commit()
+
+        updated_count = await update_flow_version_by_provider_snapshot_id(
+            db,
+            user_id=user.id,
+            provider_snapshot_id="tool-A",
+            flow_version_id=flow_version_2.id,
+        )
+        await db.commit()
+
+        assert updated_count == 2
+
+        rows = (
+            await db.exec(
+                select(FlowVersionDeploymentAttachment).where(
+                    FlowVersionDeploymentAttachment.user_id == user.id,
+                    FlowVersionDeploymentAttachment.provider_snapshot_id == "tool-A",
+                )
+            )
+        ).all()
+        assert len(rows) == 2
+        assert all(row.flow_version_id == flow_version_2.id for row in rows)
+
+    async def test_returns_zero_when_snapshot_id_not_found(self, db: AsyncSession, user: User):
+        updated_count = await update_flow_version_by_provider_snapshot_id(
+            db,
+            user_id=user.id,
+            provider_snapshot_id="missing",
+            flow_version_id=uuid4(),
+        )
+        assert updated_count == 0
 
 
 @pytest.mark.asyncio
@@ -589,7 +665,7 @@ class TestSnapshotFlowVersionConflict:
         await db.refresh(d2)
 
         # Should reject: FV2, tool-A, deployment-2 — same tool, different flow version
-        with pytest.raises(ValueError, match="already attached to a different flow version"):
+        with pytest.raises(SnapshotFlowVersionConflictError, match="already attached to a different flow version"):
             await create_deployment_attachment(
                 db,
                 user_id=user.id,
@@ -684,9 +760,11 @@ class TestSnapshotFlowVersionConflict:
         await db.commit()
 
         # Should reject: updating FV2's attachment to use tool-A (owned by FV1)
-        with pytest.raises(ValueError, match="already attached to a different flow version"):
+        with pytest.raises(SnapshotFlowVersionConflictError, match="already attached to a different flow version"):
             await update_deployment_attachment_provider_snapshot_id(
-                db, attachment=att2, provider_snapshot_id="tool-A",
+                db,
+                attachment=att2,
+                provider_snapshot_id="tool-A",
             )
 
     async def test_create_allows_null_snapshot_ids(
@@ -704,11 +782,17 @@ class TestSnapshotFlowVersionConflict:
         await db.refresh(fv2)
 
         att1 = await create_deployment_attachment(
-            db, user_id=user.id, flow_version_id=flow_version.id, deployment_id=deployment.id,
+            db,
+            user_id=user.id,
+            flow_version_id=flow_version.id,
+            deployment_id=deployment.id,
         )
         await db.commit()
         att2 = await create_deployment_attachment(
-            db, user_id=user.id, flow_version_id=fv2.id, deployment_id=deployment.id,
+            db,
+            user_id=user.id,
+            flow_version_id=fv2.id,
+            deployment_id=deployment.id,
         )
         await db.commit()
 

--- a/src/backend/base/langflow/tests/services/database/models/flow_version_deployment_attachment/test_crud.py
+++ b/src/backend/base/langflow/tests/services/database/models/flow_version_deployment_attachment/test_crud.py
@@ -89,6 +89,7 @@ async def provider_account(db: AsyncSession, user: User) -> DeploymentProviderAc
         user_id=user.id,
         provider_tenant_id="tenant-1",
         provider_key=DeploymentProviderKey.WATSONX_ORCHESTRATE,
+        name="test-provider",
         provider_url="https://provider.example.com",
         api_key="encrypted-value",  # pragma: allowlist secret
     )
@@ -541,6 +542,178 @@ class TestCountAttachmentsByDeploymentIds:
     ):
         counts = await count_attachments_by_deployment_ids(db, user_id=user.id, deployment_ids=[deployment.id])
         assert deployment.id not in counts
+
+
+@pytest.mark.asyncio
+class TestSnapshotFlowVersionConflict:
+    """Ensure a provider_snapshot_id can only be linked to one flow version.
+
+    Valid:   (FV=1, tool=A, deploy=X) + (FV=1, tool=A, deploy=Y)  — same FV, different deployments
+    Invalid: (FV=1, tool=A, deploy=X) + (FV=2, tool=A, deploy=Y)  — different FV, same tool
+    """
+
+    async def test_create_rejects_same_tool_different_flow_version(
+        self,
+        db: AsyncSession,
+        user: User,
+        flow: Flow,
+        flow_version: FlowVersion,
+        deployment: Deployment,
+        folder: Folder,
+        provider_account: DeploymentProviderAccount,
+    ):
+        # First attachment: FV1, tool-A, deployment-1
+        await create_deployment_attachment(
+            db,
+            user_id=user.id,
+            flow_version_id=flow_version.id,
+            deployment_id=deployment.id,
+            provider_snapshot_id="tool-A",
+        )
+        await db.commit()
+
+        # Second flow version + deployment
+        fv2 = FlowVersion(flow_id=flow.id, user_id=user.id, version_number=2, data={})
+        db.add(fv2)
+        d2 = Deployment(
+            user_id=user.id,
+            project_id=folder.id,
+            deployment_provider_account_id=provider_account.id,
+            resource_key="rk-2",
+            name="deploy-2",
+            deployment_type=DeploymentType.AGENT,
+        )
+        db.add(d2)
+        await db.commit()
+        await db.refresh(fv2)
+        await db.refresh(d2)
+
+        # Should reject: FV2, tool-A, deployment-2 — same tool, different flow version
+        with pytest.raises(ValueError, match="already attached to a different flow version"):
+            await create_deployment_attachment(
+                db,
+                user_id=user.id,
+                flow_version_id=fv2.id,
+                deployment_id=d2.id,
+                provider_snapshot_id="tool-A",
+            )
+
+    async def test_create_allows_same_tool_same_flow_version_different_deployment(
+        self,
+        db: AsyncSession,
+        user: User,
+        flow_version: FlowVersion,
+        deployment: Deployment,
+        folder: Folder,
+        provider_account: DeploymentProviderAccount,
+    ):
+        await create_deployment_attachment(
+            db,
+            user_id=user.id,
+            flow_version_id=flow_version.id,
+            deployment_id=deployment.id,
+            provider_snapshot_id="tool-A",
+        )
+        await db.commit()
+
+        d2 = Deployment(
+            user_id=user.id,
+            project_id=folder.id,
+            deployment_provider_account_id=provider_account.id,
+            resource_key="rk-2",
+            name="deploy-2",
+            deployment_type=DeploymentType.AGENT,
+        )
+        db.add(d2)
+        await db.commit()
+        await db.refresh(d2)
+
+        # Should succeed: same FV, same tool, different deployment
+        att2 = await create_deployment_attachment(
+            db,
+            user_id=user.id,
+            flow_version_id=flow_version.id,
+            deployment_id=d2.id,
+            provider_snapshot_id="tool-A",
+        )
+        await db.commit()
+        assert att2.provider_snapshot_id == "tool-A"
+
+    async def test_update_rejects_same_tool_different_flow_version(
+        self,
+        db: AsyncSession,
+        user: User,
+        flow: Flow,
+        flow_version: FlowVersion,
+        deployment: Deployment,
+        folder: Folder,
+        provider_account: DeploymentProviderAccount,
+    ):
+        # FV1 owns tool-A
+        await create_deployment_attachment(
+            db,
+            user_id=user.id,
+            flow_version_id=flow_version.id,
+            deployment_id=deployment.id,
+            provider_snapshot_id="tool-A",
+        )
+        await db.commit()
+
+        # FV2 has no tool yet
+        fv2 = FlowVersion(flow_id=flow.id, user_id=user.id, version_number=2, data={})
+        db.add(fv2)
+        d2 = Deployment(
+            user_id=user.id,
+            project_id=folder.id,
+            deployment_provider_account_id=provider_account.id,
+            resource_key="rk-2",
+            name="deploy-2",
+            deployment_type=DeploymentType.AGENT,
+        )
+        db.add(d2)
+        await db.commit()
+        await db.refresh(fv2)
+        await db.refresh(d2)
+
+        att2 = await create_deployment_attachment(
+            db,
+            user_id=user.id,
+            flow_version_id=fv2.id,
+            deployment_id=d2.id,
+        )
+        await db.commit()
+
+        # Should reject: updating FV2's attachment to use tool-A (owned by FV1)
+        with pytest.raises(ValueError, match="already attached to a different flow version"):
+            await update_deployment_attachment_provider_snapshot_id(
+                db, attachment=att2, provider_snapshot_id="tool-A",
+            )
+
+    async def test_create_allows_null_snapshot_ids(
+        self,
+        db: AsyncSession,
+        user: User,
+        flow: Flow,
+        flow_version: FlowVersion,
+        deployment: Deployment,
+    ):
+        """Multiple attachments with None provider_snapshot_id should not conflict."""
+        fv2 = FlowVersion(flow_id=flow.id, user_id=user.id, version_number=2, data={})
+        db.add(fv2)
+        await db.commit()
+        await db.refresh(fv2)
+
+        att1 = await create_deployment_attachment(
+            db, user_id=user.id, flow_version_id=flow_version.id, deployment_id=deployment.id,
+        )
+        await db.commit()
+        att2 = await create_deployment_attachment(
+            db, user_id=user.id, flow_version_id=fv2.id, deployment_id=deployment.id,
+        )
+        await db.commit()
+
+        assert att1.provider_snapshot_id is None
+        assert att2.provider_snapshot_id is None
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -221,13 +221,11 @@ def test_watsonx_mapper_formats_conflict_detail_fallback_without_structured_enti
         ("tool", "A tool with this name already exists in the provider. Please choose a different name."),
         (
             "connection",
-            "A connection referenced in this request already exists in the provider. "
-            "Reference it as an existing connection instead of creating a new one.",
+            "A connection referenced in this request already exists in the provider. Please choose a different name.",
         ),
         (
             "agent",
-            "An agent with this name already exists in the provider. "
-            "Please choose a different name or delete the existing agent first.",
+            "An agent with this name already exists in the provider. Please choose a different name.",
         ),
     ],
 )
@@ -247,14 +245,12 @@ def test_watsonx_mapper_formats_conflict_detail_from_structured_resource(resourc
         (
             "connection",
             "cfg",
-            "A connection with app_id 'cfg' already exists in the provider. "
-            "Reference it as an existing connection instead of creating a new one.",
+            "A connection with app_id 'cfg' already exists in the provider. Please choose a different name.",
         ),
         (
             "agent",
             "My_Agent",
-            "An agent with name 'My_Agent' already exists in the provider. "
-            "Please choose a different name or delete the existing agent first.",
+            "An agent with name 'My_Agent' already exists in the provider. Please choose a different name.",
         ),
     ],
 )

--- a/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_route_handlers.py
@@ -21,6 +21,7 @@ from langflow.api.v1.schemas.deployments import (
     DeploymentProviderAccountCreateRequest,
     DeploymentProviderAccountUpdateRequest,
     DeploymentUpdateRequest,
+    SnapshotUpdateRequest,
 )
 from langflow.services.database.models.deployment_provider_account.schemas import DeploymentProviderKey
 from lfx.services.adapters.deployment.exceptions import (
@@ -894,6 +895,151 @@ class TestConfigAndSnapshotListRoutes:
             page=1,
             size=10,
         )
+
+
+# ---------------------------------------------------------------------------
+# update_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSnapshotRoute:
+    @pytest.mark.asyncio
+    @patch("langflow.services.database.models.flow_version.crud.get_flow_version_entry", new_callable=AsyncMock)
+    @patch("langflow.services.database.models.deployment.crud.get_deployment", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.update_flow_version_by_provider_snapshot_id", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.resolve_deployment_adapter")
+    @patch(f"{ROUTES_MODULE}.get_deployment_mapper")
+    @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.get_attachment_by_provider_snapshot_id", new_callable=AsyncMock)
+    async def test_updates_all_attachment_rows_for_snapshot(
+        self,
+        mock_get_attachment,
+        mock_get_pa,
+        mock_get_mapper,
+        mock_resolve_adapter,
+        mock_update_rows,
+        mock_get_deployment_row,
+        mock_get_flow_version,
+    ):
+        from langflow.api.v1.deployments import update_snapshot
+
+        user = _fake_user()
+        flow_id = uuid4()
+        target_flow_version_id = uuid4()
+        attachment = SimpleNamespace(
+            flow_version_id=uuid4(),
+            deployment_id=uuid4(),
+            provider_snapshot_id="tool-1",
+        )
+        deployment = _fake_deployment_row(
+            id=attachment.deployment_id,
+            deployment_provider_account_id=uuid4(),
+        )
+        provider_account = _fake_provider_account()
+        provider_account.id = deployment.deployment_provider_account_id
+
+        mock_get_attachment.return_value = attachment
+        mock_get_deployment_row.return_value = deployment
+        mock_get_flow_version.return_value = SimpleNamespace(id=target_flow_version_id, flow_id=flow_id, data={})
+        mock_get_pa.return_value = provider_account
+        adapter = AsyncMock()
+        mock_resolve_adapter.return_value = adapter
+        mapper = MagicMock()
+        mapper.resolve_snapshot_update_artifact.return_value = {"artifact": "payload"}
+        mock_get_mapper.return_value = mapper
+        mock_update_rows.return_value = 2
+
+        session = AsyncMock()
+        session.get.return_value = SimpleNamespace(id=flow_id)
+
+        response = await update_snapshot(
+            provider_snapshot_id=" tool-1 ",
+            body=SnapshotUpdateRequest(flow_version_id=target_flow_version_id),
+            session=session,
+            current_user=user,
+        )
+
+        assert response.flow_version_id == target_flow_version_id
+        assert response.provider_snapshot_id == "tool-1"
+        mock_get_attachment.assert_awaited_once_with(
+            session,
+            user_id=user.id,
+            provider_snapshot_id="tool-1",
+        )
+        mock_update_rows.assert_awaited_once_with(
+            session,
+            user_id=user.id,
+            provider_snapshot_id="tool-1",
+            flow_version_id=target_flow_version_id,
+        )
+        session.commit.assert_awaited_once()
+        session.rollback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("langflow.services.database.models.flow_version.crud.get_flow_version_entry", new_callable=AsyncMock)
+    @patch("langflow.services.database.models.deployment.crud.get_deployment", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.update_flow_version_by_provider_snapshot_id", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.resolve_deployment_adapter")
+    @patch(f"{ROUTES_MODULE}.get_deployment_mapper")
+    @patch(f"{ROUTES_MODULE}.get_owned_provider_account_or_404", new_callable=AsyncMock)
+    @patch(f"{ROUTES_MODULE}.get_attachment_by_provider_snapshot_id", new_callable=AsyncMock)
+    async def test_commit_failure_attempts_provider_compensation(
+        self,
+        mock_get_attachment,
+        mock_get_pa,
+        mock_get_mapper,
+        mock_resolve_adapter,
+        mock_update_rows,
+        mock_get_deployment_row,
+        mock_get_flow_version,
+    ):
+        from langflow.api.v1.deployments import update_snapshot
+
+        user = _fake_user()
+        flow_id = uuid4()
+        previous_flow_version_id = uuid4()
+        target_flow_version_id = uuid4()
+        attachment = SimpleNamespace(
+            flow_version_id=previous_flow_version_id,
+            deployment_id=uuid4(),
+            provider_snapshot_id="tool-1",
+        )
+        deployment = _fake_deployment_row(
+            id=attachment.deployment_id,
+            deployment_provider_account_id=uuid4(),
+        )
+        provider_account = _fake_provider_account()
+        provider_account.id = deployment.deployment_provider_account_id
+
+        target_version = SimpleNamespace(id=target_flow_version_id, flow_id=flow_id, data={"nodes": []})
+        previous_version = SimpleNamespace(id=previous_flow_version_id, flow_id=flow_id, data={"nodes": []})
+        mock_get_flow_version.side_effect = [target_version, previous_version]
+        mock_get_attachment.return_value = attachment
+        mock_get_deployment_row.return_value = deployment
+        mock_get_pa.return_value = provider_account
+        adapter = AsyncMock()
+        adapter.update_snapshot.return_value = None
+        mock_resolve_adapter.return_value = adapter
+        mapper = MagicMock()
+        mapper.resolve_snapshot_update_artifact.side_effect = [{"artifact": "new"}, {"artifact": "previous"}]
+        mock_get_mapper.return_value = mapper
+        mock_update_rows.return_value = 2
+
+        session = AsyncMock()
+        session.get.return_value = SimpleNamespace(id=flow_id)
+        session.commit.side_effect = RuntimeError("commit failed")
+
+        with pytest.raises(RuntimeError, match="commit failed"):
+            await update_snapshot(
+                provider_snapshot_id="tool-1",
+                body=SnapshotUpdateRequest(flow_version_id=target_flow_version_id),
+                session=session,
+                current_user=user,
+            )
+
+        session.commit.assert_awaited_once()
+        session.rollback.assert_awaited_once()
+        assert adapter.update_snapshot.await_count == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
enforce unique snapshot to flow version relationship. mult flow versions on a single snapshot (tool, in wxo) would mean we have a corrupt state, as wxo only ever has a single payload (single flow version) on a tool.