### PR TITLE
fix: MCP server PATCH field clearing in backend and frontend [LE-891]

### DIFF
--- a/src/backend/base/langflow/api/v2/mcp.py
+++ b/src/backend/base/langflow/api/v2/mcp.py
@@ -280,6 +280,7 @@ async def update_server(
     *,
     check_existing: bool = False,
     delete: bool = False,
+    merge_existing: bool = False,
 ):
     async with _update_server_locks[str(current_user.id)]:
         server_list = await get_server_list(current_user, session, storage_service, settings_service)
@@ -294,6 +295,9 @@ async def update_server(
                 del server_list["mcpServers"][server_name]
             else:
                 raise HTTPException(status_code=500, detail="Server not found.")
+        elif merge_existing:
+            existing_config = server_list["mcpServers"].get(server_name, {})
+            server_list["mcpServers"][server_name] = {**existing_config, **server_config}
         else:
             server_list["mcpServers"][server_name] = server_config
 
@@ -359,6 +363,7 @@ async def update_server_endpoint(
         session,
         storage_service,
         settings_service,
+        merge_existing=True,
     )
 
 

--- a/src/backend/tests/unit/api/utils/test_config_utils.py
+++ b/src/backend/tests/unit/api/utils/test_config_utils.py
@@ -604,6 +604,33 @@ class TestMCPPatchServerConfig:
         finally:
             await client.delete(f"/api/v2/mcp/servers/{server_name}", headers=auth_headers)
 
+    @pytest.mark.asyncio
+    async def test_patch_replaces_headers_instead_of_deep_merging(self, client: AsyncClient, created_api_key):
+        """PATCH should replace the headers dict with the exact value provided."""
+        server_name = f"replace-headers-{uuid4()}"
+        auth_headers = {"x-api-key": created_api_key.api_key}
+        initial_config = {
+            "url": f"http://host-{uuid4()}/sse",
+            "headers": {"A": "1", "B": "2"},
+        }
+        patch_config = {"headers": {"A": "9"}}
+        expected_config = {"url": initial_config["url"], "headers": {"A": "9"}}
+
+        response = await client.post(f"/api/v2/mcp/servers/{server_name}", json=initial_config, headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json() == initial_config
+
+        try:
+            response = await client.patch(f"/api/v2/mcp/servers/{server_name}", json=patch_config, headers=auth_headers)
+            assert response.status_code == 200
+            assert response.json() == expected_config
+
+            response = await client.get(f"/api/v2/mcp/servers/{server_name}", headers=auth_headers)
+            assert response.status_code == 200
+            assert response.json() == expected_config
+        finally:
+            await client.delete(f"/api/v2/mcp/servers/{server_name}", headers=auth_headers)
+
 
 class TestMCPWithDefaultFolderName:
     """Test MCP configuration with different DEFAULT_FOLDER_NAME values."""

--- a/src/backend/tests/unit/api/utils/test_config_utils.py
+++ b/src/backend/tests/unit/api/utils/test_config_utils.py
@@ -547,6 +547,64 @@ class TestMultiUserMCPServerAccess:
         assert response_two.json() is None
 
 
+class TestMCPPatchServerConfig:
+    """Test PATCH semantics for MCP server configs."""
+
+    @pytest.mark.asyncio
+    async def test_patch_preserves_existing_headers_when_omitted(self, client: AsyncClient, created_api_key):
+        """PATCH should keep existing headers when request body omits them."""
+        server_name = f"preserve-headers-{uuid4()}"
+        auth_headers = {"x-api-key": created_api_key.api_key}
+        initial_config = {
+            "url": f"http://host-{uuid4()}/sse",
+            "headers": {"X-My-Header": "value"},
+        }
+        patch_config = {"url": f"http://new-host-{uuid4()}/sse"}
+        expected_config = {**initial_config, **patch_config}
+
+        response = await client.post(f"/api/v2/mcp/servers/{server_name}", json=initial_config, headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json() == initial_config
+
+        try:
+            response = await client.patch(f"/api/v2/mcp/servers/{server_name}", json=patch_config, headers=auth_headers)
+            assert response.status_code == 200
+            assert response.json() == expected_config
+
+            response = await client.get(f"/api/v2/mcp/servers/{server_name}", headers=auth_headers)
+            assert response.status_code == 200
+            assert response.json() == expected_config
+        finally:
+            await client.delete(f"/api/v2/mcp/servers/{server_name}", headers=auth_headers)
+
+    @pytest.mark.asyncio
+    async def test_patch_allows_explicit_header_clear(self, client: AsyncClient, created_api_key):
+        """PATCH with headers=null should clear stored headers explicitly."""
+        server_name = f"clear-headers-{uuid4()}"
+        auth_headers = {"x-api-key": created_api_key.api_key}
+        initial_config = {
+            "url": f"http://host-{uuid4()}/sse",
+            "headers": {"X-My-Header": "value"},
+        }
+        patch_config = {"headers": None}
+        expected_config = {"url": initial_config["url"], "headers": None}
+
+        response = await client.post(f"/api/v2/mcp/servers/{server_name}", json=initial_config, headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json() == initial_config
+
+        try:
+            response = await client.patch(f"/api/v2/mcp/servers/{server_name}", json=patch_config, headers=auth_headers)
+            assert response.status_code == 200
+            assert response.json() == expected_config
+
+            response = await client.get(f"/api/v2/mcp/servers/{server_name}", headers=auth_headers)
+            assert response.status_code == 200
+            assert response.json() == expected_config
+        finally:
+            await client.delete(f"/api/v2/mcp/servers/{server_name}", headers=auth_headers)
+
+
 class TestMCPWithDefaultFolderName:
     """Test MCP configuration with different DEFAULT_FOLDER_NAME values."""
 

--- a/src/frontend/src/controllers/API/queries/mcp/__tests__/use-patch-mcp-server.test.ts
+++ b/src/frontend/src/controllers/API/queries/mcp/__tests__/use-patch-mcp-server.test.ts
@@ -83,7 +83,7 @@ describe("usePatchMCPServer", () => {
       queryKey: ["useGetMCPServers"],
     });
     expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-      queryKey: ["useGetMCPServer", undefined],
+      queryKey: ["useGetMCPServer", "my-server"],
     });
   });
 });

