### PR TITLE
fix: respect renamed/deleted default folder across logins

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -1269,6 +1269,12 @@ async def get_or_create_default_folder(session: AsyncSession, user_id: UUID) -> 
 
     This implementation avoids an external distributed lock and works with both SQLite and PostgreSQL.
 
+    The function only creates a new default folder on first initialization (when the user has no
+    folders at all). If the user has already been through initial setup and has at least one folder
+    — even if they renamed the default or only kept other folders — the existing folder is returned
+    instead of creating a new "Starter Project". This prevents a phantom default folder from being
+    forced back into the UI every time the user logs in or the server restarts.
+
     Args:
         session (AsyncSession): The active database session.
         user_id (UUID): The ID of the user who owns the folder.
@@ -1310,7 +1316,18 @@ async def get_or_create_default_folder(session: AsyncSession, user_id: UUID) -> 
                     await session.rollback()
                     break
 
-    # If no existing folder found, create a new one
+    # Respect prior user intent: if the user already has folders (e.g. they renamed the
+    # default folder to something like "My Flows"), do not force a new "Starter Project" back
+    # into their UI on every login/server restart. Return any existing folder instead.
+    any_folder_stmt = (
+        select(Folder).where(Folder.user_id == user_id).order_by(Folder.id).limit(1)  # type: ignore[arg-type]
+    )
+    any_folder = (await session.exec(any_folder_stmt)).first()
+    if any_folder:
+        return FolderRead.model_validate(any_folder, from_attributes=True)
+
+    # No existing folder found for this user — this is the first-time setup path.
+    # Create the default folder.
     try:
         folder_obj = Folder(user_id=user_id, name=DEFAULT_FOLDER_NAME, description=DEFAULT_FOLDER_DESCRIPTION)
         session.add(folder_obj)

--- a/src/backend/tests/unit/initial_setup/test_setup_functions.py
+++ b/src/backend/tests/unit/initial_setup/test_setup_functions.py
@@ -9,7 +9,8 @@ from langflow.initial_setup.setup import (
     update_projects_components_with_latest_component_versions,
 )
 from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NAME
-from langflow.services.database.models.folder.model import FolderRead
+from langflow.services.database.models.folder.model import Folder, FolderRead
+from sqlmodel import select
 
 
 @pytest.mark.usefixtures("client")
@@ -56,6 +57,80 @@ async def test_get_or_create_default_folder_concurrent_calls() -> None:
     results = await asyncio.gather(get_folder(), get_folder(), get_folder())
     folder_ids = {folder.id for folder in results}
     assert len(folder_ids) == 1, "Concurrent calls must return a single, consistent folder instance."
