### PR TITLE
fix: serialize concurrent MCP session access to prevent race conditions

### DIFF
--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -6,6 +6,7 @@ This test suite validates the MCP utility functions including:
 - Utility functions for name sanitization and schema conversion
 """
 
+import asyncio
 import re
 import shutil
 import sys
@@ -121,6 +122,115 @@ class TestMCPSessionManager:
 
             assert session1 != session2
             assert mock_create.call_count == 2
+
+    async def test_concurrent_get_session_same_server_reuses_one_session(self, session_manager):
+        """Concurrent get_session calls for the same server must share one session.
+
+        Regression test for the race condition reported in
+        https://github.com/langflow-ai/langflow/issues/9860 where two MCPTools
+        components pointing at the same SSE URL would race on session
+        creation/cleanup under concurrent flow execution and intermittently
+        fail with errors such as:
+            Error updating tool list: 'streamable_http_<hash>_0'
+            Timeout updating tool list: ...
+        """
+        connection_params = {"url": "http://example.test/sse", "headers": {}}
+
+        mock_session = AsyncMock()
+        mock_task = AsyncMock()
+        mock_task.done = MagicMock(return_value=False)
+
+        create_calls = 0
+
+        async def fake_create(_session_id, _params, _preferred_transport=None):
+            nonlocal create_calls
+            create_calls += 1
+            # Simulate real network latency so callers overlap while the first
+            # creation is in flight. Without the per-server lock, every
+            # concurrent caller enters the creation path and returns its own
+            # session (or worse, races on the shared dict).
+            await asyncio.sleep(0.05)
+            return mock_session, mock_task, "streamable_http"
+
+        with (
+            patch.object(session_manager, "_create_streamable_http_session", side_effect=fake_create),
+            patch.object(session_manager, "_validate_session_connectivity", return_value=True),
+        ):
+            results = await asyncio.gather(
+                *[session_manager.get_session(f"ctx_{i}", connection_params, "streamable_http") for i in range(10)]
+            )
+
+        assert all(s is mock_session for s in results)
+        # All 10 concurrent callers must share the single created session.
+        assert create_calls == 1
+        server_key = session_manager._get_server_key(connection_params, "streamable_http")
+        assert len(session_manager.sessions_by_server[server_key]["sessions"]) == 1
+
+    async def test_concurrent_cleanup_same_session_is_idempotent(self, session_manager):
+        """_cleanup_session_by_id must be safe under concurrent invocation.
+
+        Previously the finally-block `del sessions[session_id]` raised
+        `KeyError` when two callers both passed the existence guard — the
+        visible symptom from issue #9860.
+        """
+        server_key = "streamable_http_test"
+        session_id = f"{server_key}_0"
+
+        mock_task = AsyncMock()
+        mock_task.done = MagicMock(return_value=False)
+        mock_task.cancel = MagicMock()
+
+        session_manager.sessions_by_server[server_key] = {
+            "sessions": {
+                session_id: {
+                    "session": AsyncMock(),
+                    "task": mock_task,
+                    "type": "streamable_http",
+                    "last_used": 0,
+                }
+            },
+            "last_cleanup": 0,
+        }
+
+        # Fire many concurrent cleanups; only one should actually tear the
+        # session down, the rest should be no-ops (not KeyError).
+        await asyncio.gather(*[session_manager._cleanup_session_by_id(server_key, session_id) for _ in range(10)])
+
+        assert session_id not in session_manager.sessions_by_server[server_key]["sessions"]
+        mock_task.cancel.assert_called_once()
+
+    async def test_session_ids_are_monotonic_not_len_based(self, session_manager):
+        """Session ids must come from a monotonic counter, not len(sessions).
+
+        With `len(sessions)` as the id source, removing and re-adding sessions
+        can produce colliding ids and silently overwrite a live session entry.
+        """
+        connection_params = {"url": "http://example.test/sse", "headers": {}}
+
+        async def fake_create(_session_id, _params, _preferred_transport=None):
+            # Return a fresh session/task for each creation.
+            s = AsyncMock()
+            t = AsyncMock()
+            t.done = MagicMock(return_value=False)
+            t.cancel = MagicMock()
+            return s, t, "streamable_http"
+
+        server_key = session_manager._get_server_key(connection_params, "streamable_http")
+
+        with (
+            patch.object(session_manager, "_create_streamable_http_session", side_effect=fake_create),
+            # Force health check to fail so each call creates a fresh session.
+            patch.object(session_manager, "_validate_session_connectivity", return_value=False),
+        ):
+            ids_seen: list[str] = []
+            for i in range(3):
+                await session_manager.get_session(f"ctx_{i}", connection_params, "streamable_http")
+                ids_seen.extend(session_manager.sessions_by_server[server_key]["sessions"].keys())
+
+        # Counter keeps advancing even as old sessions are cleaned up.
+        assert session_manager._session_id_counters[server_key] == 3
+        # And the new id is unique (never recycles "_0").
+        assert f"{server_key}_0" not in session_manager.sessions_by_server[server_key]["sessions"]
 
 
 class TestHeaderValidation:

--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -341,6 +341,76 @@ class TestMCPSessionManager:
         server_key = session_manager._get_server_key(connection_params, "streamable_http")
         assert f"{server_key}_0" in session_manager.sessions_by_server[server_key]["sessions"]
 
+    async def test_cleanup_does_not_wipe_cross_server_handoff(self, session_manager):
+        """Concurrent reconnect to a different server must not be wiped out.
+
+        Regression test for a cross-server race on `_context_to_session`:
+        when `_cleanup_session(ctx)` is running for server A and a concurrent
+        `get_session(ctx, serverB)` re-points the same context at server B,
+        the cleanup previously ran `self._context_to_session.pop(context_id)`
+        unconditionally — destroying the fresh mapping. The new B session
+        then had refcount 1 forever, leaking on subsequent disconnect.
+        """
+        server_a_params = {"url": "http://a.example.test/sse", "headers": {}}
+        server_b_params = {"url": "http://b.example.test/sse", "headers": {}}
+        server_key_a = session_manager._get_server_key(server_a_params, "streamable_http")
+        server_key_b = session_manager._get_server_key(server_b_params, "streamable_http")
+
+        mock_session_a = AsyncMock()
+        mock_task_a = AsyncMock()
+        mock_task_a.done = MagicMock(return_value=False)
+        mock_task_a.cancel = MagicMock()
+        mock_session_b = AsyncMock()
+        mock_task_b = AsyncMock()
+        mock_task_b.done = MagicMock(return_value=False)
+        mock_task_b.cancel = MagicMock()
+
+        async def fake_create(_session_id, params, _preferred_transport=None):
+            if params["url"] == server_a_params["url"]:
+                return mock_session_a, mock_task_a, "streamable_http"
+            return mock_session_b, mock_task_b, "streamable_http"
+
+        with (
+            patch.object(session_manager, "_create_streamable_http_session", side_effect=fake_create),
+            patch.object(session_manager, "_validate_session_connectivity", return_value=True),
+        ):
+            # Establish context on server A.
+            s_a = await session_manager.get_session("ctx_move", server_a_params, "streamable_http")
+            assert s_a is mock_session_a
+
+            # Pause cleanup-of-A inside its lock so the concurrent
+            # get-for-B can race the context_to_session.pop().
+            release = asyncio.Event()
+            original_cleanup = session_manager._cleanup_session_by_id
+
+            async def slow_cleanup(server_key, session_id):
+                if server_key == server_key_a:
+                    # Let the B-reconnect proceed while we hold server_A's lock.
+                    await release.wait()
+                await original_cleanup(server_key, session_id)
+
+            with patch.object(session_manager, "_cleanup_session_by_id", side_effect=slow_cleanup):
+                cleanup_task = asyncio.create_task(session_manager._cleanup_session("ctx_move"))
+                # Give cleanup a chance to enter server_A's lock and start awaiting.
+                await asyncio.sleep(0)
+
+                # Concurrent reconnect to server B for the same context. This
+                # runs under server_B's lock, so it is not blocked.
+                s_b = await session_manager.get_session("ctx_move", server_b_params, "streamable_http")
+                assert s_b is mock_session_b
+
+                # Now let the A-cleanup finish. With the CAS check, it must
+                # NOT pop the fresh (server_B, _) mapping.
+                release.set()
+                await cleanup_task
+
+        # The fresh B mapping survives.
+        assert session_manager._context_to_session.get("ctx_move") == (server_key_b, f"{server_key_b}_0")
+        # A's session is gone; B's session is live with refcount 1.
+        assert f"{server_key_a}_0" not in session_manager.sessions_by_server.get(server_key_a, {}).get("sessions", {})
+        assert f"{server_key_b}_0" in session_manager.sessions_by_server[server_key_b]["sessions"]
+        assert session_manager._session_refcount.get((server_key_b, f"{server_key_b}_0")) == 1
+
     async def test_server_lock_and_counter_reclaimed_when_unused(self, session_manager):
         """Per-server locks and id counters must be reclaimed with the server.
 

