### PR TITLE
fix(ui): Hide native Edge/WebView2 password reveal icon on login                                                                        

### DIFF
--- a/src/frontend/src/style/__tests__/password-native-reveal-hidden.test.ts
+++ b/src/frontend/src/style/__tests__/password-native-reveal-hidden.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Regression guard for the duplicate password reveal icon bug reported on
+ * Windows (Edge/WebView2-based browsers). The browser engine injects a native
+ * password reveal control via the ::-ms-reveal pseudo-element. Without an
+ * explicit CSS rule hiding it, the native control overlaps Langflow's own
+ * Eye/EyeOff button rendered in InputComponent, producing two visible eye
+ * icons on the login screen when AUTO_LOGIN=false.
+ *
+ * Fix lives in src/style/applies.css as a top-level CSS rule (intentionally
+ * OUTSIDE any @layer so Tailwind/PostCSS cannot reorder or deprioritize it).
+ */
+describe("password field - native Edge/WebView2 reveal icon", () => {
+  const appliesCssPath = path.resolve(__dirname, "..", "applies.css");
+  const cssSource = readFileSync(appliesCssPath, "utf8");
+  const normalized = cssSource.replace(/\s+/g, " ");
+
+  it("should_hide_native_ms_reveal_pseudo_element_for_password_inputs", () => {
+    expect(normalized).toMatch(/input\[type="password"\]::-ms-reveal/);
+    expect(normalized).toMatch(
+      /input\[type="password"\]::-ms-reveal[^{}]*,[^{}]*input\[type="password"\]::-ms-clear\s*\{[^}]*display:\s*none\s*!important/,
+    );
+  });
+
+  it("should_hide_native_ms_clear_pseudo_element_for_password_inputs", () => {
+    expect(normalized).toMatch(/input\[type="password"\]::-ms-clear/);
+  });
+
+  it("should_place_ms_reveal_rule_outside_tailwind_layers", () => {
+    const lines = cssSource.split("\n");
+    const ruleLineIndex = lines.findIndex((line) =>
+      line.includes('input[type="password"]::-ms-reveal'),
+    );
+    expect(ruleLineIndex).toBeGreaterThan(-1);
+
+    let openLayers = 0;
+    for (let i = 0; i < ruleLineIndex; i++) {
+      const line = lines[i];
+      if (/@layer\s+\w+\s*\{/.test(line)) {
+        openLayers++;
+      } else if (/^\s*\}\s*$/.test(line) && openLayers > 0) {
+        openLayers--;
+      }
+    }
+    expect(openLayers).toBe(0);
+  });
+});

--- a/src/frontend/src/style/applies.css
+++ b/src/frontend/src/style/applies.css
@@ -14,7 +14,6 @@
       "calt" 1;
     font-family: Inter, system-ui, sans-serif;
   }
-
 }
 
 input[type="password"]::-ms-reveal,

--- a/src/frontend/src/style/applies.css
+++ b/src/frontend/src/style/applies.css
@@ -14,6 +14,15 @@
       "calt" 1;
     font-family: Inter, system-ui, sans-serif;
   }
+
+}
+
+input[type="password"]::-ms-reveal,
+input[type="password"]::-ms-clear {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
+  visibility: hidden !important;
 }
 
 @keyframes slideDown {


### PR DESCRIPTION
This pull request addresses a regression where duplicate password reveal icons appeared on the login screen in Edge and WebView2-based browsers. The fix ensures that the native browser-provided reveal and clear icons are hidden, preventing overlap with Langflow's custom eye icon. A regression test is also added to guarantee this behavior remains enforced.

**Password input native icon suppression:**

* Added a top-level CSS rule in `applies.css` to explicitly hide the native `::-ms-reveal` and `::-ms-clear` pseudo-elements for password fields, ensuring only the custom eye icon is visible and fixing the duplicate icon issue on Edge/WebView2.

**Regression testing:**

* Introduced a test file `password-native-reveal-hidden.test.ts` that verifies the presence and placement of the CSS rule, ensuring it remains outside any Tailwind/PostCSS layers and continues to suppress the native icons.