+
+
+@pytest.mark.usefixtures("client")
+async def test_get_or_create_default_folder_respects_rename() -> None:
+    """Regression test: renaming the default folder must persist across calls.
+
+    Reproduces the reported bug where the server would recreate a "Starter Project" folder
+    on every login or server restart, even though the user had already renamed it to something
+    like "My Flows". After the fix, get_or_create_default_folder must detect the user's existing
+    (renamed) folder and return it instead of forcing a new default folder back into the UI.
+    """
+    test_user_id = uuid4()
+    renamed_folder_name = "My Flows"
+
+    # First call creates the default folder.
+    async with session_scope() as session:
+        folder_first = await get_or_create_default_folder(session, test_user_id)
+        assert folder_first.name == DEFAULT_FOLDER_NAME
+        original_id = folder_first.id
+
+    # Simulate the user renaming the default folder from the UI.
+    async with session_scope() as session:
+        stmt = select(Folder).where(Folder.id == original_id)
+        folder_row = (await session.exec(stmt)).first()
+        assert folder_row is not None
+        folder_row.name = renamed_folder_name
+        session.add(folder_row)
+        await session.flush()
+
+    # Second call (simulating next login / server restart) must honor the rename
+    # rather than creating a new "Starter Project" alongside the renamed one.
+    async with session_scope() as session:
+        folder_second = await get_or_create_default_folder(session, test_user_id)
+        assert folder_second.id == original_id, (
+            "The renamed folder should be returned instead of creating a new default."
+        )
+        assert folder_second.name == renamed_folder_name, (
+            "The folder's user-assigned name must be preserved across calls."
+        )
+
+        # There should still be exactly one folder for this user — no phantom duplicate.
+        all_folders_stmt = select(Folder).where(Folder.user_id == test_user_id)
+        all_folders = (await session.exec(all_folders_stmt)).all()
+        folder_names = sorted(f.name for f in all_folders)
+        assert folder_names == [renamed_folder_name], (
+            f"Expected only the renamed folder to exist, found: {folder_names}"
+        )
+
+
+@pytest.mark.usefixtures("client")
+async def test_get_or_create_default_folder_respects_other_existing_folder() -> None:
+    """Respect existing folders when the default folder is absent.
+
+    If the user already has any folder (e.g. they moved everything into 'Ideas' and
+    deleted the default), we must not resurrect the default folder on the next call.
+    """
+    test_user_id = uuid4()
+    other_folder_name = "Ideas"
+
+    # Simulate an existing user who has a non-default folder but no "Starter Project".
+    async with session_scope() as session:
+        session.add(Folder(user_id=test_user_id, name=other_folder_name, description="My ideas"))
+        await session.flush()
+
+    async with session_scope() as session:
+        returned = await get_or_create_default_folder(session, test_user_id)
+        assert returned.name == other_folder_name, (
+            "Should return the user's existing folder rather than creating a new default."
+        )
+
+        all_folders_stmt = select(Folder).where(Folder.user_id == test_user_id)
+        all_folders = (await session.exec(all_folders_stmt)).all()
+        folder_names = sorted(f.name for f in all_folders)
+        assert folder_names == [other_folder_name], f"No new default folder should be created; found: {folder_names}"
 
 
 def _make_all_types_dict():


### PR DESCRIPTION
## Summary

Closes the bug where Langflow recreates a "Starter Project" folder on every login / server restart even after the user has renamed or deleted it.

`get_or_create_default_folder` only matched the default folder by its literal name (`DEFAULT_FOLDER_NAME`, e.g. `"Starter Project"`). If a user renamed the folder from the UI to something like `"My Flows"`, the lookup would fail on the next login and a brand-new empty `"Starter Project"` would be forced back into the UI alongside their renamed folder.

### Change

- If the user already has at least one folder, return one of their existing folders instead of creating a new default. This respects the rename case — the previously-renamed folder is returned, and no phantom `"Starter Project"` is added.
- Only create the default folder on true first-time setup (when the user has zero folders).
- Legacy folder migration (`LEGACY_FOLDER_NAMES`) and the concurrent-creation retry path are preserved unchanged.
- If no folders exist, the default will be created at login as before.

### Reproduction (before the fix)

1. Launch Langflow
2. Rename the "Starter Project" folder to "My Flows"
3. Restart the server
4. Observe a new empty "Starter Project" folder appears beside "My Flows"

After this change, step 4 no longer produces a phantom folder.

## Test plan

- [x] New regression test: `test_get_or_create_default_folder_respects_rename` simulates the full rename → reboot flow and asserts only the renamed folder remains.
- [x] New test: `test_get_or_create_default_folder_respects_other_existing_folder` asserts that when the user has any non-default folder, no default is recreated.
- [x] Existing tests still pass: `test_get_or_create_default_folder_creation`, `test_get_or_create_default_folder_idempotency`, `test_get_or_create_default_folder_concurrent_calls`.
- [x] Legacy folder migration path (`test_mcp_with_legacy_folder_after_migration`) still compiles/skips appropriately — migration semantics unchanged.
- [x] Ruff check + format pass; all pre-commit hooks green.