### PR TITLE
fix: add pydantic validation on component assistant

### DIFF
--- a/src/backend/base/langflow/agentic/helpers/validation.py
+++ b/src/backend/base/langflow/agentic/helpers/validation.py
@@ -10,6 +10,7 @@ import ast
 import re
 
 from lfx.custom.validate import extract_class_name
+from pydantic import ValidationError
 
 from langflow.agentic.api.schemas import ValidationResult
 
@@ -124,28 +125,109 @@ def _extract_output_methods(tree: ast.Module, class_name: str) -> list[str]:
     return methods
 
 
-def validate_component_runtime(code: str, user_id: str | None = None) -> str | None:
-    """Try to instantiate the component at runtime to catch import/class errors.
+def _format_validation_error(exc: ValidationError) -> str:
+    """Return a compact single-line message for a pydantic ValidationError.
 
-    Returns None if validation passes, or an error message string if it fails.
-    This catches issues that static AST validation cannot detect, such as:
-    - Wrong import paths (e.g., 'from lfx.base import Component' instead of 'from lfx.custom import Component')
+    The retry loop in assistant_service feeds this string into
+    extract_friendly_error, which pattern-matches on phrases like
+    ``"input should be a valid"`` to route the error to a targeted corrective
+    prompt. Pydantic's first error line is just ``"1 validation error for X"``
+    — the actionable detail lives in subsequent lines — so we collapse the
+    full error into one line to keep the downstream patterns matching.
+    """
+    errors = exc.errors()
+    if errors:
+        parts = []
+        for err in errors[:3]:
+            loc = ".".join(str(x) for x in err.get("loc", ()))
+            msg = err.get("msg", "")
+            parts.append(f"{loc}: {msg}" if loc else msg)
+        return f"ValidationError: {'; '.join(parts)}"
+
+    text = str(exc).replace("\n", " ").strip()
+    return f"ValidationError: {text}" if text else "ValidationError"
+
+
+def _format_root_error(exc: BaseException) -> str:
+    """Collapse an exception chain to a compact, single-line error string."""
+    root = exc.__cause__ or exc
+    if isinstance(root, ValidationError):
+        return _format_validation_error(root)
+
+    error_type = type(root).__name__
+    error_msg = str(root).split("\n")[0].strip() if str(root) else str(exc).split("\n")[0].strip()
+    return f"{error_type}: {error_msg}" if error_msg else error_type
+
+
+async def _execute_output_methods_for_validation(cc_instance) -> str | None:
+    """Invoke every output method and surface pydantic-schema failures only.
+
+    Executes ``cc_instance._build_results()`` — which calls every output method
+    bound to the component — and catches ``pydantic.ValidationError`` (raised
+    when a method constructs a schema object with the wrong shape, e.g.
+    ``Data(data=[list])`` or ``Message(sender=<not-a-string>)``).
+
+    Non-schema runtime errors (network failures, missing inputs, auth problems)
+    are **intentionally swallowed**: a correct component can still fail
+    execution in the validation sandbox for environmental reasons, and we must
+    not mark it as broken on that basis. The retry loop in assistant_service
+    consumes only the schema errors this helper returns.
+
+    Note: uses ``_build_results`` directly instead of the public ``build_results``
+    because the latter emits events via ``send_error`` and relies on a
+    tracing/event manager that the validation sandbox does not wire up.
+    """
+    try:
+        cc_instance.set_attributes({})
+    except ValidationError as exc:
+        return _format_root_error(exc)
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+    try:
+        await cc_instance._build_results()  # noqa: SLF001 — sandbox bypass of send_error/tracing
+    except ValidationError as exc:
+        return _format_validation_error(exc)
+    except Exception as exc:  # noqa: BLE001 — see sandbox rationale in docstring
+        cause = exc.__cause__ or exc.__context__
+        if isinstance(cause, ValidationError):
+            return _format_validation_error(cause)
+        return None
+    return None
+
+
+async def validate_component_runtime(code: str, user_id: str | None = None) -> str | None:
+    """Try to instantiate and execute the component at runtime.
+
+    Returns None if validation passes, or a compact error message string if
+    it fails. Catches issues that static AST validation cannot detect:
+
+    - Wrong import paths (e.g., ``from lfx.base import Component`` instead of
+      ``from lfx.custom import Component``)
     - Missing dependencies
     - Invalid class hierarchy
