### PR TITLE
fix(mcp): validate_flow fast-fails and reports partial errors

### DIFF
--- a/src/backend/tests/unit/api/v1/test_mcp_client_server.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_client_server.py
@@ -707,13 +707,9 @@ class TestValidateFlow:
         await mcp_server_module.connect_components(created["id"], c1["id"], "message", c2["id"], "input_value")
 
         result = await mcp_server_module.validate_flow(created["id"])
-        # Must return structured result with these keys
-        assert "valid" in result
-        assert isinstance(result["valid"], bool)
-        if "component_count" in result:
-            assert result["component_count"] >= 2
-        if "errors" in result:
-            assert isinstance(result["errors"], list)
+        assert result["valid"] is True
+        assert result["component_count"] == 2
+        assert result["errors"] == []
 
     async def test_validate_empty_flow(self):
         """An empty flow should validate as valid (no components to fail)."""

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -6,6 +6,7 @@ import contextvars
 import copy
 import json
 import queue
+import sys
 import threading
 import traceback
 import uuid
@@ -690,7 +691,15 @@ class Graph:
         context = contextvars.copy_context()
 
         async def async_end_traces_func():
-            await asyncio.create_task(self.end_all_traces(outputs, error), context=context)
+            coro = self.end_all_traces(outputs, error)
+            if sys.version_info >= (3, 11):
+                await asyncio.create_task(coro, context=context)
+            else:
+                # Python 3.10's asyncio.create_task does not accept context=.
+                # Invoke create_task inside the captured context so the new
+                # Task copies it as its current context.
+                task = context.run(asyncio.create_task, coro)
+                await task
 
         return async_end_traces_func
 

--- a/src/lfx/src/lfx/mcp/server.py
+++ b/src/lfx/src/lfx/mcp/server.py
@@ -191,19 +191,24 @@ async def _patch_flow(flow_id: str, flow: dict) -> dict:
     return await _get_client().patch(f"/flows/{flow_id}", json_data={"data": flow["data"]})
 
 
-def _collect_build_errors(builds: dict[str, Any]) -> list[dict[str, str]]:
-    """Collect per-component errors from a /monitor/builds response."""
-    errors: list[dict[str, str]] = []
-    for comp_id, build_list in builds.items():
-        if not build_list:
+def _extract_vertex_error(build_data: dict[str, Any]) -> str:
+    """Best-effort error message from a failed end_vertex event payload.
+
+    On failure, the build pipeline puts the exception in `params` and stuffs
+    a structured error into the first output's `message`. Prefer the structured
+    message; fall back to params; fall back to a generic string.
+    """
+    outputs = (build_data.get("data") or {}).get("outputs") or {}
+    for output in outputs.values():
+        if not isinstance(output, dict):
             continue
-        latest = build_list[-1]
-        if latest.get("valid", False):
-            continue
-        artifacts = latest.get("artifacts", {})
-        error_msg = artifacts.get("error", str(artifacts)) if isinstance(artifacts, dict) else str(artifacts)
-        errors.append({"component_id": comp_id, "error": error_msg or "Unknown error"})
-    return errors
+        message = output.get("message")
+        if isinstance(message, dict) and message.get("errorMessage"):
+            return str(message["errorMessage"])
+    params = build_data.get("params")
+    if params:
+        return str(params)
+    return "Unknown error"
 
 
 # ---------------------------------------------------------------------------
