### PR TITLE
fix: prevent space key from being swallowed in shareable playground chat input

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/input-wrapper.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatInput/components/input-wrapper.tsx
@@ -75,6 +75,13 @@ const InputWrapper: React.FC<InputWrapperProps> = ({
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    // Don't intercept keyboard events that originate from the textarea
+    // (e.g. space/enter), as calling e.preventDefault() would prevent the
+    // character from being inserted into the input field.
+    if (target.closest("textarea")) {
+      return;
+    }
     if (e.key !== "Enter" && e.key !== " ") {
       return;
     }


### PR DESCRIPTION
Fixes #12731

## Problem

In the shareable playground (`/playground/<flowID>`), typing a space in the chat input would be silently dropped, so "this is a phrase" became "thisisaphrase".

The root cause: the outer `div` container wrapping the textarea has an `onKeyDown` handler that calls `e.preventDefault()` for Space and Enter key events. When a user types a space inside the textarea, the `keydown` event **bubbles up** to the div, and `e.preventDefault()` is called on the same event object. Because the browser evaluates `defaultPrevented` after all handlers complete (including bubbled ones), this suppresses the default action of inserting the space character into the textarea.

## Solution

Add the same guard that already exists in the `playgroundComponent` version of the same handler:

```tsx
const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
  const target = e.target as HTMLElement;
  // Don't intercept keyboard events that originate from the textarea
  if (target.closest("textarea")) {
    return;
  }
  // ... rest of handler
};
```

The fix only touches `src/frontend/src/modals/IOModal/components/chatView/chatInput/components/input-wrapper.tsx`, which is the code path used by the shareable playground page (via `CustomIOModal → IOModal`). The sibling component in `playgroundComponent/` already had the correct guard.

## Testing

- Verified the fix by code review: `e.target.closest("textarea")` returns the textarea element when events originate from it, so the handler exits early without calling `e.preventDefault()`.
- Regression: the `onKeyDown` handler still correctly handles Space/Enter when the outer div itself has focus (e.g. keyboard navigation), redirecting focus to the textarea.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where keyboard input in the chat message textarea was being interrupted, preventing normal text entry and key functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->