--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -232,6 +232,158 @@ class TestMCPSessionManager:
         # And the new id is unique (never recycles "_0").
         assert f"{server_key}_0" not in session_manager.sessions_by_server[server_key]["sessions"]
 
+    async def test_cleanup_idle_vs_get_session_are_serialized(self, session_manager):
+        """Idle cleanup must not race a concurrent get_session().
+
+        Without holding the per-server lock, the idle-cleanup task could pop
+        and cancel a session mid-validation; `get_session()` would then hand
+        the caller a dead session plus a dangling refcount entry.
+        """
+        connection_params = {"url": "http://example.test/sse", "headers": {}}
+        server_key = session_manager._get_server_key(connection_params, "streamable_http")
+
+        mock_session = AsyncMock()
+        mock_task = AsyncMock()
+        mock_task.done = MagicMock(return_value=False)
+        mock_task.cancel = MagicMock()
+
+        # Seed one idle session (last_used in the distant past).
+        session_manager.sessions_by_server[server_key] = {
+            "sessions": {
+                f"{server_key}_0": {
+                    "session": mock_session,
+                    "task": mock_task,
+                    "type": "streamable_http",
+                    "last_used": 0,  # definitely past the idle timeout
+                }
+            },
+            "last_cleanup": 0,
+        }
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_validate(_session):
+            started.set()
+            await release.wait()
+            return True
+
+        with patch.object(session_manager, "_validate_session_connectivity", side_effect=slow_validate):
+            # Start a get_session() that will block inside the health check
+            # while holding the per-server lock.
+            getter = asyncio.create_task(
+                session_manager.get_session("ctx_reader", connection_params, "streamable_http")
+            )
+            await started.wait()
+
+            # Fire the idle cleanup concurrently. It must wait for the lock.
+            cleaner = asyncio.create_task(session_manager._cleanup_idle_sessions())
+            # Give it a chance to run if it were going to race.
+            await asyncio.sleep(0.02)
+
+            # While the getter still holds the lock, the session must not have
+            # been cleaned up.
+            assert f"{server_key}_0" in session_manager.sessions_by_server[server_key]["sessions"]
+            assert not mock_task.cancel.called
+
+            # Let the getter finish.
+            release.set()
+            result = await getter
+            await cleaner
+
+        # Getter returned the healthy cached session. Because `get_session`
+        # bumps `last_used` on reuse, the idle-cleanup pass — which ran only
+        # after the getter released the lock — correctly left the session
+        # alone. Without the lock, the cleaner could have torn it down
+        # mid-validation and the getter would have returned a dead session.
+        assert result is mock_session
+        assert not mock_task.cancel.called
+        assert f"{server_key}_0" in session_manager.sessions_by_server[server_key]["sessions"]
+
+    async def test_concurrent_cleanup_session_and_get_session_safe(self, session_manager):
+        """Disconnect path must honor the per-server lock.
+
+        `_cleanup_session(context_id)` previously mutated refcounts without
+        the per-server lock, so a concurrent `get_session()` could observe
+        state mid-transition and return a session that's about to be torn
+        down by the other caller's disconnect path.
+        """
+        connection_params = {"url": "http://example.test/sse", "headers": {}}
+
+        mock_session = AsyncMock()
+        mock_task = AsyncMock()
+        mock_task.done = MagicMock(return_value=False)
+        mock_task.cancel = MagicMock()
+
+        async def fake_create(_session_id, _params, _preferred_transport=None):
+            return mock_session, mock_task, "streamable_http"
+
+        with (
+            patch.object(session_manager, "_create_streamable_http_session", side_effect=fake_create),
+            patch.object(session_manager, "_validate_session_connectivity", return_value=True),
+        ):
+            # Establish the session with one context.
+            s1 = await session_manager.get_session("ctx_a", connection_params, "streamable_http")
+            assert s1 is mock_session
+
+            # Concurrently: a second caller grabs the session (bumping refcount)
+            # while the first caller disconnects (decrementing refcount).
+            results = await asyncio.gather(
+                session_manager.get_session("ctx_b", connection_params, "streamable_http"),
+                session_manager._cleanup_session("ctx_a"),
+            )
+
+        s2 = results[0]
+        # ctx_b still has a live session because ctx_a's cleanup only decremented
+        # refcount to 1, not zero.
+        assert s2 is mock_session
+        assert not mock_task.cancel.called
+        server_key = session_manager._get_server_key(connection_params, "streamable_http")
+        assert f"{server_key}_0" in session_manager.sessions_by_server[server_key]["sessions"]
+
+    async def test_server_lock_and_counter_reclaimed_when_unused(self, session_manager):
+        """Per-server locks and id counters must be reclaimed with the server.
+
+        Without this, rotating auth/session headers (which change `server_key`
+        via `_get_server_key`) causes `_server_locks` and
+        `_session_id_counters` to grow without bound in long-lived processes.
+        """
+        connection_params = {"url": "http://example.test/sse", "headers": {}}
+        server_key = session_manager._get_server_key(connection_params, "streamable_http")
+
+        mock_session = AsyncMock()
+        mock_task = AsyncMock()
+        mock_task.done = MagicMock(return_value=False)
+        mock_task.cancel = MagicMock()
+
+        async def fake_create(_session_id, _params, _preferred_transport=None):
+            return mock_session, mock_task, "streamable_http"
+
+        with (
+            patch.object(session_manager, "_create_streamable_http_session", side_effect=fake_create),
+            patch.object(session_manager, "_validate_session_connectivity", return_value=True),
+        ):
+            await session_manager.get_session("ctx_gc", connection_params, "streamable_http")
+
+        # While the session is live, the lock entry exists (pin count back to 0
+        # but the sessions_by_server entry holds the server_key alive).
+        assert server_key in session_manager._server_locks
+        assert server_key in session_manager._session_id_counters
+
+        # Disconnect the only context.
+        await session_manager._cleanup_session("ctx_gc")
+
+        # Trigger the periodic cleanup to remove the now-empty server entry.
+        # Mark the session as already expired so it gets swept on this pass,
+        # then run cleanup.
+        # (After _cleanup_session above, the sessions dict is already empty
+        # for this server_key, so _cleanup_idle_sessions will drop the entry.)
+        await session_manager._cleanup_idle_sessions()
+
+        assert server_key not in session_manager.sessions_by_server
+        assert server_key not in session_manager._session_id_counters
+        assert server_key not in session_manager._server_locks
+
 
 class TestHeaderValidation:
     """Test the header validation functionality."""