+    - **Pydantic-schema bugs raised while running the output methods**
+      (e.g. ``Data(data=[list])`` when a dict is expected, ``Message`` built
+      with the wrong field types, ``DataFrame`` with malformed rows, or any
+      other pydantic model the component tries to construct)
+
+    The execution step is a sandbox: non-schema runtime errors (network,
+    filesystem, auth, missing inputs) are swallowed because a correctly
+    generated component can legitimately fail in the sandbox for environmental
+    reasons. Only pydantic-schema errors — which are almost always LLM-coding
+    mistakes — are surfaced so the retry loop can recover before the component
+    is handed to the user.
     """
     try:
         from lfx.custom.custom_component.component import Component as ComponentClass
         from lfx.custom.utils import build_custom_component_template
 
         component_instance = ComponentClass(_code=code)
-        build_custom_component_template(component_instance, user_id=user_id)
-    except Exception as e:  # noqa: BLE001
-        # Extract just the root cause, not the full traceback
-        root = e.__cause__ or e
-        error_type = type(root).__name__
-        error_msg = str(root).split("\n")[0].strip() if str(root) else str(e).split("\n")[0].strip()
-        return f"{error_type}: {error_msg}" if error_msg else error_type
-    return None
+        _, cc_instance = build_custom_component_template(component_instance, user_id=user_id)
+    except Exception as e:  # noqa: BLE001 — compact one-line error for the retry prompt
+        return _format_root_error(e)
+
+    return await _execute_output_methods_for_validation(cc_instance)
 
 
 def validate_component_code(code: str) -> ValidationResult:

--- a/src/backend/base/langflow/agentic/services/assistant_service.py
+++ b/src/backend/base/langflow/agentic/services/assistant_service.py
@@ -417,8 +417,10 @@ async def execute_flow_with_validation_streaming(
                 continue
 
             if validation.is_valid:
-                # Runtime validation: try to actually instantiate the component
-                runtime_error = validate_component_runtime(code, user_id=user_id)
+                # Runtime validation: instantiate AND execute the component's output
+                # methods so pydantic-schema bugs (e.g. Data(data=[list])) are caught
+                # before the component is handed to the user.
+                runtime_error = await validate_component_runtime(code, user_id=user_id)
                 if runtime_error:
                     logger.warning(f"Runtime validation failed (attempt {attempt}): {runtime_error}")
                     validation = type(validation)(

--- a/src/backend/tests/unit/agentic/helpers/test_validation.py
+++ b/src/backend/tests/unit/agentic/helpers/test_validation.py
@@ -6,14 +6,17 @@ validate_component_code, and static validation helpers.
 
 import ast
 import os
+from textwrap import dedent
 from unittest.mock import patch
 
+import pytest
 from langflow.agentic.helpers.validation import (
     _extract_class_name_regex,
     _extract_io_names,
     _extract_output_methods,
     _safe_extract_class_name,
     validate_component_code,
+    validate_component_runtime,
 )
 
 MODULE = "langflow.agentic.helpers.validation"
@@ -313,3 +316,126 @@ class InputOnlyComponent(Component):
 """
         result = validate_component_code(code)
         assert result.is_valid is True
