### PR TITLE
fix: add ON DELETE CASCADE to span.trace_id foreign key

### DIFF
--- a/src/backend/base/langflow/services/database/models/traces/model.py
+++ b/src/backend/base/langflow/services/database/models/traces/model.py
@@ -251,7 +251,7 @@ class SpanTable(SpanBase, table=True):  # type: ignore[call-arg]
     __tablename__ = "span"
 
     id: UUID = Field(default_factory=uuid4, primary_key=True)
-    trace_id: UUID = Field(foreign_key="trace.id", index=True, description="Parent trace ID")
+    trace_id: UUID = Field(foreign_key="trace.id", ondelete="CASCADE", index=True, description="Parent trace ID")
     parent_span_id: UUID | None = Field(
         default=None,
         foreign_key="span.id",


### PR DESCRIPTION
## Summary

When deleting a flow, trace rows get deleted (flow_id -> trace ON DELETE CASCADE).
But span.trace_id -> trace.id did NOT have ON DELETE CASCADE,
causing FK violation when trace rows tried to delete:

```
psycopg.errors.ForeignKeyViolation: update or delete on table "trace" violates foreign key constraint "span_trace_id_fkey" on table "span"
```

## Fix

Added `ondelete="CASCADE"` to `SpanTable.trace_id` field:

```python
# Before
trace_id: UUID = Field(foreign_key="trace.id", index=True, ...)

# After
trace_id: UUID = Field(foreign_key="trace.id", ondelete="CASCADE", index=True, ...)
```

## Testing

1. Start Langflow with PostgreSQL
2. Create and run a flow (creates tracing data)
3. Delete the flow from UI
4. Flow deletion succeeds without FK violation

Closes #12732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data integrity by ensuring trace-related records are automatically removed when parent traces are deleted, preventing orphaned data in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->