### PR TITLE
fix(ci): prevent duplicate tags and validate tag format in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,46 @@ jobs:
 
           echo "Validated: '${{ inputs.release_tag }}' is a valid tag."
 
+  validate-tag-format:
+    name: Validate Tag Format and Check for Duplicates
+    runs-on: ubuntu-latest
+    needs: [validate-tag]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      
+      - name: Validate Tag Has v Prefix
+        run: |
+          TAG="${{ inputs.release_tag }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Error: Tag must start with 'v' and follow semver format (v1.2.3)"
+            echo "   Got: $TAG"
+            echo ""
+            echo "This is required to ensure GitHub's generateReleaseNotes uses the correct base comparison."
+            exit 1
+          fi
+          echo "✅ Tag format is valid: $TAG"
+      
+      - name: Check for Duplicate Tag Without v Prefix
+        run: |
+          TAG="${{ inputs.release_tag }}"
+          TAG_WITHOUT_V="${TAG#v}"
+          
+          if git rev-parse "$TAG_WITHOUT_V" >/dev/null 2>&1; then
+            echo "❌ Error: Duplicate tag without 'v' prefix exists: $TAG_WITHOUT_V"
+            echo "   This will cause release notes to use the wrong base comparison."
+            echo ""
+            echo "   The tag '$TAG_WITHOUT_V' points to commit: $(git rev-parse --short $TAG_WITHOUT_V)"
+            echo "   The tag '$TAG' points to commit: $(git rev-parse --short $TAG)"
+            echo ""
+            echo "   To fix this, delete the duplicate tag:"
+            echo "   git push origin :refs/tags/$TAG_WITHOUT_V"
+            exit 1
+          fi
+          echo "✅ No duplicate tag found"
+
   validate-dependencies:
     name: Validate Release Dependencies
     runs-on: ubuntu-latest
@@ -1000,14 +1040,15 @@ jobs:
   create_release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [determine-main-version, build-main, publish-main]
+    needs: [determine-main-version, build-main, publish-main, validate-tag-format]
     if: |
       always() &&
       !cancelled() &&
       !inputs.dry_run &&
       inputs.create_release &&
       needs.build-main.result == 'success' &&
-      needs.publish-main.result == 'success'
+      needs.publish-main.result == 'success' &&
+      needs.validate-tag-format.result == 'success'
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Problem

The v1.9.0 release notes were incomplete, missing 58 commits. Investigation revealed a systematic issue with duplicate tags in the repository.

### Root Cause
- Repository has duplicate tags for each version: `1.8.3` and `v1.8.3` (pointing to different commits)
- GitHub's `generateReleaseNotes: true` uses alphabetical sorting to find the previous release
- Tags without `v` prefix come before tags with `v` prefix alphabetically
- Example: `1.8.3` < `v1.8.3` (alphabetically)
- Result: GitHub picked `1.8.3` instead of `v1.8.3`, missing 58 commits between them

### Impact
- v1.9.0 release notes: Missing 58 commits from v1.8.3
- Historical releases (v1.8.1, v1.8.2, v1.8.3): Also affected
- Total: 362 commits "hidden" across these versions

## Solution

Added tag validation to the release workflow:

### Changes
1. **New job: `validate-tag-format`**
   - Validates tag starts with `v` and follows semver format (v1.2.3)
   - Checks for duplicate tags without `v` prefix
   - Fails with clear error message if issues found

2. **Updated `create_release` job**
   - Added dependency on `validate-tag-format`
   - Release creation only proceeds if validation passes

### What This Prevents
- ❌ Creating releases with tags that don't start with `v`
- ❌ Creating releases when duplicate tags exist
- ❌ Incomplete release notes due to wrong base comparison
- ✅ Ensures accurate, complete release notes for all future releases

## Testing

Validated the logic locally with test cases:
- ✅ Correctly rejects `v1.9.0` (duplicate `1.9.0` exists)
- ✅ Correctly accepts `v1.8.4` (no duplicate)
- ✅ Correctly rejects `1.8.3` (no `v` prefix)