+
+
+class TestValidateComponentRuntimeExecution:
+    r"""Runtime execution validation catches pydantic-schema bugs static passes cannot detect.
+
+    Bug report: the Assistant generated a Web Scraper component whose
+    ``build_articles`` output method constructed ``Data(data=[...])`` with a list
+    instead of a dict. Static + template validation passed; the bug only
+    surfaced when the user later ran the flow and pydantic raised
+    ``ValidationError: data\n  Input should be a valid dictionary``. Runtime
+    validation must execute the output methods and surface these pydantic-schema
+    failures so the retry loop can recover before the component is handed to the
+    user.
+    """
+
+    @pytest.mark.asyncio
+    async def test_should_return_error_when_output_method_builds_data_with_list_payload(self):
+        """Bug: Data(data=[list]) slips through runtime validation.
+
+        Exercises the EXACT error path from the bug report: an output method
+        that constructs ``Data(data=[{"title": ...}])`` — which pydantic rejects
+        because ``Data.data`` must be a dict. The test asserts that
+        validate_component_runtime surfaces the pydantic ValidationError
+        instead of returning None.
+        """
+        buggy_code = dedent(
+            """
+            from lfx.custom import Component
+            from lfx.schema.data import Data
+            from lfx.template.field.base import Output
+
+
+            class DummyScraper(Component):
+                display_name = "Dummy Scraper"
+                description = "Returns dummy articles"
+
+                inputs = []
+                outputs = [
+                    Output(display_name="Articles", name="articles", method="build_articles"),
+                ]
+
+                def build_articles(self) -> Data:
+                    return Data(data=[{"title": "Dummy Article", "content": "Placeholder."}])
+            """
+        ).strip()
+
+        error = await validate_component_runtime(buggy_code)
+
+        assert error is not None, (
+            "validate_component_runtime should surface Data(data=[list]) pydantic "
+            "errors instead of silently returning None"
+        )
+        lowered = error.lower()
+        assert "valid" in lowered, f"Expected a pydantic validation error message, got: {error!r}"
+        assert "dict" in lowered, f"Expected the pydantic message to mention 'dict', got: {error!r}"
+
+    @pytest.mark.asyncio
+    async def test_should_return_error_when_output_method_builds_message_with_wrong_type(self):
+        """Fix must extend beyond Data to any pydantic model the method builds.
+
+        Exercises the same class of bug against ``Message``: the method passes
+        a list to ``text`` (which pydantic coerces to str but validates on
+        field-shape). Using ``sender`` with a non-string dict triggers
+        ValidationError too.
+        """
+        buggy_code = dedent(
+            """
+            from lfx.custom import Component
+            from lfx.schema.message import Message
+            from lfx.template.field.base import Output
+
+
+            class DummyMessageComponent(Component):
+                display_name = "Dummy Message"
+                description = "Builds a broken Message"
+
+                inputs = []
+                outputs = [
+                    Output(display_name="Out", name="out", method="build_message"),
+                ]
+
+                def build_message(self) -> Message:
+                    return Message(text="ok", sender={"not": "a string"})
+            """
+        ).strip()
+
+        error = await validate_component_runtime(buggy_code)
+
+        assert error is not None, (
+            "validate_component_runtime should surface pydantic errors for Message, not only for Data"
+        )
+
+    @pytest.mark.asyncio
+    async def test_should_return_none_when_output_method_builds_valid_data(self):
+        """Baseline: a correctly built Data object must not produce an error.
+
+        Guards against the fix becoming too aggressive and rejecting valid
+        components (e.g. marking every execution failure as a bug).
+        """
+        good_code = dedent(
+            """
+            from lfx.custom import Component
+            from lfx.schema.data import Data
+            from lfx.template.field.base import Output
+
+
+            class GoodScraper(Component):
+                display_name = "Good Scraper"
+                description = "Returns a valid Data object"
+
+                inputs = []
+                outputs = [
+                    Output(display_name="Articles", name="articles", method="build_articles"),
+                ]
+
+                def build_articles(self) -> Data:
+                    return Data(data={"title": "Dummy Article", "content": "Placeholder."})
+            """
+        ).strip()
+
+        error = await validate_component_runtime(good_code)
+
+        assert error is None, f"Expected None for a valid component, got: {error!r}"

--- a/src/backend/tests/unit/agentic/services/test_assistant_service_intermediate_visibility.py
+++ b/src/backend/tests/unit/agentic/services/test_assistant_service_intermediate_visibility.py
@@ -72,7 +72,7 @@ class TestValidatingStepIncludesCode:
             patch(f"{MODULE}.extract_component_code", return_value=component_code),
             patch(f"{MODULE}.validate_component_code", return_value=mock_validation),
             patch(f"{MODULE}.scan_code_security", return_value=_safe_security()),
-            patch(f"{MODULE}.validate_component_runtime", return_value=None),
+            patch(f"{MODULE}.validate_component_runtime", new_callable=AsyncMock, return_value=None),
             patch(f"{MODULE}.extract_response_text", return_value=response_text),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
@@ -112,7 +112,7 @@ class TestValidatingStepIncludesCode:
             patch(f"{MODULE}.extract_component_code", return_value=component_code),
             patch(f"{MODULE}.validate_component_code", return_value=mock_validation),
             patch(f"{MODULE}.scan_code_security", return_value=_safe_security()),
