### PR TITLE
fix: lfx env var resolution when value is empty

### DIFF
--- a/src/backend/tests/unit/test_credential_resolution.py
+++ b/src/backend/tests/unit/test_credential_resolution.py
@@ -100,3 +100,32 @@ class TestGetApiKeyForProviderDbFallback:
         result = get_api_key_for_provider(user_id, "OpenAI", None)
 
         assert result == "sk-from-database"
+
+    @patch("lfx.base.models.unified_models.credentials.get_model_provider_variable_mapping")
+    def test_should_fallback_to_env_when_user_id_is_none(self, mock_mapping, monkeypatch):
+        """No user_id (lfx run) must still resolve credentials from os.environ.
+
+        Reproducer: a flow exported with empty api_key + load_from_db=False is executed
+        via `lfx run`. user_id is None, api_key is empty/None — the function should still
+        try the canonical env var (e.g. WATSONX_APIKEY) before giving up.
+        """
+        from lfx.base.models.unified_models.credentials import get_api_key_for_provider
+
+        mock_mapping.return_value = {"IBM WatsonX": "WATSONX_APIKEY"}
+        monkeypatch.setenv("WATSONX_APIKEY", "shell-exported-key")
+
+        result = get_api_key_for_provider(None, "IBM WatsonX", None)
+
+        assert result == "shell-exported-key"
+
+    @patch("lfx.base.models.unified_models.credentials.get_model_provider_variable_mapping")
+    def test_should_return_none_when_user_id_none_and_env_unset(self, mock_mapping, monkeypatch):
+        """No user_id and no env var: nothing to return."""
+        from lfx.base.models.unified_models.credentials import get_api_key_for_provider
+
+        mock_mapping.return_value = {"IBM WatsonX": "WATSONX_APIKEY"}
+        monkeypatch.delenv("WATSONX_APIKEY", raising=False)
+
+        result = get_api_key_for_provider(None, "IBM WatsonX", None)
+
+        assert result is None

--- a/src/lfx/src/lfx/base/models/unified_models/credentials.py
+++ b/src/lfx/src/lfx/base/models/unified_models/credentials.py
@@ -79,6 +79,7 @@ def get_api_key_for_provider(user_id: UUID | str | None, provider: str, api_key:
     has_user = user_id is not None and not (isinstance(user_id, str) and user_id == "None")
     api_key = None
     if has_user:
+
         async def _get_variable():
             async with session_scope() as session:
                 variable_service = get_variable_service()

--- a/src/lfx/src/lfx/base/models/unified_models/credentials.py
+++ b/src/lfx/src/lfx/base/models/unified_models/credentials.py
@@ -67,36 +67,37 @@ def get_api_key_for_provider(user_id: UUID | str | None, provider: str, api_key:
         # Literal API key (e.g. sk-...)
         return var_name
 
-    # If no user_id or user_id is the string "None", we can't look up global variables
-    if user_id is None or (isinstance(user_id, str) and user_id == "None"):
-        return None
-
     # Get primary variable (first required secret) from provider metadata
     provider_variable_map = get_model_provider_variable_mapping()
     variable_name = provider_variable_map.get(provider)
     if not variable_name:
         return None
 
-    # Try to get from global variables, fall back to environment
-    async def _get_variable():
-        async with session_scope() as session:
-            variable_service = get_variable_service()
-            if variable_service is None:
-                return None
-            try:
-                return await variable_service.get_variable(
-                    user_id=UUID(user_id) if isinstance(user_id, str) else user_id,
-                    name=variable_name,
-                    field="",
-                    session=session,
-                )
-            except ValueError:
-                return None
+    # Try the database-backed variable service first when a user_id is available.
+    # Fall through to os.environ regardless so lfx run (no user_id) can still pick
+    # up canonical credentials from the shell.
+    has_user = user_id is not None and not (isinstance(user_id, str) and user_id == "None")
+    api_key = None
+    if has_user:
+        async def _get_variable():
+            async with session_scope() as session:
+                variable_service = get_variable_service()
+                if variable_service is None:
+                    return None
+                try:
+                    return await variable_service.get_variable(
+                        user_id=UUID(user_id) if isinstance(user_id, str) else user_id,
+                        name=variable_name,
+                        field="",
+                        session=session,
+                    )
+                except ValueError:
+                    return None
 
-    try:
-        api_key = run_until_complete(_get_variable())
-    except (ValueError, Exception):  # noqa: BLE001
-        api_key = None
+        try:
+            api_key = run_until_complete(_get_variable())
+        except (ValueError, Exception):  # noqa: BLE001
+            api_key = None
 
     if api_key:
         return api_key


### PR DESCRIPTION
Ensures that key resolution falls back to environment variable provider mapping if the value is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP error status code returned when file uploads exceed size limits to align with HTTP standards

* **Tests**
  * Expanded test coverage for deployment operations and credential resolution scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->