### PR TITLE
fix: add uv sync step to SDK version determination job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,6 +293,9 @@ jobs:
           python-version: "3.13"
           prune-cache: false
 
+      - name: Install SDK dependencies
+        run: uv sync --dev --package langflow-sdk
+
       - name: Determine version
         id: version
         run: |


### PR DESCRIPTION
The determine-sdk-version job was missing the 'uv sync' step that creates the cache, causing the 'Post Setup Environment' step to fail with: 'cache path does not exist on disk'

This matches the pattern used in determine-lfx-version job (line 247) and the nightly build workflow (line 104-105).

Fixes the SDK build failure in release workflow dry run.