### PR TITLE
fix: update `isinstance(value, Data)` logic

### DIFF
--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -358,7 +358,10 @@ class ArizePhoenixTracer(BaseTracer):
             value = value.text
 
         elif isinstance(value, Data):
-            value = value.get_text()
+            if isinstance(value.value, (dict, list)):
+                value = value.value
+            else:
+                value = value.get_text()
 
         elif isinstance(value, (BaseMessage | HumanMessage | SystemMessage)):
             value = value.content

--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -358,7 +358,8 @@ class ArizePhoenixTracer(BaseTracer):
             value = value.text
 
         elif isinstance(value, Data):
-            value = value.data if isinstance(value.data, (dict, list)) else value.get_text()
+            data = value.data
+            value = self._convert_to_arize_phoenix_type(data) if isinstance(data, (dict, list)) else value.get_text()
 
         elif isinstance(value, (BaseMessage | HumanMessage | SystemMessage)):
             value = value.content

--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -358,12 +358,7 @@ class ArizePhoenixTracer(BaseTracer):
             value = value.text
 
         elif isinstance(value, Data):
-            data_value = value.data
-            value = (
-                self._convert_to_arize_phoenix_type(data_value)
-                if isinstance(data_value, (dict, list))
-                else value.get_text()
-            )
+            value = value.data if isinstance(value.data, (dict, list)) else value.get_text()
 
         elif isinstance(value, (BaseMessage | HumanMessage | SystemMessage)):
             value = value.content

--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -79,8 +79,8 @@ class ArizePhoenixTracer(BaseTracer):
         self.project_name = project_name
         self.trace_id = trace_id
         self.session_id = session_id
-        self.flow_name = trace_name.split(" - ")[0]
-        self.flow_id = trace_name.split(" - ")[-1]
+        self.flow_name = trace_name.split(" - ", maxsplit=1)[0]
+        self.flow_id = trace_name.rsplit(" - ", maxsplit=1)[-1]
         self.chat_input_value = ""
         self.chat_output_value = ""
 
@@ -262,7 +262,7 @@ class ArizePhoenixTracer(BaseTracer):
         if vertex and vertex.id is not None:
             child_span.set_attribute("vertex_id", vertex.id)
 
-        component_name = trace_id.split("-")[0]
+        component_name = trace_id.split("-", maxsplit=1)[0]
         if component_name == "ChatInput":
             self.chat_input_value = processed_inputs["input_value"]
         elif component_name == "ChatOutput":
@@ -371,7 +371,7 @@ class ArizePhoenixTracer(BaseTracer):
         elif isinstance(value, Document):
             value = value.page_content
 
-        elif isinstance(value, (types.GeneratorType | types.NoneType)):
+        elif isinstance(value, (types.GeneratorType, type(None))):
             value = str(value)
 
         elif isinstance(value, float) and not math.isfinite(value):

--- a/src/backend/base/langflow/services/tracing/arize_phoenix.py
+++ b/src/backend/base/langflow/services/tracing/arize_phoenix.py
@@ -358,10 +358,12 @@ class ArizePhoenixTracer(BaseTracer):
             value = value.text
 
         elif isinstance(value, Data):
-            if isinstance(value.value, (dict, list)):
-                value = value.value
-            else:
-                value = value.get_text()
+            data_value = value.data
+            value = (
+                self._convert_to_arize_phoenix_type(data_value)
+                if isinstance(data_value, (dict, list))
+                else value.get_text()
+            )
 
         elif isinstance(value, (BaseMessage | HumanMessage | SystemMessage)):
             value = value.content

--- a/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
+++ b/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
@@ -1,0 +1,131 @@
+import math
+import types
+
+import pytest
+from lfx.schema.data import Data
+
+from src.backend.base.langflow.services.tracing.arize_phoenix import (
+    ArizePhoenixTracer,
+)
+
+
+@pytest.fixture
+def tracer():
+    tracer = ArizePhoenixTracer.__new__(ArizePhoenixTracer)
+    return tracer
+
+
+def test_data_dict_conversion(tracer):
+    value = Data(data={"a": 1, "b": "x"})
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == {"a": 1, "b": "x"}
+
+
+def test_data_list_conversion(tracer):
+    value = Data(data=[1, 2, 3])
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == [1, 2, 3]
+
+
+def test_data_text_fallback(tracer):
+    value = Data(data="hello")
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == value.get_text()
+
+
+def test_data_nested_structure(tracer):
+    value = Data(data={"nested": [1, {"x": 2}]})
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == {"nested": [1, {"x": 2}]}
+
+
+def test_data_none(tracer):
+    value = Data(data=None)
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == value.get_text()
+
+
+def test_dict_recursive_conversion(tracer):
+    value = {
+        "a": Data(data={"b": 1}),
+        "c": [Data(data="text"), 2],
+    }
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == {
+        "a": {"b": 1},
+        "c": ["text", 2],
+    }
+
+
+def test_list_recursive_conversion(tracer):
+    value = [
+        Data(data={"x": 1}),
+        Data(data="y"),
+    ]
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == [{"x": 1}, "y"]
+
+
+def test_float_nan_conversion(tracer):
+    value = float("nan")
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == "NaN"
+
+
+def test_float_inf_conversion(tracer):
+    value = float("inf")
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == "NaN"
+
+
+def test_none_type_conversion(tracer):
+    value = None
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == "None"
+
+
+def test_generator_conversion(tracer):
+    def gen():
+        yield 1
+
+    value = gen()
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert isinstance(result, str)
+
+
+def test_plain_dict_unchanged(tracer):
+    value = {"a": 1, "b": 2}
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == value
+
+
+def test_plain_list_unchanged(tracer):
+    value = [1, 2, 3]
+
+    result = tracer._convert_to_arize_phoenix_type(value)
+
+    assert result == value

