### PR TITLE
fix(security): default WEBHOOK_AUTH_ENABLE to True

### DIFF
--- a/docs/docs/API-Reference/curl-examples/api-reference-api-examples/result-get-configuration.json
+++ b/docs/docs/API-Reference/curl-examples/api-reference-api-examples/result-get-configuration.json
@@ -13,7 +13,7 @@
   "public_flow_cleanup_interval": 3600,
   "public_flow_expiration": 86400,
   "event_delivery": "streaming",
-  "webhook_auth_enable": false,
+  "webhook_auth_enable": true,
   "voice_mode_available": false,
   "default_folder_name": "Starter Project",
   "hide_getting_started_progress": false

--- a/docs/docs/Develop/api-keys-and-authentication.mdx
+++ b/docs/docs/Develop/api-keys-and-authentication.mdx
@@ -465,11 +465,11 @@ This variable controls whether API key authentication is required for webhook en
 
 | Variable | Format | Default | Description |
 |----------|--------|---------|-------------|
-| `LANGFLOW_WEBHOOK_AUTH_ENABLE` | Boolean | `False` | When `True`, webhook endpoints require API key authentication and validate that the authenticated user owns the flow being executed. When `False`, no Langflow API key is required and all requests to the webhook endpoint are treated as being sent by the flow owner. |
+| `LANGFLOW_WEBHOOK_AUTH_ENABLE` | Boolean | `True` | When `True`, webhook endpoints require API key authentication and validate that the authenticated user owns the flow being executed. When `False`, no Langflow API key is required and all requests to the webhook endpoint are treated as being sent by the flow owner. |
 
-By default, webhooks run as the flow owner without authentication with `LANGFLOW_WEBHOOK_AUTH_ENABLE=False`.
+By default, webhooks require API key authentication with `LANGFLOW_WEBHOOK_AUTH_ENABLE=True`.
 
