### PR TITLE
fix(kb): harden DB connector setup

### DIFF
--- a/src/backend/base/langflow/api/v1/knowledge_bases.py
+++ b/src/backend/base/langflow/api/v1/knowledge_bases.py
@@ -249,6 +249,7 @@ async def create_knowledge_base(
             "id": str(kb_id),
             "embedding_provider": request.embedding_provider,
             "embedding_model": request.embedding_model,
+            "model_selection": request.model_selection,
             "created_at": datetime.now(timezone.utc).isoformat(),
             "chunks": 0,
             "words": 0,
@@ -282,6 +283,7 @@ async def create_knowledge_base(
                 name=kb_name,
                 embedding_provider=request.embedding_provider,
                 embedding_model=request.embedding_model,
+                model_selection=request.model_selection,
                 column_config=column_config_dicts or [],
                 backend_type=backend_type_value,
                 backend_config=backend_config_value,
@@ -589,8 +591,18 @@ class IngestFolderRequest(BaseModel):
     )
     max_file_size_bytes: int | None = Field(None, description="Per-file size cap; None → 25 MB default.")
     source_name: str = Field("", description="Optional grouping label stamped on every chunk's 'source'.")
-    chunk_size: int = Field(1000, description="Chunk size in characters.")
-    chunk_overlap: int = Field(200, description="Chunk overlap in characters.")
+    chunk_size: int = Field(
+        1000,
+        ge=MIN_CHUNK_SIZE,
+        le=MAX_CHUNK_SIZE,
+        description="Chunk size in characters.",
+    )
+    chunk_overlap: int = Field(
+        200,
+        ge=MIN_CHUNK_OVERLAP,
+        le=MAX_CHUNK_OVERLAP,
+        description="Chunk overlap in characters.",
+    )
     separator: str = Field("", description="Custom separator (\\n → newline).")
 
 

--- a/src/backend/base/langflow/schema/knowledge_base.py
+++ b/src/backend/base/langflow/schema/knowledge_base.py
@@ -1,7 +1,17 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from lfx.base.knowledge_bases.backends import BackendType
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from langflow.utils.kb_constants import MAX_CHUNK_OVERLAP, MAX_CHUNK_SIZE, MIN_CHUNK_OVERLAP, MIN_CHUNK_SIZE
+
+_REQUIRED_BACKEND_CONFIG: dict[str, tuple[str, ...]] = {
+    BackendType.MONGODB.value: ("database", "collection"),
+    BackendType.ASTRA.value: ("collection_name",),
+    BackendType.POSTGRES.value: ("collection_name",),
+    BackendType.OPENSEARCH.value: ("index_name",),
+}
 
 
 class KnowledgeBaseInfo(BaseModel):
@@ -21,10 +31,10 @@ class KnowledgeBaseInfo(BaseModel):
     status: str = "empty"
     failure_reason: str | None = None
     last_job_id: str | None = None
-    source_types: list[str] = []
+    source_types: list[str] = Field(default_factory=list)
     column_config: list[dict] | None = None
     backend_type: str = "chroma"
-    backend_config: dict[str, Any] = {}
+    backend_config: dict[str, Any] = Field(default_factory=dict)
 
 
 class BulkDeleteRequest(BaseModel):
@@ -41,10 +51,30 @@ class CreateKnowledgeBaseRequest(BaseModel):
     name: str
     embedding_provider: str
     embedding_model: str
+    model_selection: dict[str, Any] | list[dict[str, Any]] | None = None
     column_config: list[ColumnConfigItem] | None = None
     # Phase 4 additions. Default keeps existing KBs on Chroma.
     backend_type: str = "chroma"
-    backend_config: dict[str, Any] = {}
+    backend_config: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("backend_type")
+    @classmethod
+    def validate_backend_type(cls, value: str) -> str:
+        try:
+            return BackendType(value or BackendType.CHROMA.value).value
+        except ValueError as exc:
+            allowed = ", ".join(backend.value for backend in BackendType)
+            msg = f"Unknown vector-store backend {value!r}. Expected one of: {allowed}."
+            raise ValueError(msg) from exc
+
+    @model_validator(mode="after")
+    def validate_backend_config(self) -> "CreateKnowledgeBaseRequest":
+        required_keys = _REQUIRED_BACKEND_CONFIG.get(self.backend_type, ())
+        missing = [key for key in required_keys if not str(self.backend_config.get(key) or "").strip()]
+        if missing:
+            msg = f"{self.backend_type} backend requires backend_config field(s): {', '.join(missing)}."
+            raise ValueError(msg)
+        return self
 
 
 class AddSourceRequest(BaseModel):
@@ -109,8 +139,8 @@ class IngestionRunDetail(IngestionRunInfo):
     a file-by-file drill-down with individual error messages.
     """
 
-    source_config: dict[str, Any] = {}
-    items: list[IngestionRunItemInfo] = []
+    source_config: dict[str, Any] = Field(default_factory=dict)
+    items: list[IngestionRunItemInfo] = Field(default_factory=list)
 
 
 class PaginatedIngestionRunResponse(BaseModel):
@@ -140,8 +170,8 @@ class ConnectorIngestRequest(BaseModel):
     """Body payload for the generic ``POST /{kb}/ingest/connector`` route."""
 
     source_type: str
-    source_config: dict[str, Any] = {}
+    source_config: dict[str, Any] = Field(default_factory=dict)
     source_name: str = ""
-    chunk_size: int = 1000
-    chunk_overlap: int = 200
+    chunk_size: int = Field(1000, ge=MIN_CHUNK_SIZE, le=MAX_CHUNK_SIZE)
+    chunk_overlap: int = Field(200, ge=MIN_CHUNK_OVERLAP, le=MAX_CHUNK_OVERLAP)
     separator: str = ""

--- a/src/backend/tests/unit/base/knowledge_bases/test_connector_endpoints.py
+++ b/src/backend/tests/unit/base/knowledge_bases/test_connector_endpoints.py
@@ -164,3 +164,32 @@ class TestConnectorIngest:
         )
         assert response.status_code == 400
         assert "bucket" in response.json()["detail"].lower()
+
+    async def test_rejects_unbounded_chunk_parameters(self, client: AsyncClient, logged_in_headers):
+        response = await client.post(
+            "api/v1/knowledge_bases/connector_kb/ingest/connector",
+            headers=logged_in_headers,
+            json={
+                "source_type": "s3",
+                "source_config": {"bucket": "demo"},
+                "chunk_size": 100_000_000,
+                "chunk_overlap": 0,
+            },
+        )
+
+        assert response.status_code == 422
+        assert "chunk_size" in response.text
+
+    async def test_folder_ingest_rejects_unbounded_chunk_parameters(self, client: AsyncClient, logged_in_headers):
+        response = await client.post(
+            "api/v1/knowledge_bases/folder_kb/ingest/folder",
+            headers=logged_in_headers,
+            json={
+                "path": "/example-folder",
+                "chunk_size": 100_000_000,
+                "chunk_overlap": 0,
+            },
+        )
+
+        assert response.status_code == 422
+        assert "chunk_size" in response.text

--- a/src/backend/tests/unit/test_knowledge_bases_api.py
+++ b/src/backend/tests/unit/test_knowledge_bases_api.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pandas as pd
 import pytest
 from httpx import AsyncClient
+from langflow.api.utils import knowledge_base_service
 from langflow.api.utils.kb_helpers import (
     KBAnalysisHelper,
     KBIngestionHelper,
@@ -194,11 +195,17 @@ class TestKnowledgeBaseAPI:
     @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_fresh_chroma_client")
     @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
     async def test_create_knowledge_base(
-        self, mock_root, mock_fresh_client, client: AsyncClient, logged_in_headers, tmp_path
+        self, mock_root, mock_fresh_client, client: AsyncClient, logged_in_headers, active_user, tmp_path
     ):
         mock_fresh_client.return_value = MagicMock()
         mock_root.return_value = tmp_path
         kb_name = "New_KB"
+        model_selection = {
+            "id": "text-embedding-3-small",
+            "name": "text-embedding-3-small",
+            "provider": "OpenAI",
+            "metadata": {"model_type": "embeddings"},
+        }
         response = await client.post(
             "api/v1/knowledge_bases",
             headers=logged_in_headers,
@@ -206,6 +213,7 @@ class TestKnowledgeBaseAPI:
                 "name": kb_name,
                 "embedding_provider": "OpenAI",
                 "embedding_model": "text-embedding-3-small",
+                "model_selection": model_selection,
                 "backend_type": "opensearch",
                 "backend_config": {"index_name": "new_kb_index"},
             },
@@ -215,6 +223,42 @@ class TestKnowledgeBaseAPI:
         assert data["name"] == "New KB"
         assert data["backend_type"] == "opensearch"
         assert data["backend_config"] == {"index_name": "new_kb_index"}
+        record = await knowledge_base_service.get_by_user_and_name(active_user.id, kb_name)
+        assert record is not None
+        assert record.model_selection == model_selection
+        metadata = json.loads((tmp_path / active_user.username / kb_name / "embedding_metadata.json").read_text())
+        assert metadata["model_selection"] == model_selection
+
+    async def test_create_knowledge_base_rejects_unknown_backend(self, client: AsyncClient, logged_in_headers):
+        response = await client.post(
+            "api/v1/knowledge_bases",
+            headers=logged_in_headers,
+            json={
+                "name": "Bad_Backend_KB",
+                "embedding_provider": "OpenAI",
+                "embedding_model": "text-embedding-3-small",
+                "backend_type": "not-a-backend",
+            },
+        )
+
+        assert response.status_code == 422
+        assert "unknown vector-store backend" in response.text.lower()
+
+    async def test_create_knowledge_base_rejects_missing_backend_config(self, client: AsyncClient, logged_in_headers):
+        response = await client.post(
+            "api/v1/knowledge_bases",
+            headers=logged_in_headers,
+            json={
+                "name": "Missing_Backend_Config_KB",
+                "embedding_provider": "OpenAI",
+                "embedding_model": "text-embedding-3-small",
+                "backend_type": "postgres",
+                "backend_config": {},
+            },
+        )
+
+        assert response.status_code == 422
+        assert "collection_name" in response.text
 
     @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
     async def test_create_kb_path_traversal_single_level(

--- a/src/frontend/src/controllers/API/queries/knowledge-bases/use-create-knowledge-base.ts
+++ b/src/frontend/src/controllers/API/queries/knowledge-bases/use-create-knowledge-base.ts
@@ -9,6 +9,12 @@ export interface CreateKnowledgeBaseRequest {
   name: string;
   embedding_provider: string;
   embedding_model: string;
+  /**
+   * Exact unified-model selection captured at create time. Retrieval uses
+   * this instead of resolving by provider/name again, which avoids drift
+   * when multiple providers expose the same model name.
+   */
+  model_selection?: unknown;
   column_config?: Array<{
     column_name: string;
     vectorize: boolean;
@@ -42,7 +48,7 @@ export const useCreateKnowledgeBase: useMutationFunctionType<
   CreateKnowledgeBaseRequest,
   KnowledgeBaseInfo
 > = (options?) => {
-  const { mutate, queryClient } = UseRequestProcessor();
+  const { mutate } = UseRequestProcessor();
 
   const createKnowledgeBaseFn = async (
     payload: CreateKnowledgeBaseRequest,

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
@@ -425,6 +425,7 @@ export function useKnowledgeBaseForm({
           name: kbName,
           embedding_provider: selectedModel.provider || "Unknown",
           embedding_model: selectedModel.id || selectedModel.name,
+          model_selection: selectedModel,
           column_config: columnConfig,
           backend_type: backendType,
           backend_config: backendConfig,


### PR DESCRIPTION
## Summary

Stacked on https://github.com/langflow-ai/langflow/pull/12802. This addresses the review gaps that were quick enough to harden before landing the larger Knowledge Bases DB connectors PR.

## Changes

- Validates `backend_type` against the registered vector-store enum before create-time side effects.
- Requires minimum backend config for non-Chroma stores (`database`/`collection`, `collection_name`, or `index_name` depending on backend).
- Persists the full frontend unified-model selection into both the KB DB record and legacy `embedding_metadata.json`, so retrieval can avoid provider/name drift.
- Sends `model_selection` from the KB creation drawer.
- Adds Pydantic bounds for connector and folder ingestion chunk parameters.
- Replaces mutable schema defaults with `Field(default_factory=...)`.
- Adds regression coverage for backend validation, model-selection persistence, and chunk bound rejection.

## Validation

- `uv run ruff check src/backend/base/langflow/schema/knowledge_base.py src/backend/base/langflow/api/v1/knowledge_bases.py src/backend/tests/unit/test_knowledge_bases_api.py src/backend/tests/unit/base/knowledge_bases/test_connector_endpoints.py`
- `npm run lint -- src/controllers/API/queries/knowledge-bases/use-create-knowledge-base.ts src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts`
- `uv run pytest src/backend/tests/unit/test_knowledge_bases_api.py src/backend/tests/unit/base/knowledge_bases/test_connector_endpoints.py -q` - 49 passed
