### PR TITLE
fix(logging): route loguru component logs through Langflow sinks

### DIFF
--- a/src/backend/tests/unit/test_logger.py
+++ b/src/backend/tests/unit/test_logger.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import structlog
+from loguru import logger as loguru_logger
 from lfx.log.logger import (
     LOG_LEVEL_MAP,
     VALID_LOG_LEVELS,
@@ -100,6 +101,27 @@ class TestConfigure:
             if log_file_path.exists():
                 log_file_path.unlink()
             # Remove any file handlers from root logger
+            for handler in logging.root.handlers[:]:
+                if isinstance(handler, logging.handlers.RotatingFileHandler):
+                    logging.root.removeHandler(handler)
+
+    def test_configure_routes_loguru_messages_to_log_file(self):
+        """Test raw loguru logger messages are captured by Langflow file logging."""
+        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+            log_file_path = Path(tmp_file.name)
+
+        try:
+            configure(log_level="INFO", log_file=log_file_path)
+            loguru_logger.info("Test message from loguru")
+
+            for handler in logging.root.handlers:
+                if isinstance(handler, logging.handlers.RotatingFileHandler):
+                    handler.flush()
+
+            assert "Test message from loguru" in log_file_path.read_text()
+        finally:
+            if log_file_path.exists():
+                log_file_path.unlink()
             for handler in logging.root.handlers[:]:
                 if isinstance(handler, logging.handlers.RotatingFileHandler):
                     logging.root.removeHandler(handler)

--- a/src/backend/tests/unit/test_logger.py
+++ b/src/backend/tests/unit/test_logger.py
@@ -20,7 +20,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 import structlog
-from loguru import logger as loguru_logger
 from lfx.log.logger import (
     LOG_LEVEL_MAP,
     VALID_LOG_LEVELS,
@@ -34,6 +33,7 @@ from lfx.log.logger import (
     setup_gunicorn_logger,
     setup_uvicorn_logger,
 )
+from loguru import logger as loguru_logger
 
 
 class TestConfigure:

--- a/src/lfx/src/lfx/log/logger.py
+++ b/src/lfx/src/lfx/log/logger.py
@@ -13,6 +13,7 @@ from typing import Any, TypedDict
 
 import orjson
 import structlog
+from loguru import logger as loguru_logger
 from platformdirs import user_cache_dir
 from typing_extensions import NotRequired
 
@@ -202,6 +203,29 @@ class LogConfig(TypedDict):
     log_format: NotRequired[str]
 
 
+def _forward_loguru_message(message: Any) -> None:
+    """Route raw loguru messages through structlog.
+
+    Custom components and some backend modules still import ``loguru.logger`` directly.
+    Forwarding those records through structlog keeps stdout/file logging behavior aligned
+    with ``lfx.log.logger.configure()``.
+    """
+    record = message.record
+    structlog_logger = structlog.get_logger(record["name"] or "loguru")
+    log_method = getattr(structlog_logger, record["level"].name.lower(), structlog_logger.info)
+    exception = record.get("exception")
+    if exception is not None:
+        log_method(record["message"], exception=exception)
+    else:
+        log_method(record["message"])
+
+
+def _configure_loguru_logger(numeric_level: int) -> None:
+    """Keep the global loguru logger wired into Langflow's logging pipeline."""
+    loguru_logger.remove()
+    loguru_logger.add(_forward_loguru_message, level=numeric_level)
+
+
 def configure(
     *,
     log_level: str | None = None,
@@ -349,6 +373,8 @@ def configure(
         logging.root.addHandler(file_handler)
         logging.root.setLevel(numeric_level)
 
+    _configure_loguru_logger(numeric_level)
+
     # Set up interceptors for uvicorn and gunicorn
     setup_uvicorn_logger()
     setup_gunicorn_logger()
@@ -362,6 +388,7 @@ def configure(
         structlog.configure(
             wrapper_class=structlog.make_filtering_bound_logger(logging.CRITICAL),
         )
+        _configure_loguru_logger(logging.CRITICAL)
 
     logger.debug("Logger set up with log level: %s", log_level)
 


### PR DESCRIPTION
Custom components importing `from loguru import logger` were bypassing Langflow's configured sinks, so their messages never reached `LANGFLOW_LOG_FILE`.

This wires the shared loguru logger back through the structlog pipeline and adds a regression test covering the file logging path.
Verified with a direct reproduction script that now writes both `lfx.log.logger` output and raw loguru output into the same log file.

Fixes #12805