### PR TITLE
refactor(kb): migrate ingestion-source registry to AdapterRegistry

### DIFF
--- a/src/backend/tests/unit/base/knowledge_bases/ingestion_sources/test_registry_plugin_discovery.py
+++ b/src/backend/tests/unit/base/knowledge_bases/ingestion_sources/test_registry_plugin_discovery.py
@@ -1,0 +1,234 @@
+"""Plugin-discovery tests for the ingestion-source registry.
+
+Covers what the original hand-rolled registry couldn't do:
+
+* Third-party entry-point registration under ``lfx.ingestion_source.adapters``.
+* TOML config-file registration under ``[ingestion_source.adapters]`` in
+  ``lfx.toml`` (and the ``[tool.lfx.ingestion_source.adapters]`` fallback
+  in ``pyproject.toml``).
+
+Behavioral parity with the pre-AdapterRegistry registry is covered in
+``src/backend/tests/unit/base/knowledge_bases/ingestion_sources/`` — this
+module focuses on the new plugin surface.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from lfx.base.knowledge_bases.ingestion_sources import registry as ingestion_registry
+from lfx.base.knowledge_bases.ingestion_sources.base import (
+    IngestionItem,
+    IngestionItemContent,
+    KBIngestionSource,
+    SourceType,
+)
+from lfx.services.adapters import registry as adapter_registry_mod
+from lfx.services.adapters.schema import AdapterType
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class _StubSource(KBIngestionSource):
+    """Minimal KBIngestionSource stub for plugin-discovery tests."""
+
+    source_type = SourceType.FILE_UPLOAD  # placeholder; not used by tests
+    display_name = "Stub"
+    description = "Plugin-discovery stub"
+
+    async def list_items(self) -> AsyncIterator[IngestionItem]:  # pragma: no cover - unused
+        if False:
+            yield  # type: ignore[unreachable]
+
+    async def fetch_content(self, item: IngestionItem) -> IngestionItemContent:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def validate_config(self) -> None:  # pragma: no cover - unused
+        return None
+
+
+class _StubEntryPoint:
+    """importlib.metadata EntryPoint stand-in for monkeypatching."""
+
+    def __init__(self, name: str, obj: type):
+        self.name = name
+        self._obj = obj
+
+    def load(self):
+        return self._obj
+
+
+@pytest.fixture(autouse=True)
+async def _reset_registry(monkeypatch, tmp_path):
+    """Reset adapter-registry state per test + force lazy discovery to re-run.
+
+    The registry is a process-global singleton, and the ingestion-sources
+    module uses a separate ``is_discovered`` flag to avoid re-running
+    discovery on every lookup. ``_reset_registries`` clears both.
+
+    The built-ins (``FileUploadSource``, ``FolderSource``, …) register
+    via module-level side effects in
+    ``lfx.base.knowledge_bases.ingestion_sources.__init__``. That
+    ``import`` fires exactly once per process, so after a reset the
+    built-ins would stay missing and leak into sibling tests that
+    assume a populated registry. We reinstall them explicitly in the
+    fixture's teardown so the process-wide registry is restored to
+    its post-import state.
+    """
+    await adapter_registry_mod._reset_registries()
+
+    # ``_ensure_discovered`` routes config lookup through the settings
+    # service → config_dir path. Point that at ``tmp_path`` so TOML
+    # files laid down by tests are the ones the registry reads.
+    import lfx.base.knowledge_bases.ingestion_sources.registry as reg
+
+    monkeypatch.setattr(
+        reg,
+        "_ensure_discovered",
+        _make_ensure_discovered(tmp_path),
+    )
+    try:
+        yield
+    finally:
+        await adapter_registry_mod._reset_registries()
+        _reinstall_builtin_sources()
+
+
+def _reinstall_builtin_sources() -> None:
+    """Re-register the six built-in sources.
+
+    These normally register via module-level side effects in
+    ``lfx.base.knowledge_bases.ingestion_sources.__init__`` at import
+    time; after ``_reset_registries`` we reinstall them explicitly.
+    """
+    from lfx.base.knowledge_bases.ingestion_sources.file_upload import FileUploadSource
+    from lfx.base.knowledge_bases.ingestion_sources.folder import FolderSource
+    from lfx.base.knowledge_bases.ingestion_sources.google_drive import GoogleDriveSource
+    from lfx.base.knowledge_bases.ingestion_sources.onedrive import OneDriveSource
+    from lfx.base.knowledge_bases.ingestion_sources.s3 import S3Source
+    from lfx.base.knowledge_bases.ingestion_sources.sharepoint import SharePointSource
+
+    ingestion_registry.register_source(SourceType.FILE_UPLOAD, FileUploadSource)
+    ingestion_registry.register_source(SourceType.FOLDER, FolderSource)
+    ingestion_registry.register_source(SourceType.S3, S3Source)
+    ingestion_registry.register_source(SourceType.GOOGLE_DRIVE, GoogleDriveSource)
+    ingestion_registry.register_source(SourceType.ONEDRIVE, OneDriveSource)
+    ingestion_registry.register_source(SourceType.SHAREPOINT, SharePointSource)
+
+
+def _make_ensure_discovered(config_dir):
+    """Bind a fresh ``_ensure_discovered`` that uses ``config_dir`` directly.
+
+    The production implementation resolves the config dir through the
+    settings service; for tests we inject the tmp_path directly to
+    avoid standing up a full settings service just to read a TOML file.
+    """
+    import threading
+
+    from lfx.base.knowledge_bases.ingestion_sources import registry as reg
+
+    lock = threading.Lock()
+
+    def _impl() -> None:
+        registry = reg._registry()
+        if registry.is_discovered:
+            return
+        with lock:
+            if registry.is_discovered:
+                return
+            registry.discover(config_dir=config_dir)
+
+    return _impl
+
+
+# --------------------------------------------------------------------- #
+# Entry-point discovery                                                  #
+# --------------------------------------------------------------------- #
+
+
+def test_entry_point_registers_plugin_source(monkeypatch):
+    """Third-party entry points should appear in the registry on first lookup.
+
+    A package publishing an entry point under
+    ``lfx.ingestion_source.adapters`` should register lazily when
+    ``get_source_class`` is called for the first time.
+    """
+
+    def fake_entry_points(*, group: str):
+        if group == AdapterType.INGESTION_SOURCE.entry_point_group:
+            return [_StubEntryPoint("box", _StubSource)]
+        return []
+
+    monkeypatch.setattr("importlib.metadata.entry_points", fake_entry_points)
+
+    cls = ingestion_registry.get_source_class("box")
+    assert cls is _StubSource
+    assert "box" in ingestion_registry.registered_source_keys()
+
+
+def test_builtin_sources_are_not_shadowed_by_entry_points(monkeypatch):
+    """Entry-point registration must not overwrite built-in sources.
+
+    Entry-point discovery calls ``register_class(..., override=False)``,
+    so a third-party plugin reusing a built-in key cannot silently
+    replace the built-in implementation.
+    """
+    # Ensure the built-in is registered first (as it would be in
+    # production — modules self-register at import time).
+    from lfx.base.knowledge_bases.ingestion_sources.s3 import S3Source
+
+    ingestion_registry.register_source(SourceType.S3, S3Source)
+
+    def fake_entry_points(*, group: str):
+        if group == AdapterType.INGESTION_SOURCE.entry_point_group:
+            return [_StubEntryPoint("s3", _StubSource)]
+        return []
+
+    monkeypatch.setattr("importlib.metadata.entry_points", fake_entry_points)
+
+    assert ingestion_registry.get_source_class(SourceType.S3) is S3Source
+
+
+# --------------------------------------------------------------------- #
+# TOML discovery                                                         #
+# --------------------------------------------------------------------- #
+
+
+def test_lfx_toml_registers_plugin_source(tmp_path, monkeypatch):
+    """``lfx.toml`` entries register with ``override=True``.
+
+    ``[ingestion_source.adapters]`` in ``lfx.toml`` should register the
+    referenced class at higher priority than entry points (config files
+    are the highest-priority discovery source).
+    """
+    # Make the stub importable through an import path.
+    import sys
+    import types
+
+    fake_module = types.ModuleType("fake_plugin_pkg.ingestion")
+    fake_module._StubSource = _StubSource
+    sys.modules["fake_plugin_pkg.ingestion"] = fake_module
+
+    (tmp_path / "lfx.toml").write_text(
+        '[ingestion_source.adapters]\nnotion = "fake_plugin_pkg.ingestion:_StubSource"\n'
+    )
+
+    # No entry points — isolate the TOML path.
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda *, group: [])  # noqa: ARG005
+
+    cls = ingestion_registry.get_source_class("notion")
+    assert cls is _StubSource
+
+
+def test_unknown_plugin_key_raises_unknown_not_unregistered(monkeypatch):
+    """Typos surface as ``"Unknown ingestion source"`` not ``"not registered"``.
+
+    API routes rely on this split to distinguish user-supplied typos
+    (HTTP 400) from missing-import internal errors (HTTP 500). See
+    ``get_source_class`` for the split.
+    """
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda *, group: [])  # noqa: ARG005
+    with pytest.raises(ValueError, match="Unknown ingestion source"):
+        ingestion_registry.get_source_class("does-not-exist-anywhere")

--- a/src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/__init__.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/__init__.py
@@ -45,6 +45,7 @@ from lfx.base.knowledge_bases.ingestion_sources.registry import (
     create_source,
     get_source_class,
     register_source,
+    registered_source_keys,
     registered_sources,
 )
 from lfx.base.knowledge_bases.ingestion_sources.s3 import S3Source
@@ -78,5 +79,6 @@ __all__ = [
     "create_source",
     "get_source_class",
     "register_source",
+    "registered_source_keys",
     "registered_sources",
 ]

--- a/src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/registry.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/registry.py
@@ -1,55 +1,185 @@
-"""Ingestion-source registry — mirror of ``backends.registry`` for sources.
+"""Ingestion-source registry.
 
-Sources register themselves on import (see ``ingestion_sources/__init__.py``).
-Call sites use ``create_source`` so swapping or adding a source is a
-one-line change.
+Thin wrapper over :class:`lfx.services.adapters.registry.AdapterRegistry`
+that keeps the original ``register_source`` / ``create_source`` /
+``get_source_class`` / ``registered_sources`` public API while adding
+third-party plugin discovery.
+
+Third parties can ship an ingestion source in two new ways on top of
+the original in-tree registration:
+
+* **Entry point** under the ``lfx.ingestion_source.adapters`` group::
+
+      [project.entry-points."lfx.ingestion_source.adapters"]
+      box = "langflow_box.source:BoxSource"
+
+* **Config file** — ``lfx.toml`` (preferred) or ``pyproject.toml``::
+
+      [ingestion_source.adapters]
+      box = "langflow_box.source:BoxSource"
+
+Both paths resolve to the same registry as an import-time
+``register_source(...)`` call. Sources are instantiated per request
+(each call to ``create_source`` returns a fresh object) — we use the
+registry's ``get_class`` accessor and do not share singleton instances
+because each source carries request-scoped ``user_id`` + ``source_config``.
+
+The ``SourceType`` enum stays the source of truth for the built-in
+source identifiers so typos in call sites still fail at static
+analysis time. Third-party plugins may register under any string key —
+``create_source("box", ...)`` works whether or not ``box`` is in the
+enum.
 """
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any
 
 from lfx.base.knowledge_bases.ingestion_sources.base import KBIngestionSource, SourceType