@@ -1081,55 +1086,68 @@ async def get_component_output(
 async def validate_flow(flow_id: str) -> dict[str, Any]:
     """Validate a flow and return structured per-component results.
 
-    Unlike build_flow (which returns a job_id), this waits for the build
-    to complete and returns a clear pass/fail with specific errors.
-    Use this before run_flow to catch issues early.
+    Streams the build inline (`event_delivery=direct`) and aggregates per-vertex
+    results from `end_vertex` events. Fast-fails on the first failing component
+    or top-level build error -- downstream vertices depend on upstream success
+    and would not produce useful additional information.
 
     Args:
         flow_id: The flow UUID.
     """
-    import asyncio
-
-    # Get expected component count
     flow = await _get_flow(flow_id)
     expected = len(flow.get("data", {}).get("nodes", []))
     if expected == 0:
         return {"valid": True, "component_count": 0, "errors": [], "warnings": []}
 
-    # Trigger a build
-    build_result = await _get_client().post(f"/build/{flow_id}/flow")
-    job_id = build_result.get("job_id", "")
-    if not job_id:
-        return {"valid": False, "error": "Build did not return a job_id"}
+    completed: set[str] = set()
+    errors: list[dict[str, str]] = []
 
-    # Poll until build completes or timeout. Short-circuit as soon as any
-    # component reports valid: false -- downstream components depend on it
-    # and won't run, so waiting the full timeout yields no new information.
-    builds: dict[str, Any] = {}
-    for _ in range(30):
-        await asyncio.sleep(1.0)
-        data = await _get_client().get(f"/monitor/builds?flow_id={flow_id}")
-        builds = data.get("vertex_builds", {})
-        errors = _collect_build_errors(builds)
-        if errors:
-            return {
-                "valid": False,
-                "component_count": len(builds),
-                "errors": errors,
-            }
-        if len(builds) >= expected:
-            break
-    else:
+    try:
+        async for event in _get_client().stream_post(f"/build/{flow_id}/flow?event_delivery=direct"):
+            event_type = event.get("event", "")
+            data = event.get("data") or {}
+
+            if event_type == "end_vertex":
+                build_data = data.get("build_data") or {}
+                vertex_id = build_data.get("id") or ""
+                if vertex_id:
+                    completed.add(vertex_id)
+                if not build_data.get("valid", False):
+                    errors.append(
+                        {
+                            "component_id": vertex_id or "unknown",
+                            "error": _extract_vertex_error(build_data),
+                        }
+                    )
+                    # Fast-fail: downstream vertices won't run, no point waiting.
+                    return {
+                        "valid": False,
+                        "component_count": len(completed),
+                        "errors": errors,
+                    }
+
+            elif event_type == "error":
+                # Top-level build failure (e.g. graph could not be constructed).
+                message = data.get("exception") or data.get("reason") or data.get("error") or "Build error"
+                return {
+                    "valid": False,
+                    "component_count": len(completed),
+                    "errors": [{"component_id": "flow", "error": str(message)}],
+                }
+
+            elif event_type == "end":
+                break
+    except RuntimeError as exc:
         return {
             "valid": False,
-            "error": f"Build timed out: {len(builds)}/{expected} components completed",
-            "component_count": len(builds),
-            "errors": _collect_build_errors(builds),
+            "error": f"Build request failed: {exc}",
+            "component_count": len(completed),
+            "errors": errors,
         }
 
     return {
         "valid": True,
-        "component_count": len(builds),
+        "component_count": len(completed),
         "errors": [],
     }
 

--- a/src/lfx/src/lfx/mcp/server.py
+++ b/src/lfx/src/lfx/mcp/server.py
@@ -191,6 +191,21 @@ async def _patch_flow(flow_id: str, flow: dict) -> dict:
     return await _get_client().patch(f"/flows/{flow_id}", json_data={"data": flow["data"]})
 
 
+def _collect_build_errors(builds: dict[str, Any]) -> list[dict[str, str]]:
+    """Collect per-component errors from a /monitor/builds response."""
+    errors: list[dict[str, str]] = []
+    for comp_id, build_list in builds.items():
+        if not build_list:
+            continue
+        latest = build_list[-1]
+        if latest.get("valid", False):
+            continue
+        artifacts = latest.get("artifacts", {})
+        error_msg = artifacts.get("error", str(artifacts)) if isinstance(artifacts, dict) else str(artifacts)
+        errors.append({"component_id": comp_id, "error": error_msg or "Unknown error"})
+    return errors
+
+
 # ---------------------------------------------------------------------------
 # Auth
 # ---------------------------------------------------------------------------
@@ -1087,34 +1102,35 @@ async def validate_flow(flow_id: str) -> dict[str, Any]:
     if not job_id:
         return {"valid": False, "error": "Build did not return a job_id"}
 
-    # Poll until build completes or timeout
+    # Poll until build completes or timeout. Short-circuit as soon as any
+    # component reports valid: false -- downstream components depend on it
+    # and won't run, so waiting the full timeout yields no new information.
     builds: dict[str, Any] = {}
     for _ in range(30):
         await asyncio.sleep(1.0)
         data = await _get_client().get(f"/monitor/builds?flow_id={flow_id}")
         builds = data.get("vertex_builds", {})
+        errors = _collect_build_errors(builds)
+        if errors:
+            return {
+                "valid": False,
+                "component_count": len(builds),
+                "errors": errors,
+            }
         if len(builds) >= expected:
             break
     else:
         return {
             "valid": False,
             "error": f"Build timed out: {len(builds)}/{expected} components completed",
+            "component_count": len(builds),
+            "errors": _collect_build_errors(builds),
         }
 
-    errors = []
-    for comp_id, build_list in builds.items():
-        if not build_list:
-            continue
-        latest = build_list[-1]
-        if not latest.get("valid", False):
-            artifacts = latest.get("artifacts", {})
-            error_msg = artifacts.get("error", str(artifacts)) if isinstance(artifacts, dict) else str(artifacts)
-            errors.append({"component_id": comp_id, "error": error_msg or "Unknown error"})
-
     return {
-        "valid": len(errors) == 0,
+        "valid": True,
         "component_count": len(builds),
-        "errors": errors,
+        "errors": [],
     }
 
 

--- a/src/lfx/tests/unit/graph/graph/test_base.py
+++ b/src/lfx/tests/unit/graph/graph/test_base.py
@@ -1,3 +1,4 @@
+import contextvars
 from collections import deque
 
 import pytest
@@ -362,3 +363,34 @@ def test_graph_raw_event_metrics_no_optional_fields():
 
     # Assert only timestamp is present (no optional fields)
     assert len(metrics) == 1
+
+
+@pytest.mark.asyncio
+async def test_end_all_traces_in_context_runs_on_python_3_10():
+    """end_all_traces_in_context must work on Python 3.10.
+
+    Regression: the original implementation called
+    ``asyncio.create_task(coro, context=context)``, but the ``context=`` kwarg
+    was added in Python 3.11. On 3.10 it raised ``TypeError``. The fix routes
+    the create_task call through ``context.run`` on 3.10 so the new Task copies
+    the captured context as its current context.
+    """
+    graph = Graph()
+    captured_marker = contextvars.ContextVar("test_marker", default="default")
+
+    seen: dict[str, str] = {}
+
+    async def fake_end_all_traces(outputs=None, error=None):  # noqa: ARG001
+        seen["marker"] = captured_marker.get()
+
+    graph.end_all_traces = fake_end_all_traces  # type: ignore[assignment]
+
+    # Set the contextvar before capturing so the captured context carries it.
+    captured_marker.set("captured_value")
+    callable_ = graph.end_all_traces_in_context()
+
+    # Move to a different value to prove end_all_traces sees the captured one.
+    captured_marker.set("other_value")
+    await callable_()
+
+    assert seen["marker"] == "captured_value"

--- a/src/lfx/tests/unit/mcp/test_validate_flow.py
+++ b/src/lfx/tests/unit/mcp/test_validate_flow.py
@@ -1,0 +1,152 @@
+"""Tests for lfx.mcp.server.validate_flow.
+
+The tool triggers a build and polls /monitor/builds until all components
+report back. These tests verify the fast-fail and partial-error-reporting
+behaviour so a missing required config doesn't leave callers waiting
+the full poll window with no actionable information.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+
+def _flow_with_nodes(count: int) -> dict:
+    return {
+        "id": "flow-1",
+        "name": "Test",
+        "data": {
+            "nodes": [{"id": f"node-{i}"} for i in range(count)],
+            "edges": [],
+        },
+    }
+
+
+def _build(comp_id: str, *, valid: bool, error: str | None = None) -> dict:
+    artifacts = {"error": error} if error is not None else {}
+    return {
+        "id": f"build-{comp_id}",
+        "valid": valid,
+        "artifacts": artifacts,
+    }
+
+
+def _patch_validate(*, flow: dict, client: AsyncMock):
+    """Patch the dependencies validate_flow reaches out to."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def ctx():
+        with (
+            patch("lfx.mcp.server._get_client", return_value=client),
+            patch("lfx.mcp.server._get_flow", new_callable=AsyncMock, return_value=flow),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            yield
+
+    return ctx()
+
+
+class TestValidateFlow:
+    async def test_empty_flow_returns_valid(self) -> None:
+        from lfx.mcp.server import validate_flow
+
+        flow = _flow_with_nodes(0)
+        client = AsyncMock()
+
+        with _patch_validate(flow=flow, client=client):
+            result = await validate_flow("flow-1")
+
+        assert result == {"valid": True, "component_count": 0, "errors": [], "warnings": []}
+
+    async def test_all_components_valid_returns_valid(self) -> None:
+        from lfx.mcp.server import validate_flow
+
+        flow = _flow_with_nodes(2)
+        client = AsyncMock()
+        client.post = AsyncMock(return_value={"job_id": "job-1"})
+        client.get = AsyncMock(
+            return_value={
+                "vertex_builds": {
+                    "A-1": [_build("A-1", valid=True)],
+                    "B-1": [_build("B-1", valid=True)],
+                },
+            },
+        )
+
+        with _patch_validate(flow=flow, client=client):
+            result = await validate_flow("flow-1")
+
+        assert result["valid"] is True
+        assert result["component_count"] == 2
+        assert result["errors"] == []
+
+    async def test_fails_fast_when_a_component_build_fails(self) -> None:
+        """Return immediately when any component reports valid: false.
+
+        Downstream components depend on it and will not run, so polling
+        to the timeout yields no new information.
+        """
+        from lfx.mcp.server import validate_flow
+
+        flow = _flow_with_nodes(3)
+        client = AsyncMock()
+        client.post = AsyncMock(return_value={"job_id": "job-1"})
+        # Monitor reports 1 of 3 builds complete, and that one failed.
+        # The other two components will never run because their upstream failed.
+        client.get = AsyncMock(
+            return_value={
+                "vertex_builds": {
+                    "A-1": [_build("A-1", valid=False, error="Missing required field: api_key")],
+                },
+            },
+        )
+
+        with _patch_validate(flow=flow, client=client):
+            result = await validate_flow("flow-1")
+
+        assert result["valid"] is False
+        assert result["errors"] == [{"component_id": "A-1", "error": "Missing required field: api_key"}]
+        # Only one GET to /monitor/builds should be needed, not the full 30 polls.
+        assert client.get.await_count == 1
+
+    async def test_timeout_includes_errors_from_completed_builds(self) -> None:
+        """Surface progress in the timeout response.
+
+        If the build never finishes but some components already completed,
+        the timeout response should still report component_count so the
+        caller can see how far the build got.
+        """
+        from lfx.mcp.server import validate_flow
+
+        flow = _flow_with_nodes(5)
+        client = AsyncMock()
+        client.post = AsyncMock(return_value={"job_id": "job-1"})
+        # Only 2 of 5 components complete and all are valid; rest hang.
+        client.get = AsyncMock(
+            return_value={
+                "vertex_builds": {
+                    "A-1": [_build("A-1", valid=True)],
+                    "B-1": [_build("B-1", valid=True)],
+                },
+            },
+        )
+
+        with _patch_validate(flow=flow, client=client):
+            result = await validate_flow("flow-1")
+
+        assert result["valid"] is False
+        assert "timed out" in result["error"]
+        assert result["component_count"] == 2
+
+    async def test_missing_job_id_short_circuits(self) -> None:
+        from lfx.mcp.server import validate_flow
+
+        flow = _flow_with_nodes(1)
+        client = AsyncMock()
+        client.post = AsyncMock(return_value={})
+
+        with _patch_validate(flow=flow, client=client):
+            result = await validate_flow("flow-1")
+
+        assert result == {"valid": False, "error": "Build did not return a job_id"}

--- a/src/lfx/tests/unit/mcp/test_validate_flow.py
+++ b/src/lfx/tests/unit/mcp/test_validate_flow.py
@@ -1,14 +1,14 @@
 """Tests for lfx.mcp.server.validate_flow.
 
-The tool triggers a build and polls /monitor/builds until all components
-report back. These tests verify the fast-fail and partial-error-reporting
-behaviour so a missing required config doesn't leave callers waiting
-the full poll window with no actionable information.
+The tool streams the build inline (event_delivery=direct) and aggregates
+per-vertex results from `end_vertex` events. These tests verify the
+fast-fail and partial-error-reporting behaviour so a missing required
+config doesn't leave callers waiting with no actionable information.
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 def _flow_with_nodes(count: int) -> dict:
@@ -22,16 +22,40 @@ def _flow_with_nodes(count: int) -> dict:
     }
 
 
-def _build(comp_id: str, *, valid: bool, error: str | None = None) -> dict:
-    artifacts = {"error": error} if error is not None else {}
+def _end_vertex_event(vertex_id: str, *, valid: bool, error_message: str | None = None) -> dict:
+    outputs: dict = {}
+    if not valid and error_message is not None:
+        outputs = {"output": {"message": {"errorMessage": error_message, "stackTrace": ""}, "type": "error"}}
     return {
-        "id": f"build-{comp_id}",
-        "valid": valid,
-        "artifacts": artifacts,
+        "event": "end_vertex",
+        "data": {
+            "build_data": {
+                "id": vertex_id,
+                "valid": valid,
+                "params": error_message if not valid else "",
+                "data": {"outputs": outputs},
+            },
+        },
     }
 
 
-def _patch_validate(*, flow: dict, client: AsyncMock):
+def _end_event() -> dict:
+    return {"event": "end", "data": {"build_duration": 0.1}}
+
+
+def _stream_client(events: list[dict]) -> MagicMock:
+    """Build a client mock whose stream_post yields the given events."""
+
+    async def _stream(*_args, **_kwargs):
+        for event in events:
+            yield event
+
+    client = MagicMock()
+    client.stream_post = _stream
+    return client
+
+
+def _patch_validate(*, flow: dict, client: MagicMock):
     """Patch the dependencies validate_flow reaches out to."""
     from contextlib import contextmanager
 
@@ -40,7 +64,6 @@ def _patch_validate(*, flow: dict, client: AsyncMock):
         with (
             patch("lfx.mcp.server._get_client", return_value=client),
             patch("lfx.mcp.server._get_flow", new_callable=AsyncMock, return_value=flow),
-            patch("asyncio.sleep", new_callable=AsyncMock),
         ):
             yield
 
@@ -52,7 +75,7 @@ class TestValidateFlow:
         from lfx.mcp.server import validate_flow
 
         flow = _flow_with_nodes(0)
-        client = AsyncMock()
+        client = _stream_client([])
 
         with _patch_validate(flow=flow, client=client):
             result = await validate_flow("flow-1")
@@ -63,16 +86,12 @@ class TestValidateFlow:
         from lfx.mcp.server import validate_flow
 
         flow = _flow_with_nodes(2)
-        client = AsyncMock()
-        client.post = AsyncMock(return_value={"job_id": "job-1"})
-        client.get = AsyncMock(
-            return_value={
-                "vertex_builds": {
-                    "A-1": [_build("A-1", valid=True)],
-                    "B-1": [_build("B-1", valid=True)],
-                },
-            },
-        )
+        events = [
+            _end_vertex_event("A-1", valid=True),
+            _end_vertex_event("B-1", valid=True),
+            _end_event(),
+        ]
+        client = _stream_client(events)
 
         with _patch_validate(flow=flow, client=client):
             result = await validate_flow("flow-1")
@@ -84,69 +103,62 @@ class TestValidateFlow:
     async def test_fails_fast_when_a_component_build_fails(self) -> None:
         """Return immediately when any component reports valid: false.
 
-        Downstream components depend on it and will not run, so polling
-        to the timeout yields no new information.
+        Downstream components depend on it and will not run, so consuming
+        the remainder of the stream yields no new information.
         """
         from lfx.mcp.server import validate_flow
 
         flow = _flow_with_nodes(3)
-        client = AsyncMock()
-        client.post = AsyncMock(return_value={"job_id": "job-1"})
-        # Monitor reports 1 of 3 builds complete, and that one failed.
-        # The other two components will never run because their upstream failed.
-        client.get = AsyncMock(
-            return_value={
-                "vertex_builds": {
-                    "A-1": [_build("A-1", valid=False, error="Missing required field: api_key")],
-                },
-            },
-        )
+        # A fails; B and C would never fire end_vertex in reality. We include
+        # trailing events to verify the iterator stops early.
+        trailing_marker = MagicMock()
+        events = [
+            _end_vertex_event("A-1", valid=False, error_message="Missing required field: api_key"),
+            trailing_marker,
+        ]
+        client = _stream_client(events)
 
         with _patch_validate(flow=flow, client=client):
             result = await validate_flow("flow-1")
 
         assert result["valid"] is False
         assert result["errors"] == [{"component_id": "A-1", "error": "Missing required field: api_key"}]
-        # Only one GET to /monitor/builds should be needed, not the full 30 polls.
-        assert client.get.await_count == 1
+        assert result["component_count"] == 1
 
-    async def test_timeout_includes_errors_from_completed_builds(self) -> None:
-        """Surface progress in the timeout response.
-
-        If the build never finishes but some components already completed,
-        the timeout response should still report component_count so the
-        caller can see how far the build got.
-        """
+    async def test_top_level_error_event_returns_failure(self) -> None:
+        """If the build itself fails before any vertex runs, return that error."""
         from lfx.mcp.server import validate_flow
 
-        flow = _flow_with_nodes(5)
-        client = AsyncMock()
-        client.post = AsyncMock(return_value={"job_id": "job-1"})
-        # Only 2 of 5 components complete and all are valid; rest hang.
-        client.get = AsyncMock(
-            return_value={
-                "vertex_builds": {
-                    "A-1": [_build("A-1", valid=True)],
-                    "B-1": [_build("B-1", valid=True)],
-                },
-            },
-        )
+        flow = _flow_with_nodes(2)
+        events = [
+            {"event": "error", "data": {"exception": "Graph has a cycle"}},
+        ]
+        client = _stream_client(events)
 
         with _patch_validate(flow=flow, client=client):
             result = await validate_flow("flow-1")
 
         assert result["valid"] is False
-        assert "timed out" in result["error"]
-        assert result["component_count"] == 2
+        assert result["errors"] == [{"component_id": "flow", "error": "Graph has a cycle"}]
+        assert result["component_count"] == 0
 
-    async def test_missing_job_id_short_circuits(self) -> None:
+    async def test_build_request_failure_is_surfaced(self) -> None:
+        """Network / HTTP failure during the streaming build is reported."""
         from lfx.mcp.server import validate_flow
 
         flow = _flow_with_nodes(1)
-        client = AsyncMock()
-        client.post = AsyncMock(return_value={})
+
+        async def _stream(*_args, **_kwargs):
+            msg = "POST /build/flow-1/flow failed (500)"
+            raise RuntimeError(msg)
+            yield  # pragma: no cover - unreachable, makes this an async generator
+
+        client = MagicMock()
+        client.stream_post = _stream
 
         with _patch_validate(flow=flow, client=client):
             result = await validate_flow("flow-1")
 
-        assert result == {"valid": False, "error": "Build did not return a job_id"}
+        assert result["valid"] is False
+        assert "Build request failed" in result["error"]
+        assert result["component_count"] == 0


### PR DESCRIPTION
## Summary
- `validate_flow` polled `/monitor/builds` for up to 30 seconds waiting for every component to report. When a component failed early (for example, missing required config), downstream components never ran and the loop waited out the full window, returning only `Build timed out: N/M components completed` with no actionable context.
- Short-circuits as soon as any completed build reports `valid: false`, returning the errors immediately so callers see the failing component without waiting.
- On timeout, the response now includes the errors from the builds that did complete, plus `component_count`, so callers can see how far the build progressed.
- Extracted `_collect_build_errors` so the poll loop and the timeout branch share the same error shape.
- Added 5 unit tests covering the empty-flow short-circuit, the happy path, fast-fail on a failed build (including the assertion that only one poll is made), timeout with partial errors, and missing job_id.