--- a/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
+++ b/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
@@ -8,8 +8,7 @@ from src.backend.base.langflow.services.tracing.arize_phoenix import (
 
 @pytest.fixture
 def tracer():
-    tracer = ArizePhoenixTracer.__new__(ArizePhoenixTracer)
-    return tracer
+    return ArizePhoenixTracer.__new__(ArizePhoenixTracer)
 
 
 def test_data_dict_conversion(tracer):

--- a/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
+++ b/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
@@ -1,6 +1,3 @@
-import math
-import types
-
 import pytest
 from lfx.schema.data import Data
 

--- a/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
+++ b/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
@@ -1,13 +1,6 @@
-import os
-
-os.environ["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
-
 import pytest
+from langflow.services.tracing.arize_phoenix import ArizePhoenixTracer
 from lfx.schema.data import Data
-
-from src.backend.base.langflow.services.tracing.arize_phoenix import (
-    ArizePhoenixTracer,
-)
 
 
 @pytest.fixture
@@ -24,27 +17,27 @@ def test_data_dict_conversion(tracer):
 
 
 def test_data_list_conversion(tracer):
-    value = Data(data=[1, 2, 3])
+    value = Data.model_construct(data=[1, Data(data={"x": 2})], text_key="text", default_value="")
 
     result = tracer._convert_to_arize_phoenix_type(value)
 
-    assert result == [1, 2, 3]
+    assert result == [1, {"x": 2}]
 
 
-def test_data_text_fallback(tracer):
-    value = Data(data="hello")
+def test_data_text_payload_preserved(tracer):
+    value = Data(data={"text": "hello"})
 
     result = tracer._convert_to_arize_phoenix_type(value)
 
-    assert result == value.get_text()
+    assert result == {"text": "hello"}
 
 
 def test_data_nested_structure(tracer):
-    value = Data(data={"nested": [1, {"x": 2}]})
+    value = Data(data={"nested": [1, Data(data={"x": float("inf")})]})
 
     result = tracer._convert_to_arize_phoenix_type(value)
 
-    assert result == {"nested": [1, {"x": 2}]}
+    assert result == {"nested": [1, {"x": "NaN"}]}
 
 
 def test_data_none(tracer):
@@ -52,32 +45,32 @@ def test_data_none(tracer):
 
     result = tracer._convert_to_arize_phoenix_type(value)
 
-    assert result == value.get_text()
+    assert result == {}
 
 
 def test_dict_recursive_conversion(tracer):
     value = {
         "a": Data(data={"b": 1}),
-        "c": [Data(data="text"), 2],
+        "c": [Data(data={"text": "text"}), 2],
     }
 
     result = tracer._convert_to_arize_phoenix_type(value)
 
     assert result == {
         "a": {"b": 1},
-        "c": ["text", 2],
+        "c": [{"text": "text"}, 2],
     }
 
 
 def test_list_recursive_conversion(tracer):
     value = [
         Data(data={"x": 1}),
-        Data(data="y"),
+        Data(data={"text": "y"}),
     ]
 
     result = tracer._convert_to_arize_phoenix_type(value)
 
-    assert result == [{"x": 1}, "y"]
+    assert result == [{"x": 1}, {"text": "y"}]
 
 
 def test_float_nan_conversion(tracer):

--- a/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
+++ b/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
@@ -1,4 +1,5 @@
 import os
+
 os.environ["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
 
 import pytest

--- a/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
+++ b/src/backend/tests/unit/services/tracing/test_arize_phoenix.py
@@ -1,3 +1,6 @@
+import os
+os.environ["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+
 import pytest
 from lfx.schema.data import Data
 


### PR DESCRIPTION
Currently, `Data` outputs are always converted using `get_text()`, which forces structured data into string form. This PR preserves `Data.value` when it is JSON-serializable (e.g., dict/list), allowing Phoenix to receive structured outputs instead of stringified JSON.

**Behavior change**
- Before: `"data": "{\"score\":40}"`
- After: `"data": {"score": 40}`

**Backward compatibility**
- Falls back to `get_text()` if `value` is not structured

Resolving issue: https://github.com/langflow-ai/langflow/issues/11738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of complex data types (dictionaries and lists) in tracing services, enhancing data conversion accuracy and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->