+from lfx.services.adapters.registry import get_adapter_registry
+from lfx.services.adapters.schema import AdapterType
 
 if TYPE_CHECKING:
     from uuid import UUID
 
+    from lfx.services.adapters.registry import AdapterRegistry
 
-_SOURCE_REGISTRY: dict[SourceType, type[KBIngestionSource]] = {}
+
+_discovery_lock = threading.Lock()
 
 
-def register_source(source_type: SourceType, source_class: type[KBIngestionSource]) -> None:
+def _registry() -> AdapterRegistry[KBIngestionSource]:
+    """Return the singleton ``AdapterRegistry`` for ingestion sources."""
+    return get_adapter_registry(adapter_type=AdapterType.INGESTION_SOURCE)
+
+
+def _ensure_discovered() -> None:
+    """Run entry-point + config-file discovery exactly once.
+
+    Mirrors the pattern in :func:`lfx.services.deps.get_deployment_adapter`:
+    discovery is lazy so importing this module doesn't pay for TOML
+    parsing or entry-point enumeration until a source is actually
+    resolved.
+    """
+    registry = _registry()
+    if registry.is_discovered:
+        return
+    with _discovery_lock:
+        if registry.is_discovered:
+            return
+        # Import here to avoid a top-level dependency on settings when
+        # lfx is used as a plain library (e.g. from tests) — the
+        # deployment path does the same.
+        from lfx.services.config_discovery import resolve_config_dir
+        from lfx.services.deps import get_settings_service
+
+        config_dir = resolve_config_dir(None, settings_service=get_settings_service())
+        registry.discover(config_dir=config_dir)
+
+
+def register_source(source_type: SourceType | str, source_class: type[KBIngestionSource]) -> None:
     """Register ``source_class`` under ``source_type``.
 
-    Idempotent: re-registering the same class is a no-op; re-registering
-    a different class raises ``ValueError`` so accidental collisions
-    surface at import time rather than producing mysterious runtime
-    behavior.
+    Re-registering the same class under the same key is a no-op.
+    Re-registering a *different* class raises ``ValueError`` so
+    accidental collisions surface at import time rather than as
+    mysterious runtime behavior. ``AdapterRegistry.register_class`` is
+    otherwise permissive (override=True by default); the collision
+    check is added here to preserve the behavior of the original
+    hand-rolled registry.
     """
