### PR TITLE
[codex] Add Knowledge Backends settings

### DIFF
--- a/src/frontend/src/constants/__tests__/knowledgeBackendConstants.test.ts
+++ b/src/frontend/src/constants/__tests__/knowledgeBackendConstants.test.ts
@@ -1,0 +1,53 @@
+import {
+  ACTIVE_KNOWLEDGE_BACKEND_VARIABLE,
+  getActiveKnowledgeBackend,
+  getDefaultKnowledgeBackendConfig,
+  OPENSEARCH_VARIABLES,
+} from "../knowledgeBackendConstants";
+
+const variable = (name: string, value: string) => ({
+  id: name,
+  name,
+  value,
+  type: "Generic" as const,
+  default_fields: [],
+});
+
+describe("knowledgeBackendConstants", () => {
+  it("defaults to Chroma when no backend is configured", () => {
+    expect(getActiveKnowledgeBackend([])).toBe("chroma");
+    expect(getDefaultKnowledgeBackendConfig([])).toEqual({
+      backendType: "chroma",
+      backendConfig: {},
+    });
+  });
+
+  it("falls back to Chroma for unsupported configured backend values", () => {
+    expect(
+      getActiveKnowledgeBackend([
+        variable(ACTIVE_KNOWLEDGE_BACKEND_VARIABLE, "astra"),
+      ]),
+    ).toBe("chroma");
+  });
+
+  it("builds OpenSearch backend config from saved global variables", () => {
+    expect(
+      getDefaultKnowledgeBackendConfig([
+        variable(ACTIVE_KNOWLEDGE_BACKEND_VARIABLE, "opensearch"),
+        variable(OPENSEARCH_VARIABLES.INDEX_NAME, "kb-index"),
+        variable(OPENSEARCH_VARIABLES.VECTOR_FIELD, "embedding"),
+        variable(OPENSEARCH_VARIABLES.TEXT_FIELD, "content"),
+      ]),
+    ).toEqual({
+      backendType: "opensearch",
+      backendConfig: {
+        url_variable: OPENSEARCH_VARIABLES.URL,
+        username_variable: OPENSEARCH_VARIABLES.USERNAME,
+        password_variable: OPENSEARCH_VARIABLES.PASSWORD,
+        index_name: "kb-index",
+        vector_field: "embedding",
+        text_field: "content",
+      },
+    });
+  });
+});

