### PR TITLE
feat: add UTM tracking to outbound watsonx Orchestrate links

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/add-provider-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/add-provider-modal.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { usePostProviderAccount } from "@/controllers/API/queries/deployment-provider-accounts/use-post-provider-account";
+import { decorateWxoUrl } from "@/utils/decorate-wxo-url";
 import { useErrorAlert } from "../hooks/use-error-alert";
 import type { ProviderCredentials } from "../types";
 import ProviderCredentialsForm from "./provider-credentials-form";
@@ -93,7 +94,10 @@ export default function AddProviderModal({
             <p className="text-sm text-muted-foreground">
               Configure your watsonx Orchestrate credentials below. New to wxO?{" "}
               <a
-                href="https://www.ibm.com/products/watsonx-orchestrate#pricing"
+                href={decorateWxoUrl(
+                  "https://www.ibm.com/products/watsonx-orchestrate#pricing",
+                  "signup-pricing",
+                )}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-medium text-primary hover:underline"
@@ -102,7 +106,10 @@ export default function AddProviderModal({
               </a>
               . Already have an account?{" "}
               <a
-                href="https://www.ibm.com/docs/en/watsonx/watson-orchestrate/base?topic=api-getting-started"
+                href={decorateWxoUrl(
+                  "https://www.ibm.com/docs/en/watsonx/watson-orchestrate/base?topic=api-getting-started",
+                  "docs-credentials",
+                )}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-medium text-primary hover:underline"

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-provider.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-provider.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Badge } from "@/components/ui/badge";
 import { useGetProviderAccounts } from "@/controllers/API/queries/deployment-provider-accounts/use-get-provider-accounts";
+import { decorateWxoUrl } from "@/utils/decorate-wxo-url";
 import { cn } from "@/utils/utils";
 import { useDeploymentStepper } from "../contexts/deployment-stepper-context";
 import type { DeploymentProvider, ProviderAccount } from "../types";
@@ -143,7 +144,10 @@ export default function StepProvider() {
         <p className="text-sm text-muted-foreground">
           Configure your watsonx Orchestrate credentials below. New to wxO?{" "}
           <a
-            href="https://www.ibm.com/products/watsonx-orchestrate#pricing"
+            href={decorateWxoUrl(
+              "https://www.ibm.com/products/watsonx-orchestrate#pricing",
+              "signup-pricing",
+            )}
             target="_blank"
             rel="noopener noreferrer"
             className="font-medium text-primary hover:underline"
@@ -152,7 +156,10 @@ export default function StepProvider() {
           </a>
           . Already have an account?{" "}
           <a
-            href="https://www.ibm.com/docs/en/watsonx/watson-orchestrate/base?topic=api-getting-started"
+            href={decorateWxoUrl(
+              "https://www.ibm.com/docs/en/watsonx/watson-orchestrate/base?topic=api-getting-started",
+              "docs-credentials",
+            )}
             target="_blank"
             rel="noopener noreferrer"
             className="font-medium text-primary hover:underline"

--- a/src/frontend/src/utils/__tests__/decorate-wxo-url.test.ts
+++ b/src/frontend/src/utils/__tests__/decorate-wxo-url.test.ts
@@ -1,0 +1,78 @@
+import { decorateWxoUrl } from "../decorate-wxo-url";
+
+describe("decorateWxoUrl", () => {
+  it("appends UTM params to an IBM URL with no existing query", () => {
+    const result = decorateWxoUrl(
+      "https://www.ibm.com/products/watsonx-orchestrate",
+    );
+    const parsed = new URL(result);
+    expect(parsed.searchParams.get("utm_source")).toBe("langflow");
+    expect(parsed.searchParams.get("utm_medium")).toBe("integration");
+    expect(parsed.searchParams.get("utm_campaign")).toBe("wxo-integration");
+  });
+
+  it("preserves fragment identifier and places query before it", () => {
+    const result = decorateWxoUrl(
+      "https://www.ibm.com/products/watsonx-orchestrate#pricing",
+    );
+    expect(result).toMatch(/\?[^#]*#pricing$/);
+    const parsed = new URL(result);
+    expect(parsed.hash).toBe("#pricing");
+    expect(parsed.searchParams.get("utm_source")).toBe("langflow");
+  });
+
+  it("merges with existing query parameters without duplicating them", () => {
+    const result = decorateWxoUrl(
+      "https://www.ibm.com/docs/en/watsonx/watson-orchestrate/base?topic=api-getting-started",
+    );
+    const parsed = new URL(result);
+    expect(parsed.searchParams.get("topic")).toBe("api-getting-started");
+    expect(parsed.searchParams.get("utm_source")).toBe("langflow");
+    expect(parsed.searchParams.get("utm_medium")).toBe("integration");
+  });
+
+  it("adds utm_content when provided", () => {
+    const result = decorateWxoUrl(
+      "https://www.ibm.com/products/watsonx-orchestrate",
+      "signup-pricing",
+    );
+    const parsed = new URL(result);
+    expect(parsed.searchParams.get("utm_content")).toBe("signup-pricing");
+  });
+
+  it("omits utm_content when not provided", () => {
+    const result = decorateWxoUrl(
+      "https://www.ibm.com/products/watsonx-orchestrate",
+    );
+    expect(new URL(result).searchParams.has("utm_content")).toBe(false);
+  });
+
+  it("overwrites any pre-existing utm_source to avoid duplication", () => {
+    const result = decorateWxoUrl(
+      "https://www.ibm.com/foo?utm_source=other&utm_medium=email",
+    );
+    const parsed = new URL(result);
+    expect(parsed.searchParams.getAll("utm_source")).toEqual(["langflow"]);
+    expect(parsed.searchParams.getAll("utm_medium")).toEqual(["integration"]);
+  });
+
+  it("returns non-IBM URLs unchanged", () => {
+    const url = "https://example.com/path?a=1";
+    expect(decorateWxoUrl(url)).toBe(url);
+  });
+
+  it("does not match hostnames that only contain 'ibm.com' as a substring", () => {
+    const url = "https://notibm.com/path";
+    expect(decorateWxoUrl(url)).toBe(url);
+  });
+
+  it("returns the input unchanged when the URL cannot be parsed", () => {
+    const url = "not a url";
+    expect(decorateWxoUrl(url)).toBe(url);
+  });
+
+  it("decorates subdomains of ibm.com", () => {
+    const result = decorateWxoUrl("https://www.ibm.com/anything");
+    expect(new URL(result).searchParams.get("utm_source")).toBe("langflow");
+  });
+});

--- a/src/frontend/src/utils/decorate-wxo-url.ts
+++ b/src/frontend/src/utils/decorate-wxo-url.ts
@@ -1,0 +1,36 @@
+const UTM_MEDIUM = "integration";
+const UTM_CAMPAIGN = "wxo-integration";
+const DEFAULT_UTM_SOURCE = "langflow";
+
+function getUtmSource(): string {
+  const configured = import.meta.env.LANGFLOW_WXO_UTM_SOURCE;
+  return typeof configured === "string" && configured.length > 0
+    ? configured
+    : DEFAULT_UTM_SOURCE;
+}
+
+function isIbmHost(hostname: string): boolean {
+  return hostname === "ibm.com" || hostname.endsWith(".ibm.com");
+}
+
+export function decorateWxoUrl(url: string, utmContent?: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  if (!isIbmHost(parsed.hostname)) {
+    return url;
+  }
+
+  parsed.searchParams.set("utm_source", getUtmSource());
+  parsed.searchParams.set("utm_medium", UTM_MEDIUM);
+  parsed.searchParams.set("utm_campaign", UTM_CAMPAIGN);
+  if (utmContent) {
+    parsed.searchParams.set("utm_content", utmContent);
+  }
+
+  return parsed.toString();
+}

--- a/src/frontend/vite.config.mts
+++ b/src/frontend/vite.config.mts
@@ -57,6 +57,9 @@ export default defineConfig(({ mode }) => {
       "import.meta.env.LANGFLOW_MCP_COMPOSER_ENABLED": JSON.stringify(
         envLangflow.LANGFLOW_MCP_COMPOSER_ENABLED ?? "true",
       ),
+      "import.meta.env.LANGFLOW_WXO_UTM_SOURCE": JSON.stringify(
+        envLangflow.LANGFLOW_WXO_UTM_SOURCE ?? "langflow",
+      ),
     },
     plugins: [
       react(),


### PR DESCRIPTION
Introduces a decorateWxoUrl utility that appends utm_source, utm_medium, utm_campaign, and a per-link utm_content to IBM-hosted URLs using the URL API. The utm_source is configurable via LANGFLOW_WXO_UTM_SOURCE with a "langflow" default. Applied to the Sign-up and Find-your-credentials links in step-provider and add-provider-modal.