-    existing = _SOURCE_REGISTRY.get(source_type)
+    key = _resolve_key(source_type)
+    registry = _registry()
+    existing = registry.get_class(key)
     if existing is not None and existing is not source_class:
         msg = (
-            f"Ingestion source {source_type.value!r} is already registered to "
+            f"Ingestion source {key!r} is already registered to "
             f"{existing.__name__}; refusing to overwrite with {source_class.__name__}."
         )
         raise ValueError(msg)
-    _SOURCE_REGISTRY[source_type] = source_class
+    registry.register_class(key, source_class, override=True)
 
 
 def get_source_class(source_type: SourceType | str) -> type[KBIngestionSource]:
-    """Return the registered class for ``source_type`` or raise."""
-    resolved = _resolve_source_type(source_type)
+    """Return the registered class for ``source_type`` or raise.
+
+    Looks up the class only — instantiation happens in ``create_source``
+    so each call builds a fresh source with its own ``user_id`` and
+    ``source_config``. Triggers lazy discovery on first use.
+
+    Raises:
+        ValueError: With ``"Unknown ingestion source"`` when the input
+            is a string that is neither a built-in ``SourceType`` value
+            nor a registered plugin key (typo at the call site).
+            With ``"not registered"`` when the input is a known key
+            but no class is bound to it (built-in source not imported,
+            or plugin not yet discovered).
+    """
+    _ensure_discovered()
+    key = _resolve_key(source_type)
+    registry = _registry()
+    source_class = registry.get_class(key)
+    if source_class is not None:
+        return source_class
+
+    # Split the error message to preserve the contract of the original
+    # hand-rolled registry:
+    #   * unknown string (not a built-in enum AND not a plugin key) →
+    #     "Unknown ingestion source …" — surfaces config typos.
+    #   * known enum / plugin key without a bound class →
+    #     "Ingestion source … is not registered" — surfaces missing
+    #     import / failed plugin discovery.
+    if isinstance(source_type, str) and not _is_known_key(key, registry):
+        allowed = ", ".join(st.value for st in SourceType)
+        msg = f"Unknown ingestion source {key!r}. Expected one of: {allowed}."
+        raise ValueError(msg)
+
+    available = ", ".join(registry.list_keys())
+    msg = f"Ingestion source {key!r} is not registered. Registered sources: {available or '<none>'}."
+    raise ValueError(msg)
+
+
+def _is_known_key(key: str, registry: AdapterRegistry[KBIngestionSource]) -> bool:
+    """Return True if ``key`` is a built-in ``SourceType`` value or a registered plugin key."""
+    if key in registry.list_keys():
+        return True
     try:
