### PR TITLE
fix(tests): Skip assistant-panel e2e test when OPENAI_API_KEY is missing                                                                                      

### DIFF
--- a/src/frontend/tests/core/integrations/assistant-panel.spec.ts
+++ b/src/frontend/tests/core/integrations/assistant-panel.spec.ts
@@ -3,6 +3,11 @@ import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 
 test.describe("Assistant Panel UI", { tag: ["@release"] }, () => {
   test("should open and close from canvas controls", async ({ page }) => {
+    test.skip(
+      !process?.env?.OPENAI_API_KEY,
+      "OPENAI_API_KEY required to run this test",
+    );
+
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();


### PR DESCRIPTION
## Objective                                                                                                                                                    
Unblock frontend test shard 24 for contributor (fork) pull requests, where the `Assistant Panel UI` test fails because GitHub doesn't forward repository secrets to workflows triggered from forks.                                                                                                                             
  
## Changes                                                                                                                                                      
  - Add `test.skip(!process?.env?.OPENAI_API_KEY, …)` as the first statement of `should open and close from canvas controls` in
  `src/frontend/tests/core/integrations/assistant-panel.spec.ts`, matching the pattern already used across ~15 other tests (e.g.                                  
  `session-deletion-data-leakage.spec.ts`, `generalBugs-shard-*.spec.ts`)