### PR TITLE
docs: clarify autosaving and versioned flow saving

### DIFF
--- a/docs/docs/Develop/environment-variables.mdx
+++ b/docs/docs/Develop/environment-variables.mdx
@@ -433,7 +433,7 @@ See [Telemetry](/contributing-telemetry).
 
 | Variable | Format | Default | Description |
 |----------|--------|---------|-------------|
-| `LANGFLOW_AUTO_SAVING` | Boolean | `True` | Whether to automatically save flows. |
+| `LANGFLOW_AUTO_SAVING` | Boolean | `True` | Whether to automatically save the current flow draft. Auto-save only updates the live draft, and doesn't create [saved flow versions](/concepts-flows#save-and-restore-flow-versions). |
 | `LANGFLOW_AUTO_SAVING_INTERVAL` | Integer | `1000` | Set the auto-save interval in milliseconds if `LANGFLOW_AUTO_SAVING=True`. |
 | `LANGFLOW_BUNDLE_URLS` | List[String] | `[]` | A list of URLs from which to load custom bundles. Supports GitHub URLs. If `LANGFLOW_AUTO_LOGIN=True`, flows from these bundles are loaded into the database. |
 | `LANGFLOW_COMPONENTS_PATH` | String | Not set | Path to a directory containing custom components. Typically used if you have local custom components or you are building a Docker image with custom components. |

--- a/docs/docs/Flows/concepts-flows.mdx
+++ b/docs/docs/Flows/concepts-flows.mdx
@@ -108,11 +108,17 @@ You can save versions of a flow from the <Icon name="History" aria-hidden="true"
 4. Select a previously saved version to preview the flow in read-only mode.
 5. To replace the current draft with the selected version, click **Restore**.
 
-When restoring a version, you can keep **Save current draft before restoring** enabled to create a backup of your current work before the selected version replaces it.
-
 From a saved version's <Icon name="EllipsesVertical" aria-hidden="true" /> menu, you can also **Export** or **Delete** that version.
 
 Saved flow versions are stored in the database configured for your Langflow deployment.
+
+When restoring a saved version, keep **Save current draft before restoring** enabled to create a backup of your current work before the selected version replaces it.
+
+[Flow auto-save](/environment-variables#visual-editor-and-playground-behavior) and flow versions serve different purposes.
+Auto-save keeps your current flow draft up to date in the background, but it doesn't create version entries.
+A saved _version_ is an explicit snapshot that you create when you want a restore point.
+
+When previewing a saved version, Langflow temporarily pauses auto-save so the preview doesn't overwrite your current draft.
 
 ### Lock a flow
 

--- a/docs/docs/Flows/concepts-flows.mdx
+++ b/docs/docs/Flows/concepts-flows.mdx
@@ -112,7 +112,7 @@ From a saved version's <Icon name="EllipsesVertical" aria-hidden="true" /> menu,
 
 Saved flow versions are stored in the database configured for your Langflow deployment.
 
-When restoring a saved version, keep **Save current draft before restoring** enabled to create a backup of your current work before the selected version replaces it.
+When restoring a saved version, if **Save current draft before restoring** is enabled, then Langflow creates a backup of your current work before the selected version replaces it.
 
 [Flow auto-save](/environment-variables#visual-editor-and-playground-behavior) and flow versions serve different purposes.
 Auto-save keeps your current flow draft up to date in the background, but it doesn't create version entries.

--- a/docs/versioned_docs/version-1.9.0/Develop/environment-variables.mdx
+++ b/docs/versioned_docs/version-1.9.0/Develop/environment-variables.mdx
@@ -433,7 +433,7 @@ See [Telemetry](/contributing-telemetry).
 
 | Variable | Format | Default | Description |
 |----------|--------|---------|-------------|
-| `LANGFLOW_AUTO_SAVING` | Boolean | `True` | Whether to automatically save flows. |
+| `LANGFLOW_AUTO_SAVING` | Boolean | `True` | Whether to automatically save the current flow draft. Auto-save only updates the live draft, and doesn't create [saved flow versions](/concepts-flows#save-and-restore-flow-versions). |
 | `LANGFLOW_AUTO_SAVING_INTERVAL` | Integer | `1000` | Set the auto-save interval in milliseconds if `LANGFLOW_AUTO_SAVING=True`. |
 | `LANGFLOW_BUNDLE_URLS` | List[String] | `[]` | A list of URLs from which to load custom bundles. Supports GitHub URLs. If `LANGFLOW_AUTO_LOGIN=True`, flows from these bundles are loaded into the database. |
 | `LANGFLOW_COMPONENTS_PATH` | String | Not set | Path to a directory containing custom components. Typically used if you have local custom components or you are building a Docker image with custom components. |

--- a/docs/versioned_docs/version-1.9.0/Flows/concepts-flows.mdx
+++ b/docs/versioned_docs/version-1.9.0/Flows/concepts-flows.mdx
@@ -108,11 +108,17 @@ You can save versions of a flow from the <Icon name="History" aria-hidden="true"
 4. Select a previously saved version to preview the flow in read-only mode.
 5. To replace the current draft with the selected version, click **Restore**.
 
-When restoring a version, you can keep **Save current draft before restoring** enabled to create a backup of your current work before the selected version replaces it.
-
 From a saved version's <Icon name="EllipsesVertical" aria-hidden="true" /> menu, you can also **Export** or **Delete** that version.
 
 Saved flow versions are stored in the database configured for your Langflow deployment.
+
+When restoring a saved version, keep **Save current draft before restoring** enabled to create a backup of your current work before the selected version replaces it.
+
+[Flow auto-save](/environment-variables#visual-editor-and-playground-behavior) and flow versions serve different purposes.
+Auto-save keeps your current flow draft up to date in the background, but it doesn't create version entries.
+A saved _version_ is an explicit snapshot that you create when you want a restore point.
+
+When previewing a saved version, Langflow temporarily pauses auto-save so the preview doesn't overwrite your current draft.
 
 ### Lock a flow
 

--- a/docs/versioned_docs/version-1.9.0/Flows/concepts-flows.mdx
+++ b/docs/versioned_docs/version-1.9.0/Flows/concepts-flows.mdx
@@ -112,7 +112,7 @@ From a saved version's <Icon name="EllipsesVertical" aria-hidden="true" /> menu,
 
 Saved flow versions are stored in the database configured for your Langflow deployment.
 
-When restoring a saved version, keep **Save current draft before restoring** enabled to create a backup of your current work before the selected version replaces it.
+When restoring a saved version, if **Save current draft before restoring** is enabled, then Langflow creates a backup of your current work before the selected version replaces it.
 
 [Flow auto-save](/environment-variables#visual-editor-and-playground-behavior) and flow versions serve different purposes.
 Auto-save keeps your current flow draft up to date in the background, but it doesn't create version entries.


### PR DESCRIPTION
Clarify how LANGFLOW_AUTO_SAVING and versioned flow saving interact with each other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `LANGFLOW_AUTO_SAVING` updates only the current live draft and does not create version entries.
  * Added explanation distinguishing auto-save from saved flow versions as explicit restore-point snapshots.
  * Documented that auto-save pauses during saved-version preview to prevent accidental draft overwrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->