### PR TITLE
fix(frontend): validate deployment agent name

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/create-mode.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/create-mode.test.tsx
@@ -218,6 +218,42 @@ describe("Create mode — canGoNext validation", () => {
 
       expect(result.current.canGoNext).toBe(true);
     });
+
+    it("blocks when trimmed name does not start with a letter", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+        initialInstance: mockInstance,
+      });
+
+      act(() => result.current.handleNext()); // → step 2
+
+      act(() => {
+        result.current.setDeploymentName(" 1 Agent");
+        result.current.setSelectedLlm("gpt-4");
+      });
+
+      expect(result.current.canGoNext).toBe(false);
+      expect(result.current.isDeploymentNameValid).toBe(false);
+      expect(result.current.hasDeploymentNameFormatError).toBe(true);
+    });
+
+    it("allows when trimmed name starts with a unicode letter", () => {
+      const { result } = renderCreateHook({
+        initialProvider: mockProvider,
+        initialInstance: mockInstance,
+      });
+
+      act(() => result.current.handleNext()); // → step 2
+
+      act(() => {
+        result.current.setDeploymentName(" Ágent");
+        result.current.setSelectedLlm("gpt-4");
+      });
+
+      expect(result.current.canGoNext).toBe(true);
+      expect(result.current.isDeploymentNameValid).toBe(true);
+      expect(result.current.hasDeploymentNameFormatError).toBe(false);
+    });
   });
 
   describe("Step 3 (Attach Flows)", () => {

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/custom-tool-naming.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/custom-tool-naming.test.tsx
@@ -180,4 +180,18 @@ describe("Custom tool naming", () => {
       "Tool Beta",
     );
   });
+
+  it("rejects create payload when agent name does not start with a letter", () => {
+    const { result } = renderStepperHook();
+
+    act(() => {
+      result.current.setDeploymentName("1 Agent");
+      result.current.setSelectedLlm("test-model");
+      result.current.handleSelectVersion("flow-1", "ver-1", "v1");
+    });
+
+    expect(() => result.current.buildDeploymentPayload("provider-1")).toThrow(
+      "Deployment name must start with a letter",
+    );
+  });
 });

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/edit-mode.test.tsx
@@ -92,6 +92,31 @@ describe("Edit mode — basic state", () => {
     expect(result.current.canGoNext).toBe(true);
   });
 
