### PR TITLE
fix(tests): Restore Windows-compatible slider Playwright test                                                                                            

### DIFF
--- a/src/frontend/tests/core/unit/sliderComponent.spec.ts
+++ b/src/frontend/tests/core/unit/sliderComponent.spec.ts
@@ -149,47 +149,47 @@ async function extractAndCleanCode(page: Page): Promise<string> {
   return codeContent.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
-// Reliably replace the Ace editor content cross-platform. Every keyboard route
-// fails on at least one OS: locator.fill() bypasses Ace's internal buffer,
-// keyboard.insertText() silently drops embedded "\n" characters on Windows
-// (flattening the code into a single invalid line — the `invalid decimal
-// literal (<unknown>, line 1)` failure mode), and pressSequentially() triggers
-// Ace's Python auto-indent and corrupts whitespace.
+// Reliably replace the Ace editor content cross-platform.
 //
-// Instead, drive Ace via its own API: ace-builds exposes `window.ace` and
-// `ace.edit(element)` returns the existing editor instance, so setValue()
-// applies the change atomically. We also assert at each step that newlines
-// survived, so a future regression surfaces a precise diagnostic instead of
-// the same opaque backend 400.
+// Why not the obvious approaches:
+// - locator.fill() bypasses Ace's input handlers and on Windows strips
+//   newlines from the textarea's `.value` for single-line semantics.
+// - keyboard.insertText() drops embedded "\n" on Windows (the entire source
+//   ends up on line 1, and the backend rejects it as `invalid decimal
+//   literal`).
+// - pressSequentially() triggers Ace's Python auto-indent on every Enter.
+// - `window.ace.edit(el).setValue()` updates Ace's buffer but it turned out
+//   that react-ace's change listener isn't always invoked for programmatic
+//   setValue calls — the Ace buffer ends up correct, the React state never
+//   reflects it, and the unchanged code is what gets POSTed on save. That's
+//   the failure mode where the slider keeps rendering with the old range.
+//
+// What works: dispatch a synthetic `paste` event on Ace's hidden text-input
+// textarea. Ace's native paste handler reads `clipboardData.getData("text")`,
+// inserts the multi-line text via the same code path as a real user paste,
+// fires a `change` event that react-ace listens to, and the React state
+// updates. This is the only path that survived all four CI runs.
 async function setAceEditorValue(page: Page, newCode: string): Promise<void> {
   const expectedNewlines = (newCode.match(/\n/g) || []).length;
   if (expectedNewlines < 10) {
     throw new Error(
-      `setAceEditorValue: newCode has only ${expectedNewlines} newlines (length ${newCode.length}); the slider replacement template alone should produce >=11. Upstream extractAndCleanCode likely lost newlines.`,
+      `setAceEditorValue: newCode has only ${expectedNewlines} newlines (length ${newCode.length}); upstream extractAndCleanCode likely lost newlines.`,
     );
   }
 
   await page.locator(".ace_editor").first().waitFor({ state: "visible" });
 
-  const result = await page.evaluate(
+  // Focus the editor and clear any existing content via real keyboard events,
+  // so Ace's selection/delete handlers run normally.
+  await page.locator(".ace_content").first().click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Delete");
+
+  // Insert the new code via a synthetic paste event. We craft a real
+  // ClipboardEvent with DataTransfer so Ace's text-input paste listener
+  // receives `text/plain` exactly as it would from a user paste.
+  const insertResult = await page.evaluate(
     ({ code, expectedNewlines }) => {
-      const aceEl = document.querySelector(".ace_editor");
-      const globalAce = (
-        window as unknown as {
-          ace?: {
-            edit: (el: Element) => {
-              setValue: (v: string, cursorPos?: number) => void;
-              getValue: () => string;
-              session: { setNewLineMode: (mode: string) => void };
-            };
-          };
-        }
-      ).ace;
-
-      if (!aceEl) return { ok: false as const, reason: "ace_editor element not found" };
-      if (!globalAce?.edit)
-        return { ok: false as const, reason: "window.ace not exposed" };
-
       const incomingNewlines = (code.match(/\n/g) || []).length;
       if (incomingNewlines !== expectedNewlines) {
         return {
@@ -198,41 +198,38 @@ async function setAceEditorValue(page: Page, newCode: string): Promise<void> {
         };
       }
 
-      const editor = globalAce.edit(aceEl);
-      // Force LF so getValue() returns exactly what we set, regardless of the
-      // platform's autodetected line ending.
-      editor.session.setNewLineMode("unix");
-      editor.setValue(code, -1);
+      const textInput = document.querySelector(
+        ".ace_text-input",
+      ) as HTMLTextAreaElement | null;
+      if (!textInput) {
+        return { ok: false as const, reason: ".ace_text-input not found" };
+      }
+      textInput.focus();
 
-      const out = editor.getValue();
-      const outNewlines = (out.match(/\n/g) || []).length;
-      return {
-        ok: true as const,
-        incomingNewlines,
-        outNewlines,
-        outLength: out.length,
-      };
+      const dt = new DataTransfer();
+      dt.setData("text/plain", code);
+
+      const pasteEvent = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      const dispatched = textInput.dispatchEvent(pasteEvent);
+      return { ok: true as const, dispatched };
     },
     { code: newCode, expectedNewlines },
   );
 
-  if (!result.ok) {
-    throw new Error(`setAceEditorValue: ${result.reason}`);
-  }
-  if (result.outNewlines < result.incomingNewlines) {
-    throw new Error(
-      `Ace dropped newlines: setValue input had ${result.incomingNewlines}, getValue returned ${result.outNewlines} (length ${result.outLength}).`,
-    );
+  if (!insertResult.ok) {
+    throw new Error(`setAceEditorValue: ${insertResult.reason}`);
   }
 
   // Wait for Ace's change event to propagate into the controlled React state.
-  // We can't compare newline counts on the mirror's `.value` because
-  // `#codeValue` is rendered by `<Input>` (a single-line input element) and
-  // browsers strip `\n`/`\r` from `.value` of single-line inputs by spec —
-  // newlines DO survive in React state, they just don't show up via that
-  // property. The regex marker below is enough to confirm the new code
-  // landed; the `value="..."` HTML attribute on the input still carries the
-  // full multi-line source for any downstream test that needs to read it.
+  // The `#codeValue` mirror is rendered by `<Input>` (single-line), so
+  // browsers strip newlines from its `.value` — newlines survive in React
+  // state, they just don't show up via that property. Matching the regex
+  // substring is enough to confirm the new code landed.
   await expect(page.locator("#codeValue")).toHaveValue(
     /range_spec=RangeSpec\(min=3, max=30, step=1\)/,
     { timeout: 10000 },

--- a/src/frontend/tests/core/unit/sliderComponent.spec.ts
+++ b/src/frontend/tests/core/unit/sliderComponent.spec.ts
@@ -41,13 +41,13 @@ test(
 
     const cleanCode = await extractAndCleanCode(page);
 
-    // Replace the multiline string in the code
+    // Replace the multiline string in the code.
+    // Use a regex so the match is resilient to line-ending differences
+    // (LF on macOS/Linux vs CRLF on Windows after git checkout).
+    const originalSliderBlockRegex =
+      /name="temperature",\s+display_name="Temperature",\s+value=0\.1,\s+range_spec=RangeSpec\(min=0, max=1, step=0\.01\),\s+advanced=True,/;
     const newCode = cleanCode.replace(
-      `name="temperature",
-            display_name="Temperature",
-            value=0.1,
-            range_spec=RangeSpec(min=0, max=1, step=0.01),
-            advanced=True,`,
+      originalSliderBlockRegex,
       `name="temperature",
             display_name="Temperature",
             value=0.2,
@@ -63,9 +63,7 @@ test(
     );
     // make sure codes are different
     expect(cleanCode).not.toEqual(newCode);
-    await page.locator("textarea").last().press(`ControlOrMeta+a`);
-    await page.keyboard.press("Backspace");
-    await page.locator("textarea").last().fill(newCode);
+    await setAceEditorValue(page, newCode);
     await page.locator('//*[@id="checkAndSaveBtn"]').click();
     await adjustScreenView(page);
 
@@ -104,24 +102,41 @@ test(
 );
 
 async function extractAndCleanCode(page: Page): Promise<string> {
-  const outerHTML = await page
+  const codeContent = await page
     .locator('//*[@id="codeValue"]')
-    .evaluate((el) => el.outerHTML);
+    .evaluate((el) => (el as HTMLInputElement).value);
 
-  const valueMatch = outerHTML.match(/value="([\s\S]*?)"/);
-  if (!valueMatch) {
-    throw new Error("Could not find value attribute in the HTML");
-  }
+  // Normalize line endings so downstream string operations are OS-agnostic
+  // (Windows git checkouts of .py files can end up with CRLF).
+  return codeContent.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
 
-  const codeContent = valueMatch[1]
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&#x27;/g, "'")
-    .replace(/&#x2F;/g, "/");
+// Reliably replace the Ace editor content. Using page.locator("textarea").fill()
+// directly is flaky on Windows because Ace's internal buffer may not pick up the
+// change (the "Check & Save" would then submit the old code). We clear through
+// the keyboard and insert the new text via an input event, then wait until the
+// hidden #codeValue input mirrors the new code before returning.
+async function setAceEditorValue(page: Page, newCode: string): Promise<void> {
+  const aceContent = page.locator(".ace_content").first();
+  await aceContent.click();
 
-  return codeContent;
+  // The ace textarea captures keystrokes; scope to a single element so we don't
+  // get a different textarea from elsewhere on the page.
+  const aceTextarea = page.locator("textarea.ace_text-input").first();
+  await aceTextarea.focus();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Delete");
+
+  // insertText dispatches a proper `beforeinput`/`input` event that Ace listens
+  // to, which is more reliable cross-platform than locator.fill() for Ace.
+  await page.keyboard.insertText(newCode);
+
+  // Wait for Ace to propagate the change to the controlled React state so the
+  // hidden #codeValue mirror contains the expected value before we save.
+  await expect(page.locator("#codeValue")).toHaveValue(
+    /range_spec=RangeSpec\(min=3, max=30, step=1\)/,
+    { timeout: 10000 },
+  );
 }
 
 async function mutualValidation(page: Page) {

--- a/src/frontend/tests/core/unit/sliderComponent.spec.ts
+++ b/src/frontend/tests/core/unit/sliderComponent.spec.ts
@@ -112,9 +112,37 @@ test(
 );
 
 async function extractAndCleanCode(page: Page): Promise<string> {
-  const codeContent = await page
+  // The hidden `#codeValue` mirror is rendered with `<Input value={code} />`,
+  // i.e. a single-line `<input>` rather than a textarea. Browsers strip
+  // newlines from `.value` of single-line inputs by HTML spec, so reading
+  // `(el as HTMLInputElement).value` returns the entire source concatenated
+  // onto one line. The backend then rejects it as
+  // `invalid decimal literal (<unknown>, line 1)`.
+  //
+  // Read the rendered HTML attribute instead — React serializes the prop as
+  // `value="..."` with newlines encoded (`&#10;`, `&#13;`, or literal LF
+  // inside attribute text), and the regex below recovers them faithfully.
+  // This is the same strategy queryInputComponent.spec.ts uses.
+  const outerHTML = await page
     .locator('//*[@id="codeValue"]')
-    .evaluate((el) => (el as HTMLInputElement).value);
+    .evaluate((el) => el.outerHTML);
+
+  const valueMatch = outerHTML.match(/value="([\s\S]*?)"/);
+  if (!valueMatch) {
+    throw new Error("Could not find value attribute in the #codeValue HTML");
+  }
+
+  const codeContent = valueMatch[1]
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#x27;/g, "'")
+    .replace(/&#x2F;/g, "/")
+    .replace(/&#10;/g, "\n")
+    .replace(/&#13;/g, "\r")
+    .replace(/&#xA;/gi, "\n")
+    .replace(/&#xD;/gi, "\r");
 
   // Normalize line endings so downstream string operations are OS-agnostic
   // (Windows git checkouts of .py files can end up with CRLF).

--- a/src/frontend/tests/core/unit/sliderComponent.spec.ts
+++ b/src/frontend/tests/core/unit/sliderComponent.spec.ts
@@ -149,26 +149,14 @@ async function extractAndCleanCode(page: Page): Promise<string> {
   return codeContent.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
-// Reliably replace the Ace editor content cross-platform.
-//
-// Why not the obvious approaches:
-// - locator.fill() bypasses Ace's input handlers and on Windows strips
-//   newlines from the textarea's `.value` for single-line semantics.
-// - keyboard.insertText() drops embedded "\n" on Windows (the entire source
-//   ends up on line 1, and the backend rejects it as `invalid decimal
-//   literal`).
-// - pressSequentially() triggers Ace's Python auto-indent on every Enter.
-// - `window.ace.edit(el).setValue()` updates Ace's buffer but it turned out
-//   that react-ace's change listener isn't always invoked for programmatic
-//   setValue calls — the Ace buffer ends up correct, the React state never
-//   reflects it, and the unchanged code is what gets POSTed on save. That's
-//   the failure mode where the slider keeps rendering with the old range.
-//
-// What works: dispatch a synthetic `paste` event on Ace's hidden text-input
-// textarea. Ace's native paste handler reads `clipboardData.getData("text")`,
-// inserts the multi-line text via the same code path as a real user paste,
-// fires a `change` event that react-ace listens to, and the React state
-// updates. This is the only path that survived all four CI runs.
+// Set the Ace editor's content using the exact same pattern that
+// queryInputComponent.spec.ts uses successfully on Windows CI:
+// `textarea.last().fill(newCode)` against Ace's hidden text-input textarea.
+// Textareas (unlike single-line `<input>`s) preserve `\n` in `.value`, so
+// fill() reliably round-trips the multi-line source. Ace's text-input
+// listener picks up the resulting `input` event, applies it to the buffer,
+// and fires the `change` event that react-ace listens to — which is what
+// updates the React `code` state that gets POSTed on save.
 async function setAceEditorValue(page: Page, newCode: string): Promise<void> {
   const expectedNewlines = (newCode.match(/\n/g) || []).length;
   if (expectedNewlines < 10) {
@@ -177,59 +165,14 @@ async function setAceEditorValue(page: Page, newCode: string): Promise<void> {
     );
   }
 
-  await page.locator(".ace_editor").first().waitFor({ state: "visible" });
+  await page.locator("textarea").last().press("ControlOrMeta+a");
+  await page.keyboard.press("Backspace");
+  await page.locator("textarea").last().fill(newCode);
 
-  // Focus the editor and clear any existing content via real keyboard events,
-  // so Ace's selection/delete handlers run normally.
-  await page.locator(".ace_content").first().click();
-  await page.keyboard.press("ControlOrMeta+a");
-  await page.keyboard.press("Delete");
-
-  // Insert the new code via a synthetic paste event. We craft a real
-  // ClipboardEvent with DataTransfer so Ace's text-input paste listener
-  // receives `text/plain` exactly as it would from a user paste.
-  const insertResult = await page.evaluate(
-    ({ code, expectedNewlines }) => {
-      const incomingNewlines = (code.match(/\n/g) || []).length;
-      if (incomingNewlines !== expectedNewlines) {
-        return {
-          ok: false as const,
-          reason: `newlines lost crossing into evaluate: expected ${expectedNewlines}, got ${incomingNewlines}`,
-        };
-      }
-
-      const textInput = document.querySelector(
-        ".ace_text-input",
-      ) as HTMLTextAreaElement | null;
-      if (!textInput) {
-        return { ok: false as const, reason: ".ace_text-input not found" };
-      }
-      textInput.focus();
-
-      const dt = new DataTransfer();
-      dt.setData("text/plain", code);
-
-      const pasteEvent = new ClipboardEvent("paste", {
-        clipboardData: dt,
-        bubbles: true,
-        cancelable: true,
-      });
-
-      const dispatched = textInput.dispatchEvent(pasteEvent);
-      return { ok: true as const, dispatched };
-    },
-    { code: newCode, expectedNewlines },
-  );
-
-  if (!insertResult.ok) {
-    throw new Error(`setAceEditorValue: ${insertResult.reason}`);
-  }
-
-  // Wait for Ace's change event to propagate into the controlled React state.
-  // The `#codeValue` mirror is rendered by `<Input>` (single-line), so
-  // browsers strip newlines from its `.value` — newlines survive in React
-  // state, they just don't show up via that property. Matching the regex
-  // substring is enough to confirm the new code landed.
+  // Wait for the change to propagate into the controlled React state. The
+  // `#codeValue` mirror is rendered by `<Input>` (single-line), so browsers
+  // strip newlines from its `.value` — matching the substring is enough to
+  // confirm the new code landed.
   await expect(page.locator("#codeValue")).toHaveValue(
     /range_spec=RangeSpec\(min=3, max=30, step=1\)/,
     { timeout: 10000 },

--- a/src/frontend/tests/core/unit/sliderComponent.spec.ts
+++ b/src/frontend/tests/core/unit/sliderComponent.spec.ts
@@ -111,25 +111,24 @@ async function extractAndCleanCode(page: Page): Promise<string> {
   return codeContent.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
-// Reliably replace the Ace editor content. Using page.locator("textarea").fill()
-// directly is flaky on Windows because Ace's internal buffer may not pick up the
-// change (the "Check & Save" would then submit the old code). We clear through
-// the keyboard and insert the new text via an input event, then wait until the
-// hidden #codeValue input mirrors the new code before returning.
+// Reliably replace the Ace editor content. The keyboard-based approaches are
+// all flaky on at least one platform: locator.fill() bypasses Ace's internal
+// buffer so the editor never sees the change, keyboard.insertText() drops
+// embedded "\n" characters on Windows (flattening the code into a single
+// invalid line), and pressSequentially() triggers Ace's Python auto-indent and
+// corrupts whitespace. Instead, drive Ace through its own API: ace-builds
+// exposes `window.ace` globally and `ace.edit(element)` returns the existing
+// editor instance, so setValue() applies the change atomically.
 async function setAceEditorValue(page: Page, newCode: string): Promise<void> {
-  const aceContent = page.locator(".ace_content").first();
-  await aceContent.click();
-
-  // The ace textarea captures keystrokes; scope to a single element so we don't
-  // get a different textarea from elsewhere on the page.
-  const aceTextarea = page.locator("textarea.ace_text-input").first();
-  await aceTextarea.focus();
-  await page.keyboard.press("ControlOrMeta+a");
-  await page.keyboard.press("Delete");
-
-  // insertText dispatches a proper `beforeinput`/`input` event that Ace listens
-  // to, which is more reliable cross-platform than locator.fill() for Ace.
-  await page.keyboard.insertText(newCode);
+  await page.locator(".ace_editor").first().waitFor({ state: "visible" });
+  await page.evaluate((code) => {
+    const aceEl = document.querySelector(".ace_editor");
+    const globalAce = (window as unknown as { ace?: { edit: (el: Element) => { setValue: (v: string, cursorPos?: number) => void } } }).ace;
+    if (!aceEl || !globalAce) {
+      throw new Error("Ace editor not found on the page");
+    }
+    globalAce.edit(aceEl).setValue(code, -1);
+  }, newCode);
 
   // Wait for Ace to propagate the change to the controlled React state so the
   // hidden #codeValue mirror contains the expected value before we save.

--- a/src/frontend/tests/core/unit/sliderComponent.spec.ts
+++ b/src/frontend/tests/core/unit/sliderComponent.spec.ts
@@ -41,6 +41,16 @@ test(
 
     const cleanCode = await extractAndCleanCode(page);
 
+    // Sanity-check: the original Ollama source has many lines. If we read it
+    // back as a single concatenated line, the textarea-value path is the
+    // problem and Ace surgery downstream cannot save us.
+    const cleanCodeNewlines = (cleanCode.match(/\n/g) || []).length;
+    if (cleanCodeNewlines < 50) {
+      throw new Error(
+        `extractAndCleanCode returned code with only ${cleanCodeNewlines} newlines (length ${cleanCode.length}); expected the multi-line Ollama source. The hidden #codeValue textarea may be returning a stripped value on this platform.`,
+      );
+    }
+
     // Replace the multiline string in the code.
     // Use a regex so the match is resilient to line-ending differences
     // (LF on macOS/Linux vs CRLF on Windows after git checkout).
@@ -111,31 +121,98 @@ async function extractAndCleanCode(page: Page): Promise<string> {
   return codeContent.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
-// Reliably replace the Ace editor content. The keyboard-based approaches are
-// all flaky on at least one platform: locator.fill() bypasses Ace's internal
-// buffer so the editor never sees the change, keyboard.insertText() drops
-// embedded "\n" characters on Windows (flattening the code into a single
-// invalid line), and pressSequentially() triggers Ace's Python auto-indent and
-// corrupts whitespace. Instead, drive Ace through its own API: ace-builds
-// exposes `window.ace` globally and `ace.edit(element)` returns the existing
-// editor instance, so setValue() applies the change atomically.
+// Reliably replace the Ace editor content cross-platform. Every keyboard route
+// fails on at least one OS: locator.fill() bypasses Ace's internal buffer,
+// keyboard.insertText() silently drops embedded "\n" characters on Windows
+// (flattening the code into a single invalid line — the `invalid decimal
+// literal (<unknown>, line 1)` failure mode), and pressSequentially() triggers
+// Ace's Python auto-indent and corrupts whitespace.
+//
+// Instead, drive Ace via its own API: ace-builds exposes `window.ace` and
+// `ace.edit(element)` returns the existing editor instance, so setValue()
+// applies the change atomically. We also assert at each step that newlines
+// survived, so a future regression surfaces a precise diagnostic instead of
+// the same opaque backend 400.
 async function setAceEditorValue(page: Page, newCode: string): Promise<void> {
-  await page.locator(".ace_editor").first().waitFor({ state: "visible" });
-  await page.evaluate((code) => {
-    const aceEl = document.querySelector(".ace_editor");
-    const globalAce = (window as unknown as { ace?: { edit: (el: Element) => { setValue: (v: string, cursorPos?: number) => void } } }).ace;
-    if (!aceEl || !globalAce) {
-      throw new Error("Ace editor not found on the page");
-    }
-    globalAce.edit(aceEl).setValue(code, -1);
-  }, newCode);
+  const expectedNewlines = (newCode.match(/\n/g) || []).length;
+  if (expectedNewlines < 10) {
+    throw new Error(
+      `setAceEditorValue: newCode has only ${expectedNewlines} newlines (length ${newCode.length}); the slider replacement template alone should produce >=11. Upstream extractAndCleanCode likely lost newlines.`,
+    );
+  }
 
-  // Wait for Ace to propagate the change to the controlled React state so the
-  // hidden #codeValue mirror contains the expected value before we save.
+  await page.locator(".ace_editor").first().waitFor({ state: "visible" });
+
+  const result = await page.evaluate(
+    ({ code, expectedNewlines }) => {
+      const aceEl = document.querySelector(".ace_editor");
+      const globalAce = (
+        window as unknown as {
+          ace?: {
+            edit: (el: Element) => {
+              setValue: (v: string, cursorPos?: number) => void;
+              getValue: () => string;
+              session: { setNewLineMode: (mode: string) => void };
+            };
+          };
+        }
+      ).ace;
+
+      if (!aceEl) return { ok: false as const, reason: "ace_editor element not found" };
+      if (!globalAce?.edit)
+        return { ok: false as const, reason: "window.ace not exposed" };
+
+      const incomingNewlines = (code.match(/\n/g) || []).length;
+      if (incomingNewlines !== expectedNewlines) {
+        return {
+          ok: false as const,
+          reason: `newlines lost crossing into evaluate: expected ${expectedNewlines}, got ${incomingNewlines}`,
+        };
+      }
+
+      const editor = globalAce.edit(aceEl);
+      // Force LF so getValue() returns exactly what we set, regardless of the
+      // platform's autodetected line ending.
+      editor.session.setNewLineMode("unix");
+      editor.setValue(code, -1);
+
+      const out = editor.getValue();
+      const outNewlines = (out.match(/\n/g) || []).length;
+      return {
+        ok: true as const,
+        incomingNewlines,
+        outNewlines,
+        outLength: out.length,
+      };
+    },
+    { code: newCode, expectedNewlines },
+  );
+
+  if (!result.ok) {
+    throw new Error(`setAceEditorValue: ${result.reason}`);
+  }
+  if (result.outNewlines < result.incomingNewlines) {
+    throw new Error(
+      `Ace dropped newlines: setValue input had ${result.incomingNewlines}, getValue returned ${result.outNewlines} (length ${result.outLength}).`,
+    );
+  }
+
+  // Wait for Ace's change event to propagate into the controlled React state.
+  // We assert against the full code length, not just the regex marker, so that
+  // a newline-stripped value is rejected here rather than reaching the backend.
   await expect(page.locator("#codeValue")).toHaveValue(
     /range_spec=RangeSpec\(min=3, max=30, step=1\)/,
     { timeout: 10000 },
   );
+
+  const reactNewlines = await page
+    .locator("#codeValue")
+    .evaluate((el) => ((el as HTMLTextAreaElement).value.match(/\n/g) || []).length);
+  if (reactNewlines < result.incomingNewlines) {
+    throw new Error(
+      `React state dropped newlines after Ace change: ace=${result.outNewlines}, react=${reactNewlines}.`,
+    );
+  }
 }
 
 async function mutualValidation(page: Page) {

--- a/src/frontend/tests/core/unit/sliderComponent.spec.ts
+++ b/src/frontend/tests/core/unit/sliderComponent.spec.ts
@@ -226,21 +226,17 @@ async function setAceEditorValue(page: Page, newCode: string): Promise<void> {
   }
 
   // Wait for Ace's change event to propagate into the controlled React state.
-  // We assert against the full code length, not just the regex marker, so that
-  // a newline-stripped value is rejected here rather than reaching the backend.
+  // We can't compare newline counts on the mirror's `.value` because
+  // `#codeValue` is rendered by `<Input>` (a single-line input element) and
+  // browsers strip `\n`/`\r` from `.value` of single-line inputs by spec —
+  // newlines DO survive in React state, they just don't show up via that
+  // property. The regex marker below is enough to confirm the new code
+  // landed; the `value="..."` HTML attribute on the input still carries the
+  // full multi-line source for any downstream test that needs to read it.
   await expect(page.locator("#codeValue")).toHaveValue(
     /range_spec=RangeSpec\(min=3, max=30, step=1\)/,
     { timeout: 10000 },
   );
-
-  const reactNewlines = await page
-    .locator("#codeValue")
-    .evaluate((el) => ((el as HTMLTextAreaElement).value.match(/\n/g) || []).length);
-  if (reactNewlines < result.incomingNewlines) {
-    throw new Error(
-      `React state dropped newlines after Ace change: ace=${result.outNewlines}, react=${reactNewlines}.`,
-    );
-  }
 }
 
 async function mutualValidation(page: Page) {


### PR DESCRIPTION
OBJECTIVE: Fix theslider component E2E test that was failing on Windows CI because the hidden `<Input>` mirror strips newlines from `.value`, causing the original Python source to reach the backend on a single line and the new range_spec to never be applied.                                                    
                                                                                                                                                                  
CHANGES:                                                                                                                                                        
  - Read the original component code from the `value=` HTML attribute via `outerHTML` instead of `<Input>.value` — single-line inputs strip `\n` from the DOM property, but the attribute keeps newlines intact                                                                                                               
  - Decode HTML entities (`&#10;`, `&#xA;`, etc.) when extracting the attribute so multi-line Python is recovered exactly
  - Replace the Ace setter with the same `textarea.last().fill()` pattern queryInputComponent uses successfully on Windows, ensuring `react-ace` propagates the change to React state before save                                                                                                                               
  - Add a sanity-check that the extracted code has ≥50 newlines to surface a precise diagnostic if upstream regresses