-To require API key authentication for webhooks, in your Langflow `.env` file, set `LANGFLOW_WEBHOOK_AUTH_ENABLE=True`.
+To allow webhooks to run without authentication (not recommended; use only in trusted environments), in your Langflow `.env` file, set `LANGFLOW_WEBHOOK_AUTH_ENABLE=False`.
 
 When webhook authentication is enabled, you must provide a Langflow API key with each webhook request as an HTTP header or query parameter. For more information, see [Require authentication for webhooks](/webhook#require-authentication-for-webhooks).
 

--- a/docs/docs/Flows/webhook.mdx
+++ b/docs/docs/Flows/webhook.mdx
@@ -90,9 +90,9 @@ To learn about triggering flows with payloads from external applications, see th
 
 ## Require authentication for webhooks {#require-authentication-for-webhooks}
 
-By default, webhooks run as the flow owner without authentication (`LANGFLOW_WEBHOOK_AUTH_ENABLE=False`).
+By default, webhooks require API key authentication (`LANGFLOW_WEBHOOK_AUTH_ENABLE=True`).
 
-To require API key authentication for webhooks, in your Langflow `.env` file, set `LANGFLOW_WEBHOOK_AUTH_ENABLE=True`.
+To allow webhooks to run without authentication (not recommended; use only in trusted environments), in your Langflow `.env` file, set `LANGFLOW_WEBHOOK_AUTH_ENABLE=False`. When disabled, requests to the webhook endpoint are treated as being sent by the flow owner.
 
 When webhook authentication is enabled, you must provide a Langflow API key with each webhook request.
 

--- a/src/backend/tests/unit/test_webhook.py
+++ b/src/backend/tests/unit/test_webhook.py
@@ -165,6 +165,33 @@ async def test_webhook_with_auto_login_enabled(client, added_webhook_test):
         settings_service.auth_settings.WEBHOOK_AUTH_ENABLE = original_webhook_auth_enable
 
 
+def test_webhook_auth_enable_defaults_to_true():
+    """Regression guard: WEBHOOK_AUTH_ENABLE must default to True (secure by default).
+
+    Defaulting to False previously allowed anyone who knew a flow UUID to execute
+    that flow unauthenticated as the flow owner. We read the class-level default
+    directly so a stray LANGFLOW_WEBHOOK_AUTH_ENABLE env var can't mask a regression.
+    """
+    from lfx.services.settings.auth import AuthSettings
+
+    assert AuthSettings.model_fields["WEBHOOK_AUTH_ENABLE"].default is True
+
+
+async def test_webhook_rejects_unauthenticated_request_by_default(client, added_webhook_test):
+    """Under the default config, an unauthenticated POST to /webhook must return 403."""
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    # Confirm the runtime default matches the secure-by-default value before exercising it.
+    assert settings_service.auth_settings.WEBHOOK_AUTH_ENABLE is True
+
+    endpoint = f"api/v1/webhook/{added_webhook_test['endpoint_name']}"
+    response = await client.post(endpoint, json={"test": "unauthenticated_trigger"})
+
+    assert response.status_code == 403
+    assert "API key required" in response.json()["detail"]
+
+
 async def test_webhook_with_random_payload_requires_auth(client, added_webhook_test, created_api_key):
     """Test that webhook with random payload still requires authentication."""
     # Modify the auth_settings.WEBHOOK_AUTH_ENABLE on the real settings service

--- a/src/lfx/src/lfx/services/settings/auth.py
+++ b/src/lfx/src/lfx/services/settings/auth.py
@@ -81,9 +81,11 @@ class AuthSettings(BaseSettings):
     """If True, the application will skip authentication when AUTO_LOGIN is enabled.
     This will be removed in v2.0"""
 
-    WEBHOOK_AUTH_ENABLE: bool = False
+    WEBHOOK_AUTH_ENABLE: bool = True
     """If True, webhook endpoints will require API key authentication.
-    If False, webhooks run as flow owner without authentication."""
+    If False, webhooks run as flow owner without authentication.
+    Defaults to True for secure-by-default behavior; set to False only in
+    trusted environments where unauthenticated webhook execution is acceptable."""
 
     ENABLE_SUPERUSER_CLI: bool = Field(
         default=True,


### PR DESCRIPTION
## Summary

- `POST /api/v1/webhook/{flow_id}` previously executed any user's flow without authentication because `WEBHOOK_AUTH_ENABLE` defaulted to `False`. When `False`, the webhook handler trusted the caller unconditionally and returned the flow owner with no credential check, giving unauthenticated callers complete control over Webhook component inputs (API credit theft, prompt injection into LLM calls, unauthenticated RCE via Python-exec components).
- Change the default to `True` so webhook endpoints require an API key and validate that the caller owns the flow. Operators who need the prior behavior can explicitly opt in with `LANGFLOW_WEBHOOK_AUTH_ENABLE=False`.
- Updates docs (`Develop/api-keys-and-authentication.mdx`, `Flows/webhook.mdx`) and the sample configuration response to reflect the new secure-by-default behavior.

Reported externally against 1.8.4 (CVSS 9.8, "Unauthenticated Webhook Execution"). The vulnerable code path — `get_webhook_user` at `src/backend/base/langflow/services/auth/service.py` — is unchanged; only the default of the flag that gates it is flipped.

## Test plan

- [ ] `pytest src/backend/tests/unit/test_webhook.py` passes (all existing tests either pass an API key or explicitly set `WEBHOOK_AUTH_ENABLE`, so the default flip should not break them).
- [ ] Manually verify: unauthenticated `POST /api/v1/webhook/{flow_id}` now returns `403` without an API key.
- [ ] Manually verify: `POST /api/v1/webhook/{flow_id}` with a valid owner API key still returns `202`.
- [ ] Manually verify: setting `LANGFLOW_WEBHOOK_AUTH_ENABLE=False` restores the prior unauthenticated behavior for operators who need it.