### PR TITLE
fix: retry on flow execution failure and surface friendly message for weak models                                                             

### DIFF
--- a/src/backend/base/langflow/agentic/helpers/error_handling.py
+++ b/src/backend/base/langflow/agentic/helpers/error_handling.py
@@ -31,6 +31,15 @@ def extract_friendly_error(error_msg: str) -> str:
     if "content" in error_lower and any(term in error_lower for term in ["filter", "policy", "safety"]):
         return "Request blocked by content policy. Please modify your prompt."
 
+    # Pydantic schema validation errors — typical sign that a weak model emitted a
+    # malformed tool call or response, and the downstream component rejected it.
+    schema_error_terms = ("validation error for", "input should be a valid", "pydantic.validationerror")
+    if any(term in error_lower for term in schema_error_terms):
+        return (
+            "The selected model produced output that didn't match the expected schema. "
+            "Try again or use a more capable model."
+        )
+
     return _truncate_error_message(error_msg)
 
 

--- a/src/backend/base/langflow/agentic/helpers/error_handling.py
+++ b/src/backend/base/langflow/agentic/helpers/error_handling.py
@@ -20,6 +20,16 @@ def extract_friendly_error(error_msg: str) -> str:
     """Convert technical API errors into user-friendly messages."""
     error_lower = error_msg.lower()
 
+    # Pydantic schema validation errors — checked BEFORE the generic pattern loop
+    # so a message like "HTTPException 500: 1 validation error for InputSchema..."
+    # is not masked by the "500" → "Server error" fallback.
+    schema_error_terms = ("validation error for", "input should be a valid", "pydantic.validationerror")
+    if any(term in error_lower for term in schema_error_terms):
+        return (
+            "The selected model produced output that didn't match the expected schema. "
+            "Try again or use a more capable model."
+        )
+
     for patterns, friendly_message in ERROR_PATTERNS:
         if any(pattern in error_lower or pattern in error_msg for pattern in patterns):
             return friendly_message
@@ -30,15 +40,6 @@ def extract_friendly_error(error_msg: str) -> str:
 
     if "content" in error_lower and any(term in error_lower for term in ["filter", "policy", "safety"]):
         return "Request blocked by content policy. Please modify your prompt."
-
-    # Pydantic schema validation errors — typical sign that a weak model emitted a
-    # malformed tool call or response, and the downstream component rejected it.
-    schema_error_terms = ("validation error for", "input should be a valid", "pydantic.validationerror")
-    if any(term in error_lower for term in schema_error_terms):
-        return (
-            "The selected model produced output that didn't match the expected schema. "
-            "Try again or use a more capable model."
-        )
 
     return _truncate_error_message(error_msg)
 

