### PR TITLE
feat(benchmarks): skip verify for unanchored baselines (runs=0)

### DIFF
--- a/src/backend/tests/benchmarks/driver.py
+++ b/src/backend/tests/benchmarks/driver.py
@@ -878,9 +878,15 @@ def compare_against_thresholds(
     Behavior:
       - measurement_mode mismatch -> stderr WARNING only (not a failure; see D-11a note).
       - any scenario delta_pct > allowed_regression_pct/100 -> exit code EXIT_VERIFY_REGRESSION.
-      - baseline mean_ms <= 0 -> treat any finite current mean as FAIL (Path-B sentinel trip).
+      - baseline runs == 0 AND mean_ms <= 0 -> UNANCHORED (scenario exists in
+        thresholds.json as a placeholder but has never been snapshotted); the
+        row is recorded with status SKIP and does not trip the gate. A new
+        scenario can land in thresholds.json alongside its code change without
+        failing its first real measurement.
+      - baseline mean_ms <= 0 (with runs > 0) -> FAIL on any finite current
+        mean (Path-B sentinel trip: intentionally-zeroed baseline).
       - on any FAIL, write reports/regression_comment.md.
-      - on all PASS, no regression_comment.md file is written.
+      - on all PASS/SKIP, no regression_comment.md file is written.
     """
     if not thresholds_path.exists():
         sys.stderr.write(
@@ -905,9 +911,17 @@ def compare_against_thresholds(
         if not current:
             continue
         baseline_ms = float(t_entry.get("mean_ms", 0.0))
+        baseline_runs = int(t_entry.get("runs", 0) or 0)
         current_ms = float(current.get("mean_ms", 0.0))
-        if baseline_ms <= 0.0:
-            # Sentinel baseline: any finite current trips the gate.
+        if baseline_ms <= 0.0 and baseline_runs <= 0:
+            # Unanchored baseline: scenario is a placeholder that has never been
+            # snapshotted. Record the current number for visibility but do not
+            # trip the gate — the next snapshot run will anchor it.
+            status = "SKIP"
+            delta_pct = 0.0
+        elif baseline_ms <= 0.0:
+            # Sentinel baseline with prior runs: any finite current trips the
+            # gate (intentionally-zeroed baseline, Path-B sentinel trip).
             status = "FAIL"
             delta_pct = float("inf") if current_ms > 0 else 0.0
         else:

--- a/src/backend/tests/benchmarks/tests/test_driver_verify.py
+++ b/src/backend/tests/benchmarks/tests/test_driver_verify.py
@@ -1,11 +1,15 @@
 """Unit tests for driver --verify mode (compare_against_thresholds).
 
-Four cases per task 4 of plan 01-05:
+Cases:
   A. FAIL: current mean 50% above baseline -> non-zero exit + regression_comment.md.
   B. PASS: current mean 10% above baseline (below 15% allowed) -> exit 0 + no comment.
-  C. Sentinel: baseline mean_ms=0 (Path B sentinel) -> non-zero + regression_comment.md.
+  C. Sentinel: baseline mean_ms=0 with prior runs (intentionally zeroed) -> non-zero
+     + regression_comment.md.
   D. Mode mismatch: thresholds.measurement_mode != driver.MEASUREMENT_MODE -> stderr warning
      but NOT a failure by itself (still exits 0 when within threshold).
+  E. Unanchored: baseline mean_ms=0 AND runs=0 (placeholder for a scenario that has
+     never been snapshotted) -> exit 0 + no comment; the current number is recorded
+     for visibility but does not gate the PR.
 
 No mocks (user global rule). The verify helper is directly callable with dict inputs.
 """
@@ -29,6 +33,7 @@ def _write_thresholds(
     mean_ms: float,
     measurement_mode: str = "bytecode_compile_delta",
     allowed_pct: int = 15,
+    runs: int = 10,
 ) -> None:
     """Helper: write a minimal thresholds.json at `path` with one lfx_bare entry."""
     payload = {
@@ -40,7 +45,7 @@ def _write_thresholds(
         "python_version": "3.13.0",
         "allowed_regression_pct": allowed_pct,
         "scenarios": {
-            "lfx_bare": {"mean_ms": mean_ms, "stddev_ms": 50.0, "runs": 10},
+            "lfx_bare": {"mean_ms": mean_ms, "stddev_ms": 50.0, "runs": runs},
         },
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -94,6 +99,21 @@ def test_verify_sentinel_baseline_always_trips(tmp_path: Path) -> None:
     assert rc != 0, "sentinel baseline (mean_ms=0) must trip the gate"
     comment = output_dir / "regression_comment.md"
     assert comment.exists(), "sentinel trip must write regression_comment.md"
+
+
+def test_verify_unanchored_baseline_skips(tmp_path: Path) -> None:
+    """E: baseline mean_ms=0 AND runs=0 (unanchored placeholder) does NOT trip the gate."""
+    thresholds_path = tmp_path / "thresholds.json"
+    output_dir = tmp_path / "reports"
+    output_dir.mkdir()
+    _write_thresholds(thresholds_path, mean_ms=0.0, runs=0)
+
+    current = {"lfx_bare": {"mean_ms": 22183.74, "stddev_ms": 246.06, "runs": 5}}
+    rc = driver.compare_against_thresholds(current, thresholds_path, output_dir)
+
+    assert rc == 0, "unanchored baseline (runs=0) must NOT trip the gate"
+    comment = output_dir / "regression_comment.md"
+    assert not comment.exists(), "unanchored skip must NOT write regression_comment.md"
 
 
 def test_verify_measurement_mode_mismatch_warns_not_fails(


### PR DESCRIPTION
## Summary

Teaches the cold-start benchmark driver's verify gate to distinguish between two sentinel shapes in `thresholds.json`:

- **Unanchored** (`runs: 0`, `mean_ms <= 0`): scenario is a tracked placeholder that has never been snapshotted. First real measurement lands as `SKIP`; no gate trip, no regression comment. The next `run-benchmark-snapshot` anchors the baseline.
- **Intentionally zeroed Path-B sentinel** (`runs > 0`, `mean_ms <= 0`): unchanged behavior. Any finite current mean still trips the gate.

## Why

Before this change, any `mean_ms <= 0` tripped the gate unconditionally. That meant a new scenario landing as a sentinel entry (the convention for "tracked but not yet anchored") failed CI on its very first measurement, forcing the contributor to either:

- Snapshot on their PR branch to seed the baseline, which we discourage (authoritative baselines should come from main), or
- Add `continue-on-error: true` on the matrix cell as a workaround, then remember to remove it in a followup PR after the baseline lands.

Both are friction. With this change, the natural workflow — land the scenario with a `runs: 0` placeholder, let the next snapshot anchor it — just works.

## What changed

- `src/backend/tests/benchmarks/driver.py`: `compare_against_thresholds` reads `runs` from each thresholds entry and treats `runs <= 0 and mean_ms <= 0` as `SKIP`.
- `src/backend/tests/benchmarks/tests/test_driver_verify.py`: new case `E` (`test_verify_unanchored_baseline_skips`) covers the new branch. Existing sentinel-trip case stays green (the helper's default `runs=10` still routes through the Path-B branch).

## Verification

- `uv run pytest tests/benchmarks/tests/test_driver_verify.py` — 5/5 pass (4 existing + 1 new).
- `uv run ruff check` / `ruff format --check` — clean.

## Stacked on

#12798 (`cold-start/fix-http-ready-tcp-probe`) — the benchmarks driver only exists on that stack until the umbrella merges.