### PR TITLE
fix(security): drop URL substring checks for WXO auth scheme selection (#201-204)

### DIFF
--- a/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/client.py
+++ b/src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/client.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
+from urllib.parse import urlparse
 
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator, MCSPAuthenticator
 from ibm_watsonx_orchestrate_core.types.connections import KeyValueConnectionCredentials
@@ -126,10 +127,16 @@ def set_request_context_provider_clients(*, provider_id: UUID, user_id: UUID | s
 
 
 def get_authenticator(instance_url: str, api_key: str) -> IAMAuthenticator | MCSPAuthenticator:
-    """Return the appropriate authenticator for the Watsonx Orchestrate API."""
-    if ".cloud.ibm.com" in instance_url:
+    """Return the appropriate authenticator for the Watsonx Orchestrate API.
+
+    Scheme selection is driven by the *hostname* of ``instance_url`` — never by a
+    raw substring match against the full URL string, which would let a URL like
+    ``https://evil.example.com/.cloud.ibm.com`` bypass the branching intent.
+    """
+    hostname = (urlparse(instance_url).hostname or "").lower()
+    if hostname == "cloud.ibm.com" or hostname.endswith(".cloud.ibm.com"):
         authenticator = IAMAuthenticator(apikey=api_key, url=WxOAuthURL.IBM_IAM.value)
-    elif ".ibm.com" in instance_url:
+    elif hostname == "ibm.com" or hostname.endswith(".ibm.com"):
         authenticator = MCSPAuthenticator(apikey=api_key, url=WxOAuthURL.MCSP.value)
     else:
         msg = f"Could not determine authentication scheme for instance URL: {instance_url}"

--- a/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
+++ b/src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py
@@ -1809,7 +1809,7 @@ def test_wxo_mapper_verify_credentials_create_filters_non_credential_fields() ->
     )
     result = mapper.resolve_verify_credentials_for_create(payload=payload)
     assert isinstance(result, VerifyCredentials)
-    assert "cloud.ibm.com" in result.base_url
+    assert result.base_url == "https://api.us-south.wxo.cloud.ibm.com/"
     assert result.provider_data is not None
     assert result.provider_data["api_key"] == "my-secret-key"  # pragma: allowlist secret
     assert "tenant_id" not in result.provider_data
@@ -1832,7 +1832,7 @@ def test_wxo_mapper_verify_credentials_create_accepts_missing_tenant() -> None:
 
     result = mapper.resolve_verify_credentials_for_create(payload=payload)
     assert isinstance(result, VerifyCredentials)
-    assert "cloud.ibm.com" in result.base_url
+    assert result.base_url == "https://api.us-south.wxo.cloud.ibm.com/"
 
 
 def test_wxo_mapper_provider_account_create_requires_tenant() -> None:

--- a/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
+++ b/src/backend/tests/unit/services/deployment/test_watsonx_orchestrate.py
@@ -5165,6 +5165,29 @@ def test_get_authenticator_unknown_url():
         get_authenticator("https://example.com", "test-key")
 
 
+@pytest.mark.parametrize(
+    "bypass_url",
+    [
+        # Path smuggling: IBM domain appears in the path, not the hostname.
+        "https://evil.example.com/.cloud.ibm.com",
+        "https://evil.example.com/.ibm.com",
+        # Query-string smuggling: IBM domain in query parameters.
+        "https://evil.example.com/?host=.cloud.ibm.com",
+        # Userinfo smuggling: IBM domain in userinfo before @.
+        "https://cloud.ibm.com@evil.example.com/",
+        # Fragment smuggling.
+        "https://evil.example.com/#.cloud.ibm.com",
+    ],
+)
+def test_get_authenticator_rejects_substring_bypass(bypass_url):
+    """Regression for CodeQL py/incomplete-url-substring-sanitization: scheme selection must be hostname-based."""
+    from langflow.services.adapters.deployment.watsonx_orchestrate.client import get_authenticator
+    from lfx.services.adapters.deployment.exceptions import AuthSchemeError
+
+    with pytest.raises(AuthSchemeError, match="Could not determine"):
+        get_authenticator(bypass_url, "test-key")
+
+
 def test_get_authenticator_sets_http_timeout_on_iam():
     from langflow.services.adapters.deployment.watsonx_orchestrate.client import get_authenticator
 


### PR DESCRIPTION
## Summary

Closes CodeQL code-scanning alerts [#201](https://github.com/langflow-ai/langflow/security/code-scanning/201) – [#204](https://github.com/langflow-ai/langflow/security/code-scanning/204) (all `py/incomplete-url-substring-sanitization`, severity **high**).

`get_authenticator` in the Watsonx Orchestrate adapter chose between the IBM Cloud (IAM) and MCSP authenticators by testing `".cloud.ibm.com" in instance_url` / `".ibm.com" in instance_url` against the raw URL string. Because the check scanned the whole URL, a provider URL whose hostname passes the existing `.ibm.com` hostname allowlist but whose path, userinfo, query, or fragment contains `.cloud.ibm.com` could flip the wrong authenticator — an auth-scheme confusion that the CWE-20 rule flags as high-severity.

Example bypasses (all pre-fix would have wrongly picked IAM):

```
https://api.sso.ibm.com/.cloud.ibm.com        # path smuggling
https://cloud.ibm.com@attacker.example/…     # userinfo smuggling
https://host.ibm.com/?trick=.cloud.ibm.com    # query smuggling
https://host.ibm.com/#.cloud.ibm.com          # fragment smuggling
```

### Fix

Scheme selection now drives off `urlparse(instance_url).hostname` with `hostname == "…"` or `hostname.endswith(".…")` — the exact pattern documented as safe in CodeQL's rule help.

### Alert → fix map

| Alerts | File | Change |
| --- | --- | --- |
| [#201](https://github.com/langflow-ai/langflow/security/code-scanning/201), [#202](https://github.com/langflow-ai/langflow/security/code-scanning/202) | [client.py](src/backend/base/langflow/services/adapters/deployment/watsonx_orchestrate/client.py) | Replace `in instance_url` with hostname-parsed `endswith` checks. |
| [#203](https://github.com/langflow-ai/langflow/security/code-scanning/203), [#204](https://github.com/langflow-ai/langflow/security/code-scanning/204) | [test_deployment_mapper_watsonx.py](src/backend/tests/unit/api/v1/test_deployment_mapper_watsonx.py) | Swap `assert \"cloud.ibm.com\" in result.base_url` for exact equality against the normalised mapper output (`https://api.us-south.wxo.cloud.ibm.com/`). |

### New regression coverage

Added a parametrised `test_get_authenticator_rejects_substring_bypass` covering the five smuggling shapes above — all reject with `AuthSchemeError` after the fix.

## Test plan

- [x] `pytest tests/unit/services/deployment/test_watsonx_orchestrate.py -k get_authenticator` — 14 pass (9 existing + 5 new regression)
- [x] `pytest tests/unit/api/v1/test_deployment_mapper_watsonx.py tests/unit/services/deployment/test_watsonx_orchestrate.py` — 403 pass
- [x] `ruff check` on both modified modules
- [ ] CI CodeQL rerun confirms alerts #201–#204 auto-close