### PR TITLE
fix(custom): honor asname in `from X import Y as Z` for custom components

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2968,7 +2968,7 @@
         "filename": "src/backend/tests/unit/api/v1/test_mcp_projects.py",
         "hashed_secret": "4258d43e3b1f9658067ceea9c682a96cbdbb5ca0",
         "is_verified": false,
-        "line_number": 575,
+        "line_number": 596,
         "is_secret": false
       }
     ],
@@ -8373,5 +8373,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-14T23:44:15Z"
+  "generated_at": "2026-04-15T15:25:36Z"
 }

--- a/docs/docs/Develop/environment-variables.mdx
+++ b/docs/docs/Develop/environment-variables.mdx
@@ -411,11 +411,26 @@ The following environment variables set base Langflow server configuration, such
 | `LANGFLOW_HEALTH_CHECK_MAX_RETRIES` | Integer | `5` | Set the maximum number of retries for Langflow's server status health checks. |
 | `LANGFLOW_WORKERS` | Integer | `1` | Number of worker processes. |
 | `LANGFLOW_WORKER_TIMEOUT` | Integer | `300` | Worker timeout in seconds. |
+| `LANGFLOW_GUNICORN_PRELOAD` | Boolean | `False` | **Experimental.** When `true`, enables Gunicorn `preload_app` (non-Windows): the app is loaded in the master process before worker processes fork. Can reduce per-worker startup cost; behavior and compatibility may change. |
 | `LANGFLOW_SSL_CERT_FILE` | String | Not set | Path to the SSL certificate file for enabling HTTPS on the Langflow web server. This is separate from [database SSL connections](/configuration-custom-database#connect-langflow-to-a-local-postgresql-database). |
 | `LANGFLOW_SSL_KEY_FILE` | String | Not set | Path to the SSL key file for enabling HTTPS on the Langflow web server. This is separate from [database SSL connections](/configuration-custom-database#connect-langflow-to-a-local-postgresql-database). |
 | `LANGFLOW_DEACTIVATE_TRACING` | Boolean | `False` | Deactivate tracing functionality. |
 | `LANGFLOW_CELERY_ENABLED` | Boolean | `False` | Enable Celery for distributed task processing. |
 | `LANGFLOW_ALEMBIC_LOG_TO_STDOUT` | Boolean | `False` | Whether to log Alembic database migration output to stdout instead of a log file. If `true`, Alembic logs to `stdout` and the default log file is ignored. |
+
+#### Gunicorn configuration
+
+When running Langflow in a production environment using Gunicorn, you can configure Gunicorn workers using the `GUNICORN_CMD_ARGS` environment variable. 
+
+This is particularly useful to manage worker memory and prevent potential memory leaks over time. You can add it to your `.env` file like this:
+
+```text
+GUNICORN_CMD_ARGS="--max-requests 100 --max-requests-jitter 20"
+```
+
+Here is what these arguments do:
+- `--max-requests 100`: Automatically restarts a worker after it has processed 100 requests. This helps prevent memory leaks from accumulating over time.
+- `--max-requests-jitter 20`: Adds a random jitter of up to 20 requests to the `--max-requests` value. This ensures that all workers don't restart simultaneously, which could cause a brief downtime or spikes in latency.
 
 For more information about deploying Langflow servers, see [Langflow deployment overview](/deployment-overview).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow"
-version = "1.9.0"
+version = "1.10.0"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.14"
 license = "MIT"
@@ -17,7 +17,7 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
-    "langflow-base[complete]>=0.9.0",
+    "langflow-base[complete]>=0.10.0",
 ]
 
 

--- a/src/backend/base/langflow/__main__.py
+++ b/src/backend/base/langflow/__main__.py
@@ -8,6 +8,7 @@ import sys
 import time
 import warnings
 from contextlib import suppress
+from functools import partial
 from ipaddress import ip_address
 from pathlib import Path
 
@@ -338,8 +339,13 @@ def run(
         static_files_dir: Path | None = Path(frontend_path) if frontend_path else None
 
     # Step 2: Starting Core Services
+    app = None
+    app_factory = None
     with progress.step(2):
-        app = setup_app(static_files_dir=static_files_dir, backend_only=bool(backend_only))
+        if platform.system() == "Windows":
+            app = setup_app(static_files_dir=static_files_dir, backend_only=bool(backend_only))
+        else:
+            app_factory = partial(setup_app, static_files_dir=static_files_dir, backend_only=bool(backend_only))
 
     # Step 3: Connecting Database (this happens inside setup_app via dependencies)
     with progress.step(3):
@@ -375,6 +381,10 @@ def run(
         with progress.step(6):
             import uvicorn
 
+            if app is None:
+                msg = "Windows startup requires a pre-built FastAPI application."
+                raise RuntimeError(msg)
+
             # Print summary and banner before starting the server, since uvicorn is a blocking call.
             # We _may_ be able to subprocess, but with window's spawn behavior, we'd have to move all
             # non-picklable code to the subprocess.
@@ -406,6 +416,10 @@ def run(
             # Use Gunicorn with LangflowUvicornWorker for non-Windows systems
             from langflow.server import LangflowApplication
 
+            if app_factory is None:
+                msg = "Gunicorn startup requires an application factory."
+                raise RuntimeError(msg)
+
             options = {
                 "bind": f"{host}:{port}",
                 "workers": get_number_of_workers(workers),
@@ -415,7 +429,7 @@ def run(
                 "log_level": log_level.lower() if log_level is not None else "info",
                 "preload_app": os.environ.get("LANGFLOW_GUNICORN_PRELOAD", "false").lower() == "true",
             }
-            server = LangflowApplication(app, options)
+            server = LangflowApplication(app_factory, options)
 
             # Start the webapp process
             process_manager.webapp_process = Process(target=server.run)

--- a/src/backend/base/langflow/api/v1/auth_helpers.py
+++ b/src/backend/base/langflow/api/v1/auth_helpers.py
@@ -34,7 +34,12 @@ def handle_auth_settings_update(
         # Explicitly set to None - clear auth settings
         existing_project.auth_settings = None
         # If we were using OAuth, stop the composer
-        return {"should_start_composer": False, "should_stop_composer": current_auth_type == "oauth"}
+        return {
+            "should_start_composer": False,
+            "should_stop_composer": current_auth_type == "oauth",
+            "should_handle_composer": current_auth_type == "oauth",
+            "new_auth_type": None,
+        }
 
     # Handle different input types (dict vs Pydantic model)
     if isinstance(new_auth_settings, dict):
@@ -72,4 +77,5 @@ def handle_auth_settings_update(
         "should_start_composer": should_start_composer,
         "should_stop_composer": should_stop_composer,
         "should_handle_composer": should_handle_composer,
+        "new_auth_type": new_auth_type,
     }

--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -508,6 +508,8 @@ async def update_project_mcp_settings(
             should_handle_mcp_composer = False
             should_start_composer = False
             should_stop_composer = False
+            new_auth_type: str | None = None
+            auth_settings_updated = False
 
             # Store original auth settings in case we need to rollback
             original_auth_settings = project.auth_settings
@@ -522,6 +524,8 @@ async def update_project_mcp_settings(
                 should_handle_mcp_composer = auth_result["should_handle_composer"]
                 should_start_composer = auth_result["should_start_composer"]
                 should_stop_composer = auth_result["should_stop_composer"]
+                new_auth_type = auth_result["new_auth_type"]
+                auth_settings_updated = True
 
             # Query flows in the project
             flows = (await session.exec(select(Flow).where(Flow.folder_id == project_id))).all()
@@ -627,12 +631,34 @@ async def update_project_mcp_settings(
                         "uses_composer": False,
                     }
 
+            # Sync MCP server config for apikey/none auth; OAuth is handled by MCP Composer above.
+            if auth_settings_updated and new_auth_type in {"apikey", "none"}:
+                from langflow.api.v1.projects_mcp_helpers import reconcile_mcp_server_for_auth_update
+
+                try:
+                    await reconcile_mcp_server_for_auth_update(
+                        project,
+                        new_auth_type,
+                        current_user,
+                        session,
+                    )
+                except HTTPException:
+                    raise
+                except Exception as e:  # noqa: BLE001
+                    await logger.awarning(
+                        "Failed to reconcile MCP server config for project %s after auth update: %s",
+                        project_id,
+                        e,
+                    )
+
             # Only commit if composer started successfully (or wasn't needed)
             session.add(project)
             await session.commit()
 
             return response
 
+    except HTTPException:
+        raise
     except Exception as e:
         msg = f"Error updating project MCP settings: {e!s}"
         await logger.aexception(msg)
@@ -1440,6 +1466,34 @@ async def register_project_with_composer(project: Folder):
         await logger.awarning(f"Failed to register project {project.id} with MCP Composer: {e}")
 
 
+def _get_startup_project_auth_settings(
+    project: Folder,
+    *,
+    auto_login: bool,
+    mcp_composer_enabled: bool,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Return the auth state startup should enforce for this project.
+
+    Returns:
+        A tuple of:
+        - target auth settings used for MCP reconciliation and optional persistence
+        - a reason string when the project auth settings should be persisted
+    """
+    auth_type = project.auth_settings.get("auth_type") if project.auth_settings else None
+
+    if not auto_login and auth_type in {None, "none"}:
+        return {"auth_type": "apikey"}, "auto_enable_apikey"
+
+    if not mcp_composer_enabled and auth_type == "oauth":
+        fallback_auth_type = "apikey" if not auto_login else "none"
+        return {"auth_type": fallback_auth_type}, "oauth_fallback"
+
+    if auth_type in {"apikey", "none"}:
+        return {"auth_type": auth_type}, None
+
+    return None, None
+
+
 async def init_mcp_servers():
     """Initialize MCP servers for all projects."""
     try:
@@ -1450,42 +1504,55 @@ async def init_mcp_servers():
 
             for project in projects:
                 try:
-                    # Auto-enable API key auth for projects without auth settings or with "none" auth
-                    # when AUTO_LOGIN is false
-                    if not settings_service.auth_settings.AUTO_LOGIN:
-                        should_update_to_apikey = False
+                    target_auth_settings, persist_reason = _get_startup_project_auth_settings(
+                        project,
+                        auto_login=settings_service.auth_settings.AUTO_LOGIN,
+                        mcp_composer_enabled=settings_service.settings.mcp_composer_enabled,
+                    )
+                    reconciled_mcp_server = False
 
-                        if not project.auth_settings:
-                            # No auth settings at all
-                            should_update_to_apikey = True
-                        # Check if existing auth settings have auth_type "none"
-                        elif project.auth_settings.get("auth_type") == "none":
-                            should_update_to_apikey = True
-
-                        if should_update_to_apikey:
-                            default_auth = {"auth_type": "apikey"}
-                            project.auth_settings = encrypt_auth_settings(default_auth)
+                    async with session.begin_nested():
+                        if persist_reason is not None and target_auth_settings is not None:
+                            project.auth_settings = encrypt_auth_settings(target_auth_settings)
                             session.add(project)
-                            await logger.ainfo(
-                                f"Auto-enabled API key authentication for existing project {project.name} "
-                                f"({project.id}) due to AUTO_LOGIN=false"
-                            )
+                            await session.flush()
 
-                    # WARN: If oauth projects exist in the database and the MCP Composer is disabled,
-                    # these projects will be reset to "apikey" or "none" authentication, erasing all oauth settings.
-                    if (
-                        not settings_service.settings.mcp_composer_enabled
-                        and project.auth_settings
-                        and project.auth_settings.get("auth_type") == "oauth"
-                    ):
-                        # Reset OAuth projects to appropriate auth type based on AUTO_LOGIN setting
-                        fallback_auth_type = "apikey" if not settings_service.auth_settings.AUTO_LOGIN else "none"
-                        clean_auth = AuthSettings(auth_type=fallback_auth_type)
-                        project.auth_settings = clean_auth.model_dump(exclude_none=True)
-                        session.add(project)
+                        should_reconcile_project_server = (
+                            target_auth_settings is not None
+                            and target_auth_settings.get("auth_type") in {"apikey", "none"}
+                            and settings_service.settings.add_projects_to_mcp_servers
+                            and project.user_id is not None
+                        )
+                        if should_reconcile_project_server:
+                            from langflow.api.v1.projects_mcp_helpers import register_mcp_servers_for_project
+
+                            project_user = await session.get(User, project.user_id)
+                            if project_user is not None:
+                                reconciled_mcp_server = await register_mcp_servers_for_project(
+                                    project,
+                                    target_auth_settings,
+                                    project_user,
+                                    session,
+                                    raise_on_error=True,
+                                )
+
+                    if persist_reason == "auto_enable_apikey":
+                        await logger.ainfo(
+                            f"Auto-enabled API key authentication for existing project {project.name} "
+                            f"({project.id}) due to AUTO_LOGIN=false"
+                        )
+                    elif persist_reason == "oauth_fallback" and target_auth_settings is not None:
+                        fallback_auth_type = target_auth_settings["auth_type"]
                         await logger.adebug(
                             f"Updated OAuth project {project.name} ({project.id}) to use {fallback_auth_type} "
                             f"authentication because MCP Composer is disabled"
+                        )
+
+                    if reconciled_mcp_server:
+                        await logger.adebug(
+                            "Reconciled MCP server config for project %s (%s) on startup",
+                            project.name,
+                            project.id,
                         )
 
                     get_project_sse(project.id)
@@ -1493,7 +1560,7 @@ async def init_mcp_servers():
                     await logger.adebug(f"Initialized MCP server for project: {project.name} ({project.id})")
 
                     # Only register with MCP Composer if OAuth authentication is configured
-                    if get_settings_service().settings.mcp_composer_enabled and project.auth_settings:
+                    if settings_service.settings.mcp_composer_enabled and project.auth_settings:
                         auth_type = project.auth_settings.get("auth_type")
                         if auth_type == "oauth":
                             await logger.adebug(

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -23,6 +23,7 @@ from langflow.api.v1.projects_files import download_project_flows, upload_projec
 from langflow.api.v1.projects_mcp_helpers import (
     cleanup_mcp_on_delete,
     handle_mcp_server_rename,
+    reconcile_mcp_server_for_auth_update,
     register_mcp_servers_for_project,
 )
 from langflow.initial_setup.constants import ASSISTANT_FOLDER_NAME, STARTER_FOLDER_NAME
@@ -258,6 +259,8 @@ async def update_project(
         # Track if MCP Composer needs to be started or stopped
         should_start_mcp_composer = False
         should_stop_mcp_composer = False
+        new_auth_type: str | None = None
+        auth_settings_updated = False
 
         # Check if auth_settings is being updated
         if "auth_settings" in project.model_fields_set:  # Check if auth_settings was explicitly provided
@@ -268,6 +271,8 @@ async def update_project(
 
             should_start_mcp_composer = auth_result["should_start_composer"]
             should_stop_mcp_composer = auth_result["should_stop_composer"]
+            new_auth_type = auth_result["new_auth_type"]
+            auth_settings_updated = True
 
         # Handle project rename and corresponding MCP server rename
         if project.name and project.name != existing_project.name:
@@ -308,6 +313,24 @@ async def update_project(
                 MCPComposerService, get_service(ServiceType.MCP_COMPOSER_SERVICE)
             )
             await mcp_composer_service.stop_project_composer(str(existing_project.id))
+
+        # Sync MCP server config for apikey/none auth; OAuth is handled by MCP Composer above.
+        if auth_settings_updated and new_auth_type in {"apikey", "none"}:
+            try:
+                await reconcile_mcp_server_for_auth_update(
+                    existing_project,
+                    new_auth_type,
+                    current_user,
+                    session,
+                )
+            except HTTPException:
+                raise
+            except Exception as e:  # noqa: BLE001
+                await logger.awarning(
+                    "Failed to reconcile MCP server config for project %s after auth update: %s",
+                    existing_project.id,
+                    e,
+                )
 
         concat_project_components = project.components + project.flows
 

--- a/src/backend/base/langflow/api/v1/projects_mcp_helpers.py
+++ b/src/backend/base/langflow/api/v1/projects_mcp_helpers.py
@@ -3,7 +3,7 @@
 Extracted from projects.py to reduce file size and isolate MCP concerns (SO1).
 """
 
-from typing import cast
+from typing import Any, cast
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -19,49 +19,68 @@ from langflow.services.deps import get_service, get_settings_service, get_storag
 from langflow.services.schema import ServiceType
 
 
+def _server_config_uses_streamable_http(args: list[Any], streamable_http_url: str) -> bool:
+    """Return whether the server args target this project's Streamable HTTP endpoint."""
+    string_args = [arg for arg in args if isinstance(arg, str)]
+    return (
+        "mcp-proxy" in string_args
+        and "--transport" in string_args
+        and "streamablehttp" in string_args
+        and streamable_http_url in string_args
+    )
+
+
+def _server_config_has_project_api_key(args: list[Any]) -> bool:
+    """Return whether the server args include the generated Langflow API key header."""
+    return any(
+        arg == "--headers" and index + 2 < len(args) and args[index + 1] == "x-api-key"
+        for index, arg in enumerate(args)
+    )
+
+
+def _server_config_matches_project_auth(
+    existing_config: dict[str, Any] | None,
+    auth_type: str,
+    streamable_http_url: str,
+) -> bool:
+    """Check whether the stored MCP server config already matches the project's auth mode."""
+    if not existing_config:
+        return False
+
+    args = existing_config.get("args")
+    if not isinstance(args, list) or not _server_config_uses_streamable_http(args, streamable_http_url):
+        return False
+
+    has_project_api_key = _server_config_has_project_api_key(args)
+    if auth_type == "apikey":
+        return has_project_api_key
+    if auth_type == "none":
+        return not has_project_api_key
+    return False
+
+
 async def register_mcp_servers_for_project(
     project,
     default_auth: dict,
     current_user,
     session,
-) -> None:
+    *,
+    raise_on_error: bool = False,
+) -> bool:
     """Register MCP servers for a newly created project.
 
     This handles the full MCP auto-registration flow: building the transport URL,
     creating API keys if needed, validating conflicts, and calling update_server.
 
-    Raises HTTPException on conflicts or unsupported auth types.
+    Returns:
+        True when the server config was created or updated, otherwise False.
+
+    Raises:
+        HTTPException: On server name conflicts.
     """
     try:
         streamable_http_url = await get_project_streamable_http_url(project.id)
-
-        if default_auth.get("auth_type", "none") == "apikey":
-            api_key_name = f"MCP Project {project.name} - default"
-            unmasked_api_key = await create_api_key(session, ApiKeyCreate(name=api_key_name), current_user.id)
-            command = "uvx"
-            args = [
-                "mcp-proxy",
-                "--transport",
-                "streamablehttp",
-                "--headers",
-                "x-api-key",
-                unmasked_api_key.api_key,
-                streamable_http_url,
-            ]
-        elif default_auth.get("auth_type", "none") == "oauth":
-            msg = "OAuth authentication is not yet implemented for MCP server creation during project creation."
-            await logger.awarning(msg)
-            return
-        else:
-            command = "uvx"
-            args = [
-                "mcp-proxy",
-                "--transport",
-                "streamablehttp",
-                streamable_http_url,
-            ]
-
-        server_config = {"command": command, "args": args}
+        auth_type = default_auth.get("auth_type", "none")
 
         validation_result = await validate_mcp_server_for_project(
             project.id,
@@ -80,11 +99,53 @@ async def register_mcp_servers_for_project(
                 detail=validation_result.conflict_message,
             )
 
+        if validation_result.should_skip and _server_config_matches_project_auth(
+            validation_result.existing_config,
+            auth_type,
+            streamable_http_url,
+        ):
+            await logger.adebug(
+                "MCP server '%s' already matches auth %s for project %s, skipping",
+                validation_result.server_name,
+                auth_type,
+                project.id,
+            )
+            return False
+
+        if auth_type == "apikey":
+            api_key_name = f"MCP Project {project.name} - default"
+            unmasked_api_key = await create_api_key(session, ApiKeyCreate(name=api_key_name), current_user.id)
+            command = "uvx"
+            args = [
+                "mcp-proxy",
+                "--transport",
+                "streamablehttp",
+                "--headers",
+                "x-api-key",
+                unmasked_api_key.api_key,
+                streamable_http_url,
+            ]
+        elif auth_type == "oauth":
+            msg = "OAuth authentication is not yet implemented for MCP server creation during project creation."
+            await logger.awarning(msg)
+            return False
+        else:
+            command = "uvx"
+            args = [
+                "mcp-proxy",
+                "--transport",
+                "streamablehttp",
+                streamable_http_url,
+            ]
+
+        server_config = {"command": command, "args": args}
+
         if validation_result.should_skip:
             await logger.adebug(
-                "MCP server '%s' already exists for project %s, updating",
+                "MCP server '%s' exists for project %s but does not match auth %s, updating",
                 validation_result.server_name,
                 project.id,
+                auth_type,
             )
 
         server_name = validation_result.server_name
@@ -99,8 +160,38 @@ async def register_mcp_servers_for_project(
         )
     except HTTPException:
         raise
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         await logger.aexception("Failed to auto-register MCP server for project %s: %s", project.id, e)
+        if raise_on_error:
+            raise
+        return False
+    else:
+        return True
+
+
+async def reconcile_mcp_server_for_auth_update(
+    project,
+    new_auth_type: str | None,
+    current_user,
+    session,
+) -> bool:
+    """Sync the MCP server config for a project whose auth settings just changed.
+
+    OAuth reconciliation is driven separately by MCP Composer, so this helper only
+    touches apikey/none modes. Returns True when the server config was updated.
+    """
+    if new_auth_type not in {"apikey", "none"}:
+        return False
+
+    if not get_settings_service().settings.add_projects_to_mcp_servers:
+        return False
+
+    return await register_mcp_servers_for_project(
+        project,
+        {"auth_type": new_auth_type},
+        current_user,
+        session,
+    )
 
 
 async def handle_mcp_server_rename(

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -1269,6 +1269,12 @@ async def get_or_create_default_folder(session: AsyncSession, user_id: UUID) -> 
 
     This implementation avoids an external distributed lock and works with both SQLite and PostgreSQL.
 
+    The function only creates a new default folder on first initialization (when the user has no
+    folders at all). If the user has already been through initial setup and has at least one folder
+    — even if they renamed the default or only kept other folders — the existing folder is returned
+    instead of creating a new "Starter Project". This prevents a phantom default folder from being
+    forced back into the UI every time the user logs in or the server restarts.
+
     Args:
         session (AsyncSession): The active database session.
         user_id (UUID): The ID of the user who owns the folder.
@@ -1310,7 +1316,18 @@ async def get_or_create_default_folder(session: AsyncSession, user_id: UUID) -> 
                     await session.rollback()
                     break
 
-    # If no existing folder found, create a new one
+    # Respect prior user intent: if the user already has folders (e.g. they renamed the
+    # default folder to something like "My Flows"), do not force a new "Starter Project" back
+    # into their UI on every login/server restart. Return any existing folder instead.
+    any_folder_stmt = (
+        select(Folder).where(Folder.user_id == user_id).order_by(Folder.id).limit(1)  # type: ignore[arg-type]
+    )
+    any_folder = (await session.exec(any_folder_stmt)).first()
+    if any_folder:
+        return FolderRead.model_validate(any_folder, from_attributes=True)
+
+    # No existing folder found for this user — this is the first-time setup path.
+    # Create the default folder.
     try:
         folder_obj = Folder(user_id=user_id, name=DEFAULT_FOLDER_NAME, description=DEFAULT_FOLDER_DESCRIPTION)
         session.add(folder_obj)

--- a/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Knowledge Retrieval.json
@@ -565,7 +565,7 @@
                   },
                   {
                     "name": "langchain_openai",
-                    "version": "1.1.12"
+                    "version": "1.1.13"
                   },
                   {
                     "name": "langchain_huggingface",

--- a/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Vector Store RAG.json
@@ -3077,7 +3077,7 @@
                   },
                   {
                     "name": "langchain_openai",
-                    "version": "1.1.12"
+                    "version": "1.1.13"
                   },
                   {
                     "name": "langchain_huggingface",

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -148,7 +148,6 @@ def warn_about_future_cors_changes(settings):
 
 def get_lifespan(*, fix_migration=False, version=None):
     initialize_settings_service()
-    telemetry_service = get_telemetry_service()
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
@@ -168,6 +167,26 @@ def get_lifespan(*, fix_migration=False, version=None):
 
         try:
             start_time = asyncio.get_event_loop().time()
+
+            if get_settings_service().settings.sentry_dsn:
+                try:
+                    import sentry_sdk
+                except ImportError:
+                    await logger.awarning(
+                        "LANGFLOW_SENTRY_DSN is set but sentry-sdk is not installed; "
+                        "Sentry will not be initialized. Install it with: pip install sentry-sdk"
+                    )
+                else:
+                    try:
+                        sentry_settings = get_settings_service().settings
+                        sentry_sdk.init(
+                            dsn=sentry_settings.sentry_dsn,
+                            traces_sample_rate=sentry_settings.sentry_traces_sample_rate,
+                            profiles_sample_rate=sentry_settings.sentry_profiles_sample_rate,
+                        )
+                        await logger.adebug("Sentry SDK initialized in worker")
+                    except Exception as e:  # noqa: BLE001
+                        await logger.awarning(f"Failed to initialize Sentry SDK (check LANGFLOW_SENTRY_DSN): {e}")
 
             await logger.adebug("Initializing services")
             await initialize_services(fix_migration=fix_migration)
@@ -195,11 +214,36 @@ def get_lifespan(*, fix_migration=False, version=None):
             await initialize_auto_login_default_superuser()
             await logger.adebug(f"Super user initialized in {asyncio.get_event_loop().time() - current_time:.2f}s")
 
+            if get_settings_service().settings.prometheus_enabled:
+                try:
+                    from prometheus_client import start_http_server
+
+                    start_http_server(get_settings_service().settings.prometheus_port)
+                    await logger.adebug(
+                        f"Started Prometheus server on port {get_settings_service().settings.prometheus_port}"
+                    )
+                except ImportError:
+                    await logger.aerror(
+                        "prometheus_client is not installed. Install it with: pip install prometheus-client"
+                    )
+                except OSError as e:
+                    import errno
+
+                    if e.errno == errno.EADDRINUSE:
+                        await logger.adebug(
+                            f"Prometheus port {get_settings_service().settings.prometheus_port} already in use "
+                            "(may be running in another worker)"
+                        )
+                    else:
+                        await logger.awarning(f"Failed to start Prometheus server: {e}")
+
             current_time = asyncio.get_event_loop().time()
             await logger.adebug("Loading bundles")
             temp_dirs, bundles_components_paths = await load_bundles_with_error_handling()
             get_settings_service().settings.components_path.extend(bundles_components_paths)
             await logger.adebug(f"Bundles loaded in {asyncio.get_event_loop().time() - current_time:.2f}s")
+
+            telemetry_service = get_telemetry_service()
 
             current_time = asyncio.get_event_loop().time()
             await logger.adebug("Caching types")
@@ -445,7 +489,7 @@ def create_app():
         ContentSizeLimitMiddleware,
     )
 
-    setup_sentry(app)
+    add_sentry_middleware(app)
 
     # Warn about future CORS changes
     warn_about_future_cors_changes(settings)
@@ -535,18 +579,13 @@ def create_app():
     if prome_port_str := os.environ.get("LANGFLOW_PROMETHEUS_PORT"):
         # set here for create_app() entry point
         prome_port = int(prome_port_str)
-        if prome_port > 0 or prome_port < MAX_PORT:
-            logger.debug(f"Starting Prometheus server on port {prome_port}...")
+        if prome_port > 0 and prome_port < MAX_PORT:
+            logger.debug(f"Prometheus server port configured as {prome_port}...")
             settings.prometheus_enabled = True
             settings.prometheus_port = prome_port
         else:
             msg = f"Invalid port number {prome_port_str}"
             raise ValueError(msg)
-
-    if settings.prometheus_enabled:
-        from prometheus_client import start_http_server
-
-        start_http_server(settings.prometheus_port)
 
     if settings.mcp_server_enabled:
         from langflow.api.v1 import mcp_router
@@ -584,17 +623,27 @@ def create_app():
     return app
 
 
-def setup_sentry(app: FastAPI) -> None:
+def add_sentry_middleware(app: FastAPI) -> None:
+    """Attach SentryAsgiMiddleware to the app.
+
+    Only the ASGI middleware is registered here so it is available at request time.
+    The actual ``sentry_sdk.init()`` call is deferred to the worker lifespan
+    (see ``get_lifespan``) to avoid ghost transactions across pre-fork workers.
+    """
     settings = get_settings_service().settings
     if settings.sentry_dsn:
-        import sentry_sdk
-        from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+        try:
+            from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+        except ImportError:
+            logger.warning(
+                "LANGFLOW_SENTRY_DSN is set but sentry-sdk is not installed; "
+                "SentryAsgiMiddleware will not be added. Install it with: pip install sentry-sdk"
+            )
+            return
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Failed to import SentryAsgiMiddleware: {e}")
+            return
 
-        sentry_sdk.init(
-            dsn=settings.sentry_dsn,
-            traces_sample_rate=settings.sentry_traces_sample_rate,
-            profiles_sample_rate=settings.sentry_profiles_sample_rate,
-        )
         app.add_middleware(SentryAsgiMiddleware)
 
 

--- a/src/backend/base/langflow/server.py
+++ b/src/backend/base/langflow/server.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 import signal
+from collections.abc import Callable
+from typing import Any
 
 from gunicorn import glogging
 from gunicorn.app.base import BaseApplication
@@ -62,18 +64,92 @@ class Logger(glogging.Logger):
 
 
 class LangflowApplication(BaseApplication):
-    def __init__(self, app, options=None) -> None:
+    def __init__(self, app_factory: Callable[[], Any], options=None) -> None:
         self.options = options or {}
 
         self.options["worker_class"] = "langflow.server.LangflowUvicornWorker"
         self.options["logger_class"] = Logger
-        self.application = app
+        self.options["pre_fork"] = self.pre_fork
+        self._app_factory = app_factory
+        self.application = None
         super().__init__()
 
+    # Thread name prefixes that are known to be benign before fork.
+    # BatchSpanProcessor (OTel), Prometheus scrape threads, and loguru's
+    # async queue worker are all safe to ignore here - they never survive
+    # into workers and produce no side-effects when the fd is inherited.
+    _BENIGN_THREAD_PREFIXES = (
+        "OTel",  # OpenTelemetry SDK (BatchSpanProcessor, etc.)
+        "opentelemetry",  # alternate OTel naming
+        "prometheus",  # Prometheus client background threads
+        "loguru",  # loguru enqueue=True worker
+        "asyncio",  # event-loop helper threads (Python internals)
+        "ThreadPoolExecutor",  # stdlib executor - harmless in parent
+        "concurrent.futures",  # same pool, different prefix
+    )
+
+    @classmethod
+    def _is_benign_thread(cls, thread) -> bool:
+        return any(thread.name.startswith(prefix) for prefix in cls._BENIGN_THREAD_PREFIXES)
+
+    @classmethod
+    def pre_fork(cls, server, _worker):
+        import gc
+        import os
+        import threading
+
+        all_non_main = [t for t in threading.enumerate() if t.is_alive() and t is not threading.main_thread()]
+        debug_mode = os.environ.get("LANGFLOW_DEBUG_FORK_GHOSTS", "").lower() in ("1", "true", "yes")
+
+        if debug_mode and all_non_main:
+            names = [t.name for t in all_non_main]
+            server.log.debug("All non-main threads before fork (debug): %s", names)
+
+        suspicious = [t for t in all_non_main if not cls._is_benign_thread(t)]
+        if suspicious:
+            names = [t.name for t in suspicious]
+            server.log.warning("Ghost threads found before fork (these will be dead in workers): %s", names)
+
+        try:
+            import psutil
+
+            conns = psutil.Process().net_connections(kind="tcp")
+            ghost_conns = [c for c in conns if c.status != "LISTEN"]
+            if ghost_conns:
+                details = [(c.laddr, c.raddr, c.status) for c in ghost_conns]
+                server.log.warning(
+                    "Ghost TCP connections found before fork (will be dead in workers): %s",
+                    details,
+                )
+        except ImportError:
+            server.log.debug("psutil not installed; skipping ghost TCP connection check")
+        except Exception as e:  # noqa: BLE001
+            server.log.warning("Failed to inspect TCP connections before fork: %s", e)
+
+        try:
+            gc.collect()
+        except Exception as e:  # noqa: BLE001
+            server.log.warning("gc.collect() raised during pre-fork hook: %s", e)
+        gc.freeze()
+
     def load_config(self) -> None:
+        # Apply options from GUNICORN_CMD_ARGS env var before programmatic options
+        parser = self.cfg.parser()
+        cmd_args = self.cfg.get_cmd_args_from_env()
+        if cmd_args:
+            env_args = parser.parse_args(cmd_args)
+            for k, v in vars(env_args).items():
+                # Skip unset/positional args and only apply known settings
+                if v is None or k == "args" or k not in self.cfg.settings:
+                    continue
+                self.cfg.set(k.lower(), v)
+
+        # Programmatic options override env args
         config = {key: value for key, value in self.options.items() if key in self.cfg.settings and value is not None}
         for key, value in config.items():
             self.cfg.set(key.lower(), value)
 
     def load(self):
+        if self.application is None:
+            self.application = self._app_factory()
         return self.application

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-base"
-version = "0.9.0"
+version = "0.10.0"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.14"
 license = "MIT"
@@ -17,7 +17,7 @@ maintainers = [
 ]
 
 dependencies = [
-    "lfx~=0.4.0",
+    "lfx~=0.5.0",
     "fastapi>=0.135.0,<1.0.0",
     "httpx[http2]>=0.27,<1.0.0",
     "aiofile>=3.9.0,<4.0.0",

--- a/src/backend/tests/unit/api/v1/test_mcp_projects.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects.py
@@ -13,6 +13,7 @@ from langflow.api.v1.mcp_projects import (
     _args_reference_urls,
     get_project_mcp_server,
     get_project_sse,
+    get_project_streamable_http_url,
     init_mcp_servers,
     project_mcp_servers,
     project_sse_transports,
@@ -22,6 +23,8 @@ from langflow.services.database.models.flow import Flow
 from langflow.services.database.models.folder import Folder
 from langflow.services.database.models.user.model import User
 from langflow.services.deps import get_settings_service
+from lfx.base.mcp.constants import MAX_MCP_SERVER_NAME_LENGTH
+from lfx.base.mcp.util import sanitize_mcp_name
 from lfx.services.deps import session_scope
 from mcp.server.sse import SseServerTransport
 from sqlmodel import select
@@ -30,6 +33,24 @@ from tests.unit.utils.mcp import project_session_manager_lifespan
 
 # Mark all tests in this module as asyncio
 pytestmark = pytest.mark.asyncio
+
+
+def _set_startup_mcp_settings(
+    monkeypatch,
+    *,
+    auto_login: bool,
+    mcp_composer_enabled: bool,
+    add_projects_to_mcp_servers: bool,
+) -> None:
+    """Configure the runtime settings used by init_mcp_servers for a test."""
+    settings_service = get_settings_service()
+    monkeypatch.setattr(settings_service.auth_settings, "AUTO_LOGIN", auto_login)
+    monkeypatch.setattr(settings_service.settings, "mcp_composer_enabled", mcp_composer_enabled)
+    monkeypatch.setattr(
+        settings_service.settings,
+        "add_projects_to_mcp_servers",
+        add_projects_to_mcp_servers,
+    )
 
 
 @pytest.mark.parametrize(
@@ -844,6 +865,204 @@ async def test_init_mcp_servers_error_handling_streamable():
     with patch("langflow.api.v1.mcp_projects.get_project_mcp_server", side_effect=mock_get_project_mcp_server):
         # This should not raise any exception, as the error should be caught
         await init_mcp_servers()
+
+
+async def test_init_mcp_servers_reconciles_project_server_auth_when_oauth_falls_back(
+    user_test_project,
+):
+    """Startup should refresh MCP server config after OAuth falls back to API key auth."""
+    project_sse_transports.clear()
+    project_mcp_servers.clear()
+
+    async with session_scope() as session:
+        project = await session.get(Folder, user_test_project.id)
+        assert project is not None
+        project.auth_settings = {"auth_type": "oauth"}
+        session.add(project)
+
+    with (
+        patch("langflow.api.v1.mcp_projects.get_project_sse"),
+        patch("langflow.api.v1.mcp_projects.get_project_mcp_server"),
+        patch("langflow.api.v1.mcp_projects.auto_configure_starter_projects_mcp", new=AsyncMock()),
+        patch("langflow.api.v1.mcp_projects.get_settings_service") as mock_get_settings,
+        patch(
+            "langflow.api.v1.projects_mcp_helpers.register_mcp_servers_for_project",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        mock_service = MagicMock()
+        mock_service.settings = SimpleNamespace(mcp_composer_enabled=False, add_projects_to_mcp_servers=True)
+        mock_service.auth_settings = SimpleNamespace(AUTO_LOGIN=False)
+        mock_get_settings.return_value = mock_service
+        await init_mcp_servers()
+
+    async with session_scope() as session:
+        project = await session.get(Folder, user_test_project.id)
+        assert project is not None
+        assert project.auth_settings is not None
+        assert project.auth_settings["auth_type"] == "apikey"
+
+
+async def test_init_mcp_servers_reconciles_existing_apikey_project_server_config(
+    client: AsyncClient,
+    user_test_project,
+    created_api_key,
+    monkeypatch,
+):
+    """Startup should repair stale MCP server config even when auth was already persisted earlier."""
+    project_sse_transports.clear()
+    project_mcp_servers.clear()
+    _set_startup_mcp_settings(
+        monkeypatch,
+        auto_login=False,
+        mcp_composer_enabled=False,
+        add_projects_to_mcp_servers=True,
+    )
+
+    async with session_scope() as session:
+        project = await session.get(Folder, user_test_project.id)
+        assert project is not None
+        project.auth_settings = {"auth_type": "apikey"}
+        session.add(project)
+
+    server_name = f"lf-{sanitize_mcp_name(user_test_project.name)[: (MAX_MCP_SERVER_NAME_LENGTH - 4)]}"
+    streamable_http_url = await get_project_streamable_http_url(user_test_project.id)
+    stale_server_config = {
+        "command": "uvx",
+        "args": ["mcp-proxy", "--transport", "streamablehttp", streamable_http_url],
+    }
+    headers = {"x-api-key": created_api_key.api_key}
+
+    response = await client.post(f"/api/v2/mcp/servers/{server_name}", json=stale_server_config, headers=headers)
+    assert response.status_code == 200
+
+    try:
+        with (
+            patch("langflow.api.v1.mcp_projects.get_project_sse"),
+            patch("langflow.api.v1.mcp_projects.get_project_mcp_server"),
+            patch("langflow.api.v1.mcp_projects.auto_configure_starter_projects_mcp", new=AsyncMock()),
+        ):
+            await init_mcp_servers()
+
+        response = await client.get(f"/api/v2/mcp/servers/{server_name}", headers=headers)
+        assert response.status_code == 200
+        server_config = response.json()
+        server_args = server_config["args"]
+        assert "mcp-proxy" in server_args
+        assert "--transport" in server_args
+        assert "streamablehttp" in server_args
+        assert "--headers" in server_args
+        assert "x-api-key" in server_args
+        assert streamable_http_url in server_args
+    finally:
+        await client.delete(f"/api/v2/mcp/servers/{server_name}", headers=headers)
+
+
+async def test_patch_project_mcp_settings_syncs_server_config_for_apikey(
+    client: AsyncClient,
+    user_test_project,
+    created_api_key,
+    logged_in_headers,
+    monkeypatch,
+):
+    """PATCH /api/v1/mcp/project/{id} with auth_type=apikey must propagate x-api-key to MCP server args.
+
+    Regression test for the PATCH-path gap where auth_settings was updated in the DB but the
+    corresponding MCP server config was never reconciled, leaving args without --headers x-api-key
+    and causing subsequent startup reconciliation to generate duplicate Langflow API keys.
+    """
+    project_sse_transports.clear()
+    project_mcp_servers.clear()
+    _set_startup_mcp_settings(
+        monkeypatch,
+        auto_login=False,
+        mcp_composer_enabled=False,
+        add_projects_to_mcp_servers=True,
+    )
+
+    server_name = f"lf-{sanitize_mcp_name(user_test_project.name)[: (MAX_MCP_SERVER_NAME_LENGTH - 4)]}"
+    streamable_http_url = await get_project_streamable_http_url(user_test_project.id)
+    # Seed the server registry with a config that does NOT yet include the apikey header.
+    stale_server_config = {
+        "command": "uvx",
+        "args": ["mcp-proxy", "--transport", "streamablehttp", streamable_http_url],
+    }
+    api_headers = {"x-api-key": created_api_key.api_key}
+    response = await client.post(f"/api/v2/mcp/servers/{server_name}", json=stale_server_config, headers=api_headers)
+    assert response.status_code == 200
+
+    try:
+        patch_payload = {
+            "settings": [],
+            "auth_settings": {"auth_type": "apikey"},
+        }
+        response = await client.patch(
+            f"/api/v1/mcp/project/{user_test_project.id}",
+            headers=logged_in_headers,
+            json=patch_payload,
+        )
+        assert response.status_code == 200
+
+        # Server config should now reflect apikey auth (--headers x-api-key injected).
+        response = await client.get(f"/api/v2/mcp/servers/{server_name}", headers=api_headers)
+        assert response.status_code == 200
+        server_args = response.json()["args"]
+        assert "--headers" in server_args
+        assert "x-api-key" in server_args
+        assert streamable_http_url in server_args
+
+        # PATCHing again with the same auth should be a no-op — no duplicate key creation.
+        with patch("langflow.api.v1.projects_mcp_helpers.create_api_key") as mock_create_api_key:
+            response = await client.patch(
+                f"/api/v1/mcp/project/{user_test_project.id}",
+                headers=logged_in_headers,
+                json=patch_payload,
+            )
+            assert response.status_code == 200
+            mock_create_api_key.assert_not_called()
+    finally:
+        await client.delete(f"/api/v2/mcp/servers/{server_name}", headers=api_headers)
+
+
+async def test_init_mcp_servers_rolls_back_auth_update_when_reconciliation_fails(
+    user_test_project,
+    monkeypatch,
+):
+    """Startup should not persist auth changes if MCP server reconciliation fails."""
+    project_sse_transports.clear()
+    project_mcp_servers.clear()
+    _set_startup_mcp_settings(
+        monkeypatch,
+        auto_login=False,
+        mcp_composer_enabled=False,
+        add_projects_to_mcp_servers=True,
+    )
+
+    async with session_scope() as session:
+        project = await session.get(Folder, user_test_project.id)
+        assert project is not None
+        project.auth_settings = None
+        session.add(project)
+
+    with (
+        patch("langflow.api.v1.mcp_projects.get_project_sse"),
+        patch("langflow.api.v1.mcp_projects.get_project_mcp_server"),
+        patch("langflow.api.v1.mcp_projects.auto_configure_starter_projects_mcp", new=AsyncMock()),
+        patch(
+            "langflow.api.v1.projects_mcp_helpers.create_api_key",
+            new=AsyncMock(return_value=SimpleNamespace(api_key="generated-key")),
+        ),
+        patch(
+            "langflow.api.v1.projects_mcp_helpers.update_server",
+            new=AsyncMock(side_effect=RuntimeError("server sync failed")),
+        ),
+    ):
+        await init_mcp_servers()
+
+    async with session_scope() as session:
+        project = await session.get(Folder, user_test_project.id)
+        assert project is not None
+        assert project.auth_settings is None
 
 
 async def test_list_project_tools_with_mcp_enabled_filter(

--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -6,11 +6,14 @@ This test suite validates the MCP utility functions including:
 - Utility functions for name sanitization and schema conversion
 """
 
+import asyncio
 import re
 import shutil
 import sys
+from contextlib import suppress
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from lfx.base.mcp import util
 from lfx.base.mcp.util import (
@@ -18,7 +21,9 @@ from lfx.base.mcp.util import (
     MCPSseClient,
     MCPStdioClient,
     MCPStreamableHttpClient,
+    _is_transient_streamable_http_error,
     _process_headers,
+    _should_attempt_sse_after_streamable_failure,
     update_tools,
     validate_headers,
 )
@@ -1981,7 +1986,9 @@ class TestMCPSseClientUnit:
             patch.object(sse_client, "_get_or_create_session", side_effect=mock_get_session_side_effect),
             patch.object(sse_client, "_get_session_manager") as mock_get_manager,
         ):
-            mock_manager = AsyncMock()
+            mock_manager = MagicMock()
+            mock_manager.invalidate_server_key = AsyncMock()
+            mock_manager._get_server_key = MagicMock(return_value="streamable_http_testkey")
             mock_get_manager.return_value = mock_manager
 
             result = await sse_client.run_tool("test_tool", {"param": "value"})
@@ -1989,8 +1996,7 @@ class TestMCPSseClientUnit:
             # Should have retried and succeeded on second attempt
             assert call_count == 2
             assert result is not None
-            # Should have cleaned up the failed session
-            mock_manager._cleanup_session.assert_called_once_with("test_context")
+            mock_manager.invalidate_server_key.assert_called_once_with("streamable_http_testkey")
 
 
 class TestMCPStructuredTool:
@@ -3332,3 +3338,128 @@ class TestMCPStructuredToolToolCallId:
         assert handler.outputs[0].name == "get_image"
         assert handler.outputs[0].artifact is raw
         assert result.name == "get_image"
+
+
+class TestStreamableHttpTransportPolicy:
+    """Mocked streamable HTTP vs SSE: reconnect policy and fallback classification."""
+
+    def _connection_params(self):
+        return {
+            "url": "http://test-mcp.example/mcp",
+            "headers": {},
+            "timeout_seconds": 30,
+            "verify_ssl": True,
+        }
+
+    def _fake_client_session(self):
+        inst = MagicMock()
+        inst.initialize = AsyncMock()
+        inst.__aenter__ = AsyncMock(return_value=inst)
+        inst.__aexit__ = AsyncMock(return_value=None)
+        return inst
+
+    @pytest.mark.asyncio
+    async def test_streamable_success_sse_not_invoked(self):
+        manager = MCPSessionManager()
+        try:
+            fake = self._fake_client_session()
+            stream_cm = MagicMock()
+            stream_cm.return_value.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock(), None))
+            stream_cm.return_value.__aexit__ = AsyncMock(return_value=None)
+            with (
+                patch("lfx.base.mcp.util.ClientSession", return_value=fake),
+                patch("mcp.client.streamable_http.streamablehttp_client", stream_cm),
+                patch("mcp.client.sse.sse_client") as sse_cm,
+            ):
+                session, task, transport, sse_lock = await manager._create_streamable_http_session(
+                    "test_sess", self._connection_params(), None
+                )
+                assert transport == "streamable_http"
+                assert sse_lock is False
+                assert session is fake
+                sse_cm.assert_not_called()
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        finally:
+            await manager.cleanup_all()
+
+    @pytest.mark.asyncio
+    async def test_transient_streamable_failure_no_sse_fallback(self):
+        manager = MCPSessionManager()
+        try:
+            fake = self._fake_client_session()
+            stream_cm = MagicMock()
+            stream_cm.return_value.__aenter__ = AsyncMock(side_effect=ConnectionError("connection refused"))
+            stream_cm.return_value.__aexit__ = AsyncMock(return_value=None)
+            with (
+                patch("lfx.base.mcp.util.ClientSession", return_value=fake),
+                patch("mcp.client.streamable_http.streamablehttp_client", stream_cm),
+                patch("mcp.client.sse.sse_client") as sse_cm,
+            ):
+                with pytest.raises(ConnectionError, match="connection refused"):
+                    await manager._create_streamable_http_session("test_sess", self._connection_params(), None)
+                sse_cm.assert_not_called()
+        finally:
+            await manager.cleanup_all()
+
+    @pytest.mark.asyncio
+    async def test_streamable_404_triggers_sse(self):
+        manager = MCPSessionManager()
+        try:
+            req = httpx.Request("GET", "http://test-mcp.example/mcp")
+            resp = httpx.Response(404, request=req)
+            err404 = httpx.HTTPStatusError("not found", request=req, response=resp)
+            fake_stream = self._fake_client_session()
+            fake_sse = self._fake_client_session()
+            sessions = iter([fake_stream, fake_sse])
+
+            def client_session_factory(_r, _w, *_args):
+                return next(sessions)
+
+            stream_cm = MagicMock()
+            stream_cm.return_value.__aenter__ = AsyncMock(side_effect=err404)
+            stream_cm.return_value.__aexit__ = AsyncMock(return_value=None)
+            sse_cm = MagicMock()
+            sse_cm.return_value.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
+            sse_cm.return_value.__aexit__ = AsyncMock(return_value=None)
+            with (
+                patch("lfx.base.mcp.util.ClientSession", side_effect=client_session_factory),
+                patch("mcp.client.streamable_http.streamablehttp_client", stream_cm),
+                patch("mcp.client.sse.sse_client", sse_cm),
+            ):
+                _session, task, transport, sse_lock = await manager._create_streamable_http_session(
+                    "test_sess", self._connection_params(), None
+                )
+                assert transport == "sse"
+                assert sse_lock is True
+                sse_cm.assert_called_once()
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        finally:
+            await manager.cleanup_all()
+
+    @pytest.mark.asyncio
+    async def test_validate_connectivity_mcp_session_terminated_returns_false(self):
+        manager = MCPSessionManager()
+        try:
+            mock_session = AsyncMock()
+            mock_session.list_tools = AsyncMock(side_effect=RuntimeError("Session terminated"))
+            assert await manager._validate_session_connectivity(mock_session) is False
+        finally:
+            await manager.cleanup_all()
+
+    def test_classify_transient_includes_connection_and_taskgroup_hints(self):
+        assert _is_transient_streamable_http_error(ConnectionError("x")) is True
+        assert _is_transient_streamable_http_error(RuntimeError("unhandled errors in a TaskGroup")) is True
+        req = httpx.Request("GET", "http://x")
+        resp_404 = httpx.Response(404, request=req)
+        assert _is_transient_streamable_http_error(httpx.HTTPStatusError("x", request=req, response=resp_404)) is False
+
+    def test_sse_fallback_after_404(self):
+        req = httpx.Request("GET", "http://x")
+        resp_404 = httpx.Response(404, request=req)
+        e = httpx.HTTPStatusError("x", request=req, response=resp_404)
+        assert _should_attempt_sse_after_streamable_failure(e) is True
+        assert _should_attempt_sse_after_streamable_failure(ConnectionError("x")) is False

--- a/src/backend/tests/unit/base/test_server.py
+++ b/src/backend/tests/unit/base/test_server.py
@@ -1,0 +1,250 @@
+"""Unit tests for LangflowApplication in langflow.server."""
+
+import gc
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langflow.server import LangflowApplication
+
+
+class _FakeServer:
+    """Minimal stand-in for the gunicorn Server object passed to pre_fork."""
+
+    def __init__(self):
+        self.log = MagicMock()
+
+
+@pytest.fixture
+def fake_server():
+    return _FakeServer()
+
+
+def _find_warning(mock_log, substring: str):
+    """Return the first warning call whose format string contains *substring*, or None."""
+    return next(
+        (c for c in mock_log.warning.call_args_list if substring in (c.args[0] if c.args else "")),
+        None,
+    )
+
+
+def _make_fake_conn(status: str):
+    """Return a psutil-style connection named-tuple substitute."""
+    conn = MagicMock()
+    conn.status = status
+    conn.laddr = ("127.0.0.1", 12345)
+    conn.raddr = ("127.0.0.1", 9999)
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Thread-safety warnings
+# ---------------------------------------------------------------------------
+
+
+def test_pre_fork_warns_for_non_main_threads(fake_server):
+    """pre_fork should warn when live non-main threads are present before fork."""
+    ready = threading.Event()
+    stop = threading.Event()
+
+    def _worker():
+        ready.set()
+        stop.wait()
+
+    t = threading.Thread(target=_worker, name="ghost-worker", daemon=True)
+    t.start()
+    try:
+        ready.wait(timeout=2)
+        LangflowApplication.pre_fork(fake_server, None)
+    finally:
+        stop.set()
+        t.join(timeout=2)
+
+    warning = _find_warning(fake_server.log, "Ghost threads")
+    assert warning is not None, "Expected a 'Ghost threads' warning but none was logged"
+    assert "ghost-worker" in warning.args[1]
+
+
+def test_pre_fork_no_thread_warning_for_benign_threads(fake_server):
+    """pre_fork should not emit a thread warning for threads with known benign prefixes."""
+    mock_thread = MagicMock()
+    mock_thread.is_alive.return_value = True
+    mock_thread.name = "loguru-worker-1"
+
+    with (
+        patch("threading.enumerate", return_value=[threading.main_thread(), mock_thread]),
+        patch("psutil.Process") as mock_proc,
+    ):
+        mock_proc.return_value.net_connections.return_value = []
+        LangflowApplication.pre_fork(fake_server, None)
+
+    assert _find_warning(fake_server.log, "Ghost threads") is None
+
+
+def test_pre_fork_no_thread_warning_when_only_main_thread(fake_server):
+    """pre_fork should not emit a thread warning when only the main thread is alive."""
+    with (
+        patch("threading.enumerate", return_value=[threading.main_thread()]),
+        patch("psutil.Process") as mock_proc,
+    ):
+        mock_proc.return_value.net_connections.return_value = []
+        LangflowApplication.pre_fork(fake_server, None)
+
+    assert _find_warning(fake_server.log, "Ghost threads") is None
+
+
+# ---------------------------------------------------------------------------
+# TCP-connection warnings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", ["ESTABLISHED", "TIME_WAIT", "CLOSE_WAIT", "CLOSING", "SYN_SENT"])
+def test_pre_fork_warns_for_non_listen_tcp_connections(fake_server, status):
+    """pre_fork should warn for any non-LISTEN TCP connection status."""
+    conn = _make_fake_conn(status)
+
+    with (
+        patch("threading.enumerate", return_value=[threading.main_thread()]),
+        patch("psutil.Process") as mock_proc,
+    ):
+        mock_proc.return_value.net_connections.return_value = [conn]
+        LangflowApplication.pre_fork(fake_server, None)
+
+    warning = _find_warning(fake_server.log, "Ghost TCP connections")
+    assert warning is not None, f"Expected a 'Ghost TCP connections' warning for status={status!r}"
+    logged_details = warning.args[1]
+    assert any(status in str(d) for d in logged_details), (
+        f"Expected connection status {status!r} in logged details, got: {logged_details}"
+    )
+
+
+def test_pre_fork_no_tcp_warning_for_listen_only_connections(fake_server):
+    """pre_fork should not warn when all TCP connections are in LISTEN state."""
+    with (
+        patch("threading.enumerate", return_value=[threading.main_thread()]),
+        patch("psutil.Process") as mock_proc,
+    ):
+        mock_proc.return_value.net_connections.return_value = [_make_fake_conn("LISTEN")]
+        LangflowApplication.pre_fork(fake_server, None)
+
+    assert _find_warning(fake_server.log, "Ghost TCP connections") is None
+
+
+# ---------------------------------------------------------------------------
+# Error-resilience
+# ---------------------------------------------------------------------------
+
+
+def test_pre_fork_handles_psutil_import_error(fake_server):
+    """pre_fork should silently skip TCP inspection when psutil is unavailable."""
+    with (
+        patch("threading.enumerate", return_value=[threading.main_thread()]),
+        patch.dict("sys.modules", {"psutil": None}),
+    ):
+        LangflowApplication.pre_fork(fake_server, None)
+
+    assert _find_warning(fake_server.log, "TCP") is None, "Should not log TCP warnings when psutil is missing"
+
+
+def test_pre_fork_warns_when_psutil_raises(fake_server):
+    """pre_fork should log a warning (not raise) when psutil throws unexpectedly."""
+    with (
+        patch("threading.enumerate", return_value=[threading.main_thread()]),
+        patch("psutil.Process") as mock_proc,
+    ):
+        mock_proc.return_value.net_connections.side_effect = RuntimeError("permission denied")
+        LangflowApplication.pre_fork(fake_server, None)
+
+    warning = _find_warning(fake_server.log, "Failed to inspect")
+    assert warning is not None, "Expected a 'Failed to inspect' warning when psutil raises"
+    assert "permission denied" in str(warning.args[1])
+
+
+# ---------------------------------------------------------------------------
+# GC contract
+# ---------------------------------------------------------------------------
+
+
+def test_pre_fork_always_runs_gc(fake_server):
+    """pre_fork must call gc.collect() and gc.freeze() unconditionally."""
+    with (
+        patch("threading.enumerate", return_value=[threading.main_thread()]),
+        patch("psutil.Process") as mock_proc,
+        patch.object(gc, "collect") as mock_collect,
+        patch.object(gc, "freeze") as mock_freeze,
+    ):
+        mock_proc.return_value.net_connections.return_value = []
+        LangflowApplication.pre_fork(fake_server, None)
+
+    mock_collect.assert_called_once()
+    mock_freeze.assert_called_once()
+
+
+def test_pre_fork_handles_gc_collect_exception(fake_server):
+    """pre_fork must not crash if gc.collect() raises, and must still call gc.freeze()."""
+    with (
+        patch("threading.enumerate", return_value=[threading.main_thread()]),
+        patch("psutil.Process") as mock_proc,
+        patch.object(gc, "collect", side_effect=RuntimeError("bad finalizer")),
+        patch.object(gc, "freeze") as mock_freeze,
+    ):
+        mock_proc.return_value.net_connections.return_value = []
+        # Must not raise
+        LangflowApplication.pre_fork(fake_server, None)
+
+    warning = _find_warning(fake_server.log, "gc.collect() raised")
+    assert warning is not None, "Expected a warning when gc.collect() raises"
+    assert "bad finalizer" in str(warning.args[1])
+    mock_freeze.assert_called_once()
+
+
+def _make_app(options=None, env_args=None, monkeypatch=None):
+    """Create a LangflowApplication with a dummy WSGI app.
+
+    Args:
+        options: Programmatic options passed to LangflowApplication.
+        env_args: If provided, set GUNICORN_CMD_ARGS env var before construction.
+        monkeypatch: pytest monkeypatch fixture for env manipulation.
+    """
+    if env_args is not None and monkeypatch is not None:
+        monkeypatch.setenv("GUNICORN_CMD_ARGS", env_args)
+
+    def dummy_app(environ, start_response):
+        pass
+
+    return LangflowApplication(dummy_app, options=options)
+
+
+class TestGunicornEnvArgs:
+    def test_env_args_applied(self, monkeypatch):
+        """GUNICORN_CMD_ARGS values should be reflected in the config."""
+        app = _make_app(env_args="--max-requests 100 --max-requests-jitter 20", monkeypatch=monkeypatch)
+
+        assert app.cfg.settings["max_requests"].get() == 100
+        assert app.cfg.settings["max_requests_jitter"].get() == 20
+
+    def test_programmatic_options_override_env(self, monkeypatch):
+        """Programmatic options must take precedence over GUNICORN_CMD_ARGS."""
+        app = _make_app(
+            options={"workers": 2},
+            env_args="--workers 8",
+            monkeypatch=monkeypatch,
+        )
+
+        assert app.cfg.settings["workers"].get() == 2
+
+    def test_no_env_var_uses_defaults(self):
+        """Without GUNICORN_CMD_ARGS, Gunicorn defaults should remain intact."""
+        app = _make_app()
+
+        # Gunicorn default for max_requests is 0 (disabled)
+        assert app.cfg.settings["max_requests"].get() == 0
+
+    def test_env_does_not_override_worker_class(self, monkeypatch):
+        """worker_class is always set programmatically and must not be overridden by env."""
+        app = _make_app(
+            env_args="--worker-class sync",
+            monkeypatch=monkeypatch,
+        )
+
+        assert app.cfg.settings["worker_class"].get() == "langflow.server.LangflowUvicornWorker"

--- a/src/backend/tests/unit/initial_setup/test_setup_functions.py
+++ b/src/backend/tests/unit/initial_setup/test_setup_functions.py
@@ -9,7 +9,8 @@ from langflow.initial_setup.setup import (
     update_projects_components_with_latest_component_versions,
 )
 from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NAME
-from langflow.services.database.models.folder.model import FolderRead
+from langflow.services.database.models.folder.model import Folder, FolderRead
+from sqlmodel import select
 
 
 @pytest.mark.usefixtures("client")
@@ -56,6 +57,80 @@ async def test_get_or_create_default_folder_concurrent_calls() -> None:
     results = await asyncio.gather(get_folder(), get_folder(), get_folder())
     folder_ids = {folder.id for folder in results}
     assert len(folder_ids) == 1, "Concurrent calls must return a single, consistent folder instance."
+
+
+@pytest.mark.usefixtures("client")
+async def test_get_or_create_default_folder_respects_rename() -> None:
+    """Regression test: renaming the default folder must persist across calls.
+
+    Reproduces the reported bug where the server would recreate a "Starter Project" folder
+    on every login or server restart, even though the user had already renamed it to something
+    like "My Flows". After the fix, get_or_create_default_folder must detect the user's existing
+    (renamed) folder and return it instead of forcing a new default folder back into the UI.
+    """
+    test_user_id = uuid4()
+    renamed_folder_name = "My Flows"
+
+    # First call creates the default folder.
+    async with session_scope() as session:
+        folder_first = await get_or_create_default_folder(session, test_user_id)
+        assert folder_first.name == DEFAULT_FOLDER_NAME
+        original_id = folder_first.id
+
+    # Simulate the user renaming the default folder from the UI.
+    async with session_scope() as session:
+        stmt = select(Folder).where(Folder.id == original_id)
+        folder_row = (await session.exec(stmt)).first()
+        assert folder_row is not None
+        folder_row.name = renamed_folder_name
+        session.add(folder_row)
+        await session.flush()
+
+    # Second call (simulating next login / server restart) must honor the rename
+    # rather than creating a new "Starter Project" alongside the renamed one.
+    async with session_scope() as session:
+        folder_second = await get_or_create_default_folder(session, test_user_id)
+        assert folder_second.id == original_id, (
+            "The renamed folder should be returned instead of creating a new default."
+        )
+        assert folder_second.name == renamed_folder_name, (
+            "The folder's user-assigned name must be preserved across calls."
+        )
+
+        # There should still be exactly one folder for this user — no phantom duplicate.
+        all_folders_stmt = select(Folder).where(Folder.user_id == test_user_id)
+        all_folders = (await session.exec(all_folders_stmt)).all()
+        folder_names = sorted(f.name for f in all_folders)
+        assert folder_names == [renamed_folder_name], (
+            f"Expected only the renamed folder to exist, found: {folder_names}"
+        )
+
+
+@pytest.mark.usefixtures("client")
+async def test_get_or_create_default_folder_respects_other_existing_folder() -> None:
+    """Respect existing folders when the default folder is absent.
+
+    If the user already has any folder (e.g. they moved everything into 'Ideas' and
+    deleted the default), we must not resurrect the default folder on the next call.
+    """
+    test_user_id = uuid4()
+    other_folder_name = "Ideas"
+
+    # Simulate an existing user who has a non-default folder but no "Starter Project".
+    async with session_scope() as session:
+        session.add(Folder(user_id=test_user_id, name=other_folder_name, description="My ideas"))
+        await session.flush()
+
+    async with session_scope() as session:
+        returned = await get_or_create_default_folder(session, test_user_id)
+        assert returned.name == other_folder_name, (
+            "Should return the user's existing folder rather than creating a new default."
+        )
+
+        all_folders_stmt = select(Folder).where(Folder.user_id == test_user_id)
+        all_folders = (await session.exec(all_folders_stmt)).all()
+        folder_names = sorted(f.name for f in all_folders)
+        assert folder_names == [other_folder_name], f"No new default folder should be created; found: {folder_names}"
 
 
 def _make_all_types_dict():

--- a/src/backend/tests/unit/test_security_cors.py
+++ b/src/backend/tests/unit/test_security_cors.py
@@ -123,9 +123,9 @@ class TestCORSConfiguration:
             assert settings.cors_origins == ["https://app.example.com"]
             assert settings.cors_allow_credentials is True
 
-    @patch("langflow.main.setup_sentry")  # Mock Sentry setup
+    @patch("langflow.main.add_sentry_middleware")  # Mock Sentry setup
     @patch("langflow.main.get_settings_service")
-    def test_cors_middleware_configuration(self, mock_get_settings, mock_setup_sentry):
+    def test_cors_middleware_configuration(self, mock_get_settings, mock_add_sentry_middleware):
         """Test that CORS middleware is configured correctly in the app."""
         from langflow.main import create_app
 
@@ -141,7 +141,7 @@ class TestCORSConfiguration:
         mock_get_settings.return_value = mock_settings
 
         # Create app
-        mock_setup_sentry.return_value = None  # Use the mock
+        mock_add_sentry_middleware.return_value = None  # Use the mock
         app = create_app()
 
         # Find CORS middleware
@@ -157,11 +157,11 @@ class TestCORSConfiguration:
         assert cors_middleware.kwargs["allow_methods"] == ["GET", "POST"]
         assert cors_middleware.kwargs["allow_headers"] == ["Content-Type"]
 
-    @patch("langflow.main.setup_sentry")  # Mock Sentry setup
+    @patch("langflow.main.add_sentry_middleware")  # Mock Sentry setup
     @patch("langflow.main.get_settings_service")
     @patch("langflow.main.logger")
     def test_cors_wildcard_credentials_runtime_check_current_behavior(
-        self, mock_logger, mock_get_settings, mock_setup_sentry
+        self, mock_logger, mock_get_settings, mock_add_sentry_middleware
     ):
         """Test runtime validation prevents wildcard with credentials (current behavior)."""
         from langflow.main import create_app
@@ -178,7 +178,7 @@ class TestCORSConfiguration:
         mock_get_settings.return_value = mock_settings
 
         # Create app
-        mock_setup_sentry.return_value = None  # Use the mock
+        mock_add_sentry_middleware.return_value = None  # Use the mock
         app = create_app()
 
         # Check that warning was logged about deprecation/security
@@ -354,8 +354,8 @@ class TestCORSIntegration:
     """Integration tests for CORS with actual HTTP requests."""
 
     @pytest.mark.asyncio
-    @patch("langflow.main.setup_sentry")  # Mock Sentry setup
-    async def test_cors_headers_in_response_current_behavior(self, mock_setup_sentry):
+    @patch("langflow.main.add_sentry_middleware")  # Mock Sentry setup
+    async def test_cors_headers_in_response_current_behavior(self, mock_add_sentry_middleware):
         """Test that CORS headers are properly set in responses (current behavior)."""
         from fastapi.testclient import TestClient
 
@@ -373,7 +373,7 @@ class TestCORSIntegration:
 
             from langflow.main import create_app
 
-            mock_setup_sentry.return_value = None  # Use the mock
+            mock_add_sentry_middleware.return_value = None  # Use the mock
             app = create_app()
             client = TestClient(app)
 
@@ -403,8 +403,8 @@ class TestCORSIntegration:
         # This test represents the behavior we want in v1.7 with secure defaults
 
     @pytest.mark.asyncio
-    @patch("langflow.main.setup_sentry")  # Mock Sentry setup
-    async def test_cors_blocks_unauthorized_origin_current_behavior(self, mock_setup_sentry):
+    @patch("langflow.main.add_sentry_middleware")  # Mock Sentry setup
+    async def test_cors_blocks_unauthorized_origin_current_behavior(self, mock_add_sentry_middleware):
         """Test that CORS blocks requests from unauthorized origins."""
         from fastapi.testclient import TestClient
 
@@ -422,7 +422,7 @@ class TestCORSIntegration:
 
             from langflow.main import create_app
 
-            mock_setup_sentry.return_value = None  # Use the mock
+            mock_add_sentry_middleware.return_value = None  # Use the mock
             app = create_app()
             client = TestClient(app)
 

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langflow",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langflow",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "@chakra-ui/number-input": "^2.1.2",
         "@chakra-ui/system": "^2.6.2",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langflow",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "engines": {
     "node": ">=20.19.0"

--- a/src/frontend/src/components/common/versionLabelComponent/index.tsx
+++ b/src/frontend/src/components/common/versionLabelComponent/index.tsx
@@ -1,0 +1,23 @@
+interface VersionLabelProps {
+  versionTag: string;
+  description?: string | null;
+  className?: string;
+}
+
+export default function VersionLabel({
+  versionTag,
+  description,
+  className,
+}: VersionLabelProps) {
+  return (
+    <span className={className}>
+      {versionTag}
+      {description && (
+        <span className="font-normal text-muted-foreground">
+          {" \u2014 "}
+          {description}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx
@@ -168,7 +168,10 @@ const SideBarFoldersButtonsComponent = ({
                     console.error(err);
                     setErrorData({
                       title: t("sidebar.projectUploadError"),
-                      list: [err["response"]["data"]["message"]],
+                      list: [
+                        err?.response?.data?.detail ??
+                          (err instanceof Error ? err.message : String(err)),
+                      ],
                     });
                   },
                 },

--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -20,7 +20,7 @@ import { usePatchMCPServer } from "@/controllers/API/queries/mcp/use-patch-mcp-s
 import { CustomLink } from "@/customization/components/custom-link";
 import BaseModal from "@/modals/baseModal";
 import IOKeyPairInput, {
-  KeyPairRow,
+  type KeyPairRow,
 } from "@/modals/IOModal/components/IOFieldView/components/key-pair-input";
 import IOKeyPairInputWithVariables from "@/modals/IOModal/components/IOFieldView/components/key-pair-input-with-variables";
 import type { MCPServerType } from "@/types/mcp";
@@ -292,7 +292,7 @@ export default function AddMcpServerModal({
       setOpen={setOpen}
       size="x-small-h-full"
       onSubmit={submitForm}
-      className="!p-0 min-h-[250px] flex-grow"
+      className="!p-0 min-h-[250px] max-h-[75vh] flex-grow"
     >
       <BaseModal.Trigger>{children}</BaseModal.Trigger>
       <BaseModal.Content className="flex flex-1 flex-col overflow-hidden min-h-0">
@@ -358,7 +358,7 @@ export default function AddMcpServerModal({
               </TabsList>
             </div>
             <div
-              className="flex w-full flex-1 flex-col border-y p-4 min-h-0"
+              className="flex w-full flex-1 flex-col overflow-y-auto border-y p-4 min-h-0"
               id="global-variable-modal-inputs"
             >
               {error && (
@@ -490,7 +490,7 @@ export default function AddMcpServerModal({
             </div>
           </Tabs>
         </div>
-        <div className="flex justify-end gap-2 p-4">
+        <div className="flex shrink-0 justify-end gap-2 p-4">
           <Button variant="outline" size="sm" onClick={() => setOpen(false)}>
             <span className="text-mmd font-normal">Cancel</span>
           </Button>

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveSnapshotButton.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveSnapshotButton.tsx
@@ -4,6 +4,7 @@ import { useSidebar } from "@/components/ui/sidebar";
 import { usePostCreateSnapshot } from "@/controllers/API/queries/flow-version";
 import useAlertStore from "@/stores/alertStore";
 import CanvasBanner, { CanvasBannerButton } from "./CanvasBanner";
+import SaveVersionDialog from "./SaveVersionDialog";
 
 interface SaveSnapshotButtonProps {
   flowId: string;
@@ -19,8 +20,12 @@ export default function SaveSnapshotButton({
     usePostCreateSnapshot();
   const [isSavingDisplay, setIsSavingDisplay] = useState(false);
   const [savedSuccess, setSavedSuccess] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+
+  const isBusy = isSavingDisplay || isCreating;
 
   const handleDismiss = () => {
+    setShowModal(false);
     // Switching the section unmounts the version sidebar, whose cleanup
     // handles clearPreview, restoring auto-save, and restoring the
     // inspection panel.
@@ -28,18 +33,20 @@ export default function SaveSnapshotButton({
     if (!open) toggleSidebar();
   };
 
-  const handleSave = () => {
+  const handleSave = (description: string | null) => {
+    setShowModal(false);
     setIsSavingDisplay(true);
     createSnapshot(
-      { flowId, description: null },
+      { flowId, description },
       {
         onSuccess: () => {
           setSuccessData({ title: "Version saved" });
           setIsSavingDisplay(false);
           setSavedSuccess(true);
         },
-        onError: (err: any) => {
-          const detail = err?.response?.data?.detail;
+        onError: (err: unknown) => {
+          const detail = (err as { response?: { data?: { detail?: string } } })
+            ?.response?.data?.detail;
           setErrorData({
             title: "Failed to save version",
             ...(detail ? { list: [detail] } : {}),
@@ -50,39 +57,55 @@ export default function SaveSnapshotButton({
     );
   };
 
+  const renderSaveButtonContent = () => {
+    if (isBusy) {
+      return (
+        <>
+          <ForwardedIconComponent
+            name="Loader2"
+            className="h-3.5 w-3.5 animate-spin"
+          />
+          Saving…
+        </>
+      );
+    }
+    if (savedSuccess) {
+      return (
+        <>
+          <ForwardedIconComponent name="Check" className="h-3.5 w-3.5" />
+          Saved
+        </>
+      );
+    }
+    return "Save";
+  };
+
   return (
-    <CanvasBanner
-      icon="BookMarked"
-      title="Save a version of your flow"
-      description="Capture the current state as a restore point"
-      actionSlot={
-        <div className="flex items-center gap-2">
-          <CanvasBannerButton variant="outline" onClick={handleDismiss}>
-            Keep Building
-          </CanvasBannerButton>
-          <CanvasBannerButton
-            onClick={handleSave}
-            disabled={isSavingDisplay || isCreating || savedSuccess}
-          >
-            {isSavingDisplay || isCreating ? (
-              <>
-                <ForwardedIconComponent
-                  name="Loader2"
-                  className="h-3.5 w-3.5 animate-spin"
-                />
-                Saving…
-              </>
-            ) : savedSuccess ? (
-              <>
-                <ForwardedIconComponent name="Check" className="h-3.5 w-3.5" />
-                Saved
-              </>
-            ) : (
-              "Save"
-            )}
-          </CanvasBannerButton>
-        </div>
-      }
-    />
+    <>
+      <CanvasBanner
+        icon="BookMarked"
+        title="Save a version of your flow"
+        description="Capture the current state as a restore point"
+        actionSlot={
+          <div className="flex items-center gap-2">
+            <CanvasBannerButton variant="outline" onClick={handleDismiss}>
+              Keep Building
+            </CanvasBannerButton>
+            <CanvasBannerButton
+              onClick={() => setShowModal(true)}
+              disabled={isBusy || savedSuccess}
+            >
+              {renderSaveButtonContent()}
+            </CanvasBannerButton>
+          </div>
+        }
+      />
+
+      <SaveVersionDialog
+        open={showModal}
+        onOpenChange={setShowModal}
+        onSave={handleSave}
+      />
+    </>
   );
 }

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveVersionDialog.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/components/SaveVersionDialog.tsx
@@ -1,0 +1,88 @@
+import { useRef, useState } from "react";
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+interface SaveVersionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (description: string | null) => void;
+}
+
+export default function SaveVersionDialog({
+  open,
+  onOpenChange,
+  onSave,
+}: SaveVersionDialogProps) {
+  const [description, setDescription] = useState("");
+  const isComposing = useRef(false);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    onOpenChange(nextOpen);
+    if (!nextOpen) setDescription("");
+  };
+
+  const handleSave = () => {
+    onSave(description.trim() || null);
+    setDescription("");
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            <div className="flex items-center gap-2">
+              <ForwardedIconComponent
+                name="BookMarked"
+                className="h-5 w-5 text-primary"
+              />
+              Save Version
+            </div>
+          </DialogTitle>
+          <DialogDescription>
+            Give this version an optional name to help identify it later.
+          </DialogDescription>
+        </DialogHeader>
+        <Input
+          autoFocus
+          placeholder="Version name (optional)"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          onCompositionStart={() => {
+            isComposing.current = true;
+          }}
+          onCompositionEnd={() => {
+            isComposing.current = false;
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !isComposing.current) {
+              handleSave();
+            }
+          }}
+          maxLength={500}
+        />
+        <DialogFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handleOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleSave}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/frontend/src/pages/FlowPage/components/PageComponent/components/VersionPreviewOverlay.tsx
+++ b/src/frontend/src/pages/FlowPage/components/PageComponent/components/VersionPreviewOverlay.tsx
@@ -8,6 +8,9 @@ import SaveSnapshotButton from "./SaveSnapshotButton";
 export default function VersionPreviewOverlay() {
   const previewLabel = useVersionPreviewStore((s) => s.previewLabel);
   const previewId = useVersionPreviewStore((s) => s.previewId);
+  const previewDescription = useVersionPreviewStore(
+    (s) => s.previewDescription,
+  );
   const isPreviewLoading = useVersionPreviewStore((s) => s.isPreviewLoading);
   const currentFlowId = useFlowsManagerStore((state) => state.currentFlowId);
 
@@ -15,14 +18,21 @@ export default function VersionPreviewOverlay() {
 
   return (
     <div className="version-preview-overlay pointer-events-none absolute inset-0 z-50">
-      <CanvasBadge>
-        <span className="h-2 w-2 shrink-0 rounded-lg bg-[#6366F1]" />
-        <span className="text-sm">
-          {previewLabel === "Current Draft"
-            ? "Current Flow"
-            : `Previewing ${previewLabel}`}
-        </span>
-        <span className="text-muted-foreground text-sm">(Read-Only)</span>
+      <CanvasBadge className="flex-col items-start whitespace-normal">
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 shrink-0 rounded-lg bg-[#6366F1]" />
+          <span className="text-sm">
+            {previewLabel === "Current Draft"
+              ? "Current Flow"
+              : `Previewing ${previewLabel}`}
+          </span>
+          <span className="text-muted-foreground text-sm">(Read-Only)</span>
+        </div>
+        {previewDescription && (
+          <span className="max-w-[300px] pl-4 text-xs text-muted-foreground">
+            {previewDescription}
+          </span>
+        )}
       </CanvasBadge>
 
       {isPreviewLoading && (

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/FlowVersionSidebar/components/VersionListItem.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/FlowVersionSidebar/components/VersionListItem.tsx
@@ -1,4 +1,5 @@
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import VersionLabel from "@/components/common/versionLabelComponent";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -42,8 +43,12 @@ export default function VersionListItem({
           isSelected && "border-l-2 border-l-[#6366F1] !bg-[#6366F1]/10",
         )}
       >
-        <div className="flex flex-col items-start">
-          <span className="font-medium text-sm pb-1">{entry.version_tag}</span>
+        <div className="flex min-w-0 flex-col items-start">
+          <VersionLabel
+            versionTag={entry.version_tag}
+            description={entry.description}
+            className="w-full truncate font-medium text-sm pb-1"
+          />
           <span className="text-xs text-muted-foreground">
             {formatTimestamp(entry.created_at)}
           </span>

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/FlowVersionSidebar/use-flow-version-sidebar.ts
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/FlowVersionSidebar/use-flow-version-sidebar.ts
@@ -160,6 +160,7 @@ export function useFlowVersionSidebar(flowId: string) {
         processedPreview.edges,
         tag,
         selectedId,
+        selectedEntryFull?.description ?? null,
       );
     } else if (selectedId === CURRENT_DRAFT_ID || processedPreview?.error) {
       setPreview(
@@ -173,6 +174,7 @@ export function useFlowVersionSidebar(flowId: string) {
     processedPreview,
     selectedId,
     selectedEntryFull?.version_tag,
+    selectedEntryFull?.description,
     setPreview,
   ]);
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-version-panel.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-attach-flows-version-panel.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import VersionLabel from "@/components/common/versionLabelComponent";
 import { Badge } from "@/components/ui/badge";
 import type { FlowType } from "@/types/flow";
 import type { FlowVersionEntry } from "@/types/flow/version";
@@ -45,15 +46,19 @@ export const VersionPanel = memo(function VersionPanel({
       <div className="flex flex-1 flex-col overflow-hidden px-4 py-2">
         <h3 className="py-2 text-lg font-semibold">{selectedFlow.name}</h3>
         <div className="flex-1 space-y-3 overflow-y-auto py-3">
-          {isLoadingVersions ? (
+          {isLoadingVersions && (
             <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
               Loading versions...
             </div>
-          ) : versions.length === 0 ? (
+          )}
+
+          {!isLoadingVersions && versions.length === 0 && (
             <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
               No versions found
             </div>
-          ) : (
+          )}
+
+          {!isLoadingVersions &&
             versions.map((version) => {
               const isAttachedVersion = attachedEntry?.versionId === version.id;
               return (
@@ -69,14 +74,18 @@ export const VersionPanel = memo(function VersionPanel({
                       : "border-transparent bg-muted hover:border-border",
                   )}
                 >
-                  <span className="flex flex-col gap-1">
+                  <span className="flex min-w-0 flex-1 flex-col gap-1">
                     <span className="flex items-center gap-2 text-sm font-medium leading-tight">
-                      {version.version_tag}
+                      <VersionLabel
+                        versionTag={version.version_tag}
+                        description={version.description}
+                        className="truncate"
+                      />
                       {isAttachedVersion && (
                         <Badge
                           variant="secondaryStatic"
                           size="tag"
-                          className="bg-accent-blue-muted text-accent-blue-muted-foreground"
+                          className="shrink-0 bg-accent-blue-muted text-accent-blue-muted-foreground"
                         >
                           ATTACHED
                         </Badge>
@@ -88,8 +97,7 @@ export const VersionPanel = memo(function VersionPanel({
                   </span>
                 </button>
               );
-            })
-          )}
+            })}
         </div>
       </div>
     </>

--- a/src/frontend/src/stores/versionPreviewStore.ts
+++ b/src/frontend/src/stores/versionPreviewStore.ts
@@ -7,6 +7,8 @@ interface VersionPreviewState {
   previewLabel: string | null;
   /** The version entry ID currently being previewed, or null for current draft. */
   previewId: string | null;
+  /** Optional description of the previewed version. */
+  previewDescription: string | null;
   /** True while the sidebar is fetching a version entry to display. */
   isPreviewLoading: boolean;
   /** True after a version was activated via the restore hook. The sidebar
@@ -18,6 +20,7 @@ interface VersionPreviewState {
     edges: EdgeType[],
     label: string,
     id?: string | null,
+    description?: string | null,
   ) => void;
   clearPreview: () => void;
 }
@@ -27,15 +30,17 @@ const useVersionPreviewStore = create<VersionPreviewState>((set) => ({
   previewEdges: null,
   previewLabel: null,
   previewId: null,
+  previewDescription: null,
   isPreviewLoading: false,
   didRestore: false,
   setPreviewLoading: (loading) => set({ isPreviewLoading: loading }),
-  setPreview: (nodes, edges, label, id = null) =>
+  setPreview: (nodes, edges, label, id = null, description = null) =>
     set({
       previewNodes: nodes,
       previewEdges: edges,
       previewLabel: label,
       previewId: id,
+      previewDescription: description,
     }),
   clearPreview: () =>
     set({
@@ -43,6 +48,7 @@ const useVersionPreviewStore = create<VersionPreviewState>((set) => ({
       previewEdges: null,
       previewLabel: null,
       previewId: null,
+      previewDescription: null,
       isPreviewLoading: false,
       // NOTE: didRestore is intentionally NOT reset here. It is read and
       // reset by the sidebar unmount cleanup, which runs after clearPreview.

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -1698,6 +1698,11 @@ export function mergeNodeTemplates({
     const nodeTemplate = cloneDeep(node.data.node!.template);
     Object.keys(nodeTemplate)
       .filter((field_name) => field_name.charAt(0) !== "_")
+      .filter(
+        (field_name) =>
+          typeof nodeTemplate[field_name] === "object" &&
+          nodeTemplate[field_name] !== null,
+      )
       .forEach((key) => {
         if (
           node.type === "genericNode" &&

--- a/src/frontend/tests/core/integrations/assistant-panel.spec.ts
+++ b/src/frontend/tests/core/integrations/assistant-panel.spec.ts
@@ -3,6 +3,11 @@ import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 
 test.describe("Assistant Panel UI", { tag: ["@release"] }, () => {
   test("should open and close from canvas controls", async ({ page }) => {
+    test.skip(
+      !process?.env?.OPENAI_API_KEY,
+      "OPENAI_API_KEY required to run this test",
+    );
+
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/src/lfx/pyproject.toml
+++ b/src/lfx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx"
-version = "0.4.0"
+version = "0.5.0"
 description = "Langflow Executor - A lightweight CLI tool for executing and serving Langflow AI flows"
 readme = "README.md"
 authors = [

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -37,6 +37,7 @@ HTTP_NOT_FOUND = 404
 HTTP_METHOD_NOT_ALLOWED = 405
 HTTP_NOT_ACCEPTABLE = 406
 HTTP_BAD_REQUEST = 400
+HTTP_TOO_MANY_REQUESTS = 429
 HTTP_INTERNAL_SERVER_ERROR = 500
 HTTP_UNAUTHORIZED = 401
 HTTP_FORBIDDEN = 403
@@ -722,6 +723,99 @@ async def _validate_connection_params(mode: str, command: str | None = None, url
         raise ValueError(msg)
 
 
+# Streamable HTTP connect: retries before giving up (transient network / server restart)
+STREAMABLE_HTTP_CONNECT_ATTEMPTS = 3
+STREAMABLE_HTTP_RETRY_BASE_DELAY_SEC = 0.35
+
+
+def _iter_exception_leaves(exc: BaseException) -> list[BaseException]:
+    """Flatten ExceptionGroup / TaskGroup failures to individual exceptions (Python 3.11+)."""
+    beg = getattr(__import__("builtins"), "BaseExceptionGroup", None)
+    if beg is not None and isinstance(exc, beg):
+        leaves: list[BaseException] = []
+        for sub in exc.exceptions:
+            leaves.extend(_iter_exception_leaves(sub))
+        return leaves
+    return [exc]
+
+
+def _is_transient_streamable_http_error(exc: BaseException) -> bool:
+    """True when Streamable HTTP failed for a likely-temporary reason; do not fall back to SSE."""
+    for leaf in _iter_exception_leaves(exc):
+        if isinstance(leaf, (asyncio.TimeoutError, ConnectionError, OSError, BrokenPipeError)):
+            return True
+        if isinstance(leaf, ClosedResourceError):
+            return True
+        if isinstance(leaf, httpx.RequestError):
+            return True
+        if isinstance(leaf, httpx.HTTPStatusError):
+            # Server errors and rate limits — retry Streamable HTTP, not SSE switch
+            if leaf.response.status_code >= HTTP_INTERNAL_SERVER_ERROR:
+                return True
+            if leaf.response.status_code == HTTP_TOO_MANY_REQUESTS:
+                return True
+            # 404/405/406: try SSE; other 4xx: retry Streamable HTTP
+            return leaf.response.status_code not in (
+                HTTP_NOT_FOUND,
+                HTTP_METHOD_NOT_ALLOWED,
+                HTTP_NOT_ACCEPTABLE,
+            )
+        if isinstance(leaf, McpError):
+            msg = str(leaf).lower()
+            return not any(x in msg for x in ("404", "405", "406", "not found", "method not allowed"))
+        msg = str(leaf).lower()
+        if any(
+            x in msg
+            for x in (
+                "session terminated",
+                "connection closed",
+                "connection lost",
+                "connection reset",
+                "taskgroup",
+                "unhandled errors in a taskgroup",
+                "broken pipe",
+                "transport closed",
+                "stream closed",
+            )
+        ):
+            return True
+    return False
+
+
+def _should_attempt_sse_after_streamable_failure(exc: BaseException) -> bool:
+    """True when Streamable HTTP likely failed because the endpoint expects legacy SSE, not transient outage."""
+    if _is_transient_streamable_http_error(exc):
+        return False
+    for leaf in _iter_exception_leaves(exc):
+        if isinstance(leaf, httpx.HTTPStatusError) and leaf.response.status_code in (
+            HTTP_NOT_FOUND,
+            HTTP_METHOD_NOT_ALLOWED,
+            HTTP_NOT_ACCEPTABLE,
+        ):
+            return True
+        if isinstance(leaf, McpError):
+            msg = str(leaf).lower()
+            if any(x in msg for x in ("404", "405", "406", "not found", "method not allowed", "not acceptable")):
+                return True
+    lowered = str(exc).lower()
+    return any(x in lowered for x in ("404", "405", "406", "not found", "method not allowed", "not acceptable"))
+
+
+def _is_mcp_session_bust_error(exc: BaseException) -> bool:
+    """Whether cached ClientSession should be discarded and re-established (run_tool / list_tools)."""
+    for leaf in _iter_exception_leaves(exc):
+        if isinstance(leaf, ClosedResourceError):
+            return True
+        if isinstance(leaf, McpError):
+            msg = str(leaf).lower()
+            if any(x in msg for x in ("connection closed", "session terminated", "connection lost")):
+                return True
+        msg = str(leaf).lower()
+        if any(x in msg for x in ("session terminated", "connection closed", "connection lost")):
+            return True
+    return False
+
+
 class MCPSessionManager:
     """Manages persistent MCP sessions with proper context manager lifecycle.
 
@@ -813,31 +907,32 @@ class MCPSessionManager:
         # Fallback to a generic key
         return f"{transport_type}_{hash(str(connection_params))}"
 
+    async def invalidate_server_key(self, server_key: str) -> None:
+        """Tear down all sessions for this server and reset transport preference (e.g. remote MCP restart)."""
+        self._transport_preference.pop(server_key, None)
+        if server_key in self.sessions_by_server:
+            server_data = self.sessions_by_server[server_key]
+            sessions = server_data.get("sessions", {}) if isinstance(server_data, dict) else server_data
+            for sid in list(sessions.keys()):
+                await self._cleanup_session_by_id(server_key, sid)
+            self.sessions_by_server.pop(server_key, None)
+        for k in list(self._session_refcount):
+            if k[0] == server_key:
+                self._session_refcount.pop(k, None)
+        for ctx, pair in list(self._context_to_session.items()):
+            if pair[0] == server_key:
+                self._context_to_session.pop(ctx, None)
+
     async def _validate_session_connectivity(self, session) -> bool:
         """Validate that the session is actually usable by testing a simple operation."""
         try:
             # Try to list tools as a connectivity test (this is a lightweight operation)
             # Use a shorter timeout for the connectivity test to fail fast
             response = await asyncio.wait_for(session.list_tools(), timeout=3.0)
-        except (asyncio.TimeoutError, ConnectionError, OSError, ValueError) as e:
-            await logger.adebug(f"Session connectivity test failed (standard error): {e}")
+        except Exception as e:  # noqa: BLE001
+            # Any failure means the session is not safe to reuse (SDK errors, terminated session, etc.)
+            await logger.adebug(f"Session connectivity test failed: {type(e).__name__}: {e}")
             return False
-        except Exception as e:
-            # Handle MCP-specific errors that might not be in the standard list
-            error_str = str(e)
-            if (
-                "ClosedResourceError" in str(type(e))
-                or "Connection closed" in error_str
-                or "Connection lost" in error_str
-                or "Connection failed" in error_str
-                or "Transport closed" in error_str
-                or "Stream closed" in error_str
-            ):
-                await logger.adebug(f"Session connectivity test failed (MCP connection error): {e}")
-                return False
-            # Re-raise unexpected errors
-            await logger.awarning(f"Unexpected error in connectivity test: {e}")
-            raise
         else:
             # Validate that we got a meaningful response
             if response is None:
@@ -915,13 +1010,15 @@ class MCPSessionManager:
             session, task = await self._create_stdio_session(session_id, connection_params)
             actual_transport = "stdio"
         elif transport_type == "streamable_http":
-            # Pass the cached transport preference if available
+            # Pass the cached transport preference if available (SSE only when last success required it)
             preferred_transport = self._transport_preference.get(server_key)
-            session, task, actual_transport = await self._create_streamable_http_session(
+            session, task, actual_transport, sse_pref_lock = await self._create_streamable_http_session(
                 session_id, connection_params, preferred_transport
             )
-            # Cache the transport that worked for future connections
-            self._transport_preference[server_key] = actual_transport
+            if actual_transport == "streamable_http":
+                self._transport_preference[server_key] = "streamable_http"
+            elif sse_pref_lock:
+                self._transport_preference[server_key] = "sse"
         else:
             msg = f"Unknown transport type: {transport_type}"
             raise ValueError(msg)
@@ -997,30 +1094,26 @@ class MCPSessionManager:
     async def _create_streamable_http_session(
         self, session_id: str, connection_params, preferred_transport: str | None = None
     ):
-        """Create a new Streamable HTTP session with SSE fallback as a background task to avoid context issues.
+        """Create Streamable HTTP session with selective SSE fallback (background task lifecycle).
 
-        Args:
-            session_id: Unique identifier for this session
-            connection_params: Connection parameters including URL, headers, timeouts, verify_ssl
-            preferred_transport: If set to "sse", skip Streamable HTTP and go directly to SSE
+        SSE is attempted only when Streamable HTTP fails with an endpoint/transport mismatch signal
+        (e.g. HTTP 404/405/406), not for transient outages (connection reset, TaskGroup teardown, etc.).
 
         Returns:
-            tuple: (session, task, transport_used) where transport_used is "streamable_http" or "sse"
+            tuple: (session, task, transport_used, sse_preference_lock) where sse_preference_lock is True
+            iff SSE connected successfully and the server key should prefer legacy SSE in the future.
         """
         import asyncio
 
         from mcp.client.sse import sse_client
         from mcp.client.streamable_http import streamablehttp_client
 
-        # Create a future to get the session
         session_future: asyncio.Future[ClientSession] = asyncio.Future()
-        # Track which transport succeeded
         used_transport: list[str] = []
+        sse_preference_locked: list[bool] = [False]
 
-        # Get verify_ssl option from connection params, default to True
         verify_ssl = connection_params.get("verify_ssl", True)
 
-        # Create custom httpx client factory with SSL verification option
         def custom_httpx_factory(
             headers: dict[str, str] | None = None,
             timeout: httpx.Timeout | None = None,
@@ -1034,117 +1127,128 @@ class MCPSessionManager:
             """Background task that keeps the session alive."""
             streamable_error = None
 
-            # Skip Streamable HTTP if we know SSE works for this server
             if preferred_transport != "sse":
-                # Try Streamable HTTP first with a quick timeout
-                try:
-                    await logger.adebug(f"Attempting Streamable HTTP connection for session {session_id}")
-                    # Use a shorter timeout for the initial connection attempt (2 seconds)
-                    async with streamablehttp_client(
-                        url=connection_params["url"],
-                        headers=connection_params["headers"],
-                        timeout=connection_params["timeout_seconds"],
-                        httpx_client_factory=custom_httpx_factory,
-                    ) as (read, write, _):
-                        session = ClientSession(read, write)
-                        async with session:
-                            # Initialize with a timeout to fail fast
-                            await asyncio.wait_for(session.initialize(), timeout=2.0)
-                            used_transport.append("streamable_http")
-                            await logger.ainfo(f"Session {session_id} connected via Streamable HTTP")
-                            # Signal that session is ready
-                            session_future.set_result(session)
+                for attempt in range(STREAMABLE_HTTP_CONNECT_ATTEMPTS):
+                    try:
+                        await logger.adebug(
+                            f"Attempting Streamable HTTP connection for session {session_id} "
+                            f"(attempt {attempt + 1}/{STREAMABLE_HTTP_CONNECT_ATTEMPTS})"
+                        )
+                        async with streamablehttp_client(
+                            url=connection_params["url"],
+                            headers=connection_params["headers"],
+                            timeout=connection_params["timeout_seconds"],
+                            httpx_client_factory=custom_httpx_factory,
+                        ) as (read, write, _):
+                            session = ClientSession(read, write)
+                            async with session:
+                                await asyncio.wait_for(session.initialize(), timeout=2.0)
+                                used_transport.append("streamable_http")
+                                await logger.ainfo(f"Session {session_id} connected via Streamable HTTP")
+                                session_future.set_result(session)
 
-                            # Keep the session alive until cancelled
-                            import anyio
+                                import anyio
 
-                            event = anyio.Event()
-                            try:
-                                await event.wait()
-                            except asyncio.CancelledError:
-                                await logger.ainfo(f"Session {session_id} (Streamable HTTP) is shutting down")
-                except (asyncio.TimeoutError, Exception) as e:  # noqa: BLE001
-                    # If Streamable HTTP fails or times out, try SSE as fallback immediately
-                    streamable_error = e
-                    error_type = "timed out" if isinstance(e, asyncio.TimeoutError) else "failed"
+                                event = anyio.Event()
+                                try:
+                                    await event.wait()
+                                except asyncio.CancelledError:
+                                    await logger.ainfo(f"Session {session_id} (Streamable HTTP) is shutting down")
+                        return  # noqa: TRY300
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:  # noqa: BLE001
+                        if _is_transient_streamable_http_error(e) and attempt < STREAMABLE_HTTP_CONNECT_ATTEMPTS - 1:
+                            await logger.awarning(
+                                f"Streamable HTTP transient failure for session {session_id} "
+                                f"(attempt {attempt + 1}): {e}; retrying..."
+                            )
+                            await asyncio.sleep(STREAMABLE_HTTP_RETRY_BASE_DELAY_SEC * (attempt + 1))
+                            continue
+                        streamable_error = e
+                        break
+
+                if streamable_error is not None:
+                    if _is_transient_streamable_http_error(streamable_error):
+                        await logger.aerror(
+                            f"Streamable HTTP failed after {STREAMABLE_HTTP_CONNECT_ATTEMPTS} attempt(s) "
+                            f"for session {session_id}: {streamable_error}. Not attempting SSE fallback."
+                        )
+                        if not session_future.done():
+                            session_future.set_exception(streamable_error)
+                        return
+                    if not _should_attempt_sse_after_streamable_failure(streamable_error):
+                        if not session_future.done():
+                            session_future.set_exception(streamable_error)
+                        return
                     await logger.awarning(
-                        f"Streamable HTTP {error_type} for session {session_id}: {e}. Falling back to SSE..."
+                        f"Streamable HTTP failed for session {session_id}: {streamable_error}. "
+                        "Trying SSE (endpoint may require legacy transport)..."
                     )
             else:
                 await logger.adebug(f"Skipping Streamable HTTP for session {session_id}, using cached SSE preference")
 
-            # Try SSE if Streamable HTTP failed or if SSE is preferred
-            if streamable_error is not None or preferred_transport == "sse":
-                try:
-                    await logger.adebug(f"Attempting SSE connection for session {session_id}")
-                    # Extract SSE read timeout from connection params, default to 30s if not present
-                    sse_read_timeout = connection_params.get("sse_read_timeout_seconds", 30)
+            # SSE path: preferred mode, or Streamable indicated legacy transport
+            try:
+                await logger.adebug(f"Attempting SSE connection for session {session_id}")
+                sse_read_timeout = connection_params.get("sse_read_timeout_seconds", 30)
 
-                    async with sse_client(
-                        connection_params["url"],
-                        connection_params["headers"],
-                        connection_params["timeout_seconds"],
-                        sse_read_timeout,
-                        httpx_client_factory=custom_httpx_factory,
-                    ) as (read, write):
-                        session = ClientSession(read, write)
-                        async with session:
-                            await session.initialize()
-                            used_transport.append("sse")
-                            fallback_msg = " (fallback)" if streamable_error else " (preferred)"
-                            await logger.ainfo(f"Session {session_id} connected via SSE{fallback_msg}")
-                            # Signal that session is ready
-                            if not session_future.done():
-                                session_future.set_result(session)
-
-                            # Keep the session alive until cancelled
-                            import anyio
-
-                            event = anyio.Event()
-                            try:
-                                await event.wait()
-                            except asyncio.CancelledError:
-                                await logger.ainfo(f"Session {session_id} (SSE) is shutting down")
-                except Exception as sse_error:  # noqa: BLE001
-                    # Both transports failed (or just SSE if it was preferred)
-                    if streamable_error:
-                        await logger.aerror(
-                            f"Both Streamable HTTP and SSE failed for session {session_id}. "
-                            f"Streamable HTTP error: {streamable_error}. SSE error: {sse_error}"
-                        )
+                async with sse_client(
+                    connection_params["url"],
+                    connection_params["headers"],
+                    connection_params["timeout_seconds"],
+                    sse_read_timeout,
+                    httpx_client_factory=custom_httpx_factory,
+                ) as (read, write):
+                    session = ClientSession(read, write)
+                    async with session:
+                        await session.initialize()
+                        used_transport.append("sse")
+                        sse_preference_locked[0] = True
+                        fallback_msg = " (fallback)" if streamable_error else " (preferred)"
+                        await logger.ainfo(f"Session {session_id} connected via SSE{fallback_msg}")
                         if not session_future.done():
-                            session_future.set_exception(
-                                ValueError(
-                                    f"Failed to connect via Streamable HTTP ({streamable_error}) or SSE ({sse_error})"
-                                )
+                            session_future.set_result(session)
+
+                        import anyio
+
+                        event = anyio.Event()
+                        try:
+                            await event.wait()
+                        except asyncio.CancelledError:
+                            await logger.ainfo(f"Session {session_id} (SSE) is shutting down")
+            except Exception as sse_error:  # noqa: BLE001
+                if streamable_error:
+                    await logger.aerror(
+                        f"Both Streamable HTTP and SSE failed for session {session_id}. "
+                        f"Streamable HTTP error: {streamable_error}. SSE error: {sse_error}"
+                    )
+                    if not session_future.done():
+                        session_future.set_exception(
+                            ValueError(
+                                f"Failed to connect via Streamable HTTP ({streamable_error}) or SSE ({sse_error})"
                             )
-                    else:
-                        await logger.aerror(f"SSE connection failed for session {session_id}: {sse_error}")
-                        if not session_future.done():
-                            session_future.set_exception(ValueError(f"Failed to connect via SSE: {sse_error}"))
+                        )
+                else:
+                    await logger.aerror(f"SSE connection failed for session {session_id}: {sse_error}")
+                    if not session_future.done():
+                        session_future.set_exception(ValueError(f"Failed to connect via SSE: {sse_error}"))
 
-        # Start the background task
         task = asyncio.create_task(session_task())
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
-        # Wait for session to be ready (use longer timeout for remote connections)
         try:
             session = await asyncio.wait_for(session_future, timeout=30.0)
-            # Log which transport was used
             if used_transport:
                 transport_used = used_transport[0]
                 await logger.ainfo(f"Session {session_id} successfully established using {transport_used}")
-                return session, task, transport_used
-            # This shouldn't happen, but handle it just in case
+                return session, task, transport_used, sse_preference_locked[0]
             msg = f"Session {session_id} established but transport not recorded"
             raise ValueError(msg)
         except asyncio.TimeoutError as timeout_err:
-            # Clean up the failed task
             if not task.done():
                 task.cancel()
-                import contextlib
-
                 with contextlib.suppress(asyncio.CancelledError):
                     await task
             self._background_tasks.discard(task)
@@ -1591,9 +1695,17 @@ class MCPStreamableHttpClient:
             param_hash = uuid.uuid4().hex[:8]
             self._session_context = f"default_http_{param_hash}"
 
-        # Get or create a persistent session (will try Streamable HTTP, then SSE fallback)
+        # Get or create a persistent session (will try Streamable HTTP, then selective SSE fallback)
         session = await self._get_or_create_session()
-        response = await session.list_tools()
+        try:
+            response = await session.list_tools()
+        except Exception:
+            self._connected = False
+            if self._connection_params:
+                session_manager = self._get_session_manager()
+                sk = session_manager._get_server_key(self._connection_params, "streamable_http")
+                await session_manager.invalidate_server_key(sk)
+            raise
         self._connected = True
         return response.tools
 
@@ -1698,16 +1810,7 @@ class MCPStreamableHttpClient:
                 current_error_type = type(e).__name__
                 await logger.awarning(f"Tool '{tool_name}' failed on attempt {attempt + 1}: {current_error_type} - {e}")
 
-                # Import specific MCP error types for detection
-                try:
-                    from anyio import ClosedResourceError
-                    from mcp.shared.exceptions import McpError
-
-                    is_closed_resource_error = isinstance(e, ClosedResourceError)
-                    is_mcp_connection_error = isinstance(e, McpError) and "Connection closed" in str(e)
-                except ImportError:
-                    is_closed_resource_error = "ClosedResourceError" in str(type(e))
-                    is_mcp_connection_error = "Connection closed" in str(e)
+                bust_session = _is_mcp_session_bust_error(e)
 
                 # Detect timeout errors
                 is_timeout_error = isinstance(e, asyncio.TimeoutError | TimeoutError)
@@ -1719,16 +1822,14 @@ class MCPStreamableHttpClient:
 
                 last_error_type = current_error_type
 
-                # If it's a connection error (ClosedResourceError or MCP connection closed) and we have retries left
-                if (is_closed_resource_error or is_mcp_connection_error) and attempt < max_retries - 1:
+                if bust_session and attempt < max_retries - 1:
                     await logger.awarning(
-                        f"MCP session connection issue for tool '{tool_name}', retrying with fresh session..."
+                        f"MCP session issue for tool '{tool_name}', invalidating server sessions and retrying..."
                     )
-                    # Clean up the dead session
-                    if self._session_context:
+                    if self._connection_params:
                         session_manager = self._get_session_manager()
-                        await session_manager._cleanup_session(self._session_context)
-                    # Add a small delay before retry
+                        sk = session_manager._get_server_key(self._connection_params, "streamable_http")
+                        await session_manager.invalidate_server_key(sk)
                     await asyncio.sleep(0.5)
                     continue
 
@@ -1742,8 +1843,7 @@ class MCPStreamableHttpClient:
                 # For other errors or no retries left, handle as before
                 if (
                     isinstance(e, ConnectionError | TimeoutError | OSError | ValueError)
-                    or is_closed_resource_error
-                    or is_mcp_connection_error
+                    or bust_session
                     or is_timeout_error
                 ):
                     msg = f"Failed to run tool '{tool_name}' after {attempt + 1} attempts: {e}"

--- a/src/lfx/src/lfx/custom/validate.py
+++ b/src/lfx/src/lfx/custom/validate.py
@@ -341,7 +341,8 @@ def _resolve_attribute(imported_module, module_name, attr_name):
 def _handle_module_attributes(imported_module, node, module_name, exec_globals):
     """Handle importing specific attributes from a module."""
     for alias in node.names:
-        exec_globals[alias.name] = _resolve_attribute(imported_module, module_name, alias.name)
+        key = alias.asname or alias.name
+        exec_globals[key] = _resolve_attribute(imported_module, module_name, alias.name)
 
 
 class _MissingModulePlaceholder:

--- a/src/lfx/tests/unit/custom/component/test_validate.py
+++ b/src/lfx/tests/unit/custom/component/test_validate.py
@@ -97,6 +97,38 @@ def to_url(path):
     assert scope["urllib"].request.pathname2url("folder name/file.txt") == "folder%20name/file.txt"
 
 
+def test_prepare_global_scope_supports_aliased_from_imports():
+    """Regression test: `from X import Y as Z` must bind Z in scope, not Y."""
+    module = ast.parse(
+        dedent("""
+from urllib.request import pathname2url as to_url_path
+
+def to_url(path):
+    return to_url_path(path)
+""")
+    )
+    scope = prepare_global_scope(module)
+
+    assert "to_url_path" in scope
+    assert "pathname2url" not in scope
+    assert scope["to_url_path"]("folder name/file.txt") == "folder%20name/file.txt"
+
+
+def test_create_class_supports_aliased_from_imports():
+    """End-to-end: a component using `from X import Y as Z` should load and Z is usable."""
+    code = dedent("""
+from urllib.request import pathname2url as to_url_path
+from lfx.custom import Component
+
+class AliasedImportComponent(Component):
+    def to_url(self, path):
+        return to_url_path(path)
+""")
+    cls = create_class(code, "AliasedImportComponent")
+    assert cls.__name__ == "AliasedImportComponent"
+    assert cls().to_url("folder name/file.txt") == "folder%20name/file.txt"
+
+
 # ---------------------------------------------------------------------------
 # _get_module_fallbacks
 # ---------------------------------------------------------------------------

--- a/src/sdk/pyproject.toml
+++ b/src/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-sdk"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python SDK for the Langflow REST API"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/src/sdk/src/langflow_sdk/testing.py
+++ b/src/sdk/src/langflow_sdk/testing.py
@@ -30,6 +30,7 @@ Usage inside a test file::
 
 from __future__ import annotations
 
+import contextlib
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -54,34 +55,39 @@ if TYPE_CHECKING:
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register Langflow-specific CLI options."""
     group = parser.getgroup("langflow", "Langflow integration testing options")
-    group.addoption(
-        "--langflow-env",
-        dest="langflow_env",
-        default=None,
-        metavar="NAME",
-        help="Environment name from langflow-environments.toml to use for integration tests.",
-    )
-    group.addoption(
-        "--langflow-url",
-        dest="langflow_url",
-        default=None,
-        metavar="URL",
-        help="Base URL of the Langflow instance (overrides --langflow-env).",
-    )
-    group.addoption(
-        "--langflow-api-key",
-        dest="langflow_api_key",
-        default=None,
-        metavar="KEY",
-        help="API key for the Langflow instance (overrides environment config).",
-    )
-    group.addoption(
-        "--langflow-environments-file",
-        dest="langflow_environments_file",
-        default=None,
-        metavar="PATH",
-        help="Path to langflow-environments.toml (overrides default discovery).",
-    )
+    options = {
+        "--langflow-env": {
+            "dest": "langflow_env",
+            "default": None,
+            "metavar": "NAME",
+            "help": "Environment name from langflow-environments.toml to use for integration tests.",
+        },
+        "--langflow-url": {
+            "dest": "langflow_url",
+            "default": None,
+            "metavar": "URL",
+            "help": "Base URL of the Langflow instance (overrides --langflow-env).",
+        },
+        "--langflow-api-key": {
+            "dest": "langflow_api_key",
+            "default": None,
+            "metavar": "KEY",
+            "help": "API key for the Langflow instance (overrides environment config).",
+        },
+        "--langflow-environments-file": {
+            "dest": "langflow_environments_file",
+            "default": None,
+            "metavar": "PATH",
+            "help": "Path to langflow-environments.toml (overrides default discovery).",
+        },
+    }
+
+    # langflow-sdk and lfx can both be installed in the same environment and
+    # expose the same remote-testing flags. Keep registration idempotent so
+    # pytest plugin auto-discovery can load both entry points safely.
+    for flag, kwargs in options.items():
+        with contextlib.suppress(ValueError):
+            group.addoption(flag, **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/src/sdk/tests/test_testing.py
+++ b/src/sdk/tests/test_testing.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import httpx
 import respx
+from _pytest.config.argparsing import Parser
 from langflow_sdk.client import AsyncLangflowClient, LangflowClient
 from langflow_sdk.models import RunOutput, RunResponse
-from langflow_sdk.testing import AsyncFlowRunner, FlowRunner
+from langflow_sdk.testing import AsyncFlowRunner, FlowRunner, pytest_addoption
 
 _BASE = "http://langflow.test"
 
@@ -307,3 +308,11 @@ def test_pytest_addoption_registers_options(pytestconfig):
         "--langflow-environments-file",
     ):
         assert pytestconfig.getoption(name) is None, f"Option {name!r} missing or has unexpected default"
+
+
+def test_pytest_addoption_is_idempotent():
+    """Registering the plugin twice should not fail when another plugin owns the same flags."""
+    parser = Parser(_ispytest=True)
+
+    pytest_addoption(parser)
+    pytest_addoption(parser)

--- a/uv.lock
+++ b/uv.lock
@@ -3406,11 +3406,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.25.2"
+version = "3.28.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/17/6e8890271880903e3538660a21d63a6c1fea969ac71d0d6b608b78727fa9/filelock-3.28.0.tar.gz", hash = "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6", size = 56474, upload-time = "2026-04-14T22:54:33.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl", hash = "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db", size = 39189, upload-time = "2026-04-14T22:54:32.037Z" },
 ]
 
 [[package]]
@@ -3641,10 +3641,10 @@ name = "gassist"
 version = "0.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "flask", marker = "sys_platform == 'win32'" },
-    { name = "flask-cors", marker = "sys_platform == 'win32'" },
-    { name = "tqdm", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform != 'darwin'" },
+    { name = "flask", marker = "sys_platform != 'darwin'" },
+    { name = "flask-cors", marker = "sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/2e/f79632d7300874f7f0e60b61a6ab22455a245e1556116a1729542a77b0da/gassist-0.0.1-py3-none-any.whl", hash = "sha256:bb0fac74b453153a6c74b2db40a14fdde7879cbc10ec692ed170e576c8e2b6aa", size = 23819, upload-time = "2025-05-09T18:22:23.609Z" },
@@ -3907,7 +3907,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-aiplatform"
-version = "1.147.0"
+version = "1.148.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
@@ -3923,9 +3923,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/93/9bfcaaf1ceab12999a881ccf69ebd9b30f467ec5623989c66894e81fc139/google_cloud_aiplatform-1.147.0.tar.gz", hash = "sha256:b2e1b669ba37f02426e03eb13187eebf4cbfeaa0a3bfed37b5578abb375ab689", size = 10235245, upload-time = "2026-04-09T17:14:49.179Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/5f/4d7c5e1e35f1a514e7f23882cf68738c5ef96d12a74383e6d008e698d207/google_cloud_aiplatform-1.148.0.tar.gz", hash = "sha256:86a736a6a90cb97d17b51c8a973cda474ca9ace44ee00a2da96f8e60e6c6d5df", size = 10275203, upload-time = "2026-04-15T02:35:09.001Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/d2/1c1c582f6bbed9bbc0daa5acf3a5d98751ca8bc48584548d28569b8ce1a7/google_cloud_aiplatform-1.147.0-py2.py3-none-any.whl", hash = "sha256:29f7ae020718d3c45094f0475464e06a97f81b1572bea150ae6a1b22c5f45997", size = 8408951, upload-time = "2026-04-09T17:14:45.482Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f7/f3af0f8b4cee02be64e1f3dede9219b0624f95d788ad334971f5269ed35d/google_cloud_aiplatform-1.148.0-py2.py3-none-any.whl", hash = "sha256:0c4a20e7f096e9a5a3cecc90ba3b67ce27f94afdf089cd9b3a738ff5af2f3b00", size = 8433269, upload-time = "2026-04-15T02:35:05.594Z" },
 ]
 
 [[package]]
@@ -4057,7 +4057,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.73.0"
+version = "1.73.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4071,9 +4071,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/5f/b293b1a78a547b0dd061642a3f6087f0a52c1b723eafa58f94ccdc3e0d2a/google_genai-1.73.0.tar.gz", hash = "sha256:569395b2c225e12bcd8758b8affe1af480e0a1b1c71d652d38c705677057e05f", size = 530812, upload-time = "2026-04-13T20:40:02.642Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/73/fb36ced456688c9b95a8ab49a1f408f5b3e69a589788f3eb25016002dd7a/google_genai-1.73.0-py3-none-any.whl", hash = "sha256:dfb0214b834bf977e3841de512cfb651d2fe76309f85064b80c2bc11da99d76b", size = 786072, upload-time = "2026-04-13T20:40:00.365Z" },
+    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
 ]
 
 [[package]]
@@ -4623,15 +4623,15 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.152.0"
+version = "6.152.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/84/0745a9d34f71394af0123fe9b66a2fa261555ea2b39cf5f52815889bf30f/hypothesis-6.152.0.tar.gz", hash = "sha256:c0a7619904f5c218c2a5eac1fed7889b1fdc22cf09d8970775c5b13c8cd57e97", size = 465087, upload-time = "2026-04-14T18:21:08.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/b1/c32bcddb9aab9e3abc700f1f56faf14e7655c64a16ca47701a57362276ea/hypothesis-6.152.1.tar.gz", hash = "sha256:4f4ed934eee295dd84ee97592477d23e8dc03e9f12ae0ee30a4e7c9ef3fca3b0", size = 465029, upload-time = "2026-04-14T22:29:24.062Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/68/5c52f30714a1058879e72420bd599eef87ae01007db444619b03e50368fc/hypothesis-6.152.0-py3-none-any.whl", hash = "sha256:824037e8214559ad037362c6aaa51f6118f62e548e62b2ad215fbf52f2f45eb4", size = 530765, upload-time = "2026-04-14T18:21:05.594Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl", hash = "sha256:40a3619d9e0cb97b018857c7986f75cf5de2e5ec0fa8a0b172d00747758f749e", size = 530752, upload-time = "2026-04-14T22:29:20.893Z" },
 ]
 
 [[package]]
@@ -6015,16 +6015,16 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.12"
+version = "1.1.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/fd/7dee16e882c4c1577d48db174d85aa3a0ee09ba61eb6a5d41650285ca80c/langchain_openai-1.1.12.tar.gz", hash = "sha256:ccf5ef02c896f6807b4d0e51aaf678a72ce81ae41201cae8d65e11eeff9ecb79", size = 1114119, upload-time = "2026-03-23T18:59:19.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/63/0fed7cae7103e4b7aced76208aa92c02ae78bdf1be48bd9d83e4051d6c31/langchain_openai-1.1.13.tar.gz", hash = "sha256:88e13342407016785bd3c48be32ded1f28b992403bbb82505b558d81b038adc2", size = 1114743, upload-time = "2026-04-15T01:37:19.409Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/a6/68fb22e3604015e6f546fa1d3677d24378b482855ae74710cbf4aec44132/langchain_openai-1.1.12-py3-none-any.whl", hash = "sha256:da71ca3f2d18c16f7a2443cc306aa195ad2a07054335ac9b0626dcae02b6a0c5", size = 88487, upload-time = "2026-03-23T18:59:17.978Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d1/ca789988897096883289f9597ee653574b67b4b2a8f40bc306dfd73742d5/langchain_openai-1.1.13-py3-none-any.whl", hash = "sha256:54ba1e9f2f0f428aeea68271a87823a0a1b22360283990a713c731d2ef7da926", size = 88723, upload-time = "2026-04-15T01:37:18.062Z" },
 ]
 
 [[package]]
@@ -6124,7 +6124,7 @@ wheels = [
 
 [[package]]
 name = "langflow"
-version = "1.9.0"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "langflow-base", extra = ["complete"] },
@@ -6271,7 +6271,7 @@ dev = [
 
 [[package]]
 name = "langflow-base"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "src/backend/base" }
 dependencies = [
     { name = "aiofile" },
@@ -7294,7 +7294,7 @@ dev = [
 
 [[package]]
 name = "langflow-sdk"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "src/sdk" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
@@ -7478,11 +7478,11 @@ wheels = [
 
 [[package]]
 name = "latex2mathml"
-version = "3.80.0"
+version = "3.81.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/4a/3d5bd6070990396c6360dcb2664df695d44b2e51160af423c94c0b63b8e4/latex2mathml-3.80.0.tar.gz", hash = "sha256:104b102ed2e16d4eb565f427fffa9c3928a544db9b274149bb821b3baf194e28", size = 148128, upload-time = "2026-04-12T00:16:12.549Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/62/35bb816c5c19d4d0cde5bdfb82ebb996306243d5f94e03f201658c629960/latex2mathml-3.81.0.tar.gz", hash = "sha256:4b959cdc3cac8686bc0e3e5aece8127dfb1b81ca1241bed8e00ef31b82bb4022", size = 77584, upload-time = "2026-04-15T00:55:27.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/c4/660f9df164330e2396baa2facb72a7c492fc729f764f2ccf6e365e070394/latex2mathml-3.80.0-py3-none-any.whl", hash = "sha256:2ddc8269896c1c29257267b74a050676692255def766feaddeab56e8831f1115", size = 76868, upload-time = "2026-04-12T00:16:13.852Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/b1/c488b530994c4f68e46efa99a4d6ca6741aaf158e35779fe6c4d8a9a427d/latex2mathml-3.81.0-py3-none-any.whl", hash = "sha256:d317710393fe20579aea39cfe8928fa2ad9b8780896e585326c75e89c1d1d1a4", size = 79185, upload-time = "2026-04-15T00:55:29.301Z" },
 ]
 
 [[package]]
@@ -7499,7 +7499,7 @@ wheels = [
 
 [[package]]
 name = "lfx"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "src/lfx" }
 dependencies = [
     { name = "ag-ui-protocol" },
@@ -8315,7 +8315,7 @@ name = "milvus-lite"
 version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "tqdm", marker = "platform_machine == 'arm64' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2e/746f5bb1d6facd1e73eb4af6dd5efda11125b0f29d7908a097485ca6cad9/milvus_lite-2.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2e031088bf308afe5f8567850412d618cfb05a65238ed1a6117f60decccc95a", size = 24421451, upload-time = "2025-06-30T04:23:51.747Z" },
@@ -9060,9 +9060,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
+    { name = "click" },
+    { name = "pillow" },
+    { name = "pyobjc-framework-vision" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -10371,7 +10371,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -11656,7 +11656,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -11672,8 +11672,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -11689,8 +11689,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -11706,10 +11706,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreml" },
+    { name = "pyobjc-framework-quartz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [
@@ -15353,7 +15353,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.2.3"
+version = "21.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -15362,9 +15362,9 @@ dependencies = [
     { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/8c/bdd9f89f89e4a787ac61bb2da4d884bc45e0c287ec694dfa3170dddd5cfe/virtualenv-21.2.3.tar.gz", hash = "sha256:9bb6d1414ab55ca624371e30c7719c32f183ef44da544ef8aa44a456de7ac191", size = 5844776, upload-time = "2026-04-14T01:10:36.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/19/bc7c4e05f42532863cf2ae7e7e847beab25835934e0410160b47eeff1e35/virtualenv-21.2.3-py3-none-any.whl", hash = "sha256:486652347ea8526d91e9807c0274583cb7ba31dd4942ff10fb5621402f0fe0d8", size = 5828329, upload-time = "2026-04-14T01:10:34.809Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Fix [#12706](https://github.com/langflow-ai/langflow/issues/12706): custom components using `from pkg import Foo as Bar` failed with `NameError: name 'Bar' is not defined` and never appeared in the sidebar.
- `_handle_module_attributes` in [src/lfx/src/lfx/custom/validate.py](src/lfx/src/lfx/custom/validate.py) was keying `exec_globals` on `alias.name`, so the original name was bound in the component's exec scope instead of the alias.
- Use `alias.asname or alias.name` as the key, matching the `import X as Y` branch a few lines above in the same file and standard Python import semantics.

## Reproduction (before fix)

```python
from urllib.request import pathname2url as to_url_path
from lfx.custom import Component

class MyComponent(Component):
    def to_url(self, path):
        return to_url_path(path)  # NameError: name 'to_url_path' is not defined
```

## Test plan

- [x] Added `test_prepare_global_scope_supports_aliased_from_imports` — asserts the alias (`to_url_path`) is bound and the original name (`pathname2url`) is not.
- [x] Added `test_create_class_supports_aliased_from_imports` — end-to-end through `create_class`, instantiates the component and calls the aliased function.
- [x] `pytest src/lfx/tests/unit/custom/component/test_validate.py` — 46 passed.
- [ ] Reviewer: confirm CI is green on the full lfx test suite.

## Notes

- The same bug also exists on `main`; this PR targets `release-1.10.0` per the reporter's request. Happy to cherry-pick to `main` if preferred.
- `execute_function` has a separate, pre-existing limitation (it does not handle `ast.ImportFrom` at all), but that is out of scope for this issue.