--- a/src/backend/base/langflow/agentic/helpers/streaming_retry.py
+++ b/src/backend/base/langflow/agentic/helpers/streaming_retry.py
@@ -1,0 +1,64 @@
+"""SSE event emitters for the assistant's retry cycle.
+
+Kept separate from the orchestration service so the retry-event composition
+lives in one place and the orchestrator stays under the file-size limit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from langflow.agentic.helpers.sse import format_complete_event, format_progress_event
+from langflow.agentic.services.flow_types import VALIDATION_UI_DELAY_SECONDS
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+async def emit_execution_retry_events(
+    *,
+    attempt: int,
+    total_attempts: int,
+    error: str,
+) -> AsyncGenerator[str, None]:
+    """Yield SSE events for a flow-execution failure inside the retry loop.
+
+    Emits a ``validation_failed`` event, waits for the UX delay, and then either:
+    - emits a final ``complete`` event with ``validated=False`` if attempts are
+      exhausted (so the frontend renders the "Component generation failed" card), or
+    - emits a ``retrying`` event so the caller can try again with an updated prompt.
+
+    Args:
+        attempt: Zero-based index of the attempt that just failed.
+        total_attempts: Total attempts allowed before giving up.
+        error: User-facing friendly error message produced by extract_friendly_error.
+    """
+    yield format_progress_event(
+        "validation_failed",
+        attempt + 1,
+        total_attempts,
+        message="Generation failed",
+        error=error,
+    )
+    await asyncio.sleep(VALIDATION_UI_DELAY_SECONDS)
+
+    if attempt >= total_attempts - 1:
+        yield format_complete_event(
+            {
+                "result": "",
+                "validated": False,
+                "validation_error": error,
+                "validation_attempts": attempt + 1,
+            }
+        )
+        return
+
+    yield format_progress_event(
+        "retrying",
+        attempt + 1,
+        total_attempts,
+        message="Retrying with error context...",
+        error=error,
+    )
+    await asyncio.sleep(VALIDATION_UI_DELAY_SECONDS)

--- a/src/backend/base/langflow/agentic/services/assistant_service.py
+++ b/src/backend/base/langflow/agentic/services/assistant_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import aclosing
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException
@@ -19,6 +20,7 @@ from langflow.agentic.helpers.sse import (
     format_progress_event,
     format_token_event,
 )
+from langflow.agentic.helpers.streaming_retry import emit_execution_retry_events
 from langflow.agentic.helpers.validation import validate_component_code, validate_component_runtime
 from langflow.agentic.services.flow_executor import (
     execute_flow_file,
@@ -31,6 +33,7 @@ from langflow.agentic.services.flow_types import (
     OFF_TOPIC_REFUSAL_MESSAGE,
     VALIDATION_RETRY_TEMPLATE,
     VALIDATION_UI_DELAY_SECONDS,
+    FlowExecutionError,
 )
 from langflow.agentic.services.helpers.intent_classification import classify_intent
 
@@ -239,46 +242,48 @@ async def execute_flow_with_validation_streaming(
             result = None
             cancelled = False
             execution_error: str | None = None
-            flow_generator = execute_flow_file_streaming(
-                flow_filename=flow_filename,
-                input_value=current_input,
-                global_variables=global_variables,
-                user_id=user_id,
-                session_id=session_id,
-                provider=provider,
-                model_name=model_name,
-                api_key_var=api_key_var,
-                is_disconnected=is_disconnected,
-                cancel_event=cancel_event,
-            )
-            try:
-                # Use streaming executor to get token events
-                async for event_type, event_data in flow_generator:
-                    if event_type == "token":
-                        # Stream tokens for both Q&A and component generation
-                        # For components, the frontend shows live code preview
-                        yield format_token_event(event_data)
-                    elif event_type == "end":
-                        # Flow completed, store result
-                        result = event_data
-                    elif event_type == "cancelled":
-                        # Flow was cancelled due to client disconnect
-                        logger.info("Flow execution cancelled by client disconnect")
-                        cancelled = True
-                        break
-            except GeneratorExit:
-                # This generator was closed (client disconnected)
-                logger.info("Assistant generator closed, setting cancel event")
-                cancel_event.set()
-                await flow_generator.aclose()
-                yield format_cancelled_event()
-                return
-            except HTTPException as e:
-                execution_error = extract_friendly_error(str(e.detail))
-            except (ValueError, RuntimeError, OSError) as e:
-                execution_error = extract_friendly_error(str(e))
+            # aclosing guarantees the async generator is closed on every exit path
+            # (normal completion, exception, or cancellation) — not relying on GC.
+            async with aclosing(
+                execute_flow_file_streaming(
+                    flow_filename=flow_filename,
+                    input_value=current_input,
+                    global_variables=global_variables,
+                    user_id=user_id,
+                    session_id=session_id,
+                    provider=provider,
+                    model_name=model_name,
+                    api_key_var=api_key_var,
+                    is_disconnected=is_disconnected,
+                    cancel_event=cancel_event,
+                )
+            ) as flow_generator:
+                try:
+                    async for event_type, event_data in flow_generator:
+                        if event_type == "token":
+                            # Stream tokens for both Q&A and component generation
+                            # For components, the frontend shows live code preview
+                            yield format_token_event(event_data)
+                        elif event_type == "end":
+                            result = event_data
+                        elif event_type == "cancelled":
+                            logger.info("Flow execution cancelled by client disconnect")
+                            cancelled = True
+                            break
+                except GeneratorExit:
+                    logger.info("Assistant generator closed, setting cancel event")
+                    cancel_event.set()
+                    yield format_cancelled_event()
+                    return
+                except FlowExecutionError as e:
+                    # Internal retry loop reads the raw error to pick a friendly message;
+                    # the public HTTP detail stays generic (see FlowExecutionError docstring).
+                    execution_error = extract_friendly_error(e.original_error_message)
+                except HTTPException as e:
+                    execution_error = extract_friendly_error(str(e.detail))
+                except (ValueError, RuntimeError, OSError) as e:
+                    execution_error = extract_friendly_error(str(e))
 
-            # Handle cancellation
             if cancelled:
                 yield format_cancelled_event()
                 return
@@ -291,37 +296,15 @@ async def execute_flow_with_validation_streaming(
                     yield format_error_event(execution_error)
                     return
 
-                # Component generation: surface the failure and retry if attempts remain
-                yield format_progress_event(
-                    "validation_failed",
-                    attempt + 1,
-                    total_attempts,
-                    message="Generation failed",
+                async for event in emit_execution_retry_events(
+                    attempt=attempt,
+                    total_attempts=total_attempts,
                     error=execution_error,
-                )
-                await asyncio.sleep(VALIDATION_UI_DELAY_SECONDS)
+                ):
+                    yield event
 
                 if attempt >= total_attempts - 1:
-                    # Max attempts exhausted — emit a complete event so the frontend
-                    # renders the "Component generation failed" card with the spec message
-                    yield format_complete_event(
-                        {
-                            "result": "",
-                            "validated": False,
-                            "validation_error": execution_error,
-                            "validation_attempts": attempt + 1,
-                        }
-                    )
-                    return
-
-                yield format_progress_event(
-                    "retrying",
-                    attempt + 1,
-                    total_attempts,
-                    message="Retrying with error context...",
-                    error=execution_error,
-                )
-                await asyncio.sleep(VALIDATION_UI_DELAY_SECONDS)
+                    return  # complete event already emitted by the helper
                 current_input = EXECUTION_RETRY_TEMPLATE.format(
                     error=execution_error,
                     original_input=sanitization.sanitized_input,

--- a/src/backend/base/langflow/agentic/services/assistant_service.py
+++ b/src/backend/base/langflow/agentic/services/assistant_service.py
@@ -26,6 +26,7 @@ from langflow.agentic.services.flow_executor import (
     extract_response_text,
 )
 from langflow.agentic.services.flow_types import (
+    EXECUTION_RETRY_TEMPLATE,
     MAX_VALIDATION_RETRIES,
     OFF_TOPIC_REFUSAL_MESSAGE,
     VALIDATION_RETRY_TEMPLATE,
@@ -237,6 +238,7 @@ async def execute_flow_with_validation_streaming(
 
             result = None
             cancelled = False
+            execution_error: str | None = None
             flow_generator = execute_flow_file_streaming(
                 flow_filename=flow_filename,
                 input_value=current_input,
@@ -272,20 +274,59 @@ async def execute_flow_with_validation_streaming(
                 yield format_cancelled_event()
                 return
             except HTTPException as e:
-                friendly_msg = extract_friendly_error(str(e.detail))
-                logger.error(f"Flow execution failed: {friendly_msg}")
-                yield format_error_event(friendly_msg)
-                return
+                execution_error = extract_friendly_error(str(e.detail))
             except (ValueError, RuntimeError, OSError) as e:
-                friendly_msg = extract_friendly_error(str(e))
-                logger.error(f"Flow execution failed: {friendly_msg}")
-                yield format_error_event(friendly_msg)
-                return
+                execution_error = extract_friendly_error(str(e))
 
             # Handle cancellation
             if cancelled:
                 yield format_cancelled_event()
                 return
+
+            if execution_error is not None:
+                logger.error(f"Flow execution failed (attempt {attempt + 1}): {execution_error}")
+
+                # Q&A has no retry semantics — emit error and exit immediately
+                if not is_component_request:
+                    yield format_error_event(execution_error)
+                    return
+
+                # Component generation: surface the failure and retry if attempts remain
+                yield format_progress_event(
+                    "validation_failed",
+                    attempt + 1,
+                    total_attempts,
+                    message="Generation failed",
+                    error=execution_error,
+                )
+                await asyncio.sleep(VALIDATION_UI_DELAY_SECONDS)
+
+                if attempt >= total_attempts - 1:
+                    # Max attempts exhausted — emit a complete event so the frontend
+                    # renders the "Component generation failed" card with the spec message
+                    yield format_complete_event(
+                        {
+                            "result": "",
+                            "validated": False,
+                            "validation_error": execution_error,
+                            "validation_attempts": attempt + 1,
+                        }
+                    )
+                    return
+
+                yield format_progress_event(
+                    "retrying",
+                    attempt + 1,
+                    total_attempts,
+                    message="Retrying with error context...",
+                    error=execution_error,
+                )
+                await asyncio.sleep(VALIDATION_UI_DELAY_SECONDS)
+                current_input = EXECUTION_RETRY_TEMPLATE.format(
+                    error=execution_error,
+                    original_input=sanitization.sanitized_input,
+                )
+                continue
 
             if result is None:
                 logger.error("Flow execution returned no result")

--- a/src/backend/base/langflow/agentic/services/flow_executor.py
+++ b/src/backend/base/langflow/agentic/services/flow_executor.py
@@ -18,6 +18,7 @@ from lfx.utils.flow_validation import CustomComponentValidationError
 
 from langflow.agentic.services.flow_types import (
     STREAMING_QUEUE_MAX_SIZE,
+    FlowExecutionError,
     FlowExecutionResult,
 )
 from langflow.agentic.services.helpers.event_consumer import consume_streaming_events
@@ -246,9 +247,11 @@ async def execute_flow_file_streaming(
 
     if execution_result.has_error:
         logger.error(f"Flow execution error: {execution_result.error}")
-        raise HTTPException(
-            status_code=500,
-            detail=str(execution_result.error),
+        # Raise a FlowExecutionError that keeps the raw error internal:
+        # the public `detail` stays generic so no stack traces leak to HTTP clients,
+        # while internal callers read `original_error_message` to build friendly UX.
+        raise FlowExecutionError(
+            original_error_message=str(execution_result.error),
         ) from execution_result.error
 
     yield ("end", execution_result.result if execution_result.has_result else {})

--- a/src/backend/base/langflow/agentic/services/flow_executor.py
+++ b/src/backend/base/langflow/agentic/services/flow_executor.py
@@ -248,7 +248,7 @@ async def execute_flow_file_streaming(
         logger.error(f"Flow execution error: {execution_result.error}")
         raise HTTPException(
             status_code=500,
-            detail="An internal error occurred while executing the flow.",
+            detail=str(execution_result.error),
         ) from execution_result.error
 
     yield ("end", execution_result.result if execution_result.has_result else {})

--- a/src/backend/base/langflow/agentic/services/flow_types.py
+++ b/src/backend/base/langflow/agentic/services/flow_types.py
@@ -4,6 +4,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from fastapi import HTTPException
+
+_GENERIC_FLOW_EXECUTION_DETAIL = "An internal error occurred while executing the flow."
+
 # Base path for flow files (JSON and Python)
 FLOWS_BASE_PATH = Path(__file__).parent.parent / "flows"
 
@@ -69,3 +73,17 @@ class FlowExecutionResult:
     @property
     def has_result(self) -> bool:
         return bool(self.result)
+
+
+class FlowExecutionError(HTTPException):
+    """Flow execution failure that keeps the raw error internal.
+
+    The public ``detail`` stays generic so external HTTP callers never receive
+    stack traces or internal identifiers. Internal callers (the assistant retry
+    loop) read ``original_error_message`` to feed the friendly-error mapper for
+    user-facing display.
+    """
+
+    def __init__(self, original_error_message: str, status_code: int = 500) -> None:
+        super().__init__(status_code=status_code, detail=_GENERIC_FLOW_EXECUTION_DETAIL)
+        self.original_error_message = original_error_message

--- a/src/backend/base/langflow/agentic/services/flow_types.py
+++ b/src/backend/base/langflow/agentic/services/flow_types.py
@@ -35,6 +35,17 @@ BROKEN CODE:
 
 Please provide a corrected version of the component code."""
 
