### PR TITLE
feat: disable frontend retries for client errors

### DIFF
--- a/src/frontend/src/controllers/API/queries/deployment-provider-accounts/use-delete-provider-account.ts
+++ b/src/frontend/src/controllers/API/queries/deployment-provider-accounts/use-delete-provider-account.ts
@@ -19,10 +19,8 @@ export const useDeleteProviderAccount: useMutationFunctionType<
     );
   };
 
-  // TODO: Add retries for transient server-side errors (5xx, timeouts).
   return mutate(["useDeleteProviderAccount"], fn, {
     ...options,
-    retry: false,
     onSuccess: (...args) => {
       queryClient.refetchQueries({ queryKey: ["useGetProviderAccounts"] });
       options?.onSuccess?.(...args);

--- a/src/frontend/src/controllers/API/queries/deployments/use-delete-deployment.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-delete-deployment.ts
@@ -17,10 +17,8 @@ export const useDeleteDeployment: useMutationFunctionType<
     await api.delete(`${getURL("DEPLOYMENTS")}/${deployment_id}`);
   };
 
-  // TODO: Add retries for transient server-side errors (5xx, timeouts).
   return mutate(["useDeleteDeployment"], fn, {
     ...options,
-    retry: false,
     onSuccess: (...args) => {
       queryClient.refetchQueries({ queryKey: ["useGetDeployments"] });
       options?.onSuccess?.(...args);

--- a/src/frontend/src/controllers/API/queries/deployments/use-patch-deployment.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-patch-deployment.ts
@@ -50,10 +50,8 @@ export const usePatchDeployment: useMutationFunctionType<
     return res.data;
   };
 
-  // TODO: Add retries for transient server-side errors (5xx, timeouts).
   return mutate(["usePatchDeployment"], fn, {
     ...options,
-    retry: false,
     onSuccess: (...args) => {
       queryClient.refetchQueries({ queryKey: ["useGetDeployments"] });
       queryClient.removeQueries({

--- a/src/frontend/src/controllers/API/queries/deployments/use-patch-snapshot.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-patch-snapshot.ts
@@ -26,10 +26,8 @@ export const usePatchSnapshot: useMutationFunctionType<
     return data;
   };
 
-  // TODO: Add retries for transient server-side errors (5xx, timeouts).
   return mutate(["usePatchSnapshot"], fn, {
     ...options,
-    retry: false,
     onSuccess: (...args) => {
       queryClient.refetchQueries({ queryKey: ["useGetDeployments"] });
       options?.onSuccess?.(...args);

--- a/src/frontend/src/controllers/API/queries/deployments/use-post-deployment-run.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-post-deployment-run.ts
@@ -47,6 +47,5 @@ export const usePostDeploymentRun: useMutationFunctionType<
     return res.data;
   };
 
-  // TODO: Add retries for transient server-side errors (5xx, timeouts).
-  return mutate(["usePostDeploymentRun"], fn, { ...options, retry: false });
+  return mutate(["usePostDeploymentRun"], fn, options);
 };

--- a/src/frontend/src/controllers/API/queries/deployments/use-post-deployment.ts
+++ b/src/frontend/src/controllers/API/queries/deployments/use-post-deployment.ts
@@ -53,10 +53,8 @@ export const usePostDeployment: useMutationFunctionType<
     return res.data;
   };
 
-  // TODO: Add retries for transient server-side errors (5xx, timeouts).
   return mutate(["usePostDeployment"], fn, {
     ...options,
-    retry: false,
     onSuccess: () => {
       return queryClient.refetchQueries({ queryKey: ["useGetDeployments"] });
     },

--- a/src/frontend/src/controllers/API/services/__tests__/request-processor.test.ts
+++ b/src/frontend/src/controllers/API/services/__tests__/request-processor.test.ts
@@ -1,0 +1,164 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test mocks
+const mockQueryClient = {
+  invalidateQueries: jest.fn(),
+};
+
+let capturedQueryOptions: any = null;
+let capturedMutationOptions: any = null;
+
+jest.mock("@tanstack/react-query", () => ({
+  useQueryClient: jest.fn(() => mockQueryClient),
+  useQuery: jest.fn((options: any) => {
+    capturedQueryOptions = options;
+    return { data: undefined, isLoading: false };
+  }),
+  useMutation: jest.fn((options: any) => {
+    capturedMutationOptions = options;
+    return { mutate: jest.fn(), mutateAsync: jest.fn() };
+  }),
+}));
+
+import { UseRequestProcessor } from "../request-processor";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const axiosError = (status: number) => ({ response: { status } });
+const networkError = () => new Error("Network Error"); // no `.response`
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  capturedQueryOptions = null;
+  capturedMutationOptions = null;
+});
+
+// ---------------------------------------------------------------------------
+// Queries: retry policy
+// ---------------------------------------------------------------------------
+
+describe("UseRequestProcessor.query retry policy", () => {
+  const setup = (options: any = {}) => {
+    const { query } = UseRequestProcessor();
+    query(["k"], async () => ({}), options);
+    return capturedQueryOptions;
+  };
+
+  it("does not retry on any 4xx response", () => {
+    const { retry } = setup();
+    for (const status of [400, 401, 403, 404, 409, 422, 429, 499]) {
+      expect(retry(0, axiosError(status))).toBe(false);
+    }
+  });
+
+  it("retries up to 5 times on 5xx responses", () => {
+    const { retry } = setup();
+    for (const status of [500, 502, 503, 504]) {
+      expect(retry(0, axiosError(status))).toBe(true);
+      expect(retry(4, axiosError(status))).toBe(true);
+      expect(retry(5, axiosError(status))).toBe(false);
+    }
+  });
+
+  it("retries up to 5 times on network errors with no response", () => {
+    const { retry } = setup();
+    expect(retry(0, networkError())).toBe(true);
+    expect(retry(4, networkError())).toBe(true);
+    expect(retry(5, networkError())).toBe(false);
+  });
+
+  it("treats non-numeric / missing status as transient (retries)", () => {
+    const { retry } = setup();
+    expect(retry(0, undefined)).toBe(true);
+    expect(retry(0, {})).toBe(true);
+    expect(retry(0, { response: {} })).toBe(true);
+  });
+
+  it("allows per-call options.retry to override the default", () => {
+    const { retry } = setup({ retry: false });
+    expect(retry).toBe(false);
+  });
+
+  it("allows per-call options.retry as a number to override the default", () => {
+    const { retry } = setup({ retry: 10 });
+    expect(retry).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mutations: retry policy
+// ---------------------------------------------------------------------------
+
+describe("UseRequestProcessor.mutate retry policy", () => {
+  const setup = (options: any = {}) => {
+    const { mutate } = UseRequestProcessor();
+    mutate(["k"], async () => ({}), options);
+    return capturedMutationOptions;
+  };
+
+  it("does not retry on any 4xx response", () => {
+    const { retry } = setup();
+    for (const status of [400, 401, 403, 404, 409, 422, 429, 499]) {
+      expect(retry(0, axiosError(status))).toBe(false);
+    }
+  });
+
+  it("retries up to 3 times on 5xx responses", () => {
+    const { retry } = setup();
+    expect(retry(0, axiosError(500))).toBe(true);
+    expect(retry(2, axiosError(500))).toBe(true);
+    expect(retry(3, axiosError(500))).toBe(false);
+  });
+
+  it("retries up to 3 times on network errors", () => {
+    const { retry } = setup();
+    expect(retry(0, networkError())).toBe(true);
+    expect(retry(2, networkError())).toBe(true);
+    expect(retry(3, networkError())).toBe(false);
+  });
+
+  it("respects options.retry === false", () => {
+    const { retry } = setup({ retry: false });
+    expect(retry).toBe(false);
+  });
+
+  it("respects options.retry === 0 (nullish coalescing, not falsy)", () => {
+    const { retry } = setup({ retry: 0 });
+    expect(retry).toBe(0);
+  });
+
+  it("respects a custom options.retry callback", () => {
+    const customRetry = jest.fn(() => true);
+    const { retry } = setup({ retry: customRetry });
+    expect(retry).toBe(customRetry);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// retryDelay: exponential backoff capped at 30s
+// ---------------------------------------------------------------------------
+
+describe("UseRequestProcessor retryDelay", () => {
+  it("uses exponential backoff capped at 30s for queries", () => {
+    const { query } = UseRequestProcessor();
+    query(["k"], async () => ({}));
+    const { retryDelay } = capturedQueryOptions;
+    expect(retryDelay(0)).toBe(1000);
+    expect(retryDelay(1)).toBe(2000);
+    expect(retryDelay(2)).toBe(4000);
+    expect(retryDelay(3)).toBe(8000);
+    expect(retryDelay(4)).toBe(16000);
+    expect(retryDelay(5)).toBe(30000);
+    expect(retryDelay(10)).toBe(30000);
+  });
+
+  it("uses exponential backoff capped at 30s for mutations", () => {
+    const { mutate } = UseRequestProcessor();
+    mutate(["k"], async () => ({}));
+    const { retryDelay } = capturedMutationOptions;
+    expect(retryDelay(0)).toBe(1000);
+    expect(retryDelay(1)).toBe(2000);
+    expect(retryDelay(2)).toBe(4000);
+    expect(retryDelay(10)).toBe(30000);
+  });
+});

--- a/src/frontend/src/controllers/API/services/__tests__/request-processor.test.ts
+++ b/src/frontend/src/controllers/API/services/__tests__/request-processor.test.ts
@@ -3,17 +3,17 @@ const mockQueryClient = {
   invalidateQueries: jest.fn(),
 };
 
-let capturedQueryOptions: any = null;
-let capturedMutationOptions: any = null;
+let mockCapturedQueryOptions: any = null;
+let mockCapturedMutationOptions: any = null;
 
 jest.mock("@tanstack/react-query", () => ({
   useQueryClient: jest.fn(() => mockQueryClient),
   useQuery: jest.fn((options: any) => {
-    capturedQueryOptions = options;
+    mockCapturedQueryOptions = options;
     return { data: undefined, isLoading: false };
   }),
   useMutation: jest.fn((options: any) => {
-    capturedMutationOptions = options;
+    mockCapturedMutationOptions = options;
     return { mutate: jest.fn(), mutateAsync: jest.fn() };
   }),
 }));
@@ -24,13 +24,19 @@ import { UseRequestProcessor } from "../request-processor";
 // Helpers
 // ---------------------------------------------------------------------------
 
-const axiosError = (status: number) => ({ response: { status } });
-const networkError = () => new Error("Network Error"); // no `.response`
+// `axios.isAxiosError` checks `error.isAxiosError === true`, so fixtures must
+// set that flag to be classified as HTTP errors rather than transient.
+const axiosError = (status: number) => ({
+  isAxiosError: true,
+  response: { status },
+});
+const axiosNetworkError = () => ({ isAxiosError: true, response: undefined });
+const nonAxiosError = () => new Error("Network Error");
 
 beforeEach(() => {
   jest.clearAllMocks();
-  capturedQueryOptions = null;
-  capturedMutationOptions = null;
+  mockCapturedQueryOptions = null;
+  mockCapturedMutationOptions = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -41,7 +47,10 @@ describe("UseRequestProcessor.query retry policy", () => {
   const setup = (options: any = {}) => {
     const { query } = UseRequestProcessor();
     query(["k"], async () => ({}), options);
-    return capturedQueryOptions;
+    if (mockCapturedQueryOptions == null) {
+      throw new Error("query was not called by UseRequestProcessor");
+    }
+    return mockCapturedQueryOptions;
   };
 
   it("does not retry on any 4xx response", () => {
@@ -60,18 +69,19 @@ describe("UseRequestProcessor.query retry policy", () => {
     }
   });
 
-  it("retries up to 5 times on network errors with no response", () => {
+  it("retries up to 5 times on axios errors with no response", () => {
     const { retry } = setup();
-    expect(retry(0, networkError())).toBe(true);
-    expect(retry(4, networkError())).toBe(true);
-    expect(retry(5, networkError())).toBe(false);
+    expect(retry(0, axiosNetworkError())).toBe(true);
+    expect(retry(4, axiosNetworkError())).toBe(true);
+    expect(retry(5, axiosNetworkError())).toBe(false);
   });
 
-  it("treats non-numeric / missing status as transient (retries)", () => {
+  it("treats non-axios / unknown errors as transient (retries)", () => {
     const { retry } = setup();
     expect(retry(0, undefined)).toBe(true);
     expect(retry(0, {})).toBe(true);
     expect(retry(0, { response: {} })).toBe(true);
+    expect(retry(0, nonAxiosError())).toBe(true);
   });
 
   it("allows per-call options.retry to override the default", () => {
@@ -83,6 +93,12 @@ describe("UseRequestProcessor.query retry policy", () => {
     const { retry } = setup({ retry: 10 });
     expect(retry).toBe(10);
   });
+
+  it("allows per-call options.retryDelay to override the default", () => {
+    const customDelay = jest.fn(() => 42);
+    const { retryDelay } = setup({ retryDelay: customDelay });
+    expect(retryDelay).toBe(customDelay);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -93,7 +109,10 @@ describe("UseRequestProcessor.mutate retry policy", () => {
   const setup = (options: any = {}) => {
     const { mutate } = UseRequestProcessor();
     mutate(["k"], async () => ({}), options);
-    return capturedMutationOptions;
+    if (mockCapturedMutationOptions == null) {
+      throw new Error("mutate was not called by UseRequestProcessor");
+    }
+    return mockCapturedMutationOptions;
   };
 
   it("does not retry on any 4xx response", () => {
@@ -110,11 +129,11 @@ describe("UseRequestProcessor.mutate retry policy", () => {
     expect(retry(3, axiosError(500))).toBe(false);
   });
 
-  it("retries up to 3 times on network errors", () => {
+  it("retries up to 3 times on axios errors with no response", () => {
     const { retry } = setup();
-    expect(retry(0, networkError())).toBe(true);
-    expect(retry(2, networkError())).toBe(true);
-    expect(retry(3, networkError())).toBe(false);
+    expect(retry(0, axiosNetworkError())).toBe(true);
+    expect(retry(2, axiosNetworkError())).toBe(true);
+    expect(retry(3, axiosNetworkError())).toBe(false);
   });
 
   it("respects options.retry === false", () => {
@@ -132,6 +151,12 @@ describe("UseRequestProcessor.mutate retry policy", () => {
     const { retry } = setup({ retry: customRetry });
     expect(retry).toBe(customRetry);
   });
+
+  it("respects a custom options.retryDelay", () => {
+    const customDelay = jest.fn(() => 42);
+    const { retryDelay } = setup({ retryDelay: customDelay });
+    expect(retryDelay).toBe(customDelay);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -142,7 +167,7 @@ describe("UseRequestProcessor retryDelay", () => {
   it("uses exponential backoff capped at 30s for queries", () => {
     const { query } = UseRequestProcessor();
     query(["k"], async () => ({}));
-    const { retryDelay } = capturedQueryOptions;
+    const { retryDelay } = mockCapturedQueryOptions;
     expect(retryDelay(0)).toBe(1000);
     expect(retryDelay(1)).toBe(2000);
     expect(retryDelay(2)).toBe(4000);
@@ -155,7 +180,7 @@ describe("UseRequestProcessor retryDelay", () => {
   it("uses exponential backoff capped at 30s for mutations", () => {
     const { mutate } = UseRequestProcessor();
     mutate(["k"], async () => ({}));
-    const { retryDelay } = capturedMutationOptions;
+    const { retryDelay } = mockCapturedMutationOptions;
     expect(retryDelay(0)).toBe(1000);
     expect(retryDelay(1)).toBe(2000);
     expect(retryDelay(2)).toBe(4000);

--- a/src/frontend/src/controllers/API/services/request-processor.ts
+++ b/src/frontend/src/controllers/API/services/request-processor.ts
@@ -6,10 +6,28 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
 import type {
   MutationFunctionType,
   QueryFunctionType,
 } from "../../../types/api";
+
+// 4xx responses are intentional client-side rejections (auth, validation,
+// deployment guards, etc.).
+function isClientError(error: unknown): boolean {
+  const status = (error as AxiosError | undefined)?.response?.status;
+  return typeof status === "number" && status >= 400 && status < 500;
+}
+
+function makeRetry(maxRetries: number) {
+  return (failureCount: number, error: unknown) => {
+    if (isClientError(error)) return false;
+    return failureCount < maxRetries;
+  };
+}
+
+const retryDelay = (attemptIndex: number) =>
+  Math.min(1000 * 2 ** attemptIndex, 30000);
 
 export function UseRequestProcessor(): {
   query: QueryFunctionType;
@@ -26,8 +44,8 @@ export function UseRequestProcessor(): {
     return useQuery({
       queryKey,
       queryFn,
-      retry: 5,
-      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+      retry: makeRetry(5),
+      retryDelay,
       ...options,
     });
   }
@@ -45,8 +63,8 @@ export function UseRequestProcessor(): {
         options.onSettled && options.onSettled(data, error, variables, context);
       },
       ...options,
-      retry: options.retry ?? 3,
-      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+      retry: options.retry ?? makeRetry(3),
+      retryDelay,
     });
   }
 

--- a/src/frontend/src/controllers/API/services/request-processor.ts
+++ b/src/frontend/src/controllers/API/services/request-processor.ts
@@ -6,16 +6,17 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import type { AxiosError } from "axios";
+import axios from "axios";
 import type {
   MutationFunctionType,
   QueryFunctionType,
 } from "../../../types/api";
 
 // 4xx responses are intentional client-side rejections (auth, validation,
-// deployment guards, etc.).
+// deployment guards, etc.) and won't change on retry.
 function isClientError(error: unknown): boolean {
-  const status = (error as AxiosError | undefined)?.response?.status;
+  if (!axios.isAxiosError(error)) return false;
+  const status = error.response?.status;
   return typeof status === "number" && status >= 400 && status < 500;
 }
 
@@ -25,6 +26,9 @@ function makeRetry(maxRetries: number) {
     return failureCount < maxRetries;
   };
 }
+
+const queryRetry = makeRetry(5);
+const mutationRetry = makeRetry(3);
 
 const retryDelay = (attemptIndex: number) =>
   Math.min(1000 * 2 ** attemptIndex, 30000);
@@ -44,7 +48,7 @@ export function UseRequestProcessor(): {
     return useQuery({
       queryKey,
       queryFn,
-      retry: makeRetry(5),
+      retry: queryRetry,
       retryDelay,
       ...options,
     });
@@ -63,8 +67,8 @@ export function UseRequestProcessor(): {
         options.onSettled && options.onSettled(data, error, variables, context);
       },
       ...options,
-      retry: options.retry ?? makeRetry(3),
-      retryDelay,
+      retry: options.retry ?? mutationRetry,
+      retryDelay: options.retryDelay ?? retryDelay,
     });
   }
 


### PR DESCRIPTION
affects all api calls made by the FE, disabling retries for client errors (4xx http status code)

removes hardcoded disabling of retries in the deployment files

main purpose is to reduce delays for the deployment guard errors, which occur in non-deployment routes, e.g., PATCH/DELETE on /flows/{flow_id}, /projects/{project_id}
