### PR TITLE
fix(kb): address 13 HIGH findings from review of #12802

### DIFF
--- a/src/backend/base/langflow/alembic/versions/15fe9304bca7_add_knowledge_base_table.py
+++ b/src/backend/base/langflow/alembic/versions/15fe9304bca7_add_knowledge_base_table.py
@@ -18,7 +18,18 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 from langflow.utils import migration
+from sqlalchemy import JSON
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel.sql.sqltypes import AutoString
+
+# Use JSONB on Postgres (binary, dedup, GIN-indexable) and fall back to
+# JSON on SQLite / other dialects. Same type binding used on the
+# matching SQLModel so ORM and DDL agree.
+JsonVariant = JSON().with_variant(JSONB(), "postgresql")
+
+# Allow-list for ``knowledge_base.status``. Keep in sync with
+# ``KnowledgeBaseStatus`` (services/database/models/knowledge_base/model.py).
+KB_STATUS_VALUES = ("creating", "ready", "ingesting", "failed")
 
 # revision identifiers, used by Alembic.
 revision: str = "15fe9304bca7"  # pragma: allowlist secret
@@ -35,6 +46,7 @@ def upgrade() -> None:
     if migration.table_exists(TABLE_NAME, conn):
         return
 
+    status_values = ", ".join(f"'{v}'" for v in KB_STATUS_VALUES)
     op.create_table(
         TABLE_NAME,
         sa.Column("id", sa.Uuid(), nullable=False),
@@ -42,24 +54,33 @@ def upgrade() -> None:
         sa.Column("user_id", sa.Uuid(), nullable=False),
         sa.Column("embedding_provider", AutoString(), nullable=False),
         sa.Column("embedding_model", AutoString(), nullable=False),
-        sa.Column("model_selection", sa.JSON(), nullable=False),
+        sa.Column("model_selection", JsonVariant, nullable=False),
         sa.Column("chunk_size", sa.Integer(), nullable=False, server_default="1000"),
         sa.Column("chunk_overlap", sa.Integer(), nullable=False, server_default="200"),
         sa.Column("separator", AutoString(), nullable=True),
-        sa.Column("column_config", sa.JSON(), nullable=False),
+        sa.Column("column_config", JsonVariant, nullable=False),
         sa.Column("backend_type", AutoString(), nullable=False, server_default="chroma"),
-        sa.Column("backend_config", sa.JSON(), nullable=False),
+        sa.Column("backend_config", JsonVariant, nullable=False),
         sa.Column("chunks", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("words", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("characters", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("size_bytes", sa.BigInteger(), nullable=False, server_default="0"),
-        sa.Column("source_types", sa.JSON(), nullable=False),
+        sa.Column("source_types", JsonVariant, nullable=False),
         sa.Column("status", AutoString(), nullable=False, server_default="ready"),
         sa.Column("failure_reason", AutoString(), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_knowledge_base")),
         sa.UniqueConstraint("user_id", "name", name=UNIQUE_CONSTRAINT_NAME),
+        # Referential integrity: a deleted user takes their KBs with
+        # them. Application-level scoping already filters by user_id,
+        # but DB-enforced CASCADE prevents orphans from surviving a
+        # raw ``DELETE FROM user``.
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], name="fk_knowledge_base_user_id_user", ondelete="CASCADE"),
+        # Value allow-list mirrors the ``KnowledgeBaseStatus`` Python
+        # enum. A typo in app code now fails at COMMIT instead of
+        # silently storing an invalid state.
+        sa.CheckConstraint(f"status IN ({status_values})", name="ck_knowledge_base_status"),
     )
 
     with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:

--- a/src/backend/base/langflow/alembic/versions/72df732be86b_add_ingestion_run_table.py
+++ b/src/backend/base/langflow/alembic/versions/72df732be86b_add_ingestion_run_table.py
@@ -16,7 +16,17 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 from langflow.utils import migration
+from sqlalchemy import JSON
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel.sql.sqltypes import AutoString
+
+# JSONB on Postgres, JSON elsewhere — same variant used on the
+# matching SQLModel so ORM/DDL stay in sync.
+JsonVariant = JSON().with_variant(JSONB(), "postgresql")
+
+# Allow-list for ``ingestion_run.status``. Keep in sync with the
+# ``IngestionRunStatus`` Python enum.
+RUN_STATUS_VALUES = ("pending", "running", "succeeded", "partial", "failed", "cancelled")
 
 # revision identifiers, used by Alembic.
 revision: str = "72df732be86b"  # pragma: allowlist secret
@@ -32,6 +42,7 @@ def upgrade() -> None:
     if migration.table_exists(TABLE_NAME, conn):
         return
 
+    status_values = ", ".join(f"'{v}'" for v in RUN_STATUS_VALUES)
     op.create_table(
         TABLE_NAME,
         sa.Column("id", sa.Uuid(), nullable=False),
@@ -39,19 +50,26 @@ def upgrade() -> None:
         sa.Column("kb_name", AutoString(), nullable=False),
         sa.Column("user_id", sa.Uuid(), nullable=True),
         sa.Column("source_type", AutoString(), nullable=False),
-        sa.Column("source_config", sa.JSON(), nullable=False),
+        sa.Column("source_config", JsonVariant, nullable=False),
         sa.Column("status", AutoString(), nullable=False, server_default="pending"),
         sa.Column("error_message", AutoString(), nullable=True),
         sa.Column("total_items", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("succeeded", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("failed", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("skipped", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("total_bytes", sa.Integer(), nullable=False, server_default="0"),
+        # BigInteger: a run ingesting large cloud-storage blobs can
+        # exceed the 2 GB int32 ceiling. ``knowledge_base.size_bytes``
+        # uses BigInteger for the same reason.
+        sa.Column("total_bytes", sa.BigInteger(), nullable=False, server_default="0"),
         sa.Column("chunks_created", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("items", sa.JSON(), nullable=False),
+        sa.Column("items", JsonVariant, nullable=False),
         sa.Column("started_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
         sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_ingestion_run")),
+        # Value allow-list mirrors ``IngestionRunStatus``. Prevents
+        # typos ("Running" vs "running") from silently storing an
+        # invalid state that list filters can't match.
+        sa.CheckConstraint(f"status IN ({status_values})", name="ck_ingestion_run_status"),
     )
 
     with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
@@ -60,6 +78,9 @@ def upgrade() -> None:
         batch_op.create_index(batch_op.f("ix_ingestion_run_user_id"), ["user_id"], unique=False)
         batch_op.create_index(batch_op.f("ix_ingestion_run_source_type"), ["source_type"], unique=False)
         batch_op.create_index(batch_op.f("ix_ingestion_run_status"), ["status"], unique=False)
+        # List endpoints sort by started_at DESC — without this index,
+        # a KB with hundreds of thousands of runs sequential-scans.
+        batch_op.create_index(batch_op.f("ix_ingestion_run_started_at"), ["started_at"], unique=False)
 
 
 def downgrade() -> None:
@@ -68,6 +89,7 @@ def downgrade() -> None:
         return
 
     with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_ingestion_run_started_at"))
         batch_op.drop_index(batch_op.f("ix_ingestion_run_status"))
         batch_op.drop_index(batch_op.f("ix_ingestion_run_source_type"))
         batch_op.drop_index(batch_op.f("ix_ingestion_run_user_id"))

--- a/src/backend/base/langflow/api/utils/kb_helpers.py
+++ b/src/backend/base/langflow/api/utils/kb_helpers.py
@@ -6,7 +6,6 @@ import shutil
 import time
 import uuid
 from datetime import datetime, timezone
-from functools import lru_cache
 from pathlib import Path
 
 import chromadb
@@ -18,7 +17,7 @@ from langchain_chroma import Chroma
 from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from lfx.base.data.utils import extract_text_from_bytes
-from lfx.base.knowledge_bases.backends import BackendType, ChromaBackend, create_backend
+from lfx.base.knowledge_bases.backends import BackendType, create_backend
 from lfx.base.knowledge_bases.backends.base import (
     METADATA_KEY_CHUNK_INDEX,
     METADATA_KEY_FILE_NAME,
@@ -28,6 +27,7 @@ from lfx.base.knowledge_bases.backends.base import (
     METADATA_KEY_SOURCE_METADATA,
     METADATA_KEY_SOURCE_TYPE,
     METADATA_KEY_TOTAL_CHUNKS,
+    BaseVectorStoreBackend,
 )
 from lfx.base.knowledge_bases.ingestion_sources import (
     FileUploadSource,
@@ -67,9 +67,15 @@ class KBStorageHelper:
     """Helper class for Knowledge Base storage and path management."""
 
     @staticmethod
-    @lru_cache
     def get_root_path() -> Path:
-        """Lazy load and return the knowledge bases root directory."""
+        """Lazy load and return the knowledge bases root directory.
+
+        Not cached: reading from the settings service is cheap, and a
+        process-wide ``@lru_cache`` would lock in a mis-configured
+        value until restart even when the operator fixes it. Making
+        the read live also keeps the behaviour consistent with other
+        settings-dependent helpers in the codebase.
+        """
         settings = get_settings_service().settings
         knowledge_directory = settings.knowledge_bases_dir
         if not knowledge_directory:
@@ -558,7 +564,11 @@ class KBIngestionHelper:
         )
         await ingestion_run_service.mark_running(run_id)
 
-        backend: ChromaBackend | None = None
+        # ``create_backend`` can return any ``BaseVectorStoreBackend``
+        # subclass. Typing the local as the narrower ``ChromaBackend``
+        # would hide type errors when this code path routes to
+        # MongoDB/Astra/Postgres.
+        backend: BaseVectorStoreBackend | None = None
         final_status = IngestionRunStatus.SUCCEEDED
         final_error: str | None = None
         encoded_metadata_tag = json.dumps(source_metadata) if source_metadata else ""

--- a/src/backend/base/langflow/api/v1/knowledge_bases.py
+++ b/src/backend/base/langflow/api/v1/knowledge_bases.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import json
 import uuid
 from datetime import datetime, timezone
@@ -44,7 +43,13 @@ from langflow.services.jobs.service import JobService
 from langflow.services.task.service import TaskService
 from langflow.utils.kb_constants import (
     CHUNK_PREVIEW_MULTIPLIER,
+    MAX_CHUNK_OVERLAP,
+    MAX_CHUNK_SIZE,
+    MAX_MAX_CHUNKS,
+    MIN_CHUNK_OVERLAP,
+    MIN_CHUNK_SIZE,
     MIN_KB_NAME_LENGTH,
+    MIN_MAX_CHUNKS,
 )
 
 router = APIRouter(tags=["Knowledge Bases"], prefix="/knowledge_bases", include_in_schema=False)
@@ -241,10 +246,14 @@ async def create_knowledge_base(
 async def preview_chunks(
     _current_user: CurrentActiveUser,
     files: Annotated[list[UploadFile], File(description="Files to preview chunking for")],
-    chunk_size: Annotated[int, Form()] = 1000,
-    chunk_overlap: Annotated[int, Form()] = 200,
+    # Upper bounds cap the memory footprint of a preview request.
+    # ``max_chunks * chunk_size * CHUNK_PREVIEW_MULTIPLIER`` is the
+    # largest text slice this endpoint will hold in memory — without
+    # these bounds, an authenticated user can request gigabytes.
+    chunk_size: Annotated[int, Form(ge=MIN_CHUNK_SIZE, le=MAX_CHUNK_SIZE)] = 1000,
+    chunk_overlap: Annotated[int, Form(ge=MIN_CHUNK_OVERLAP, le=MAX_CHUNK_OVERLAP)] = 200,
     separator: Annotated[str, Form()] = "\n",
-    max_chunks: Annotated[int, Form()] = 5,
+    max_chunks: Annotated[int, Form(ge=MIN_MAX_CHUNKS, le=MAX_MAX_CHUNKS)] = 5,
 ) -> dict[str, object]:
     """Preview how files will be chunked without storing anything.
 
@@ -352,8 +361,10 @@ async def ingest_files_to_knowledge_base(
     current_user: CurrentActiveUser,
     files: Annotated[list[UploadFile], File(description="Files to ingest into the knowledge base")],
     source_name: Annotated[str, Form()] = "",
-    chunk_size: Annotated[int, Form()] = 1000,
-    chunk_overlap: Annotated[int, Form()] = 200,
+    # Mirrors the bounds on ``preview_chunks`` so ingestion can't be
+    # used to bypass the memory-footprint cap.
+    chunk_size: Annotated[int, Form(ge=MIN_CHUNK_SIZE, le=MAX_CHUNK_SIZE)] = 1000,
+    chunk_overlap: Annotated[int, Form(ge=MIN_CHUNK_OVERLAP, le=MAX_CHUNK_OVERLAP)] = 200,
     separator: Annotated[str, Form()] = "",
     column_config: Annotated[str, Form()] = "",
 ) -> dict[str, object] | TaskResponse:
@@ -601,7 +612,15 @@ async def list_knowledge_bases(
     """List all available knowledge bases."""
     try:
         kb_root_path = KBStorageHelper.get_root_path()
-        kb_path = kb_root_path / current_user.username
+        # Resolve + containment-check on par with every other path
+        # construction in this file. A username containing path
+        # separators (from a compromised token, or a weird legacy
+        # account) would otherwise escape the root directory.
+        kb_user_path = (kb_root_path / current_user.username).resolve()
+        _validate_kb_path_containment(
+            kb_root_path.resolve(), kb_user_path, current_user.username, current_user.username
+        )
+        kb_path = kb_user_path
 
         if not kb_path.exists():
             return []
@@ -801,6 +820,7 @@ async def get_knowledge_base_chunks(
     """
     kb_path: Path | None = None
     backend = None
+    backend_type_value: str = BackendType.CHROMA.value
     try:
         kb_path = _resolve_kb_path(kb_name, current_user)
 
@@ -892,9 +912,17 @@ async def get_knowledge_base_chunks(
         raise HTTPException(status_code=500, detail="Error getting chunks.") from e
     finally:
         if backend is not None:
-            with contextlib.suppress(Exception):
+            try:
                 await backend.teardown()
-        if kb_path is not None:
+            except Exception as teardown_exc:  # noqa: BLE001
+                # Surface at debug level so teardown failures stay
+                # visible without masking the original error path.
+                await logger.adebug("Backend teardown failed: %s", teardown_exc)
+        # ``release_chroma_resources`` clears Chroma's shared
+        # ``SharedSystemClient`` registry entry. Calling it for a
+        # MongoDB/Astra/Postgres-backed KB would mutate that registry
+        # for unrelated Chroma KBs served from the same path.
+        if kb_path is not None and backend_type_value == BackendType.CHROMA.value:
             KBStorageHelper.release_chroma_resources(kb_path)
 
 

--- a/src/backend/base/langflow/services/database/models/ingestion_run/model.py
+++ b/src/backend/base/langflow/services/database/models/ingestion_run/model.py
@@ -30,8 +30,18 @@ from typing import Any
 from uuid import UUID, uuid4
 
 import sqlalchemy as sa
-from sqlalchemy import JSON, Column, DateTime, ForeignKey
+from sqlalchemy import JSON, BigInteger, CheckConstraint, Column, DateTime, ForeignKey, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
+
+# JSONB on Postgres (binary, dedup, GIN-indexable on the ``items``
+# column), JSON elsewhere. Matches the variant used in migration
+# ``72df732be86b``.
+JsonVariant = JSON().with_variant(JSONB(), "postgresql")
+
+# Status allow-list — mirrors ``IngestionRunStatus``. Keep in sync
+# with migration ``72df732be86b``.
+_RUN_STATUS_VALUES = ("pending", "running", "succeeded", "partial", "failed", "cancelled")
 
 
 class IngestionRunStatus(str, Enum):
@@ -75,7 +85,7 @@ class IngestionRunBase(SQLModel):
     source_type: str = Field(index=True, nullable=False)
     source_config: dict[str, Any] = Field(
         default_factory=dict,
-        sa_column=Column(JSON, nullable=False),
+        sa_column=Column(JsonVariant, nullable=False),
     )
 
     status: str = Field(default=IngestionRunStatus.PENDING.value, index=True, nullable=False)
@@ -85,17 +95,26 @@ class IngestionRunBase(SQLModel):
     succeeded: int = Field(default=0, nullable=False)
     failed: int = Field(default=0, nullable=False)
     skipped: int = Field(default=0, nullable=False)
-    total_bytes: int = Field(default=0, nullable=False)
+    # BigInteger: cumulative byte count of an ingestion run can
+    # exceed the int32 ~2GB cap when ingesting large cloud blobs.
+    # Matches ``knowledge_base.size_bytes``.
+    total_bytes: int = Field(
+        default=0,
+        sa_column=Column(BigInteger, nullable=False, server_default="0"),
+    )
     chunks_created: int = Field(default=0, nullable=False)
 
     items: list[dict[str, Any]] = Field(
         default_factory=list,
-        sa_column=Column(JSON, nullable=False),
+        sa_column=Column(JsonVariant, nullable=False),
     )
 
+    # ``server_default=func.now()`` keeps ``started_at`` populated on
+    # raw-SQL inserts. Indexed because list endpoints order by this
+    # column — without the index, large run histories sequential-scan.
     started_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
-        sa_column=Column(DateTime(timezone=True), nullable=False),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), index=True),
     )
     finished_at: datetime | None = Field(
         default=None,
@@ -105,3 +124,9 @@ class IngestionRunBase(SQLModel):
 
 class IngestionRun(IngestionRunBase, table=True):  # type: ignore[call-arg]
     __tablename__ = "ingestion_run"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN (" + ", ".join(f"'{v}'" for v in _RUN_STATUS_VALUES) + ")",
+            name="ck_ingestion_run_status",
+        ),
+    )

--- a/src/backend/base/langflow/services/database/models/knowledge_base/model.py
+++ b/src/backend/base/langflow/services/database/models/knowledge_base/model.py
@@ -34,8 +34,19 @@ from enum import Enum
 from typing import Any
 from uuid import UUID, uuid4
 
-from sqlalchemy import JSON, BigInteger, Column, DateTime, UniqueConstraint
+import sqlalchemy as sa
+from sqlalchemy import JSON, BigInteger, CheckConstraint, Column, DateTime, ForeignKey, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
+
+# JSONB on Postgres for GIN indexability + binary storage; JSON on
+# SQLite. The migration uses the identical variant so the ORM and DDL
+# produce matching columns.
+JsonVariant = JSON().with_variant(JSONB(), "postgresql")
+
+# Status allow-list mirrors ``KnowledgeBaseStatus`` below — keep both
+# in sync with migration ``15fe9304bca7``.
+_KB_STATUS_VALUES = ("creating", "ready", "ingesting", "failed")
 
 
 class KnowledgeBaseStatus(str, Enum):
@@ -50,13 +61,23 @@ class KnowledgeBaseStatus(str, Enum):
 class KnowledgeBaseRecordBase(SQLModel):
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     name: str = Field(index=True, nullable=False)
-    user_id: UUID = Field(index=True, nullable=False)
+    # FK with ``ON DELETE CASCADE``: deleting a user deletes their KBs
+    # at the DB layer, preventing orphan rows from surviving a raw
+    # ``DELETE FROM user``.
+    user_id: UUID = Field(
+        sa_column=Column(
+            sa.Uuid(),
+            ForeignKey("user.id", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+    )
 
     embedding_provider: str = Field(nullable=False)
     embedding_model: str = Field(nullable=False)
     model_selection: dict[str, Any] = Field(
         default_factory=dict,
-        sa_column=Column(JSON, nullable=False),
+        sa_column=Column(JsonVariant, nullable=False),
     )
 
     chunk_size: int = Field(default=1000, nullable=False)
@@ -64,14 +85,14 @@ class KnowledgeBaseRecordBase(SQLModel):
     separator: str | None = Field(default=None, nullable=True)
     column_config: list[dict[str, Any]] = Field(
         default_factory=list,
-        sa_column=Column(JSON, nullable=False),
+        sa_column=Column(JsonVariant, nullable=False),
     )
 
     # Phase 4 surface, reserved today.
     backend_type: str = Field(default="chroma", nullable=False)
     backend_config: dict[str, Any] = Field(
         default_factory=dict,
-        sa_column=Column(JSON, nullable=False),
+        sa_column=Column(JsonVariant, nullable=False),
     )
 
     # Cached aggregates refreshed after each ingestion run.
@@ -86,22 +107,32 @@ class KnowledgeBaseRecordBase(SQLModel):
     )
     source_types: list[str] = Field(
         default_factory=list,
-        sa_column=Column(JSON, nullable=False),
+        sa_column=Column(JsonVariant, nullable=False),
     )
 
     status: str = Field(default=KnowledgeBaseStatus.READY.value, nullable=False, index=True)
     failure_reason: str | None = Field(default=None, nullable=True)
 
+    # ``server_default=func.now()`` keeps the column populated even
+    # when rows are inserted via raw SQL (backfill, admin scripts).
+    # The Python ``default_factory`` remains so ORM-level inserts get
+    # a timezone-aware UTC value without a round-trip.
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
-        sa_column=Column(DateTime(timezone=True), nullable=False),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
-        sa_column=Column(DateTime(timezone=True), nullable=False),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
 
 
 class KnowledgeBaseRecord(KnowledgeBaseRecordBase, table=True):  # type: ignore[call-arg]
     __tablename__ = "knowledge_base"
-    __table_args__ = (UniqueConstraint("user_id", "name", name="uq_knowledge_base_user_name"),)
+    __table_args__ = (
+        UniqueConstraint("user_id", "name", name="uq_knowledge_base_user_name"),
+        CheckConstraint(
+            "status IN (" + ", ".join(f"'{v}'" for v in _KB_STATUS_VALUES) + ")",
+            name="ck_knowledge_base_status",
+        ),
+    )

--- a/src/backend/base/langflow/utils/kb_constants.py
+++ b/src/backend/base/langflow/utils/kb_constants.py
@@ -4,6 +4,18 @@ EXPONENTIAL_BACKOFF_MULTIPLIER = 2
 MIN_KB_NAME_LENGTH = 3
 CHUNK_PREVIEW_MULTIPLIER = 3
 
+# Safety bounds for user-supplied chunking parameters. The upper
+# bounds cap the worst-case memory footprint of a single request.
+# With the defaults below a preview-chunks call peaks at
+# max_chunks * chunk_size * CHUNK_PREVIEW_MULTIPLIER == 50 * 10_000 * 3
+# == 1.5 MB of text — comfortable even for low-memory deployments.
+MIN_CHUNK_SIZE = 1
+MAX_CHUNK_SIZE = 10_000
+MIN_CHUNK_OVERLAP = 0
+MAX_CHUNK_OVERLAP = 5_000
+MIN_MAX_CHUNKS = 1
+MAX_MAX_CHUNKS = 50
+
 # KB deletion retry constants
 MAX_DELETE_RETRIES = 5
 DELETE_BACKOFF_SECONDS = 0.5

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
@@ -55,8 +55,8 @@ interface StepConfigurationProps {
   onFieldChange?: () => void;
   columnConfig: ColumnConfigRow[];
   onColumnConfigChange: (value: ColumnConfigRow[]) => void;
-  backendType: string;
-  onBackendTypeChange: (value: string) => void;
+  backendType: BackendValue;
+  onBackendTypeChange: (value: BackendValue) => void;
   backendConfig: Record<string, string>;
   onBackendConfigChange: (value: Record<string, string>) => void;
   activeConnector: string | null;
@@ -180,7 +180,7 @@ export function StepConfiguration({
         {!isAddSourcesMode && (
           <div className="flex flex-col gap-2 pt-4">
             <BackendPicker
-              value={backendType as BackendValue}
+              value={backendType}
               onValueChange={(v) => {
                 onBackendTypeChange(v);
                 onFieldChange?.();

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
@@ -7,6 +7,7 @@ import { useCreateKnowledgeBase } from "@/controllers/API/queries/knowledge-base
 import { useGetIngestionJobStatus } from "@/controllers/API/queries/knowledge-bases/use-get-ingestion-job-status";
 import { useIngestViaConnector } from "@/controllers/API/queries/knowledge-bases/use-ingest-via-connector";
 import { useGetModelProviders } from "@/controllers/API/queries/models/use-get-model-providers";
+import type { BackendValue } from "@/modals/knowledgeBaseUploadModal/components/BackendPicker";
 import type { DeferredConnectorPayload } from "@/pages/MainPage/pages/knowledgePage/components/connectorPayload";
 import useAlertStore from "@/stores/alertStore";
 import {
@@ -34,7 +35,7 @@ import { formatFileSize } from "../utils";
  * the request ever lands.
  */
 function validateBackendConfig(
-  backendType: string,
+  backendType: BackendValue,
   config: Record<string, string>,
 ): string | null {
   if (backendType === "mongodb") {
@@ -113,7 +114,10 @@ export function useKnowledgeBaseForm({
   >([]);
   // Phase 4 vector-store backend picker. Defaults keep existing KBs
   // on the local Chroma store. Backend is immutable after create.
-  const [backendType, setBackendType] = useState<string>("chroma");
+  // Typed as the ``BackendValue`` union so ``StepConfiguration`` no
+  // longer needs an unsound ``as BackendValue`` cast. Any value that
+  // isn't in ``BACKEND_OPTIONS`` becomes a TypeScript error here.
+  const [backendType, setBackendType] = useState<BackendValue>("chroma");
   const [backendConfig, setBackendConfig] = useState<Record<string, string>>(
     {},
   );
@@ -450,11 +454,14 @@ export function useKnowledgeBaseForm({
       }
 
       // Connector source (S3 / Google Drive / OneDrive / SharePoint).
-      // Same fire-and-forget pattern — status polling is unified with
-      // file ingestion via the KB's ``status`` field.
+      // ``await`` the mutation so we do NOT close the modal with a
+      // misleading "success" toast when the ingestion dispatch fails.
+      // The KB itself was already created above — we keep it, surface
+      // the connector error inline, and leave the modal open so the
+      // user can retry or switch sources.
       if (activeConnector && connectorPayload) {
-        ingestViaConnector.mutate(
-          {
+        try {
+          await ingestViaConnector.mutateAsync({
             kb_name: kbName,
             source_type: connectorPayload.source_type,
             source_config: connectorPayload.source_config,
@@ -462,21 +469,18 @@ export function useKnowledgeBaseForm({
             chunk_size: chunkSize || undefined,
             chunk_overlap: chunkOverlap || undefined,
             separator: separator || undefined,
-          },
-          {
-            onError: (ingestError) => {
-              const err = ingestError as AxiosError<{ detail?: string }>;
-              setErrorData({
-                title: `Failed to start ingestion for "${sourceName}"`,
-                list: [
-                  err?.response?.data?.detail ||
-                    err?.message ||
-                    "Unknown error",
-                ],
-              });
-            },
-          },
-        );
+          });
+        } catch (ingestError: unknown) {
+          const err = ingestError as AxiosError<{ detail?: string }>;
+          setErrorData({
+            title: `Failed to start ingestion for "${sourceName}"`,
+            list: [
+              err?.response?.data?.detail || err?.message || "Unknown error",
+            ],
+          });
+          setIsSubmitting(false);
+          return;
+        }
       }
 
       const callbackData: KnowledgeBaseFormData = {

--- a/src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/connector_base.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/connector_base.py
@@ -167,13 +167,17 @@ class OAuthConnectorBase(KBConnectorSource):
     # Subclass must override.
     token_endpoint: str = ""
     # Default cache: most providers issue 1-hour tokens; refresh 5
-    # minutes before expiry to give clock skew a margin.
-    token_ttl_seconds: int = 55 * 60
+    # minutes before expiry to give clock skew a margin. This is the
+    # *class-level default* only — each instance stores its own
+    # ``token_ttl_seconds`` on ``self`` so a provider-reported
+    # ``expires_in`` tune-up never mutates shared state.
+    default_token_ttl_seconds: int = 55 * 60
 
-    def __init__(self, user_id, source_config) -> None:
+    def __init__(self, user_id: UUID | str | None, source_config: dict[str, Any]) -> None:
         super().__init__(user_id=user_id, source_config=source_config)
         self._cached_access_token: str | None = None
         self._cached_token_expires_at: float = 0.0
+        self.token_ttl_seconds: int = self.default_token_ttl_seconds
 
     async def get_access_token(self) -> str:
         """Return a currently-valid access token, refreshing if needed.


### PR DESCRIPTION
## Summary

Rolls up the HIGH-severity findings from the four parallel review agents on #12802 — DB migration, Python backend, security, and frontend — into one change set. The 4 CRITICAL findings were already handled in #12809.

### Database schema
- `ingestion_run.total_bytes`: `Integer` → `BigInteger`. Cloud-backed runs routinely exceed the 2 GB int32 ceiling.
- `ingestion_run.started_at`: add a DB-level index. List endpoints sort by this column — without the index a KB with hundreds of thousands of runs sequential-scans.
- All JSON columns now use `JSON().with_variant(JSONB, \"postgresql\")` so Postgres gets JSONB (binary storage, dedup, GIN-indexable on `items`/`backend_config`/`source_config`) and SQLite keeps JSON. Matching variant binding on both the migration and the SQLModel.
- `knowledge_base.user_id`: now a proper FK to `user.id` with `ON DELETE CASCADE`. Mirrors the `folder` table's pattern so deleted users take their KBs with them instead of leaving orphan rows.
- Status CHECK constraints on `knowledge_base.status` and `ingestion_run.status` that mirror their Python enums (`KnowledgeBaseStatus`, `IngestionRunStatus`). Typos now fail at COMMIT instead of silently storing values that list filters can't match.
- `server_default=func.now()` on every `DateTime` `sa_column` so raw-SQL inserts (backfill, admin scripts, fixtures) don't need to supply `now()` manually.

### Python backend
- `KBIngestionHelper.perform_ingestion`: `backend` typed as `BaseVectorStoreBackend | None` instead of `ChromaBackend | None`. Type checkers no longer silently pass Chroma-specific method calls on other backends.
- `get_knowledge_base_chunks` finally block: only call `KBStorageHelper.release_chroma_resources` when `backend_type == chroma`. Calling it for a MongoDB/Astra/Postgres KB mutated Chroma's shared `SharedSystemClient` registry and could corrupt unrelated Chroma KBs on the same host.
- `OAuthConnectorBase`: rename the class default to `default_token_ttl_seconds` and initialise an instance-scoped `self.token_ttl_seconds` in `__init__`. Provider-reported `expires_in` tune-ups now mutate instance state only — no class-state leakage across concurrent runs.
- `OAuthConnectorBase.__init__` gains full type hints (`user_id: UUID | str | None`, `source_config: dict[str, Any]`) matching the parent class.

### Security
- Bound `chunk_size` / `chunk_overlap` / `max_chunks` via `Form(ge=..., le=...)` on both `POST /preview-chunks` and `POST /{kb}/ingest`. An authenticated user could previously request a 6 GB text slice (`max_chunks=1000 × chunk_size=2_000_000 × CHUNK_PREVIEW_MULTIPLIER=3`). Bounds live in `kb_constants`.
- `list_knowledge_bases`: resolve + containment-check `kb_root_path / current_user.username` on par with every other path construction in this file. A pathological username can no longer escape the root dir on this endpoint.
- `KBStorageHelper.get_root_path`: drop the `@lru_cache` decorator. A mis-configured settings path previously stayed locked in for the process lifetime; the helper is cheap enough to read fresh from settings each call.

### Frontend
- Fire-and-forget connector ingestion fixed: `useKnowledgeBaseForm` now `await`s `ingestViaConnector.mutateAsync` and keeps the modal open with an inline error on failure, instead of closing with a deceptively-successful toast while the ingestion errors out asynchronously.
- `backendType` state typed as `BackendValue` directly (not `string`). The unsound `backendType as BackendValue` cast in `StepConfiguration.tsx` is gone, as is the matching looseness on the `onBackendTypeChange` prop and `validateBackendConfig` signature. Any value not in `BACKEND_OPTIONS` is now a TypeScript error at the call site.

## Out of scope / follow-ups
- Frontend stale-closure `useEffect` suppression across the four connector forms (marked HIGH by the reviewer but acknowledged as \"safe today, fragile\" — worth a dedicated refactor).
- Second security pass against the OAuth/connector files (`connector_base.py`, `google_drive.py`, `microsoft_graph.py`, etc.) that the first reviewer couldn't reach because they were on the wrong worktree.
- Frontend MEDIUM items (modal a11y, polling for in-progress runs, connector source types missing from the chunk filter dropdown, shared `Field` component extraction).

## Test plan

- [ ] CI: `Model/Migration Consistency` stays green with the new FK + CHECK + BigInteger (validates autogen equivalence).
- [ ] CI: `Run Backend Tests` groups 1–5, especially `test_knowledge_base_service`, `test_ingestion_run_endpoints`, `test_chroma_backend`, `test_s3_source`.
- [ ] CI: `Frontend Jest Unit Tests` for `KnowledgeBaseUploadModal`.
- [ ] Smoke: create a KB → delete the user → verify `knowledge_base` rows cascade and no `ingestion_run` rows dangle.
- [ ] Smoke: `POST /preview-chunks chunk_size=100000` → 422 with clear validation error (previously 200 + OOM).
- [ ] Smoke: create a KB with a connector that errors at dispatch time → verify the modal stays open with an inline error instead of flashing success.