### PR TITLE
fix(security): close IDOR in get_flow_by_id_or_endpoint_name (LE-639)

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -411,6 +411,33 @@ async def check_flow_user_permission(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You do not have permission to run this flow")
 
 
+async def get_flow_for_api_key_user(
+    flow_id_or_name: str,
+    api_key_user: Annotated[UserRead, Depends(api_key_security)],
+) -> FlowRead:
+    """Auth-aware wrapper around ``get_flow_by_id_or_endpoint_name`` for API-key routes.
+
+    Using the raw helper as a FastAPI ``Depends`` exposed ``user_id`` as a
+    plain query parameter that no real caller sets, so flow lookups on the
+    ``/run*`` routes bypassed user scoping entirely and relied on
+    ``check_flow_user_permission`` later in the handler for a 403.  That gave
+    attackers a 403-vs-404 existence oracle on flow UUIDs.  This wrapper
+    pulls the authenticated user from ``api_key_security`` and passes it to
+    the helper, so cross-user access fails closed with 404 at the helper
+    layer.  ``check_flow_user_permission`` is kept in the handler chain as
+    defense in depth.
+    """
+    return await get_flow_by_id_or_endpoint_name(flow_id_or_name, api_key_user.id)
+
+
+async def get_flow_for_current_user(
+    flow_id_or_name: str,
+    current_user: CurrentActiveUser,
+) -> FlowRead:
+    """Session-auth variant of :func:`get_flow_for_api_key_user`."""
+    return await get_flow_by_id_or_endpoint_name(flow_id_or_name, current_user.id)
+
+
 async def _run_flow_internal(
     *,
     background_tasks: BackgroundTasks,
@@ -555,7 +582,7 @@ async def _run_flow_internal(
 async def simplified_run_flow(
     *,
     background_tasks: BackgroundTasks,
-    flow: Annotated[FlowRead, Depends(get_flow_by_id_or_endpoint_name)],
+    flow: Annotated[FlowRead, Depends(get_flow_for_api_key_user)],
     input_request: SimplifiedAPIRequest | None = None,
     stream: bool = False,
     api_key_user: Annotated[UserRead, Depends(api_key_security)],
@@ -615,7 +642,7 @@ async def simplified_run_flow(
 async def simplified_run_flow_session(
     *,
     background_tasks: BackgroundTasks,
-    flow: Annotated[FlowRead, Depends(get_flow_by_id_or_endpoint_name)],
+    flow: Annotated[FlowRead, Depends(get_flow_for_current_user)],
     input_request: SimplifiedAPIRequest | None = None,
     stream: bool = False,
     api_key_user: CurrentActiveUser,
@@ -825,7 +852,7 @@ async def webhook_run_flow(
 async def experimental_run_flow(
     *,
     session: DbSession,
-    flow: Annotated[Flow, Depends(get_flow_by_id_or_endpoint_name)],
+    flow: Annotated[Flow, Depends(get_flow_for_api_key_user)],
     inputs: list[InputValueRequest] | None = None,
     outputs: list[str] | None = None,
     tweaks: Annotated[Tweaks | None, Body(embed=True)] = None,

--- a/src/backend/base/langflow/helpers/flow.py
+++ b/src/backend/base/langflow/helpers/flow.py
@@ -410,7 +410,17 @@ async def get_flow_by_id_or_endpoint_name(flow_id_or_name: str, user_id: str | U
         # another user's flow.
         uuid_user_id: UUID | None = None
         if user_id is not None:
-            uuid_user_id = UUID(user_id) if isinstance(user_id, str) else user_id
+            # Malformed user_id -- e.g. ``?user_id=foo`` on a legacy Depends
+            # route -- previously raised a raw ValueError (500 to the client).
+            # Fail closed: convert to 404 so we never disclose a flow to a
+            # caller whose identity we can't resolve.
+            try:
+                uuid_user_id = UUID(user_id) if isinstance(user_id, str) else user_id
+            except (ValueError, AttributeError) as exc:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Flow identifier {flow_id_or_name} not found",
+                ) from exc
         try:
             flow_id = UUID(flow_id_or_name)
             flow = await session.get(Flow, flow_id)

--- a/src/backend/base/langflow/helpers/flow.py
+++ b/src/backend/base/langflow/helpers/flow.py
@@ -398,15 +398,28 @@ def get_arg_names(inputs: list[Vertex]) -> list[dict[str, str]]:
 
 async def get_flow_by_id_or_endpoint_name(flow_id_or_name: str, user_id: str | UUID | None = None) -> FlowRead:
     async with session_scope() as session:
-        endpoint_name = None
+        # SECURITY (LE-639): previously the UUID branch below called
+        # ``session.get(Flow, flow_id)`` with no ownership check, so any
+        # authenticated caller could resolve any other user's flow by UUID.
+        # The endpoint_name branch scoped by ``user_id`` only when a truthy
+        # value was passed, so callers using this as a FastAPI ``Depends``
+        # (which resolves ``user_id`` from a query param that no one sets) had
+        # the same hole on both branches.  Normalize ``user_id`` once and
+        # enforce it on both branches -- returning None on cross-user lookup
+        # so the shared 404 below fires and we don't disclose existence of
+        # another user's flow.
+        uuid_user_id: UUID | None = None
+        if user_id is not None:
+            uuid_user_id = UUID(user_id) if isinstance(user_id, str) else user_id
         try:
             flow_id = UUID(flow_id_or_name)
             flow = await session.get(Flow, flow_id)
+            if flow is not None and uuid_user_id is not None and flow.user_id != uuid_user_id:
+                flow = None
         except ValueError:
             endpoint_name = flow_id_or_name
             stmt = select(Flow).where(Flow.endpoint_name == endpoint_name)
-            if user_id:
-                uuid_user_id = UUID(user_id) if isinstance(user_id, str) else user_id
+            if uuid_user_id is not None:
                 stmt = stmt.where(Flow.user_id == uuid_user_id)
             flow = (await session.exec(stmt)).first()
         if flow is None:

--- a/src/backend/tests/unit/helpers/test_flow_helpers.py
+++ b/src/backend/tests/unit/helpers/test_flow_helpers.py
@@ -1,8 +1,10 @@
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
+from fastapi import HTTPException
 from langflow.helpers.flow import (
+    get_flow_by_id_or_endpoint_name,
     get_flow_by_id_or_name,
     list_flows,
     list_flows_by_flow_folder,
@@ -230,3 +232,203 @@ class TestGetFlowByIdOrName:
             assert isinstance(result, Data)
             # The query should have been made with flow_id (checking it was called)
             mock_session.exec.assert_called_once()
+
+
+class TestGetFlowByIdOrEndpointName:
+    """Regression tests for the IDOR fix in get_flow_by_id_or_endpoint_name (LE-639).
+
+    The UUID branch previously called ``session.get(Flow, flow_id)`` without
+    applying any ownership check, so any authenticated caller could resolve
+    another user's flow by UUID.  The endpoint_name branch had the matching
+    issue when ``user_id`` was not supplied (the FastAPI ``Depends`` pattern
+    provided no user_id by default).  These tests lock in the fix.
+    """
+
+    @staticmethod
+    def _patch_session(mock_session):
+        """Patch session_scope to yield the provided mock session."""
+        patcher = patch("langflow.helpers.flow.session_scope")
+        mock_scope = patcher.start()
+        mock_scope.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_scope.return_value.__aexit__ = AsyncMock(return_value=False)
+        return patcher
+
+    @pytest.mark.asyncio
+    async def test_uuid_branch_returns_flow_for_owner(self):
+        """Same-user UUID lookup returns the flow (happy path)."""
+        owner_id = uuid4()
+        flow_id = uuid4()
+        flow = MagicMock(spec=Flow)
+        flow.id = flow_id
+        flow.user_id = owner_id
+        flow.name = "test_flow"
+        flow.endpoint_name = None
+        flow.data = {}
+        flow.description = None
+        flow.is_component = False
+        flow.updated_at = None
+        flow.folder_id = None
+        flow.user_id = owner_id
+
+        mock_session = MagicMock()
+        mock_session.get = AsyncMock(return_value=flow)
+
+        patcher = self._patch_session(mock_session)
+        try:
+            with patch("langflow.helpers.flow.FlowRead") as mock_flow_read:
+                mock_flow_read.model_validate = MagicMock(return_value="validated_flow")
+                result = await get_flow_by_id_or_endpoint_name(str(flow_id), str(owner_id))
+                assert result == "validated_flow"
+                mock_session.get.assert_awaited_once_with(Flow, flow_id)
+        finally:
+            patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_uuid_branch_rejects_cross_user_access(self):
+        """Cross-user UUID lookup raises 404 (the core IDOR fix)."""
+        attacker_id = uuid4()
+        victim_id = uuid4()
+        flow_id = uuid4()
+        victim_flow = MagicMock(spec=Flow)
+        victim_flow.id = flow_id
+        victim_flow.user_id = victim_id
+
+        mock_session = MagicMock()
+        mock_session.get = AsyncMock(return_value=victim_flow)
+
+        patcher = self._patch_session(mock_session)
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                await get_flow_by_id_or_endpoint_name(str(flow_id), str(attacker_id))
+            assert exc_info.value.status_code == 404
+            # Must NOT 403 -- returning 403 would confirm the flow exists to
+            # an attacker enumerating UUIDs.  404 hides existence.
+            assert "not found" in exc_info.value.detail.lower()
+        finally:
+            patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_uuid_branch_accepts_uuid_instance_for_user_id(self):
+        """Callers passing a UUID object (not str) are handled correctly."""
+        attacker_id = uuid4()
+        victim_id = uuid4()
+        flow_id = uuid4()
+        victim_flow = MagicMock(spec=Flow)
+        victim_flow.id = flow_id
+        victim_flow.user_id = victim_id
+
+        mock_session = MagicMock()
+        mock_session.get = AsyncMock(return_value=victim_flow)
+
+        patcher = self._patch_session(mock_session)
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                # Pass UUID, not str -- matches workflow.py:151 call style.
+                await get_flow_by_id_or_endpoint_name(str(flow_id), attacker_id)
+            assert exc_info.value.status_code == 404
+        finally:
+            patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_uuid_branch_without_user_id_returns_flow(self):
+        """No user_id = no scoping (preserves webhook/internal caller behavior)."""
+        flow_id = uuid4()
+        flow = MagicMock(spec=Flow)
+        flow.id = flow_id
+        flow.user_id = uuid4()
+
+        mock_session = MagicMock()
+        mock_session.get = AsyncMock(return_value=flow)
+
+        patcher = self._patch_session(mock_session)
+        try:
+            with patch("langflow.helpers.flow.FlowRead") as mock_flow_read:
+                mock_flow_read.model_validate = MagicMock(return_value="validated_flow")
+                # user_id=None: any flow is returned.
+                result = await get_flow_by_id_or_endpoint_name(str(flow_id), user_id=None)
+                assert result == "validated_flow"
+        finally:
+            patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_uuid_branch_missing_flow_raises_404(self):
+        """Non-existent UUID returns 404 regardless of user_id."""
+        owner_id = uuid4()
+        flow_id = uuid4()
+
+        mock_session = MagicMock()
+        mock_session.get = AsyncMock(return_value=None)
+
+        patcher = self._patch_session(mock_session)
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                await get_flow_by_id_or_endpoint_name(str(flow_id), str(owner_id))
+            assert exc_info.value.status_code == 404
+        finally:
+            patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_endpoint_name_branch_scopes_by_user(self):
+        """endpoint_name lookup filters by user_id when supplied."""
+        owner_id = uuid4()
+
+        mock_session = MagicMock()
+        mock_result = MagicMock()
+        mock_result.first = MagicMock(return_value=None)
+        mock_session.exec = AsyncMock(return_value=mock_result)
+
+        patcher = self._patch_session(mock_session)
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                await get_flow_by_id_or_endpoint_name("my-webhook", str(owner_id))
+            assert exc_info.value.status_code == 404
+            # The select statement should have been filtered by user_id --
+            # verified indirectly by the exec call count (1 call, scoped).
+            mock_session.exec.assert_awaited_once()
+            stmt = mock_session.exec.await_args.args[0]
+            # Compile the where clauses and confirm the user_id filter is present.
+            where_sql = str(stmt.whereclause)
+            assert "user_id" in where_sql
+
+        finally:
+            patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_endpoint_name_branch_without_user_id_not_scoped(self):
+        """No user_id on endpoint_name branch = no user scoping (webhook behavior)."""
+        flow = MagicMock(spec=Flow)
+        flow.id = uuid4()
+        flow.user_id = uuid4()
+
+        mock_session = MagicMock()
+        mock_result = MagicMock()
+        mock_result.first = MagicMock(return_value=flow)
+        mock_session.exec = AsyncMock(return_value=mock_result)
+
+        patcher = self._patch_session(mock_session)
+        try:
+            with patch("langflow.helpers.flow.FlowRead") as mock_flow_read:
+                mock_flow_read.model_validate = MagicMock(return_value="validated_flow")
+                result = await get_flow_by_id_or_endpoint_name("webhook-ep", user_id=None)
+                assert result == "validated_flow"
+                stmt = mock_session.exec.await_args.args[0]
+                where_sql = str(stmt.whereclause) if stmt.whereclause is not None else ""
+                # With no user_id, the only filter should be endpoint_name.
+                assert "user_id" not in where_sql
+        finally:
+            patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_accepts_uuid_instance_for_user_id_parameter(self):
+        """user_id can be a UUID object (matches workflow.py call sites)."""
+        owner_id = UUID(str(uuid4()))
+
+        mock_session = MagicMock()
+        mock_session.get = AsyncMock(return_value=None)
+
+        patcher = self._patch_session(mock_session)
+        try:
+            with pytest.raises(HTTPException):
+                await get_flow_by_id_or_endpoint_name(str(uuid4()), owner_id)
+        finally:
+            patcher.stop()

--- a/src/backend/tests/unit/helpers/test_flow_helpers.py
+++ b/src/backend/tests/unit/helpers/test_flow_helpers.py
@@ -432,3 +432,27 @@ class TestGetFlowByIdOrEndpointName:
                 await get_flow_by_id_or_endpoint_name(str(uuid4()), owner_id)
         finally:
             patcher.stop()
+
+    @pytest.mark.parametrize("bad_user_id", ["not-a-uuid", "", "12345-not-a-real-uuid"])
+    @pytest.mark.asyncio
+    async def test_malformed_user_id_raises_404_not_500(self, bad_user_id):
+        """Malformed user_id (e.g. ``?user_id=foo``) must fail closed with 404.
+
+        Previously the eager ``UUID(user_id)`` normalization raised a raw
+        ``ValueError`` that surfaced as a 500 to the client.  The helper now
+        converts that into the same 404 we'd return for "flow not found" so
+        that a malformed caller identity can never be used to enumerate or
+        exfiltrate flows, and doesn't give attackers a new error signal.
+        """
+        mock_session = MagicMock()
+        mock_session.get = AsyncMock(return_value=None)
+
+        patcher = self._patch_session(mock_session)
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                await get_flow_by_id_or_endpoint_name(str(uuid4()), bad_user_id)
+            assert exc_info.value.status_code == 404
+            # Session lookup should never happen if user_id couldn't be parsed.
+            mock_session.get.assert_not_awaited()
+        finally:
+            patcher.stop()

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -972,3 +972,84 @@ async def test_openai_responses_response_schema_has_usage_field(client: AsyncCli
         assert "id" in json_response
         assert "output" in json_response
         assert "usage" in json_response  # usage field should always be present (can be None)
+
+
+async def test_openai_responses_rejects_cross_user_flow_access(
+    client: AsyncClient,
+    simple_api_test,
+    created_api_key,  # noqa: ARG001 - used only to establish the owner's API key
+):
+    """Regression (LE-639): authenticated user cannot execute another user's flow.
+
+    Reproduces the IDOR PoC from the Jira ticket: a user with a valid API key
+    passes a flow UUID owned by a different user in the ``model`` field.  The
+    pre-fix behavior was that the endpoint executed the victim's flow and
+    returned 200 with real output; after the fix the helper resolves to
+    flow_not_found because UUID lookups now enforce user scope.
+    """
+    from langflow.services.auth.utils import get_password_hash
+    from langflow.services.database.models.api_key.model import ApiKey
+    from langflow.services.database.models.user.model import User
+    from lfx.services.deps import session_scope
+    from sqlmodel import select
+
+    attacker_api_key = "attacker_random_key"  # pragma: allowlist secret
+    attacker_username = "idor_attacker_user"
+
+    # Create a second, unrelated user + API key inline.  Kept local to this
+    # test rather than promoted to a shared fixture to minimize blast radius.
+    async with session_scope() as session:
+        existing = (await session.exec(select(User).where(User.username == attacker_username))).first()
+        if existing is None:
+            attacker = User(
+                username=attacker_username,
+                password=get_password_hash("testpassword"),
+                is_active=True,
+                is_superuser=False,
+            )
+            session.add(attacker)
+            await session.flush()
+            await session.refresh(attacker)
+        else:
+            attacker = existing
+        existing_key = (await session.exec(select(ApiKey).where(ApiKey.api_key == attacker_api_key))).first()
+        if existing_key is None:
+            key = ApiKey(
+                name="idor_attacker_key",
+                user_id=attacker.id,
+                api_key=attacker_api_key,
+                hashed_api_key=get_password_hash(attacker_api_key),
+            )
+            session.add(key)
+            await session.flush()
+        attacker_id = attacker.id
+
+    try:
+        victim_flow_id = simple_api_test["id"]  # owned by active_user via logged_in_headers
+        payload = {
+            "model": victim_flow_id,
+            "input": "Hello",
+            "stream": False,
+        }
+        response = await client.post(
+            "/api/v1/responses",
+            json=payload,
+            headers={"x-api-key": attacker_api_key},
+        )
+
+        # The endpoint returns 200 with an OpenAI-style error body on flow-not-found
+        # (matches test_openai_responses_nonexistent_flow_uuid behavior).
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert "error" in body, f"Expected flow_not_found error for cross-user access, got: {body}"
+        assert body["error"]["code"] == "flow_not_found", (
+            f"Expected flow_not_found for cross-user access, got code: {body['error'].get('code')}"
+        )
+    finally:
+        # Clean up the second user + key we created for this test.
+        async with session_scope() as session:
+            for api_key_row in (await session.exec(select(ApiKey).where(ApiKey.user_id == attacker_id))).all():
+                await session.delete(api_key_row)
+            user = await session.get(User, attacker_id)
+            if user:
+                await session.delete(user)

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -717,20 +717,26 @@ async def test_user_can_run_own_flow(client: AsyncClient, simple_api_test, creat
 
 @pytest.mark.benchmark
 async def test_user_cannot_run_other_users_flow(client: AsyncClient, simple_api_test, user_two_api_key):
-    """Test that a user cannot run another user's flow - should return 403 Forbidden."""
+    """Test that a user cannot run another user's flow.
+
+    LE-639: post-fix behavior is 404 (not 403) so we don't leak flow existence
+    via a 403-vs-404 oracle.  See ``get_flow_for_api_key_user`` in
+    ``api/v1/endpoints.py``.
+    """
     # simple_api_test belongs to active_user, but we're using user_two's API key
     headers = {"x-api-key": user_two_api_key}
     flow_id = simple_api_test["id"]
 
     response = await client.post(f"/api/v1/run/{flow_id}", headers=headers)
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
-    assert "You do not have permission to run this flow" in response.text
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+    # Must not leak that the flow exists under another user's account.
+    assert "permission" not in response.text.lower()
 
 
 @pytest.mark.benchmark
 async def test_user_cannot_run_other_users_flow_with_payload(client: AsyncClient, simple_api_test, user_two_api_key):
-    """Test that a user cannot run another user's flow even with valid payload."""
+    """Test that a user cannot run another user's flow even with valid payload (LE-639)."""
     headers = {"x-api-key": user_two_api_key}
     flow_id = simple_api_test["id"]
     payload = {
@@ -741,8 +747,8 @@ async def test_user_cannot_run_other_users_flow_with_payload(client: AsyncClient
 
     response = await client.post(f"/api/v1/run/{flow_id}", headers=headers, json=payload)
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
-    assert "You do not have permission to run this flow" in response.text
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+    assert "permission" not in response.text.lower()
 
 
 @pytest.mark.benchmark
@@ -763,7 +769,7 @@ async def test_user_can_run_own_flow_with_streaming(client: AsyncClient, simple_
 
 @pytest.mark.benchmark
 async def test_user_cannot_run_other_users_flow_with_streaming(client: AsyncClient, simple_api_test, user_two_api_key):
-    """Test that a user cannot run another user's flow with streaming."""
+    """Test that a user cannot run another user's flow with streaming (LE-639)."""
     headers = {"x-api-key": user_two_api_key}
     flow_id = simple_api_test["id"]
     payload = {
@@ -774,8 +780,8 @@ async def test_user_cannot_run_other_users_flow_with_streaming(client: AsyncClie
 
     response = await client.post(f"/api/v1/run/{flow_id}?stream=true", headers=headers, json=payload)
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
-    assert "You do not have permission to run this flow" in response.text
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+    assert "permission" not in response.text.lower()
 
 
 @pytest.mark.benchmark
@@ -802,7 +808,7 @@ async def test_user_can_run_own_flow_advanced_endpoint(client: AsyncClient, simp
 async def test_user_cannot_run_other_users_flow_advanced_endpoint(
     client: AsyncClient, simple_api_test, user_two_api_key
 ):
-    """Test that a user cannot run another user's flow using the advanced endpoint."""
+    """Test that a user cannot run another user's flow using the advanced endpoint (LE-639)."""
     headers = {"x-api-key": user_two_api_key}
     flow_id = simple_api_test["id"]
     payload = {
@@ -814,8 +820,94 @@ async def test_user_cannot_run_other_users_flow_advanced_endpoint(
 
     response = await client.post(f"/api/v1/run/advanced/{flow_id}", headers=headers, json=payload)
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
-    assert "You do not have permission to run this flow" in response.text
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+    assert "permission" not in response.text.lower()
+
+
+@pytest.mark.benchmark
+async def test_user_cannot_run_other_users_flow_session_endpoint(
+    client: AsyncClient, simple_api_test, logged_in_headers, monkeypatch
+):
+    """LE-639 regression: cross-user access on /run/session/{flow_id} returns 404.
+
+    ``simplified_run_flow_session`` is feature-flagged behind
+    ``agentic_experience`` and uses session auth (``CurrentActiveUser``).
+    We flip the flag on via monkeypatch and log in as ``active_super_user``
+    (a different user than ``active_user`` who owns ``simple_api_test``) to
+    exercise the session-auth variant of the wrapper dependency.
+    """
+    from langflow.services.auth.utils import get_password_hash
+    from langflow.services.database.models.user.model import User
+    from langflow.services.deps import get_settings_service
+    from lfx.services.deps import session_scope
+    from sqlmodel import select
+
+    settings_service = get_settings_service()
+    monkeypatch.setattr(settings_service.settings, "agentic_experience", True)
+
+    # Create a second user with session credentials and log in.
+    other_username = "le639_session_user"
+    other_password = "testpassword"  # noqa: S105  # pragma: allowlist secret
+    async with session_scope() as session:
+        existing = (await session.exec(select(User).where(User.username == other_username))).first()
+        if existing is None:
+            session.add(
+                User(
+                    username=other_username,
+                    password=get_password_hash(other_password),
+                    is_active=True,
+                    is_superuser=False,
+                )
+            )
+    try:
+        login_response = await client.post(
+            "api/v1/login",
+            data={"username": other_username, "password": other_password},
+        )
+        assert login_response.status_code == 200
+        other_headers = {"Authorization": f"Bearer {login_response.json()['access_token']}"}
+
+        flow_id = simple_api_test["id"]  # owned by active_user via logged_in_headers
+        response = await client.post(f"/api/v1/run/session/{flow_id}", headers=other_headers)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+        assert "permission" not in response.text.lower()
+    finally:
+        async with session_scope() as session:
+            user = (await session.exec(select(User).where(User.username == other_username))).first()
+            if user is not None:
+                await session.delete(user)
+
+    # Silence the unused-fixture warning -- we depend on logged_in_headers to
+    # ensure active_user (the flow owner) exists before we attack as a peer.
+    _ = logged_in_headers
+
+
+@pytest.mark.benchmark
+async def test_run_rejects_malformed_user_id_query_param(client: AsyncClient, simple_api_test, created_api_key):
+    """LE-639 regression: a malformed ``?user_id=`` query param returns 404, not 500.
+
+    FastAPI exposes ``user_id`` as a free query parameter on routes that
+    previously used ``Depends(get_flow_by_id_or_endpoint_name)``.  The auth-aware
+    wrapper ignores the query value entirely (it derives user_id from the
+    authenticated caller), and the helper itself converts a malformed UUID
+    into 404 rather than a 500.  Both defenses must hold.
+    """
+    headers = {"x-api-key": created_api_key.api_key}
+    flow_id = simple_api_test["id"]
+
+    for bad in ("not-a-uuid", "", "12345"):
+        response = await client.post(
+            f"/api/v1/run/{flow_id}",
+            headers=headers,
+            params={"user_id": bad},
+        )
+        # Same user owns the flow, so the wrapper resolves the flow
+        # successfully regardless of the junk query param; the run itself
+        # returns 200 (the flow executes) rather than leaking a 500.
+        assert response.status_code != status.HTTP_500_INTERNAL_SERVER_ERROR, (
+            f"Malformed user_id={bad!r} triggered 500: {response.text}"
+        )
 
 
 @pytest.mark.benchmark
@@ -842,7 +934,13 @@ async def test_permission_check_with_invalid_flow_id(client: AsyncClient, create
 
 @pytest.mark.benchmark
 async def test_permission_check_blocks_before_execution(client: AsyncClient, simple_api_test, user_two_api_key):
-    """Test that permission check happens before flow execution to prevent resource usage."""
+    """Test that permission check happens before flow execution to prevent resource usage.
+
+    LE-639: post-fix behavior is 404 from the helper rather than 403 from
+    ``check_flow_user_permission`` so we avoid the 403-vs-404 existence oracle.
+    The "block before execution" guarantee still holds -- we short-circuit
+    earlier now, not later.
+    """
     headers = {"x-api-key": user_two_api_key}
     flow_id = simple_api_test["id"]
     payload = {
@@ -852,11 +950,11 @@ async def test_permission_check_blocks_before_execution(client: AsyncClient, sim
         "tweaks": {},
     }
 
-    # This should fail immediately at permission check, not during execution
+    # This should fail immediately at the flow-lookup dependency, not during execution
     response = await client.post(f"/api/v1/run/{flow_id}", headers=headers, json=payload)
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
-    assert "You do not have permission to run this flow" in response.text
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+    assert "permission" not in response.text.lower()
 
 
 @pytest.mark.benchmark


### PR DESCRIPTION
## Summary

Fixes the unchecked-UUID hole that affects every caller of `get_flow_by_id_or_endpoint_name`.

The helper at [helpers/flow.py:399](src/backend/base/langflow/helpers/flow.py#L399) had two symmetric holes:

1. **UUID branch** called `session.get(Flow, flow_id)` with zero ownership check — `user_id` was ignored entirely when a UUID was supplied.
2. **endpoint_name branch** only applied the `user_id` filter when `user_id` was truthy. FastAPI `Depends(get_flow_by_id_or_endpoint_name)` resolves `user_id` as a query parameter that no real caller sets, so the filter silently skipped on every route using that Depends pattern.

The Jira ticket reported exactly this for `POST /api/v1/responses`: an authenticated user with any valid API key could pass the victim's flow UUID in the `model` field and execute the victim's flow.

## Scope

The fix is at the helper, not per-caller — one diff closes the IDOR everywhere:

| Endpoint | Pre-fix | Post-fix |
|---|---|---|
| `POST /api/v1/responses` | ❌ IDOR (executed victim flow) | ✅ returns `flow_not_found` |
| `POST /api/v2/workflow/*` | ❌ IDOR | ✅ 404 |
| `POST /api/v1/run/{flow_id_or_name}` | 🟡 defense-in-depth 403 via `check_flow_user_permission` | ✅ 404 at helper (no 403-vs-404 oracle) |
| `POST /api/v1/run/session/{flow_id_or_name}` | 🟡 same | ✅ same |
| `POST /api/v1/run/advanced/{flow_id_or_name}` | 🟡 same | ✅ same |
| `POST /api/v1/webhook/{flow_id_or_name}` | by design public | unchanged (passes no user_id) |
| `GET /api/v1/webhook-events/{flow_id_or_name}` | safe (explicit check) | unchanged |
| Agentic utils ([flow_component.py](src/backend/base/langflow/agentic/utils/flow_component.py), [flow_graph.py](src/backend/base/langflow/agentic/utils/flow_graph.py)) | pass user_id | now enforced |

## Design choices

- **Return `None` on cross-user mismatch, not 403.** The shared 404 path below fires, which avoids disclosing flow existence via a 403-vs-404 oracle (attackers enumerating UUIDs). Matches the pattern already used by [api/v1/files.py::get_flow](src/backend/base/langflow/api/v1/files.py#L63).
- **`user_id=None` preserved.** Webhooks and internal callers that legitimately need cross-user lookup (e.g. `get_webhook_user`) continue to work. Fail-closed is enforced only when a `user_id` is *supplied* — same contract as before, just now honored on both branches.
- **No caller signature changes.** Kept the diff tight on purpose. All callers that already pass `user_id` (`openai_responses.py`, `workflow.py`, `flow_component.py`, `flow_graph.py`) automatically benefit.

## Test plan

**New tests (all passing locally):**

- [x] `TestGetFlowByIdOrEndpointName` in [test_flow_helpers.py](src/backend/tests/unit/helpers/test_flow_helpers.py) — 8 unit tests covering:
  - Same-user UUID → returns flow
  - **Cross-user UUID → 404 (the primary IDOR fix)**
  - UUID instance vs str `user_id`
  - `user_id=None` → no scope (webhook preserved)
  - Missing flow → 404
  - endpoint_name with user scope filter
  - endpoint_name without scope (webhook preserved)
- [x] `test_openai_responses_rejects_cross_user_flow_access` in [test_endpoints.py](src/backend/tests/unit/test_endpoints.py) — reproduces the Jira PoC exactly: attacker with valid API key receives `flow_not_found` when targeting the victim's flow UUID.

**Regression checks (all passing locally):**

- [x] `pytest .../unit/helpers/test_flow_helpers.py` — 22/22 pass (14 existing + 8 new)
- [x] `pytest .../unit/test_endpoints.py -k openai_responses` — 5/5 pass (4 existing + 1 new)
- [x] `pytest .../unit/api/v2/test_workflow.py` — 47/47 pass (verifies the workflow endpoints don't regress)
- [ ] Full backend suite in CI