### PR TITLE
fix(kb): address 4 CRITICAL findings from review of #12802

### DIFF
--- a/src/backend/base/langflow/alembic/versions/e728126476a8_add_kb_id_to_ingestion_run.py
+++ b/src/backend/base/langflow/alembic/versions/e728126476a8_add_kb_id_to_ingestion_run.py
@@ -18,6 +18,7 @@ from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
+from langflow.utils import migration
 
 # revision identifiers, used by Alembic.
 revision: str = "e728126476a8"  # pragma: allowlist secret
@@ -28,36 +29,55 @@ depends_on: str | Sequence[str] | None = None
 TABLE_NAME = "ingestion_run"
 COLUMN_NAME = "kb_id"
 INDEX_NAME = "ix_ingestion_run_kb_id"
+FK_NAME = "fk_ingestion_run_kb_id_knowledge_base"
+REF_TABLE = "knowledge_base"
 
 
 def upgrade() -> None:
     conn = op.get_bind()
-    inspector = sa.inspect(conn)
-    if not inspector.has_table(TABLE_NAME):
+    if not migration.table_exists(TABLE_NAME, conn):
         return
 
-    existing_columns = {col["name"] for col in inspector.get_columns(TABLE_NAME)}
-    if COLUMN_NAME not in existing_columns:
+    if not migration.column_exists(TABLE_NAME, COLUMN_NAME, conn):
         op.add_column(TABLE_NAME, sa.Column(COLUMN_NAME, sa.Uuid(), nullable=True))
 
+    inspector = sa.inspect(conn)
     existing_indexes = {idx["name"] for idx in inspector.get_indexes(TABLE_NAME)}
     if INDEX_NAME not in existing_indexes:
         with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
             batch_op.create_index(batch_op.f(INDEX_NAME), [COLUMN_NAME], unique=False)
 
+    # Enforce referential integrity at the DB layer. ``ON DELETE SET NULL``
+    # keeps run history readable after a KB is deleted (runs show
+    # "deleted KB" rather than disappearing) while guaranteeing no
+    # dangling ``kb_id`` values. Only create when the target table
+    # exists and the FK isn't already present.
+    if migration.table_exists(REF_TABLE, conn) and not migration.foreign_key_exists(TABLE_NAME, FK_NAME, conn):
+        with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
+            batch_op.create_foreign_key(
+                FK_NAME,
+                REF_TABLE,
+                [COLUMN_NAME],
+                ["id"],
+                ondelete="SET NULL",
+            )
+
 
 def downgrade() -> None:
     conn = op.get_bind()
-    inspector = sa.inspect(conn)
-    if not inspector.has_table(TABLE_NAME):
+    if not migration.table_exists(TABLE_NAME, conn):
         return
 
+    if migration.foreign_key_exists(TABLE_NAME, FK_NAME, conn):
+        with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
+            batch_op.drop_constraint(FK_NAME, type_="foreignkey")
+
+    inspector = sa.inspect(conn)
     existing_indexes = {idx["name"] for idx in inspector.get_indexes(TABLE_NAME)}
     if INDEX_NAME in existing_indexes:
         with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
             batch_op.drop_index(batch_op.f(INDEX_NAME))
 
-    existing_columns = {col["name"] for col in inspector.get_columns(TABLE_NAME)}
-    if COLUMN_NAME in existing_columns:
+    if migration.column_exists(TABLE_NAME, COLUMN_NAME, conn):
         with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
             batch_op.drop_column(COLUMN_NAME)

