### PR TITLE
fix: Allow >= specifications in dependencies

### DIFF
--- a/scripts/ci/update_uv_dependency.py
+++ b/scripts/ci/update_uv_dependency.py
@@ -21,7 +21,7 @@ def update_uv_dep(base_version: str) -> None:
     # Also handles both langflow-base and langflow-base-nightly names
     # Captures extras in group 3 to preserve them in the replacement
     pattern = re.compile(
-        r'(dependencies\s*=\s*\[\s*\n\s*)("langflow-base(?:-nightly)?((?:\[[^\]]+\])?)(?:~=|==)[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*")'
+        r'(dependencies\s*=\s*\[\s*\n\s*)("langflow-base(?:-nightly)?((?:\[[^\]]+\])?)(?:~=|==|>=)[\d.]+(?:\.(?:post|dev|a|b|rc)\d+)*")'
     )
 
     # Check if the pattern is found

--- a/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Document Q&A.json
@@ -1319,7 +1319,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   },
                   {
                     "name": "pydantic",
@@ -1327,7 +1327,7 @@
                   },
                   {
                     "name": "googleapiclient",
-                    "version": "2.193.0"
+                    "version": "2.194.0"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Hybrid Search RAG.json
@@ -1521,7 +1521,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   },
                   {
                     "name": "lfx",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Instagram Copywriter.json
@@ -2084,7 +2084,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Invoice Summarizer.json
@@ -712,7 +712,7 @@
               }
             ],
             "pinned": false,
-            "score": 7.568328950209746e-06,
+            "score": 7.568328950209746e-6,
             "template": {
               "_type": "Component",
               "code": {
@@ -1192,7 +1192,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
@@ -541,11 +541,11 @@
                 "dependencies": [
                   {
                     "name": "chromadb",
-                    "version": "1.5.6"
+                    "version": "1.5.7"
                   },
                   {
                     "name": "cryptography",
-                    "version": "46.0.6"
+                    "version": "46.0.7"
                   },
                   {
                     "name": "langchain_chroma",
@@ -565,7 +565,7 @@
                   },
                   {
                     "name": "langchain_openai",
-                    "version": "1.1.9"
+                    "version": "1.1.12"
                   },
                   {
                     "name": "langchain_huggingface",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Market Research.json
@@ -1204,7 +1204,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3
@@ -2094,6 +2094,7 @@
                 "list_add_label": "Add More",
                 "model_type": "language",
                 "name": "model",
+                "options": [],
                 "override_skip": false,
                 "placeholder": "Setup Provider",
                 "real_time_refresh": true,
@@ -2105,8 +2106,7 @@
                 "trace_as_input": true,
                 "track_in_telemetry": false,
                 "type": "model",
-                "value": "",
-                "options": []
+                "value": ""
               },
               "output_schema": {
                 "_input_type": "TableInput",

--- a/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/News Aggregator.json
@@ -1186,7 +1186,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3
@@ -1781,7 +1781,7 @@
                   },
                   {
                     "name": "googleapiclient",
-                    "version": "2.193.0"
+                    "version": "2.194.0"
                   }
                 ],
                 "total_dependencies": 7

--- a/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Nvidia Remix.json
@@ -813,7 +813,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3
@@ -2105,7 +2105,7 @@
                 "dependencies": [
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Pokédex Agent.json
@@ -1251,7 +1251,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Portfolio Website Code Generator.json
@@ -941,7 +941,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   },
                   {
                     "name": "pydantic",
@@ -949,7 +949,7 @@
                   },
                   {
                     "name": "googleapiclient",
-                    "version": "2.193.0"
+                    "version": "2.194.0"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Price Deal Finder.json
@@ -1620,7 +1620,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Research Agent.json
@@ -2823,7 +2823,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/SaaS Pricing.json
@@ -905,7 +905,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Search agent.json
@@ -952,7 +952,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Sequential Tasks Agents.json
@@ -370,7 +370,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3
@@ -958,7 +958,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3
@@ -2403,7 +2403,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3
@@ -2976,7 +2976,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   },
                   {
                     "name": "pydantic",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json
@@ -951,7 +951,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Social Media Agent.json
@@ -160,7 +160,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   },
                   {
                     "name": "pydantic",
@@ -392,7 +392,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   },
                   {
                     "name": "pydantic",
@@ -1301,7 +1301,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Text Sentiment Analysis.json
@@ -2633,7 +2633,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   },
                   {
                     "name": "pydantic",
@@ -2641,7 +2641,7 @@
                   },
                   {
                     "name": "googleapiclient",
-                    "version": "2.193.0"
+                    "version": "2.194.0"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Travel Planning Agents.json
@@ -1717,7 +1717,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3
@@ -2300,7 +2300,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3
@@ -2883,7 +2883,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -1635,7 +1635,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   },
                   {
                     "name": "pydantic",
@@ -1643,7 +1643,7 @@
                   },
                   {
                     "name": "googleapiclient",
-                    "version": "2.193.0"
+                    "version": "2.194.0"
                   }
                 ],
                 "total_dependencies": 4
@@ -2687,7 +2687,7 @@
                   },
                   {
                     "name": "cryptography",
-                    "version": "46.0.6"
+                    "version": "46.0.7"
                   },
                   {
                     "name": "langchain_chroma",
@@ -2707,7 +2707,7 @@
                   },
                   {
                     "name": "chromadb",
-                    "version": "1.5.6"
+                    "version": "1.5.7"
                   }
                 ],
                 "total_dependencies": 7
@@ -3053,11 +3053,11 @@
                 "dependencies": [
                   {
                     "name": "chromadb",
-                    "version": "1.5.6"
+                    "version": "1.5.7"
                   },
                   {
                     "name": "cryptography",
-                    "version": "46.0.6"
+                    "version": "46.0.7"
                   },
                   {
                     "name": "langchain_chroma",
@@ -3077,7 +3077,7 @@
                   },
                   {
                     "name": "langchain_openai",
-                    "version": "1.1.9"
+                    "version": "1.1.12"
                   },
                   {
                     "name": "langchain_huggingface",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Youtube Analysis.json
@@ -274,7 +274,7 @@
                   },
                   {
                     "name": "googleapiclient",
-                    "version": "2.193.0"
+                    "version": "2.194.0"
                   },
                   {
                     "name": "lfx",
@@ -513,7 +513,7 @@
                   },
                   {
                     "name": "langchain_core",
-                    "version": "1.2.27"
+                    "version": "1.2.28"
                   }
                 ],
                 "total_dependencies": 3


### PR DESCRIPTION
This pull request makes a small change to the regular expression used for updating the `langflow-base` dependency version in the `update_uv_dependency.py` script. The pattern now also matches dependencies specified with a `>=` version constraint, in addition to the previous `~=` and `==` constraints.