### PR TITLE
fix(frontend): cap MCP server modal height

### DIFF
--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -20,7 +20,7 @@ import { usePatchMCPServer } from "@/controllers/API/queries/mcp/use-patch-mcp-s
 import { CustomLink } from "@/customization/components/custom-link";
 import BaseModal from "@/modals/baseModal";
 import IOKeyPairInput, {
-  KeyPairRow,
+  type KeyPairRow,
 } from "@/modals/IOModal/components/IOFieldView/components/key-pair-input";
 import IOKeyPairInputWithVariables from "@/modals/IOModal/components/IOFieldView/components/key-pair-input-with-variables";
 import type { MCPServerType } from "@/types/mcp";
@@ -292,7 +292,7 @@ export default function AddMcpServerModal({
       setOpen={setOpen}
       size="x-small-h-full"
       onSubmit={submitForm}
-      className="!p-0 min-h-[250px] flex-grow"
+      className="!p-0 min-h-[250px] max-h-[75vh] flex-grow"
     >
       <BaseModal.Trigger>{children}</BaseModal.Trigger>
       <BaseModal.Content className="flex flex-1 flex-col overflow-hidden min-h-0">
@@ -358,7 +358,7 @@ export default function AddMcpServerModal({
               </TabsList>
             </div>
             <div
-              className="flex w-full flex-1 flex-col border-y p-4 min-h-0"
+              className="flex w-full flex-1 flex-col overflow-y-auto border-y p-4 min-h-0"
               id="global-variable-modal-inputs"
             >
               {error && (
@@ -490,7 +490,7 @@ export default function AddMcpServerModal({
             </div>
           </Tabs>
         </div>
-        <div className="flex justify-end gap-2 p-4">
+        <div className="flex shrink-0 justify-end gap-2 p-4">
           <Button variant="outline" size="sm" onClick={() => setOpen(false)}>
             <span className="text-mmd font-normal">Cancel</span>
           </Button>


### PR DESCRIPTION
## Summary
- Modal grew past viewport as args/env rows were added, hiding fields below (including Add Server button) with no scroll.
- Cap modal at `max-h-[75vh]`, make tab body `overflow-y-auto` so inner content scrolls while header/tabs/footer stay fixed.
- `shrink-0` on footer so action buttons can't be squashed.

Fixes LE-881

https://github.com/user-attachments/assets/3ff4933d-79cf-4645-a48f-5dce589e9250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced MCP Server modal with better scrollability, optimized height constraints, and stable action button positioning for improved configuration experience.
  * Increased testing framework robustness for more reliable plugin option handling.

* **Chores**
  * Bumped version to 1.10.0 across all components.
  * Updated core dependencies for enhanced compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->