--- a/src/frontend/src/controllers/API/queries/mcp/__tests__/use-patch-mcp-server.test.ts
+++ b/src/frontend/src/controllers/API/queries/mcp/__tests__/use-patch-mcp-server.test.ts
@@ -1,0 +1,89 @@
+const mockApiPatch = jest.fn();
+const mockQueryClient = {
+  setQueryData: jest.fn(),
+  invalidateQueries: jest.fn(),
+};
+
+type MutationOptions<TData, TVariables> = {
+  onSuccess?: (data: TData, variables: TVariables, context: undefined) => void;
+  onSettled?: (data: TData) => void;
+};
+
+type MutationFn<TVariables, TData> = (payload: TVariables) => Promise<TData>;
+
+jest.mock("@/controllers/API/api", () => ({
+  api: { patch: mockApiPatch },
+}));
+
+jest.mock("@/controllers/API/helpers/constants", () => ({
+  getURL: jest.fn(() => "/api/v2/mcp/servers"),
+}));
+
+jest.mock("@/controllers/API/services/request-processor", () => ({
+  UseRequestProcessor: jest.fn(() => ({
+    mutate: jest.fn(
+      <TVariables, TData>(
+        _key: unknown,
+        fn: MutationFn<TVariables, TData>,
+        options: MutationOptions<TData, TVariables>,
+      ) => ({
+        mutate: async (payload: TVariables) => {
+          const result = await fn(payload);
+          options?.onSuccess?.(result, payload, undefined);
+          options?.onSettled?.(result);
+          return result;
+        },
+      }),
+    ),
+    queryClient: mockQueryClient,
+  })),
+}));
+
+import { usePatchMCPServer } from "../use-patch-mcp-server";
+
+describe("usePatchMCPServer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("preserves explicit empty collections in patch payload", async () => {
+    mockApiPatch.mockResolvedValue({ data: {} });
+
+    const mutation = usePatchMCPServer();
+    await mutation.mutate({
+      name: "my-server",
+      url: "http://host/sse",
+      headers: {},
+      env: {},
+      args: [],
+    });
+
+    expect(mockApiPatch).toHaveBeenCalledWith("/api/v2/mcp/servers/my-server", {
+      url: "http://host/sse",
+      headers: {},
+      env: {},
+      args: [],
+    });
+  });
+
+  it("updates cached server list and invalidates MCP queries on success", async () => {
+    mockApiPatch.mockResolvedValue({ data: {} });
+
+    const mutation = usePatchMCPServer();
+    await mutation.mutate({
+      name: "my-server",
+      url: "http://host/sse",
+    });
+
+    expect(mockQueryClient.setQueryData).toHaveBeenCalledWith(
+      ["useGetMCPServers"],
+      expect.any(Function),
+    );
+    expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["useGetMCPServers"],
+    });
+    expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["useGetMCPServer", undefined],
+    });
+  });
+});

