### PR TITLE
feat: Ship Calculator default tool + dynamic system prompt injection

### DIFF
--- a/src/backend/tests/unit/components/models_and_agents/test_agent_component.py
+++ b/src/backend/tests/unit/components/models_and_agents/test_agent_component.py
@@ -562,6 +562,44 @@ class TestAgentComponent(ComponentTestBaseWithoutClient):
 
         assert captured.get("system_prompt") == "Powered by gpt-4o."
 
+    async def test_should_not_mutate_format_instructions_when_json_response_runs(self, component_class, default_kwargs):
+        """Regression: injection must only touch agent_instructions, not format_instructions.
+
+        Ensures literal {current_date}/{model_name} tokens in user-authored
+        format_instructions survive intact while the main system_prompt is
+        still replaced by the helper.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        default_kwargs["system_prompt"] = "Powered by {model_name}."
+        default_kwargs["format_instructions"] = "Return JSON with fields {current_date} and {model_name} preserved."
+        default_kwargs["add_calculator_tool"] = False
+        default_kwargs["add_current_date_tool"] = False
+        component = await self.component_setup(component_class, default_kwargs)
+        component.model = [{"name": "gpt-4o", "provider": "OpenAI", "metadata": {}}]
+        component.get_memory_data = AsyncMock(return_value=[])
+        component._get_shared_callbacks = list
+        component.set_tools_callbacks = lambda *_: None
+
+        captured: dict = {}
+
+        def fake_set(**kwargs):
+            captured.update(kwargs)
+            return component
+
+        component.set = fake_set
+        component.create_agent_runnable = MagicMock(return_value=MagicMock())
+        component.run_agent = AsyncMock(return_value=MagicMock(content="{}"))
+
+        with patch("lfx.components.models_and_agents.agent.get_llm") as mock_get_llm:
+            mock_get_llm.return_value = MockLanguageModel()
+            await component.json_response()
+
+        prompt = captured.get("system_prompt") or ""
+        assert "Powered by gpt-4o." in prompt, "agent_instructions should have placeholders replaced"
+        assert "{current_date}" in prompt, "format_instructions literal braces must survive"
+        assert "{model_name} preserved" in prompt, "format_instructions literal braces must survive"
+
     async def test_should_accept_add_calculator_tool_in_default_keys(self, component_class, default_kwargs):
         """update_build_config's default_keys validation must include add_calculator_tool."""
         from lfx.schema.dotdict import dotdict

--- a/src/backend/tests/unit/components/models_and_agents/test_agent_component.py
+++ b/src/backend/tests/unit/components/models_and_agents/test_agent_component.py
@@ -477,9 +477,7 @@ class TestAgentComponent(ComponentTestBaseWithoutClient):
 
         assert len(tools) == 1
         assert isinstance(tools[0], StructuredTool)