+  it("blocks update flow when existing name does not start with a letter", () => {
+    const invalidDeployment = { ...mockDeployment, name: "1 Agent" };
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DeploymentStepperProvider
+        initialState={{
+          editingDeployment: invalidDeployment,
+          selectedVersionByFlow: initialVersions,
+          initialLlm: "test-model",
+          initialToolNameByFlow: initialToolNames,
+          initialConnectionsByFlow: initialConnections,
+        }}
+      >
+        {children}
+      </DeploymentStepperProvider>
+    );
+    const { result } = renderHook(() => useDeploymentStepper(), { wrapper });
+
+    expect(result.current.canGoNext).toBe(false);
+    expect(result.current.isDeploymentNameValid).toBe(false);
+    expect(result.current.hasDeploymentNameFormatError).toBe(true);
+    expect(() => result.current.buildDeploymentUpdatePayload()).toThrow(
+      "Deployment name must start with a letter",
+    );
+  });
+
   it("canGoNext on step 2 (Attach) allows proceeding in edit mode", () => {
     const { result } = renderEditHook();
     act(() => result.current.handleNext()); // step 2

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-type.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/step-type.test.tsx
@@ -13,6 +13,8 @@ const mockSetSelectedLlm = jest.fn();
 let mockIsEditMode = false;
 let mockDeploymentType = "agent";
 let mockDeploymentName = "";
+let mockIsDeploymentNameValid = false;
+let mockHasDeploymentNameFormatError = false;
 let mockDeploymentDescription = "";
 let mockSelectedLlm = "";
 let mockSelectedInstance: { id: string } | null = { id: "inst-1" };
@@ -26,6 +28,8 @@ jest.mock("../contexts/deployment-stepper-context", () => ({
     setDeploymentType: mockSetDeploymentType,
     deploymentName: mockDeploymentName,
     setDeploymentName: mockSetDeploymentName,
+    isDeploymentNameValid: mockIsDeploymentNameValid,
+    hasDeploymentNameFormatError: mockHasDeploymentNameFormatError,
     deploymentDescription: mockDeploymentDescription,
     setDeploymentDescription: mockSetDeploymentDescription,
     selectedLlm: mockSelectedLlm,
@@ -61,6 +65,8 @@ beforeEach(() => {
   mockIsEditMode = false;
   mockDeploymentType = "agent";
   mockDeploymentName = "";
+  mockIsDeploymentNameValid = false;
+  mockHasDeploymentNameFormatError = false;
   mockDeploymentDescription = "";
   mockSelectedLlm = "";
   mockSelectedInstance = { id: "inst-1" };
@@ -142,6 +148,30 @@ describe("Name input", () => {
     expect(
       screen.queryByText("Name cannot be changed after creation."),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows validation error when name does not start with a letter", () => {
+    mockDeploymentName = "1 Agent";
+    mockHasDeploymentNameFormatError = true;
+    render(<StepType />);
+    expect(
+      screen.getByText("Agent name must start with a letter."),
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("e.g., Sales Bot")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("does not show validation error for empty name", () => {
+    render(<StepType />);
+    expect(
+      screen.queryByText("Agent name must start with a letter."),
+    ).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText("e.g., Sales Bot")).toHaveAttribute(
+      "aria-invalid",
+      "false",
+    );
   });
 });
 

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-type.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/step-type.tsx
@@ -32,6 +32,7 @@ export default function StepType() {
     setDeploymentType,
     deploymentName,
     setDeploymentName,
+    hasDeploymentNameFormatError,
     deploymentDescription,
     setDeploymentDescription,
     selectedLlm,
@@ -142,11 +143,21 @@ export default function StepType() {
         </span>
         <Input
           placeholder="e.g., Sales Bot"
-          className="bg-muted"
+          className={cn(
+            "bg-muted",
+            hasDeploymentNameFormatError &&
+              "border-destructive focus-visible:ring-0",
+          )}
           value={deploymentName}
           onChange={(e) => setDeploymentName(e.target.value)}
           disabled={isEditMode}
+          aria-invalid={hasDeploymentNameFormatError}
         />
+        {hasDeploymentNameFormatError && (
+          <span className="mt-1 text-xs text-destructive">
+            Agent name must start with a letter.
+          </span>
+        )}
         {isEditMode && (
           <span className="mt-1 text-xs text-muted-foreground">
             Name cannot be changed after creation.

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/contexts/deployment-stepper-context.tsx
@@ -73,6 +73,8 @@ interface DeploymentStepperContextType {
   setDeploymentType: (type: DeploymentType) => void;
   deploymentName: string;
   setDeploymentName: (name: string) => void;
+  isDeploymentNameValid: boolean;
+  hasDeploymentNameFormatError: boolean;
   deploymentDescription: string;
   setDeploymentDescription: (description: string) => void;
   selectedLlm: string;
@@ -168,6 +170,11 @@ export function DeploymentStepperProvider({
   >(initialState?.initialConnectionsByFlow ?? new Map());
 
   const [hasToolNameErrors, setHasToolNameErrors] = useState(false);
+  const trimmedDeploymentName = deploymentName.trim();
+  const hasDeploymentNameFormatError =
+    trimmedDeploymentName !== "" && !/^\p{L}/u.test(trimmedDeploymentName);
+  const isDeploymentNameValid =
+    trimmedDeploymentName !== "" && !hasDeploymentNameFormatError;
 
   // Edit mode: track which pre-existing flows the user wants to detach.
   const [removedFlowIds, setRemovedFlowIds] = useState<Set<string>>(new Set());
@@ -253,7 +260,7 @@ export function DeploymentStepperProvider({
       );
     }
     if (logical === 2) {
-      return deploymentName.trim() !== "" && selectedLlm.trim() !== "";
+      return isDeploymentNameValid && selectedLlm.trim() !== "";
     }
     if (logical === 3) {
       // In edit mode, user can proceed without new attachments (may just change desc/LLM).
@@ -270,6 +277,7 @@ export function DeploymentStepperProvider({
     selectedInstance,
     hasValidCredentials,
     deploymentName,
+    isDeploymentNameValid,
     selectedLlm,
     selectedVersionByFlow,
     isEditMode,
@@ -357,6 +365,9 @@ export function DeploymentStepperProvider({
 
   const buildDeploymentPayload = useCallback(
     (providerId: string): DeploymentCreateRequest => {
+      if (!isDeploymentNameValid) {
+        throw new Error("Deployment name must start with a letter");
+      }
       const allConnectionIds = new Set<string>();
       Array.from(attachedConnectionByFlow.values()).forEach((ids) => {
         ids.forEach((id) => allConnectionIds.add(id));
@@ -381,7 +392,7 @@ export function DeploymentStepperProvider({
         ...(initialState?.projectId
           ? { project_id: initialState.projectId }
           : {}),
-        name: deploymentName,
+        name: trimmedDeploymentName,
         description: deploymentDescription,
         type: deploymentType,
         provider_data: {
@@ -396,10 +407,11 @@ export function DeploymentStepperProvider({
       buildConnectionPayloads,
       initialState?.projectId,
       deploymentDescription,
-      deploymentName,
       deploymentType,
+      isDeploymentNameValid,
       selectedLlm,
       selectedVersionByFlow,
+      trimmedDeploymentName,
       toolNameByFlow,
     ],
   );
@@ -410,6 +422,9 @@ export function DeploymentStepperProvider({
         throw new Error(
           "buildDeploymentUpdatePayload called outside edit mode",
         );
+      }
+      if (!isDeploymentNameValid) {
+        throw new Error("Deployment name must start with a letter");
       }
 
       const result: DeploymentUpdateRequest = {
@@ -510,6 +525,7 @@ export function DeploymentStepperProvider({
     }, [
       editingDeployment,
       deploymentDescription,
+      isDeploymentNameValid,
       selectedLlm,
       initialVersionByFlow,
       initialToolNameByFlow,
@@ -541,6 +557,8 @@ export function DeploymentStepperProvider({
       setDeploymentType,
       deploymentName,
       setDeploymentName,
+      isDeploymentNameValid,
+      hasDeploymentNameFormatError,
       deploymentDescription,
       setDeploymentDescription,
       selectedLlm,
@@ -581,6 +599,8 @@ export function DeploymentStepperProvider({
       credentials,
       deploymentType,
       deploymentName,
+      isDeploymentNameValid,
+      hasDeploymentNameFormatError,
       deploymentDescription,
       selectedLlm,
       connections,


### PR DESCRIPTION
## Summary
- validate deployment agent names in deployment stepper so trimmed names must start with a letter
- show inline validation state in type step and prevent create/update payloads when invalid
- add regression coverage for create mode, edit mode, payload building, and step UI

<img width="1034" height="950" alt="Screenshot 2026-04-27 at 8 30 54 AM" src="https://github.com/user-attachments/assets/6f7afaaf-6d69-427c-91d6-3052cb8fcc47" />
<img width="1025" height="924" alt="Screenshot 2026-04-27 at 8 30 47 AM" src="https://github.com/user-attachments/assets/f60dc307-2f56-46bf-9233-fb7a88c11824" />
