### PR TITLE
fix(i18n): fallback unsupported locales on startup

### DIFF
--- a/src/frontend/src/i18n.test.ts
+++ b/src/frontend/src/i18n.test.ts
@@ -7,7 +7,11 @@
 
 // Import the real i18n instance and loadLanguage (not the mock from jest.setup.js)
 jest.unmock("react-i18next");
-import i18n, { loadLanguage } from "./i18n";
+import i18n, {
+  loadLanguage,
+  normalizeLanguageCode,
+  resolveLanguage,
+} from "./i18n";
 
 describe("loadLanguage", () => {
   beforeEach(() => {
@@ -49,5 +53,23 @@ describe("loadLanguage", () => {
     await loadLanguage("ja");
     expect(i18n.hasResourceBundle("fr", "translation")).toBe(true);
     expect(i18n.hasResourceBundle("ja", "translation")).toBe(true);
+  });
+
+  it("normalizes Chinese locale variants to zh-Hans", async () => {
+    expect(normalizeLanguageCode("zh")).toBe("zh-Hans");
+    expect(normalizeLanguageCode("zh-CN")).toBe("zh-Hans");
+
+    await loadLanguage("zh");
+    expect(i18n.hasResourceBundle("zh-Hans", "translation")).toBe(true);
+  });
+
+  it("falls back unsupported locales to English without throwing", async () => {
+    expect(resolveLanguage("ru-RU")).toBe("en");
+    expect(resolveLanguage("ko-KR")).toBe("en");
+
+    await expect(loadLanguage("ru-RU")).resolves.toBeUndefined();
+    await expect(loadLanguage("ko-KR")).resolves.toBeUndefined();
+    expect(i18n.hasResourceBundle("ru", "translation")).toBe(false);
+    expect(i18n.hasResourceBundle("ko", "translation")).toBe(false);
   });
 });

--- a/src/frontend/src/i18n.ts
+++ b/src/frontend/src/i18n.ts
@@ -1,23 +1,67 @@
-import i18n from "i18next";
-import { initReactI18next } from "react-i18next";
-import en from "./locales/en.json";
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en.json';
+
+const localeLoaders: Record<
+  string,
+  () => Promise<{ default: Record<string, string> }>
+> = {
+  fr: () => import('./locales/fr.json'),
+  es: () => import('./locales/es.json'),
+  de: () => import('./locales/de.json'),
+  pt: () => import('./locales/pt.json'),
+  ja: () => import('./locales/ja.json'),
+  'zh-Hans': () => import('./locales/zh-Hans.json'),
+};
+
+const supportedLanguages = new Set(['en', ...Object.keys(localeLoaders)]);
+
+export function normalizeLanguageCode(lang: string): string {
+  const normalized = lang.toLowerCase();
+
+  if (normalized.startsWith('zh')) {
+    return 'zh-Hans';
+  }
+
+  return normalized.split('-')[0];
+}
+
+export function resolveLanguage(lang?: string | null): string {
+  if (!lang) {
+    return 'en';
+  }
+
+  const normalizedLang = normalizeLanguageCode(lang);
+
+  return supportedLanguages.has(normalizedLang) ? normalizedLang : 'en';
+}
 
 i18n.use(initReactI18next).init({
   resources: {
     en: { translation: en },
   },
-  lng: "en",
-  fallbackLng: "en",
+  lng: 'en',
+  fallbackLng: 'en',
   interpolation: {
     escapeValue: false,
   },
 });
 
 export async function loadLanguage(lang: string): Promise<void> {
-  if (lang === "en") return;
-  if (i18n.hasResourceBundle(lang, "translation")) return;
-  const messages = await import(`./locales/${lang}.json`);
-  i18n.addResourceBundle(lang, "translation", messages.default);
+  const resolvedLang = resolveLanguage(lang);
+
+  if (resolvedLang === 'en') return;
+  if (i18n.hasResourceBundle(resolvedLang, 'translation')) return;
+
+  const localeLoader = localeLoaders[resolvedLang];
+
+  if (!localeLoader) {
+    return;
+  }
+
+  const messages = await localeLoader();
+  i18n.addResourceBundle(resolvedLang, 'translation', messages.default);
 }
 
 export default i18n;
+

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -1,5 +1,4 @@
-import "./i18n";
-import { loadLanguage } from "./i18n";
+import i18n, { loadLanguage, resolveLanguage } from "./i18n";
 import ReactDOM from "react-dom/client";
 import reportWebVitals from "./reportWebVitals";
 
@@ -13,15 +12,27 @@ import "./style/applies.css";
 // @ts-ignore
 import App from "./customization/custom-App";
 
-const detectedLang =
-  localStorage.getItem("languagePreference") ||
-  navigator.language.split("-")[0] ||
-  "en";
+const detectedLang = resolveLanguage(
+  localStorage.getItem("languagePreference") || navigator.language || "en",
+);
 
-loadLanguage(detectedLang).then(() => {
+const renderApp = () => {
   const root = ReactDOM.createRoot(
     document.getElementById("root") as HTMLElement,
   );
   root.render(<App />);
   reportWebVitals();
-});
+};
+
+const initializeApp = async () => {
+  try {
+    await loadLanguage(detectedLang);
+    await i18n.changeLanguage(detectedLang);
+  } catch {
+    await i18n.changeLanguage("en");
+  }
+
+  renderApp();
+};
+
+void initializeApp();


### PR DESCRIPTION
## Summary
- resolve browser and saved language preferences against supported locale bundles
- fall back unsupported locales like `ru-RU` and `ko-KR` to English instead of importing missing JSON files
- prevent blank screen during app startup when locale initialization fails
- add tests for unsupported locale fallback and Chinese locale normalization

## Testing
- npm test -- --runInBand src/i18n.test.ts
- make build_frontend

Fixes #12740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced language and locale detection with intelligent fallback to English for unsupported languages.
  * Improved handling of Chinese locale variants ensuring consistent language resource loading.

* **Bug Fixes**
  * Refined app initialization process to gracefully handle language loading failures with automatic fallback.

* **Tests**
  * Added comprehensive test coverage for locale normalization and unsupported language scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->