### PR TITLE
fix: Make sdk env flag idempotent

### DIFF
--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
@@ -565,7 +565,7 @@
                   },
                   {
                     "name": "langchain_openai",
-                    "version": "1.1.12"
+                    "version": "1.1.13"
                   },
                   {
                     "name": "langchain_huggingface",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -3077,7 +3077,7 @@
                   },
                   {
                     "name": "langchain_openai",
-                    "version": "1.1.12"
+                    "version": "1.1.13"
                   },
                   {
                     "name": "langchain_huggingface",

--- a/src/sdk/src/langflow_sdk/testing.py
+++ b/src/sdk/src/langflow_sdk/testing.py
@@ -30,6 +30,7 @@ Usage inside a test file::
 
 from __future__ import annotations
 
+import contextlib
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -54,34 +55,39 @@ if TYPE_CHECKING:
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register Langflow-specific CLI options."""
     group = parser.getgroup("langflow", "Langflow integration testing options")
-    group.addoption(
-        "--langflow-env",
-        dest="langflow_env",
-        default=None,
-        metavar="NAME",
-        help="Environment name from langflow-environments.toml to use for integration tests.",
-    )
-    group.addoption(
-        "--langflow-url",
-        dest="langflow_url",
-        default=None,
-        metavar="URL",
-        help="Base URL of the Langflow instance (overrides --langflow-env).",
-    )
-    group.addoption(
-        "--langflow-api-key",
-        dest="langflow_api_key",
-        default=None,
-        metavar="KEY",
-        help="API key for the Langflow instance (overrides environment config).",
-    )
-    group.addoption(
-        "--langflow-environments-file",
-        dest="langflow_environments_file",
-        default=None,
-        metavar="PATH",
-        help="Path to langflow-environments.toml (overrides default discovery).",
-    )
+    options = {
+        "--langflow-env": {
+            "dest": "langflow_env",
+            "default": None,
+            "metavar": "NAME",
+            "help": "Environment name from langflow-environments.toml to use for integration tests.",
+        },
+        "--langflow-url": {
+            "dest": "langflow_url",
+            "default": None,
+            "metavar": "URL",
+            "help": "Base URL of the Langflow instance (overrides --langflow-env).",
+        },
+        "--langflow-api-key": {
+            "dest": "langflow_api_key",
+            "default": None,
+            "metavar": "KEY",
+            "help": "API key for the Langflow instance (overrides environment config).",
+        },
+        "--langflow-environments-file": {
+            "dest": "langflow_environments_file",
+            "default": None,
+            "metavar": "PATH",
+            "help": "Path to langflow-environments.toml (overrides default discovery).",
+        },
+    }
+
+    # langflow-sdk and lfx can both be installed in the same environment and
+    # expose the same remote-testing flags. Keep registration idempotent so
+    # pytest plugin auto-discovery can load both entry points safely.
+    for flag, kwargs in options.items():
+        with contextlib.suppress(ValueError):
+            group.addoption(flag, **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/src/sdk/tests/test_testing.py
+++ b/src/sdk/tests/test_testing.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import httpx
 import respx
+from _pytest.config.argparsing import Parser
 from langflow_sdk.client import AsyncLangflowClient, LangflowClient
 from langflow_sdk.models import RunOutput, RunResponse
-from langflow_sdk.testing import AsyncFlowRunner, FlowRunner
+from langflow_sdk.testing import AsyncFlowRunner, FlowRunner, pytest_addoption
 
 _BASE = "http://langflow.test"
 
@@ -307,3 +308,11 @@ def test_pytest_addoption_registers_options(pytestconfig):
         "--langflow-environments-file",
     ):
         assert pytestconfig.getoption(name) is None, f"Option {name!r} missing or has unexpected default"
+
+
+def test_pytest_addoption_is_idempotent():
+    """Registering the plugin twice should not fail when another plugin owns the same flags."""
+    parser = Parser(_ispytest=True)
+
+    pytest_addoption(parser)
+    pytest_addoption(parser)


### PR DESCRIPTION
This pull request refactors the way custom pytest CLI options are registered for Langflow integration testing, making the registration process idempotent to support environments where multiple plugins may attempt to register the same options. It also adds related tests to ensure this behavior.

Refactoring and robustness improvements for pytest option registration:

* Refactored the `pytest_addoption` function in `langflow_sdk/testing.py` to use a loop over a dictionary of option definitions and wrapped `addoption` calls in a `contextlib.suppress(ValueError)` block. This ensures that registering the same options multiple times (e.g., when both `langflow-sdk` and `lfx` are installed) does not raise errors, making plugin registration idempotent.
* Added the `contextlib` import to support exception suppression in the option registration logic in `langflow_sdk/testing.py`.

Testing enhancements:

* Imported `pytest_addoption` and the `Parser` class in `test_testing.py` to enable direct testing of the registration logic.
* Added a new test, `test_pytest_addoption_is_idempotent`, in `test_testing.py` to verify that calling `pytest_addoption` multiple times does not raise errors, confirming idempotency.