### PR TITLE
docs: clarify trace storage when multiple providers are enabled

### DIFF
--- a/docs/versioned_docs/version-1.9.0/Develop/traces.mdx
+++ b/docs/versioned_docs/version-1.9.0/Develop/traces.mdx
@@ -13,7 +13,11 @@ Trace data is stored in the Langflow database in the `trace` and `span` tables.
 Trace data is presented in the **Flow Activity** and **Trace Details** pages in the UI, and can be retrieved from the `/monitor/traces` API endpoint.
 
 Traces are enabled by default.
-To disable Langflow tracing and use a different tracing provider, set `LANGFLOW_NATIVE_TRACING` to `false`.
+
+Langflow traces can run alongside supported third-party tracing providers.
+If both are enabled, Langflow stores native traces in the `trace` and `span` database tables for the **Trace View**, and also sends tracing data to the configured external provider.
+
+To disable Langflow native tracing and use only an external tracing provider, set `LANGFLOW_NATIVE_TRACING=false`.
 
 ## What traces capture
 


### PR DESCRIPTION
Clarify the interaction between internal Langflow tracing and external providers like Langfuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced tracing documentation to clarify that native and third-party tracing providers can operate concurrently. When enabled together, Langflow maintains trace data in the Trace View while simultaneously sending data to configured external providers. Clarified the specific behavior when disabling native tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->