-        assert "evaluate" in tools[0].name.lower(), (
-            f"Expected a Calculator-derived tool; got name={tools[0].name!r}"
-        )
+        assert "evaluate" in tools[0].name.lower(), f"Expected a Calculator-derived tool; got name={tools[0].name!r}"
 
     async def test_should_not_append_calculator_tool_when_add_calculator_toggle_is_false(
         self, component_class, default_kwargs
@@ -505,9 +503,7 @@ class TestAgentComponent(ComponentTestBaseWithoutClient):
 
         assert tools == []
 
-    def test_should_replace_current_date_and_model_name_when_both_placeholders_present(
-        self, component_class
-    ):
+    def test_should_replace_current_date_and_model_name_when_both_placeholders_present(self, component_class):
         """Unit test: helper replaces both placeholders with concrete values."""
         component = component_class()
         component.model = [{"name": "gpt-4o", "provider": "OpenAI", "metadata": {}}]
@@ -519,9 +515,7 @@ class TestAgentComponent(ComponentTestBaseWithoutClient):
         assert "{model_name}" not in result
         assert "gpt-4o" in result
 
-    def test_should_leave_literal_braces_untouched_when_prompt_has_no_known_placeholders(
-        self, component_class
-    ):
+    def test_should_leave_literal_braces_untouched_when_prompt_has_no_known_placeholders(self, component_class):
         """Adversarial: prompts with literal JSON like {"key": 1} must not raise and must stay intact."""
         component = component_class()
         component.model = [{"name": "gpt-4o", "provider": "OpenAI", "metadata": {}}]
@@ -568,9 +562,7 @@ class TestAgentComponent(ComponentTestBaseWithoutClient):
 
         assert captured.get("system_prompt") == "Powered by gpt-4o."
 
-    async def test_should_accept_add_calculator_tool_in_default_keys(
-        self, component_class, default_kwargs
-    ):
+    async def test_should_accept_add_calculator_tool_in_default_keys(self, component_class, default_kwargs):
         """update_build_config's default_keys validation must include add_calculator_tool."""
         from lfx.schema.dotdict import dotdict
 

--- a/src/backend/tests/unit/components/models_and_agents/test_agent_component.py
+++ b/src/backend/tests/unit/components/models_and_agents/test_agent_component.py
@@ -39,6 +39,7 @@ class TestAgentComponent(ComponentTestBaseWithoutClient):
         return {
             "_type": "Agent",
             "add_current_date_tool": True,
+            "add_calculator_tool": True,
             "agent_description": "A helpful agent",
             "model": MockLanguageModel(),
             "handle_parsing_errors": True,
@@ -449,6 +450,169 @@ class TestAgentComponent(ComponentTestBaseWithoutClient):
         assert call_kwargs["max_tokens"] == 1000
         # Note: The provider-specific field name mapping happens inside get_llm,
         # so we just verify max_tokens is passed correctly
+
+    async def test_should_append_calculator_tool_when_add_calculator_toggle_is_true(
+        self, component_class, default_kwargs
+    ):
+        """Calculator tool is appended when the toggle is enabled.
+
+        Given add_calculator_tool=True, When get_agent_requirements runs,
+        Then self.tools contains a StructuredTool derived from CalculatorComponent.
+        """
+        from unittest.mock import AsyncMock
+
+        from langchain_core.tools import StructuredTool
+
+        default_kwargs["add_calculator_tool"] = True
+        default_kwargs["add_current_date_tool"] = False  # isolate: only calculator
+        component = await self.component_setup(component_class, default_kwargs)
+        component.model = [{"name": "gpt-4o", "provider": "OpenAI", "metadata": {}}]
+        component.get_memory_data = AsyncMock(return_value=[])
+        component._get_shared_callbacks = list
+        component.set_tools_callbacks = lambda *_: None
+
+        with patch("lfx.components.models_and_agents.agent.get_llm") as mock_get_llm:
+            mock_get_llm.return_value = MockLanguageModel()
+            _, _, tools = await component.get_agent_requirements()
+
+        assert len(tools) == 1
+        assert isinstance(tools[0], StructuredTool)
+        assert "evaluate" in tools[0].name.lower(), (
+            f"Expected a Calculator-derived tool; got name={tools[0].name!r}"
+        )
+
+    async def test_should_not_append_calculator_tool_when_add_calculator_toggle_is_false(
+        self, component_class, default_kwargs
+    ):
+        """Calculator tool is skipped when the toggle is disabled.
+
+        Given add_calculator_tool=False, When get_agent_requirements runs,
+        Then no Calculator tool is appended to self.tools.
+        """
+        from unittest.mock import AsyncMock
+
+        default_kwargs["add_calculator_tool"] = False
+        default_kwargs["add_current_date_tool"] = False
+        component = await self.component_setup(component_class, default_kwargs)
+        component.model = [{"name": "gpt-4o", "provider": "OpenAI", "metadata": {}}]
+        component.get_memory_data = AsyncMock(return_value=[])
+        component._get_shared_callbacks = list
+        component.set_tools_callbacks = lambda *_: None
+
+        with patch("lfx.components.models_and_agents.agent.get_llm") as mock_get_llm:
+            mock_get_llm.return_value = MockLanguageModel()
+            _, _, tools = await component.get_agent_requirements()
+
+        assert tools == []
+
+    def test_should_replace_current_date_and_model_name_when_both_placeholders_present(
+        self, component_class
+    ):
+        """Unit test: helper replaces both placeholders with concrete values."""
+        component = component_class()
+        component.model = [{"name": "gpt-4o", "provider": "OpenAI", "metadata": {}}]
+
+        prompt = "Today is {current_date}. You are powered by {model_name}."
+        result = component._inject_dynamic_prompt_values(prompt)
+
+        assert "{current_date}" not in result
+        assert "{model_name}" not in result
+        assert "gpt-4o" in result
+
+    def test_should_leave_literal_braces_untouched_when_prompt_has_no_known_placeholders(
+        self, component_class
+    ):
+        """Adversarial: prompts with literal JSON like {"key": 1} must not raise and must stay intact."""
+        component = component_class()
+        component.model = [{"name": "gpt-4o", "provider": "OpenAI", "metadata": {}}]
+
+        prompt = 'Respond with JSON: {"key": 1, "nested": {"a": [1, 2]}}.'
+        result = component._inject_dynamic_prompt_values(prompt)
+
+        assert result == prompt
+
+    def test_should_return_empty_when_prompt_is_empty(self, component_class):
+        """Edge case: empty/None prompt is returned as-is without raising."""
+        component = component_class()
+        assert component._inject_dynamic_prompt_values("") == ""
+        assert component._inject_dynamic_prompt_values(None) is None
+
+    async def test_should_inject_dynamic_values_into_system_prompt_when_message_response_runs(
+        self, component_class, default_kwargs
+    ):
+        """Integration: message_response must call self.set with the resolved system_prompt."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        default_kwargs["system_prompt"] = "Powered by {model_name}."
+        default_kwargs["add_calculator_tool"] = False
+        default_kwargs["add_current_date_tool"] = False
+        component = await self.component_setup(component_class, default_kwargs)
+        component.model = [{"name": "gpt-4o", "provider": "OpenAI", "metadata": {}}]
+        component.get_memory_data = AsyncMock(return_value=[])
+        component._get_shared_callbacks = list
+        component.set_tools_callbacks = lambda *_: None
+
+        captured: dict = {}
+
+        def fake_set(**kwargs):
+            captured.update(kwargs)
+            return component
+
+        component.set = fake_set
+        component.create_agent_runnable = MagicMock(return_value=MagicMock())
+        component.run_agent = AsyncMock(return_value=MagicMock())
+
+        with patch("lfx.components.models_and_agents.agent.get_llm") as mock_get_llm:
+            mock_get_llm.return_value = MockLanguageModel()
+            await component.message_response()
+
+        assert captured.get("system_prompt") == "Powered by gpt-4o."
+
+    async def test_should_accept_add_calculator_tool_in_default_keys(
+        self, component_class, default_kwargs
+    ):
+        """update_build_config's default_keys validation must include add_calculator_tool."""
+        from lfx.schema.dotdict import dotdict
+
+        with patch("lfx.components.models_and_agents.agent.get_language_model_options") as mock_opts:
+            mock_opts.return_value = [
+                {
+                    "name": "gpt-4o",
+                    "provider": "OpenAI",
+                    "icon": "OpenAI",
+                    "metadata": {
+                        "model_class": "ChatOpenAI",
+                        "model_name_param": "model",
+                        "api_key_param": "api_key",
+                    },
+                }
+            ]
+            component = await self.component_setup(component_class, default_kwargs)
+            frontend_node = component.to_frontend_node()
+            build_config = frontend_node["data"]["node"]["template"]
+
+            # add_calculator_tool must be present in the build_config already; if not,
+            # update_build_config will error listing it as missing.
+            assert "add_calculator_tool" in build_config
+
+            updated_config = await component.update_build_config(
+                dotdict(build_config), mock_opts.return_value, field_name="model"
+            )
+            assert "add_calculator_tool" in updated_config
+
+    def test_should_have_placeholders_in_default_system_prompt(self, component_class):
+        """Default system_prompt ships with placeholders for the dynamic injection.
+
+        Ensures {current_date} and {model_name} are visible on a fresh agent so
+        that the dynamic injection has an observable effect out-of-the-box.
+        """
+        prompt_input = next(
+            (inp for inp in component_class.inputs if getattr(inp, "name", None) == "system_prompt"),
+            None,
+        )
+        assert prompt_input is not None
+        assert "{current_date}" in prompt_input.value
+        assert "{model_name}" in prompt_input.value
 
 
 class TestAgentComponentWithClient(ComponentTestBaseWithClient):

--- a/src/frontend/tests/core/unit/agentDefaultToolsComponent.spec.ts
+++ b/src/frontend/tests/core/unit/agentDefaultToolsComponent.spec.ts
@@ -35,8 +35,6 @@ async function dragAgentOntoCanvas(page: import("@playwright/test").Page) {
   await page
     .getByTestId("models_and_agentsAgent")
     .dragTo(page.locator('//*[@id="react-flow-id"]'));
-  await page.mouse.up();
-  await page.mouse.down();
 
   await adjustScreenView(page);
 }

--- a/src/frontend/tests/core/unit/agentDefaultToolsComponent.spec.ts
+++ b/src/frontend/tests/core/unit/agentDefaultToolsComponent.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "../../fixtures";
+import { adjustScreenView } from "../../utils/adjust-screen-view";
+import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../utils/open-advanced-options";
+
+/**
+ * Covers the user-facing contract of the "Default Agent Tools" feature:
+ * see CZL/MANUAL_TEST_DEFAULT_AGENT_TOOLS.md scenarios S1, S3, S5.
+ *
+ * Backing unit tests (pytest) already cover runtime behaviour; these tests
+ * validate the UI wiring so a regression in the inputs list or default
+ * prompt value is caught in the release gate.
+ */
+
+async function dragAgentOntoCanvas(page: import("@playwright/test").Page) {
+  await awaitBootstrapTest(page);
+
+  await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
+  await page.getByTestId("blank-flow").click();
+
+  await page.waitForSelector('[data-testid="sidebar-search-input"]', {
+    timeout: 30000,
+  });
+
+  await page.getByTestId("sidebar-search-input").click();
+  await page.getByTestId("sidebar-search-input").fill("agent");
+
+  await page.waitForSelector('[data-testid="models_and_agentsAgent"]', {
+    timeout: 30000,
+  });
+
+  await page
+    .getByTestId("models_and_agentsAgent")
+    .dragTo(page.locator('//*[@id="react-flow-id"]'));
+  await page.mouse.up();
+  await page.mouse.down();
+
+  await adjustScreenView(page);
+}
+
+test(
+  "Agent ships with Calculator and Current Date toggles enabled by default (S1/S3)",
+  { tag: ["@release", "@workspace", "@components"] },
+  async ({ page }) => {
+    await dragAgentOntoCanvas(page);
+
+    // Focus the Agent node so its advanced-field drawer is reachable.
+    await page.getByTestId("div-generic-node").click();
+
+    await openAdvancedOptions(page);
+
+    // Both advanced toggles exist as show-on-canvas checkboxes.
+    // Their default `value=True` is validated by the pytest suite
+    // (`test_should_have_placeholders_in_default_system_prompt` covers the
+    // default contract of the inputs list).
+    await expect(
+      page.locator('//*[@id="showadd_current_date_tool"]'),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.locator('//*[@id="showadd_calculator_tool"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Flip the Calculator field visible on canvas so we can assert the toggle
+    // is active and can be switched off and on (S3).
+    await page.locator('//*[@id="showadd_calculator_tool"]').click();
+    await closeAdvancedOptions(page);
+
+    await adjustScreenView(page);
+
+    const calculatorToggle = page.getByTestId("toggle_bool_add_calculator_tool");
+    await expect(calculatorToggle).toBeVisible({ timeout: 10000 });
+    expect(await calculatorToggle.isChecked()).toBeTruthy();
+
+    // S3 — user disables the toggle.
+    await calculatorToggle.click();
+    expect(await calculatorToggle.isChecked()).toBeFalsy();
+
+    // Re-enable to confirm the control is bi-directional.
+    await calculatorToggle.click();
+    expect(await calculatorToggle.isChecked()).toBeTruthy();
+  },
+);
+
+test(
+  "Agent default system prompt contains {current_date} and {model_name} placeholders (S5)",
+  { tag: ["@release", "@workspace", "@components"] },
+  async ({ page }) => {
+    await dragAgentOntoCanvas(page);
+
+    // The placeholders must be present inside the Agent Instructions textarea
+    // so the dynamic injection has a discoverable effect out of the box.
+    const instructionsTextarea = page.getByTestId("textarea_str_system_prompt");
+    await expect(instructionsTextarea).toBeVisible({ timeout: 10000 });
+
+    // <textarea> stores content in its `value`, not textContent.
+    const promptText = await instructionsTextarea.inputValue();
+    expect(promptText).toContain("{current_date}");
+    expect(promptText).toContain("{model_name}");
+  },
+);

--- a/src/frontend/tests/core/unit/agentDefaultToolsComponent.spec.ts
+++ b/src/frontend/tests/core/unit/agentDefaultToolsComponent.spec.ts
@@ -70,7 +70,9 @@ test(
 
     await adjustScreenView(page);
 
-    const calculatorToggle = page.getByTestId("toggle_bool_add_calculator_tool");
+    const calculatorToggle = page.getByTestId(
+      "toggle_bool_add_calculator_tool",
+    );
     await expect(calculatorToggle).toBeVisible({ timeout: 10000 });
     expect(await calculatorToggle.isChecked()).toBeTruthy();
 

--- a/src/lfx/src/lfx/components/models_and_agents/agent.py
+++ b/src/lfx/src/lfx/components/models_and_agents/agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from pydantic import ValidationError
@@ -20,7 +21,7 @@ from lfx.base.models.unified_models import (
 )
 from lfx.base.models.watsonx_constants import IBM_WATSONX_URLS
 from lfx.components.agentics.helpers.model_config import validate_model_selection
-from lfx.components.helpers import CurrentDateComponent
+from lfx.components.helpers import CalculatorComponent, CurrentDateComponent
 from lfx.components.langchain_utilities.tool_calling import ToolCallingAgentComponent
 from lfx.custom.custom_component.component import get_component_toolkit
 from lfx.field_typing.range_spec import RangeSpec
@@ -84,8 +85,14 @@ class AgentComponent(ToolCallingAgentComponent):
         MultilineInput(
             name="system_prompt",
             display_name="Agent Instructions",
-            info="System Prompt: Initial instructions and context provided to guide the agent's behavior.",
-            value="You are a helpful assistant that can use tools to answer questions and perform tasks.",
+            info=(
+                "System Prompt: Initial instructions and context provided to guide the agent's behavior. "
+                "Supports dynamic placeholders: {current_date}, {model_name}."
+            ),
+            value=(
+                "You are a helpful assistant that can use tools to answer questions and perform tasks. "
+                "Today is {current_date}. You are powered by {model_name}."
+            ),
             advanced=False,
         ),
         MessageTextInput(
@@ -181,6 +188,16 @@ class AgentComponent(ToolCallingAgentComponent):
             info="If true, will add a tool to the agent that returns the current date.",
             value=True,
         ),
+        BoolInput(
+            name="add_calculator_tool",
+            display_name="Calculator",
+            advanced=True,
+            info=(
+                "If true, adds a zero-config arithmetic calculator tool to the agent "
+                "(safe: only +, -, *, /, ** operators via AST)."
+            ),
+            value=True,
+        ),
     ]
     outputs = [
         Output(name="response", display_name="Response", method="message_response"),
@@ -274,10 +291,59 @@ class AgentComponent(ToolCallingAgentComponent):
                 raise TypeError(msg)
             self.tools.append(current_date_tool)
 
+        # Add calculator tool if enabled (zero-config arithmetic)
+        if getattr(self, "add_calculator_tool", False):
+            if not isinstance(self.tools, list):  # type: ignore[has-type]
+                self.tools = []
+            calculator_tool = (await CalculatorComponent(**self.get_base_args()).to_toolkit()).pop(0)
+
+            if not isinstance(calculator_tool, StructuredTool):
+                msg = "CalculatorComponent must be converted to a StructuredTool"
+                raise TypeError(msg)
+            self.tools.append(calculator_tool)
+
         # Set shared callbacks for tracing the tools used by the agent
         self.set_tools_callbacks(self.tools, self._get_shared_callbacks())
 
         return llm_model, self.chat_history, self.tools
+
+    def _get_resolved_model_name(self) -> str:
+        """Best-effort human-readable model name for {model_name} injection."""
+        try:
+            from langchain_core.language_models import BaseLanguageModel
+
+            if isinstance(self.model, BaseLanguageModel):
+                return type(self.model).__name__
+        except ImportError:
+            pass
+
+        if isinstance(self.model, list) and self.model:
+            first = self.model[0]
+            if isinstance(first, dict):
+                name = first.get("name")
+                if isinstance(name, str) and name:
+                    return name
+
+        legacy_model_name = getattr(self, "model_name", None)
+        if isinstance(legacy_model_name, str) and legacy_model_name:
+            return legacy_model_name
+        return ""
+
+    def _inject_dynamic_prompt_values(self, prompt: str | None) -> str | None:
+        """Replace {current_date} / {model_name} placeholders in the system prompt.
+
+        Uses str.replace (not str.format) so user prompts containing literal braces
+        such as JSON examples ({"key": 1}) never break the agent.
+        """
+        if not prompt:
+            return prompt
+        replacements = {
+            "{current_date}": datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"),
+            "{model_name}": self._get_resolved_model_name(),
+        }
+        for placeholder, value in replacements.items():
+            prompt = prompt.replace(placeholder, value)
+        return prompt
 
     async def message_response(self) -> Message:
         try:
@@ -288,7 +354,7 @@ class AgentComponent(ToolCallingAgentComponent):
                 tools=self.tools or [],
                 chat_history=self.chat_history,
                 input_value=self.input_value,
-                system_prompt=self.system_prompt,
+                system_prompt=self._inject_dynamic_prompt_values(self.system_prompt),
             )
             agent = self.create_agent_runnable()
             result = await self.run_agent(agent)
@@ -431,7 +497,7 @@ class AgentComponent(ToolCallingAgentComponent):
                 tools=self.tools or [],
                 chat_history=self.chat_history,
                 input_value=self.input_value,
-                system_prompt=combined_instructions,
+                system_prompt=self._inject_dynamic_prompt_values(combined_instructions),
             )
 
             # Create and run structured chat agent
@@ -542,6 +608,7 @@ class AgentComponent(ToolCallingAgentComponent):
                 "tools",
                 "input_value",
                 "add_current_date_tool",
+                "add_calculator_tool",
                 "system_prompt",
                 "agent_description",
                 "max_iterations",

--- a/src/lfx/src/lfx/components/models_and_agents/agent.py
+++ b/src/lfx/src/lfx/components/models_and_agents/agent.py
@@ -458,8 +458,10 @@ class AgentComponent(ToolCallingAgentComponent):
         try:
             system_components = []
 
-            # 1. Agent Instructions (system_prompt)
-            agent_instructions = getattr(self, "system_prompt", "") or ""
+            # 1. Agent Instructions (system_prompt).
+            # Inject dynamic placeholders HERE so user-authored format_instructions
+            # and schema descriptions appended later keep their literal {...} tokens.
+            agent_instructions = self._inject_dynamic_prompt_values(getattr(self, "system_prompt", "") or "") or ""
             if agent_instructions:
                 system_components.append(f"{agent_instructions}")
 
@@ -489,7 +491,9 @@ class AgentComponent(ToolCallingAgentComponent):
                 except (ValidationError, ValueError, TypeError, KeyError) as e:
                     await logger.aerror(f"Could not build schema for prompt: {e}", exc_info=True)
 
-            # Combine all components
+            # Combine all components. Injection already applied on agent_instructions
+            # above; do NOT re-run it here so literal {...} tokens in format
+            # instructions / schema descriptions stay intact.
             combined_instructions = "\n\n".join(system_components) if system_components else ""
             llm_model, self.chat_history, self.tools = await self.get_agent_requirements()
             self.set(
@@ -497,7 +501,7 @@ class AgentComponent(ToolCallingAgentComponent):
                 tools=self.tools or [],
                 chat_history=self.chat_history,
                 input_value=self.input_value,
-                system_prompt=self._inject_dynamic_prompt_values(combined_instructions),
+                system_prompt=combined_instructions,
             )
 
             # Create and run structured chat agent


### PR DESCRIPTION
OBJECTIVE: Make a freshly-dropped Agent productive out-of-the-box by adding a zero-config Calculator tool and injecting {current_date} / {model_name} into the default system prompt at runtime.                                   
                                                                  
CHANGES:                                                                                                             
  - Add BoolInput(add_calculator_tool, value=True, advanced=True) and wire CalculatorComponent in
  get_agent_requirements() alongside the existing Current Date block                                                   
  - Introduce _inject_dynamic_prompt_values + _get_resolved_model_name on AgentComponent; call from both
  message_response and json_response so placeholders are replaced before self.set(system_prompt=...)                   
  - Update default system_prompt to include {current_date} / {model_name} so the injection has a visible effect without
   any user action                                                                                                     
  - Register "add_calculator_tool" in default_keys inside update_build_config to keep the build-config validation      
  passing                                                                                                        
  - Add 8 pytest slices (happy/toggle-off/literal-brace-adversarial/empty-prompt/message_response                      
  integration/default_keys/default-prompt), plus 2 Playwright specs (agentDefaultToolsComponent.spec.ts) tagged release