-        return _SOURCE_REGISTRY[resolved]
-    except KeyError as exc:
-        available = ", ".join(sorted(st.value for st in _SOURCE_REGISTRY))
-        msg = f"Ingestion source {resolved.value!r} is not registered. Registered sources: {available or '<none>'}."
-        raise ValueError(msg) from exc
+        SourceType(key)
+    except ValueError:
+        return False
+    return True
 
 
 def registered_sources() -> tuple[SourceType, ...]:
-    """Tuple of registered source-type identifiers (stable ordering)."""
-    return tuple(sorted(_SOURCE_REGISTRY, key=lambda st: st.value))
+    """Tuple of registered ``SourceType`` identifiers (stable ordering).
+
+    Third-party plugins registering under keys not in the ``SourceType``
+    enum are *excluded* from this tuple — the return type is still
+    ``tuple[SourceType, ...]`` for backward compatibility with callers
+    that key UI pickers and switch statements off the enum. Use
+    ``registered_source_keys`` for the full list including plugins.
+    """
+    _ensure_discovered()
+    built_ins: list[SourceType] = []
+    for key in _registry().list_keys():
+        try:
+            built_ins.append(SourceType(key))
+        except ValueError:
+            # Third-party plugin using a key outside the built-in enum.
+            continue
+    return tuple(sorted(built_ins, key=lambda st: st.value))
+
+
+def registered_source_keys() -> tuple[str, ...]:
+    """All registered source keys including third-party plugin keys.
+
+    New API introduced with the AdapterRegistry migration. Call sites
+    that want to expose plugin sources in a picker (e.g. the connector
+    catalog endpoint) should prefer this over ``registered_sources``.
+    """
+    _ensure_discovered()
+    return tuple(_registry().list_keys())
 
 
 def create_source(
@@ -58,23 +188,25 @@ def create_source(
     user_id: UUID | str | None,
     source_config: dict[str, Any] | None = None,
 ) -> KBIngestionSource:
-    """Factory: build a source instance for ``source_type``.
+    """Factory: build a fresh source instance for ``source_type``.
 
-    Single entry point so call sites never import concrete source
-    classes directly. Keeps the source catalog open for Phase 3
-    connectors without touching ``perform_ingestion``.
+    Each call instantiates a new source — the registry does not cache
+    instances. Sources carry request-scoped state (``user_id``,
+    ``source_config``) so instance sharing would be incorrect.
     """
     source_class = get_source_class(source_type)
     return source_class(user_id=user_id, source_config=source_config or {})
 
 
-def _resolve_source_type(value: SourceType | str) -> SourceType:
-    """Coerce strings from config / API payloads into a ``SourceType``."""
+def _resolve_key(value: SourceType | str) -> str:
+    """Coerce an enum or string into the registry key.
+
+    Built-in callers pass ``SourceType.S3``; HTTP payloads pass the
+    string ``"s3"``. Unknown strings pass through unchanged so
+    third-party plugin keys are honoured. Validation against the
+    built-in enum still happens at API boundaries (see the
+    ``ConnectorIngestRequest`` schema).
+    """
     if isinstance(value, SourceType):
-        return value
-    try:
-        return SourceType(value)
-    except ValueError as exc:
-        allowed = ", ".join(st.value for st in SourceType)
-        msg = f"Unknown ingestion source {value!r}. Expected one of: {allowed}."
-        raise ValueError(msg) from exc
+        return value.value
+    return value

--- a/src/lfx/src/lfx/services/adapters/schema.py
+++ b/src/lfx/src/lfx/services/adapters/schema.py
@@ -13,6 +13,11 @@ class AdapterType(str, Enum):
     """
 
     DEPLOYMENT = "deployment"
+    # Knowledge Base ingestion sources (file upload, folder, S3,
+    # Google Drive, OneDrive, SharePoint, plus any third-party source
+    # published as an ``lfx.ingestion_source.adapters`` entry point or
+    # wired up through ``[ingestion_source.adapters]`` in ``lfx.toml``).
+    INGESTION_SOURCE = "ingestion_source"
 
     @property
     def entry_point_group(self) -> str:


### PR DESCRIPTION
## Summary

Stacked on top of [#12802](https://github.com/langflow-ai/langflow/pull/12802). Ports the hand-rolled ``ingestion_sources/registry.py`` onto the existing [``lfx.services.adapters.registry.AdapterRegistry``](../blob/main/src/lfx/src/lfx/services/adapters/registry.py) so third parties can publish ingestion sources as pip-installable plugins without modifying core.

Follow-up to the audit in [#12878](https://github.com/langflow-ai/langflow/pull/12878) — that PR mentioned the adapter-registry was the right landing pad for ingestion sources but out-of-scope for the consolidation work.

### Two new plugin surfaces

Plugin authors can register sources two ways on top of the in-tree ``register_source(SourceType.X, Y)`` call:

```toml
# lfx.toml  (or [tool.lfx.ingestion_source.adapters] in pyproject.toml)
[ingestion_source.adapters]
notion = "langflow_notion.source:NotionSource"
box = "langflow_box.source:BoxSource"
```

```toml
# pyproject.toml — entry point
[project.entry-points."lfx.ingestion_source.adapters"]
notion = "langflow_notion.source:NotionSource"
```

Both paths resolve to the same registry as an in-tree ``register_source`` call. Discovery runs lazily on first lookup.

### What stays the same

- ``SourceType`` enum remains the source of truth for built-in identifiers. ``ConnectorIngestRequest`` still validates HTTP payloads against it.
- Every existing caller (``register_source``, ``get_source_class``, ``create_source``, ``registered_sources``) keeps its contract. The six built-ins self-register at import time via [``ingestion_sources/__init__.py``](../blob/main/src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/__init__.py).
- ``create_source`` returns a fresh instance per call. Sources carry request-scoped ``user_id``/``source_config``, so ``AdapterRegistry.get_instance`` (which caches singletons) is bypassed in favour of ``get_class``.
- Collision semantics preserved: re-registering a different class under an existing key raises ``ValueError`` at import time.
- Error-message split preserved: unknown strings (call-site typo) → ``"Unknown ingestion source"``; known-but-unregistered → ``"not registered"``. API routes key HTTP 400 vs 500 off this.

### New public helper

``registered_source_keys()`` returns the full set of registered keys (built-ins **plus** third-party plugins) for callers that want plugins to show up in a picker. ``registered_sources()`` still returns only the built-in ``SourceType`` enum members for backward compatibility.

### Files

| File | Change |
|---|---|
| [``src/lfx/src/lfx/services/adapters/schema.py``](../blob/main/src/lfx/src/lfx/services/adapters/schema.py) | Add ``AdapterType.INGESTION_SOURCE`` |
| [``src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/registry.py``](../blob/main/src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/registry.py) | Rewrite on top of ``AdapterRegistry`` |
| [``src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/__init__.py``](../blob/main/src/lfx/src/lfx/base/knowledge_bases/ingestion_sources/__init__.py) | Export ``registered_source_keys`` |
| [``src/backend/tests/unit/base/knowledge_bases/ingestion_sources/test_registry_plugin_discovery.py``](../blob/main/src/backend/tests/unit/base/knowledge_bases/ingestion_sources/test_registry_plugin_discovery.py) | 4 new tests for plugin surface |

## Test plan

- [x] All 49 existing ingestion-source tests pass unmodified (behavior parity)
- [x] All 132 ``tests/unit/base/knowledge_bases/`` tests green after migration
- [x] 4 new tests cover:
   - Entry-point registration (``lfx.ingestion_source.adapters`` group)
   - ``lfx.toml`` registration (``[ingestion_source.adapters]`` section)
   - Built-ins not shadowed by entry points with conflicting keys
   - Unknown-vs-not-registered error-message split
- [x] ``ruff check`` clean across changed files
- [ ] CI
- [ ] Smoke: drop a ``lfx.toml`` with a dummy plugin source into the config dir, hit ``GET /knowledge_bases/connectors``, verify the plugin source appears in the catalog