### PR TITLE
feat: add Level 5 agent architecture audit to flow validation

### DIFF
--- a/src/lfx/src/lfx/cli/_authoring_commands.py
+++ b/src/lfx/src/lfx/cli/_authoring_commands.py
@@ -133,13 +133,25 @@ def register(app: typer.Typer) -> None:
             "--level",
             "-l",
             min=1,
-            max=4,
+            max=5,
             help=(
                 "Validation depth: "
                 "1=structural JSON, "
                 "2=+component existence, "
                 "3=+edge type compatibility, "
-                "4=+required inputs connected"
+                "4=+required inputs connected, "
+                "5=+agent architecture audit"
+            ),
+        ),
+        audit: bool = typer.Option(
+            False,
+            "--audit",
+            "-a",
+            help=(
+                "Run agent architecture audit (Level 5). "
+                "Checks for hardcoded secrets, unrestricted code execution, "
+                "missing error handling, runaway agent loops, unbounded memory growth, "
+                "missing observability, and state-mutator safety."
             ),
         ),
         skip_components: bool = typer.Option(
@@ -196,6 +208,7 @@ def register(app: typer.Typer) -> None:
         validate_command(
             flow_paths=effective_paths,
             level=level,
+            audit=audit,
             skip_components=skip_components,
             skip_edge_types=skip_edge_types,
             skip_required_inputs=skip_required_inputs,

--- a/src/lfx/src/lfx/cli/validate.py
+++ b/src/lfx/src/lfx/cli/validate.py
@@ -22,8 +22,14 @@ Validation levels (each level implies all levels below it):
         incoming edge connected to it.  Also checks that password/secret fields
         have a value or a matching environment variable set.
 
+    Level 5 - agent architecture audit (--audit flag)
+        Audits flows for wrapper-level failures such as hardcoded secrets,
+        unrestricted code execution, missing error handling, runaway loops,
+        unbounded memory growth, missing observability, and mutator safety.
+
 Use ``--level`` to select how deep to go, or ``--skip-*`` flags to opt out of
-individual checks while still running the others.
+individual checks while still running the others. Use ``--audit`` / ``-a`` to
+enable the Level 5 audit regardless of the selected level.
 
 Pass ``--strict`` to treat warnings as errors (exit code 1).
 
@@ -38,8 +44,10 @@ from __future__ import annotations
 # This keeps ``from lfx.cli.validate import ...`` working for all consumers
 # (the CLI entry point in __main__.py, tests, etc.).
 from lfx.cli.validation import (  # noqa: F401
+    LEVEL_AUDIT,
     ValidationIssue,
     ValidationResult,
+    _check_agent_audit,
     _check_missing_credentials,
     _check_orphaned_nodes,
     _check_unused_nodes,
@@ -53,6 +61,7 @@ from lfx.cli.validation import (  # noqa: F401
 
 # Level constants (re-exported for backwards compatibility)
 from lfx.cli.validation.core import (  # noqa: F401
+    _LEVEL_AUDIT,
     _LEVEL_COMPONENTS,
     _LEVEL_EDGE_TYPES,
     _LEVEL_REQUIRED_INPUTS,

--- a/src/lfx/src/lfx/cli/validation/__init__.py
+++ b/src/lfx/src/lfx/cli/validation/__init__.py
@@ -8,7 +8,9 @@ from lfx.cli.validation._env_validation import (
     is_valid_env_var_name,
     validate_global_variables_for_env,
 )
+from lfx.cli.validation.audit import _check_agent_audit
 from lfx.cli.validation.core import (
+    LEVEL_AUDIT,
     LEVEL_COMPONENTS,
     LEVEL_EDGE_TYPES,
     LEVEL_REQUIRED_INPUTS,
@@ -36,12 +38,14 @@ from lfx.cli.validation.structural import (
 )
 
 __all__ = [
+    "LEVEL_AUDIT",
     "LEVEL_COMPONENTS",
     "LEVEL_EDGE_TYPES",
     "LEVEL_REQUIRED_INPUTS",
     "LEVEL_STRUCTURAL",
     "ValidationIssue",
     "ValidationResult",
+    "_check_agent_audit",
     "_check_component_existence",
     "_check_edge_type_compatibility",
     "_check_missing_credentials",

--- a/src/lfx/src/lfx/cli/validation/audit.py
+++ b/src/lfx/src/lfx/cli/validation/audit.py
@@ -146,9 +146,7 @@ def _check_missing_error_handling(flow: dict[str, Any], result: ValidationResult
         if node_type in _SAFETY_SENSITIVE:
             safety_nodes.append(node)
         if node_type and (
-            "error" in node_type.lower()
-            or "catch" in node_type.lower()
-            or "fallback" in node_type.lower()
+            "error" in node_type.lower() or "catch" in node_type.lower() or "fallback" in node_type.lower()
         ):
             node_id = node.get("id")
             if node_id:

--- a/src/lfx/src/lfx/cli/validation/audit.py
+++ b/src/lfx/src/lfx/cli/validation/audit.py
@@ -1,0 +1,333 @@
+"""Level 5 — agent architecture audit checks for Langflow flows."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lfx.cli.validation.core import ValidationResult
+
+
+def _make_issue(
+    severity: str,
+    node_id: str | None,
+    node_name: str | None,
+    message: str,
+) -> Any:
+    from lfx.cli.validation.core import LEVEL_AUDIT, ValidationIssue
+
+    return ValidationIssue(
+        level=LEVEL_AUDIT,
+        severity=severity,
+        node_id=node_id,
+        node_name=node_name,
+        message=message,
+    )
+
+
+def _node_display_name(node: dict[str, Any]) -> str | None:
+    from lfx.cli.validation.core import _node_display_name as _display_name
+
+    return _display_name(node)
+
+
+_SECRET_PATTERNS = [
+    (r"sk-[A-Za-z0-9]{20,}", "OpenAI API key"),
+    (r"ghp_[A-Za-z0-9]{36}", "GitHub personal access token"),
+    (r"glpat-[A-Za-z0-9\-]{20,}", "GitLab personal access token"),
+    (r"AKIA[0-9A-Z]{16}", "AWS access key ID"),
+]
+_SECRET_FIELD_HINTS = ("api_key", "apikey", "token", "secret", "password", "credential")
+_CODE_EXEC_TYPES = {"PythonFunction", "Code", "CustomComponent", "PythonCode", "Shell"}
+_STATE_MUTATORS = {"FileWriter", "DatabaseWrite", "VectorStoreUpsert", "UpdateMemory"}
+_SAFETY_SENSITIVE = {"Agent", "ToolCallingAgent", "ReActAgent", "Supervisor", "MultiAgent"}
+_OBSERVABILITY = {"Tracing", "LangSmith", "LangFuse", "CallbackHandler", "Observable"}
+_LIMIT_KEYWORDS = ("max_", "limit", "ttl", "expire", "top_", "threshold", "retention")
+_EXACT_LIMIT_KEYS = {"k", "top_k", "ttl", "limit", "max_tokens", "max_results"}
+
+
+def _iter_nodes(flow: dict[str, Any]) -> list[dict[str, Any]]:
+    return [node for node in flow.get("data", {}).get("nodes", []) if isinstance(node, dict)]
+
+
+def _build_graph(flow: dict[str, Any]) -> dict[str, set[str]]:
+    graph: dict[str, set[str]] = {}
+    for edge in flow.get("data", {}).get("edges", []):
+        if not isinstance(edge, dict):
+            continue
+        source = edge.get("source")
+        target = edge.get("target")
+        if not source or not target:
+            continue
+        graph.setdefault(source, set()).add(target)
+    return graph
+
+
+def _reachable_from(starts: set[str], graph: dict[str, set[str]]) -> set[str]:
+    visited: set[str] = set()
+    stack = [node_id for node_id in starts if node_id]
+    while stack:
+        current = stack.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+        stack.extend(neighbor for neighbor in graph.get(current, ()) if neighbor not in visited)
+    return visited
+
+
+def _check_hardcoded_secrets(flow: dict[str, Any], result: ValidationResult) -> None:
+    for node in _iter_nodes(flow):
+        template: dict[str, Any] = node.get("data", {}).get("node", {}).get("template", {})
+        for field_name, field_def in template.items():
+            if not isinstance(field_def, dict):
+                continue
+            metadata_parts = [
+                str(field_name).strip().lower(),
+                str(field_def.get("name", "")).strip().lower(),
+                str(field_def.get("display_name", "")).strip().lower(),
+                str(field_def.get("label", "")).strip().lower(),
+            ]
+            if not any(hint in part for part in metadata_parts for hint in _SECRET_FIELD_HINTS if part):
+                continue
+
+            value = str(field_def.get("value", "")).strip()
+            if not value:
+                continue
+
+            for pattern, label in _SECRET_PATTERNS:
+                if re.search(pattern, value):
+                    result.issues.append(
+                        _make_issue(
+                            severity="error",
+                            node_id=node.get("id"),
+                            node_name=_node_display_name(node),
+                            message=(
+                                f"Hardcoded {label} detected in field '{field_name}'. "
+                                "Use environment variables or Langflow global secrets instead."
+                            ),
+                        )
+                    )
+                    break
+
+
+def _check_unrestricted_code_exec(flow: dict[str, Any], result: ValidationResult) -> None:
+    has_sandbox = False
+    code_nodes: list[dict[str, Any]] = []
+
+    for node in _iter_nodes(flow):
+        node_type = node.get("data", {}).get("type")
+        if node_type in _CODE_EXEC_TYPES:
+            code_nodes.append(node)
+        if node_type and "sandbox" in node_type.lower():
+            has_sandbox = True
+
+    if code_nodes and not has_sandbox:
+        names = ", ".join(_node_display_name(node) or node.get("id", "?") for node in code_nodes[:5])
+        result.issues.append(
+            _make_issue(
+                severity="warning",
+                node_id=None,
+                node_name=None,
+                message=(
+                    f"Unrestricted code execution detected ({len(code_nodes)} node(s): {names}). "
+                    "Consider wrapping in a sandbox component for production flows."
+                ),
+            )
+        )
+
+
+def _check_missing_error_handling(flow: dict[str, Any], result: ValidationResult) -> None:
+    safety_nodes: list[dict[str, Any]] = []
+    error_handlers: set[str] = set()
+
+    for node in _iter_nodes(flow):
+        node_type = node.get("data", {}).get("type")
+        if node_type in _SAFETY_SENSITIVE:
+            safety_nodes.append(node)
+        if node_type and (
+            "error" in node_type.lower()
+            or "catch" in node_type.lower()
+            or "fallback" in node_type.lower()
+        ):
+            node_id = node.get("id")
+            if node_id:
+                error_handlers.add(node_id)
+
+    graph = _build_graph(flow)
+
+    def has_error_handler_downstream(start_id: str | None) -> bool:
+        if not start_id:
+            return False
+        visited: set[str] = set()
+        stack: list[str] = [start_id]
+        while stack:
+            current = stack.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+            if current != start_id and current in error_handlers:
+                return True
+            stack.extend(neighbor for neighbor in graph.get(current, ()) if neighbor not in visited)
+        return False
+
+    for node in safety_nodes:
+        node_id = node.get("id")
+        if not has_error_handler_downstream(node_id):
+            result.issues.append(
+                _make_issue(
+                    severity="warning",
+                    node_id=node_id,
+                    node_name=_node_display_name(node),
+                    message=(
+                        "Agent node has no error-handling or fallback path. "
+                        "Add an error handler or retry component for production reliability."
+                    ),
+                )
+            )
+
+
+def _check_runaway_agent_loops(flow: dict[str, Any], result: ValidationResult) -> None:
+    nodes = _iter_nodes(flow)
+    nodes_by_id = {node.get("id"): node for node in nodes if node.get("id")}
+    agent_ids = {
+        node.get("id")
+        for node in nodes
+        if "agent" in str(node.get("data", {}).get("type", "")).lower()
+        or "loop" in str(node.get("data", {}).get("type", "")).lower()
+        or "react" in str(node.get("data", {}).get("type", "")).lower()
+    }
+    graph = _build_graph(flow)
+
+    for agent_id in {node_id for node_id in agent_ids if node_id}:
+        visited: set[str] = set()
+        queue = list(graph.get(agent_id, set()))
+        while queue:
+            current = queue.pop(0)
+            if current == agent_id:
+                result.issues.append(
+                    _make_issue(
+                        severity="warning",
+                        node_id=agent_id,
+                        node_name=_node_display_name(nodes_by_id.get(agent_id, {})),
+                        message=(
+                            "Agent loop detected. Ensure a max-iterations or max-tokens guard is configured "
+                            "to prevent runaway execution."
+                        ),
+                    )
+                )
+                break
+            if current not in visited and current in agent_ids:
+                visited.add(current)
+                queue.extend(graph.get(current, set()))
+
+
+def _check_unbounded_memory_growth(flow: dict[str, Any], result: ValidationResult) -> None:
+    for node in _iter_nodes(flow):
+        node_type = str(node.get("data", {}).get("type", ""))
+        if "memory" not in node_type.lower() and "vector" not in node_type.lower():
+            continue
+
+        template: dict[str, Any] = node.get("data", {}).get("node", {}).get("template", {})
+        has_limit = False
+        for field_name, field_def in template.items():
+            if not isinstance(field_def, dict):
+                continue
+
+            normalized_field_name = str(field_name).strip().lower()
+            metadata_parts = [
+                normalized_field_name,
+                str(field_def.get("name", "")).strip().lower(),
+                str(field_def.get("display_name", "")).strip().lower(),
+                str(field_def.get("label", "")).strip().lower(),
+            ]
+            input_types = field_def.get("input_types")
+            if isinstance(input_types, list):
+                metadata_parts.extend(str(item).strip().lower() for item in input_types)
+
+            matches_limit_field = (
+                normalized_field_name in _EXACT_LIMIT_KEYS
+                or any(part in _EXACT_LIMIT_KEYS for part in metadata_parts if part)
+                or any(keyword in part for part in metadata_parts for keyword in _LIMIT_KEYWORDS if part)
+            )
+            if not matches_limit_field:
+                continue
+
+            value = field_def.get("value")
+            if value is None:
+                continue
+            if isinstance(value, str) and not value.strip():
+                continue
+
+            has_limit = True
+            break
+
+        if not has_limit:
+            result.issues.append(
+                _make_issue(
+                    severity="warning",
+                    node_id=node.get("id"),
+                    node_name=_node_display_name(node),
+                    message=(
+                        f"Memory/vector component '{_node_display_name(node) or node.get('id')}' has no "
+                        "size limit, TTL, or retention policy configured. "
+                        "This may cause unbounded context growth in long-running agents."
+                    ),
+                )
+            )
+
+
+def _check_missing_observability(flow: dict[str, Any], result: ValidationResult) -> None:
+    node_types = {node.get("data", {}).get("type") for node in _iter_nodes(flow)}
+    if not bool(node_types & _OBSERVABILITY):
+        result.issues.append(
+            _make_issue(
+                severity="warning",
+                node_id=None,
+                node_name=None,
+                message=(
+                    "No observability or tracing component detected. "
+                    "Add LangSmith, LangFuse, or a callback handler for production debugging."
+                ),
+            )
+        )
+
+
+def _check_state_mutator_safety(flow: dict[str, Any], result: ValidationResult) -> None:
+    mutator_nodes: list[dict[str, Any]] = []
+    upstream_validators: set[str] = set()
+
+    for node in _iter_nodes(flow):
+        node_type = str(node.get("data", {}).get("type", ""))
+        if node_type in _STATE_MUTATORS:
+            mutator_nodes.append(node)
+        if "validate" in node_type.lower() or "guard" in node_type.lower() or "filter" in node_type.lower():
+            node_id = node.get("id")
+            if node_id:
+                upstream_validators.add(node_id)
+
+    validator_downstream = _reachable_from(upstream_validators, _build_graph(flow))
+    for node in mutator_nodes:
+        node_id = node.get("id")
+        if node_id not in validator_downstream:
+            result.issues.append(
+                _make_issue(
+                    severity="warning",
+                    node_id=node_id,
+                    node_name=_node_display_name(node),
+                    message=(
+                        f"State-mutating component '{_node_display_name(node) or node_id}' has no upstream "
+                        "validation or guard. Add a validation node to prevent corrupt data writes."
+                    ),
+                )
+            )
+
+
+def _check_agent_audit(flow: dict[str, Any], result: ValidationResult) -> None:
+    _check_hardcoded_secrets(flow, result)
+    _check_unrestricted_code_exec(flow, result)
+    _check_missing_error_handling(flow, result)
+    _check_runaway_agent_loops(flow, result)
+    _check_unbounded_memory_growth(flow, result)
+    _check_missing_observability(flow, result)
+    _check_state_mutator_safety(flow, result)

--- a/src/lfx/src/lfx/cli/validation/core.py
+++ b/src/lfx/src/lfx/cli/validation/core.py
@@ -36,12 +36,14 @@ LEVEL_STRUCTURAL = 1
 LEVEL_COMPONENTS = 2
 LEVEL_EDGE_TYPES = 3
 LEVEL_REQUIRED_INPUTS = 4
+LEVEL_AUDIT = 5
 
 # Keep underscore-prefixed aliases for backwards compatibility
 _LEVEL_STRUCTURAL = LEVEL_STRUCTURAL
 _LEVEL_COMPONENTS = LEVEL_COMPONENTS
 _LEVEL_EDGE_TYPES = LEVEL_EDGE_TYPES
 _LEVEL_REQUIRED_INPUTS = LEVEL_REQUIRED_INPUTS
+_LEVEL_AUDIT = LEVEL_AUDIT
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +117,7 @@ def validate_flow_file(
     skip_required_inputs: bool = False,
     skip_version_check: bool = False,
     skip_credentials: bool = False,
+    audit: bool = False,
 ) -> ValidationResult:
     result = ValidationResult(path=path)
 
@@ -172,6 +175,11 @@ def validate_flow_file(
         _check_required_inputs(flow, result)
     if not skip_credentials:
         _check_missing_credentials(flow, result)
+
+    if audit or level >= LEVEL_AUDIT:
+        from lfx.cli.validation.audit import _check_agent_audit
+
+        _check_agent_audit(flow, result)
 
     return result
 
@@ -236,6 +244,7 @@ def validate_command(
     flow_paths: list[str],
     level: int,
     *,
+    audit: bool = False,
     skip_components: bool,
     skip_edge_types: bool,
     skip_required_inputs: bool,
@@ -259,6 +268,7 @@ def validate_command(
         result = validate_flow_file(
             p,
             level=level,
+            audit=audit,
             skip_components=skip_components,
             skip_edge_types=skip_edge_types,
             skip_required_inputs=skip_required_inputs,

--- a/src/lfx/tests/unit/cli/test_validate_command.py
+++ b/src/lfx/tests/unit/cli/test_validate_command.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 from lfx.cli.validate import (
+    LEVEL_AUDIT,
     ValidationResult,
     _check_missing_credentials,
     _check_orphaned_nodes,
@@ -332,6 +333,123 @@ class TestRequiredInputs:
         result = validate_flow_file(p, level=4, skip_components=True, skip_edge_types=True)
         req_errors = [e for e in result.errors if "Required input" in e.message]
         assert not req_errors
+
+
+class TestAuditLevel:
+    def _code_node(self, node_id: str = "code-node") -> dict:
+        return {
+            "id": node_id,
+            "data": {
+                "id": node_id,
+                "type": "PythonFunction",
+                "node": {"display_name": "Python Function", "template": {}},
+            },
+        }
+
+    def test_level_five_runs_agent_audit(self, tmp_path):
+        flow = {**_MINIMAL_VALID, "data": {"nodes": [self._code_node()], "edges": []}}
+        p = _write_flow(tmp_path, "flow.json", flow)
+        result = validate_flow_file(
+            p,
+            level=LEVEL_AUDIT,
+            skip_components=True,
+            skip_edge_types=True,
+            skip_required_inputs=True,
+            skip_credentials=True,
+            skip_version_check=True,
+        )
+        assert any("Unrestricted code execution detected" in issue.message for issue in result.warnings)
+        assert any(issue.level == LEVEL_AUDIT for issue in result.issues)
+
+    def test_audit_flag_runs_agent_audit_even_below_level_five(self, tmp_path):
+        flow = {**_MINIMAL_VALID, "data": {"nodes": [self._code_node()], "edges": []}}
+        p = _write_flow(tmp_path, "flow.json", flow)
+        result = validate_flow_file(
+            p,
+            level=4,
+            audit=True,
+            skip_components=True,
+            skip_edge_types=True,
+            skip_required_inputs=True,
+            skip_credentials=True,
+            skip_version_check=True,
+        )
+        assert any("Unrestricted code execution detected" in issue.message for issue in result.warnings)
+
+    def test_state_mutator_reachability_counts_non_direct_validator_paths(self, tmp_path):
+        validator = {
+            "id": "validator",
+            "data": {
+                "id": "validator",
+                "type": "ValidationFilter",
+                "node": {"display_name": "Validator", "template": {}},
+            },
+        }
+        middle = {
+            "id": "middle",
+            "data": {
+                "id": "middle",
+                "type": "Transform",
+                "node": {"display_name": "Middle", "template": {}},
+            },
+        }
+        mutator = {
+            "id": "mutator",
+            "data": {
+                "id": "mutator",
+                "type": "FileWriter",
+                "node": {"display_name": "File Writer", "template": {}},
+            },
+        }
+        flow = {
+            **_MINIMAL_VALID,
+            "data": {
+                "nodes": [validator, middle, mutator],
+                "edges": [
+                    {"source": "validator", "target": "middle"},
+                    {"source": "middle", "target": "mutator"},
+                ],
+            },
+        }
+        p = _write_flow(tmp_path, "flow.json", flow)
+        result = validate_flow_file(
+            p,
+            level=LEVEL_AUDIT,
+            skip_components=True,
+            skip_edge_types=True,
+            skip_required_inputs=True,
+            skip_credentials=True,
+            skip_version_check=True,
+        )
+        assert not any("State-mutating component" in issue.message for issue in result.warnings)
+
+    def test_memory_limit_detection_uses_field_names_not_numeric_values(self, tmp_path):
+        memory_node = {
+            "id": "memory",
+            "data": {
+                "id": "memory",
+                "type": "VectorMemory",
+                "node": {
+                    "display_name": "Vector Memory",
+                    "template": {
+                        "ttl": {"value": 4},
+                        "top_k": {"value": 10},
+                    },
+                },
+            },
+        }
+        flow = {**_MINIMAL_VALID, "data": {"nodes": [memory_node], "edges": []}}
+        p = _write_flow(tmp_path, "flow.json", flow)
+        result = validate_flow_file(
+            p,
+            level=LEVEL_AUDIT,
+            skip_components=True,
+            skip_edge_types=True,
+            skip_required_inputs=True,
+            skip_credentials=True,
+            skip_version_check=True,
+        )
+        assert not any("Memory/vector component" in issue.message for issue in result.warnings)
 
     def test_required_field_without_value_or_edge_fails(self, tmp_path):
         node = self._node_with_required_field(has_value=False)


### PR DESCRIPTION
## What Changed

Extended the existing 4-level `lfx validate` CLI with a **Level 5 agent architecture audit**.

After building any agent or workflow in Langflow, developers can now automatically run an audit to produce a health report **before execution**:

```bash
lfx validate my-flow.json --audit
lfx validate flows/ --level 5 --format json
```

## Why Every Agent Developer Needs This

**The base model rarely fails. The wrapper architecture corrupts good answers into bad behavior.**

Existing validation (Levels 1-4) catches structural issues: broken JSON, missing components, disconnected edges, empty inputs. But it misses the failures that actually break agents in production.

Level 5 fills that gap by auditing:

| Check | What It Catches |
|-------|----------------|
| Hardcoded secrets | API keys/tokens embedded in flow JSON instead of using env vars |
| Unrestricted code exec | Python/Code components without sandbox guards |
| Missing error handling | Agent nodes with no fallback or retry path |
| Runaway agent loops | Circular agent dependencies without iteration guards |
| Unbounded memory growth | Memory/vector components with no size limit or TTL |
| Missing observability | No tracing/callback components for production debugging |
| State-mutator safety | Write components (file, DB, vector store) without upstream validation |

## Files Changed

| File | Change |
|------|--------|
| `src/lfx/src/lfx/cli/validation/audit.py` | **New** — 7 audit check functions + public `_check_agent_audit()` entry point |
| `src/lfx/src/lfx/cli/validation/core.py` | Added `LEVEL_AUDIT = 5` constant, integrated audit into `validate_flow_file()` and `validate_command()` |
| `src/lfx/src/lfx/cli/validation/__init__.py` | Re-exported `LEVEL_AUDIT` and `_check_agent_audit` |
| `src/lfx/src/lfx/cli/validate.py` | Updated docstring with Level 5 description, re-exported `LEVEL_AUDIT` |
| `src/lfx/src/lfx/cli/_authoring_commands.py` | Added `--audit` / `-a` CLI flag, increased `--level` max to 5 |

## How It Works

1. Developer builds an agent or workflow in Langflow
2. Runs `lfx validate flows/ --audit` (or `--level 5`)
3. Gets a structured report (text or JSON) with severity-ranked findings
4. Fixes issues before running the agent

No new dependencies. Pure Python stdlib. Follows the exact same `ValidationIssue` / `ValidationResult` contract as existing levels so existing tests, CI, and rendering work unchanged.

## Usage Examples

```bash
# Quick audit of a single flow
lfx validate my-agent.json --audit

# Audit all flows in a directory, output as JSON
lfx validate flows/ --level 5 --format json

# Strict mode — warnings treated as errors
lfx validate flows/ --audit --strict
```