### PR TITLE
fix(composio): prevent KeyError('type') on Gmail/Calendar tool execution

### DIFF
--- a/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
@@ -1,0 +1,130 @@
+"""Tests for SafeLangchainProvider schema sanitization (issues #12894/#12895).
+
+Composio's ``_substitute_file_uploads_recursively`` and
+``pydantic_model_from_param_schema`` raw-subscript ``properties[name]["type"]``,
+so any tool whose ``input_parameters`` schema has a property without an explicit
+``"type"`` (Gmail/Calendar actions hit this) raises ``KeyError: 'type'`` at
+execute time. ``_sanitize_schema`` injects a sensible ``type`` for every node so
+those raw subscripts succeed.
+"""
+
+import pytest
+
+composio = pytest.importorskip("composio", reason="composio extra not installed in this env")
+pytest.importorskip("composio_langchain", reason="composio extra not installed in this env")
+
+from lfx.base.composio.safe_provider import SafeLangchainProvider, _sanitize_schema  # noqa: E402
+
+
+class TestSanitizeSchema:
+    def test_object_with_typeless_property_gets_string_type(self):
+        schema = {"properties": {"foo": {}}}
+        _sanitize_schema(schema)
+        assert schema["type"] == "object"
+        assert schema["properties"]["foo"]["type"] == "string"
+
+    def test_nested_object_inferred_from_properties(self):
+        schema = {"properties": {"outer": {"properties": {"inner": {}}}}}
+        _sanitize_schema(schema)
+        assert schema["properties"]["outer"]["type"] == "object"
+        assert schema["properties"]["outer"]["properties"]["inner"]["type"] == "string"
+
+    def test_array_inferred_from_items(self):
+        schema = {"properties": {"tags": {"items": {}}}}
+        _sanitize_schema(schema)
+        assert schema["properties"]["tags"]["type"] == "array"
+        assert schema["properties"]["tags"]["items"]["type"] == "string"
+
+    def test_anyof_property_gets_default_type(self):
+        # Composio's _files.py:308 raw-subscripts ["type"] without resolving
+        # anyOf, so a default ``type`` must be injected even on union schemas.
+        schema = {"properties": {"x": {"anyOf": [{"type": "string"}, {"type": "null"}]}}}
+        _sanitize_schema(schema)
+        assert schema["properties"]["x"]["type"] == "string"
+        # Union arms must still be walked + sanitized.
+        assert all("type" in arm for arm in schema["properties"]["x"]["anyOf"])
+
+    def test_ref_only_property_gets_default_type(self):
+        schema = {"properties": {"x": {"$ref": "#/$defs/Foo"}}}
+        _sanitize_schema(schema)
+        assert schema["properties"]["x"]["type"] == "string"
+
+    def test_existing_types_preserved(self):
+        schema = {
+            "type": "object",
+            "properties": {"count": {"type": "integer"}, "name": {"type": "string"}},
+        }
+        _sanitize_schema(schema)
+        assert schema["type"] == "object"
+        assert schema["properties"]["count"]["type"] == "integer"
+        assert schema["properties"]["name"]["type"] == "string"
+
+    def test_defs_walked(self):
+        schema = {
+            "$defs": {"Item": {"properties": {"id": {}}}},
+            "properties": {"thing": {"$ref": "#/$defs/Item"}},
+        }
+        _sanitize_schema(schema)
+        assert schema["$defs"]["Item"]["type"] == "object"
+        assert schema["$defs"]["Item"]["properties"]["id"]["type"] == "string"
+
+    def test_non_dict_input_no_op(self):
+        _sanitize_schema(None)
+        _sanitize_schema("not a dict")
+        _sanitize_schema(42)
+
+
+class TestSafeLangchainProviderRegression:
+    """Reproduces the GMAIL_FETCH_EMAILS / GOOGLECALENDAR_* failure mode."""
+
+    def test_substitute_file_uploads_no_longer_keyerrors_after_sanitize(self):
+        # Schema shape that triggers KeyError("type") in
+        # composio.core.models._files._substitute_file_uploads_recursively:
+        # property "attachment" lacks a "type" key but request supplies a dict.
+        schema = {"properties": {"attachment": {"description": "binary blob"}}}
+
+        # Without sanitize -> raw subscript would KeyError on params["attachment"]["type"]
+        # because the property has no "type". Sanitize first, then assert lookup is safe.
+        _sanitize_schema(schema)
+        params = schema["properties"]
+        # Composio's raw expression: params[_param]["type"] == "object"
+        # After sanitize, lookup must succeed and (correctly) be False here.
+        assert params["attachment"]["type"] == "string"
+
+    def test_provider_subclass_instantiable(self):
+        provider = SafeLangchainProvider()
+        assert provider is not None
+        # Confirms LangchainProvider's metaclass-required `name` kwarg is satisfied.
+        assert getattr(provider.__class__, "name", None) == "langchain"
+
+    def test_file_helper_methods_patched(self):
+        """FileHelper must be monkey-patched on import.
+
+        Direct execute_action paths bypass wrap_tool, so the patch on
+        FileHelper is the only place that catches them.
+        """
+        from composio.core.models._files import FileHelper
+
+        assert getattr(FileHelper, "_lfx_safe_patched", False) is True
+
+    def test_file_helper_uploads_no_keyerror_on_untyped_property(self):
+        """End-to-end guard against the original KeyError site.
+
+        Drives Composio's upload walker with a schema whose property has no
+        ``type`` key. Without the patch this raises ``KeyError('type')``; with
+        it, the call returns the request unchanged.
+        """
+        from composio.core.models._files import FileHelper
+
+        helper = FileHelper.__new__(FileHelper)  # bypass __init__ — no client needed for this code path
+
+        schema = {"type": "object", "properties": {"payload": {"description": "blob"}}}
+        request = {"payload": {"foo": "bar"}}
+
+        # ``tool`` argument is unused on this happy path
+        result = helper._substitute_file_uploads_recursively(tool=None, schema=schema, request=request)
+        assert result == request
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
@@ -125,6 +125,85 @@ class TestSafeLangchainProviderRegression:
         result = helper._substitute_file_uploads_recursively(tool=None, schema=schema, request=request)
         assert result == request
 
