### PR TITLE
fix typos: "occured" → "occurred", "recieved" → "received"

### DIFF
--- a/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/content-view.tsx
+++ b/src/frontend/src/modals/IOModal/components/chatView/chatMessage/components/content-view.tsx
@@ -67,7 +67,7 @@ export const ErrorView = ({
                             {content.component && (
                               <>
                                 <span>
-                                  An error occured in the{" "}
+                                  An error occurred in the{" "}
                                   <span
                                     className={cn(
                                       closeChat ?? "cursor-pointer underline",

--- a/src/frontend/tests/fixtures.ts
+++ b/src/frontend/tests/fixtures.ts
@@ -174,7 +174,7 @@ export const test = base.extend({
               /AttributeError: .+/,
               /ImportError: .+/,
               /KeyError: .+/,
-              /An error occured .+/,
+              /An error occurred .+/,
             ];
 
             for (const pattern of exceptionPatterns) {

--- a/src/lfx/src/lfx/components/cuga/cuga_agent.py
+++ b/src/lfx/src/lfx/components/cuga/cuga_agent.py
@@ -282,7 +282,7 @@ class CugaComponent(ToolCallingAgentComponent):
                 async for event in cuga_agent.run_task_generic_yield(
                     eval_mode=False, goal=current_input, chat_messages=lc_messages
                 ):
-                    logger.debug(f"[CUGA] recieved event {event}")
+                    logger.debug(f"[CUGA] received event {event}")
                     if last_event is not None and tool_run_id is not None:
                         logger.debug(f"[CUGA] last event {last_event}")
                         try:


### PR DESCRIPTION

**Repo:** langflow-ai/langflow (⭐ 147165)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Corrects three misspellings in the codebase:
1. `src/frontend/src/modals/IOModal/.../content-view.tsx` — "An error occured in the" → "An error occurred in the" (user-facing chat error message).
2. `src/frontend/tests/fixtures.ts` — exception-pattern regex updated from `/An error occured .+/` to `/An error occurred .+/` so the Playwright fixture continues to match the corrected UI string.
3. `src/lfx/src/lfx/components/cuga/cuga_agent.py` — debug log "[CUGA] recieved event" → "[CUGA] received event".

## Why
"occured" and "recieved" are common English misspellings. Fixing the chat error message improves polish in a UI string that end-users see. The test fixture was updated in the same patch so the exception-pattern regex stays in sync with the corrected user-facing copy (otherwise the Playwright check would silently stop matching). The CUGA debug log fix is a tiny consistency improvement.

## Testing
- `git diff --stat` confirms 3 files / +3/-3 lines, all string-only changes.
- No logic or types touched; the regex update mirrors the literal UI string change exactly.
- Did not run the full Playwright/pytest suites (out of scope for a string-only patch).

## Risk
Low — string-only edits; the Playwright fixture regex was updated together with its target string to avoid drift.
