### PR TITLE
fix(frontend): filter duplicate draft/live connections in deploy modal

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/connection-search-list.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/connection-search-list.tsx
@@ -1,6 +1,5 @@
 import { memo, useMemo, useState } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
-import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/utils/utils";
 import type { ConnectionItem } from "../types";
@@ -85,19 +84,10 @@ export const ConnectionSearchList = memo(function ConnectionSearchList({
               onChange={() => onToggleConnection(conn.id)}
               data-testid={`connection-item-${conn.id}`}
             >
-              <div className="flex min-w-0 flex-1 items-center gap-1.5">
+              <div className="min-w-0 flex-1">
                 <span className="block truncate text-sm font-medium leading-tight">
                   {conn.name}
                 </span>
-                {conn.environment && (
-                  <Badge
-                    variant="secondaryStatic"
-                    size="tag"
-                    className="bg-border text-muted-foreground"
-                  >
-                    {conn.environment}
-                  </Badge>
-                )}
               </div>
             </CheckboxSelectItem>
           ))}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/connection-search-list.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/connection-search-list.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo, useState } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/utils/utils";
 import type { ConnectionItem } from "../types";
@@ -84,10 +85,19 @@ export const ConnectionSearchList = memo(function ConnectionSearchList({
               onChange={() => onToggleConnection(conn.id)}
               data-testid={`connection-item-${conn.id}`}
             >
-              <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 flex-1 items-center gap-1.5">
                 <span className="block truncate text-sm font-medium leading-tight">
                   {conn.name}
                 </span>
+                {conn.environment && (
+                  <Badge
+                    variant="secondaryStatic"
+                    size="tag"
+                    className="bg-border text-muted-foreground"
+                  >
+                    {conn.environment}
+                  </Badge>
+                )}
               </div>
             </CheckboxSelectItem>
           ))}

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows.tsx
@@ -78,16 +78,17 @@ export default function StepAttachFlows() {
       return;
     seededExistingConnections.current = true;
 
-    const existingConnections: ConnectionItem[] = configsData.configs.map(
-      (cfg) => ({
+    const existingConnections: ConnectionItem[] = configsData.configs
+      .filter((cfg) => cfg.environment !== "live")
+      .map((cfg) => ({
         id: cfg.app_id,
         connectionId: cfg.connection_id,
         name: cfg.app_id,
+        environment: cfg.environment,
         variableCount: 0,
         isNew: false,
         environmentVariables: {},
-      }),
-    );
+      }));
 
     setConnections((prev) => {
       // Avoid duplicates if user already created connections with the same id


### PR DESCRIPTION
## Summary
- filter out `live` environment connections when seeding existing deployment connections
- keep the deploy modal focused on `draft` connections to avoid duplicate entries for the same app
