### PR TITLE
fix(kb): delete opensearch metadata matches

### DIFF
--- a/src/backend/tests/unit/base/knowledge_bases/test_vector_store_backends.py
+++ b/src/backend/tests/unit/base/knowledge_bases/test_vector_store_backends.py
@@ -654,6 +654,94 @@ class TestOpenSearchBackendBuild:
         await backend.teardown()
         client.close.assert_called_once()
 
+    async def test_build_forwards_vector_field_and_knn_options(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENSEARCH_URL", "https://demo:9200")
+
+        client = MagicMock(name="os_client")
+        store = MagicMock(name="os_vector_store")
+        os_ctor, wrapper_ctor = _install_opensearch_stubs(monkeypatch, client_instance=client, store_instance=store)
+
+        backend = OpenSearchBackend(
+            kb_name="kb",
+            kb_path=tmp_path,
+            backend_config={
+                "index_name": "kb_idx",
+                "vector_field": "embedding",
+                "text_field": "body",
+                "engine": "faiss",
+                "space_type": "cosinesimil",
+                "use_ssl": False,
+                "verify_certs": False,
+            },
+            embedding_function=MagicMock(),
+        )
+        await backend.ensure_ready()
+        built = backend._build_vector_store()
+
+        assert built is store
+        os_kwargs = os_ctor.call_args.kwargs
+        assert os_kwargs["use_ssl"] is False
+        assert os_kwargs["verify_certs"] is False
+
+        wrapper_kwargs = wrapper_ctor.call_args.kwargs
+        assert wrapper_kwargs["vector_field"] == "embedding"
+        assert wrapper_kwargs["text_field"] == "body"
+        assert wrapper_kwargs["engine"] == "faiss"
+        assert wrapper_kwargs["space_type"] == "cosinesimil"
+        assert wrapper_kwargs["use_ssl"] is False
+        assert wrapper_kwargs["verify_certs"] is False
+
+
+class TestOpenSearchDeleteBy:
+    async def test_delete_by_matches_top_level_or_nested_metadata(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENSEARCH_URL", "https://demo:9200")
+
+        client = MagicMock(name="os_client")
+        store = MagicMock(name="os_vector_store")
+        _install_opensearch_stubs(monkeypatch, client_instance=client, store_instance=store)
+
+        backend = OpenSearchBackend(
+            kb_name="kb",
+            kb_path=tmp_path,
+            backend_config={"index_name": "idx"},
+            embedding_function=MagicMock(),
+        )
+        await backend.ensure_ready()
+        _ = backend.vector_store
+
+        await backend.delete_by({"job_id": "job-123", "source_type": "folder"})
+
+        client.delete_by_query.assert_called_once()
+        kwargs = client.delete_by_query.call_args.kwargs
+        assert kwargs["index"] == "idx"
+        assert kwargs["refresh"] is True
+        assert kwargs["body"] == {
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "bool": {
+                                "should": [
+                                    {"match": {"job_id": "job-123"}},
+                                    {"match": {"metadata.job_id": "job-123"}},
+                                ],
+                                "minimum_should_match": 1,
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {"match": {"source_type": "folder"}},
+                                    {"match": {"metadata.source_type": "folder"}},
+                                ],
+                                "minimum_should_match": 1,
+                            }
+                        },
+                    ]
+                }
+            }
+        }
+
 
 class TestOpenSearchIterDocumentsCancellation:
     async def _build_backend_with_rows(self, tmp_path, monkeypatch, rows: list[dict]):

--- a/src/lfx/src/lfx/base/knowledge_bases/backends/opensearch.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/backends/opensearch.py
@@ -295,10 +295,10 @@ class OpenSearchBackend(BaseVectorStoreBackend):
     async def delete_by(self, where: dict[str, Any]) -> None:
         """Delete documents via ``delete_by_query``.
 
-        ``where`` is translated to a bool-must match query on top-level
-        ``_source`` fields. This mirrors what the Mongo backend does
-        with its filter dict — keeping the cross-backend surface simple
-        rather than exposing the full OpenSearch DSL.
+        ``where`` is translated to a bool-must query. LangChain's
+        OpenSearch adapter stores ``Document.metadata`` under the nested
+        ``metadata`` source key, while older/manual indexes may expose
+        metadata fields at top level, so each key matches either shape.
         """
         await self.ensure_ready()
         client = getattr(self, "_os_client", None)
@@ -307,7 +307,18 @@ class OpenSearchBackend(BaseVectorStoreBackend):
             client = self._os_client
         if not where:
             return
-        must = [{"match": {key: value}} for key, value in where.items()]
+        must = [
+            {
+                "bool": {
+                    "should": [
+                        {"match": {key: value}},
+                        {"match": {f"metadata.{key}": value}},
+                    ],
+                    "minimum_should_match": 1,
+                }
+            }
+            for key, value in where.items()
+        ]
         body = {"query": {"bool": {"must": must}}}
         try:
             await asyncio.to_thread(


### PR DESCRIPTION
Summary:
- Make OpenSearchBackend.delete_by match both top-level fields and LangChain's nested metadata.<key> shape.
- Add regression coverage for rollback-style metadata deletes.
- Add coverage that OpenSearch vector_field, text_field, k-NN engine, space_type, and TLS flags are forwarded to the raw client / LangChain wrapper.

Validation:
- uv run ruff check src/lfx/src/lfx/base/knowledge_bases/backends/opensearch.py src/backend/tests/unit/base/knowledge_bases/test_vector_store_backends.py
- uv run pytest src/backend/tests/unit/base/knowledge_bases/test_vector_store_backends.py -q