-            patch(f"{MODULE}.validate_component_runtime", return_value=None),
+            patch(f"{MODULE}.validate_component_runtime", new_callable=AsyncMock, return_value=None),
             patch(f"{MODULE}.extract_response_text", return_value=response_text),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
@@ -239,7 +239,7 @@ class TestRetryingStepIncludesError:
             patch(f"{MODULE}.extract_component_code", return_value=component_code),
             patch(f"{MODULE}.validate_component_code", side_effect=[mock_fail, mock_success]),
             patch(f"{MODULE}.scan_code_security", return_value=_safe_security()),
-            patch(f"{MODULE}.validate_component_runtime", return_value=None),
+            patch(f"{MODULE}.validate_component_runtime", new_callable=AsyncMock, return_value=None),
             patch(f"{MODULE}.extract_response_text", return_value=response_text),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
@@ -281,7 +281,7 @@ class TestRetryingStepIncludesError:
             patch(f"{MODULE}.extract_component_code", return_value=component_code),
             patch(f"{MODULE}.validate_component_code", side_effect=[mock_fail, mock_success]),
             patch(f"{MODULE}.scan_code_security", return_value=_safe_security()),
-            patch(f"{MODULE}.validate_component_runtime", return_value=None),
+            patch(f"{MODULE}.validate_component_runtime", new_callable=AsyncMock, return_value=None),
             patch(f"{MODULE}.extract_response_text", return_value=response_text),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
@@ -327,7 +327,7 @@ class TestProgressEventSequence:
             patch(f"{MODULE}.extract_component_code", return_value=component_code),
             patch(f"{MODULE}.validate_component_code", return_value=mock_validation),
             patch(f"{MODULE}.scan_code_security", return_value=_safe_security()),
-            patch(f"{MODULE}.validate_component_runtime", return_value=None),
+            patch(f"{MODULE}.validate_component_runtime", new_callable=AsyncMock, return_value=None),
             patch(f"{MODULE}.extract_response_text", return_value=response_text),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
@@ -377,7 +377,7 @@ class TestProgressEventSequence:
             patch(f"{MODULE}.extract_component_code", return_value=component_code),
             patch(f"{MODULE}.validate_component_code", side_effect=[mock_fail, mock_success]),
             patch(f"{MODULE}.scan_code_security", return_value=_safe_security()),
-            patch(f"{MODULE}.validate_component_runtime", return_value=None),
+            patch(f"{MODULE}.validate_component_runtime", new_callable=AsyncMock, return_value=None),
             patch(f"{MODULE}.extract_response_text", return_value=response_text),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
@@ -426,7 +426,7 @@ class TestProgressEventSequence:
             patch(f"{MODULE}.extract_component_code", return_value=component_code),
             patch(f"{MODULE}.validate_component_code", return_value=mock_validation),
             patch(f"{MODULE}.scan_code_security", return_value=_safe_security()),
-            patch(f"{MODULE}.validate_component_runtime", return_value=None),
+            patch(f"{MODULE}.validate_component_runtime", new_callable=AsyncMock, return_value=None),
             patch(f"{MODULE}.extract_response_text", return_value=response_text),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):

--- a/src/backend/tests/unit/agentic/services/test_assistant_service_streaming.py
+++ b/src/backend/tests/unit/agentic/services/test_assistant_service_streaming.py
@@ -224,7 +224,7 @@ class TestComponentGeneration:
             patch(f"{MODULE}.execute_flow_file_streaming", return_value=flow_gen()),
             patch(f"{MODULE}.extract_component_code", return_value=component_code),
             patch(f"{MODULE}.validate_component_code", return_value=mock_validation),
-            patch(f"{MODULE}.validate_component_runtime", return_value=None),
+            patch(f"{MODULE}.validate_component_runtime", new_callable=AsyncMock, return_value=None),
             patch(f"{MODULE}.extract_response_text", return_value=response_text),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
@@ -270,7 +270,7 @@ class TestComponentGeneration:
             patch(f"{MODULE}.execute_flow_file_streaming", side_effect=lambda **_kw: mock_streaming()),
             patch(f"{MODULE}.extract_component_code", return_value=component_code),
             patch(f"{MODULE}.validate_component_code", side_effect=[mock_fail, mock_success]),