--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -141,24 +141,34 @@ class TestMCPSessionManager:
         mock_task.done = MagicMock(return_value=False)
 
         create_calls = 0
+        # Deterministic rendezvous: the first caller enters ``fake_create`` and
+        # parks on ``release``, giving every other caller time to queue on the
+        # per-server lock. Without the lock, they would all enter the creation
+        # path and ``create_calls`` would exceed 1. This replaces a timing-
+        # based ``asyncio.sleep(0.05)`` so the test does not rely on CI speed.
+        create_started = asyncio.Event()
+        release = asyncio.Event()
 
         async def fake_create(_session_id, _params, _preferred_transport=None):
             nonlocal create_calls
             create_calls += 1
-            # Simulate real network latency so callers overlap while the first
-            # creation is in flight. Without the per-server lock, every
-            # concurrent caller enters the creation path and returns its own
-            # session (or worse, races on the shared dict).
-            await asyncio.sleep(0.05)
+            create_started.set()
+            await release.wait()
             return mock_session, mock_task, "streamable_http"
 
         with (
             patch.object(session_manager, "_create_streamable_http_session", side_effect=fake_create),
             patch.object(session_manager, "_validate_session_connectivity", return_value=True),
         ):
-            results = await asyncio.gather(
-                *[session_manager.get_session(f"ctx_{i}", connection_params, "streamable_http") for i in range(10)]
-            )
+            getters = [
+                asyncio.create_task(session_manager.get_session(f"ctx_{i}", connection_params, "streamable_http"))
+                for i in range(10)
+            ]
+            # Wait until the first caller is in ``fake_create``; every other
+            # caller is now queued on the per-server lock.
+            await create_started.wait()
+            release.set()
+            results = await asyncio.gather(*getters)
 
         assert all(s is mock_session for s in results)
         # All 10 concurrent callers must share the single created session.
@@ -278,8 +288,15 @@ class TestMCPSessionManager:
 
             # Fire the idle cleanup concurrently. It must wait for the lock.
             cleaner = asyncio.create_task(session_manager._cleanup_idle_sessions())
-            # Give it a chance to run if it were going to race.
-            await asyncio.sleep(0.02)
+            # Deterministic rendezvous: wait until the cleaner has pinned the
+            # per-server lock (but is still blocked on the getter releasing
+            # it). Polling ``pins`` with scheduler-only yields replaces a
+            # timing-based ``asyncio.sleep(0.02)`` so the test does not rely
+            # on CI speed to expose a race. ``asyncio.Lock`` does not expose
+            # a waiters count, so internal-state polling is the deterministic
+            # primitive we have.
+            while session_manager._server_locks.get(server_key, {}).get("pins", 0) < 2:  # noqa: ASYNC110
+                await asyncio.sleep(0)
 
             # While the getter still holds the lock, the session must not have
             # been cleaned up.

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1365,6 +1365,15 @@ class MCPSessionManager:
         Acquires the per-server lock so concurrent `get_session()` calls don't
         observe a half-torn-down session (e.g. returning a ClientSession whose
         background task was just cancelled out from under them).
