### PR TITLE
fix(mcp): dedupe edges in connect_components

### DIFF
--- a/src/lfx/src/lfx/graph/flow_builder/connect.py
+++ b/src/lfx/src/lfx/graph/flow_builder/connect.py
@@ -144,6 +144,15 @@ def add_connection(
 
     edge_id = f"reactflow__edge-{source_id}{source_handle_s}-{target_id}{target_handle_s}"
 
+    # Idempotent: if an edge with this exact id already exists, return it
+    # rather than appending a duplicate. The id is deterministic from
+    # source/target/handles, so a repeat call (batch retry, UI-then-MCP, etc.)
+    # would otherwise create a second edge with the same id and double-wire
+    # the flow at runtime.
+    for existing in flow["data"]["edges"]:
+        if existing.get("id") == edge_id:
+            return existing
+
     edge = {
         "animated": False,
         "className": "",

--- a/src/lfx/src/lfx/graph/flow_builder/connect.py
+++ b/src/lfx/src/lfx/graph/flow_builder/connect.py
@@ -144,13 +144,20 @@ def add_connection(
 
     edge_id = f"reactflow__edge-{source_id}{source_handle_s}-{target_id}{target_handle_s}"
 
-    # Idempotent: if an edge with this exact id already exists, return it
-    # rather than appending a duplicate. The id is deterministic from
-    # source/target/handles, so a repeat call (batch retry, UI-then-MCP, etc.)
-    # would otherwise create a second edge with the same id and double-wire
-    # the flow at runtime.
+    # Idempotent: if a connection between the same source output and target
+    # input already exists, return it rather than appending a duplicate. We
+    # compare structurally (source/target ids + handle name/fieldName) instead
+    # of by edge id, since UI-saved edges from older Langflow versions use a
+    # different id prefix (`xy-edge__` vs `reactflow__edge-`) even though the
+    # underlying connection is the same. A repeat call (batch retry, UI-then-MCP)
+    # would otherwise double-wire the flow at runtime.
     for existing in flow["data"]["edges"]:
-        if existing.get("id") == edge_id:
+        if (
+            existing.get("source") == source_id
+            and existing.get("target") == target_id
+            and (existing.get("data") or {}).get("sourceHandle", {}).get("name") == source_output
+            and (existing.get("data") or {}).get("targetHandle", {}).get("fieldName") == target_input
+        ):
             return existing
 
     edge = {

--- a/src/lfx/tests/unit/test_flow_builder.py
+++ b/src/lfx/tests/unit/test_flow_builder.py
@@ -331,6 +331,21 @@ class TestConnect:
         assert edge["animated"] is False
         assert edge["selected"] is False
 
+    def test_add_connection_is_idempotent(self):
+        """Repeating add_connection for the same pair must not duplicate the edge.
+
+        Regression for LE-866: connecting components via batch (or after the
+        edge was already created in the UI) appended a second edge with the
+        same deterministic id, double-wiring the flow at runtime.
+        """
+        flow = _fresh_flow()
+        r1 = add_component(flow, "ChatInput", REGISTRY)
+        r2 = add_component(flow, "ChatOutput", REGISTRY)
+        first = add_connection(flow, r1["id"], "message", r2["id"], "input_value")
+        second = add_connection(flow, r1["id"], "message", r2["id"], "input_value")
+        assert len(flow["data"]["edges"]) == 1
+        assert first is second  # returns the existing edge dict
+
     def test_remove_connection(self):
         flow = _fresh_flow()
         r1 = add_component(flow, "ChatInput", REGISTRY)

--- a/src/lfx/tests/unit/test_flow_builder.py
+++ b/src/lfx/tests/unit/test_flow_builder.py
@@ -4,6 +4,9 @@ All tests use synthetic registries (plain dicts) — no lfx component loading,
 no I/O, no network.
 """
 
+import json
+from pathlib import Path
+
 import pytest
 from lfx.graph.flow_builder import (
     add_component,
@@ -336,7 +339,7 @@ class TestConnect:
 
         Regression for LE-866: connecting components via batch (or after the
         edge was already created in the UI) appended a second edge with the
-        same deterministic id, double-wiring the flow at runtime.
+        same connection, double-wiring the flow at runtime.
         """
         flow = _fresh_flow()
         r1 = add_component(flow, "ChatInput", REGISTRY)
@@ -345,6 +348,34 @@ class TestConnect:
         second = add_connection(flow, r1["id"], "message", r2["id"], "input_value")
         assert len(flow["data"]["edges"]) == 1
         assert first is second  # returns the existing edge dict
+
+    def test_add_connection_dedupes_against_ui_saved_edges(self):
+        """Re-adding connections to a real UI-saved flow must not grow the edge list.
+
+        Regression for LE-866 against an actual UI-exported fixture. UI-saved
+        edges from older Langflow versions use the `xy-edge__` id prefix
+        instead of `reactflow__edge-`, so dedup must be structural (source,
+        target, handle name, handle fieldName) rather than by edge id.
+        """
+        fixture = Path(__file__).parent.parent / "data" / "MemoryChatbotNoLLM.json"
+        flow = json.loads(fixture.read_text())
+        original_count = len(flow["data"]["edges"])
+        assert original_count > 0, "fixture should have edges to test against"
+
+        # Replay every existing connection through add_connection — exactly what
+        # batch -> connect_components does when called for an already-wired pair.
+        for conn in list_connections(flow):
+            add_connection(
+                flow,
+                conn["source_id"],
+                conn["source_output"],
+                conn["target_id"],
+                conn["target_input"],
+                source_types=conn["source_types"],
+                target_types=conn["target_types"],
+            )
+
+        assert len(flow["data"]["edges"]) == original_count
 
     def test_remove_connection(self):
         flow = _fresh_flow()


### PR DESCRIPTION
## Summary
- `add_connection` appended a new edge unconditionally, so calling `connect_components` for a pair the flow already had wired up (UI-then-MCP, batch retry, repeat call) created a second edge with the same deterministic id and double-wired the flow at runtime.
- Make the append idempotent: if an edge with the same id already exists, return it instead. Different outputs/inputs between the same pair still get distinct ids and remain supported.

## Repro (from Alice on the ticket)
- Create a flow in the UI with 3 edges (chat input → agent → chat output, with a web search tool wired into the agent).
- Run a batch with `connect_components` for those same 3 pairs.
- Before: 3 edges. After: 6 edges. Each pair duplicated.