### PR TITLE
fix(kb): P1 cross-thread cursor + P2 connector validation (outside review)

### DIFF
--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
@@ -364,6 +364,11 @@ export function StepConfiguration({
                     </div>
                   )}
 
+                  {validationErrors.connector && (
+                    <span className="text-xs text-destructive">
+                      {validationErrors.connector}
+                    </span>
+                  )}
                   {validationErrors.files && (
                     <span className="text-xs text-destructive">
                       {validationErrors.files}

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
@@ -256,11 +256,18 @@ export function useKnowledgeBaseForm({
   const toggleAdvanced = useCallback(() => {
     setShowAdvanced((prev) => {
       if (prev) {
-        // Hiding advanced: reset chunk settings and close panel
+        // Hiding advanced: reset chunk settings and close the file
+        // panel. Connector state is also cleared here — collapsing
+        // Advanced is meant to *disable* the advanced source path,
+        // not just hide it. Leaving stale ``activeConnector`` around
+        // would let a connector-with-missing-fields state survive
+        // into the simple-submit flow.
         setChunkSize(0);
         setChunkOverlap(0);
         setSeparator("");
         setIsFilePanelOpen(false);
+        setActiveConnector(null);
+        setConnectorPayload(null);
       } else {
         // Showing advanced: apply defaults
         setChunkSize(DEFAULT_CHUNK_SIZE);
@@ -361,6 +368,15 @@ export function useKnowledgeBaseForm({
         errors.backend = backendErrors;
       }
     }
+    // Connector submission gate: if the user picked a connector
+    // (S3 / Google Drive / OneDrive / SharePoint) but the inline
+    // form hasn't emitted a valid payload yet, block submission.
+    // Without this gate, ``handleSubmit`` would create an empty
+    // KB and close the modal with a success toast while silently
+    // skipping the ingestion dispatch.
+    if (activeConnector && !connectorPayload) {
+      errors.connector = `Complete the ${activeConnector} connector configuration before continuing`;
+    }
     const totalBytes = files.reduce((acc, file) => acc + file.size, 0);
     if (totalBytes > MAX_TOTAL_FILE_SIZE) {
       errors.files = "Total file size exceeds the 1 GB limit";
@@ -374,6 +390,8 @@ export function useKnowledgeBaseForm({
     backendConfig,
     files,
     existingKnowledgeBaseNames,
+    activeConnector,
+    connectorPayload,
   ]);
 
   const clearValidationErrors = useCallback(() => {

--- a/src/lfx/src/lfx/base/knowledge_bases/backends/astra.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/backends/astra.py
@@ -17,6 +17,7 @@ the UI.
 from __future__ import annotations
 
 import asyncio
+import queue as sync_queue
 from typing import TYPE_CHECKING, Any
 
 from lfx.base.knowledge_bases.backends.base import (
@@ -120,48 +121,68 @@ class AstraBackend(BaseVectorStoreBackend):
         if include_embeddings:
             projection["$vector"] = 1
 
-        try:
-            cursor = await asyncio.to_thread(collection.find, {}, projection=projection)
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Astra cursor open failed: %s", exc)
-            return
+        # astrapy cursors hold per-operation state tied to the HTTP
+        # client that opened them. ``asyncio.to_thread`` can schedule
+        # successive calls on different workers, so we run the entire
+        # cursor lifetime (open → iterate → close) on *one* worker
+        # thread and stream batches back via a thread-safe queue.
+        # ``maxsize=2`` gives natural backpressure.
+        sentinel = object()
+        batch_queue: sync_queue.Queue[Any] = sync_queue.Queue(maxsize=2)
 
-        def _fetch_chunk(cursor_iter: Any, limit: int) -> list[dict[str, Any]]:
-            collected: list[dict[str, Any]] = []
-            for _ in range(limit):
-                try:
-                    collected.append(next(cursor_iter))
-                except StopIteration:
-                    break
-            return collected
-
-        cursor_iter = iter(cursor)
-        try:
-            while True:
-                raw_docs = await asyncio.to_thread(_fetch_chunk, cursor_iter, batch_size)
-                if not raw_docs:
-                    break
-                batch: list[IngestedDocument] = []
-                for raw in raw_docs:
+        def _stream_batches() -> None:
+            cursor = None
+            try:
+                cursor = collection.find({}, projection=projection)
+                buf: list[IngestedDocument] = []
+                for raw in cursor:
                     content = raw.get("content") or raw.get("text") or ""
                     metadata = raw.get("metadata") or {}
                     embedding = raw.get("$vector") if include_embeddings else None
-                    batch.append(
+                    buf.append(
                         IngestedDocument(
                             content=str(content),
                             metadata=dict(metadata) if isinstance(metadata, dict) else {},
                             embedding=list(embedding) if embedding else None,
                         )
                     )
-                if batch:
-                    yield batch
+                    if len(buf) >= batch_size:
+                        batch_queue.put(buf)
+                        buf = []
+                if buf:
+                    batch_queue.put(buf)
+            except Exception as exc:  # noqa: BLE001
+                batch_queue.put(exc)
+            finally:
+                close = getattr(cursor, "close", None) if cursor is not None else None
+                if callable(close):
+                    try:
+                        close()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("Astra cursor close failed: %s", exc)
+                batch_queue.put(sentinel)
+
+        worker = asyncio.create_task(asyncio.to_thread(_stream_batches))
+        sentinel_seen = False
+        try:
+            while True:
+                item = await asyncio.to_thread(batch_queue.get)
+                if item is sentinel:
+                    sentinel_seen = True
+                    break
+                if isinstance(item, Exception):
+                    logger.debug("Astra iter_documents worker failed: %s", item)
+                    sentinel_seen = True
+                    await asyncio.to_thread(batch_queue.get)
+                    break
+                yield item
         finally:
-            close = getattr(cursor, "close", None)
-            if callable(close):
-                try:
-                    await asyncio.to_thread(close)
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("Astra cursor close failed: %s", exc)
+            if not sentinel_seen:
+                while True:
+                    drained = await asyncio.to_thread(batch_queue.get)
+                    if drained is sentinel:
+                        break
+            await worker
 
     async def storage_size_bytes(self) -> int:
         # Astra doesn't surface a simple bytes figure; approximate via

--- a/src/lfx/src/lfx/base/knowledge_bases/backends/mongodb.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/backends/mongodb.py
@@ -26,6 +26,7 @@ selects this backend without installing the extra.
 from __future__ import annotations
 
 import asyncio
+import queue as sync_queue
 from typing import TYPE_CHECKING, Any
 
 from lfx.base.knowledge_bases.backends.base import (
@@ -152,43 +153,69 @@ class MongoDBBackend(BaseVectorStoreBackend):
         if include_embeddings:
             projection[embedding_key] = 1
 
-        # Iterate the sync pymongo cursor off the event loop, fetching
-        # ``batch_size`` documents per hop so we never block the loop
-        # on a full collection scan.
-        def _fetch_chunk(cursor_iter: Any, limit: int) -> list[dict[str, Any]]:
-            collected: list[dict[str, Any]] = []
-            for _ in range(limit):
-                try:
-                    collected.append(next(cursor_iter))
-                except StopIteration:
-                    break
-            return collected
+        # pymongo cursors are NOT thread-safe (client pools are, but
+        # the cursor state is not). ``asyncio.to_thread`` can schedule
+        # successive calls on different workers, so we run the entire
+        # cursor lifetime (open → iterate → close) on *one* worker
+        # thread and stream batches back to the async side via a
+        # thread-safe queue. ``maxsize=2`` gives natural backpressure.
+        sentinel = object()
+        batch_queue: sync_queue.Queue[Any] = sync_queue.Queue(maxsize=2)
 
-        cursor = collection.find({}, projection=projection).batch_size(batch_size)
-        cursor_iter = iter(cursor)
-        try:
-            while True:
-                raw_docs = await asyncio.to_thread(_fetch_chunk, cursor_iter, batch_size)
-                if not raw_docs:
-                    break
-                batch: list[IngestedDocument] = []
-                for raw in raw_docs:
+        def _stream_batches() -> None:
+            cursor = None
+            try:
+                cursor = collection.find({}, projection=projection).batch_size(batch_size)
+                buf: list[IngestedDocument] = []
+                for raw in cursor:
                     content = raw.get(text_key) or ""
                     metadata = raw.get("metadata") or {
                         k: v for k, v in raw.items() if k not in {text_key, embedding_key, "_id", "metadata"}
                     }
                     embedding = raw.get(embedding_key) if include_embeddings else None
-                    batch.append(
+                    buf.append(
                         IngestedDocument(
                             content=str(content),
                             metadata=dict(metadata) if isinstance(metadata, dict) else {},
                             embedding=list(embedding) if embedding else None,
                         )
                     )
-                if batch:
-                    yield batch
+                    if len(buf) >= batch_size:
+                        batch_queue.put(buf)
+                        buf = []
+                if buf:
+                    batch_queue.put(buf)
+            except Exception as exc:  # noqa: BLE001
+                batch_queue.put(exc)
+            finally:
+                if cursor is not None:
+                    try:
+                        cursor.close()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("MongoDB cursor close failed: %s", exc)
+                batch_queue.put(sentinel)
+
+        worker = asyncio.create_task(asyncio.to_thread(_stream_batches))
+        sentinel_seen = False
+        try:
+            while True:
+                item = await asyncio.to_thread(batch_queue.get)
+                if item is sentinel:
+                    sentinel_seen = True
+                    break
+                if isinstance(item, Exception):
+                    logger.debug("MongoDB iter_documents worker failed: %s", item)
+                    sentinel_seen = True
+                    await asyncio.to_thread(batch_queue.get)
+                    break
+                yield item
         finally:
-            await asyncio.to_thread(cursor.close)
+            if not sentinel_seen:
+                while True:
+                    drained = await asyncio.to_thread(batch_queue.get)
+                    if drained is sentinel:
+                        break
+            await worker
 
     async def storage_size_bytes(self) -> int:
         client = getattr(self, "_mongo_client", None)

--- a/src/lfx/src/lfx/base/knowledge_bases/backends/postgres.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/backends/postgres.py
@@ -19,6 +19,7 @@ credentials.
 from __future__ import annotations
 
 import asyncio
+import queue as sync_queue
 from typing import TYPE_CHECKING, Any
 
 from lfx.base.knowledge_bases.backends.base import (
@@ -120,55 +121,79 @@ class PostgresBackend(BaseVectorStoreBackend):
         if session_maker is None:
             return
 
-        # Execute the query and fetch rows off the event loop in
-        # ``batch_size`` chunks via ``result.fetchmany``. The session
-        # stays open across thread hops — this is safe because only
-        # one thread touches it at a time.
-        def _open_session_and_execute() -> tuple[Any, Any]:
-            session = session_maker()
+        # SQLAlchemy ``Session`` and psycopg ``Cursor`` objects are
+        # NOT safe to share across threads — even sequential access
+        # from different threads breaks the DB-API connection state.
+        # ``asyncio.to_thread`` cannot pin subsequent calls to the
+        # same worker thread, so we run the entire session lifetime
+        # (open → iterate → close) inside *one* ``to_thread`` call
+        # and stream batches back to the async side via a thread-
+        # safe ``queue.Queue``.
+        #
+        # ``maxsize=2`` gives natural backpressure: the worker
+        # blocks on ``queue.put`` once two batches are buffered,
+        # matching what the caller is ready to consume.
+        sentinel = object()
+        batch_queue: sync_queue.Queue[Any] = sync_queue.Queue(maxsize=2)
+
+        def _stream_batches() -> None:
             try:
-                query = _select_rows_query(store, include_embeddings=include_embeddings)
-                result = session.execute(query)
-            except Exception:
-                session.close()
-                raise
-            return session, result
+                with session_maker() as session:
+                    query = _select_rows_query(store, include_embeddings=include_embeddings)
+                    result = session.execute(query)
+                    while True:
+                        rows = result.fetchmany(batch_size)
+                        if not rows:
+                            break
+                        batch: list[IngestedDocument] = []
+                        for row in rows:
+                            content = row[0] or ""
+                            metadata = row[1] or {}
+                            embedding: list[float] | None = None
+                            if include_embeddings and len(row) >= _ROWS_WITH_EMBEDDING_COLS:
+                                raw_vec = row[2]
+                                if raw_vec is not None:
+                                    embedding = list(raw_vec)
+                            batch.append(
+                                IngestedDocument(
+                                    content=str(content),
+                                    metadata=dict(metadata) if isinstance(metadata, dict) else {},
+                                    embedding=embedding,
+                                )
+                            )
+                        if batch:
+                            batch_queue.put(batch)
+            except Exception as exc:  # noqa: BLE001
+                batch_queue.put(exc)
+            finally:
+                batch_queue.put(sentinel)
 
-        try:
-            session, result = await asyncio.to_thread(_open_session_and_execute)
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Postgres iter_documents failed to start: %s", exc)
-            return
-
+        worker = asyncio.create_task(asyncio.to_thread(_stream_batches))
+        sentinel_seen = False
         try:
             while True:
-                try:
-                    rows = await asyncio.to_thread(result.fetchmany, batch_size)
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("Postgres iter_documents fetch failed: %s", exc)
+                item = await asyncio.to_thread(batch_queue.get)
+                if item is sentinel:
+                    sentinel_seen = True
                     break
-                if not rows:
+                if isinstance(item, Exception):
+                    logger.debug("Postgres iter_documents worker failed: %s", item)
+                    sentinel_seen = True
+                    # Worker has already queued the sentinel before
+                    # re-raising — drain it so ``worker`` terminates.
+                    await asyncio.to_thread(batch_queue.get)
                     break
-                batch: list[IngestedDocument] = []
-                for row in rows:
-                    content = row[0] or ""
-                    metadata = row[1] or {}
-                    embedding: list[float] | None = None
-                    if include_embeddings and len(row) >= _ROWS_WITH_EMBEDDING_COLS:
-                        raw_vec = row[2]
-                        if raw_vec is not None:
-                            embedding = list(raw_vec)
-                    batch.append(
-                        IngestedDocument(
-                            content=str(content),
-                            metadata=dict(metadata) if isinstance(metadata, dict) else {},
-                            embedding=embedding,
-                        )
-                    )
-                if batch:
-                    yield batch
+                yield item
         finally:
-            await asyncio.to_thread(session.close)
+            # If the caller abandoned iteration before the sentinel,
+            # the worker may be blocked in ``queue.put``. Keep
+            # draining until the sentinel arrives so it can exit.
+            if not sentinel_seen:
+                while True:
+                    drained = await asyncio.to_thread(batch_queue.get)
+                    if drained is sentinel:
+                        break
+            await worker
 
     async def storage_size_bytes(self) -> int:
         return 0


### PR DESCRIPTION
## Summary

Addresses the two findings from the outside review against \`593baa28\`.

### P1 — Vector-store \`iter_documents\` ran across multiple worker threads

\`\`\`
[P1] Postgres iter_documents shares one Session/result across multiple to_thread workers
\`\`\`

\`asyncio.to_thread\` has no worker-thread affinity. Opening a SQLAlchemy \`Session\`/\`Result\` (or pymongo / astrapy cursor) in one \`to_thread\` and iterating it via separate \`to_thread\` calls was not safe — every backend driver documents its cursor as thread-unsafe, so intermittent failures were possible on metrics refresh, chunk browsing, and \`include_embeddings\`.

Fix applied to \`postgres.py\`, \`mongodb.py\`, and \`astra.py\`: run the full cursor lifetime (open → iterate → close) inside a single \`to_thread\` worker, and stream batches back to the async generator through a thread-safe \`queue.Queue(maxsize=2)\`. That gives natural backpressure, keeps the session/cursor pinned to one thread, and still yields incrementally instead of materialising the whole result set. Worker exceptions are re-surfaced on the async side and early consumer exits drain the queue so the worker can terminate cleanly.

The reviewer called out Postgres specifically; the same root cause applied to MongoDB and Astra because their cursors carry identical thread-safety contracts, so all three are fixed together.

### P2 — Connector submission could false-positive as a successful create

\`\`\`
[P2] Incomplete connector forms still submit as a successful KB create
\`\`\`

Selecting S3 / Google Drive / OneDrive / SharePoint with missing required fields passed validation, so \`handleSubmit\` created an empty KB and closed the modal with a success toast while silently skipping the ingestion dispatch. \`getValidationErrors\` now emits a \`connector\` error whenever \`activeConnector\` is set but \`connectorPayload\` is \`null\`, and \`StepConfiguration.tsx\` renders the message next to the existing per-field errors.

Additionally, \`toggleAdvanced\` now clears \`activeConnector\` + \`connectorPayload\` when collapsing Advanced. Per the reviewer's assumption, collapsing Advanced is meant to *disable* the advanced-source path, not just hide it; without this reset, stale connector state could leak back into the simple-submit flow.

## Test plan

- \`uv run pytest src/backend/tests/unit/base/knowledge_bases/test_vector_store_backends.py src/backend/tests/unit/components/files_and_knowledge/test_retrieval.py src/backend/tests/unit/test_knowledge_bases_api.py -q\` → **70 passed, 4 skipped** locally on this head.
- [ ] CI: Backend Tests groups 1–5 green (no regressions in KB paths).
- [ ] Smoke: open the KB modal in Advanced, pick S3, leave fields empty, click Create → inline error "Complete the s3 connector configuration before continuing", modal stays open, no KB row.
- [ ] Smoke: pick S3 in Advanced, collapse Advanced, click Create → simple-submit path runs with no ingestion dispatch, no stale connector state.
- [ ] Smoke: create a Postgres-backed KB with pgvector installed, ingest ~10 files, open chunk browser → batches stream in without event-loop stalls or intermittent \`Cursor\` errors.