--- a/src/frontend/src/constants/knowledgeBackendConstants.ts
+++ b/src/frontend/src/constants/knowledgeBackendConstants.ts
@@ -1,0 +1,178 @@
+import type { GlobalVariable } from "@/types/global_variables";
+
+export const ACTIVE_KNOWLEDGE_BACKEND_VARIABLE = "LANGFLOW_KNOWLEDGE_BACKEND";
+
+export const OPENSEARCH_VARIABLES = {
+  URL: "OPENSEARCH_URL",
+  USERNAME: "OPENSEARCH_USERNAME",
+  PASSWORD: "OPENSEARCH_PASSWORD", // pragma: allowlist secret
+  INDEX_NAME: "OPENSEARCH_INDEX_NAME",
+  VECTOR_FIELD: "OPENSEARCH_VECTOR_FIELD",
+  TEXT_FIELD: "OPENSEARCH_TEXT_FIELD",
+} as const;
+
+export type KnowledgeBackendId =
+  | "chroma"
+  | "opensearch"
+  | "astra"
+  | "mongodb"
+  | "postgres";
+
+export interface KnowledgeBackendConfigField {
+  label: string;
+  variableKey: string;
+  required: boolean;
+  isSecret: boolean;
+  placeholder: string;
+  defaultValue?: string;
+}
+
+export interface KnowledgeBackendOption {
+  id: KnowledgeBackendId;
+  label: string;
+  description: string;
+  icon: string;
+  status: "available" | "coming_soon";
+  defaultEnabled?: boolean;
+  configFields: KnowledgeBackendConfigField[];
+}
+
+export const KNOWLEDGE_BACKEND_OPTIONS: KnowledgeBackendOption[] = [
+  {
+    id: "chroma",
+    label: "Chroma",
+    description:
+      "Local vector storage bundled with Langflow. No additional configuration required.",
+    icon: "Chroma",
+    status: "available",
+    defaultEnabled: true,
+    configFields: [],
+  },
+  {
+    id: "opensearch",
+    label: "OpenSearch",
+    description:
+      "External OpenSearch k-NN index for self-hosted or managed clusters.",
+    icon: "Search",
+    status: "available",
+    configFields: [
+      {
+        label: "Cluster URL",
+        variableKey: OPENSEARCH_VARIABLES.URL,
+        required: true,
+        isSecret: false,
+        placeholder: "https://search.example.com:9200",
+      },
+      {
+        label: "Username",
+        variableKey: OPENSEARCH_VARIABLES.USERNAME,
+        required: false,
+        isSecret: false,
+        placeholder: "admin",
+      },
+      {
+        label: "Password",
+        variableKey: OPENSEARCH_VARIABLES.PASSWORD,
+        required: false,
+        isSecret: true,
+        placeholder: "Enter OpenSearch password",
+      },
+      {
+        label: "Default index name",
+        variableKey: OPENSEARCH_VARIABLES.INDEX_NAME,
+        required: true,
+        isSecret: false,
+        placeholder: "langflow_knowledge",
+      },
+      {
+        label: "Vector field",
+        variableKey: OPENSEARCH_VARIABLES.VECTOR_FIELD,
+        required: false,
+        isSecret: false,
+        placeholder: "vector_field",
+        defaultValue: "vector_field",
+      },
+      {
+        label: "Text field",
+        variableKey: OPENSEARCH_VARIABLES.TEXT_FIELD,
+        required: false,
+        isSecret: false,
+        placeholder: "text",
+        defaultValue: "text",
+      },
+    ],
+  },
+  {
+    id: "astra",
+    label: "Astra DB",
+    description: "Managed Cassandra vector storage.",
+    icon: "AstraDB",
+    status: "coming_soon",
+    configFields: [],
+  },
+  {
+    id: "mongodb",
+    label: "MongoDB Atlas",
+    description: "Atlas Vector Search backend.",
+    icon: "Database",
+    status: "coming_soon",
+    configFields: [],
+  },
+  {
+    id: "postgres",
+    label: "Postgres pgvector",
+    description: "Postgres-backed vector storage.",
+    icon: "Database",
+    status: "coming_soon",
+    configFields: [],
+  },
+];
+
+export const AVAILABLE_KNOWLEDGE_BACKEND_OPTIONS =
+  KNOWLEDGE_BACKEND_OPTIONS.filter((backend) => backend.status === "available");
+
+export function getGlobalVariableValue(
+  variables: GlobalVariable[],
+  name: string,
+): string | undefined {
+  const value = variables.find((variable) => variable.name === name)?.value;
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+export function getActiveKnowledgeBackend(
+  variables: GlobalVariable[],
+): "chroma" | "opensearch" {
+  const configuredBackend = getGlobalVariableValue(
+    variables,
+    ACTIVE_KNOWLEDGE_BACKEND_VARIABLE,
+  );
+  return configuredBackend === "opensearch" ? "opensearch" : "chroma";
+}
+
+export function getDefaultKnowledgeBackendConfig(variables: GlobalVariable[]): {
+  backendType: "chroma" | "opensearch";
+  backendConfig: Record<string, string>;
+} {
+  const backendType = getActiveKnowledgeBackend(variables);
+  if (backendType !== "opensearch") {
+    return { backendType: "chroma", backendConfig: {} };
+  }
+
+  return {
+    backendType,
+    backendConfig: {
+      url_variable: OPENSEARCH_VARIABLES.URL,
+      username_variable: OPENSEARCH_VARIABLES.USERNAME,
+      password_variable: OPENSEARCH_VARIABLES.PASSWORD,
+      index_name:
+        getGlobalVariableValue(variables, OPENSEARCH_VARIABLES.INDEX_NAME) ??
+        "",
+      vector_field:
+        getGlobalVariableValue(variables, OPENSEARCH_VARIABLES.VECTOR_FIELD) ??
+        "vector_field",
+      text_field:
+        getGlobalVariableValue(variables, OPENSEARCH_VARIABLES.TEXT_FIELD) ??
+        "text",
+    },
+  };
+}

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/BackendPicker.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/BackendPicker.tsx
@@ -187,7 +187,7 @@ function BackendConfigSection({ children }: { children: React.ReactNode }) {
       </span>
       <span className="text-[11px] text-muted-foreground">
         Credential fields accept Langflow variable <em>names</em>. Store the
-        actual secrets via the provider settings page.
+        actual values via the Knowledge Backends settings page.
       </span>
       <div className="grid grid-cols-1 gap-2">{children}</div>
     </div>

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
@@ -1,11 +1,13 @@
 import { type AxiosError } from "axios";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ModelOption } from "@/components/core/parameterRenderComponent/components/modelInputComponent";
+import { getDefaultKnowledgeBackendConfig } from "@/constants/knowledgeBackendConstants";
 import { api } from "@/controllers/API/api";
 import { getURL } from "@/controllers/API/helpers/constants";
 import { useCreateKnowledgeBase } from "@/controllers/API/queries/knowledge-bases/use-create-knowledge-base";
 import { useGetIngestionJobStatus } from "@/controllers/API/queries/knowledge-bases/use-get-ingestion-job-status";
 import { useGetModelProviders } from "@/controllers/API/queries/models/use-get-model-providers";
+import { useGetGlobalVariables } from "@/controllers/API/queries/variables";
 import type { BackendValue } from "@/modals/knowledgeBaseUploadModal/components/BackendPicker";
 import useAlertStore from "@/stores/alertStore";
 import {
@@ -68,6 +70,9 @@ export function useKnowledgeBaseForm({
 
   // Fetch embedding model data from API
   const { data: modelProviders = [] } = useGetModelProviders({});
+  const { data: globalVariables = [], isFetched: areGlobalVariablesFetched } =
+    useGetGlobalVariables();
+  const hasAppliedBackendDefaults = useRef(false);
 
   // Transform provider data into ModelOption[] for embedding models only
   const embeddingModelOptions = useMemo<ModelOption[]>(() => {
@@ -118,6 +123,11 @@ export function useKnowledgeBaseForm({
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const defaultBackendSelection = useMemo(
+    () => getDefaultKnowledgeBackendConfig(globalVariables),
+    [globalVariables],
+  );
   const [isFilePanelOpen, setIsFilePanelOpen] = useState(false);
 
   // Preview state
@@ -208,6 +218,29 @@ export function useKnowledgeBaseForm({
     }
   }, [existingKnowledgeBase, open, embeddingModelOptions]);
 
+  useEffect(() => {
+    if (!open) {
+      hasAppliedBackendDefaults.current = false;
+      return;
+    }
+    if (
+      existingKnowledgeBase ||
+      hasAppliedBackendDefaults.current ||
+      !areGlobalVariablesFetched
+    ) {
+      return;
+    }
+
+    setBackendType(defaultBackendSelection.backendType);
+    setBackendConfig(defaultBackendSelection.backendConfig);
+    hasAppliedBackendDefaults.current = true;
+  }, [
+    areGlobalVariablesFetched,
+    defaultBackendSelection,
+    existingKnowledgeBase,
+    open,
+  ]);
+
   const resetForm = useCallback(() => {
     setSourceName("");
     setFiles([]);
@@ -228,6 +261,7 @@ export function useKnowledgeBaseForm({
     setShowAdvanced(false);
     setIngestionJobId(null);
     setValidationErrors({});
+    hasAppliedBackendDefaults.current = false;
   }, []);
 
   const toggleAdvanced = useCallback(() => {

--- a/src/frontend/src/pages/SettingsPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/index.tsx
@@ -1,5 +1,5 @@
-import { Outlet, type To } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { Outlet, type To } from "react-router-dom";
 import SideBarButtonsComponent from "@/components/core/sidebarComponent";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { CustomStoreSidebar } from "@/customization/components/custom-store-sidebar";
@@ -76,6 +76,16 @@ export default function SettingsPage(): JSX.Element {
       icon: (
         <ForwardedIconComponent
           name="Brain"
+          className="w-4 flex-shrink-0 justify-start stroke-[1.5]"
+        />
+      ),
+    },
+    {
+      title: "Knowledge Backends",
+      href: "/settings/knowledge-backends",
+      icon: (
+        <ForwardedIconComponent
+          name="Database"
           className="w-4 flex-shrink-0 justify-start stroke-[1.5]"
         />
       ),

--- a/src/frontend/src/pages/SettingsPage/pages/KnowledgeBackendsPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/KnowledgeBackendsPage/index.tsx
@@ -1,0 +1,505 @@
+import { useEffect, useMemo, useState } from "react";
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  ACTIVE_KNOWLEDGE_BACKEND_VARIABLE,
+  getActiveKnowledgeBackend,
+  getGlobalVariableValue,
+  KNOWLEDGE_BACKEND_OPTIONS,
+  type KnowledgeBackendConfigField,
+  type KnowledgeBackendOption,
+} from "@/constants/knowledgeBackendConstants";
+import { VARIABLE_CATEGORY } from "@/constants/providerConstants";
+import {
+  useGetGlobalVariables,
+  usePatchGlobalVariables,
+  usePostGlobalVariables,
+} from "@/controllers/API/queries/variables";
+import useAlertStore from "@/stores/alertStore";
+import type { GlobalVariable } from "@/types/global_variables";
+import { cn } from "@/utils/utils";
+
+const MASKED_VALUE = "••••••••";
+
+type ApiError = {
+  response?: {
+    data?: {
+      detail?: string;
+    };
+  };
+};
+
+const getErrorDetail = (error: unknown) =>
+  (error as ApiError)?.response?.data?.detail ||
+  "An unexpected error occurred. Please try again.";
+
+export default function KnowledgeBackendsPage() {
+  const { data: globalVariables = [] } = useGetGlobalVariables();
+  const [selectedBackendId, setSelectedBackendId] = useState(
+    getActiveKnowledgeBackend(globalVariables),
+  );
+  const [hasManuallySelectedBackend, setHasManuallySelectedBackend] =
+    useState(false);
+  const [variableValues, setVariableValues] = useState<Record<string, string>>(
+    {},
+  );
+  const [editingSecret, setEditingSecret] = useState<Record<string, boolean>>(
+    {},
+  );
+
+  const { mutateAsync: createGlobalVariable, isPending: isCreating } =
+    usePostGlobalVariables();
+  const { mutateAsync: updateGlobalVariable, isPending: isUpdating } =
+    usePatchGlobalVariables();
+
+  const setSuccessData = useAlertStore((state) => state.setSuccessData);
+  const setErrorData = useAlertStore((state) => state.setErrorData);
+
+  const activeBackendId = useMemo(
+    () => getActiveKnowledgeBackend(globalVariables),
+    [globalVariables],
+  );
+
+  useEffect(() => {
+    if (!hasManuallySelectedBackend) {
+      setSelectedBackendId(activeBackendId);
+    }
+  }, [activeBackendId, hasManuallySelectedBackend]);
+
+  const selectedBackend =
+    KNOWLEDGE_BACKEND_OPTIONS.find(
+      (backend) => backend.id === selectedBackendId,
+    ) ?? KNOWLEDGE_BACKEND_OPTIONS[0];
+
+  const isPending = isCreating || isUpdating;
+
+  const findVariable = (name: string) =>
+    globalVariables.find((variable) => variable.name === name);
+
+  const setVariable = async ({
+    name,
+    value,
+    isSecret,
+  }: {
+    name: string;
+    value: string;
+    isSecret: boolean;
+  }) => {
+    const existingVariable = findVariable(name);
+    if (existingVariable) {
+      await updateGlobalVariable({ id: existingVariable.id, value });
+      return;
+    }
+
+    await createGlobalVariable({
+      name,
+      value,
+      type: isSecret ? "Credential" : "Generic",
+      category: VARIABLE_CATEGORY.GLOBAL,
+      default_fields: [],
+    });
+  };
+
+  const activateBackend = async (backend: KnowledgeBackendOption) => {
+    const activeBackendVariable = findVariable(
+      ACTIVE_KNOWLEDGE_BACKEND_VARIABLE,
+    );
+    if (activeBackendVariable) {
+      await updateGlobalVariable({
+        id: activeBackendVariable.id,
+        value: backend.id,
+      });
+      return;
+    }
+
+    await createGlobalVariable({
+      name: ACTIVE_KNOWLEDGE_BACKEND_VARIABLE,
+      value: backend.id,
+      type: "Generic",
+      category: VARIABLE_CATEGORY.SETTINGS,
+      default_fields: [],
+    });
+  };
+
+  const getFieldValue = (field: KnowledgeBackendConfigField) => {
+    if (field.variableKey in variableValues) {
+      return variableValues[field.variableKey];
+    }
+    return (
+      getGlobalVariableValue(globalVariables, field.variableKey) ??
+      field.defaultValue ??
+      ""
+    );
+  };
+
+  const hasConfiguredValue = (variableKey: string) =>
+    globalVariables.some((variable) => variable.name === variableKey);
+
+  const canSave = selectedBackend.configFields
+    .filter((field) => field.required)
+    .every((field) => getFieldValue(field).trim());
+
+  const handleSave = async () => {
+    if (selectedBackend.status !== "available") return;
+    if (!canSave) {
+      setErrorData({
+        title: "Missing required configuration",
+        list: [
+          `${selectedBackend.label} requires ${selectedBackend.configFields
+            .filter((field) => field.required && !getFieldValue(field).trim())
+            .map((field) => field.label)
+            .join(", ")}.`,
+        ],
+      });
+      return;
+    }
+
+    try {
+      const fieldsToSave = selectedBackend.configFields.filter((field) => {
+        const nextValue = getFieldValue(field).trim();
+        return (
+          nextValue && (field.variableKey in variableValues || field.required)
+        );
+      });
+
+      await Promise.all(
+        fieldsToSave.map((field) =>
+          setVariable({
+            name: field.variableKey,
+            value: getFieldValue(field).trim(),
+            isSecret: field.isSecret,
+          }),
+        ),
+      );
+      await activateBackend(selectedBackend);
+      setVariableValues({});
+      setEditingSecret({});
+      setHasManuallySelectedBackend(false);
+      setSuccessData({
+        title:
+          selectedBackend.id === "chroma"
+            ? "Chroma selected"
+            : `${selectedBackend.label} configuration saved`,
+      });
+    } catch (error: unknown) {
+      setErrorData({
+        title: "Error saving knowledge backend",
+        list: [getErrorDetail(error)],
+      });
+    }
+  };
+
+  const handleUseChroma = async () => {
+    const chromaBackend = KNOWLEDGE_BACKEND_OPTIONS[0];
+    try {
+      await activateBackend(chromaBackend);
+      setSelectedBackendId("chroma");
+      setHasManuallySelectedBackend(false);
+      setSuccessData({ title: "Chroma selected" });
+    } catch (error: unknown) {
+      setErrorData({
+        title: "Error selecting Chroma",
+        list: [getErrorDetail(error)],
+      });
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex w-full items-start justify-between gap-6">
+        <div className="flex flex-col">
+          <h2
+            className="flex items-center text-lg font-semibold tracking-tight"
+            data-testid="settings_menu_header"
+          >
+            Knowledge Backends
+            <ForwardedIconComponent
+              name="Database"
+              className="ml-2 h-5 w-5 text-primary"
+            />
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Configure vector-store backends for Knowledge Bases.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex h-[calc(100vh-305px)] w-full overflow-hidden rounded-lg border">
+        <div
+          className={cn(
+            "flex flex-col gap-1 p-2 transition-all duration-300 ease-in-out",
+            selectedBackend ? "w-1/3 border-r" : "w-full",
+          )}
+        >
+          {KNOWLEDGE_BACKEND_OPTIONS.map((backend) => (
+            <BackendListItem
+              key={backend.id}
+              backend={backend}
+              isActive={activeBackendId === backend.id}
+              isSelected={selectedBackend.id === backend.id}
+              isConfigured={
+                backend.id === "chroma" ||
+                backend.configFields
+                  .filter((field) => field.required)
+                  .every((field) => hasConfiguredValue(field.variableKey))
+              }
+              onSelect={() => {
+                setHasManuallySelectedBackend(true);
+                setSelectedBackendId(backend.id);
+              }}
+            />
+          ))}
+        </div>
+
+        <div className="flex min-h-0 w-2/3 flex-col overflow-hidden">
+          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-4">
+            <BackendConfigurationPanel
+              backend={selectedBackend}
+              activeBackendId={activeBackendId}
+              globalVariables={globalVariables}
+              variableValues={variableValues}
+              editingSecret={editingSecret}
+              isPending={isPending}
+              canSave={canSave}
+              getFieldValue={getFieldValue}
+              onVariableChange={(key, value) =>
+                setVariableValues((prev) => ({ ...prev, [key]: value }))
+              }
+              onSecretEditingChange={(key, editing) =>
+                setEditingSecret((prev) => ({ ...prev, [key]: editing }))
+              }
+              onSave={
+                selectedBackend.id === "chroma" ? handleUseChroma : handleSave
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BackendListItem({
+  backend,
+  isActive,
+  isSelected,
+  isConfigured,
+  onSelect,
+}: {
+  backend: KnowledgeBackendOption;
+  isActive: boolean;
+  isSelected: boolean;
+  isConfigured: boolean;
+  onSelect: () => void;
+}) {
+  const isComingSoon = backend.status === "coming_soon";
+
+  return (
+    <button
+      type="button"
+      data-testid={`knowledge-backend-item-${backend.id}`}
+      className={cn(
+        "flex w-full cursor-pointer items-center justify-between rounded-lg px-2 py-3 text-left transition-colors hover:bg-muted/50",
+        isSelected && "bg-muted/50",
+        isComingSoon && "cursor-default opacity-70",
+      )}
+      onClick={onSelect}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <ForwardedIconComponent
+          name={backend.icon}
+          className={cn(
+            "h-5 w-5 flex-shrink-0",
+            !isConfigured && !backend.defaultEnabled && "opacity-50 grayscale",
+          )}
+        />
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <span
+            className={cn(
+              "truncate text-sm font-medium",
+              !isConfigured &&
+                !backend.defaultEnabled &&
+                "text-muted-foreground",
+            )}
+          >
+            {backend.label}
+          </span>
+          {isComingSoon && (
+            <Badge variant="secondaryStatic" size="sq" className="text-xs">
+              Coming soon
+            </Badge>
+          )}
+          {isActive && !isComingSoon && (
+            <Badge variant="secondary" size="sq" className="text-xs">
+              Active
+            </Badge>
+          )}
+        </div>
+      </div>
+      {!isComingSoon && (
+        <ForwardedIconComponent
+          name={isActive ? "Check" : "Plus"}
+          className={cn(
+            "h-4 w-4",
+            isActive ? "text-status-green" : "text-muted-foreground",
+          )}
+        />
+      )}
+    </button>
+  );
+}
+
+function BackendConfigurationPanel({
+  backend,
+  activeBackendId,
+  globalVariables,
+  variableValues,
+  editingSecret,
+  isPending,
+  canSave,
+  getFieldValue,
+  onVariableChange,
+  onSecretEditingChange,
+  onSave,
+}: {
+  backend: KnowledgeBackendOption;
+  activeBackendId: "chroma" | "opensearch";
+  globalVariables: GlobalVariable[];
+  variableValues: Record<string, string>;
+  editingSecret: Record<string, boolean>;
+  isPending: boolean;
+  canSave: boolean;
+  getFieldValue: (field: KnowledgeBackendConfigField) => string;
+  onVariableChange: (key: string, value: string) => void;
+  onSecretEditingChange: (key: string, editing: boolean) => void;
+  onSave: () => void;
+}) {
+  const isComingSoon = backend.status === "coming_soon";
+  const isActive = activeBackendId === backend.id;
+
+  return (
+    <div className="flex max-w-[680px] flex-col gap-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <ForwardedIconComponent
+            name={backend.icon}
+            className="h-6 w-6 flex-shrink-0 text-primary"
+          />
+          <div className="flex min-w-0 flex-col">
+            <div className="flex items-center gap-2">
+              <span className="text-[13px] font-semibold">{backend.label}</span>
+              {isActive && !isComingSoon && (
+                <Badge variant="secondary" size="sq" className="text-xs">
+                  Active
+                </Badge>
+              )}
+              {isComingSoon && (
+                <Badge variant="secondaryStatic" size="sq" className="text-xs">
+                  Coming soon
+                </Badge>
+              )}
+            </div>
+            <span className="pt-1 text-[13px] text-muted-foreground">
+              {backend.description}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {isComingSoon ? (
+        <div className="rounded-md border border-dashed border-border bg-muted/30 p-3 text-[13px] text-muted-foreground">
+          This backend is stubbed in the Knowledge Base backend registry and
+          will become configurable after the provider implementation is wired
+          through end-to-end.
+        </div>
+      ) : backend.id === "chroma" ? (
+        <div className="flex flex-col gap-3">
+          <div className="rounded-md border border-border bg-muted/30 p-3 text-[13px] text-muted-foreground">
+            Chroma stores vectors on disk next to Langflow and is enabled by
+            default. Selecting it here makes it the default backend for new
+            Knowledge Bases.
+          </div>
+          <div className="flex justify-end">
+            <Button
+              onClick={onSave}
+              size="sm"
+              loading={isPending}
+              disabled={isPending || isActive}
+            >
+              {isActive ? "Chroma selected" : "Use Chroma"}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {backend.configFields.map((field) => {
+            const existingValue = getGlobalVariableValue(
+              globalVariables,
+              field.variableKey,
+            );
+            const hasNewValue = field.variableKey in variableValues;
+            const isEditingSecret = editingSecret[field.variableKey];
+            const inputValue =
+              field.isSecret &&
+              existingValue &&
+              !hasNewValue &&
+              !isEditingSecret
+                ? MASKED_VALUE
+                : getFieldValue(field);
+
+            return (
+              <label key={field.variableKey} className="flex flex-col gap-1">
+                <span className="text-[12px] font-medium text-muted-foreground">
+                  {field.label}
+                  {field.required && (
+                    <span className="ml-1 text-destructive">*</span>
+                  )}
+                </span>
+                <Input
+                  placeholder={field.placeholder}
+                  value={inputValue}
+                  type={
+                    field.isSecret && (isEditingSecret || hasNewValue)
+                      ? "password"
+                      : "text"
+                  }
+                  disabled={isPending}
+                  onChange={(event) =>
+                    onVariableChange(field.variableKey, event.target.value)
+                  }
+                  onFocus={() => {
+                    if (field.isSecret && existingValue && !hasNewValue) {
+                      onSecretEditingChange(field.variableKey, true);
+                      onVariableChange(field.variableKey, "");
+                    }
+                  }}
+                  onBlur={() => {
+                    if (!variableValues[field.variableKey]) {
+                      onSecretEditingChange(field.variableKey, false);
+                    }
+                  }}
+                />
+                <span className="text-[11px] text-muted-foreground">
+                  Saved as global variable{" "}
+                  <span className="font-mono">{field.variableKey}</span>
+                </span>
+              </label>
+            );
+          })}
+          <div className="flex justify-end">
+            <Button
+              onClick={onSave}
+              size="sm"
+              loading={isPending}
+              disabled={!canSave || isPending}
+            >
+              {isActive ? "Save" : `Save and use ${backend.label}`}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -35,6 +35,7 @@ import SettingsPage from "./pages/SettingsPage";
 import ApiKeysPage from "./pages/SettingsPage/pages/ApiKeysPage";
 import GeneralPage from "./pages/SettingsPage/pages/GeneralPage";
 import GlobalVariablesPage from "./pages/SettingsPage/pages/GlobalVariablesPage";
+import KnowledgeBackendsPage from "./pages/SettingsPage/pages/KnowledgeBackendsPage";
 import MCPServersPage from "./pages/SettingsPage/pages/MCPServersPage";
 import McpClientPage from "./pages/SettingsPage/pages/McpClientPage";
 import ModelProvidersPage from "./pages/SettingsPage/pages/ModelProvidersPage";
@@ -154,6 +155,10 @@ const router = createBrowserRouter(
                   <Route
                     path="model-providers"
                     element={<ModelProvidersPage />}
+                  />
+                  <Route
+                    path="knowledge-backends"
+                    element={<KnowledgeBackendsPage />}
                   />
                   <Route path="mcp-servers" element={<MCPServersPage />} />
                   <Route path="mcp-client" element={<McpClientPage />} />


### PR DESCRIPTION
## Summary
- Add a new Settings > Knowledge Backends page modeled after Model Providers.
- Keep Chroma enabled by default, add OpenSearch configuration that persists to Langflow global variables, and show Astra/MongoDB/Postgres as coming soon.
- Reuse the saved global backend settings to prefill new Knowledge Base backend configuration.

## Validation
- `npx @biomejs/biome check src/constants/knowledgeBackendConstants.ts src/constants/__tests__/knowledgeBackendConstants.test.ts src/pages/SettingsPage/pages/KnowledgeBackendsPage/index.tsx src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts src/modals/knowledgeBaseUploadModal/components/BackendPicker.tsx src/pages/SettingsPage/index.tsx src/routes.tsx`
- `npm test -- knowledgeBackendConstants.test.ts --runInBand`
- `npm test -- KnowledgeBaseUploadModal.test.tsx --runInBand`

## Notes
- `npx tsc --noEmit --pretty false --project tsconfig.json` was attempted but the repo currently reports existing unrelated frontend type errors outside this change.