+
+        Uses a compare-and-swap on `_context_to_session[context_id]` before
+        popping it: if a concurrent `get_session()` has re-pointed the same
+        context at a *different* server (e.g. a component reconnecting to a
+        new MCP URL while the old disconnect is in flight), we must not wipe
+        out the fresh mapping — otherwise the new session leaks. The per-
+        server lock doesn't cover this case because the new and old sessions
+        live under different server_keys, so the two operations run in
+        parallel.
         """
         mapping = self._context_to_session.get(context_id)
         if not mapping:
@@ -1382,8 +1391,12 @@ class MCPSessionManager:
             else:
                 self._session_refcount[ref_key] = remaining
 
-            # Remove the mapping for this context
-            self._context_to_session.pop(context_id, None)
+            # CAS: only drop the context->session mapping if it still points
+            # at the session we just cleaned up. The get() and pop() below run
+            # synchronously with no `await` between them, so no other coroutine
+            # can interleave and re-point the mapping after our check.
+            if self._context_to_session.get(context_id) == (server_key, session_id):
+                self._context_to_session.pop(context_id, None)
 
 
 class MCPStdioClient:

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -9,9 +9,9 @@ import shlex
 import shutil
 import subprocess
 import unicodedata
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from types import UnionType
-from typing import Any, Union, get_args, get_origin
+from typing import Any, TypedDict, Union, get_args, get_origin
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -722,6 +722,22 @@ async def _validate_connection_params(mode: str, command: str | None = None, url
         raise ValueError(msg)
 
 
+class _ServerLockEntry(TypedDict):
+    """Shape of each value in ``MCPSessionManager._server_locks``.
+
+    ``pins`` is the number of callers that have obtained (but not yet
+    released) the lock via ``_server_lock``; it gates reclamation of the
+    entry so a new caller can't grab a fresh lock while an older caller is
+    about to enter the old one.
+    """
+
+    lock: asyncio.Lock
+    pins: int
+
+
+# TODO(langflow-ai/langflow#12541-followup): MCPSessionManager lives in this
+# 2k+ line module; extract it (and the concurrency primitives below) into a
+# dedicated ``mcp/session_manager.py`` so future edits stay small.
 class MCPSessionManager:
     """Manages persistent MCP sessions with proper context manager lifecycle.
 
@@ -750,12 +766,12 @@ class MCPSessionManager:
         # KeyError from `del sessions[session_id]` in `_cleanup_session_by_id`, or
         # create colliding session_ids from `len(sessions)`.
         #
-        # Each entry is {"lock": asyncio.Lock(), "pins": int}. The pin count is
-        # the number of callers that have obtained (but not yet released) the
-        # lock via `_server_lock`. We reclaim the entry only when pins == 0 and
-        # the lock is not held, to avoid a new caller grabbing a fresh lock
-        # while an older caller is about to enter the old one.
-        self._server_locks: dict[str, dict[str, Any]] = {}
+        # Each entry is a `_ServerLockEntry` {"lock": asyncio.Lock(), "pins": int}.
+        # The pin count is the number of callers that have obtained (but not yet
+        # released) the lock via `_server_lock`. We reclaim the entry only when
+        # pins == 0 and the lock is not held, to avoid a new caller grabbing a
+        # fresh lock while an older caller is about to enter the old one.
+        self._server_locks: dict[str, _ServerLockEntry] = {}
         self._locks_guard = asyncio.Lock()
         # Monotonic counter per server_key to generate unique session_ids even
         # when sessions are removed between allocations.
@@ -764,7 +780,7 @@ class MCPSessionManager:
         self._start_cleanup_task()
 
     @contextlib.asynccontextmanager
-    async def _server_lock(self, server_key: str):
+    async def _server_lock(self, server_key: str) -> AsyncIterator[None]:
         """Acquire the per-server lock with pin counting for safe reclamation.
 
         The pin count prevents reclaiming a lock that another task is about to
@@ -775,7 +791,7 @@ class MCPSessionManager:
         async with self._locks_guard:
             entry = self._server_locks.get(server_key)
             if entry is None:
-                entry = {"lock": asyncio.Lock(), "pins": 0}
+                entry = _ServerLockEntry(lock=asyncio.Lock(), pins=0)
                 self._server_locks[server_key] = entry
             entry["pins"] += 1
             lock = entry["lock"]
@@ -803,15 +819,43 @@ class MCPSessionManager:
             if entry is None:
                 return
             entry["pins"] -= 1
+            if entry["pins"] < 0:
+                # A negative pin count means a missing acquire or a double release.
+                # Log loudly so it surfaces in telemetry instead of being swept.
+                await logger.awarning(
+                    f"Negative pin count ({entry['pins']}) for server_key {server_key}; "
+                    "this indicates a missing _server_lock acquire or a double release.",
+                )
             if entry["pins"] <= 0 and not entry["lock"].locked() and server_key not in self.sessions_by_server:
                 self._server_locks.pop(server_key, None)
                 self._session_id_counters.pop(server_key, None)
 
     def _next_session_id(self, server_key: str) -> str:
-        """Generate a monotonically unique session_id for *server_key*."""
+        """Generate a monotonically unique session_id for *server_key*.
+
+        Caller must hold ``self._server_lock(server_key)`` while invoking this.
+        The increment is otherwise unsynchronised — two concurrent callers
+        without the lock would race on ``_session_id_counters[server_key]`` and
+        produce colliding ids.
+        """
         current = self._session_id_counters.get(server_key, 0)
         self._session_id_counters[server_key] = current + 1
         return f"{server_key}_{current}"
+
+    def _sessions_for(self, server_key: str) -> dict[str, dict[str, Any]]:
+        """Return the sessions dict for *server_key* (empty dict if absent).
+
+        Encapsulates the ``sessions_by_server[server_key]["sessions"]`` shape
+        so callers don't have to reach through the outer envelope. Handles the
+        legacy structure (sessions stored directly under the server_key)
+        uniformly as well.
+        """
+        server_data = self.sessions_by_server.get(server_key)
+        if server_data is None:
+            return {}
+        if isinstance(server_data, dict) and "sessions" in server_data:
+            return server_data["sessions"]
+        return server_data  # legacy flat structure
 
     def _start_cleanup_task(self):
         """Start the periodic cleanup task."""
@@ -845,10 +889,9 @@ class MCPSessionManager:
         # Snapshot keys to avoid mutating-while-iterating.
         for server_key in list(self.sessions_by_server.keys()):
             async with self._server_lock(server_key):
-                server_data = self.sessions_by_server.get(server_key)
-                if server_data is None:
+                sessions = self._sessions_for(server_key)
+                if not sessions and server_key not in self.sessions_by_server:
                     continue
-                sessions = server_data.get("sessions", {})
 
                 sessions_to_remove = [
                     session_id
@@ -1244,16 +1287,9 @@ class MCPSessionManager:
         task or `del` the same key (which raised `KeyError: 'streamable_http_..._0'`
         previously under concurrent flow execution).
         """
