### PR TITLE
fix: guard output logs against non-dict artifacts

### DIFF
--- a/src/lfx/src/lfx/graph/schema.py
+++ b/src/lfx/src/lfx/graph/schema.py
@@ -41,6 +41,9 @@ class ResultData(BaseModel):
                 if message is None:
                     continue
 
+                if not isinstance(message, dict):
+                    continue
+
                 if "stream_url" in message and "type" in message:
                     stream_url = StreamURL(location=message["stream_url"])
                     values["outputs"].update({key: OutputValue(message=stream_url, type=message["type"])})

--- a/src/lfx/src/lfx/schema/schema.py
+++ b/src/lfx/src/lfx/schema/schema.py
@@ -110,7 +110,7 @@ def build_output_logs(vertex, result) -> dict:
         type_ = get_type(output_result)
 
         match type_:
-            case LogType.STREAM if "stream_url" in message:
+            case LogType.STREAM if isinstance(message, dict) and "stream_url" in message:
                 message = StreamURL(location=message["stream_url"])
 
             case LogType.STREAM:
@@ -123,9 +123,13 @@ def build_output_logs(vertex, result) -> dict:
                 message = ""
 
             case LogType.ARRAY:
-                if isinstance(message, DataFrame):
+                if message is None:
+                    message = []
+                elif isinstance(message, DataFrame):
                     message = message.to_dict(orient="records")
-                message = [serialize(item) for item in message]
+                    message = [serialize(item) for item in message]
+                else:
+                    message = [serialize(item) for item in message]
         name = output.get("name", f"output_{index}")
         outputs |= {name: OutputValue(message=message, type=type_).model_dump()}
 

--- a/src/lfx/tests/unit/graph/test_result_data.py
+++ b/src/lfx/tests/unit/graph/test_result_data.py
@@ -1,0 +1,13 @@
+import threading
+
+from lfx.graph.schema import ResultData
+
+
+def test_result_data_ignores_non_dict_artifact_values():
+    """Vector DB artifacts may include non-iterable objects such as locks."""
+    lock = threading.Lock()
+
+    result = ResultData(artifacts={"vector_db": lock})
+
+    assert result.artifacts == {"vector_db": lock}
+    assert result.outputs == {}


### PR DESCRIPTION
## Summary

- Cherry-picks `4e0b4e8191b5172917a841142bc520ab39ac574f` onto `release-1.10.0`.
- Guards `ResultData.validate_model()` against artifact values that are not dictionaries.
- Guards output log building so stream and array handling does not crash on unexpected artifact message shapes.
- Adds a dedicated regression test for a `threading.Lock` artifact value.

## Attribution

This fix was authored by @octo-patch. The cherry-picked fix commit preserves the original author metadata:

`octo-patch <octo-patch@github.com>`

The additional regression test was added separately so the original fix attribution remains intact.

## Root Cause

Some vector DB flows can store non-dict objects, such as `threading.Lock`, in artifact values. The output serialization path assumed artifact messages supported dictionary membership checks, which could raise `TypeError` when building result data or output logs.

## Impact

Loop/vector DB flows affected by issue #12591 should no longer fail while serializing outputs that include non-dict artifact values.

Fixes #12591.

## Validation

- `uv run ruff check src/lfx/src/lfx/graph/schema.py src/lfx/src/lfx/schema/schema.py`
- `uv run ruff check src/lfx/tests/unit/graph/test_result_data.py`
- `cd src/lfx && uv sync`
- `cd src/lfx && uv run pytest tests/unit/graph/test_token_usage_accumulation.py -q`
- `cd src/lfx && uv run pytest tests/unit/graph/test_result_data.py -q`
- `cd src/lfx && uv run python -c "from lfx.graph.schema import ResultData; from lfx.schema.schema import build_output_logs; ResultData(artifacts={'lock': object()}); print('schema smoke ok')"`

Note: `cd src/lfx && uv run pytest tests/unit/graph/test_token_usage_accumulation.py tests/unit/cli/test_script_loader.py -q` was also attempted, but `test_script_loader.py` could not collect because the isolated LFX environment did not include `typer`.