### PR TITLE
docs: document tag format requirements and release artifacts in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,8 +39,27 @@ This step also usually lasts about a week.
 After QA and bugfixing are complete for both OSS and Desktop:
 
 * Final releases are cut from their respective RC branches.
-* Release timing is coordinated with Langflow’s DevRel team.
+* Release timing is coordinated with Langflow's DevRel team.
 * For at least 24 hours after release, Discord, GitHub, and other support channels should be monitored for critical bug reports.
+
+### 4. Release Artifacts
+
+The release workflow automatically publishes the following artifacts:
+
+* **PyPI Packages:**
+  * `langflow` - Main package with all integrations
+  * `langflow-base` - Core framework without integrations
+  * `lfx` - Lightweight executor CLI
+  * `langflow-sdk` - SDK for programmatic access (when updated)
+
+* **Docker Images:**
+  * `langflowai/langflow` - Full Langflow image
+  * `langflowai/langflow-backend` - Backend-only image (published independently)
+  * `langflowai/langflow-frontend` - Frontend-only image (published independently)
+  * `langflowai/langflow-ep` - Enterprise edition image (published independently)
+  * `langflowai/langflow-base` - Base image without integrations
+
+**Note:** Backend, frontend, and enterprise images are published separately from the main image and will be built even if the main version already exists on Docker Hub.
 
 ## Branch Model
 
@@ -101,6 +120,10 @@ git merge --ff-only release-X.Y.Z      # Fast-forward main to include RC changes
 
 * Follows [Semantic Versioning](https://semver.org): `MAJOR.MINOR.PATCH`.
 * RC tags use `-rc.N`, e.g. `v1.8.0-rc.1`.
+* **All tags MUST start with `v` prefix** (e.g., `v1.9.1`, not `1.9.1`).
+  * The release workflow validates this format and rejects tags without the `v` prefix.
+  * Duplicate tags (e.g., both `1.8.3` and `v1.8.3`) cause GitHub's release notes generation to use the wrong base comparison, resulting in incomplete changelogs.
+  * The workflow automatically checks for and prevents duplicate tags.
 
 ## Roles
 


### PR DESCRIPTION
## Summary
Updates RELEASE.md to document critical tag format requirements and release artifacts based on lessons learned from the 1.9.1 release.

## Changes
- **Tag Format Requirements**: All tags MUST use `v` prefix (e.g., `v1.9.1`)
  - Explains duplicate tag issue that caused v1.9.0 release notes to miss 58 commits
  - Documents automatic validation in release workflow
- **Release Artifacts Section**: Documents all PyPI packages and Docker images published during release
  - Notes that backend/frontend/EP images are published independently

## Related
- #12847 (prevent duplicate tags and validate tag format)
- #12854 (allow backend/frontend Docker builds when main version exists)

## Checklist
- [x] Documentation updated
- [x] Based on release-1.10.0
- [x] No code changes