+EXECUTION_RETRY_TEMPLATE = """The previous attempt to generate a component failed during flow execution.
+
+ERROR:
+{error}
+
+ORIGINAL REQUEST:
+{original_input}
+
+Respond with a complete, valid Langflow component as a Python class extending Component, \
+inside a single ```python code block. Do not emit raw tool calls or partial JSON."""
+
 
 @dataclass
 class IntentResult:

--- a/src/backend/tests/unit/agentic/api/test_streaming_validation.py
+++ b/src/backend/tests/unit/agentic/api/test_streaming_validation.py
@@ -350,13 +350,24 @@ class TestStreamingValidationFlow:
         assert "validated" not in complete_events[0]["data"]
 
     @pytest.mark.asyncio
-    async def test_flow_execution_error_returnsformat_error_event(self):
-        """When flow execution fails, should return SSE error event."""
+    async def test_flow_execution_error_on_component_generation_retries_then_emits_complete_event(self):
+        """Component generation failures retry up to max_retries, then emit a complete event.
+
+        Before the retry fix: a single flow-execution failure emitted format_error_event
+        and returned immediately, so the user saw "An internal error occurred" with no
+        retry attempts — even though the spec defines automatic retry on failure.
+
+        After the fix: for component generation intent, each attempt that raises is
+        surfaced via validation_failed + retrying progress events, and only when all
+        attempts are exhausted is a final complete event emitted with validated=false
+        so the frontend renders the "Component generation failed" card (NOT a bare
+        error event).
+        """
         from fastapi import HTTPException
 
         async def mock_streaming_error(*_args, **_kwargs):
             raise HTTPException(status_code=429, detail="Rate limit exceeded")
