### PR TITLE
fix(frontend): add backdrop blur to test deployment modal

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/test-deployment-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/test-deployment-modal/test-deployment-modal.tsx
@@ -38,6 +38,7 @@ export default function TestDeploymentModal({
       <DialogContent
         className="flex h-[85vh] w-[700px] !max-w-none flex-col gap-0 overflow-hidden border-none bg-transparent p-0 shadow-none"
         closeButtonClassName="top-5 right-4"
+        overlayClassName="bg-black/30 dark:bg-black/50 backdrop-blur"
       >
         <DialogTitle className="sr-only">Test Deployment</DialogTitle>
         <DialogDescription className="sr-only">


### PR DESCRIPTION
## Summary
- Add `overlayClassName` with backdrop blur to test deployment modal, matching the stepper modal's stronger backdrop style from #12696