### PR TITLE
fix(kb): Ingest Content rename, ingest-open-by-default, deprecated badge for Google/IBM embeddings

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelList.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelList.tsx
@@ -1,4 +1,5 @@
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Badge } from "@/components/ui/badge";
 import {
   CommandGroup,
   CommandItem,
@@ -52,6 +53,15 @@ const ModelList = ({
                   className="h-4 w-4 shrink-0 text-primary ml-2"
                 />
                 <div className="truncate text-[13px]">{data.name}</div>
+                {data.metadata?.deprecated ? (
+                  <Badge
+                    variant="secondaryStatic"
+                    size="tag"
+                    data-testid={`${data.name}-deprecated-badge`}
+                  >
+                    Deprecated
+                  </Badge>
+                ) : null}
                 <div className="pl-2 ml-auto">
                   <ForwardedIconComponent
                     name="Check"

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/KnowledgeBaseUploadModal.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/KnowledgeBaseUploadModal.tsx
@@ -59,7 +59,7 @@ export default function KnowledgeBaseUploadModal({
             separator={form.separator}
             onSeparatorChange={form.setSeparator}
             showAdvanced={form.showAdvanced}
-            toggleAdvanced={form.toggleAdvanced}
+            hasFiles={form.files.length > 0}
             onFileSelect={form.handleFileSelect}
             onFolderSelect={form.handleFolderSelect}
             validationErrors={form.validationErrors}
@@ -91,13 +91,10 @@ export default function KnowledgeBaseUploadModal({
   };
 
   const errorCount = Object.keys(form.validationErrors).length;
-  const modalBase =
-    !hideAdvanced && form.showAdvanced
-      ? MODAL_HEIGHT_WITH_ADVANCED
-      : MODAL_HEIGHT_DEFAULT;
+  const modalBase = hideAdvanced
+    ? MODAL_HEIGHT_DEFAULT
+    : MODAL_HEIGHT_WITH_ADVANCED;
   const modalHeight = `${modalBase + errorCount * VALIDATION_ERROR_LINE_HEIGHT}`;
-
-  const showHelpButton = !hideAdvanced && form.currentStep === 1;
 
   return (
     <StepperModal
@@ -129,7 +126,7 @@ export default function KnowledgeBaseUploadModal({
       footer={
         <StepperModalFooter
           currentStep={form.currentStep}
-          totalSteps={!hideAdvanced && form.showAdvanced ? 2 : 1}
+          totalSteps={hideAdvanced ? 1 : 2}
           onBack={form.handleBack}
           onNext={form.handleNext}
           onSubmit={form.handleSubmit}
@@ -141,14 +138,6 @@ export default function KnowledgeBaseUploadModal({
           isSubmitting={form.isSubmitting}
           submitTestId="kb-create-button"
           submitLabel={form.isAddSourcesMode ? "Add Sources" : "Create"}
-          helpLabel={
-            showHelpButton
-              ? form.showAdvanced
-                ? "Hide Configuration"
-                : "Configure Sources"
-              : undefined
-          }
-          onHelp={showHelpButton ? form.toggleAdvanced : undefined}
         />
       }
     >

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/__tests__/KnowledgeBaseUploadModal.test.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/__tests__/KnowledgeBaseUploadModal.test.tsx
@@ -204,13 +204,51 @@ describe("KnowledgeBaseUploadModal", () => {
       expect(screen.getByText("Embedding Model")).toBeInTheDocument();
     });
 
-    it("renders Configure Sources toggle button in footer", () => {
+    it("renders Ingest Content section open by default", () => {
+      render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
+        wrapper: createWrapper(),
+      });
+      expect(screen.getByText(/Ingest Content/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Add Files/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render the Hide Configuration footer toggle", () => {
       render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
         wrapper: createWrapper(),
       });
       expect(
-        screen.getByRole("button", { name: /Configure Sources/i }),
-      ).toBeInTheDocument();
+        screen.queryByRole("button", { name: /Hide Configuration/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /^Configure Sources$/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("disables chunking inputs until at least one source is added", async () => {
+      render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
+        wrapper: createWrapper(),
+      });
+      expect(screen.getByTestId("kb-chunk-size-input")).toBeDisabled();
+      expect(screen.getByTestId("kb-chunk-overlap-input")).toBeDisabled();
+      expect(screen.getByTestId("kb-separator-input")).toBeDisabled();
+
+      const fileInput = document.getElementById(
+        "file-input",
+      ) as HTMLInputElement;
+      const event = {
+        target: {
+          files: [new File(["x"], "doc.txt", { type: "text/plain" })],
+        },
+      } as unknown as React.ChangeEvent<HTMLInputElement>;
+      fireEvent.change(fileInput, event);
+
+      await waitFor(() =>
+        expect(screen.getByTestId("kb-chunk-size-input")).not.toBeDisabled(),
+      );
+      expect(screen.getByTestId("kb-chunk-overlap-input")).not.toBeDisabled();
+      expect(screen.getByTestId("kb-separator-input")).not.toBeDisabled();
     });
 
     it('shows "Add Sources" title in add-sources mode', async () => {
@@ -272,14 +310,17 @@ describe("KnowledgeBaseUploadModal", () => {
   // ── Form Validation ────────────────────────────────────────────────────────
 
   describe("Form Validation", () => {
-    it("submit button is disabled when form is empty", () => {
+    it("step 1 shows Next Step button rather than submit", () => {
       render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
         wrapper: createWrapper(),
       });
-      expect(screen.getByTestId("kb-create-button")).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /Next Step/i }),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("kb-create-button")).not.toBeInTheDocument();
     });
 
-    it("submit button is disabled when only source name is filled", async () => {
+    it("Next Step does not advance when only source name is filled", async () => {
       const user = userEvent.setup();
       render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
         wrapper: createWrapper(),
@@ -288,16 +329,23 @@ describe("KnowledgeBaseUploadModal", () => {
         screen.getByTestId("kb-source-name-input"),
         "MyKnowledgeBase",
       );
-      expect(screen.getByTestId("kb-create-button")).toBeDisabled();
+      await user.click(screen.getByRole("button", { name: /Next Step/i }));
+      expect(
+        screen.getByText("Embedding model is required"),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("kb-create-button")).not.toBeInTheDocument();
     });
 
-    it("submit button is enabled when name and embedding model are both provided", async () => {
+    it("submit button enabled on step 2 when name and embedding model are provided", async () => {
       const user = userEvent.setup();
       render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
         wrapper: createWrapper(),
       });
       await fillRequiredFields(user);
-      expect(screen.getByTestId("kb-create-button")).not.toBeDisabled();
+      await user.click(screen.getByRole("button", { name: /Next Step/i }));
+      await waitFor(() =>
+        expect(screen.getByTestId("kb-create-button")).not.toBeDisabled(),
+      );
     });
 
     it("shows inline error when name is shorter than 3 characters", async () => {
@@ -310,7 +358,7 @@ describe("KnowledgeBaseUploadModal", () => {
         screen.getByTestId("embedding-model-select"),
         "text-embedding-3-small",
       );
-      await user.click(screen.getByTestId("kb-create-button"));
+      await user.click(screen.getByRole("button", { name: /Next Step/i }));
       await waitFor(() =>
         expect(
           screen.getByText("Name must be between 3 and 512 characters"),
@@ -328,7 +376,7 @@ describe("KnowledgeBaseUploadModal", () => {
         screen.getByTestId("embedding-model-select"),
         "text-embedding-3-small",
       );
-      await user.click(screen.getByTestId("kb-create-button"));
+      await user.click(screen.getByRole("button", { name: /Next Step/i }));
       await waitFor(() =>
         expect(screen.getByText(/Name must only contain/)).toBeInTheDocument(),
       );
@@ -345,7 +393,7 @@ describe("KnowledgeBaseUploadModal", () => {
         { wrapper: createWrapper() },
       );
       await fillRequiredFields(user);
-      await user.click(screen.getByTestId("kb-create-button"));
+      await user.click(screen.getByRole("button", { name: /Next Step/i }));
       await waitFor(() =>
         expect(
           screen.getByText("A knowledge base with this name already exists"),
@@ -357,12 +405,22 @@ describe("KnowledgeBaseUploadModal", () => {
   // ── Form Submission ────────────────────────────────────────────────────────
 
   describe("Form Submission", () => {
+    const advanceToReview = async (
+      user: ReturnType<typeof userEvent.setup>,
+    ) => {
+      await fillRequiredFields(user);
+      await user.click(screen.getByRole("button", { name: /Next Step/i }));
+      await waitFor(() =>
+        expect(screen.getByTestId("kb-create-button")).toBeInTheDocument(),
+      );
+    };
+
     it("calls mutateAsync with correct payload on valid submission", async () => {
       const user = userEvent.setup();
       render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
         wrapper: createWrapper(),
       });
-      await fillRequiredFields(user);
+      await advanceToReview(user);
       await user.click(screen.getByTestId("kb-create-button"));
       await waitFor(() =>
         expect(mockMutateAsync).toHaveBeenCalledWith({
@@ -381,7 +439,7 @@ describe("KnowledgeBaseUploadModal", () => {
       render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
         wrapper: createWrapper(),
       });
-      await fillRequiredFields(user);
+      await advanceToReview(user);
       await user.click(screen.getByTestId("kb-create-button"));
       await waitFor(() =>
         expect(mockSetSuccessData).toHaveBeenCalledWith({
@@ -396,7 +454,7 @@ describe("KnowledgeBaseUploadModal", () => {
       render(<KnowledgeBaseUploadModal open={true} setOpen={mockSetOpen} />, {
         wrapper: createWrapper(),
       });
-      await fillRequiredFields(user);
+      await advanceToReview(user);
       await user.click(screen.getByTestId("kb-create-button"));
       await waitFor(() => expect(mockSetOpen).toHaveBeenCalledWith(false));
     });
@@ -412,7 +470,7 @@ describe("KnowledgeBaseUploadModal", () => {
         />,
         { wrapper: createWrapper() },
       );
-      await fillRequiredFields(user);
+      await advanceToReview(user);
       await user.click(screen.getByTestId("kb-create-button"));
       await waitFor(() => expect(mockOnSubmit).toHaveBeenCalled());
       expect(mockOnSubmit.mock.calls[0][0]).toMatchObject({
@@ -429,7 +487,7 @@ describe("KnowledgeBaseUploadModal", () => {
       render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
         wrapper: createWrapper(),
       });
-      await fillRequiredFields(user);
+      await advanceToReview(user);
       await user.click(screen.getByTestId("kb-create-button"));
       await waitFor(() =>
         expect(mockSetErrorData).toHaveBeenCalledWith({
@@ -463,14 +521,11 @@ describe("KnowledgeBaseUploadModal", () => {
       expect(input).toHaveValue("");
     });
 
-    it("opens file-upload dropdown when Add Sources button is clicked", async () => {
+    it("opens file-upload dropdown when Add Files button is clicked", async () => {
       const user = userEvent.setup();
       render(<KnowledgeBaseUploadModal open={true} setOpen={jest.fn()} />, {
         wrapper: createWrapper(),
       });
-      await user.click(
-        screen.getByRole("button", { name: /Configure Sources/i }),
-      );
       await user.click(screen.getByTestId("kb-browse-btn"));
       expect(screen.getByText("Upload Files")).toBeInTheDocument();
       expect(screen.getByText("Upload Folder")).toBeInTheDocument();
@@ -623,9 +678,6 @@ describe("KnowledgeBaseUploadModal", () => {
       name = "TestKnowledgeBase",
     ) => {
       await fillRequiredFields(user, name);
-      await user.click(
-        screen.getByRole("button", { name: /Configure Sources/i }),
-      );
       await user.click(screen.getByRole("button", { name: /Next Step/i }));
     };
 

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
@@ -39,7 +39,7 @@ interface StepConfigurationProps {
   separator: string;
   onSeparatorChange: (value: string) => void;
   showAdvanced: boolean;
-  toggleAdvanced: () => void;
+  hasFiles: boolean;
   onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onFolderSelect: (e: React.ChangeEvent<HTMLInputElement>) => void;
   validationErrors?: Record<string, string>;
@@ -64,7 +64,7 @@ export function StepConfiguration({
   separator,
   onSeparatorChange,
   showAdvanced,
-  toggleAdvanced,
+  hasFiles,
   onFileSelect,
   onFolderSelect,
   validationErrors = {},
@@ -166,7 +166,7 @@ export function StepConfiguration({
           } as React.HTMLAttributes<HTMLInputElement>)}
         />
 
-        {/* Configure Sources - Animated */}
+        {/* Ingest Content - Animated */}
         <div
           className={cn(
             "grid transition-all duration-300 ease-in-out",
@@ -184,7 +184,7 @@ export function StepConfiguration({
                   className="h-4 w-4 text-muted-foreground"
                 />
                 <span className="text-sm font-medium">
-                  Configure Sources
+                  Ingest Content
                   <span className="text-xs text-muted-foreground ml-1">
                     (1 GB max upload)
                   </span>
@@ -202,7 +202,7 @@ export function StepConfiguration({
                         variant="outline"
                         data-testid="kb-browse-btn"
                         className={cn(
-                          "w-full justify-between focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-offset-background ",
+                          "w-full justify-between focus-visible:ring-1 focus-visible:ring-input focus-visible:ring-offset-0 focus-visible:ring-offset-background",
                           validationErrors.files && "border-destructive",
                         )}
                       >
@@ -211,7 +211,7 @@ export function StepConfiguration({
                             name="Upload"
                             className="h-4 w-4"
                           />
-                          Add Sources
+                          Add Files
                         </span>
                         <ForwardedIconComponent
                           name="ChevronDown"
@@ -291,7 +291,13 @@ export function StepConfiguration({
         >
           <div className="overflow-hidden">
             <Separator className="my-4" />
-            <div className="flex flex-col gap-4">
+            <div
+              className={cn(
+                "flex flex-col gap-4 transition-opacity",
+                !hasFiles && "opacity-50",
+              )}
+              aria-disabled={!hasFiles}
+            >
               <div className="flex items-center gap-2">
                 <ForwardedIconComponent
                   name="Settings2"
@@ -334,6 +340,7 @@ export function StepConfiguration({
                     }
                     min={1}
                     max={10000}
+                    disabled={!hasFiles}
                     data-testid="kb-chunk-size-input"
                   />
                 </div>
@@ -370,6 +377,7 @@ export function StepConfiguration({
                     }
                     min={0}
                     max={chunkSize - 1}
+                    disabled={!hasFiles}
                     data-testid="kb-chunk-overlap-input"
                   />
                 </div>
@@ -405,6 +413,7 @@ export function StepConfiguration({
                   placeholder="\n"
                   value={separator}
                   onChange={(e) => onSeparatorChange(e.target.value)}
+                  disabled={!hasFiles}
                   data-testid="kb-separator-input"
                 />
               </div>

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
@@ -44,8 +44,11 @@ export function useKnowledgeBaseForm({
   // Wizard state
   const [currentStep, setCurrentStep] = useState<WizardStep>(1);
 
-  // Fetch embedding model data from API
-  const { data: modelProviders = [] } = useGetModelProviders({});
+  // Fetch embedding model data from API. Include deprecated entries so the
+  // picker can surface them with a "Deprecated" badge instead of dropping them.
+  const { data: modelProviders = [] } = useGetModelProviders({
+    includeDeprecated: true,
+  });
 
   // Transform provider data into ModelOption[] for embedding models only
   const embeddingModelOptions = useMemo<ModelOption[]>(() => {

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
@@ -69,9 +69,9 @@ export function useKnowledgeBaseForm({
   // Form state - Step 1
   const [sourceName, setSourceName] = useState("");
   const [files, setFiles] = useState<File[]>([]);
-  const [chunkSize, setChunkSize] = useState(0);
-  const [chunkOverlap, setChunkOverlap] = useState(0);
-  const [separator, setSeparator] = useState("");
+  const [chunkSize, setChunkSize] = useState(DEFAULT_CHUNK_SIZE);
+  const [chunkOverlap, setChunkOverlap] = useState(DEFAULT_CHUNK_OVERLAP);
+  const [separator, setSeparator] = useState(DEFAULT_SEPARATOR);
   const [columnConfig, setColumnConfig] = useState<ColumnConfigRow[]>([
     { column_name: "text", vectorize: true, identifier: true },
   ]);
@@ -86,7 +86,7 @@ export function useKnowledgeBaseForm({
     ModelOption[]
   >([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(!hideAdvanced);
   const [isFilePanelOpen, setIsFilePanelOpen] = useState(false);
 
   // Preview state
@@ -158,7 +158,7 @@ export function useKnowledgeBaseForm({
         existingKnowledgeBase.chunkSize != null ||
         existingKnowledgeBase.chunkOverlap != null ||
         existingKnowledgeBase.separator != null;
-      if (hasAdvancedConfig) {
+      if (hasAdvancedConfig && !hideAdvanced) {
         setShowAdvanced(true);
       }
       if (
@@ -173,9 +173,9 @@ export function useKnowledgeBaseForm({
   const resetForm = useCallback(() => {
     setSourceName("");
     setFiles([]);
-    setChunkSize(0);
-    setChunkOverlap(0);
-    setSeparator("");
+    setChunkSize(DEFAULT_CHUNK_SIZE);
+    setChunkOverlap(DEFAULT_CHUNK_OVERLAP);
+    setSeparator(DEFAULT_SEPARATOR);
     setColumnConfig([
       { column_name: "text", vectorize: true, identifier: true },
     ]);
@@ -185,28 +185,10 @@ export function useKnowledgeBaseForm({
     setSelectedPreviewFileIndex(0);
     setCurrentStep(1);
     setIsFilePanelOpen(false);
-    setShowAdvanced(false);
+    setShowAdvanced(!hideAdvanced);
     setIngestionJobId(null);
     setValidationErrors({});
-  }, []);
-
-  const toggleAdvanced = useCallback(() => {
-    setShowAdvanced((prev) => {
-      if (prev) {
-        // Hiding advanced: reset chunk settings and close panel
-        setChunkSize(0);
-        setChunkOverlap(0);
-        setSeparator("");
-        setIsFilePanelOpen(false);
-      } else {
-        // Showing advanced: apply defaults
-        setChunkSize(DEFAULT_CHUNK_SIZE);
-        setChunkOverlap(DEFAULT_CHUNK_OVERLAP);
-        setSeparator(DEFAULT_SEPARATOR);
-      }
-      return !prev;
-    });
-  }, []);
+  }, [hideAdvanced]);
 
   // Generate chunk previews via backend API
   const generateChunkPreviews = useCallback(async () => {
@@ -506,7 +488,6 @@ export function useKnowledgeBaseForm({
 
     // UI state
     showAdvanced,
-    toggleAdvanced,
     isFilePanelOpen,
     isSubmitting,
 

--- a/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx
@@ -1,4 +1,5 @@
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { useGetEnabledModels } from "@/controllers/API/queries/models/use-get-enabled-models";
 
@@ -40,6 +41,15 @@ const ModelRow = ({
       >
         {model.model_name}
       </span>
+      {model.metadata?.deprecated ? (
+        <Badge
+          variant="secondaryStatic"
+          size="tag"
+          data-testid={`${testIdPrefix}-deprecated-${model.model_name}`}
+        >
+          Deprecated
+        </Badge>
+      ) : null}
     </div>
     {isEnabledModel && (
       <Switch

--- a/src/frontend/src/modals/modelProviderModal/components/ProviderList.tsx
+++ b/src/frontend/src/modals/modelProviderModal/components/ProviderList.tsx
@@ -22,7 +22,7 @@ const ProviderList = ({
     data: rawProviders = [],
     isLoading,
     isFetching,
-  } = useGetModelProviders({});
+  } = useGetModelProviders({ includeDeprecated: true });
 
   const filteredProviders: Provider[] = useMemo(() => {
     return rawProviders.map((provider) => {

--- a/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
+++ b/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
@@ -105,7 +105,7 @@ export const useProviderConfiguration = ({
   const { refreshAllModelInputs } = useRefreshModelInputs();
   const { data: modelProviders = [], isFetching: isFetchingModels } =
     useGetModelProviders(
-      {},
+      { includeDeprecated: true },
       {
         refetchInterval:
           syncedSelectedProvider?.provider?.toLowerCase() === "ollama"

--- a/src/lfx/src/lfx/base/models/google_generative_ai_constants.py
+++ b/src/lfx/src/lfx/base/models/google_generative_ai_constants.py
@@ -113,6 +113,8 @@ GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS = [
 ]
 
 # Embedding models as detailed metadata
+# Marked deprecated: not natively supported by the Knowledge Base ingestion
+# flow; hidden from the embedding model picker until support is added.
 GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS_DETAILED = [
     create_model_metadata(
         provider="Google Generative AI",
@@ -120,6 +122,7 @@ GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS_DETAILED = [
         icon="GoogleGenerativeAI",
         model_type="embeddings",
         default=True,
+        deprecated=True,
     )
     for name in GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS
 ]

--- a/src/lfx/src/lfx/base/models/google_generative_ai_constants.py
+++ b/src/lfx/src/lfx/base/models/google_generative_ai_constants.py
@@ -112,9 +112,15 @@ GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS = [
     "models/embedding-001",
 ]
 
-# Embedding models as detailed metadata
-# Marked deprecated: not natively supported by the Knowledge Base ingestion
-# flow; hidden from the embedding model picker until support is added.
+# Embedding models as detailed metadata.
+# `text-embedding-004` and `embedding-001` are marked deprecated because they
+# are no longer served by the Google Generative AI v1beta endpoint used by KB
+# ingestion (404). `gemini-embedding-001` is the current supported model.
+_GOOGLE_DEPRECATED_EMBEDDING_MODELS = {
+    "models/text-embedding-004",
+    "models/embedding-001",
+}
+
 GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS_DETAILED = [
     create_model_metadata(
         provider="Google Generative AI",
@@ -122,7 +128,7 @@ GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS_DETAILED = [
         icon="GoogleGenerativeAI",
         model_type="embeddings",
         default=True,
-        deprecated=True,
+        deprecated=name in _GOOGLE_DEPRECATED_EMBEDDING_MODELS,
     )
     for name in GOOGLE_GENERATIVE_AI_EMBEDDING_MODELS
 ]

--- a/src/lfx/src/lfx/base/models/watsonx_constants.py
+++ b/src/lfx/src/lfx/base/models/watsonx_constants.py
@@ -27,6 +27,8 @@ WATSONX_DEFAULT_LLM_MODELS = [
     ),
 ]
 
+# Marked deprecated: not natively supported by the Knowledge Base ingestion
+# flow; hidden from the embedding model picker until support is added.
 WATSONX_DEFAULT_EMBEDDING_MODELS = [
     create_model_metadata(
         provider="IBM WatsonX",
@@ -35,6 +37,7 @@ WATSONX_DEFAULT_EMBEDDING_MODELS = [
         model_type="embeddings",
         tool_calling=True,
         default=True,
+        deprecated=True,
     ),
     create_model_metadata(
         provider="IBM WatsonX",
@@ -43,6 +46,7 @@ WATSONX_DEFAULT_EMBEDDING_MODELS = [
         model_type="embeddings",
         tool_calling=True,
         default=True,
+        deprecated=True,
     ),
     create_model_metadata(
         provider="IBM WatsonX",
@@ -51,6 +55,7 @@ WATSONX_DEFAULT_EMBEDDING_MODELS = [
         model_type="embeddings",
         tool_calling=True,
         default=True,
+        deprecated=True,
     ),
     create_model_metadata(
         provider="IBM WatsonX",
@@ -59,6 +64,7 @@ WATSONX_DEFAULT_EMBEDDING_MODELS = [
         model_type="embeddings",
         tool_calling=True,
         default=True,
+        deprecated=True,
     ),
 ]
 


### PR DESCRIPTION
## Summary

Tightens the Knowledge Base upload UX and surfaces unsupported embedding models without misleading users.

- Rename **Configure Sources** heading → **Ingest Content** and the dropdown trigger **Add Sources** → **Add Files** in the KB upload modal.
- Drop the **Hide Configuration** footer toggle so the ingest section is open by default; chunk size/overlap/separator inputs render disabled until at least one source is added.
- Match the **Add Files** dropdown's `focus-visible` ring to `border-input` so the Radix-managed focus return no longer flashes a black outline after the menu closes.
- Flag all Google Generative AI (3) and IBM WatsonX (4) embedding models with `deprecated=True` in the unified model catalog. They are not natively supported by KB ingestion, so users were attempting invalid configurations.
- KB upload picker (`ModelList`) and Model Providers modal (`ModelSelection`) now fetch with `include_deprecated=true` and render a **Deprecated** badge so the models stay visible but are clearly marked as unsupported.

Anthropic still has no embedding models — they don't ship an embedding API.

Fixes #12277

### Files touched

- `src/lfx/src/lfx/base/models/google_generative_ai_constants.py`
- `src/lfx/src/lfx/base/models/watsonx_constants.py`
- `src/frontend/src/modals/knowledgeBaseUploadModal/**`
- `src/frontend/src/modals/modelProviderModal/components/{ModelSelection,ProviderList}.tsx`
- `src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts`
- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelList.tsx`

## Test plan

- [x] `npx jest src/components/core/parameterRenderComponent/components/modelInputComponent src/modals/modelProviderModal src/modals/knowledgeBaseUploadModal` — 144/144 pass
- [x] Backend restart, then verify `/api/v1/models?include_deprecated=true&model_type=embeddings` returns Google + IBM entries with `metadata.deprecated == true`
- [x] Open KB upload modal: heading reads **Ingest Content**, dropdown reads **Add Files**, chunking inputs are disabled before any file is added, no **Hide Configuration** button in footer
- [x] Click **Add Files**, close the menu, confirm no black focus ring stays on the trigger
- [x] Open **Model Providers** modal → IBM WatsonX and Google Generative AI tabs show their embedding models with a grey **Deprecated** badge
- [x] Open KB embedding picker → Google + IBM entries appear with **Deprecated** badge; OpenAI/Ollama remain unbadged