### PR TITLE
fix(traces): serialize enum values for PostgreSQL on trace/span tables

### DIFF
--- a/src/backend/base/langflow/services/database/models/traces/model.py
+++ b/src/backend/base/langflow/services/database/models/traces/model.py
@@ -6,9 +6,21 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
 from pydantic import Field as PydanticField
 from pydantic.alias_generators import to_camel
+from sqlalchemy import Enum as SQLEnum
 from sqlmodel import JSON, Column, Field, Relationship, SQLModel, Text
 
 from langflow.serialization.serialization import serialize
+
+
+def _enum_values(enum_cls: type[Enum]) -> list[str]:
+    """Return the enum's string values so SQLAlchemy serializes them instead of the enum NAMEs.
+
+    The trace/span PostgreSQL enums (``spanstatus``, ``spantype``, ``spankind``) are defined
+    in migration ``3478f0bd6ccb`` using the enum *values*. Without this callable, SQLAlchemy
+    sends the enum *names* (e.g. ``"OK"`` instead of ``"ok"``) on insert, which PostgreSQL
+    rejects with ``invalid input value for enum spanstatus: "OK"``.
+    """
+    return [member.value for member in enum_cls]
 
 
 class SpanKind(str, Enum):
@@ -60,7 +72,14 @@ class TraceBase(SQLModel):
     """Base model for traces."""
 
     name: str = Field(nullable=False, description="Name of the trace (usually flow name)")
-    status: SpanStatus = Field(default=SpanStatus.UNSET, description="Overall trace status")
+    status: SpanStatus = Field(
+        default=SpanStatus.UNSET,
+        sa_column=Column(
+            SQLEnum(SpanStatus, name="spanstatus", values_callable=_enum_values),
+            nullable=False,
+        ),
+        description="Overall trace status",
+    )
     start_time: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         description="When the trace started",
@@ -203,8 +222,22 @@ class SpanBase(SQLModel):
     """Base model for spans (individual execution steps)."""
 
     name: str = Field(nullable=False, description="Name of the span following OTel convention: '{operation} {model}'")
-    span_type: SpanType = Field(default=SpanType.CHAIN, description="Type of operation")
-    status: SpanStatus = Field(default=SpanStatus.UNSET, description="Execution status")
+    span_type: SpanType = Field(
+        default=SpanType.CHAIN,
+        sa_column=Column(
+            SQLEnum(SpanType, name="spantype", values_callable=_enum_values),
+            nullable=False,
+        ),
+        description="Type of operation",
+    )
+    status: SpanStatus = Field(
+        default=SpanStatus.UNSET,
+        sa_column=Column(
+            SQLEnum(SpanStatus, name="spanstatus", values_callable=_enum_values),
+            nullable=False,
+        ),
+        description="Execution status",
+    )
     start_time: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         description="When the span started",
@@ -216,6 +249,10 @@ class SpanBase(SQLModel):
     error: str | None = Field(default=None, sa_column=Column(Text), description="Error message if failed")
     span_kind: SpanKind = Field(
         default=SpanKind.INTERNAL,
+        sa_column=Column(
+            SQLEnum(SpanKind, name="spankind", values_callable=_enum_values),
+            nullable=False,
+        ),
         description="OpenTelemetry SpanKind",
     )
     # OTel-compliant extensible attributes

