### PR TITLE
docs: change upgrade reinstall order

### DIFF
--- a/docs/docs/Get-Started/get-started-installation.mdx
+++ b/docs/docs/Get-Started/get-started-installation.mdx
@@ -182,13 +182,14 @@ For more information, see [Deploy Langflow on Docker](/deployment-docker).
     To install a specific version of the Langflow package, add the required version to the command, such as `uv pip install langflow==1.4.22`.
 
     <details>
-    <summary>Reinstall or upgrade Langflow</summary>
-
-    To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
+    <summary>Upgrade or reinstall Langflow</summary>
 
     To upgrade Langflow to the latest version, run `uv pip install langflow -U`.
     However, the Langflow team recommends taking steps to backup your existing installation before you upgrade Langflow.
+
     For more information, see [Prepare to upgrade](/release-notes#prepare-to-upgrade).
+
+    To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
 
     </details>
 

--- a/docs/docs/Get-Started/get-started-installation.mdx
+++ b/docs/docs/Get-Started/get-started-installation.mdx
@@ -179,20 +179,6 @@ For more information, see [Deploy Langflow on Docker](/deployment-docker).
     uv pip install langflow
     ```
 
-    To install a specific version of the Langflow package, add the required version to the command, such as `uv pip install langflow==1.4.22`.
-
-    <details>
-    <summary>Upgrade or reinstall Langflow</summary>
-
-    To upgrade Langflow to the latest version, run `uv pip install langflow -U`.
-    However, the Langflow team recommends taking steps to backup your existing installation before you upgrade Langflow.
-
-    For more information, see [Prepare to upgrade](/release-notes#prepare-to-upgrade).
-
-    To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
-
-    </details>
-
 4. Start Langflow:
 
     ```bash
@@ -205,9 +191,15 @@ For more information, see [Deploy Langflow on Docker](/deployment-docker).
 
 6. Create your first flow with the [Quickstart](/get-started-quickstart).
 
-For upgrade information, see the [Release notes](/release-notes).
+### Manage the Langflow OSS version
 
-For information about optional dependency groups and support for custom dependencies to extend Langflow OSS functionality, see [Install custom dependencies](/install-custom-dependencies).
+To upgrade Langflow to the latest version, run `uv pip install langflow -U`.
+However, the Langflow team recommends taking steps to backup your existing installation before you upgrade Langflow.
+For more information, see [Prepare to upgrade](/release-notes#prepare-to-upgrade).
+
+To install a specific version of the Langflow package, add the required version to the command, such as `uv pip install langflow==1.4.22`.
+
+To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
 
 ## Next steps
 

--- a/docs/versioned_docs/version-1.8.0/Get-Started/get-started-installation.mdx
+++ b/docs/versioned_docs/version-1.8.0/Get-Started/get-started-installation.mdx
@@ -171,20 +171,6 @@ For more information, see [Deploy Langflow on Docker](/deployment-docker).
     uv pip install langflow
     ```
 
-    To install a specific version of the Langflow package, add the required version to the command, such as `uv pip install langflow==1.4.22`.
-
-    <details>
-    <summary>Upgrade or reinstall Langflow</summary>
-
-    To upgrade Langflow to the latest version, run `uv pip install langflow -U`.
-    However, the Langflow team recommends taking steps to backup your existing installation before you upgrade Langflow.
-
-    For more information, see [Prepare to upgrade](/release-notes#prepare-to-upgrade).
-
-    To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
-
-    </details>
-
 4. Start Langflow:
 
     ```bash
@@ -197,9 +183,15 @@ For more information, see [Deploy Langflow on Docker](/deployment-docker).
 
 6. Create your first flow with the [Quickstart](/get-started-quickstart).
 
-For upgrade information, see the [Release notes](/release-notes).
+### Manage the Langflow OSS version
 
-For information about optional dependency groups and support for custom dependencies to extend Langflow OSS functionality, see [Install custom dependencies](/install-custom-dependencies).
+To upgrade Langflow to the latest version, run `uv pip install langflow -U`.
+However, the Langflow team recommends taking steps to backup your existing installation before you upgrade Langflow.
+For more information, see [Prepare to upgrade](/release-notes#prepare-to-upgrade).
+
+To install a specific version of the Langflow package, add the required version to the command, such as `uv pip install langflow==1.4.22`.
+
+To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
 
 ## Next steps
 

--- a/docs/versioned_docs/version-1.8.0/Get-Started/get-started-installation.mdx
+++ b/docs/versioned_docs/version-1.8.0/Get-Started/get-started-installation.mdx
@@ -174,13 +174,14 @@ For more information, see [Deploy Langflow on Docker](/deployment-docker).
     To install a specific version of the Langflow package, add the required version to the command, such as `uv pip install langflow==1.4.22`.
 
     <details>
-    <summary>Reinstall or upgrade Langflow</summary>
-
-    To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
+    <summary>Upgrade or reinstall Langflow</summary>
 
     To upgrade Langflow to the latest version, run `uv pip install langflow -U`.
     However, the Langflow team recommends taking steps to backup your existing installation before you upgrade Langflow.
+
     For more information, see [Prepare to upgrade](/release-notes#prepare-to-upgrade).
+
+    To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
 
     </details>
 

--- a/docs/versioned_docs/version-1.9.0/Get-Started/get-started-installation.mdx
+++ b/docs/versioned_docs/version-1.9.0/Get-Started/get-started-installation.mdx
@@ -182,13 +182,14 @@ For more information, see [Deploy Langflow on Docker](/deployment-docker).
     To install a specific version of the Langflow package, add the required version to the command, such as `uv pip install langflow==1.4.22`.
 
     <details>
-    <summary>Reinstall or upgrade Langflow</summary>
-
-    To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
+    <summary>Upgrade or reinstall Langflow</summary>
 
     To upgrade Langflow to the latest version, run `uv pip install langflow -U`.
     However, the Langflow team recommends taking steps to backup your existing installation before you upgrade Langflow.
+
     For more information, see [Prepare to upgrade](/release-notes#prepare-to-upgrade).
+
+    To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
 
     </details>
 

--- a/docs/versioned_docs/version-1.9.0/Get-Started/get-started-installation.mdx
+++ b/docs/versioned_docs/version-1.9.0/Get-Started/get-started-installation.mdx
@@ -179,20 +179,6 @@ For more information, see [Deploy Langflow on Docker](/deployment-docker).
     uv pip install langflow
     ```
 
-    To install a specific version of the Langflow package, add the required version to the command, such as `uv pip install langflow==1.4.22`.
-
-    <details>
-    <summary>Upgrade or reinstall Langflow</summary>
-
-    To upgrade Langflow to the latest version, run `uv pip install langflow -U`.
-    However, the Langflow team recommends taking steps to backup your existing installation before you upgrade Langflow.
-
-    For more information, see [Prepare to upgrade](/release-notes#prepare-to-upgrade).
-
-    To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
-
-    </details>
-
 4. Start Langflow:
 
     ```bash
@@ -205,9 +191,15 @@ For more information, see [Deploy Langflow on Docker](/deployment-docker).
 
 6. Create your first flow with the [Quickstart](/get-started-quickstart).
 
-For upgrade information, see the [Release notes](/release-notes).
+### Manage the Langflow OSS version
 
-For information about optional dependency groups and support for custom dependencies to extend Langflow OSS functionality, see [Install custom dependencies](/install-custom-dependencies).
+To upgrade Langflow to the latest version, run `uv pip install langflow -U`.
+However, the Langflow team recommends taking steps to backup your existing installation before you upgrade Langflow.
+For more information, see [Prepare to upgrade](/release-notes#prepare-to-upgrade).
+
+To install a specific version of the Langflow package, add the required version to the command, such as `uv pip install langflow==1.4.22`.
+
+To reinstall Langflow and all of its dependencies, run `uv pip install langflow --force-reinstall`.
 
 ## Next steps
 


### PR DESCRIPTION
Users are missing the "Upgrade" section.

Change 
Reinstall or upgrade Langflow
to
Upgrade or reinstall Langflow
and the order of the tasks presented.