### PR TITLE
fix(frontend): auto-populate global variable key-value pairs

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-attach-flows.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-attach-flows.test.tsx
@@ -150,19 +150,41 @@ jest.mock(
       placeholder,
       value,
       onChange,
+      options,
+      selectedOption,
+      setSelectedOption,
     }: {
       id: string;
       placeholder: string;
       value: string;
       onChange: (v: string) => void;
+      options?: string[];
+      selectedOption?: string;
+      setSelectedOption?: (v: string) => void;
     }) {
       return (
-        <input
-          data-testid={`input-${id}`}
-          placeholder={placeholder}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-        />
+        <div data-testid={`input-component-${id}`}>
+          <input
+            data-testid={`input-${id}`}
+            placeholder={placeholder}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+          />
+          {options && options.length > 0 && (
+            <select
+              data-testid={`select-${id}`}
+              value={selectedOption ?? ""}
+              onChange={(e) => setSelectedOption?.(e.target.value)}
+            >
+              <option value="">Select...</option>
+              {options.map((o) => (
+                <option key={o} value={o}>
+                  {o}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
       );
     },
 );
@@ -430,5 +452,92 @@ describe("Edit mode features", () => {
     const flowItems = screen.getAllByTestId(/^flow-item-/);
     // flow-1 is attached, so it should appear first
     expect(flowItems[0]).toHaveAttribute("data-testid", "flow-item-flow-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Detected env vars auto-population
+// ---------------------------------------------------------------------------
+
+describe("Detected env vars auto-population", () => {
+  it("populates env var rows with keys and global variable selections from detection", async () => {
+    const user = userEvent.setup();
+    mockDetectEnvVars.mockResolvedValueOnce({
+      variables: ["OPENAI_API_KEY", "DB_PASS"],
+    });
+    render(<StepAttachFlows />);
+
+    await user.click(screen.getByTestId("version-item-ver-1"));
+
+    await waitFor(() => {
+      const keyInputs = screen.getAllByPlaceholderText("Key");
+      expect(keyInputs).toHaveLength(2);
+      expect(keyInputs[0]).toHaveValue("OPENAI_API_KEY");
+      expect(keyInputs[1]).toHaveValue("DB_PASS");
+    });
+
+    const selects = screen.getAllByTestId(/^select-env-val-/);
+    expect(selects).toHaveLength(2);
+  });
+
+  it("renders empty row when detection returns no variables", async () => {
+    const user = userEvent.setup();
+    mockDetectEnvVars.mockResolvedValueOnce({ variables: [] });
+    render(<StepAttachFlows />);
+
+    await user.click(screen.getByTestId("version-item-ver-1"));
+
+    await waitFor(() => {
+      const keyInputs = screen.getAllByPlaceholderText("Key");
+      expect(keyInputs).toHaveLength(1);
+      expect(keyInputs[0]).toHaveValue("");
+    });
+  });
+
+  it("renders empty row when detection fails", async () => {
+    const user = userEvent.setup();
+    mockDetectEnvVars.mockRejectedValueOnce(new Error("network error"));
+    render(<StepAttachFlows />);
+
+    await user.click(screen.getByTestId("version-item-ver-1"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Select or Create New Connection"),
+      ).toBeInTheDocument();
+    });
+
+    const keyInputs = screen.getAllByPlaceholderText("Key");
+    expect(keyInputs).toHaveLength(1);
+    expect(keyInputs[0]).toHaveValue("");
+  });
+
+  it("auto-detects env vars for pre-selected flow version on mount", async () => {
+    const user = userEvent.setup();
+    mockInitialFlowId = "flow-1";
+    mockSelectedVersionByFlow = new Map([
+      ["flow-1", { versionId: "ver-1", versionTag: "v1" }],
+    ]);
+    mockDetectEnvVars.mockResolvedValueOnce({
+      variables: ["GLOBAL_SECRET"],
+    });
+
+    render(<StepAttachFlows />);
+
+    await waitFor(() => {
+      expect(mockDetectEnvVars).toHaveBeenCalledWith({
+        flow_version_ids: ["ver-1"],
+      });
+    });
+
+    // The pre-selected useEffect switches to the connection panel but defaults
+    // to the "available" tab. Switch to "Create Connection" to see env var rows.
+    await user.click(screen.getByText("Create Connection"));
+
+    await waitFor(() => {
+      const keyInputs = screen.getAllByPlaceholderText("Key");
+      expect(keyInputs).toHaveLength(1);
+      expect(keyInputs[0]).toHaveValue("GLOBAL_SECRET");
+    });
   });
 });

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
@@ -176,8 +176,7 @@ export default function StepAttachFlows() {
         const result = await detectEnvVars({
           flow_version_ids: [preSelected.versionId],
         });
-        const detected = result.variables ?? [];
-        updateDetectedEnvVars(detected);
+        updateDetectedEnvVars(result.variables ?? []);
       } catch {
         setErrorData({
           title: "Could not auto-detect environment variables",
@@ -215,8 +214,7 @@ export default function StepAttachFlows() {
         const result = await detectEnvVars({
           flow_version_ids: [versionId],
         });
-        const detected = result.variables ?? [];
-        updateDetectedEnvVars(detected);
+        updateDetectedEnvVars(result.variables ?? []);
       } catch {
         updateDetectedEnvVars([]);
         setErrorData({

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-connection-panel-state.test.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/__tests__/use-connection-panel-state.test.ts
@@ -1,0 +1,182 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ConnectionItem } from "../../types";
+import { useConnectionPanelState } from "../use-connection-panel-state";
+
+const baseParams = () => ({
+  connections: [] as ConnectionItem[],
+  setConnections: jest.fn(),
+  effectiveFlowId: "flow-1",
+  attachedConnectionByFlow: new Map<string, string[]>(),
+  onAttachConnection: jest.fn(),
+  commitPendingAttachment: jest.fn(),
+  resetPendingAttachment: jest.fn(),
+  setRightPanel: jest.fn(),
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// updateDetectedEnvVars
+// ---------------------------------------------------------------------------
+
+describe("updateDetectedEnvVars", () => {
+  it("populates env var rows using each name as both key and global var value", () => {
+    const { result } = renderHook(() => useConnectionPanelState(baseParams()));
+
+    act(() => {
+      result.current.updateDetectedEnvVars(["OPENAI_API_KEY", "DB_PASS"]);
+    });
+
+    const vars = result.current.envVars;
+    expect(vars).toHaveLength(2);
+
+    expect(vars[0].key).toBe("OPENAI_API_KEY");
+    expect(vars[0].value).toBe("OPENAI_API_KEY");
+    expect(vars[0].globalVar).toBe(true);
+
+    expect(vars[1].key).toBe("DB_PASS");
+    expect(vars[1].value).toBe("DB_PASS");
+    expect(vars[1].globalVar).toBe(true);
+  });
+
+  it("sets detectedVarCount to the number of detected variables", () => {
+    const { result } = renderHook(() => useConnectionPanelState(baseParams()));
+
+    act(() => {
+      result.current.updateDetectedEnvVars(["A", "B", "C"]);
+    });
+
+    expect(result.current.detectedVarCount).toBe(3);
+  });
+
+  it("resets to a single empty row when given an empty array", () => {
+    const { result } = renderHook(() => useConnectionPanelState(baseParams()));
+
+    act(() => {
+      result.current.updateDetectedEnvVars(["X"]);
+    });
+    expect(result.current.envVars).toHaveLength(1);
+    expect(result.current.detectedVarCount).toBe(1);
+
+    act(() => {
+      result.current.updateDetectedEnvVars([]);
+    });
+
+    expect(result.current.envVars).toHaveLength(1);
+    expect(result.current.envVars[0].key).toBe("");
+    expect(result.current.envVars[0].value).toBe("");
+    expect(result.current.detectedVarCount).toBe(0);
+  });
+
+  it("assigns unique ids to each generated env var row", () => {
+    const { result } = renderHook(() => useConnectionPanelState(baseParams()));
+
+    act(() => {
+      result.current.updateDetectedEnvVars(["A", "B"]);
+    });
+
+    const ids = result.current.envVars.map((v) => v.id);
+    expect(new Set(ids).size).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleEnvVarSelectGlobalVar
+// ---------------------------------------------------------------------------
+
+describe("handleEnvVarSelectGlobalVar", () => {
+  it("sets value to selected global var and marks globalVar true", () => {
+    const { result } = renderHook(() => useConnectionPanelState(baseParams()));
+
+    const id = result.current.envVars[0].id;
+    act(() => {
+      result.current.handleEnvVarSelectGlobalVar(id, "MY_SECRET");
+    });
+
+    const updated = result.current.envVars[0];
+    expect(updated.value).toBe("MY_SECRET");
+    expect(updated.globalVar).toBe(true);
+    expect(updated.key).toBe("MY_SECRET");
+  });
+
+  it("clears globalVar when deselecting (empty string)", () => {
+    const { result } = renderHook(() => useConnectionPanelState(baseParams()));
+
+    const id = result.current.envVars[0].id;
+    act(() => {
+      result.current.handleEnvVarSelectGlobalVar(id, "MY_SECRET");
+    });
+    expect(result.current.envVars[0].globalVar).toBe(true);
+
+    act(() => {
+      result.current.handleEnvVarSelectGlobalVar(id, "");
+    });
+    expect(result.current.envVars[0].globalVar).toBe(false);
+    expect(result.current.envVars[0].value).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleEnvVarChange
+// ---------------------------------------------------------------------------
+
+describe("handleEnvVarChange", () => {
+  it("clears globalVar flag when user manually types a value", () => {
+    const { result } = renderHook(() => useConnectionPanelState(baseParams()));
+
+    const id = result.current.envVars[0].id;
+    act(() => {
+      result.current.handleEnvVarSelectGlobalVar(id, "MY_SECRET");
+    });
+    expect(result.current.envVars[0].globalVar).toBe(true);
+
+    act(() => {
+      result.current.handleEnvVarChange(id, "value", "raw-text");
+    });
+    expect(result.current.envVars[0].globalVar).toBe(false);
+    expect(result.current.envVars[0].value).toBe("raw-text");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCreateConnection — globalVarKeys
+// ---------------------------------------------------------------------------
+
+describe("handleCreateConnection", () => {
+  it("tracks globalVar keys in the created connection", () => {
+    const setConnections = jest.fn();
+    const params = { ...baseParams(), setConnections };
+    const { result } = renderHook(() => useConnectionPanelState(params));
+
+    act(() => {
+      result.current.updateDetectedEnvVars(["API_KEY"]);
+    });
+    // Add a manual (non-global) row
+    act(() => {
+      result.current.handleAddEnvVar();
+    });
+    act(() => {
+      const manualId = result.current.envVars[1].id;
+      result.current.handleEnvVarChange(manualId, "key", "RAW_VAL");
+    });
+    act(() => {
+      result.current.setNewConnectionName("test-conn");
+    });
+    act(() => {
+      result.current.handleCreateConnection();
+    });
+
+    expect(setConnections).toHaveBeenCalled();
+    const updater = setConnections.mock.calls[0][0];
+    const newList = updater([]);
+    expect(newList).toHaveLength(1);
+
+    const conn = newList[0];
+    expect(conn.environmentVariables.API_KEY).toBe("API_KEY");
+    expect(conn.environmentVariables.RAW_VAL).toBe("");
+    expect(conn.globalVarKeys?.has("API_KEY")).toBe(true);
+    expect(conn.globalVarKeys?.has("RAW_VAL")).toBe(false);
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/use-connection-panel-state.ts
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/hooks/use-connection-panel-state.ts
@@ -180,25 +180,22 @@ export function useConnectionPanelState({
     [attachedConnectionByFlow, connections.length],
   );
 
-  const updateDetectedEnvVars = useCallback(
-    (vars: Array<{ key: string; global_variable_name?: string | null }>) => {
-      if (vars.length > 0) {
-        setDetectedVarCount(vars.length);
-        setEnvVars(
-          vars.map((v) => ({
-            id: crypto.randomUUID(),
-            key: v.key,
-            value: v.global_variable_name ?? "",
-            globalVar: Boolean(v.global_variable_name),
-          })),
-        );
-      } else {
-        setDetectedVarCount(0);
-        setEnvVars([{ id: crypto.randomUUID(), key: "", value: "" }]);
-      }
-    },
-    [],
-  );
+  const updateDetectedEnvVars = useCallback((names: string[]) => {
+    if (names.length > 0) {
+      setDetectedVarCount(names.length);
+      setEnvVars(
+        names.map((name) => ({
+          id: crypto.randomUUID(),
+          key: name,
+          value: name,
+          globalVar: true,
+        })),
+      );
+    } else {
+      setDetectedVarCount(0);
+      setEnvVars([{ id: crypto.randomUUID(), key: "", value: "" }]);
+    }
+  }, []);
 
   return {
     connectionTab,


### PR DESCRIPTION
updateDetectedEnvVars expected objects with key/global_variable_name fields, but the backend detection endpoint returns a flat string array of variable names. Simplified the function to accept string[] directly, using each name as both the env var key and the global variable binding.