### PR TITLE
feat: enable F.Ks in SQLite Pragmas

### DIFF
--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -146,7 +146,12 @@ class Settings(BaseSettings):
     reap idle sessions."""
 
     # sqlite configuration
-    sqlite_pragmas: dict | None = {"synchronous": "NORMAL", "journal_mode": "WAL", "busy_timeout": 30000}
+    sqlite_pragmas: dict | None = {
+        "synchronous": "NORMAL",
+        "journal_mode": "WAL",
+        "busy_timeout": 30000,
+        "foreign_keys": "ON",
+    }
     """SQLite pragmas to use when connecting to the database."""
 
     db_driver_connection_settings: dict | None = None


### PR DESCRIPTION
Enable and enforce Foreign Key constraints in SQLite settings.

Main motivation is to have the DB handle cascade deletions via F.K cascade declarations, so that Langflow does not have to manually cascade delete and risk orphaned resources