### PR TITLE
fix(frontend): show backend error detail on project upload failure

### DIFF
--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -1,4 +1,5 @@
 import { useIsFetching, useIsMutating } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
 import { useEffect, useRef, useState } from "react";
 import { useLocation, useParams } from "react-router-dom";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
@@ -166,9 +167,17 @@ const SideBarFoldersButtonsComponent = ({
                   },
                   onError: (err) => {
                     console.error(err);
+                    const axiosErr = err as AxiosError<{
+                      detail?: string;
+                      message?: string;
+                    }>;
+                    const detail =
+                      axiosErr?.response?.data?.detail ??
+                      axiosErr?.response?.data?.message ??
+                      (err instanceof Error ? err.message : String(err));
                     setErrorData({
                       title: t("sidebar.projectUploadError"),
-                      list: [err["response"]["data"]["message"]],
+                      list: [detail],
                     });
                   },
                 },

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -1,5 +1,4 @@
 import { useIsFetching, useIsMutating } from "@tanstack/react-query";
-import type { AxiosError } from "axios";
 import { useEffect, useRef, useState } from "react";
 import { useLocation, useParams } from "react-router-dom";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
@@ -167,17 +166,9 @@ const SideBarFoldersButtonsComponent = ({
                   },
                   onError: (err) => {
                     console.error(err);
-                    const axiosErr = err as AxiosError<{
-                      detail?: string;
-                      message?: string;
-                    }>;
-                    const detail =
-                      axiosErr?.response?.data?.detail ??
-                      axiosErr?.response?.data?.message ??
-                      (err instanceof Error ? err.message : String(err));
                     setErrorData({
                       title: t("sidebar.projectUploadError"),
-                      list: [detail],
+                      list: [err["response"]["data"]["detail"]],
                     });
                   },
                 },

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -168,7 +168,10 @@ const SideBarFoldersButtonsComponent = ({
                     console.error(err);
                     setErrorData({
                       title: t("sidebar.projectUploadError"),
-                      list: [err["response"]["data"]["detail"]],
+                      list: [
+                        err?.response?.data?.detail ??
+                          (err instanceof Error ? err.message : String(err)),
+                      ],
                     });
                   },
                 },


### PR DESCRIPTION
## Summary
- Swap sidebar upload error handler to read `err.response.data.detail` (FastAPI convention) instead of the non-existent `message` key.
- Guard with optional chaining + `Error.message` fallback so network/timeout errors don't crash the handler.
- Error alert now surfaces the real backend message (e.g. `"No flows found in the file"`) rather than an empty bullet.

Fixes #11293

## Test plan
- [x] Upload an empty or invalid JSON file (e.g. `[]`) from the sidebar upload action.
- [x] Confirm the error toast title shows the localized `sidebar.projectUploadError` and the list item shows the backend `detail` string.
- [x] Upload a valid project JSON; confirm success toast still fires.
- [x] `npx jest src/components/core/folderSidebarComponent` — 1 suite passed.