-            patch(f"{MODULE}.validate_component_runtime", return_value=None),
+            patch(f"{MODULE}.validate_component_runtime", new_callable=AsyncMock, return_value=None),
             patch(f"{MODULE}.extract_response_text", return_value=response_text),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
@@ -468,7 +468,7 @@ class TestErrorHandling:
             patch(f"{MODULE}.execute_flow_file_streaming", side_effect=streaming_factory),
             patch(f"{MODULE}.extract_component_code", return_value=component_code),
             patch(f"{MODULE}.validate_component_code", return_value=mock_success),
-            patch(f"{MODULE}.validate_component_runtime", return_value=None),
+            patch(f"{MODULE}.validate_component_runtime", new_callable=AsyncMock, return_value=None),
             patch(f"{MODULE}.extract_response_text", return_value=response_text),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):


### PR DESCRIPTION
This pull request significantly improves runtime validation for custom components by ensuring that output methods are actually executed during validation, so that pydantic schema errors (such as constructing models with the wrong field types) are surfaced before the component is handed to the user. The validation logic is now asynchronous, and test coverage has been expanded to cover these scenarios. Several test files are updated to patch the now-async `validate_component_runtime`.

**Runtime validation improvements:**

* Refactored `validate_component_runtime` in `validation.py` to instantiate and execute component output methods, surfacing pydantic schema errors (e.g., constructing `Data(data=[list])` where a dict is expected) that static validation cannot catch. Non-schema runtime errors are intentionally ignored to avoid false negatives due to environmental issues. Introduced helper functions for formatting errors and executing output methods. (`src/backend/base/langflow/agentic/helpers/validation.py`)
* Updated the assistant service to `await` the now-async `validate_component_runtime`, ensuring proper execution of output methods during validation. (`src/backend/base/langflow/agentic/services/assistant_service.py`)

**Testing and test infrastructure:**

* Added comprehensive async tests for runtime validation, including cases where output methods construct invalid pydantic models (e.g., `Data` with a list, `Message` with wrong types), and a baseline test for valid components. (`src/backend/tests/unit/agentic/helpers/test_validation.py`)
* Updated test imports to support new async validation and added `pytest` where needed. (`src/backend/tests/unit/agentic/helpers/test_validation.py`)
* Updated all affected test suites to patch `validate_component_runtime` as an async function using `AsyncMock`. (`src/backend/tests/unit/agentic/services/test_assistant_service_intermediate_visibility.py`, `src/backend/tests/unit/agentic/services/test_assistant_service_streaming.py`) [[1]](diffhunk://#diff-10936124416fe03c78b2a217c8f0ca415e8fafee3c99af96901e4fe8c208b035L75-R75) [[2]](diffhunk://#diff-10936124416fe03c78b2a217c8f0ca415e8fafee3c99af96901e4fe8c208b035L115-R115) [[3]](diffhunk://#diff-10936124416fe03c78b2a217c8f0ca415e8fafee3c99af96901e4fe8c208b035L242-R242) [[4]](diffhunk://#diff-10936124416fe03c78b2a217c8f0ca415e8fafee3c99af96901e4fe8c208b035L284-R284) [[5]](diffhunk://#diff-10936124416fe03c78b2a217c8f0ca415e8fafee3c99af96901e4fe8c208b035L330-R330) [[6]](diffhunk://#diff-10936124416fe03c78b2a217c8f0ca415e8fafee3c99af96901e4fe8c208b035L380-R380) [[7]](diffhunk://#diff-10936124416fe03c78b2a217c8f0ca415e8fafee3c99af96901e4fe8c208b035L429-R429) [[8]](diffhunk://#diff-6c3bb4b9cbd6fa064d3d894f4fc0de70bd15fecb0016a36863301ab240b5e966L227-R227) [[9]](diffhunk://#diff-6c3bb4b9cbd6fa064d3d894f4fc0de70bd15fecb0016a36863301ab240b5e966L273-R273) [[10]](diffhunk://#diff-6c3bb4b9cbd6fa064d3d894f4fc0de70bd15fecb0016a36863301ab240b5e966L471-R471)

**Dependency updates:**

* Added `pydantic.ValidationError` import for error handling in validation helpers. (`src/backend/base/langflow/agentic/helpers/validation.py`)