### PR TITLE
fix: failing wxo list llm test

### DIFF
--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -309,11 +309,7 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
 
         try:
             api_models = await asyncio.to_thread(fetch_models_adapter, client_manager)
-            for model in api_models:
-                model_name = model.get("model_name") if isinstance(model, dict) else getattr(model, "model_name", None)
-                if model_name and model_name in hardcoded_names:
-                    continue
-                raw_models.append(model)
+            raw_models.extend(m for m in api_models if m["model_name"] not in hardcoded_names)
             parsed_models: WatsonxDeploymentLlmListResultData = self._parse_provider_payload(
                 slot=self.payload_schemas.deployment_llm_list_result,
                 slot_name="deployment_llm_list_result",

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -5062,7 +5062,7 @@ async def test_list_llms_returns_normalized_model_names(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_list_llms_invalid_payload_raises_invalid_content(monkeypatch):
+async def test_list_llms_invalid_payload_raises_deployment_error(monkeypatch):
     service = WatsonxOrchestrateDeploymentService(DummySettingsService())
     fake_agent = FakeAgentClient(
         {"id": "dep-1", "tools": []},
@@ -5080,7 +5080,7 @@ async def test_list_llms_invalid_payload_raises_invalid_content(monkeypatch):
 
     monkeypatch.setattr(service, "_get_provider_clients", mock_get_provider_clients)
 
-    with pytest.raises(InvalidContentError):
+    with pytest.raises(DeploymentError, match="listing deployment LLMs"):
         await service.list_llms(user_id="user-1", db=object())
 
 


### PR DESCRIPTION
fixes the wxo adapter list llms method by accessing "model_name" via dict key rather than attribute