### PR TITLE
fix(frontend): default event_delivery to STREAMING, not POLLING

### DIFF
--- a/src/frontend/src/controllers/API/queries/config/use-get-config.ts
+++ b/src/frontend/src/controllers/API/queries/config/use-get-config.ts
@@ -103,7 +103,7 @@ export const useGetConfig: useQueryFunctionType<
 
       // Set fields present in both public and full config
       setMaxFileSizeUpload(data.max_file_size_upload);
-      setEventDelivery(data.event_delivery ?? EventDeliveryType.POLLING);
+      setEventDelivery(data.event_delivery ?? EventDeliveryType.STREAMING);
       const allowCustomComponents = data.allow_custom_components ?? true;
       setAllowCustomComponents(allowCustomComponents);
       setMcpBaseUrl(data.mcp_base_url ?? "");

--- a/src/frontend/src/stores/__tests__/utilityStore.test.ts
+++ b/src/frontend/src/stores/__tests__/utilityStore.test.ts
@@ -38,7 +38,7 @@ describe("useUtilityStore", () => {
       featureFlags: {},
       webhookPollingInterval: 5000,
       currentSessionId: "",
-      eventDelivery: EventDeliveryType.POLLING,
+      eventDelivery: EventDeliveryType.STREAMING,
       webhookAuthEnable: true,
       defaultFolderName: "Starter Project",
       hideGettingStartedProgress: false,
@@ -61,7 +61,7 @@ describe("useUtilityStore", () => {
       expect(result.current.featureFlags).toEqual({});
       expect(result.current.webhookPollingInterval).toBe(5000);
       expect(result.current.currentSessionId).toBe("");
-      expect(result.current.eventDelivery).toBe(EventDeliveryType.POLLING);
+      expect(result.current.eventDelivery).toBe(EventDeliveryType.STREAMING);
       expect(result.current.webhookAuthEnable).toBe(true);
       expect(result.current.defaultFolderName).toBe("Starter Project");
       expect(result.current.hideGettingStartedProgress).toBe(false);

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -49,7 +49,7 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   currentSessionId: "",
   setCurrentSessionId: (sessionId: string) =>
     set({ currentSessionId: sessionId }),
-  eventDelivery: EventDeliveryType.POLLING,
+  eventDelivery: EventDeliveryType.STREAMING,
   setEventDelivery: (eventDelivery: EventDeliveryType) =>
     set({ eventDelivery }),
   webhookAuthEnable: true,

--- a/src/frontend/src/utils/buildUtils.ts
+++ b/src/frontend/src/utils/buildUtils.ts
@@ -240,7 +240,7 @@ export async function buildFlowVertices({
 
   queryParams.append(
     "event_delivery",
-    eventDelivery ?? EventDeliveryType.POLLING,
+    eventDelivery ?? EventDeliveryType.STREAMING,
   );
 
   if (queryParams.toString()) {


### PR DESCRIPTION
Fixes #12291: Frontend was hardcoding POLLING as default, ignoring server's LANGFLOW_EVENT_DELIVERY config (which defaults to streaming).

Changes:
- Updated default from EventDeliveryType.POLLING to EventDeliveryType.STREAMING
- Affects buildFlowVertices, useGetConfig, and utility store initialization
- Updated corresponding test expectations
- Fallback to POLLING only when server doesn't support streaming