### PR TITLE
fix(chroma): replace deprecated Client(settings=) with HttpClient for chromadb >=1.0

### DIFF
--- a/src/lfx/src/lfx/components/chroma/chroma.py
+++ b/src/lfx/src/lfx/components/chroma/chroma.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
-from chromadb.config import Settings
 from langchain_chroma import Chroma
 from typing_extensions import override
 
@@ -92,23 +91,22 @@ class ChromaVectorStoreComponent(LCVectorStoreComponent):
     def build_vector_store(self) -> Chroma:
         """Builds the Chroma object."""
         try:
-            from chromadb import Client
             from langchain_chroma import Chroma
         except ImportError as e:
             msg = "Could not import Chroma integration package. Please install it with `pip install langchain-chroma`."
             raise ImportError(msg) from e
-        # Chroma settings
-        chroma_settings = None
         client = None
         if self.chroma_server_host:
-            chroma_settings = Settings(
-                chroma_server_cors_allow_origins=self.chroma_server_cors_allow_origins or [],
-                chroma_server_host=self.chroma_server_host,
-                chroma_server_http_port=self.chroma_server_http_port or None,
-                chroma_server_grpc_port=self.chroma_server_grpc_port or None,
-                chroma_server_ssl_enabled=self.chroma_server_ssl_enabled,
+            try:
+                from chromadb import HttpClient
+            except ImportError as e:
+                msg = "Could not import chromadb. Please install it with `pip install chromadb`."
+                raise ImportError(msg) from e
+            client = HttpClient(
+                host=self.chroma_server_host,
+                port=self.chroma_server_http_port or 8000,
+                ssl=bool(self.chroma_server_ssl_enabled),
             )
-            client = Client(settings=chroma_settings)
 
         # Check persist_directory and expand it if it is a relative path
         persist_directory = self.resolve_path(self.persist_directory) if self.persist_directory is not None else None


### PR DESCRIPTION
Fixes #12665

## Problem

On chromadb 1.0+, `chromadb.Client(settings=Settings(chroma_server_host=...))` silently creates a local in-memory ephemeral database instead of connecting to the configured remote server. The server-related settings fields are ignored without any error or warning.

This caused the Chroma DB component to always return empty results (`dataframe: []`) when configured to point at a remote ChromaDB server, even though 75+ documents existed in the collection.

## Solution

Replace the deprecated `Client(settings=...)` call with `chromadb.HttpClient(host, port, ssl)`, which is the correct API for connecting to a remote ChromaDB HTTP server introduced in chromadb 1.0.

The `component_index.json` is also updated with the fixed component code and a recomputed sha256, since Langflow's flow runner executes the code string from the index JSON rather than the `.py` file directly.

## Testing

The fix can be verified by:
1. Running a standalone ChromaDB server (`docker run -p 8100:8000 chromadb/chroma`)
2. Ingesting documents using `chromadb.HttpClient`
3. Configuring the Chroma DB node with the correct host/port
4. Confirming that queries now return documents from the remote collection instead of empty results