### PR TITLE
fix(kb): unstick remote-backend deletes + hydrate stale embedding metadata

### DIFF
--- a/src/backend/base/langflow/api/v1/knowledge_bases.py
+++ b/src/backend/base/langflow/api/v1/knowledge_bases.py
@@ -143,8 +143,19 @@ def _check_memory_base_association(kb_name: str, current_user: CurrentActiveUser
     ``kb_name`` from the path parameter and ``current_user`` via its own
     dependency.  The list endpoint filters memory KBs inline using
     ``_is_memory_base_associated`` directly.
+
+    A missing local directory is NOT treated as a 404 here because the
+    delete route handles the orphan-DB-row case downstream. This dep
+    only blocks Memory-Base-managed KBs from being touched; an
+    orphan row can't have Memory-Base metadata because that metadata
+    lives in the on-disk ``embedding_metadata.json`` which is gone.
     """
-    kb_path = _resolve_kb_path(kb_name, current_user)
+    try:
+        kb_path = _resolve_kb_path(kb_name, current_user)
+    except HTTPException as exc:
+        if exc.status_code == HTTPStatus.NOT_FOUND:
+            return  # Let the route body handle the missing-dir case.
+        raise
 
     metadata = KBAnalysisHelper.get_metadata(kb_path, fast=True)
     if _is_memory_base_associated(metadata):
@@ -210,19 +221,97 @@ async def _resolve_backend_selection(
     )
 
 
+async def _cleanup_orphan_db_row(
+    *,
+    kb_name: str,
+    current_user: CurrentActiveUser,
+) -> tuple[bool, str | None]:
+    """Clean up a KB whose local directory is gone but whose DB row lingers.
+
+    The usual delete flow requires the KB directory to exist — but
+    remote-backed KBs (Astra / Mongo / Postgres / OpenSearch) store
+    their vectors off-box, and the on-disk sidecar can go missing if
+    the filesystem was cleaned out of band or creation failed partway
+    through. Before this helper, such a KB would keep showing up in
+    the UI list forever because the list endpoint reads the DB row
+    while the delete endpoint 404s on the missing path.
+
+    Returns ``(True, warning_or_None)`` when a row was found and
+    deleted, ``(False, None)`` when no row exists (truly not found).
+    The remote-backend cleanup is best-effort just like the normal
+    delete path.
+    """
+    record = await knowledge_base_service.get_by_user_and_name(current_user.id, kb_name)
+    if record is None:
+        return False, None
+
+    backend_type_value = record.backend_type or BackendType.CHROMA.value
+    backend_config = _coerce_backend_config(record.backend_config)
+
+    warning: str | None = None
+    if backend_type_value != BackendType.CHROMA.value:
+        backend = create_backend(
+            backend_type_value,
+            kb_name=kb_name,
+            kb_path=Path("/tmp"),  # noqa: S108 — unused; backend is remote-only
+            backend_config=backend_config,
+            user_id=current_user.id,
+        )
+        try:
+            await backend.ensure_ready()
+            await backend.delete_collection()
+        except Exception as exc:  # noqa: BLE001
+            await logger.aerror(
+                "Failed to delete remote backend resources for orphan KB %s (%s): %s",
+                kb_name,
+                backend_type_value,
+                exc,
+            )
+            warning = (
+                f"Remote {backend_type_value} resources for knowledge base "
+                f"'{kb_name}' could not be deleted ({exc}). The local record "
+                "has been removed; please clean up the remote collection manually."
+            )
+        finally:
+            await backend.teardown()
+
+    try:
+        await knowledge_base_service.delete_by_user_and_name(current_user.id, kb_name)
+    except Exception as exc:  # noqa: BLE001
+        await logger.awarning("KB DB delete lagged for orphan %s: %s", kb_name, exc)
+
+    return True, warning
+
+
 async def _delete_remote_backend_collection(
     *,
     kb_name: str,
     kb_path: Path,
     current_user: CurrentActiveUser,
-) -> None:
+) -> str | None:
+    """Delete the remote vector-store collection on a best-effort basis.
+
+    Returns a human-readable warning string when the remote cleanup
+    failed so the caller can surface it alongside the (successful)
+    local-storage + DB-row deletions; returns ``None`` on success or
+    when the backend is local-only (Chroma).
+
+    Rationale for best-effort: a stale Astra token / missing MongoDB
+    credential / network blip should not leave the user unable to
+    delete the KB from Langflow's UI at all. Before this, the backend
+    ``ensure_ready()`` failure would abort the whole delete flow and
+    the row plus on-disk metadata would stay indefinitely. Remote
+    resources that linger are surfaced to the user through the
+    response warning and a high-severity log line so they can be
+    cleaned up out-of-band.
+    """
     backend_type_value, backend_config = await _resolve_backend_selection(
         kb_name=kb_name,
         kb_path=kb_path,
         current_user=current_user,
     )
     if backend_type_value == BackendType.CHROMA.value:
-        return
+        return None
 
     backend = create_backend(
         backend_type_value,
@@ -234,22 +323,23 @@ async def _delete_remote_backend_collection(
     try:
         await backend.ensure_ready()
         await backend.delete_collection()
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         await logger.aerror(
-            "Failed to delete remote backend resources for %s (%s): %s",
+            "Failed to delete remote backend resources for %s (%s): %s — "
+            "proceeding with local cleanup; the remote collection may need "
+            "manual cleanup.",
             kb_name,
             backend_type_value,
             exc,
         )
-        raise HTTPException(
-            status_code=500,
-            detail=(
-                f"Failed to delete the remote {backend_type_value} resources for "
-                f"knowledge base '{kb_name}'. Please retry after checking the backend credentials."
-            ),
-        ) from exc
+        return (
+            f"Remote {backend_type_value} resources for knowledge base "
+            f"'{kb_name}' could not be deleted ({exc}). The local record "
+            "has been removed; please clean up the remote collection manually."
+        )
     finally:
         await backend.teardown()
+    return None
 
 
 @router.post("", status_code=HTTPStatus.CREATED)
@@ -1255,8 +1345,28 @@ def _run_row_to_info(row) -> IngestionRunInfo:
 async def delete_knowledge_base(kb_name: str, current_user: CurrentActiveUser) -> dict[str, str]:
     """Delete a specific knowledge base."""
     try:
-        kb_path = _resolve_kb_path(kb_name, current_user)
-        await _delete_remote_backend_collection(
+        try:
+            kb_path = _resolve_kb_path(kb_name, current_user)
+        except HTTPException as exc:
+            # The local directory is gone but a DB row may still be
+            # dangling (remote-backed KBs created without a sidecar,
+            # or a partially-cleaned-up delete from a prior attempt).
+            # Fall through to an orphan-row cleanup so the UI stops
+            # showing the KB.
+            if exc.status_code != HTTPStatus.NOT_FOUND:
+                raise
+            handled, orphan_warning = await _cleanup_orphan_db_row(
+                kb_name=kb_name,
+                current_user=current_user,
+            )
+            if not handled:
+                raise
+            response: dict[str, str] = {"message": f"Knowledge base '{kb_name}' deleted successfully"}
+            if orphan_warning:
+                response["warning"] = orphan_warning
+            return response
+
+        remote_warning = await _delete_remote_backend_collection(
             kb_name=kb_name,
             kb_path=kb_path,
             current_user=current_user,
@@ -1283,7 +1393,10 @@ async def delete_knowledge_base(kb_name: str, current_user: CurrentActiveUser) -
         await logger.aerror("Error deleting knowledge base '%s': %s", kb_name, e)
         raise HTTPException(status_code=500, detail="Error deleting knowledge base.") from e
     else:
-        return {"message": f"Knowledge base '{kb_name}' deleted successfully"}
+        response: dict[str, str] = {"message": f"Knowledge base '{kb_name}' deleted successfully"}
+        if remote_warning:
+            response["warning"] = remote_warning
+        return response
 
 
 @router.delete("", status_code=HTTPStatus.OK)
@@ -1294,22 +1407,39 @@ async def delete_knowledge_bases_bulk(request: BulkDeleteRequest, current_user: 
         deleted_count = 0
         not_found_kbs = []
         failed_kbs = []
+        remote_warnings: list[str] = []
 
         for kb_name in request.kb_names:
             try:
                 kb_path = _resolve_kb_path(kb_name, current_user)
             except HTTPException as exc:
                 if exc.status_code == HTTPStatus.NOT_FOUND:
-                    not_found_kbs.append(kb_name)
+                    # Try the orphan-row cleanup before declaring the
+                    # KB not found — a remote-backed KB (Astra /
+                    # Mongo / Postgres / OpenSearch) whose local dir
+                    # is missing must still be deletable so the UI
+                    # stops showing it.
+                    handled, orphan_warning = await _cleanup_orphan_db_row(
+                        kb_name=kb_name,
+                        current_user=current_user,
+                    )
+                    if handled:
+                        deleted_count += 1
+                        if orphan_warning:
+                            remote_warnings.append(orphan_warning)
+                    else:
+                        not_found_kbs.append(kb_name)
                     continue
                 raise  # Re-raise 403 (traversal) and 500 errors
 
             try:
-                await _delete_remote_backend_collection(
+                remote_warning = await _delete_remote_backend_collection(
                     kb_name=kb_name,
                     kb_path=kb_path,
                     current_user=current_user,
                 )
+                if remote_warning:
+                    remote_warnings.append(remote_warning)
                 if not KBStorageHelper.delete_storage(kb_path, kb_name):
                     failed_kbs.append(kb_name)
                     continue
@@ -1329,7 +1459,7 @@ async def delete_knowledge_bases_bulk(request: BulkDeleteRequest, current_user: 
                 status_code=404, detail="Knowledge bases not found: {}".format(", ".join(not_found_kbs))
             )
 
-        result = {
+        result: dict[str, object] = {
             "message": f"Successfully deleted {deleted_count} knowledge base(s)",
             "deleted_count": deleted_count,
         }
@@ -1338,6 +1468,8 @@ async def delete_knowledge_bases_bulk(request: BulkDeleteRequest, current_user: 
             result["not_found"] = ", ".join(not_found_kbs)
         if failed_kbs:
             result["failed"] = ", ".join(failed_kbs)
+        if remote_warnings:
+            result["warnings"] = remote_warnings
 
     except HTTPException:
         raise

--- a/src/backend/tests/unit/components/files_and_knowledge/test_retrieval.py
+++ b/src/backend/tests/unit/components/files_and_knowledge/test_retrieval.py
@@ -174,6 +174,86 @@ class TestKnowledgeBaseComponent(ComponentTestBaseWithClient):
             )
         assert resolved == [catalog_entry]
 
+    def test_resolve_model_selection_hydrates_missing_embedding_class_from_catalog(
+        self, component_class, default_kwargs
+    ):
+        """Partial model_selection must be completed from the unified-models catalog.
+
+        Regression: KBs created through older frontends or third-party API
+        clients sometimes persisted ``model_selection`` as just
+        ``{name, provider}`` with an empty or missing ``metadata`` block.
+        Retrieval would then fail with
+        ``"No embedding class defined in metadata for <model>"`` even
+        though the model is fully supported by the current runtime. The
+        fix looks the model up by name in the catalog and merges the
+        missing ``embedding_class`` / ``param_mapping`` entries.
+        """
+        component = component_class(**default_kwargs)
+        persisted = {"name": "text-embedding-3-small", "provider": "OpenAI", "metadata": {}}
+        catalog_entry = {
+            "name": "text-embedding-3-small",
+            "provider": "OpenAI",
+            "metadata": {
+                "embedding_class": "OpenAIEmbeddings",
+                "param_mapping": {"api_key": "<mapped_openai_key>", "model": "model"},
+            },
+        }
+        with patch(
+            "lfx.components.files_and_knowledge.retrieval.get_embedding_model_options",
+            return_value=[catalog_entry],
+        ):
+            resolved = component._resolve_model_selection({"model_selection": persisted})
+
+        assert len(resolved) == 1
+        resolved_metadata = resolved[0]["metadata"]
+        # Missing fields were hydrated from the catalog…
+        assert resolved_metadata["embedding_class"] == "OpenAIEmbeddings"
+        assert resolved_metadata["param_mapping"] == {
+            "api_key": "<mapped_openai_key>",
+            "model": "model",
+        }
+        # …and the persisted top-level fields stay intact.
+        assert resolved[0]["name"] == "text-embedding-3-small"
+        assert resolved[0]["provider"] == "OpenAI"
+
+    def test_resolve_model_selection_preserves_existing_metadata_over_catalog(self, component_class, default_kwargs):
+        """Persisted metadata wins on conflict — catalog only fills gaps.
+
+        Guards against silent drift for users who customised
+        ``param_mapping`` or chose a specific ``embedding_class`` per KB.
+        """
+        component = component_class(**default_kwargs)
+        persisted = {
+            "name": "text-embedding-3-small",
+            "provider": "OpenAI",
+            "metadata": {
+                "embedding_class": "CustomOpenAIEmbeddings",
+                "param_mapping": {"api_key": "<mapped_custom_key>"},
+            },
+        }
+        catalog_entry = {
+            "name": "text-embedding-3-small",
+            "provider": "OpenAI",
+            "metadata": {
+                "embedding_class": "OpenAIEmbeddings",
+                "param_mapping": {"api_key": "<mapped_openai_key>"},
+                "extra_flag": True,
+            },
+        }
+        with patch(
+            "lfx.components.files_and_knowledge.retrieval.get_embedding_model_options",
+            return_value=[catalog_entry],
+        ):
+            resolved = component._resolve_model_selection({"model_selection": persisted})
+
+        # Existing entries win (hydration fills gaps only). Both
+        # ``has_class`` and ``has_mapping`` are true on the persisted
+        # side, so ``_hydrate_model_metadata`` short-circuits without
+        # touching ``extra_flag`` either.
+        assert resolved[0]["metadata"]["embedding_class"] == "CustomOpenAIEmbeddings"
+        assert resolved[0]["metadata"]["param_mapping"] == {"api_key": "<mapped_custom_key>"}
+        assert "extra_flag" not in resolved[0]["metadata"]
+
     def test_resolve_model_selection_raises_when_legacy_model_unavailable(self, component_class, default_kwargs):
         component = component_class(**default_kwargs)
         with (

--- a/src/backend/tests/unit/test_knowledge_bases_api.py
+++ b/src/backend/tests/unit/test_knowledge_bases_api.py
@@ -607,6 +607,129 @@ class TestKnowledgeBaseAPI:
         mock_delete.assert_called_once()
 
     @patch("langflow.api.utils.kb_helpers.KBStorageHelper.delete_storage", return_value=True)
+    @patch("langflow.api.v1.knowledge_bases.create_backend")
+    @patch("langflow.api.v1.knowledge_bases.knowledge_base_service.get_by_user_and_name", new_callable=AsyncMock)
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
+    async def test_delete_knowledge_base_survives_remote_backend_auth_failure(
+        self,
+        mock_root,
+        mock_get_record,
+        mock_create_backend,
+        mock_delete,
+        client: AsyncClient,
+        logged_in_headers,
+        tmp_path,
+    ):
+        """Remote-backend cleanup failure must not block local delete.
+
+        Regression for the Astra delete bug: a missing/stale Astra
+        token used to raise ``ValueError`` from
+        ``backend.ensure_ready`` which propagated as HTTP 500. The KB
+        directory + DB row were never cleaned up and the UI showed
+        the entry indefinitely. The fix makes remote cleanup
+        best-effort and surfaces the failure as a ``warning`` field
+        alongside the successful local delete.
+        """
+        mock_root.return_value = tmp_path
+        (tmp_path / "activeuser" / "Stuck_Astra").mkdir(parents=True, exist_ok=True)
+        mock_get_record.return_value = MagicMock(
+            backend_type="astra",
+            backend_config={"collection_name": "stuck_astra"},
+        )
+        backend = MagicMock()
+        backend.ensure_ready = AsyncMock(
+            side_effect=ValueError("Required credential variable 'ASTRA_DB_APPLICATION_TOKEN' is not configured.")
+        )
+        backend.delete_collection = AsyncMock()
+        backend.teardown = AsyncMock()
+        mock_create_backend.return_value = backend
+
+        response = await client.delete("api/v1/knowledge_bases/Stuck_Astra", headers=logged_in_headers)
+
+        # Local cleanup still runs and succeeds.
+        assert response.status_code == 200
+        assert mock_delete.called
+        # Teardown runs even though ensure_ready threw.
+        backend.teardown.assert_awaited_once()
+        # delete_collection is skipped because ensure_ready raised.
+        backend.delete_collection.assert_not_awaited()
+        # Response carries a user-facing warning so the UI can tell
+        # the operator the remote resources need manual cleanup.
+        data = response.json()
+        assert "warning" in data
+        assert "astra" in data["warning"].lower()
+        assert "manual" in data["warning"].lower()
+
+    @patch("langflow.api.v1.knowledge_bases.create_backend")
+    @patch("langflow.api.v1.knowledge_bases.knowledge_base_service.delete_by_user_and_name", new_callable=AsyncMock)
+    @patch("langflow.api.v1.knowledge_bases.knowledge_base_service.get_by_user_and_name", new_callable=AsyncMock)
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
+    async def test_delete_knowledge_base_cleans_up_orphan_db_row(
+        self,
+        mock_root,
+        mock_get_record,
+        mock_delete_record,
+        mock_create_backend,
+        client: AsyncClient,
+        logged_in_headers,
+        tmp_path,
+    ):
+        """Dangling DB row must still be deletable even when kb_path is gone.
+
+        Regression for the Astra delete bug: remote-backed KBs whose
+        local ``embedding_metadata.json`` directory is missing (partial
+        creation failure, manual cleanup, legacy import) were 404ing on
+        delete because ``_resolve_kb_path`` requires the dir to exist.
+        The list endpoint, meanwhile, reads from the DB row and kept
+        showing the entry — so the UI was stuck.
+        """
+        mock_root.return_value = tmp_path
+        (tmp_path / "activeuser").mkdir(parents=True, exist_ok=True)
+        # The KB has a DB row but NO on-disk directory. This is the
+        # orphan case the test is regressing.
+        mock_get_record.return_value = MagicMock(
+            backend_type="astra",
+            backend_config={"collection_name": "orphan_astra"},
+        )
+        backend = MagicMock()
+        backend.ensure_ready = AsyncMock()
+        backend.delete_collection = AsyncMock()
+        backend.teardown = AsyncMock()
+        mock_create_backend.return_value = backend
+
+        response = await client.delete("api/v1/knowledge_bases/Orphan_KB", headers=logged_in_headers)
+
+        assert response.status_code == 200
+        # Remote collection + DB row both cleaned up.
+        backend.ensure_ready.assert_awaited_once()
+        backend.delete_collection.assert_awaited_once()
+        backend.teardown.assert_awaited_once()
+        mock_delete_record.assert_awaited_once()
+
+    @patch("langflow.api.v1.knowledge_bases.knowledge_base_service.get_by_user_and_name", new_callable=AsyncMock)
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
+    async def test_delete_knowledge_base_truly_missing_still_404s(
+        self,
+        mock_root,
+        mock_get_record,
+        client: AsyncClient,
+        logged_in_headers,
+        tmp_path,
+    ):
+        """No directory AND no DB row → still 404.
+
+        The orphan cleanup must not mask genuine not-found cases —
+        those should keep returning 404 so callers can distinguish a
+        typo from a dangling row.
+        """
+        mock_root.return_value = tmp_path
+        (tmp_path / "activeuser").mkdir(parents=True, exist_ok=True)
+        mock_get_record.return_value = None
+
+        response = await client.delete("api/v1/knowledge_bases/Nonexistent", headers=logged_in_headers)
+        assert response.status_code == 404
+
+    @patch("langflow.api.utils.kb_helpers.KBStorageHelper.delete_storage", return_value=True)
     @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
     async def test_bulk_delete_knowledge_bases(
         self, mock_root, mock_delete, client: AsyncClient, logged_in_headers, tmp_path

--- a/src/lfx/src/lfx/components/files_and_knowledge/retrieval.py
+++ b/src/lfx/src/lfx/components/files_and_knowledge/retrieval.py
@@ -177,15 +177,24 @@ class KnowledgeBaseComponent(Component):
         """Resolve the ``get_embeddings``-compatible model selection from metadata.
 
         New KBs persist the full ``model_selection`` dict at ingest
-        time so we can pass it straight through. Older KBs only
-        stored ``embedding_model`` / ``embedding_provider`` strings —
-        for those we look the model up in the current unified-models
-        catalog and fail loudly if it's no longer available (indicating
-        the KB needs to be re-created with a supported model).
+        time so we can pass it straight through. Older KBs — and KBs
+        whose persisted ``model_selection`` was serialized without the
+        nested ``metadata`` block (e.g. third-party API clients, or
+        older frontend builds that dropped unknown fields) — fall
+        through to the catalog lookup.
+
+        The catalog lookup is also used as a *hydration* step when
+        ``model_selection`` is present but missing
+        ``metadata.embedding_class`` / ``metadata.param_mapping``, which
+        ``get_embeddings`` needs to instantiate the provider SDK.
+        Without this hydration the retrieval would fail with
+        ``No embedding class defined in metadata for <model>`` even
+        though the model is fully supported by the current runtime.
         """
         model_selection = metadata.get("model_selection")
         if model_selection:
-            return [model_selection] if isinstance(model_selection, dict) else model_selection
+            selection_list = [model_selection] if isinstance(model_selection, dict) else list(model_selection)
+            return [self._hydrate_model_metadata(entry) for entry in selection_list]
 
         embedding_model_name = metadata.get("embedding_model")
         embedding_provider = metadata.get("embedding_provider", "Unknown")
@@ -196,8 +205,7 @@ class KnowledgeBaseComponent(Component):
             )
             raise ValueError(msg)
 
-        options = get_embedding_model_options(user_id=self.user_id)
-        match = next((o for o in options if o.get("name") == embedding_model_name), None)
+        match = self._find_catalog_entry(embedding_model_name)
         if match is None:
             msg = (
                 f"Embedding model '{embedding_model_name}' (provider '{embedding_provider}') "
@@ -206,6 +214,36 @@ class KnowledgeBaseComponent(Component):
             )
             raise ValueError(msg)
         return [match]
+
+    def _hydrate_model_metadata(self, entry: dict[str, Any]) -> dict[str, Any]:
+        """Fill in ``metadata.embedding_class`` / ``param_mapping`` if missing.
+
+        Preserves existing keys — the catalog is only used to fill
+        gaps. Returns a shallow copy so the persisted metadata on disk
+        is not mutated in place.
+        """
+        entry_metadata = entry.get("metadata") or {}
+        has_class = bool(entry_metadata.get("embedding_class"))
+        has_mapping = bool(entry_metadata.get("param_mapping"))
+        if has_class and has_mapping:
+            return entry
+
+        model_name = entry.get("name")
+        if not model_name:
+            return entry
+
+        catalog_entry = self._find_catalog_entry(model_name)
+        if catalog_entry is None:
+            return entry
+
+        catalog_metadata = catalog_entry.get("metadata") or {}
+        merged_metadata = {**catalog_metadata, **entry_metadata}
+        return {**entry, "metadata": merged_metadata}
+
+    def _find_catalog_entry(self, model_name: str) -> dict[str, Any] | None:
+        """Look up an embedding model by name in the unified-models catalog."""
+        options = get_embedding_model_options(user_id=self.user_id)
+        return next((o for o in options if o.get("name") == model_name), None)
 
     async def retrieve_data(self) -> DataFrame:
         """Retrieve data from the selected knowledge base.


