### PR TITLE
fix: pass Google embedding dimensions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -7795,7 +7795,7 @@
         "filename": "src/lfx/src/lfx/base/models/unified_models/model_catalog.py",
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
-        "line_number": 306
+        "line_number": 307
       }
     ],
     "src/lfx/src/lfx/cli/serve_app.py": [
@@ -8245,5 +8245,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-23T21:12:19Z"
+  "generated_at": "2026-04-24T19:11:48Z"
 }

--- a/src/backend/tests/unit/test_unified_models.py
+++ b/src/backend/tests/unit/test_unified_models.py
@@ -1,9 +1,10 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from lfx.base.models.unified_models import (
     _get_all_provider_mapped_fields,
     apply_provider_variable_config_to_build_config,
+    get_embedding_model_options,
     get_embeddings,
     get_unified_models_detailed,
     handle_model_input_update,
@@ -87,6 +88,22 @@ def test_filter_by_model_type_embeddings():
     assert models, "Expected at least one embedding model"
     for model in models:
         assert model["metadata"].get("model_type", "llm") == "embeddings"
+
+
+@patch("lfx.base.models.unified_models.model_catalog._fetch_enabled_providers_for_user", new_callable=AsyncMock)
+@patch("lfx.base.models.unified_models.model_catalog._get_model_status", new_callable=AsyncMock)
+def test_google_embedding_options_map_dimensions_to_output_dimensionality(mock_get_model_status, mock_fetch_providers):
+    mock_get_model_status.return_value = (set(), set())
+    mock_fetch_providers.return_value = {"Google Generative AI"}
+
+    options = get_embedding_model_options(user_id="test-user")
+
+    google_embedding = next(
+        option
+        for option in options
+        if option["provider"] == "Google Generative AI" and option["name"] == "models/gemini-embedding-001"
+    )
+    assert google_embedding["metadata"]["param_mapping"]["dimensions"] == "output_dimensionality"
 
 
 def test_update_model_options_with_custom_field_name():
@@ -484,7 +501,7 @@ def test_get_embeddings_optional_params_only_added_when_mapped(mock_get_class, m
 @patch("lfx.base.models.unified_models.get_api_key_for_provider")
 @patch("lfx.base.models.unified_models.get_embedding_class")
 def test_get_embeddings_google_timeout_wrapped_in_dict(mock_get_class, mock_get_api_key):
-    """For Google Generative AI, request_timeout should be wrapped as {'timeout': value}."""
+    """For Google Generative AI, request_timeout is wrapped and dimensions are passed through."""
     mock_get_api_key.return_value = "google-key"
     mock_embedding_class = MagicMock()
     mock_get_class.return_value = mock_embedding_class
@@ -497,14 +514,21 @@ def test_get_embeddings_google_timeout_wrapped_in_dict(mock_get_class, mock_get_
             "param_mapping": {
                 "model": "model",
                 "api_key": "google_api_key",  # pragma: allowlist secret
+                "dimensions": "output_dimensionality",
                 "request_timeout": "request_options",
             },
         },
     }
 
-    get_embeddings([google_model], api_key="google-key", request_timeout=30.0)  # pragma: allowlist secret
+    get_embeddings(
+        [google_model],
+        api_key="google-key",  # pragma: allowlist secret
+        dimensions=768,
+        request_timeout=30.0,
+    )
 
     kwargs = mock_embedding_class.call_args.kwargs
+    assert kwargs.get("output_dimensionality") == 768
     assert kwargs.get("request_options") == {"timeout": 30.0}
 
 

--- a/src/lfx/src/lfx/base/models/unified_models/model_catalog.py
+++ b/src/lfx/src/lfx/base/models/unified_models/model_catalog.py
@@ -290,6 +290,7 @@ def get_embedding_model_options(
         "Google Generative AI": {
             "model": "model",
             "api_key": "google_api_key",
+            "dimensions": "output_dimensionality",
             "request_timeout": "request_options",
             "model_kwargs": "client_options",
         },


### PR DESCRIPTION
## Summary

- Map the Embedding Model component's `dimensions` field to `output_dimensionality` for Google Generative AI embeddings.
- Add regression coverage for the Google embedding option metadata and constructor kwargs.
- Include the generated secrets baseline line-number update from pre-commit.

## Root Cause

`get_embedding_model_options` defines provider-specific parameter mappings used by embedding instantiation. The Google Generative AI mapping did not include `dimensions`, so the UI value was dropped before constructing `GoogleGenerativeAIEmbeddings`.

## Impact

Users selecting `models/gemini-embedding-001` can now set dimensions such as `768`, avoiding mismatches with existing vector store collections that were indexed at a non-default dimensionality.

Fixes #12824.

## Validation

- `uv run ruff check src/backend/tests/unit/test_unified_models.py src/lfx/src/lfx/base/models/unified_models/model_catalog.py`
- `uv run pytest src/backend/tests/unit/test_unified_models.py -q`