+    def test_file_helper_uploads_accepts_positional_args(self):
+        """Forward-compat guard: wrapper must tolerate positional invocation.
+
+        Upstream Composio currently uses keyword args for the recursive
+        self-calls, but a future release could switch to positionals. The
+        wrapper uses ``*args, **kwargs`` so either calling convention works.
+        """
+        from composio.core.models._files import FileHelper
+
+        helper = FileHelper.__new__(FileHelper)
+
+        schema = {"type": "object", "properties": {"payload": {"description": "blob"}}}
+        request = {"payload": {"foo": "bar"}}
+
+        # Positional call mirrors a hypothetical upstream signature change.
+        result = helper._substitute_file_uploads_recursively(None, schema, request)
+        assert result == request
+
+    def test_pydantic_builder_patched(self):
+        """``pydantic_model_from_param_schema`` must be wrapped on import.
+
+        The builder runs during ``tools.get`` for the direct-execute path that
+        bypasses ``configure_tools``, so without this patch Gmail/Calendar
+        actions would still KeyError on the legacy path.
+        """
+        from composio.utils import shared as composio_shared
+
+        assert getattr(composio_shared, "_lfx_safe_patched", False) is True
+
+    def test_pydantic_builder_no_keyerror_on_untyped_property(self):
+        """End-to-end guard for the third KeyError site.
+
+        Without the patch, ``prop_info["type"]`` would raise ``KeyError('type')``
+        on the typeless ``payload`` property. With it, the builder returns a
+        valid pydantic model.
+        """
+        from composio.utils.shared import pydantic_model_from_param_schema
+
+        schema = {
+            "title": "TestParams",
+            "properties": {"payload": {"title": "Payload", "description": "blob"}},
+        }
+        model = pydantic_model_from_param_schema(schema)
+        # Defaulted type is "string", which maps to ``str`` in Composio's type table.
+        assert "payload" in model.model_fields
+
+
+class TestNoOpOnAlreadyTypedSchemas:
+    """Regression preservation: schemas that worked pre-patch must round-trip unchanged.
+
+    The non-overwrite invariant in ``_sanitize_schema`` is the basis for the
+    "no regression" claim; these tests exercise the integration layer to
+    confirm that the patch is bit-identical for fully-typed schemas.
+    """
+
+    def test_sanitize_is_no_op_on_fully_typed_schema(self):
+        import copy
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "count": {"type": "integer"},
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "meta": {"type": "object", "properties": {"k": {"type": "string"}}},
+            },
+        }
+        before = copy.deepcopy(schema)
+        _sanitize_schema(schema)
+        assert schema == before
+
+    def test_file_helper_uploads_unchanged_on_fully_typed_schema(self):
+        from composio.core.models._files import FileHelper
+
+        helper = FileHelper.__new__(FileHelper)
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        request = {"name": "value"}
+        result = helper._substitute_file_uploads_recursively(tool=None, schema=schema, request=request)
+        assert result == request
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/src/lfx/src/lfx/base/composio/composio_base.py
+++ b/src/lfx/src/lfx/base/composio/composio_base.py
@@ -5,9 +5,9 @@ from contextlib import suppress
 from typing import Any
 
 from composio import Composio
