### PR TITLE
feat: add customOpenUrl utility for secure external link handling

### DIFF
--- a/src/frontend/src/customization/utils/custom-open-url.ts
+++ b/src/frontend/src/customization/utils/custom-open-url.ts
@@ -1,0 +1,4 @@
+// This file contains a utility function to open a URL in a new tab with security features enabled.
+export function customOpenUrl(url: string): void {
+  window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/src/frontend/src/customization/utils/custom-open-url.ts
+++ b/src/frontend/src/customization/utils/custom-open-url.ts
@@ -1,4 +1,0 @@
-// This file contains a utility function to open a URL in a new tab with security features enabled.
-export function customOpenUrl(url: string): void {
-  window.open(url, "_blank", "noopener,noreferrer");
-}

--- a/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
@@ -5,8 +5,8 @@ import MultiselectComponent from "@/components/core/parameterRenderComponent/com
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { ProviderVariable } from "@/constants/providerConstants";
+import { customOpenNewTab } from "@/customization/utils/custom-open-new-tab";
 import useAlertStore from "@/stores/alertStore";
-import { openInNewTab } from "@/utils/utils";
 import DisconnectWarning from "./DisconnectWarning";
 import type { Provider } from "./types";
 
@@ -146,7 +146,7 @@ const ProviderConfigurationForm = ({
               className="underline cursor-pointer hover:text-primary"
               onClick={() => {
                 if (selectedProvider.api_docs_url) {
-                  openInNewTab(selectedProvider.api_docs_url);
+                  customOpenNewTab(selectedProvider.api_docs_url);
                 }
               }}
             >

--- a/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
@@ -5,8 +5,8 @@ import MultiselectComponent from "@/components/core/parameterRenderComponent/com
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { ProviderVariable } from "@/constants/providerConstants";
-import { customOpenUrl } from "@/customization/utils/custom-open-url";
 import useAlertStore from "@/stores/alertStore";
+import { openInNewTab } from "@/utils/utils";
 import DisconnectWarning from "./DisconnectWarning";
 import type { Provider } from "./types";
 
@@ -146,7 +146,7 @@ const ProviderConfigurationForm = ({
               className="underline cursor-pointer hover:text-primary"
               onClick={() => {
                 if (selectedProvider.api_docs_url) {
-                  customOpenUrl(selectedProvider.api_docs_url);
+                  openInNewTab(selectedProvider.api_docs_url);
                 }
               }}
             >

--- a/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx
@@ -4,10 +4,11 @@ import ShadTooltip from "@/components/common/shadTooltipComponent";
 import MultiselectComponent from "@/components/core/parameterRenderComponent/components/multiselectComponent";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ProviderVariable } from "@/constants/providerConstants";
+import type { ProviderVariable } from "@/constants/providerConstants";
+import { customOpenUrl } from "@/customization/utils/custom-open-url";
 import useAlertStore from "@/stores/alertStore";
 import DisconnectWarning from "./DisconnectWarning";
-import { Provider } from "./types";
+import type { Provider } from "./types";
 
 const PROVIDER_KEY_PREVIEW: Record<
   string,
@@ -145,11 +146,7 @@ const ProviderConfigurationForm = ({
               className="underline cursor-pointer hover:text-primary"
               onClick={() => {
                 if (selectedProvider.api_docs_url) {
-                  window.open(
-                    selectedProvider.api_docs_url,
-                    "_blank",
-                    "noopener,noreferrer",
-                  );
+                  customOpenUrl(selectedProvider.api_docs_url);
                 }
               }}
             >


### PR DESCRIPTION
## Summary
- Add `customOpenUrl` utility that wraps `window.open` with `noopener,noreferrer` for secure external links
- Use it in `ProviderConfigurationForm` to open provider API docs
- Convert imports to type-only where applicable