### PR DESCRIPTION
## Summary

Two user-reported bugs in the KB infrastructure stack that made Astra-backed KBs unusable.

### Bug 1 — Astra (and any remote-backed) KB delete got stuck

``DELETE /knowledge_bases/{name}`` went through two failure modes that both left the KB visible in the UI indefinitely:

1. **Missing on-disk sidecar → 404 before cleanup runs.** ``_resolve_kb_path`` requires the directory to exist. Remote-backed KBs whose directory was missing (partial creation failure, manual cleanup, legacy import) 404'd before any cleanup ran. The list endpoint reads the DB row, so the KB kept appearing with no way to remove it.
2. **Backend auth failure → 500, local state never cleaned up.** ``_delete_remote_backend_collection`` calls ``backend.ensure_ready``. A missing/stale ``ASTRA_DB_APPLICATION_TOKEN`` raised ``ValueError`` that propagated as HTTP 500 and aborted the whole delete — local storage and DB row both stayed behind.

**Fixes:**
- **Best-effort remote cleanup.** Remote-backend cleanup failures now surface as a ``warning`` field on the response and an error-level log line; local storage + DB row still get cleaned up so the UI stops showing the KB.
- **Orphan-DB-row fallback.** When the local directory is missing but a DB row exists, the new ``_cleanup_orphan_db_row`` helper uses the row to drive remote cleanup and then deletes the row. ``_check_memory_base_association`` had to be relaxed to allow 404-on-path cases through (Memory-Base-managed KBs always have their metadata file, so a missing path can't be Memory-Base-associated).
- **Single-delete and bulk-delete both route through the new helper.** Genuine not-found cases (no directory AND no DB row) still return 404 — the orphan cleanup does not mask typos.

### Bug 2 — "No embedding class defined in metadata for text-embedding-3-small"

Retrieval failed when ``model_selection.metadata`` was persisted without ``embedding_class`` / ``param_mapping`` — the unified-models layer raises because it can't resolve the provider SDK class. This hits KBs created through older frontends or third-party API clients that drop unknown fields from the model object, leaving only ``{name, provider}`` under ``model_selection``.

**Fix:** [``_resolve_model_selection``](src/lfx/src/lfx/components/files_and_knowledge/retrieval.py) now hydrates the saved selection from the current unified-models catalog when ``metadata.embedding_class`` or ``metadata.param_mapping`` is missing. Persisted entries always win on conflict — the catalog only fills gaps — so custom ``param_mapping`` overrides stay intact.

## Test plan

- [x] ``test_delete_knowledge_base_survives_remote_backend_auth_failure`` — Astra auth error → local delete still runs, response carries a warning
- [x] ``test_delete_knowledge_base_cleans_up_orphan_db_row`` — missing local dir + existing DB row → both cleaned up
- [x] ``test_delete_knowledge_base_truly_missing_still_404s`` — no dir AND no DB row → 404 preserved
- [x] ``test_resolve_model_selection_hydrates_missing_embedding_class_from_catalog`` — partial ``model_selection`` → hydrated from catalog
- [x] ``test_resolve_model_selection_preserves_existing_metadata_over_catalog`` — persisted metadata wins on conflict
- [x] All 198 KB + retrieval unit tests pass locally; ``ruff check`` clean
- [ ] CI green
- [ ] Manual smoke: delete an Astra KB without the env var set — row disappears from UI, warning surfaces in response, local sidecar removed
- [ ] Manual smoke: re-create the user's broken Astra KB and verify retrieval returns results without the "No embedding class" error