### PR TITLE
fix(custom): include __future__ imports in component sandbox compilation

### DIFF
--- a/src/lfx/src/lfx/custom/validate.py
+++ b/src/lfx/src/lfx/custom/validate.py
@@ -272,8 +272,11 @@ def create_class(code, class_name):
         module = ast.parse(code)
         exec_globals = prepare_global_scope(module)
 
+        future_imports = [
+            n for n in module.body if isinstance(n, ast.ImportFrom) and n.module == "__future__"
+        ]
         class_code = extract_class_code(module, class_name)
-        compiled_class = compile_class_code(class_code)
+        compiled_class = compile_class_code(class_code, future_imports)
 
         return build_class_constructor(compiled_class, exec_globals, class_name)
 
@@ -393,11 +396,15 @@ def prepare_global_scope(module):
     exec_globals = globals().copy()
     imports = []
     import_froms = []
+    future_imports = []
     definitions = []
 
     for node in module.body:
         if isinstance(node, ast.Import):
             imports.append(node)
+        elif isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            # __future__ imports are compiler directives — collect separately
+            future_imports.append(node)
         elif isinstance(node, ast.ImportFrom) and node.module is not None:
             import_froms.append(node)
         elif isinstance(node, ast.ClassDef | ast.FunctionDef | ast.Assign | ast.AnnAssign):
@@ -467,7 +474,8 @@ def prepare_global_scope(module):
             raise ModuleNotFoundError(msg)
 
     if definitions:
-        combined_module = ast.Module(body=definitions, type_ignores=[])
+        # Prepend __future__ imports so compiler directives (e.g. PEP 563 annotations) take effect
+        combined_module = ast.Module(body=future_imports + definitions, type_ignores=[])
         compiled_code = compile(combined_module, "<string>", "exec")
         exec(compiled_code, exec_globals)
 
@@ -490,16 +498,18 @@ def extract_class_code(module, class_name):
     return class_code
 
 
-def compile_class_code(class_code):
+def compile_class_code(class_code, future_imports=None):
     """Compiles the AST node of a class into a code object.
 
     Args:
         class_code: AST node of the class
+        future_imports: Optional list of __future__ ImportFrom nodes to prepend as compiler directives
 
     Returns:
         Compiled code object of the class
     """
-    return compile(ast.Module(body=[class_code], type_ignores=[]), "<string>", "exec")
+    body = (future_imports or []) + [class_code]
+    return compile(ast.Module(body=body, type_ignores=[]), "<string>", "exec")
 
 
 def build_class_constructor(compiled_class, exec_globals, class_name):

--- a/src/lfx/src/lfx/custom/validate.py
+++ b/src/lfx/src/lfx/custom/validate.py
@@ -272,9 +272,7 @@ def create_class(code, class_name):
         module = ast.parse(code)
         exec_globals = prepare_global_scope(module)
 
-        future_imports = [
-            n for n in module.body if isinstance(n, ast.ImportFrom) and n.module == "__future__"
-        ]
+        future_imports = [n for n in module.body if isinstance(n, ast.ImportFrom) and n.module == "__future__"]
         class_code = extract_class_code(module, class_name)
         compiled_class = compile_class_code(class_code, future_imports)
 

--- a/src/lfx/tests/unit/custom/component/test_validate.py
+++ b/src/lfx/tests/unit/custom/component/test_validate.py
@@ -42,7 +42,8 @@ class TestLoggingComponent(Component):
 def test_create_class_future_annotations_with_type_checking():
     """Regression test for issue #12776: `from __future__ import annotations` must act as a
     compiler directive so that TYPE_CHECKING-only imports don't raise NameError at class
-    definition time."""
+    definition time.
+    """
     code = dedent("""
 from __future__ import annotations
 from typing import TYPE_CHECKING

--- a/src/lfx/tests/unit/custom/component/test_validate.py
+++ b/src/lfx/tests/unit/custom/component/test_validate.py
@@ -39,6 +39,32 @@ class TestLoggingComponent(Component):
     assert result.__name__ == "TestLoggingComponent"
 
 
+def test_create_class_future_annotations_with_type_checking():
+    """Regression test for issue #12776: `from __future__ import annotations` must act as a
+    compiler directive so that TYPE_CHECKING-only imports don't raise NameError at class
+    definition time."""
+    code = dedent("""
+from __future__ import annotations
+from typing import TYPE_CHECKING
+from langflow.custom import Component
+
+if TYPE_CHECKING:
+    from typing import List
+
+class TypeCheckingComponent(Component):
+    display_name = "Test"
+
+    def build(self, value: List[str]) -> str:
+        return str(value)
+    """)
+    result = create_class(code, "TypeCheckingComponent")
+    assert result.__name__ == "TypeCheckingComponent"
+    # With PEP 563 active, annotations should be stored as strings rather than evaluated
+    hints = result.build.__annotations__
+    assert hints.get("value") == "List[str]"
+    assert hints.get("return") == "str"
+
+
 def test_execute_function_supports_aliased_dotted_imports():
     code = dedent("""
 import urllib.request as request


### PR DESCRIPTION
Fixes #12776

## Problem

In `prepare_global_scope()`, `from __future__ import annotations` was classified as a regular `ImportFrom` node and excluded from the definitions module. Because PEP 563 is a **compiler directive**, it must be present in the `ast.Module` at `compile()` time to activate lazy annotation evaluation.

Without this fix, any custom component using the standard `TYPE_CHECKING` + `from __future__ import annotations` pattern raised a `NameError` at class-definition time:

```
Error building Component: Error creating class.
NameError(name 'SomeType' is not defined)
```

## Solution

1. **Separate `__future__` imports** from regular `ImportFrom` nodes in `prepare_global_scope` — they are compiler directives, not runtime imports, so they should not be processed by the normal import machinery.
2. **Prepend them to the definitions module** before `compile()`, restoring PEP 563 semantics for any helper classes/functions defined alongside the component.
3. **Thread the `__future__` imports into `compile_class_code()`** via a new optional parameter so the main component class is also compiled with PEP 563.

## Testing

Added a regression test in `test_validate.py` that reproduces the exact pattern from the issue — a component class using `TYPE_CHECKING`-only imports with `from __future__ import annotations`. The test verifies that the class is created without error and that annotations are stored as strings (PEP 563), not eagerly evaluated.