### PR TITLE
fix: Make sdk env flag idempotent (release-1.9.1)

### DIFF
--- a/src/sdk/src/langflow_sdk/testing.py
+++ b/src/sdk/src/langflow_sdk/testing.py
@@ -30,6 +30,7 @@ Usage inside a test file::
 
 from __future__ import annotations
 
+import contextlib
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -54,34 +55,39 @@ if TYPE_CHECKING:
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register Langflow-specific CLI options."""
     group = parser.getgroup("langflow", "Langflow integration testing options")
-    group.addoption(
-        "--langflow-env",
-        dest="langflow_env",
-        default=None,
-        metavar="NAME",
-        help="Environment name from langflow-environments.toml to use for integration tests.",
-    )
-    group.addoption(
-        "--langflow-url",
-        dest="langflow_url",
-        default=None,
-        metavar="URL",
-        help="Base URL of the Langflow instance (overrides --langflow-env).",
-    )
-    group.addoption(
-        "--langflow-api-key",
-        dest="langflow_api_key",
-        default=None,
-        metavar="KEY",
-        help="API key for the Langflow instance (overrides environment config).",
-    )
-    group.addoption(
-        "--langflow-environments-file",
-        dest="langflow_environments_file",
-        default=None,
-        metavar="PATH",
-        help="Path to langflow-environments.toml (overrides default discovery).",
-    )
+    options = {
+        "--langflow-env": {
+            "dest": "langflow_env",
+            "default": None,
+            "metavar": "NAME",
+            "help": "Environment name from langflow-environments.toml to use for integration tests.",
+        },
+        "--langflow-url": {
+            "dest": "langflow_url",
+            "default": None,
+            "metavar": "URL",
+            "help": "Base URL of the Langflow instance (overrides --langflow-env).",
+        },
+        "--langflow-api-key": {
+            "dest": "langflow_api_key",
+            "default": None,
+            "metavar": "KEY",
+            "help": "API key for the Langflow instance (overrides environment config).",
+        },
+        "--langflow-environments-file": {
+            "dest": "langflow_environments_file",
+            "default": None,
+            "metavar": "PATH",
+            "help": "Path to langflow-environments.toml (overrides default discovery).",
+        },
+    }
+
+    # langflow-sdk and lfx can both be installed in the same environment and
+    # expose the same remote-testing flags. Keep registration idempotent so
+    # pytest plugin auto-discovery can load both entry points safely.
+    for flag, kwargs in options.items():
+        with contextlib.suppress(ValueError):
+            group.addoption(flag, **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/src/sdk/tests/test_testing.py
+++ b/src/sdk/tests/test_testing.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import httpx
 import respx
+from _pytest.config.argparsing import Parser
 from langflow_sdk.client import AsyncLangflowClient, LangflowClient
 from langflow_sdk.models import RunOutput, RunResponse
-from langflow_sdk.testing import AsyncFlowRunner, FlowRunner
+from langflow_sdk.testing import AsyncFlowRunner, FlowRunner, pytest_addoption
 
 _BASE = "http://langflow.test"
 
@@ -307,3 +308,11 @@ def test_pytest_addoption_registers_options(pytestconfig):
         "--langflow-environments-file",
     ):
         assert pytestconfig.getoption(name) is None, f"Option {name!r} missing or has unexpected default"
+
+
+def test_pytest_addoption_is_idempotent():
+    """Registering the plugin twice should not fail when another plugin owns the same flags."""
+    parser = Parser(_ispytest=True)
+
+    pytest_addoption(parser)
+    pytest_addoption(parser)


### PR DESCRIPTION
Backport of [#12716](https://github.com/langflow-ai/langflow/pull/12716) to the 1.9.1 release line (stacked on [#12715](https://github.com/langflow-ai/langflow/pull/12715) — base is \`claude/fix-custom-import-alias-1-9-1\`).

## Summary

- Refactor \`pytest_addoption\` in \`src/sdk/src/langflow_sdk/testing.py\` to register CLI options via a loop, wrapping \`addoption\` calls in \`contextlib.suppress(ValueError)\` so the plugin is idempotent.
- This allows \`langflow-sdk\` and \`lfx\` to coexist in the same environment without pytest raising on duplicate flag registration during plugin auto-discovery.
- Add \`test_pytest_addoption_is_idempotent\` in \`src/sdk/tests/test_testing.py\` to verify calling \`pytest_addoption\` twice does not raise.

## Test plan

- [ ] \`uv run pytest src/sdk/tests/test_testing.py\` passes
- [ ] With both \`langflow-sdk\` and \`lfx\` installed, \`pytest --help\` shows the \`--langflow-*\` flags without errors