--- a/src/frontend/src/controllers/API/queries/mcp/use-patch-mcp-server.ts
+++ b/src/frontend/src/controllers/API/queries/mcp/use-patch-mcp-server.ts
@@ -24,19 +24,19 @@ export const usePatchMCPServer: useMutationFunctionType<
     try {
       const payload: Omit<MCPServerType, "name"> = {};
 
-      if (body.url) {
+      if (body.url !== undefined) {
         payload.url = body.url;
       }
-      if (body.command) {
+      if (body.command !== undefined) {
         payload.command = body.command;
       }
-      if (body.args && body.args.length > 0) {
+      if (body.args !== undefined) {
         payload.args = body.args;
       }
-      if (body.env && Object.keys(body.env).length > 0) {
+      if (body.env !== undefined) {
         payload.env = body.env;
       }
-      if (body.headers && Object.keys(body.headers).length > 0) {
+      if (body.headers !== undefined) {
         payload.headers = body.headers;
       }
 
@@ -71,7 +71,7 @@ export const usePatchMCPServer: useMutationFunctionType<
 
   const mutation: UseMutationResult<
     PatchMCPServerResponse,
-    any,
+    unknown,
     MCPServerType
   > = mutate(["usePatchMCPServer"], patchMCPServer, {
     ...options,

--- a/src/frontend/src/controllers/API/queries/mcp/use-patch-mcp-server.ts
+++ b/src/frontend/src/controllers/API/queries/mcp/use-patch-mcp-server.ts
@@ -82,7 +82,7 @@ export const usePatchMCPServer: useMutationFunctionType<
         queryKey: ["useGetMCPServers"],
       });
       queryClient.invalidateQueries({
-        queryKey: ["useGetMCPServer", data.name],
+        queryKey: ["useGetMCPServer", variables.name],
       });
       options?.onSuccess?.(data, variables, context);
     },

--- a/src/frontend/src/modals/addMcpServerModal/__tests__/addMcpServerModal.test.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/__tests__/addMcpServerModal.test.tsx
@@ -1,0 +1,236 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import type { MCPServerType } from "@/types/mcp";
+import AddMcpServerModal from "..";
+
+const mockPatchMCPServer = jest.fn();
+const mockSetQueryData = jest.fn();
+
+jest.mock("nanoid", () => ({
+  nanoid: () => "test-id",
+}));
+
+jest.mock("react-router-dom", () => ({
+  useLocation: () => ({ pathname: "/settings/mcp-servers" }),
+}));
+
+jest.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    setQueryData: mockSetQueryData,
+  }),
+}));
+
+jest.mock("@/controllers/API/queries/mcp/use-add-mcp-server", () => ({
+  useAddMCPServer: () => ({
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }),
+}));
+
+jest.mock("@/controllers/API/queries/mcp/use-patch-mcp-server", () => ({
+  usePatchMCPServer: () => ({
+    mutateAsync: mockPatchMCPServer,
+    isPending: false,
+  }),
+}));
+
+jest.mock("@/components/common/genericIconComponent", () => ({
+  ForwardedIconComponent: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+jest.mock("@/customization/components/custom-link", () => ({
+  CustomLink: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    ...props
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock("@/components/ui/input", () => ({
+  Input: ({
+    value,
+    onChange,
+    "data-testid": dataTestId,
+    placeholder,
+  }: {
+    value?: string;
+    onChange?: (event: { target: { value: string } }) => void;
+    "data-testid"?: string;
+    placeholder?: string;
+  }) => (
+    <input
+      value={value}
+      placeholder={placeholder}
+      data-testid={dataTestId}
+      onChange={(event) =>
+        onChange?.({ target: { value: event.target.value } })
+      }
+    />
+  ),
+}));
+
+jest.mock("@/components/ui/label", () => ({
+  Label: ({ children }: { children: ReactNode }) => <label>{children}</label>,
+}));
+
+jest.mock("@/components/ui/textarea", () => ({
+  Textarea: ({
+    value,
+    onChange,
+    "data-testid": dataTestId,
+  }: {
+    value?: string;
+    onChange?: (event: { target: { value: string } }) => void;
+    "data-testid"?: string;
+  }) => (
+    <textarea
+      value={value}
+      data-testid={dataTestId}
+      onChange={(event) =>
+        onChange?.({ target: { value: event.target.value } })
+      }
+    />
+  ),
+}));
+
+jest.mock(
+  "@/components/core/parameterRenderComponent/components/inputListComponent",
+  () => ({
+    __esModule: true,
+    default: () => <div data-testid="stdio-args-input" />,
+  }),
+);
+
+jest.mock("@/components/ui/tabs-button", () => ({
+  Tabs: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({
+    children,
+    value,
+  }: {
+    children: ReactNode;
+    value: string;
+  }) => <button type="button">{children ?? value}</button>,
+}));
+
+jest.mock("@/modals/baseModal", () => {
+  interface ChildrenProps {
+    children: ReactNode;
+  }
+
+  interface BaseModalProps extends ChildrenProps {
+    open?: boolean;
+  }
+
+  function MockBaseModal({ children, open }: BaseModalProps) {
+    if (!open) {
+      return null;
+    }
+
+    return <div data-testid="base-modal">{children}</div>;
+  }
+
+  MockBaseModal.Trigger = ({ children }: ChildrenProps) => (
+    <div>{children}</div>
+  );
+  MockBaseModal.Content = ({ children }: ChildrenProps) => (
+    <div>{children}</div>
+  );
+
+  return { __esModule: true, default: MockBaseModal };
+});
+
+jest.mock(
+  "@/modals/IOModal/components/IOFieldView/components/key-pair-input",
+  () => ({
+    __esModule: true,
+    default: ({
+      onChange,
+      testId,
+    }: {
+      onChange: (value: Array<unknown>) => void;
+      testId?: string;
+    }) => (
+      <button
+        type="button"
+        data-testid={`${testId}-clear`}
+        onClick={() => onChange([])}
+      >
+        Clear
+      </button>
+    ),
+  }),
+);
+
+jest.mock(
+  "@/modals/IOModal/components/IOFieldView/components/key-pair-input-with-variables",
+  () => ({
+    __esModule: true,
+    default: ({
+      onChange,
+      testId,
+    }: {
+      onChange: (value: Array<unknown>) => void;
+      testId?: string;
+    }) => (
+      <button
+        type="button"
+        data-testid={`${testId}-clear`}
+        onClick={() => onChange([])}
+      >
+        Clear
+      </button>
+    ),
+  }),
+);
+
+describe("AddMcpServerModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPatchMCPServer.mockResolvedValue(undefined);
+  });
+
+  it("sends empty headers and env when deleting the last remaining HTTP entries", async () => {
+    const user = userEvent.setup();
+    const initialData: MCPServerType = {
+      name: "my-server",
+      url: "http://host/sse",
+      headers: { Authorization: "Bearer token" },
+      env: { TOKEN: "secret" },
+    };
+
+    render(
+      <AddMcpServerModal
+        open={true}
+        setOpen={jest.fn()}
+        initialData={initialData}
+      />,
+    );
+
+    await user.click(screen.getByTestId("http-headers-clear"));
+    await user.click(screen.getByTestId("http-env-clear"));
+    await user.click(screen.getByTestId("add-mcp-server-button"));
+
+    expect(mockPatchMCPServer).toHaveBeenCalledWith({
+      name: "my-server",
+      url: "http://host/sse",
+      headers: {},
+      env: {},
+    });
+  });
+});

--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -55,6 +55,31 @@ const keyPairRowToObject = (arr: KeyPairRow[]): Record<string, string> => {
   }, {});
 };
 
+const buildKeyPairPayload = (
+  rows: KeyPairRow[],
+  existing?: Record<string, string>,
+) => {
+  const nextValue = keyPairRowToObject(rows);
+  if (Object.keys(nextValue).length > 0) {
+    return nextValue;
+  }
+  if (existing && Object.keys(existing).length > 0) {
+    return {};
+  }
+  return undefined;
+};
+
+const buildArgsPayload = (args: string[], existing?: string[]) => {
+  const nextValue = args.filter((arg) => arg.trim() !== "");
+  if (nextValue.length > 0) {
+    return nextValue;
+  }
+  if (existing && existing.length > 0) {
+    return [];
+  }
+  return undefined;
+};
+
 export default function AddMcpServerModal({
   children,
   initialData,
@@ -159,12 +184,14 @@ export default function AddMcpServerModal({
         "no_blank",
         "lowercase",
       ]).slice(0, MAX_MCP_SERVER_NAME_LENGTH);
+      const argsPayload = buildArgsPayload(stdioArgs, initialData?.args);
+      const envPayload = buildKeyPairPayload(stdioEnv, initialData?.env);
       try {
         await modifyMCPServer({
           name,
           command: stdioCommand,
-          args: stdioArgs.filter((a) => a.trim() !== ""),
-          env: keyPairRowToObject(stdioEnv),
+          ...(argsPayload !== undefined ? { args: argsPayload } : {}),
+          ...(envPayload !== undefined ? { env: envPayload } : {}),
         });
         if (!initialData) {
           await queryClient.setQueryData(
@@ -209,12 +236,17 @@ export default function AddMcpServerModal({
         "no_blank",
         "lowercase",
       ]).slice(0, MAX_MCP_SERVER_NAME_LENGTH);
+      const envPayload = buildKeyPairPayload(httpEnv, initialData?.env);
+      const headersPayload = buildKeyPairPayload(
+        httpHeaders,
+        initialData?.headers,
+      );
       try {
         await modifyMCPServer({
           name,
-          env: keyPairRowToObject(httpEnv),
           url: httpUrl,
-          headers: keyPairRowToObject(httpHeaders),
+          ...(envPayload !== undefined ? { env: envPayload } : {}),
+          ...(headersPayload !== undefined ? { headers: headersPayload } : {}),
         });
         if (!initialData) {
           await queryClient.setQueryData(


### PR DESCRIPTION
## Summary
- preserve existing MCP server fields on backend PATCH when omitted from request
- allow frontend MCP server edit flow to clear the last remaining header/env value
- add backend and frontend regression coverage for these PATCH payload cases

## Testing
- uv run pytest src/backend/tests/unit/api/utils/test_config_utils.py -k 'MCPPatchServerConfig or cross_user_mcp_server_access_prevention'
- npm test -- --runInBand src/frontend/src/controllers/API/queries/mcp/__tests__/use-patch-mcp-server.test.ts
- manual live API verification for MCP server PATCH update/clear flows