-        if server_key not in self.sessions_by_server:
+        sessions = self._sessions_for(server_key)
+        if not sessions and server_key not in self.sessions_by_server:
             return
-
-        server_data = self.sessions_by_server[server_key]
-        # Handle both old and new session structure
-        if isinstance(server_data, dict) and "sessions" in server_data:
-            sessions = server_data["sessions"]
-        else:
-            # Handle old structure where sessions were stored directly
-            sessions = server_data
 
         # Atomically remove the session entry; only the caller that wins this
         # pop performs the actual teardown. Concurrent callers get None and
@@ -1307,6 +1343,10 @@ class MCPSessionManager:
                     except asyncio.CancelledError:
                         await logger.ainfo(f"Cancelled task for session {session_id}")
         except Exception as e:  # noqa: BLE001
+            # Teardown is load-bearing: MCP transports (stdio subprocess, SSE,
+            # streamable HTTP) all raise their own exception hierarchies on
+            # shutdown, and a leak on cleanup is far worse than a swallowed
+            # error. Log and continue rather than propagating.
             await logger.awarning(f"Error cleaning up session {session_id}: {e}")
 
     async def cleanup_all(self):
@@ -1319,15 +1359,7 @@ class MCPSessionManager:
 
         # Clean up all sessions
         for server_key in list(self.sessions_by_server.keys()):
-            server_data = self.sessions_by_server[server_key]
-            # Handle both old and new session structure
-            if isinstance(server_data, dict) and "sessions" in server_data:
-                sessions = server_data["sessions"]
-            else:
-                # Handle old structure where sessions were stored directly
-                sessions = server_data
-
-            for session_id in list(sessions.keys()):
+            for session_id in list(self._sessions_for(server_key).keys()):
                 await self._cleanup_session_by_id(server_key, session_id)
 
         # Clear the sessions_by_server structure completely

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -749,7 +749,13 @@ class MCPSessionManager:
         # the same MCP server URL can race on the sessions dict and raise a
         # KeyError from `del sessions[session_id]` in `_cleanup_session_by_id`, or
         # create colliding session_ids from `len(sessions)`.
-        self._server_locks: dict[str, asyncio.Lock] = {}
+        #
+        # Each entry is {"lock": asyncio.Lock(), "pins": int}. The pin count is
+        # the number of callers that have obtained (but not yet released) the
+        # lock via `_server_lock`. We reclaim the entry only when pins == 0 and
+        # the lock is not held, to avoid a new caller grabbing a fresh lock
+        # while an older caller is about to enter the old one.
+        self._server_locks: dict[str, dict[str, Any]] = {}
         self._locks_guard = asyncio.Lock()
         # Monotonic counter per server_key to generate unique session_ids even
         # when sessions are removed between allocations.
@@ -757,17 +763,49 @@ class MCPSessionManager:
         self._cleanup_task = None
         self._start_cleanup_task()
 
-    async def _get_server_lock(self, server_key: str) -> asyncio.Lock:
-        """Return (creating if needed) the lock for *server_key*.
+    @contextlib.asynccontextmanager
+    async def _server_lock(self, server_key: str):
+        """Acquire the per-server lock with pin counting for safe reclamation.
 
