### PR TITLE
chore: upgrade wxo adk to 2.8.0

### DIFF
--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Any
 from cachetools import func
 from fastapi import HTTPException
 from ibm_watsonx_orchestrate_clients.tools.tool_client import ClientAPIException
-from ibm_watsonx_orchestrate_core.types.tools.langflow_tool import LangflowTool
 from ibm_watsonx_orchestrate_core.types.tools.langflow_tool import create_langflow_tool as _create_langflow_tool
 from lfx.log.logger import logger
 from lfx.services.adapters.deployment.exceptions import (
@@ -39,6 +38,7 @@ from langflow.services.adapters.deployment.watsonx_orchestrate.utils import (
 from langflow.utils.version import get_version_info
 
 if TYPE_CHECKING:
+    from ibm_watsonx_orchestrate_core.types.tools.langflow_tool import LangflowTool
     from lfx.services.adapters.deployment.schema import BaseFlowArtifact, SnapshotItems, SnapshotListResult
 
     from langflow.services.adapters.deployment.watsonx_orchestrate.types import WxOClient
@@ -337,7 +337,13 @@ def create_langflow_tool(
     tool_definition: dict[str, Any],
     connections: dict[str, str],
 ) -> LangflowTool:
-    """Module-level wrapper to keep tool creation monkeypatchable in tests."""
+    """Create an ADK Langflow tool with show_details set to False by default.
+
+    There are multiple callsites using this helper. To avoid accidentally
+    setting show_details to True (which enables ADK logs),
+    we default to False here, and suggest all callers to use
+    this helper instead of directly using the ADK.
+    """
     return _create_langflow_tool(
         tool_definition=tool_definition,
         connections=connections,

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
@@ -303,18 +303,7 @@ def create_wxo_flow_tool(
             raise InvalidContentError(message=msg)
         flow_definition["last_tested_version"] = detected_version
 
-    tool: LangflowTool = create_langflow_tool(
-        tool_definition=flow_definition,
-        connections=connections,
-        show_details=True,
-        # TODO: show_details is only set to true because the adk
-        # has a bug where it fails to create requirements
-        # when it is set to False.
-        # Reset to False when the bug is fixed in the adk.
-        # Even better, for us, remove this parameter entirely
-        # and just default to False internally and not expose
-        # it to the caller.
-    )
+    tool: LangflowTool = create_langflow_tool(tool_definition=flow_definition, connections=connections)
 
     tool_payload = tool.__tool_spec__.model_dump(
         mode="json",
@@ -347,13 +336,12 @@ def create_langflow_tool(
     *,
     tool_definition: dict[str, Any],
     connections: dict[str, str],
-    show_details: bool,
 ) -> LangflowTool:
     """Module-level wrapper to keep tool creation monkeypatchable in tests."""
     return _create_langflow_tool(
         tool_definition=tool_definition,
         connections=connections,
-        show_details=show_details,
+        show_details=False,
     )
 
 

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/core/tools.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 from cachetools import func
 from fastapi import HTTPException
 from ibm_watsonx_orchestrate_clients.tools.tool_client import ClientAPIException
-from ibm_watsonx_orchestrate_core.types.tools.langflow_tool import create_langflow_tool as _create_langflow_tool
+from ibm_watsonx_orchestrate_core.types.tools.langflow_tool import create_langflow_tool
 from lfx.log.logger import logger
 from lfx.services.adapters.deployment.exceptions import (
     InvalidContentError,
@@ -303,7 +303,11 @@ def create_wxo_flow_tool(
             raise InvalidContentError(message=msg)
         flow_definition["last_tested_version"] = detected_version
 
-    tool: LangflowTool = create_langflow_tool(tool_definition=flow_definition, connections=connections)
+    tool: LangflowTool = create_langflow_tool(
+        tool_definition=flow_definition,
+        connections=connections,
+        show_details=False,
+    )
 
     tool_payload = tool.__tool_spec__.model_dump(
         mode="json",
@@ -330,25 +334,6 @@ def create_wxo_flow_tool(
     )
 
     return tool_payload, artifacts
-
-
-def create_langflow_tool(
-    *,
-    tool_definition: dict[str, Any],
-    connections: dict[str, str],
-) -> LangflowTool:
-    """Create an ADK Langflow tool with show_details set to False by default.
-
-    There are multiple callsites using this helper. To avoid accidentally
-    setting show_details to True (which enables ADK logs),
-    we default to False here, and suggest all callers to use
-    this helper instead of directly using the ADK.
-    """
-    return _create_langflow_tool(
-        tool_definition=tool_definition,
-        connections=connections,
-        show_details=False,
-    )
 
 
 async def create_and_upload_wxo_flow_tools(

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from fastapi import HTTPException, status
 from ibm_cloud_sdk_core import ApiException
 from ibm_watsonx_orchestrate_clients.tools.tool_client import ClientAPIException
+from ibm_watsonx_orchestrate_core.types.tools.langflow_tool import create_langflow_tool
 from lfx.services.adapters.deployment.base import BaseDeploymentService
 from lfx.services.adapters.deployment.exceptions import (
     AuthenticationError,
@@ -91,7 +92,6 @@ from langflow.services.adapters.deployment.watsonx_orchestrate.core.status impor
 )
 from langflow.services.adapters.deployment.watsonx_orchestrate.core.tools import (
     build_langflow_artifact_bytes,
-    create_langflow_tool,
     extract_langflow_connections_binding,
     upload_tool_artifact_bytes,
     verify_tools_by_ids,
@@ -1038,6 +1038,7 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
         tool = create_langflow_tool(
             tool_definition=flow_definition,
             connections={},
+            show_details=False,
         )
 
         artifact_bytes = build_langflow_artifact_bytes(

--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/service.py
@@ -91,6 +91,7 @@ from langflow.services.adapters.deployment.watsonx_orchestrate.core.status impor
 )
 from langflow.services.adapters.deployment.watsonx_orchestrate.core.tools import (
     build_langflow_artifact_bytes,
+    create_langflow_tool,
     extract_langflow_connections_binding,
     upload_tool_artifact_bytes,
     verify_tools_by_ids,
@@ -1005,10 +1006,6 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
         method; this prevents accidental overwrites of externally managed
         WXO tools.
         """
-        from ibm_watsonx_orchestrate_core.types.tools.langflow_tool import (
-            create_langflow_tool as _create_langflow_tool,
-        )
-
         from langflow.utils.version import get_version_info
 
         clients = await self._get_provider_clients(user_id=user_id, db=db)
@@ -1038,10 +1035,9 @@ class WatsonxOrchestrateDeploymentService(BaseDeploymentService):
             if detected_version:
                 flow_definition["last_tested_version"] = detected_version
 
-        tool = _create_langflow_tool(
+        tool = create_langflow_tool(
             tool_definition=flow_definition,
             connections={},
-            show_details=True,
         )
 
         artifact_bytes = build_langflow_artifact_bytes(

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -353,8 +353,8 @@ gassist = ["gassist>=0.0.1; sys_platform == 'win32'"]
 # SDKs for IBM watsonx Orchestrate deployment adapter.
 ibm-watsonx-clients = [
     "ibm-cloud-sdk-core~=3.24.4",
-    "ibm-watsonx-orchestrate-core~=2.7.0; python_version >= '3.11'",
-    "ibm-watsonx-orchestrate-clients~=2.7.0; python_version >= '3.11'",
+    "ibm-watsonx-orchestrate-core~=2.8.0; python_version >= '3.11'",
+    "ibm-watsonx-orchestrate-clients~=2.8.0; python_version >= '3.11'",
 ]
 
 complete = [

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -2690,7 +2690,7 @@ def test_create_wxo_flow_tool_keeps_load_from_db_global_values_unprefixed(monkey
         )
     )
 
-    def mock_create_langflow_tool(*, tool_definition, connections, show_details):  # noqa: ARG001
+    def mock_create_langflow_tool(*, tool_definition, connections):  # noqa: ARG001
         captured_tool_definition.update(tool_definition)
         return fake_tool
 
@@ -2757,7 +2757,7 @@ def test_create_wxo_flow_tool_excludes_provider_data_from_artifact(monkeypatch):
         )
     )
 
-    def mock_create_langflow_tool(*, tool_definition, connections, show_details):  # noqa: ARG001
+    def mock_create_langflow_tool(*, tool_definition, connections):  # noqa: ARG001
         captured_flow_definition.update(tool_definition)
         return fake_tool
 

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -2690,12 +2690,11 @@ def test_create_wxo_flow_tool_keeps_load_from_db_global_values_unprefixed(monkey
         )
     )
 
-    def mock_create_langflow_tool(*, tool_definition, connections, show_details):  # noqa: ARG001
-        assert show_details is False
+    def mock_create_langflow_tool(*, tool_definition, connections):  # noqa: ARG001
         captured_tool_definition.update(tool_definition)
         return fake_tool
 
-    monkeypatch.setattr(tools_module, "_create_langflow_tool", mock_create_langflow_tool)
+    monkeypatch.setattr(tools_module, "create_langflow_tool", mock_create_langflow_tool)
     monkeypatch.setattr(
         tools_module,
         "build_langflow_artifact_bytes",
@@ -2758,12 +2757,11 @@ def test_create_wxo_flow_tool_excludes_provider_data_from_artifact(monkeypatch):
         )
     )
 
-    def mock_create_langflow_tool(*, tool_definition, connections, show_details):  # noqa: ARG001
-        assert show_details is False
+    def mock_create_langflow_tool(*, tool_definition, connections):  # noqa: ARG001
         captured_flow_definition.update(tool_definition)
         return fake_tool
 
-    monkeypatch.setattr(tools_module, "_create_langflow_tool", mock_create_langflow_tool)
+    monkeypatch.setattr(tools_module, "create_langflow_tool", mock_create_langflow_tool)
     monkeypatch.setattr(
         tools_module,
         "build_langflow_artifact_bytes",
@@ -2824,7 +2822,7 @@ def test_create_wxo_flow_tool_normalizes_name_for_raw_payload(monkeypatch):
     )
     monkeypatch.setattr(
         tools_module,
-        "_create_langflow_tool",
+        "create_langflow_tool",
         lambda **kwargs: fake_tool,  # noqa: ARG005
     )
     monkeypatch.setattr(

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -2690,11 +2690,12 @@ def test_create_wxo_flow_tool_keeps_load_from_db_global_values_unprefixed(monkey
         )
     )
 
-    def mock_create_langflow_tool(*, tool_definition, connections):  # noqa: ARG001
+    def mock_create_langflow_tool(*, tool_definition, connections, show_details):  # noqa: ARG001
+        assert show_details is False
         captured_tool_definition.update(tool_definition)
         return fake_tool
 
-    monkeypatch.setattr(tools_module, "create_langflow_tool", mock_create_langflow_tool)
+    monkeypatch.setattr(tools_module, "_create_langflow_tool", mock_create_langflow_tool)
     monkeypatch.setattr(
         tools_module,
         "build_langflow_artifact_bytes",
@@ -2757,11 +2758,12 @@ def test_create_wxo_flow_tool_excludes_provider_data_from_artifact(monkeypatch):
         )
     )
 
-    def mock_create_langflow_tool(*, tool_definition, connections):  # noqa: ARG001
+    def mock_create_langflow_tool(*, tool_definition, connections, show_details):  # noqa: ARG001
+        assert show_details is False
         captured_flow_definition.update(tool_definition)
         return fake_tool
 
-    monkeypatch.setattr(tools_module, "create_langflow_tool", mock_create_langflow_tool)
+    monkeypatch.setattr(tools_module, "_create_langflow_tool", mock_create_langflow_tool)
     monkeypatch.setattr(
         tools_module,
         "build_langflow_artifact_bytes",
@@ -2822,7 +2824,7 @@ def test_create_wxo_flow_tool_normalizes_name_for_raw_payload(monkeypatch):
     )
     monkeypatch.setattr(
         tools_module,
-        "create_langflow_tool",
+        "_create_langflow_tool",
         lambda **kwargs: fake_tool,  # noqa: ARG005
     )
     monkeypatch.setattr(

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -2690,7 +2690,8 @@ def test_create_wxo_flow_tool_keeps_load_from_db_global_values_unprefixed(monkey
         )
     )
 
-    def mock_create_langflow_tool(*, tool_definition, connections):  # noqa: ARG001
+    def mock_create_langflow_tool(*, tool_definition, connections, show_details):  # noqa: ARG001
+        assert show_details is False
         captured_tool_definition.update(tool_definition)
         return fake_tool
 
@@ -2757,7 +2758,8 @@ def test_create_wxo_flow_tool_excludes_provider_data_from_artifact(monkeypatch):
         )
     )
 
-    def mock_create_langflow_tool(*, tool_definition, connections):  # noqa: ARG001
+    def mock_create_langflow_tool(*, tool_definition, connections, show_details):  # noqa: ARG001
+        assert show_details is False
         captured_flow_definition.update(tool_definition)
         return fake_tool
 

--- a/uv.lock
+++ b/uv.lock
@@ -3489,10 +3489,10 @@ name = "gassist"
 version = "0.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform != 'darwin'" },
-    { name = "flask", marker = "sys_platform != 'darwin'" },
-    { name = "flask-cors", marker = "sys_platform != 'darwin'" },
-    { name = "tqdm", marker = "sys_platform != 'darwin'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "flask", marker = "sys_platform == 'win32'" },
+    { name = "flask-cors", marker = "sys_platform == 'win32'" },
+    { name = "tqdm", marker = "sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/2e/f79632d7300874f7f0e60b61a6ab22455a245e1556116a1729542a77b0da/gassist-0.0.1-py3-none-any.whl", hash = "sha256:bb0fac74b453153a6c74b2db40a14fdde7879cbc10ec692ed170e576c8e2b6aa", size = 23819, upload-time = "2025-05-09T18:22:23.609Z" },
@@ -4584,29 +4584,29 @@ wheels = [
 
 [[package]]
 name = "ibm-watsonx-orchestrate-clients"
-version = "2.7.0"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ibm-cloud-sdk-core", marker = "python_full_version >= '3.11'" },
     { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11'" },
     { name = "websocket-client", marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b4/de4617db62ec12bc846fe671ef95c469b4429658c7d07cbf9a191ef6fddc/ibm_watsonx_orchestrate_clients-2.7.0.tar.gz", hash = "sha256:9c664eb87b16cfaf1e94dc8c36b14d126bdb1af9b4017f05176fd3b656a68528", size = 1880, upload-time = "2026-03-27T23:14:47.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/6b/73365345e2564fff78d612bff1289dac7d3ff00058e3064fa9aaf2c2691e/ibm_watsonx_orchestrate_clients-2.8.0.tar.gz", hash = "sha256:3d36113ed3190d5be7dae647b86937522b5af0711aa4011c13c898ee4d859938", size = 1878, upload-time = "2026-04-14T18:58:40.961Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/cd/d80c16678aebd90c72000c72393bdf523a2027f86d12dc7815e7594a5dad/ibm_watsonx_orchestrate_clients-2.7.0-py3-none-any.whl", hash = "sha256:d671ebc066e9706dc73f4ee7b0dc87cb23395dde619fb763f04a8614f0447193", size = 52424, upload-time = "2026-03-27T23:14:41.612Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c2/4bc2865cec3a503beb79b7d918d75e7cc51ddabdcbbc73d923f54462917b/ibm_watsonx_orchestrate_clients-2.8.0-py3-none-any.whl", hash = "sha256:43f2811ffdabeaa21fbc0779ab1108534a45099f6560a5f1b3be10dd4430e1b4", size = 54115, upload-time = "2026-04-14T18:58:36.479Z" },
 ]
 
 [[package]]
 name = "ibm-watsonx-orchestrate-core"
-version = "2.7.0"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic", marker = "python_full_version >= '3.11'" },
     { name = "pyyaml", marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/5c/7ac8c059044a0e02c46c310d68b8fdf73c644bbdc499eadc3644f9a659f2/ibm_watsonx_orchestrate_core-2.7.0.tar.gz", hash = "sha256:c14e7a1f578e27d57b266bd4baeee82c849186d502083efd71e2c69552177cdd", size = 1216, upload-time = "2026-03-27T23:14:47.843Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/9f/df367b888da6a11c3fc3bc675c215a6fbc71a83cd7e2396c7a7cbcdd8cd0/ibm_watsonx_orchestrate_core-2.8.0.tar.gz", hash = "sha256:3e47c5add6b94d762f90654f72b8d29181afcae32714ab190b4066c457ff3d17", size = 1216, upload-time = "2026-04-14T18:58:41.963Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/cd/9799eca2e276cab69a4368f3bbb0d46de7de104f4791444ec3fbd4f726ed/ibm_watsonx_orchestrate_core-2.7.0-py3-none-any.whl", hash = "sha256:d263e3a2588fa09323e06aa2df84dd4b06f2c4f1d03102d9022e7dc9587359cc", size = 39985, upload-time = "2026-03-27T23:14:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/be/45/aff80b59f3b362519b1ab35feac61b6593d6fad65aa3a1cb38d3bfeb656c/ibm_watsonx_orchestrate_core-2.8.0-py3-none-any.whl", hash = "sha256:a534d1767096396ab7afbc12192b82782970c6765eeee442c09aa0e3060bf13c", size = 45236, upload-time = "2026-04-14T18:58:37.287Z" },
 ]
 
 [[package]]
@@ -6824,8 +6824,8 @@ requires-dist = [
     { name = "huggingface-hub", extras = ["inference"], marker = "extra == 'huggingface'", specifier = ">=0.23.2,<1.0.0" },
     { name = "ibm-cloud-sdk-core", marker = "extra == 'ibm-watsonx-clients'", specifier = "~=3.24.4" },
     { name = "ibm-watsonx-ai", specifier = ">=1.3.1,<2.0.0" },
-    { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11' and extra == 'ibm-watsonx-clients'", specifier = "~=2.7.0" },
-    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11' and extra == 'ibm-watsonx-clients'", specifier = "~=2.7.0" },
+    { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11' and extra == 'ibm-watsonx-clients'", specifier = "~=2.8.0" },
+    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11' and extra == 'ibm-watsonx-clients'", specifier = "~=2.8.0" },
     { name = "jaraco-context", specifier = ">=6.1.0" },
     { name = "jigsawstack", marker = "extra == 'jigsawstack'", specifier = "==0.2.7" },
     { name = "jq", marker = "sys_platform != 'win32'", specifier = ">=1.7.0,<2.0.0" },
@@ -7999,7 +7999,7 @@ name = "milvus-lite"
 version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tqdm", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2e/746f5bb1d6facd1e73eb4af6dd5efda11125b0f29d7908a097485ca6cad9/milvus_lite-2.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2e031088bf308afe5f8567850412d618cfb05a65238ed1a6117f60decccc95a", size = 24421451, upload-time = "2025-06-30T04:23:51.747Z" },
@@ -8744,9 +8744,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "pyobjc-framework-vision" },
+    { name = "click", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -10046,7 +10046,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -11317,7 +11317,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -11333,8 +11333,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -11350,8 +11350,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -11367,10 +11367,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreml" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [


### PR DESCRIPTION
upgrade `ibm-watsonx-orchestrate-core` and `ibm-watsonx-orchestrate-clients` from `2.7.0` to `2.8.0`.

 Set `show_details` to `False` in `create_langflow_tool` - the regression that required `True` has been fixed in `2.8.0`