-from composio_langchain import LangchainProvider
 from langchain_core.tools import Tool
 
+from lfx.base.composio.safe_provider import SafeLangchainProvider, _sanitize_schema
 from lfx.base.mcp.util import create_input_schema_from_json_schema
 from lfx.custom.custom_component.component import Component
 from lfx.inputs.inputs import (
@@ -437,7 +437,7 @@ class ComposioBaseComponent(Component):
             if not self.api_key:
                 msg = "Composio API Key is required"
                 raise ValueError(msg)
-            return Composio(api_key=self.api_key, provider=LangchainProvider())
+            return Composio(api_key=self.api_key, provider=SafeLangchainProvider())
 
         except ValueError as e:
             logger.error(f"Error building Composio wrapper: {e}")
@@ -2354,6 +2354,14 @@ class ComposioBaseComponent(Component):
             limit = 999
 
         tools = composio.tools.get(user_id=self.entity_id, toolkits=[self.app_name.lower()], limit=limit)
+        # Composio caches a deep copy of each tool's schema in `_tool_schemas` *before* the
+        # provider wraps it, and reuses that copy at execute time for file substitution.
+        # Patch every cached schema so missing JSON Schema "type" keys don't raise
+        # KeyError("type") inside `_substitute_file_uploads_recursively` (issues #12894/#12895).
+        cached_schemas = getattr(composio.tools, "_tool_schemas", None)
+        if isinstance(cached_schemas, dict):
+            for cached_tool in cached_schemas.values():
+                _sanitize_schema(getattr(cached_tool, "input_parameters", None))
         configured_tools = []
         for tool in tools:
             # Set the sanitized name

--- a/src/lfx/src/lfx/base/composio/safe_provider.py
+++ b/src/lfx/src/lfx/base/composio/safe_provider.py
@@ -1,0 +1,117 @@
+"""Schema-hardening wrapper around composio_langchain.LangchainProvider.
+
+Composio's runtime file-substitution helpers (composio.core.models._files) and
+its Pydantic schema builder (composio.utils.shared.pydantic_model_from_param_schema)
+raw-subscript ``properties[name]["type"]``. When a Composio tool's
+``input_parameters`` schema contains a property without an explicit ``"type"``
+(common for Gmail/Calendar actions whose properties only specify
+``anyOf``/``additionalProperties``), tool execution raises
+``KeyError: 'type'`` (issues #12894, #12895).
+
+We sanitize ``tool.input_parameters`` in-place at wrap time so the cached Tool
+object that Composio reuses on ``execute`` already has a ``"type"`` for every
+node the file walker touches.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from composio.core.models._files import FileHelper
+from composio_langchain import LangchainProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from composio.types import Tool
+    from composio_langchain.provider import StructuredTool
+
+
+def _sanitize_schema(schema: Any) -> None:
+    """Recursively guarantee every JSON-schema node has a ``type`` key.
+
+    Composio's runtime walkers raw-subscript ``properties[name]["type"]`` (see
+    ``composio.core.models._files`` lines 235/308 and
+    ``composio.utils.shared.pydantic_model_from_param_schema`` line 232). They
+    don't resolve ``$ref``/``anyOf``/``oneOf``/``allOf`` before that lookup, so
+    *any* property without a literal ``"type"`` key crashes with
+    ``KeyError('type')`` even if a union arm or referenced ``$def`` would have
+    provided one.
+
+    We mutate ``schema`` in place with these inference rules:
+      - has ``properties`` -> ``type`` defaults to ``"object"``
+      - has ``items``      -> ``type`` defaults to ``"array"``
+      - otherwise          -> ``type`` defaults to ``"string"``
+
+    Existing ``type`` keys are never overwritten. The string default is
+    deliberately conservative: composio compares ``type == "object"`` to decide
+    whether to recurse into a nested file-substitution walk, so defaulting to
+    ``"string"`` is a safe no-op for that branch.
+    """
+    if not isinstance(schema, dict):
+        return
+
+    has_type = "type" in schema
+    has_props = "properties" in schema
+    has_items = "items" in schema
+
+    if not has_type:
+        if has_props:
+            schema["type"] = "object"
+        elif has_items:
+            schema["type"] = "array"
+        else:
+            schema["type"] = "string"
+
+    if has_props:
+        for sub in schema["properties"].values():
+            _sanitize_schema(sub)
+    if has_items:
+        _sanitize_schema(schema["items"])
+    for union_key in ("anyOf", "oneOf", "allOf"):
+        for sub in schema.get(union_key, []) or []:
+            _sanitize_schema(sub)
+    for defs_key in ("$defs", "definitions"):
+        defs = schema.get(defs_key)
+        if isinstance(defs, dict):
+            for sub in defs.values():
+                _sanitize_schema(sub)
+
+
+class SafeLangchainProvider(LangchainProvider, name="langchain"):
+    """LangchainProvider that patches tool schemas before delegating."""
+
+    def wrap_tool(self, tool: Tool, execute_tool: Callable[..., Any]) -> StructuredTool:
+        _sanitize_schema(tool.input_parameters)
+        return super().wrap_tool(tool=tool, execute_tool=execute_tool)
+
+
+def _patch_file_helper_once() -> None:
+    """Wrap Composio's file substitution helpers so untyped properties don't KeyError.
+
+    ``_substitute_file_uploads_recursively`` and ``_substitute_file_downloads_recursively``
+    raw-subscript ``params[name]["type"]`` while walking ``tool.input_parameters``. The
+    methods run on every ``composio.tools.execute`` call (including direct component
+    runs that don't go through ``configure_tools``), so we patch them here once at
+    import time.
+    """
+    if getattr(FileHelper, "_lfx_safe_patched", False):
+        return
+
+    original_uploads = FileHelper._substitute_file_uploads_recursively  # noqa: SLF001
+    original_downloads = FileHelper._substitute_file_downloads_recursively  # noqa: SLF001
+
+    def safe_uploads(self, tool, schema, request):
+        _sanitize_schema(schema)
+        return original_uploads(self, tool=tool, schema=schema, request=request)
+
+    def safe_downloads(self, tool, schema, request):
+        _sanitize_schema(schema)
+        return original_downloads(self, tool=tool, schema=schema, request=request)
+
+    FileHelper._substitute_file_uploads_recursively = safe_uploads  # noqa: SLF001
+    FileHelper._substitute_file_downloads_recursively = safe_downloads  # noqa: SLF001
+    FileHelper._lfx_safe_patched = True  # noqa: SLF001
+
+
+_patch_file_helper_once()

--- a/src/lfx/src/lfx/base/composio/safe_provider.py
+++ b/src/lfx/src/lfx/base/composio/safe_provider.py
@@ -8,9 +8,10 @@ raw-subscript ``properties[name]["type"]``. When a Composio tool's
 ``anyOf``/``additionalProperties``), tool execution raises
 ``KeyError: 'type'`` (issues #12894, #12895).
 
-We sanitize ``tool.input_parameters`` in-place at wrap time so the cached Tool
-object that Composio reuses on ``execute`` already has a ``"type"`` for every
-node the file walker touches.
+We sanitize ``tool.input_parameters`` in-place at wrap time, and also patch
+both the FileHelper file-substitution helpers and the pydantic schema builder
+so the agent path, the direct ``execute_action`` path, and the legacy
+``tools.get`` path all see a schema with a ``"type"`` for every node.
 """
 
 from __future__ import annotations
@@ -18,9 +19,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 try:
+    from composio.core.models import _files as _composio_files
     from composio.core.models._files import FileHelper
+    from composio.utils import shared as _composio_shared
     from composio_langchain import LangchainProvider
 except ImportError:  # composio extra not installed; module becomes a no-op
+    _composio_files = None  # type: ignore[assignment]
+    _composio_shared = None  # type: ignore[assignment]
     FileHelper = None  # type: ignore[assignment]
     LangchainProvider = None  # type: ignore[assignment,misc]
     _COMPOSIO_AVAILABLE = False
@@ -95,6 +100,22 @@ if _COMPOSIO_AVAILABLE:
             return super().wrap_tool(tool=tool, execute_tool=execute_tool)
 
 
+def _extract_schema_arg(args: tuple, kwargs: dict, positional_index: int, keyword: str) -> Any:
+    """Pull a schema-shaped argument out of ``*args``/``**kwargs`` for sanitization.
+
+    Wrappers accept ``*args, **kwargs`` so they tolerate either calling
+    convention (Composio currently uses keywords, but a future release could
+    switch to positionals). We only need to *find* the schema dict — the
+    underlying call is forwarded verbatim, so we never need to rewrite the
+    arguments.
+    """
+    if keyword in kwargs:
+        return kwargs[keyword]
+    if len(args) > positional_index:
+        return args[positional_index]
+    return None
+
+
 def _patch_file_helper_once() -> None:
     """Wrap Composio's file substitution helpers so untyped properties don't KeyError.
 
@@ -119,17 +140,50 @@ def _patch_file_helper_once() -> None:
     original_uploads = FileHelper._substitute_file_uploads_recursively  # noqa: SLF001
     original_downloads = FileHelper._substitute_file_downloads_recursively  # noqa: SLF001
 
-    def safe_uploads(self, *, tool, schema, request):
-        _sanitize_schema(schema)
-        return original_uploads(self, tool=tool, schema=schema, request=request)
+    # ``*args, **kwargs`` keeps the wrapper signature tolerant of either
+    # positional or keyword invocation. Upstream Composio currently uses
+    # keywords (composio/core/models/_files.py:236-240, :309-312), but pinning
+    # the wrapper to a stricter signature would silently break if a future
+    # release switches to positionals.
+    def safe_uploads(self, *args, **kwargs):
+        _sanitize_schema(_extract_schema_arg(args, kwargs, positional_index=1, keyword="schema"))
+        return original_uploads(self, *args, **kwargs)
 
-    def safe_downloads(self, *, tool, schema, request):
-        _sanitize_schema(schema)
-        return original_downloads(self, tool=tool, schema=schema, request=request)
+    def safe_downloads(self, *args, **kwargs):
+        _sanitize_schema(_extract_schema_arg(args, kwargs, positional_index=1, keyword="schema"))
+        return original_downloads(self, *args, **kwargs)
 
     FileHelper._substitute_file_uploads_recursively = safe_uploads  # noqa: SLF001
     FileHelper._substitute_file_downloads_recursively = safe_downloads  # noqa: SLF001
     FileHelper._lfx_safe_patched = True  # noqa: SLF001
 
 
+def _patch_pydantic_builder_once() -> None:
+    """Wrap ``composio.utils.shared.pydantic_model_from_param_schema`` so untyped properties don't KeyError.
+
+    The builder raw-subscripts ``prop_info["type"]`` while iterating
+    ``properties`` (composio/utils/shared.py:232 in 0.9.2). It runs during
+    ``tools.get`` for the legacy direct-execute path that bypasses
+    ``configure_tools``'s cached-schema sanitizer, so the FileHelper patch
+    alone is not sufficient. Sanitizing the schema before delegation injects a
+    default ``"type"`` for every node and is a no-op for already-typed
+    schemas. Recursive calls inside the builder go through the module-level
+    name we just rebound, so they're sanitized (idempotently) too.
+
+    Idempotent via the ``_lfx_safe_patched`` sentinel on the module.
+    """
+    if not _COMPOSIO_AVAILABLE or getattr(_composio_shared, "_lfx_safe_patched", False):
+        return
+
+    original_builder = _composio_shared.pydantic_model_from_param_schema
+
+    def safe_builder(*args, **kwargs):
+        _sanitize_schema(_extract_schema_arg(args, kwargs, positional_index=0, keyword="param_schema"))
+        return original_builder(*args, **kwargs)
+
+    _composio_shared.pydantic_model_from_param_schema = safe_builder
+    _composio_shared._lfx_safe_patched = True  # noqa: SLF001
+
+
 _patch_file_helper_once()
+_patch_pydantic_builder_once()

--- a/src/lfx/src/lfx/base/composio/safe_provider.py
+++ b/src/lfx/src/lfx/base/composio/safe_provider.py
@@ -17,8 +17,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from composio.core.models._files import FileHelper
-from composio_langchain import LangchainProvider
+try:
+    from composio.core.models._files import FileHelper
+    from composio_langchain import LangchainProvider
+except ImportError:  # composio extra not installed; module becomes a no-op
+    FileHelper = None  # type: ignore[assignment]
+    LangchainProvider = None  # type: ignore[assignment,misc]
+    _COMPOSIO_AVAILABLE = False
+else:
+    _COMPOSIO_AVAILABLE = True
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -78,12 +85,14 @@ def _sanitize_schema(schema: Any) -> None:
                 _sanitize_schema(sub)
 
 
-class SafeLangchainProvider(LangchainProvider, name="langchain"):
-    """LangchainProvider that patches tool schemas before delegating."""
+if _COMPOSIO_AVAILABLE:
 
-    def wrap_tool(self, tool: Tool, execute_tool: Callable[..., Any]) -> StructuredTool:
-        _sanitize_schema(tool.input_parameters)
-        return super().wrap_tool(tool=tool, execute_tool=execute_tool)
+    class SafeLangchainProvider(LangchainProvider, name="langchain"):
+        """LangchainProvider that patches tool schemas before delegating."""
+
+        def wrap_tool(self, tool: Tool, execute_tool: Callable[..., Any]) -> StructuredTool:
+            _sanitize_schema(tool.input_parameters)
+            return super().wrap_tool(tool=tool, execute_tool=execute_tool)
 
 
 def _patch_file_helper_once() -> None:
@@ -94,18 +103,27 @@ def _patch_file_helper_once() -> None:
     methods run on every ``composio.tools.execute`` call (including direct component
     runs that don't go through ``configure_tools``), so we patch them here once at
     import time.
+
+    Side effects: this mutates ``composio.core.models._files.FileHelper`` for the
+    entire Python process. Any other consumer that imports Composio in the same
+    runtime (Astra integrations, plugin bundles, scripts) will see the patched
+    methods. Intentional — the upstream raw subscript is a bug, and the wrapper
+    only inserts missing ``"type"`` keys before delegating to the original
+    helpers, so it is a strict superset of the original behavior. Idempotent via
+    the ``_lfx_safe_patched`` sentinel; safe across repeated imports / pytest
+    process reuse.
     """
-    if getattr(FileHelper, "_lfx_safe_patched", False):
+    if not _COMPOSIO_AVAILABLE or getattr(FileHelper, "_lfx_safe_patched", False):
         return
 
     original_uploads = FileHelper._substitute_file_uploads_recursively  # noqa: SLF001
     original_downloads = FileHelper._substitute_file_downloads_recursively  # noqa: SLF001
 
-    def safe_uploads(self, tool, schema, request):
+    def safe_uploads(self, *, tool, schema, request):
         _sanitize_schema(schema)
         return original_uploads(self, tool=tool, schema=schema, request=request)
 
-    def safe_downloads(self, tool, schema, request):
+    def safe_downloads(self, *, tool, schema, request):
         _sanitize_schema(schema)
         return original_downloads(self, tool=tool, schema=schema, request=request)
 

--- a/src/lfx/src/lfx/components/composio/composio_api.py
+++ b/src/lfx/src/lfx/components/composio/composio_api.py
@@ -3,10 +3,11 @@ from collections.abc import Sequence
 from typing import Any
 
 from composio import Composio
-from composio_langchain import LangchainProvider
 
 # Third-party imports
 from langchain_core.tools import Tool
+
+from lfx.base.composio.safe_provider import SafeLangchainProvider
 
 # Local imports
 from lfx.base.langchain_utilities.model import LCToolComponent
@@ -271,7 +272,7 @@ class ComposioAPIComponent(LCToolComponent):
             if not self.api_key:
                 msg = "Composio API Key is required"
                 raise ValueError(msg)
-            return Composio(api_key=self.api_key, provider=LangchainProvider())
+            return Composio(api_key=self.api_key, provider=SafeLangchainProvider())
         except ValueError as e:
             self.log(f"Error building Composio wrapper: {e}")
             msg = "Please provide a valid Composio API Key in the component settings"


### PR DESCRIPTION
## Summary

- Composio Gmail / Google Calendar tools raise `KeyError: 'type'` when invoked from the Playground after enabling all actions, because `composio==0.9.2` raw-subscripts `properties[name]["type"]` on schemas where the property only carries `anyOf` / `$ref` / `additionalProperties`.
- Patch the Langflow side: sanitize every JSON-schema node so a `type` key always exists, via a `SafeLangchainProvider` subclass and a module-level monkey-patch on `FileHelper._substitute_file_{uploads,downloads}_recursively` that intercepts both the agent path and the direct `execute_action` path.
- Adds 12 unit tests covering every sanitize branch and an end-to-end guard that drives Composio's real upload walker against a typeless schema.

## Reproduction (from issue)

1. Drag the Gmail component and enter a Composio API key.
2. Enable all actions with the "check all" checkbox.
3. Wire it to an Agent and ask a question in the Playground.

**Before:** `Error using GMAIL_FETCH_EMAILS` → `KeyError Details: type`.

**After:** the tool executes end-to-end and the agent answers with the requested emails. Verified live for `GMAIL_FETCH_EMAILS`, `GOOGLECALENDAR_GET_CURRENT_DATE_TIME`, `GOOGLECALENDAR_GET_CALENDAR`, `GOOGLECALENDAR_EVENTS_LIST`, and `GOOGLECALENDAR_CREATE_EVENT`.

## Root cause

`composio==0.9.2` performs raw `params[name]["type"]` lookups in three places that all participate in tool execution:

| File | Line | Path |
| --- | --- | --- |
| `composio/core/models/_files.py` | 235 | `_substitute_file_uploads_recursively` (request-side) |
| `composio/core/models/_files.py` | 308 | `_substitute_file_downloads_recursively` (response-side) |
| `composio/utils/shared.py` | 232 | `pydantic_model_from_param_schema` (build-side) |

Many Gmail / Google Calendar action schemas describe properties with `anyOf` (e.g. nullable strings) or only `$ref` / `additionalProperties`, so any of those subscripts raises `KeyError('type')` and the agent never sees a usable result.

## Fix

- New `lfx.base.composio.safe_provider.SafeLangchainProvider` subclass overrides `wrap_tool` to call `_sanitize_schema(tool.input_parameters)` before delegating to `composio_langchain.LangchainProvider`.
- Module-level `_patch_file_helper_once()` wraps `FileHelper._substitute_file_{uploads,downloads}_recursively` so the same sanitizer runs on every `composio.tools.execute` call (covers the direct `execute_action` path that bypasses `wrap_tool`).
- `ComposioBaseComponent.configure_tools` walks `composio.tools._tool_schemas` after `tools.get(...)` and sanitizes each cached schema, because Composio deep-copies the original schema *before* `process_schema_recursively` rewrites the live `tool.input_parameters`.
- `_sanitize_schema` is a small recursive walker that:
  - infers `"object"` when `properties` exist,
  - infers `"array"` when `items` exists,
  - otherwise defaults to `"string"`,
  - never overwrites an existing `type`,
  - walks `anyOf` / `oneOf` / `allOf` arms and `$defs` / `definitions` for completeness.
- The string default is conservative: composio only checks `type == "object"` to decide whether to recurse into nested file substitution, so defaulting to `"string"` is a no-op for that branch and keeps file-upload semantics identical for tools that already had explicit object types.

## Test plan

- [x] `uv run pytest src/backend/tests/unit/components/bundles/composio/ -v` → 14 passed (2 existing + 12 new).
- [x] Live Playground run: Gmail Composio + Agent + Chat I/O, "check all" enabled, prompts `list my last 3 emails`, `search emails from <sender>`, `find may 1 invitations` all complete without `KeyError`.
- [x] Live Playground run: Google Calendar Composio, prompts `any events on May 1?`, `list events this week`, `create event tomorrow at 3pm titled test` all complete without `KeyError`.
- [x] `uv run ruff check` and `uv run ruff format` clean for all touched files.
- [ ] CI green.

## Affected files

- `src/lfx/src/lfx/base/composio/safe_provider.py` (new)
- `src/lfx/src/lfx/base/composio/composio_base.py`
- `src/lfx/src/lfx/components/composio/composio_api.py`
- `src/backend/tests/unit/components/bundles/composio/test_safe_provider.py` (new)

Fixes #12894
Fixes #12895