-        The secondary `_locks_guard` lock makes lock creation itself race-safe.
+        The pin count prevents reclaiming a lock that another task is about to
+        enter (e.g. between obtaining a reference and calling ``async with``).
+        Reclamation in `_cleanup_idle_sessions` / `_release_server_lock_if_idle`
+        only runs when pins drop to zero *and* the lock is not held.
         """
         async with self._locks_guard:
-            lock = self._server_locks.get(server_key)
-            if lock is None:
-                lock = asyncio.Lock()
-                self._server_locks[server_key] = lock
-            return lock
+            entry = self._server_locks.get(server_key)
+            if entry is None:
+                entry = {"lock": asyncio.Lock(), "pins": 0}
+                self._server_locks[server_key] = entry
+            entry["pins"] += 1
+            lock = entry["lock"]
+        try:
+            async with lock:
+                yield
+        finally:
+            await self._release_server_lock_if_idle(server_key)
+
+    async def _release_server_lock_if_idle(self, server_key: str):
+        """Drop the pin and, once the server is fully idle, reclaim the maps.
+
+        Reclamation is deliberately conservative: we only drop the lock entry
+        (and the matching session-id counter) when *both* conditions hold —
+        pin count is zero and the server has no remaining sessions. This
+        prevents two problems:
+        - Churning the lock on every `get_session` call while a server is
+          actively in use (pin count oscillates 0↔1 between callers).
+        - Rotating auth/session headers (which change `server_key` via
+          `_get_server_key`) leaking per-key entries forever in long-lived
+          processes.
+        """
+        async with self._locks_guard:
+            entry = self._server_locks.get(server_key)
+            if entry is None:
+                return
+            entry["pins"] -= 1
+            if entry["pins"] <= 0 and not entry["lock"].locked() and server_key not in self.sessions_by_server:
+                self._server_locks.pop(server_key, None)
+                self._session_id_counters.pop(server_key, None)
 
     def _next_session_id(self, server_key: str) -> str:
         """Generate a monotonically unique session_id for *server_key*."""
@@ -795,30 +833,38 @@ class MCPSessionManager:
                 await logger.awarning(f"Error in periodic cleanup: {e}")
 
     async def _cleanup_idle_sessions(self):
-        """Clean up sessions that have been idle for too long."""
+        """Clean up sessions that have been idle for too long.
+
+        Acquires the per-server lock before mutating the sessions dict so we
+        don't race with `get_session()` — otherwise a concurrent `get_session`
+        could finish validating a session while this task pops and cancels it,
+        handing the caller a dead session plus a dangling refcount entry.
+        """
         current_time = asyncio.get_event_loop().time()
-        servers_to_remove = []
 
-        for server_key, server_data in self.sessions_by_server.items():
-            sessions = server_data.get("sessions", {})
-            sessions_to_remove = []
+        # Snapshot keys to avoid mutating-while-iterating.
+        for server_key in list(self.sessions_by_server.keys()):
+            async with self._server_lock(server_key):
+                server_data = self.sessions_by_server.get(server_key)
+                if server_data is None:
+                    continue
+                sessions = server_data.get("sessions", {})
 
-            for session_id, session_info in list(sessions.items()):
-                if current_time - session_info["last_used"] > get_session_idle_timeout():
-                    sessions_to_remove.append(session_id)
+                sessions_to_remove = [
+                    session_id
+                    for session_id, session_info in list(sessions.items())
+                    if current_time - session_info["last_used"] > get_session_idle_timeout()
+                ]
 
-            # Clean up idle sessions
-            for session_id in sessions_to_remove:
-                await logger.ainfo(f"Cleaning up idle session {session_id} for server {server_key}")
-                await self._cleanup_session_by_id(server_key, session_id)
+                for session_id in sessions_to_remove:
+                    await logger.ainfo(f"Cleaning up idle session {session_id} for server {server_key}")
+                    await self._cleanup_session_by_id(server_key, session_id)
 
-            # Remove server entry if no sessions left
-            if not sessions:
-                servers_to_remove.append(server_key)
-
-        # Clean up empty server entries
-        for server_key in servers_to_remove:
-            del self.sessions_by_server[server_key]
+                # Remove server entry if no sessions left. The counter for
+                # this server_key is reclaimed by `_release_server_lock_if_idle`
+                # once this lock's pin count hits zero.
+                if not sessions:
+                    self.sessions_by_server.pop(server_key, None)
 
     def _get_server_key(self, connection_params, transport_type: str) -> str:
         """Generate a consistent server key based on connection parameters."""
@@ -897,9 +943,8 @@ class MCPSessionManager:
         (e.g. two `MCPTools` components pointing at the same SSE URL).
         """
         server_key = self._get_server_key(connection_params, transport_type)
-        lock = await self._get_server_lock(server_key)
 