--- a/src/backend/base/langflow/api/utils/knowledge_base_service.py
+++ b/src/backend/base/langflow/api/utils/knowledge_base_service.py
@@ -304,6 +304,14 @@ async def backfill_from_disk(
         try:
             model_selection = _normalize_model_selection(metadata.get("model_selection"))
             record_id = _coerce_uuid(metadata.get("id")) or uuid4()
+            # ``backend_type``/``backend_config`` are persisted by
+            # ``create_knowledge_base`` into ``embedding_metadata.json``
+            # precisely so a later backfill can reconstruct the correct
+            # routing. Fall back to "chroma" only when the file
+            # predates the multi-backend change (legacy KBs).
+            backend_type = str(metadata.get("backend_type") or "chroma")
+            backend_config_raw = metadata.get("backend_config") or {}
+            backend_config = backend_config_raw if isinstance(backend_config_raw, dict) else {}
             await create_record(
                 user_id=user_id,
                 name=name,
@@ -314,6 +322,8 @@ async def backfill_from_disk(
                 chunk_overlap=int(metadata.get("chunk_overlap") or 200),
                 separator=metadata.get("separator"),
                 column_config=metadata.get("column_config") or [],
+                backend_type=backend_type,
+                backend_config=backend_config,
                 record_id=record_id,
             )
             inserted += 1

--- a/src/backend/base/langflow/api/v1/knowledge_bases.py
+++ b/src/backend/base/langflow/api/v1/knowledge_bases.py
@@ -135,7 +135,14 @@ async def create_knowledge_base(
         if request.column_config:
             column_config_dicts = [item.model_dump() for item in request.column_config]
 
-        # Save full embedding metadata to prevent immediate backfill
+        # Save full embedding metadata to prevent immediate backfill.
+        # ``backend_type``/``backend_config`` are persisted here too so
+        # a later ``backfill_from_disk`` reconstructs the correct
+        # backend routing even if the DB write below fails.
+        # ``backend_config`` holds only *variable names* (never raw
+        # secrets) per the credential-indirection contract.
+        backend_type_value = request.backend_type or "chroma"
+        backend_config_value = request.backend_config or {}
         embedding_metadata = {
             "id": str(kb_id),
             "embedding_provider": request.embedding_provider,
@@ -147,6 +154,8 @@ async def create_knowledge_base(
             "avg_chunk_size": 0.0,
             "size": 0,
             "column_config": column_config_dicts,
+            "backend_type": backend_type_value,
+            "backend_config": backend_config_value,
         }
         metadata_path = kb_path / "embedding_metadata.json"
         metadata_path.write_text(json.dumps(embedding_metadata, indent=2))
@@ -160,6 +169,16 @@ async def create_knowledge_base(
         # Dual-write: persist the identity + config to the DB alongside
         # the JSON file so older service versions still see the legacy
         # on-disk view, while new code reads from the DB first.
+        #
+        # For Chroma (the default backend) a missing DB row is recoverable
+        # — the next ``backfill_from_disk`` reads ``embedding_metadata.json``
+        # and upserts the row. For non-default backends (MongoDB, Postgres,
+        # Astra) we now also persist ``backend_type``/``backend_config`` to
+        # the JSON file so the backfill *can* round-trip them, but the DB
+        # remains the source of truth during the lifetime of this request.
+        # Any DB failure would cause the very next call (ingest, chunks)
+        # to fall back to Chroma and silently route to the wrong store,
+        # so we surface it immediately and roll the on-disk state back.
         try:
             await knowledge_base_service.create_record(
                 user_id=current_user.id,
@@ -167,14 +186,31 @@ async def create_knowledge_base(
                 embedding_provider=request.embedding_provider,
                 embedding_model=request.embedding_model,
                 column_config=column_config_dicts or [],
-                backend_type=request.backend_type or "chroma",
-                backend_config=request.backend_config or {},
+                backend_type=backend_type_value,
+                backend_config=backend_config_value,
                 record_id=kb_id,
             )
-        except Exception as exc:  # noqa: BLE001
-            # JSON file is already written; the next backfill on boot
-            # will upsert the missing row. Don't fail the create call
-            # for a DB-side glitch.
+        except Exception as exc:
+            if backend_type_value != "chroma":
+                # Non-default backend: the JSON fallback is insufficient
+                # because downstream code needs ``backend_type`` in the
+                # DB row to route reads/writes. Roll back the filesystem
+                # state and surface a 500 so the caller retries.
+                await logger.aerror(
+                    "KB DB persist failed for non-default backend %s (kb=%s): %s — rolling back",
+                    backend_type_value,
+                    kb_name,
+                    exc,
+                )
+                KBStorageHelper.delete_storage(kb_path, kb_name)
+                raise HTTPException(
+                    status_code=500,
+                    detail=(
+                        f"Failed to persist knowledge base '{kb_name}' with backend "
+                        f"'{backend_type_value}'. Please retry."
+                    ),
+                ) from exc
+            # Chroma fallback path: the next backfill will upsert.
             await logger.awarning("KB DB persist failed for %s; relying on JSON fallback: %s", kb_name, exc)
 
         return KnowledgeBaseInfo(

--- a/src/backend/base/langflow/services/database/models/ingestion_run/model.py
+++ b/src/backend/base/langflow/services/database/models/ingestion_run/model.py
@@ -29,7 +29,8 @@ from enum import Enum
 from typing import Any
 from uuid import UUID, uuid4
 
-from sqlalchemy import JSON, Column, DateTime
+import sqlalchemy as sa
+from sqlalchemy import JSON, Column, DateTime, ForeignKey
 from sqlmodel import Field, SQLModel
 
 
@@ -55,7 +56,20 @@ class IngestionRunBase(SQLModel):
     # ``kb_name`` is the legacy pointer (kept through an
     # expand-contract transition); ``kb_id`` is the new FK.
     kb_name: str = Field(index=True, nullable=False)
-    kb_id: UUID | None = Field(default=None, index=True, nullable=True)
+    # ``kb_id`` is the FK; ``ON DELETE SET NULL`` is set at the DB
+    # layer so KB deletion does not orphan run history — rows remain
+    # visible with a null kb_id. The physical FK constraint is
+    # created by migration ``e728126476a8``; this ``sa_column`` makes
+    # the ORM aware of it so relationships resolve correctly.
+    kb_id: UUID | None = Field(
+        default=None,
+        sa_column=Column(
+            sa.Uuid(),
+            ForeignKey("knowledge_base.id", ondelete="SET NULL"),
+            index=True,
+            nullable=True,
+        ),
+    )
     user_id: UUID | None = Field(default=None, index=True, nullable=True)
 
     source_type: str = Field(index=True, nullable=False)

--- a/src/lfx/src/lfx/base/knowledge_bases/backends/astra.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/backends/astra.py
@@ -16,7 +16,8 @@ the UI.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+from typing import TYPE_CHECKING, Any
 
 from lfx.base.knowledge_bases.backends.base import (
     BackendType,
@@ -98,7 +99,7 @@ class AstraBackend(BaseVectorStoreBackend):
         if collection is None:
             return 0
         try:
-            return int(collection.count_documents())
+            return int(await asyncio.to_thread(collection.count_documents))
         except Exception as exc:  # noqa: BLE001
             logger.debug("Astra count_documents failed: %s", exc)
             return 0
@@ -119,29 +120,48 @@ class AstraBackend(BaseVectorStoreBackend):
         if include_embeddings:
             projection["$vector"] = 1
 
-        batch: list[IngestedDocument] = []
         try:
-            cursor = collection.find({}, projection=projection)
+            cursor = await asyncio.to_thread(collection.find, {}, projection=projection)
         except Exception as exc:  # noqa: BLE001
             logger.debug("Astra cursor open failed: %s", exc)
             return
 
-        for raw in cursor:
-            content = raw.get("content") or raw.get("text") or ""
-            metadata = raw.get("metadata") or {}
-            embedding = raw.get("$vector") if include_embeddings else None
-            batch.append(
-                IngestedDocument(
-                    content=str(content),
-                    metadata=dict(metadata) if isinstance(metadata, dict) else {},
-                    embedding=list(embedding) if embedding else None,
-                )
-            )
-            if len(batch) >= batch_size:
-                yield batch
-                batch = []
-        if batch:
-            yield batch
+        def _fetch_chunk(cursor_iter: Any, limit: int) -> list[dict[str, Any]]:
+            collected: list[dict[str, Any]] = []
+            for _ in range(limit):
+                try:
+                    collected.append(next(cursor_iter))
+                except StopIteration:
+                    break
+            return collected
+
+        cursor_iter = iter(cursor)
+        try:
+            while True:
+                raw_docs = await asyncio.to_thread(_fetch_chunk, cursor_iter, batch_size)
+                if not raw_docs:
+                    break
+                batch: list[IngestedDocument] = []
+                for raw in raw_docs:
+                    content = raw.get("content") or raw.get("text") or ""
+                    metadata = raw.get("metadata") or {}
+                    embedding = raw.get("$vector") if include_embeddings else None
+                    batch.append(
+                        IngestedDocument(
+                            content=str(content),
+                            metadata=dict(metadata) if isinstance(metadata, dict) else {},
+                            embedding=list(embedding) if embedding else None,
+                        )
+                    )
+                if batch:
+                    yield batch
+        finally:
+            close = getattr(cursor, "close", None)
+            if callable(close):
+                try:
+                    await asyncio.to_thread(close)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("Astra cursor close failed: %s", exc)
 
     async def storage_size_bytes(self) -> int:
         # Astra doesn't surface a simple bytes figure; approximate via
@@ -158,8 +178,8 @@ class AstraBackend(BaseVectorStoreBackend):
         try:
             # langchain_astradb exposes a clear() helper on recent versions.
             if hasattr(store, "clear"):
-                store.clear()
+                await asyncio.to_thread(store.clear)
             elif hasattr(store, "delete_collection"):
-                store.delete_collection()
+                await asyncio.to_thread(store.delete_collection)
         except Exception as exc:  # noqa: BLE001
             logger.debug("Astra clear/delete_collection failed: %s", exc)

--- a/src/lfx/src/lfx/base/knowledge_bases/backends/mongodb.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/backends/mongodb.py
@@ -25,6 +25,7 @@ selects this backend without installing the extra.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from lfx.base.knowledge_bases.backends.base import (
@@ -125,7 +126,7 @@ class MongoDBBackend(BaseVectorStoreBackend):
             client = self._mongo_client
         try:
             collection = client[self._required("database")][self._required("collection")]
-            return int(collection.estimated_document_count())
+            return int(await asyncio.to_thread(collection.estimated_document_count))
         except Exception as exc:  # noqa: BLE001
             logger.debug("MongoDB count() failed for %s: %s", self.kb_name, exc)
             return 0
@@ -151,32 +152,53 @@ class MongoDBBackend(BaseVectorStoreBackend):
         if include_embeddings:
             projection[embedding_key] = 1
 
-        batch: list[IngestedDocument] = []
-        for raw in collection.find({}, projection=projection):
-            content = raw.get(text_key) or ""
-            metadata = raw.get("metadata") or {
-                k: v for k, v in raw.items() if k not in {text_key, embedding_key, "_id", "metadata"}
-            }
-            embedding = raw.get(embedding_key) if include_embeddings else None
-            batch.append(
-                IngestedDocument(
-                    content=str(content),
-                    metadata=dict(metadata) if isinstance(metadata, dict) else {},
-                    embedding=list(embedding) if embedding else None,
-                )
-            )
-            if len(batch) >= batch_size:
-                yield batch
-                batch = []
-        if batch:
-            yield batch
+        # Iterate the sync pymongo cursor off the event loop, fetching
+        # ``batch_size`` documents per hop so we never block the loop
+        # on a full collection scan.
+        def _fetch_chunk(cursor_iter: Any, limit: int) -> list[dict[str, Any]]:
+            collected: list[dict[str, Any]] = []
+            for _ in range(limit):
+                try:
+                    collected.append(next(cursor_iter))
+                except StopIteration:
+                    break
+            return collected
+
+        cursor = collection.find({}, projection=projection).batch_size(batch_size)
+        cursor_iter = iter(cursor)
+        try:
+            while True:
+                raw_docs = await asyncio.to_thread(_fetch_chunk, cursor_iter, batch_size)
+                if not raw_docs:
+                    break
+                batch: list[IngestedDocument] = []
+                for raw in raw_docs:
+                    content = raw.get(text_key) or ""
+                    metadata = raw.get("metadata") or {
+                        k: v for k, v in raw.items() if k not in {text_key, embedding_key, "_id", "metadata"}
+                    }
+                    embedding = raw.get(embedding_key) if include_embeddings else None
+                    batch.append(
+                        IngestedDocument(
+                            content=str(content),
+                            metadata=dict(metadata) if isinstance(metadata, dict) else {},
+                            embedding=list(embedding) if embedding else None,
+                        )
+                    )
+                if batch:
+                    yield batch
+        finally:
+            await asyncio.to_thread(cursor.close)
 
     async def storage_size_bytes(self) -> int:
         client = getattr(self, "_mongo_client", None)
         if client is None:
             return 0
         try:
-            stats = client[self._required("database")].command({"collStats": self._required("collection")})
+            stats = await asyncio.to_thread(
+                client[self._required("database")].command,
+                {"collStats": self._required("collection")},
+            )
             return int(stats.get("size") or 0)
         except Exception as exc:  # noqa: BLE001
             logger.debug("MongoDB collStats failed for %s: %s", self.kb_name, exc)
@@ -186,7 +208,7 @@ class MongoDBBackend(BaseVectorStoreBackend):
         client = getattr(self, "_mongo_client", None)
         if client is not None:
             try:
-                client.close()
+                await asyncio.to_thread(client.close)
             except Exception as exc:  # noqa: BLE001
                 logger.debug("MongoClient.close failed: %s", exc)
         self._mongo_client = None
@@ -199,6 +221,9 @@ class MongoDBBackend(BaseVectorStoreBackend):
             _ = self.vector_store
             client = self._mongo_client
         try:
-            client[self._required("database")].drop_collection(self._required("collection"))
+            await asyncio.to_thread(
+                client[self._required("database")].drop_collection,
+                self._required("collection"),
+            )
         except Exception as exc:  # noqa: BLE001
             logger.debug("MongoDB drop_collection failed: %s", exc)

--- a/src/lfx/src/lfx/base/knowledge_bases/backends/postgres.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/backends/postgres.py
@@ -18,6 +18,7 @@ credentials.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from lfx.base.knowledge_bases.backends.base import (
@@ -94,14 +95,18 @@ class PostgresBackend(BaseVectorStoreBackend):
         session_maker = getattr(store, "_session_maker", None) or getattr(store, "session_maker", None)
         if session_maker is None:
             return 0
-        try:
-            with session_maker() as session:
-                result = session.execute(_select_count_query(store))
-                row = result.first()
-                return int(row[0]) if row else 0
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Postgres count query failed: %s", exc)
-            return 0
+
+        def _run() -> int:
+            try:
+                with session_maker() as session:
+                    result = session.execute(_select_count_query(store))
+                    row = result.first()
+                    return int(row[0]) if row else 0
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Postgres count query failed: %s", exc)
+                return 0
+
+        return await asyncio.to_thread(_run)
 
     async def iter_documents(
         self,
@@ -115,13 +120,37 @@ class PostgresBackend(BaseVectorStoreBackend):
         if session_maker is None:
             return
 
-        try:
-            with session_maker() as session:
+        # Execute the query and fetch rows off the event loop in
+        # ``batch_size`` chunks via ``result.fetchmany``. The session
+        # stays open across thread hops — this is safe because only
+        # one thread touches it at a time.
+        def _open_session_and_execute() -> tuple[Any, Any]:
+            session = session_maker()
+            try:
                 query = _select_rows_query(store, include_embeddings=include_embeddings)
                 result = session.execute(query)
+            except Exception:
+                session.close()
+                raise
+            return session, result
 
+        try:
+            session, result = await asyncio.to_thread(_open_session_and_execute)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Postgres iter_documents failed to start: %s", exc)
+            return
+
+        try:
+            while True:
+                try:
+                    rows = await asyncio.to_thread(result.fetchmany, batch_size)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("Postgres iter_documents fetch failed: %s", exc)
+                    break
+                if not rows:
+                    break
                 batch: list[IngestedDocument] = []
-                for row in result:
+                for row in rows:
                     content = row[0] or ""
                     metadata = row[1] or {}
                     embedding: list[float] | None = None
@@ -136,14 +165,10 @@ class PostgresBackend(BaseVectorStoreBackend):
                             embedding=embedding,
                         )
                     )
-                    if len(batch) >= batch_size:
-                        yield batch
-                        batch = []
                 if batch:
                     yield batch
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Postgres iter_documents failed: %s", exc)
-            return
+        finally:
+            await asyncio.to_thread(session.close)
 
     async def storage_size_bytes(self) -> int:
         return 0
@@ -154,7 +179,7 @@ class PostgresBackend(BaseVectorStoreBackend):
             engine = getattr(store, "_engine", None) or getattr(store, "engine", None)
             if engine is not None and hasattr(engine, "dispose"):
                 try:
-                    engine.dispose()
+                    await asyncio.to_thread(engine.dispose)
                 except Exception as exc:  # noqa: BLE001
                     logger.debug("PGVector engine.dispose failed: %s", exc)
         self._vector_store = None
@@ -163,7 +188,7 @@ class PostgresBackend(BaseVectorStoreBackend):
         store = self.vector_store
         if hasattr(store, "delete_collection"):
             try:
-                store.delete_collection()
+                await asyncio.to_thread(store.delete_collection)
             except Exception as exc:  # noqa: BLE001
                 logger.debug("PGVector delete_collection failed: %s", exc)
 

--- a/src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/s3.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/s3.py
@@ -17,6 +17,7 @@ setting ``endpoint_url_variable`` and optionally ``region_variable``.
 
 from __future__ import annotations
 
+import asyncio
 import mimetypes
 from typing import TYPE_CHECKING, Any
 
@@ -141,7 +142,9 @@ class S3Source(KBConnectorSource):
         if endpoint_url:
             client_kwargs["endpoint_url"] = endpoint_url
 
-        return boto3.client("s3", **client_kwargs)
+        # boto3.client construction does disk + config I/O (loading
+        # botocore data, parsing ~/.aws). Run it off the event loop.
+        return await asyncio.to_thread(boto3.client, "s3", **client_kwargs)
 
     def _matches_extension(self, key: str, allowed: tuple[str, ...]) -> bool:
         if "." not in key:
@@ -169,7 +172,21 @@ class S3Source(KBConnectorSource):
 
         client = await self._build_client()
         paginator = client.get_paginator("list_objects_v2")
-        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+
+        # boto3 paginator is a sync iterable over HTTP calls. Fetch
+        # one page per thread hop so the event loop stays free between
+        # pages.
+        def _fetch_next_page(iterator: Any) -> dict[str, Any] | None:
+            try:
+                return next(iterator)
+            except StopIteration:
+                return None
+
+        page_iter = iter(paginator.paginate(Bucket=bucket, Prefix=prefix))
+        while True:
+            page = await asyncio.to_thread(_fetch_next_page, page_iter)
+            if page is None:
+                break
             for obj in page.get("Contents", []) or []:
                 key = obj.get("Key")
                 if not key or key.endswith("/"):
@@ -198,8 +215,12 @@ class S3Source(KBConnectorSource):
     async def fetch_content(self, item: IngestionItem) -> IngestionItemContent:
         bucket = self.source_config["bucket"]
         client = await self._build_client()
-        response = client.get_object(Bucket=bucket, Key=item.item_id)
-        body = response["Body"].read()
+
+        def _download() -> bytes:
+            response = client.get_object(Bucket=bucket, Key=item.item_id)
+            return response["Body"].read()
+
+        body = await asyncio.to_thread(_download)
         file_name = item.item_id.rsplit("/", 1)[-1] or item.item_id
         return IngestionItemContent(raw_bytes=bytes(body), file_name=file_name)
 


### PR DESCRIPTION
## Summary

Addresses the four CRITICAL findings raised by the PR #12802 parallel review (Python backend + DB migration + security agents).

- **Async-safety:** wrap sync `pymongo`, SQLAlchemy, `astrapy`, and `boto3` calls in `asyncio.to_thread` so MongoDB, Postgres, Astra, and S3 backends no longer block the event loop during `count`, `iter_documents`, `fetch_content`, teardown, and collection drops. The cursor loops fetch `batch_size` docs per thread hop so large collections don't stall the loop either.
- **Dual-write atomicity:** `create_knowledge_base` now persists `backend_type`/`backend_config` into `embedding_metadata.json` so the JSON fallback is sufficient. For non-Chroma backends a DB-insert failure rolls back the filesystem state and returns 500 instead of silently letting the backfill later upsert the row as Chroma. `backfill_from_disk` reads the new fields so legacy + new KBs round-trip correctly.
- **Referential integrity:** add `fk_ingestion_run_kb_id_knowledge_base` with `ON DELETE SET NULL` in migration `e728126476a8`, and mirror it on the `IngestionRun` SQLModel via `sa_column=Column(..., ForeignKey(..., ondelete="SET NULL"))`. Runs stay visible with a null `kb_id` after a KB is deleted instead of becoming orphans.
- **Migration style consistency:** switch `e728126476a8` to the repo's `migration.{table,column,foreign_key}_exists` helpers so idempotency matches the two sibling migrations added in this epic.

## Test plan

- [ ] Pre-commit hooks all green locally (ruff, ruff-format, migration validator, detect-secrets)
- [ ] CI backend unit groups — in particular `test_knowledge_base_service`, `test_ingestion_run_endpoints`, `test_chroma_backend`, `test_s3_source`
- [ ] Alembic migration validator stays green for `e728126476a8`
- [ ] Smoke: create a MongoDB-backed KB with a simulated DB failure → verify 500 + filesystem rolled back (no stray KB directory)
- [ ] Smoke: delete a KB with runs → verify `ingestion_run.kb_id` goes to NULL instead of rows disappearing
- [ ] Smoke: ingest 10k+ docs through the MongoDB/Astra/Postgres backends → event loop stays responsive under concurrent traffic (no latency spikes on other async routes)

## Out of scope — HIGH findings to follow up separately

- `user_id` FK to `user` on `knowledge_base`
- `total_bytes` int32 → BigInteger
- JSON → JSONB + CHECK constraints on status columns
- Frontend fire-and-forget connector ingestion after modal close
- `backendType as BackendValue` unsound cast
- Unbounded `chunk_size`/`max_chunks` → trivial authenticated OOM
- Second security pass against the OAuth/connector files the first pass couldn't reach

See the review notes on #12802 for the full list.