### PR TITLE
fix: allow backend/frontend Docker builds when main version exists

### DIFF
--- a/.github/workflows/docker-build-v2.yml
+++ b/.github/workflows/docker-build-v2.yml
@@ -137,7 +137,8 @@ jobs:
             echo "Latest main release version: $last_released_version"
           fi
 
-          if [ "$version" = "$last_released_version" ]; then
+          # Skip check only applies to main image, not backend/frontend which are separate images
+          if [ "$version" = "$last_released_version" ] && [[ "${{ inputs.release_type }}" != "main-backend" ]] && [[ "${{ inputs.release_type }}" != "main-frontend" ]]; then
             echo "Main docker version $version is already released. Skipping release."
             echo skipped=true >> $GITHUB_OUTPUT
             exit 0


### PR DESCRIPTION
## Problem

In the 1.9.0 release, the backend (`langflowai/langflow-backend`) and frontend (`langflowai/langflow-frontend`) Docker images were **not published** to Docker Hub, even though the release build succeeded. This required manual intervention to publish these images.

## Root Cause

The `docker-build-v2.yml` workflow has a version check that skips building if a version already exists on Docker Hub. The issue:

1. Main image (`langflowai/langflow`) builds and publishes first
2. Backend/Frontend jobs depend on main job completion (`needs: [call_docker_build_main]`)
3. When backend/frontend jobs run, they check if version exists on Docker Hub
4. Since main image was already published, the check returns true
5. Backend/Frontend builds are **incorrectly skipped** even though they are **separate Docker images** in different repositories

## Solution

Modified the version skip check in `.github/workflows/docker-build-v2.yml` to exclude backend and frontend image types:

```yaml
# Skip check only applies to main image, not backend/frontend which are separate images
if [ "$version" = "$last_released_version" ] && [[ "${{ inputs.release_type }}" != "main-backend" ]] && [[ "${{ inputs.release_type }}" != "main-frontend" ]]; then