-        async with lock:
+        async with self._server_lock(server_key):
             # Ensure server entry exists
             if server_key not in self.sessions_by_server:
                 self.sessions_by_server[server_key] = {
@@ -1292,6 +1337,13 @@ class MCPSessionManager:
         self._context_to_session.clear()
         self._session_refcount.clear()
 
+        # Reclaim per-server lock and counter maps. Safe here because
+        # cleanup_all is a shutdown/reset operation; no other manager state
+        # should be in use past this point.
+        async with self._locks_guard:
+            self._server_locks.clear()
+            self._session_id_counters.clear()
+
         # Clear all background tasks
         for task in list(self._background_tasks):
             if not task.done():
@@ -1309,6 +1361,10 @@ class MCPSessionManager:
         Decrements the ref-count for the session used by *context_id* and only
         tears the session down when the last context that references it goes
         away.
+
+        Acquires the per-server lock so concurrent `get_session()` calls don't
+        observe a half-torn-down session (e.g. returning a ClientSession whose
+        background task was just cancelled out from under them).
         """
         mapping = self._context_to_session.get(context_id)
         if not mapping:
@@ -1316,17 +1372,18 @@ class MCPSessionManager:
             return
 
         server_key, session_id = mapping
-        ref_key = (server_key, session_id)
-        remaining = self._session_refcount.get(ref_key, 1) - 1
+        async with self._server_lock(server_key):
+            ref_key = (server_key, session_id)
+            remaining = self._session_refcount.get(ref_key, 1) - 1
 
-        if remaining <= 0:
-            await self._cleanup_session_by_id(server_key, session_id)
-            self._session_refcount.pop(ref_key, None)
-        else:
-            self._session_refcount[ref_key] = remaining
+            if remaining <= 0:
+                await self._cleanup_session_by_id(server_key, session_id)
+                self._session_refcount.pop(ref_key, None)
+            else:
+                self._session_refcount[ref_key] = remaining
 
-        # Remove the mapping for this context
-        self._context_to_session.pop(context_id, None)
+            # Remove the mapping for this context
+            self._context_to_session.pop(context_id, None)
 
 
 class MCPStdioClient:

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -744,8 +744,36 @@ class MCPSessionManager:
         # Cache which transport works for each server to avoid retrying failed transports
         # server_key -> "streamable_http" | "sse"
         self._transport_preference: dict[str, str] = {}
+        # Per-server asyncio locks to serialize session create/reuse/cleanup under
+        # concurrent access. Without this, two concurrent flow executions sharing
+        # the same MCP server URL can race on the sessions dict and raise a
+        # KeyError from `del sessions[session_id]` in `_cleanup_session_by_id`, or
+        # create colliding session_ids from `len(sessions)`.
+        self._server_locks: dict[str, asyncio.Lock] = {}
+        self._locks_guard = asyncio.Lock()
+        # Monotonic counter per server_key to generate unique session_ids even
+        # when sessions are removed between allocations.
+        self._session_id_counters: dict[str, int] = {}
         self._cleanup_task = None
         self._start_cleanup_task()
+
+    async def _get_server_lock(self, server_key: str) -> asyncio.Lock:
+        """Return (creating if needed) the lock for *server_key*.
+
+        The secondary `_locks_guard` lock makes lock creation itself race-safe.
+        """
+        async with self._locks_guard:
+            lock = self._server_locks.get(server_key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._server_locks[server_key] = lock
+            return lock
+
+    def _next_session_id(self, server_key: str) -> str:
+        """Generate a monotonically unique session_id for *server_key*."""
+        current = self._session_id_counters.get(server_key, 0)
+        self._session_id_counters[server_key] = current + 1
+        return f"{server_key}_{current}"
 
     def _start_cleanup_task(self):
         """Start the periodic cleanup task."""
@@ -862,83 +890,94 @@ class MCPSessionManager:
         The key insight is that we should reuse sessions based on the server
         identity (command + args for stdio, URL for Streamable HTTP) rather than the context_id.
         This prevents creating a new subprocess for each unique context.
+
+        Concurrent callers for the same server are serialized via a per-server
+        lock. This is required to keep the `sessions` dict consistent across
+        concurrent flow executions that share a single `MCPSessionManager`
+        (e.g. two `MCPTools` components pointing at the same SSE URL).
         """
         server_key = self._get_server_key(connection_params, transport_type)
+        lock = await self._get_server_lock(server_key)
 
-        # Ensure server entry exists
-        if server_key not in self.sessions_by_server:
-            self.sessions_by_server[server_key] = {"sessions": {}, "last_cleanup": asyncio.get_event_loop().time()}
+        async with lock:
+            # Ensure server entry exists
+            if server_key not in self.sessions_by_server:
+                self.sessions_by_server[server_key] = {
+                    "sessions": {},
+                    "last_cleanup": asyncio.get_event_loop().time(),
+                }
 
-        server_data = self.sessions_by_server[server_key]
-        sessions = server_data["sessions"]
+            server_data = self.sessions_by_server[server_key]
+            sessions = server_data["sessions"]
 
-        # Try to find a healthy existing session
-        for session_id, session_info in list(sessions.items()):
-            session = session_info["session"]
-            task = session_info["task"]
+            # Try to find a healthy existing session
+            for session_id, session_info in list(sessions.items()):
+                session = session_info["session"]
+                task = session_info["task"]
 
-            # Check if session is still alive
-            if not task.done():
-                # Update last used time
-                session_info["last_used"] = asyncio.get_event_loop().time()
+                # Check if session is still alive
+                if not task.done():
+                    # Update last used time
+                    session_info["last_used"] = asyncio.get_event_loop().time()
 
-                # Quick health check
-                if await self._validate_session_connectivity(session):
-                    await logger.adebug(f"Reusing existing session {session_id} for server {server_key}")
-                    # record mapping & bump ref-count for backwards compatibility
-                    self._context_to_session[context_id] = (server_key, session_id)
-                    self._session_refcount[(server_key, session_id)] = (
-                        self._session_refcount.get((server_key, session_id), 0) + 1
-                    )
-                    return session
-                await logger.ainfo(f"Session {session_id} for server {server_key} failed health check, cleaning up")
-                await self._cleanup_session_by_id(server_key, session_id)
+                    # Quick health check
+                    if await self._validate_session_connectivity(session):
+                        await logger.adebug(f"Reusing existing session {session_id} for server {server_key}")
+                        # record mapping & bump ref-count for backwards compatibility
+                        self._context_to_session[context_id] = (server_key, session_id)
+                        self._session_refcount[(server_key, session_id)] = (
+                            self._session_refcount.get((server_key, session_id), 0) + 1
+                        )
+                        return session
+                    await logger.ainfo(f"Session {session_id} for server {server_key} failed health check, cleaning up")
+                    await self._cleanup_session_by_id(server_key, session_id)
+                else:
+                    # Task is done, clean up
+                    await logger.ainfo(f"Session {session_id} for server {server_key} task is done, cleaning up")
+                    await self._cleanup_session_by_id(server_key, session_id)
+
+            # Check if we've reached the maximum number of sessions for this server
+            if len(sessions) >= get_max_sessions_per_server():
+                # Remove the oldest session
+                oldest_session_id = min(sessions.keys(), key=lambda x: sessions[x]["last_used"])
+                await logger.ainfo(
+                    f"Maximum sessions reached for server {server_key}, removing oldest session {oldest_session_id}"
+                )
+                await self._cleanup_session_by_id(server_key, oldest_session_id)
+
+            # Create new session. Use a monotonic counter so removed sessions
+            # don't cause id collisions with newly-created sessions.
+            session_id = self._next_session_id(server_key)
+            await logger.ainfo(f"Creating new session {session_id} for server {server_key}")
+
+            if transport_type == "stdio":
+                session, task = await self._create_stdio_session(session_id, connection_params)
+                actual_transport = "stdio"
+            elif transport_type == "streamable_http":
+                # Pass the cached transport preference if available
+                preferred_transport = self._transport_preference.get(server_key)
+                session, task, actual_transport = await self._create_streamable_http_session(
+                    session_id, connection_params, preferred_transport
+                )
+                # Cache the transport that worked for future connections
+                self._transport_preference[server_key] = actual_transport
             else:
-                # Task is done, clean up
-                await logger.ainfo(f"Session {session_id} for server {server_key} task is done, cleaning up")
-                await self._cleanup_session_by_id(server_key, session_id)
+                msg = f"Unknown transport type: {transport_type}"
+                raise ValueError(msg)
 
-        # Check if we've reached the maximum number of sessions for this server
-        if len(sessions) >= get_max_sessions_per_server():
-            # Remove the oldest session
-            oldest_session_id = min(sessions.keys(), key=lambda x: sessions[x]["last_used"])
-            await logger.ainfo(
-                f"Maximum sessions reached for server {server_key}, removing oldest session {oldest_session_id}"
-            )
-            await self._cleanup_session_by_id(server_key, oldest_session_id)
+            # Store session info with the actual transport used
+            sessions[session_id] = {
+                "session": session,
+                "task": task,
+                "type": actual_transport,
+                "last_used": asyncio.get_event_loop().time(),
+            }
 
-        # Create new session
-        session_id = f"{server_key}_{len(sessions)}"
-        await logger.ainfo(f"Creating new session {session_id} for server {server_key}")
+            # register mapping & initial ref-count for the new session
+            self._context_to_session[context_id] = (server_key, session_id)
+            self._session_refcount[(server_key, session_id)] = 1
 
-        if transport_type == "stdio":
-            session, task = await self._create_stdio_session(session_id, connection_params)
-            actual_transport = "stdio"
-        elif transport_type == "streamable_http":
-            # Pass the cached transport preference if available
-            preferred_transport = self._transport_preference.get(server_key)
-            session, task, actual_transport = await self._create_streamable_http_session(
-                session_id, connection_params, preferred_transport
-            )
-            # Cache the transport that worked for future connections
-            self._transport_preference[server_key] = actual_transport
-        else:
-            msg = f"Unknown transport type: {transport_type}"
-            raise ValueError(msg)
-
-        # Store session info with the actual transport used
-        sessions[session_id] = {
-            "session": session,
-            "task": task,
-            "type": actual_transport,
-            "last_used": asyncio.get_event_loop().time(),
-        }
-
-        # register mapping & initial ref-count for the new session
-        self._context_to_session[context_id] = (server_key, session_id)
-        self._session_refcount[(server_key, session_id)] = 1
-
-        return session
+            return session
 
     async def _create_stdio_session(self, session_id: str, connection_params):
         """Create a new stdio session as a background task to avoid context issues."""
@@ -1153,7 +1192,13 @@ class MCPSessionManager:
             raise ValueError(msg) from timeout_err
 
     async def _cleanup_session_by_id(self, server_key: str, session_id: str):
-        """Clean up a specific session by server key and session ID."""
+        """Clean up a specific session by server key and session ID.
+
+        Safe against concurrent cleanup of the same session: we `pop` the entry
+        up front so two concurrent callers don't both try to cancel the same
+        task or `del` the same key (which raised `KeyError: 'streamable_http_..._0'`
+        previously under concurrent flow execution).
+        """
         if server_key not in self.sessions_by_server:
             return
 
@@ -1165,10 +1210,13 @@ class MCPSessionManager:
             # Handle old structure where sessions were stored directly
             sessions = server_data
 
-        if session_id not in sessions:
+        # Atomically remove the session entry; only the caller that wins this
+        # pop performs the actual teardown. Concurrent callers get None and
+        # return early instead of racing on del/task.cancel().
+        session_info = sessions.pop(session_id, None)
+        if session_info is None:
             return
 
-        session_info = sessions[session_id]
         try:
             # First try to properly close the session if it exists
             if "session" in session_info:
@@ -1215,9 +1263,6 @@ class MCPSessionManager:
                         await logger.ainfo(f"Cancelled task for session {session_id}")
         except Exception as e:  # noqa: BLE001
             await logger.awarning(f"Error cleaning up session {session_id}: {e}")
-        finally:
-            # Remove from sessions dict
-            del sessions[session_id]
 
     async def cleanup_all(self):
         """Clean up all sessions."""


### PR DESCRIPTION
## Summary

Fixes intermittent failures (~40–50%) when two `MCPTools` components in the same flow point at the same SSE URL and multiple flow executions run concurrently, as reported in [#9860](https://github.com/langflow-ai/langflow/issues/9860) and re-confirmed in v1.9.0 / v1.10.0.

## Root Cause

Three concurrent-access bugs in `MCPSessionManager` (`src/lfx/src/lfx/base/mcp/util.py`):

1. **Unserialized `get_session()`** — concurrent callers for the same server both iterated `sessions_by_server[server_key]["sessions"]`, both passed the health check, and both invoked `_cleanup_session_by_id()` on the same session.
2. **Unsafe cleanup delete** — `_cleanup_session_by_id()` used `del sessions[session_id]` in a `finally` block. Two callers that both passed the `if session_id not in sessions` guard raced on the delete; the loser raised `KeyError: 'streamable_http_<hash>_0'` — matching the exact reported error.
3. **Session-ID collision** — `session_id = f"{server_key}_{len(sessions)}"` could recycle IDs after cleanup, silently overwriting an existing session entry.

## Fix

- Added a per-server `asyncio.Lock` (created under a module-level guard) to serialize the reuse / create / cleanup sections of `get_session()`.
- `_cleanup_session_by_id()` now `pop()`s the session entry up front — only the winning caller tears the session down; the rest no-op.
- Session IDs now come from a monotonic per-server counter (`_session_id_counters[server_key]`), so recycled slots don't produce colliding IDs.

## Test plan

- [x] 3 new regression tests in `test_mcp_util.py::TestMCPSessionManager`:
  - `test_concurrent_get_session_same_server_reuses_one_session` — 10 concurrent `get_session()` calls share exactly one underlying session / one create call.
  - `test_concurrent_cleanup_same_session_is_idempotent` — 10 concurrent `_cleanup_session_by_id()` calls on the same session do not raise `KeyError`; `task.cancel()` runs exactly once.
  - `test_session_ids_are_monotonic_not_len_based` — the counter keeps advancing after cleanup; `{server_key}_0` is not recycled for new sessions.
- [x] Existing `test_session_caching`, `test_session_cleanup`, `test_server_switch_detection` still pass.
- [x] `ruff check` + `ruff format` pass.
- [ ] Manual verification: run the flow topology from #9860 (2 `MCPTools` → same SSE URL → 2 different Agents) with 10+ concurrent executions. No `'streamable_http_..._0'` KeyError, no `Timeout updating tool list`.

Fixes langflow-ai/langflow#9860