-            yield  # makes this an async generator
+            yield  # pragma: no cover — makes this an async generator
 
         with (
             patch(
@@ -367,6 +378,7 @@ class TestStreamingValidationFlow:
                 "langflow.agentic.services.assistant_service.execute_flow_file_streaming",
                 side_effect=mock_streaming_error,
             ),
+            patch("asyncio.sleep", new_callable=AsyncMock),
         ):
             events = [
                 event
@@ -380,6 +392,58 @@ class TestStreamingValidationFlow:
 
         parsed_events = [json.loads(e[6:-2]) for e in events]
 
+        # No bare error events — component generation failures go through the
+        # validation_failed / complete pipeline so the frontend can render the card.
+        error_events = [e for e in parsed_events if e.get("event") == "error"]
+        assert len(error_events) == 0, f"Expected 0 error events for component generation, got: {error_events}"
+
+        # Final event must be a complete event with validated=false and the friendly
+        # rate-limit message preserved in validation_error.
+        complete_events = [e for e in parsed_events if e.get("event") == "complete"]
+        assert len(complete_events) == 1, f"Expected exactly 1 complete event, got: {complete_events}"
+        complete_data = complete_events[0]["data"]
+        assert complete_data["validated"] is False
+        assert "rate limit" in complete_data["validation_error"].lower()
+        # 4 attempts total (max_retries=3 → total_attempts=4)
+        assert complete_data["validation_attempts"] == 4
+
+    @pytest.mark.asyncio
+    async def test_flow_execution_error_on_qa_intent_emits_error_event_without_retry(self):
+        """Q&A intent has no retry semantics — failures emit a bare error event immediately."""
+        from fastapi import HTTPException
+
+        call_count = 0
+
+        async def mock_streaming_error(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise HTTPException(status_code=429, detail="Rate limit exceeded")
+            yield  # pragma: no cover — makes this an async generator
+
+        with (
+            patch(
+                "langflow.agentic.services.assistant_service.classify_intent",
+                side_effect=_mock_intent_classification("question"),
+            ),
+            patch(
+                "langflow.agentic.services.assistant_service.execute_flow_file_streaming",
+                side_effect=mock_streaming_error,
+            ),
+        ):
+            events = [
+                event
+                async for event in execute_flow_with_validation_streaming(
+                    flow_filename="test.json",
+                    input_value="what is langflow?",
+                    global_variables={},
+                    max_retries=3,
+                )
+            ]
+
+        parsed_events = [json.loads(e[6:-2]) for e in events]
+
+        # Q&A: exactly one call, no retry, bare error event
+        assert call_count == 1, f"Expected 1 call for Q&A intent, got {call_count}"
         error_events = [e for e in parsed_events if e.get("event") == "error"]
         assert len(error_events) == 1
         assert "rate limit" in error_events[0]["message"].lower()

--- a/src/backend/tests/unit/agentic/helpers/test_error_handling.py
+++ b/src/backend/tests/unit/agentic/helpers/test_error_handling.py
@@ -102,6 +102,27 @@ class TestExtractFriendlyError:
             assert "model" in result.lower()
             assert "not available" in result.lower() or "different" in result.lower()
 
+    def test_should_return_friendly_message_for_schema_validation_error_from_weak_model(self):
+        """Bug: pydantic InputSchema validation errors should surface a model-capability hint.
+
+        Weak models (llama3.2 et al.) emit malformed tool calls that trip pydantic
+        InputSchema validation downstream. The raw error is unactionable — users
+        should be told to pick a more capable model instead of seeing the raw
+        pydantic stack trace.
+        """
+        error_messages = [
+            "1 validation error for InputSchema\ninput_value\n  Input should be a valid string",
+            "pydantic.ValidationError: 1 validation error for InputSchema",
+            "Input should be a valid string [type=string_type, input_value={'description': '...'}]",
+        ]
+
+        for error in error_messages:
+            result = extract_friendly_error(error)
+            assert "model" in result.lower(), f"Expected 'model' in message for {error!r}, got: {result!r}"
+            assert "capable" in result.lower() or "different" in result.lower(), (
+                f"Expected 'capable' or 'different' in message for {error!r}, got: {result!r}"
+            )
+
     def test_should_return_friendly_message_for_content_policy_error(self):
         """Should return user-friendly message for content policy errors."""
         error_messages = [

--- a/src/backend/tests/unit/agentic/services/test_assistant_service_streaming.py
+++ b/src/backend/tests/unit/agentic/services/test_assistant_service_streaming.py
@@ -374,6 +374,126 @@ class TestErrorHandling:
             assert len(error_events) >= 1
 
     @pytest.mark.asyncio
+    async def test_should_emit_complete_event_with_validated_false_when_all_attempts_raise(self):
+        """Bug: exhausted retries should emit a complete event, not a bare error event.
+
+        When every attempt fails at execution time (weak model keeps blowing up), the
+        user should see the 'Component generation failed' card rendered by the frontend
+        from a complete event with validated=False, not a bare error event.
+
+        Before Bug A's fix: first failure returned immediately with format_error_event
+        and the user saw the raw "An internal error occurred" line.
+        After fix: the streaming service retries up to total_attempts and, when all
+        attempts fail, emits a format_complete_event with validated=False so the
+        frontend renders the failure card and the spec's "use a more capable model"
+        message.
+        """
+        from fastapi import HTTPException
+
+        def streaming_factory(**_kw):
+            async def always_raises():
+                raise HTTPException(
+                    status_code=500,
+                    detail="1 validation error for InputSchema\ninput_value\n  Input should be a valid string",
+                )
+                yield  # pragma: no cover — makes this an async generator
+
+            return always_raises()
+
+        with (
+            patch(
+                f"{MODULE}.classify_intent",
+                new_callable=AsyncMock,
+                return_value=_make_intent("generate_component"),
+            ),
+            patch(f"{MODULE}.execute_flow_file_streaming", side_effect=streaming_factory),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            gen = execute_flow_with_validation_streaming(
+                flow_filename="TestFlow",
+                input_value="create a component",
+                global_variables={},
+                max_retries=1,
+            )
+            events = await _collect_events(gen)
+
+            # Final event must be a complete event with validated=false so the frontend
+            # renders the failure card rather than a raw error line.
+            complete_events = [e for e in events if '"event": "complete"' in e]
+            assert complete_events, f"Expected a complete event after exhausted retries. Events: {events}"
+            assert any('"validated": false' in e.lower() for e in complete_events), (
+                f"Expected validated=false in final complete event. Events: {complete_events}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_should_retry_component_generation_when_flow_execution_raises(self):
+        """Bug: weak models (e.g. llama3.2) emit malformed tool calls that blow up the flow.
+
+        When intent=generate_component and execute_flow_file_streaming raises an
+        HTTPException on the first attempt, the assistant should retry up to
+        max_retries instead of bailing out immediately. Today the streaming service
+        catches HTTPException and returns, so the user sees "An internal error occurred"
+        with no retry — even though the spec defines automatic retry on failure.
+        """
+        from fastapi import HTTPException
+
+        component_code = "class FixedComp(Component): pass"
+        response_text = f"```python\n{component_code}\n```"
+
+        mock_success = MagicMock()
+        mock_success.is_valid = True
+        mock_success.class_name = "FixedComp"
+
+        call_count = 0
+
+        def streaming_factory(**_kw):
+            async def first_call_raises():
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    raise HTTPException(
+                        status_code=500,
+                        detail="An internal error occurred while executing the flow.",
+                    )
+                yield "end", {"result": response_text}
+
+            return first_call_raises()
+
+        with (
+            patch(
+                f"{MODULE}.classify_intent",
+                new_callable=AsyncMock,
+                return_value=_make_intent("generate_component"),
+            ),
+            patch(f"{MODULE}.execute_flow_file_streaming", side_effect=streaming_factory),
+            patch(f"{MODULE}.extract_component_code", return_value=component_code),
+            patch(f"{MODULE}.validate_component_code", return_value=mock_success),
+            patch(f"{MODULE}.validate_component_runtime", return_value=None),
+            patch(f"{MODULE}.extract_response_text", return_value=response_text),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            gen = execute_flow_with_validation_streaming(
+                flow_filename="TestFlow",
+                input_value="create a component",
+                global_variables={},
+                max_retries=2,
+            )
+            events = await _collect_events(gen)
+
+            # Must retry — at least 2 calls to the streaming flow executor
+            assert call_count >= 2, (
+                f"Expected retry after flow execution error, but execute_flow_file_streaming "
+                f"was called only {call_count} time(s)."
+            )
+
+            # Final event should be a complete event with validated=True
+            complete_events = [e for e in events if '"event": "complete"' in e]
+            assert complete_events, "Expected a complete event after successful retry"
+            assert any('"validated": true' in e.lower() for e in complete_events), (
+                f"Expected validated=true in complete event after successful retry. Events: {complete_events}"
+            )
+
+    @pytest.mark.asyncio
     async def test_should_emit_error_when_no_result(self):
         """Should emit error event when flow returns no result."""
         flow_gen = _make_flow_events([])  # No events = no result

--- a/src/backend/tests/unit/agentic/services/test_flow_executor.py
+++ b/src/backend/tests/unit/agentic/services/test_flow_executor.py
@@ -503,25 +503,29 @@ class TestExecuteFlowFileStreamingEvents:
             assert exc_info.value.status_code == 500
 
     @pytest.mark.asyncio
-    async def test_should_propagate_original_error_message_in_http_detail_on_execution_failure(self):
+    async def test_should_carry_original_error_internally_without_leaking_in_http_detail(self):
         """Bug: streaming execution wrapped any error as a generic 'An internal error occurred'.
 
-        That hides the root cause (e.g. pydantic InputSchema validation failures from a
+        That hid the root cause (e.g. pydantic InputSchema validation failures from a
         weak model emitting malformed tool calls) from the upstream friendly-error
-        mapper, so the user always sees the same generic message instead of an
-        actionable one. The HTTPException detail should include the original error
-        text so extract_friendly_error can pattern-match on it.
+        mapper, so the user always saw the same generic message instead of an
+        actionable one.
+
+        Fix: raise FlowExecutionError — a custom HTTPException that keeps the public
+        ``detail`` generic (no stack traces leak to HTTP clients) while exposing
+        ``original_error_message`` for internal callers (the assistant retry loop)
+        to feed into extract_friendly_error.
         """
+        from langflow.agentic.services.flow_types import FlowExecutionError
 
         async def mock_consume(*_args, **_kwargs):
             yield ("end", None)
 
+        raw_error_text = "1 validation error for InputSchema\ninput_value\n  Input should be a valid string"
         mock_result = MagicMock()
         mock_result.has_error = True
         mock_result.has_result = False
-        mock_result.error = RuntimeError(
-            "1 validation error for InputSchema\ninput_value\n  Input should be a valid string"
-        )
+        mock_result.error = RuntimeError(raw_error_text)
 
         with (
             patch(f"{MODULE}.resolve_flow_path", return_value=(Path("/fake/test.json"), "json")),
@@ -531,14 +535,21 @@ class TestExecuteFlowFileStreamingEvents:
             patch(f"{MODULE}._run_graph_with_events", new_callable=AsyncMock),
             patch(f"{MODULE}.FlowExecutionResult", return_value=mock_result),
         ):
-            with pytest.raises(HTTPException) as exc_info:
+            with pytest.raises(FlowExecutionError) as exc_info:
                 async for _ in execute_flow_file_streaming("test.json"):
                     pass
 
+            # Public HTTP detail MUST be generic — no raw error text leaked
             assert exc_info.value.status_code == 500
             detail = str(exc_info.value.detail)
-            assert "InputSchema" in detail or "Input should be a valid string" in detail, (
-                f"Expected original error text in HTTPException detail, got: {detail!r}"
+            assert "InputSchema" not in detail, f"Raw error text leaked in public detail: {detail!r}"
+            assert "Input should be a valid string" not in detail, f"Raw error text leaked in public detail: {detail!r}"
+
+            # Internal original_error_message MUST carry the raw error so the
+            # friendly-error mapper in assistant_service can pattern-match on it
+            original = exc_info.value.original_error_message
+            assert "InputSchema" in original or "Input should be a valid string" in original, (
+                f"Expected original error text in FlowExecutionError.original_error_message, got: {original!r}"
             )
 
     @pytest.mark.asyncio

--- a/src/backend/tests/unit/agentic/services/test_flow_executor.py
+++ b/src/backend/tests/unit/agentic/services/test_flow_executor.py
@@ -503,6 +503,45 @@ class TestExecuteFlowFileStreamingEvents:
             assert exc_info.value.status_code == 500
 
     @pytest.mark.asyncio
+    async def test_should_propagate_original_error_message_in_http_detail_on_execution_failure(self):
+        """Bug: streaming execution wrapped any error as a generic 'An internal error occurred'.
+
+        That hides the root cause (e.g. pydantic InputSchema validation failures from a
+        weak model emitting malformed tool calls) from the upstream friendly-error
+        mapper, so the user always sees the same generic message instead of an
+        actionable one. The HTTPException detail should include the original error
+        text so extract_friendly_error can pattern-match on it.
+        """
+
+        async def mock_consume(*_args, **_kwargs):
+            yield ("end", None)
+
+        mock_result = MagicMock()
+        mock_result.has_error = True
+        mock_result.has_result = False
+        mock_result.error = RuntimeError(
+            "1 validation error for InputSchema\ninput_value\n  Input should be a valid string"
+        )
+
+        with (
+            patch(f"{MODULE}.resolve_flow_path", return_value=(Path("/fake/test.json"), "json")),
+            patch(f"{MODULE}.load_graph_for_execution", new_callable=AsyncMock, return_value=MagicMock(context={})),
+            patch(f"{MODULE}.create_default_event_manager"),
+            patch(f"{MODULE}.consume_streaming_events", side_effect=mock_consume),
+            patch(f"{MODULE}._run_graph_with_events", new_callable=AsyncMock),
+            patch(f"{MODULE}.FlowExecutionResult", return_value=mock_result),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                async for _ in execute_flow_file_streaming("test.json"):
+                    pass
+
+            assert exc_info.value.status_code == 500
+            detail = str(exc_info.value.detail)
+            assert "InputSchema" in detail or "Input should be a valid string" in detail, (
+                f"Expected original error text in HTTPException detail, got: {detail!r}"
+            )
+
+    @pytest.mark.asyncio
     async def test_should_handle_preparation_error(self):
         """Should raise HTTPException on JSONDecodeError/OSError/ValueError."""
         with (

--- a/src/frontend/src/components/core/assistantPanel/assistant-panel.constants.ts
+++ b/src/frontend/src/components/core/assistantPanel/assistant-panel.constants.ts
@@ -8,7 +8,6 @@ export const ASSISTANT_SESSION_STORAGE_KEY_PREFIX =
 export const ASSISTANT_PLACEHOLDERS = [
   "Create an agent component...",
   "Build a RAG pipeline...",
-  "Make a chatbot with memory...",
   "Create a web scraper component...",
   "Build a document parser...",
   "Ask me anything about Langflow...",

--- a/src/frontend/src/components/core/assistantPanel/components/__tests__/assistant-loading-state.test.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/__tests__/assistant-loading-state.test.tsx
@@ -208,6 +208,17 @@ describe("AssistantLoadingState", () => {
       );
       expect(screen.queryByText(/Attempt/)).not.toBeInTheDocument();
     });
+
+    it("should not render empty padded body on first attempt with no streaming, error, code, or ready state", () => {
+      // Bug: wrapper used progress.attempt > 0 while the retry counter used > 1,
+      // so attempt=1 painted px-4 pb-4 with no visible children below the header.
+      const { container } = render(
+        <AssistantLoadingState
+          progress={createProgress({ attempt: 1, maxAttempts: 3 })}
+        />,
+      );
+      expect(container.querySelector(".pb-4")).toBeNull();
+    });
   });
 
   describe("Continue button", () => {

--- a/src/frontend/src/components/core/assistantPanel/components/__tests__/assistant-loading-state.test.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/__tests__/assistant-loading-state.test.tsx
@@ -209,9 +209,11 @@ describe("AssistantLoadingState", () => {
       expect(screen.queryByText(/Attempt/)).not.toBeInTheDocument();
     });
 
-    it("should not render empty padded body on first attempt with no streaming, error, code, or ready state", () => {
+    it("should not render empty padded body for attempt 1 (pre-retry) with no streaming, error, code, or ready state", () => {
+      // Attempts are 1-indexed in the UI: attempt=1 is the first attempt, no retry yet.
       // Bug: wrapper used progress.attempt > 0 while the retry counter used > 1,
       // so attempt=1 painted px-4 pb-4 with no visible children below the header.
+      // Fix: wrapper now uses > 1 to match the retry counter.
       const { container } = render(
         <AssistantLoadingState
           progress={createProgress({ attempt: 1, maxAttempts: 3 })}

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-loading-state.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-loading-state.tsx
@@ -63,7 +63,7 @@ function AssistantLoadingStateComponent({
         className={
           showStreamingPreview ||
           progress.error ||
-          progress.attempt > 0 ||
+          progress.attempt > 1 ||
           finalCode ||
           isReady
             ? "px-4 pb-4"


### PR DESCRIPTION
OBJECTIVE: Prevent the Langflow Assistant from aborting on the first execution failure when a weak model emits malformed tool calls, and render the spec's "Component generation failed" card with an actionable message instead of "An internal error occurred".                                                          
                                                                                                                                                                  
CHANGES:                                                                                                                                                        
  - Wrap streaming flow-execution errors in a retry loop (up to max_retries) for generate_component intents, with a new EXECUTION_RETRY_TEMPLATE corrective       
  prompt; keep immediate-error behavior for Q&A                                                                                                                   
  - Emit format_complete_event(validated=False) instead of format_error_event when retries are exhausted, so the frontend renders the "Component generation
  failed" card per spec                                                                                                                                           
  - Propagate the original execution error text in execute_flow_file_streaming's HTTPException detail instead of replacing it with a generic string               
  - Add a pydantic/schema-validation pattern to extract_friendly_error that routes to "The selected model produced output that didn't match the expected schema.
  Try again or use a more capable model."                                                                                                                         
  - Add regression tests for each of the four defects