--- a/src/backend/tests/unit/services/database/models/traces/test_enum_serialization.py
+++ b/src/backend/tests/unit/services/database/models/traces/test_enum_serialization.py
@@ -1,0 +1,116 @@
+"""Regression tests for PostgreSQL enum serialization on the trace/span tables.
+
+The PostgreSQL enums ``spanstatus``, ``spantype`` and ``spankind`` (created in
+migration ``3478f0bd6ccb``) are defined with the enum *values* as labels.  If
+SQLAlchemy falls back to its default behaviour of serialising the enum *name*,
+inserts fail with e.g. ``invalid input value for enum spanstatus: "OK"``.
+
+These tests pin the fix to issue #12817 by asserting the SQLAlchemy ``Enum``
+columns on ``TraceTable`` / ``SpanTable`` advertise the enum values (not names)
+and keep the PG enum type names aligned with the migration.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langflow.services.database.models.traces.model import (
+    SpanKind,
+    SpanStatus,
+    SpanTable,
+    SpanType,
+    TraceTable,
+)
+from sqlalchemy import Enum as SQLEnum
+from sqlalchemy.dialects import postgresql
+
+
+def _column_enum(table, column_name: str) -> SQLEnum:
+    column = table.__table__.c[column_name]
+    assert isinstance(column.type, SQLEnum), f"{table.__name__}.{column_name} is not a SQLAlchemy Enum column"
+    return column.type
+
+
+class TestTraceStatusEnumColumn:
+    def test_uses_lowercase_enum_values_not_names(self):
+        enum_type = _column_enum(TraceTable, "status")
+        assert enum_type.enums == ["unset", "ok", "error"]
+
+    def test_pg_type_name_matches_migration(self):
+        enum_type = _column_enum(TraceTable, "status")
+        assert enum_type.name == "spanstatus"
+
+    @pytest.mark.parametrize(
+        ("member", "expected"),
+        [
+            (SpanStatus.UNSET, "unset"),
+            (SpanStatus.OK, "ok"),
+            (SpanStatus.ERROR, "error"),
+        ],
+    )
+    def test_bind_processor_emits_enum_value(self, member, expected):
+        enum_type = _column_enum(TraceTable, "status")
+        dialect = postgresql.dialect()
+        bind_processor = enum_type.bind_processor(dialect)
+        # If bind_processor is None, SQLAlchemy passes the value through unchanged;
+        # in that case the value coming from a ``str`` Enum is already the value
+        # string, which is what PostgreSQL expects.
+        bound = bind_processor(member) if bind_processor else member
+        assert bound == expected
+
+
+class TestSpanStatusEnumColumn:
+    def test_uses_lowercase_enum_values_not_names(self):
+        enum_type = _column_enum(SpanTable, "status")
+        assert enum_type.enums == ["unset", "ok", "error"]
+
+    def test_shares_pg_type_name_with_trace_status(self):
+        # Both columns must point at the same PG enum type created by the migration.
+        assert _column_enum(SpanTable, "status").name == "spanstatus"
+
+
+class TestSpanTypeEnumColumn:
+    def test_uses_lowercase_enum_values_not_names(self):
+        enum_type = _column_enum(SpanTable, "span_type")
+        assert enum_type.enums == [
+            "chain",
+            "llm",
+            "tool",
+            "retriever",
+            "embedding",
+            "parser",
+            "agent",
+        ]
+
+    def test_pg_type_name_matches_migration(self):
+        assert _column_enum(SpanTable, "span_type").name == "spantype"
+
+    @pytest.mark.parametrize("member", list(SpanType))
+    def test_bind_processor_emits_enum_value(self, member):
+        enum_type = _column_enum(SpanTable, "span_type")
+        dialect = postgresql.dialect()
+        bind_processor = enum_type.bind_processor(dialect)
+        bound = bind_processor(member) if bind_processor else member
+        assert bound == member.value
+
+
+class TestSpanKindEnumColumn:
+    """Pin ``values_callable`` wiring on the ``span_kind`` column.
+
+    SpanKind values happen to be uppercase, but we still want ``values_callable``
+    configured so the column is explicit and consistent with the sibling enums.
+    """
+
+    def test_column_advertises_migration_labels(self):
+        enum_type = _column_enum(SpanTable, "span_kind")
+        assert enum_type.enums == ["INTERNAL", "CLIENT", "SERVER", "PRODUCER", "CONSUMER"]
+
+    def test_pg_type_name_matches_migration(self):
+        assert _column_enum(SpanTable, "span_kind").name == "spankind"
+
+    @pytest.mark.parametrize("member", list(SpanKind))
+    def test_bind_processor_emits_enum_value(self, member):
+        enum_type = _column_enum(SpanTable, "span_kind")
+        dialect = postgresql.dialect()
+        bind_processor = enum_type.bind_processor(dialect)
+        bound = bind_processor(member) if bind_processor else member
+        assert bound == member.value


### PR DESCRIPTION
## Summary
- Root-cause fix for #12817: native tracing silently fails on PostgreSQL because SQLAlchemy persists enum **names** (`"OK"`, `"CHAIN"`, …) while the `spanstatus` / `spantype` / `spankind` PG enum types created in migration `3478f0bd6ccb` use the enum **values** (`"ok"`, `"chain"`, …).
- Wire `sa_column=Column(SQLEnum(..., values_callable=lambda e: [m.value for m in e]))` on `TraceBase.status`, `SpanBase.status`, `SpanBase.span_type`, and `SpanBase.span_kind`, matching the pattern already used by `JobStatus`, `AccessTypeEnum`, and `DeploymentType`.
- Pin the PG enum type names (`spanstatus`, `spantype`, `spankind`) on each column so a future autogen revision doesn't drift from the migration.
- Add regression tests (`test_enum_serialization.py`) that assert column `enums` labels, PG type names, and that the SQLAlchemy bind processor emits the value (not the name) under the `postgresql` dialect — covers every `SpanStatus`, `SpanType`, `SpanKind` member.

### Before
```
psycopg.errors.InvalidTextRepresentation:
  invalid input value for enum spanstatus: "OK"
```
Traces never appear in the UI; `Error flushing trace data to database` log spam when `LANGFLOW_NATIVE_TRACING=true` is combined with an external tracer.

### After
`SpanStatus.OK` → `"ok"`, `SpanType.CHAIN` → `"chain"`, etc. — inserts succeed on PostgreSQL and remain a no-op on SQLite.

### Why this over the narrower open PRs (#12200 / #12209)
Those PRs only address `spanstatus`. The issue lists `spantype` and `spankind` failures too, so all three enum columns need the same treatment; this PR fixes them together and adds regression coverage for each.

## Test plan
- [x] `uv run pytest src/backend/tests/unit/services/database/models/traces/test_enum_serialization.py` — 23/23 pass
- [x] `uv run pytest src/backend/tests/unit/services/tracing/ src/backend/tests/unit/api/v1/test_traces_api.py` — 282/282 pass (no regressions)
- [ ] Manual: run Langflow 1.9.x against PostgreSQL with `LANGFLOW_NATIVE_TRACING=true` + Langfuse; confirm traces land in DB and UI
- [ ] Manual: SQLite smoke (existing behavior unchanged — SQLite stores enums as VARCHAR)

Fixes #12817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database storage of trace and span data with enhanced enum handling for better PostgreSQL compatibility and data integrity.

* **Tests**
  * Added comprehensive test coverage for enum serialization validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->