### PR TITLE
fix: route custom Loguru logs through Langflow logger

### DIFF
--- a/src/backend/tests/unit/test_logger.py
+++ b/src/backend/tests/unit/test_logger.py
@@ -33,6 +33,7 @@ from lfx.log.logger import (
     setup_gunicorn_logger,
     setup_uvicorn_logger,
 )
+from loguru import logger as loguru_logger
 
 
 class TestConfigure:
@@ -103,6 +104,29 @@ class TestConfigure:
             for handler in logging.root.handlers[:]:
                 if isinstance(handler, logging.handlers.RotatingFileHandler):
                     logging.root.removeHandler(handler)
+
+    def test_configure_routes_loguru_messages_to_log_file(self):
+        """Test configure() routes Loguru messages through Langflow logging."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_file_path = Path(tmp_dir) / "langflow.log"
+
+            for handler in logging.root.handlers[:]:
+                if isinstance(handler, logging.handlers.RotatingFileHandler):
+                    logging.root.removeHandler(handler)
+
+            try:
+                configure(log_level="INFO", log_file=log_file_path, cache=False)
+                loguru_logger.info("Custom component log message")
+
+                for handler in logging.root.handlers:
+                    if hasattr(handler, "flush"):
+                        handler.flush()
+
+                assert "Custom component log message" in log_file_path.read_text()
+            finally:
+                for handler in logging.root.handlers[:]:
+                    if isinstance(handler, logging.handlers.RotatingFileHandler):
+                        logging.root.removeHandler(handler)
 
     def test_configure_with_invalid_log_file_path(self):
         """Test configure() with invalid log file path falls back to cache dir."""

--- a/src/lfx/src/lfx/log/logger.py
+++ b/src/lfx/src/lfx/log/logger.py
@@ -1,5 +1,6 @@
 """Logging configuration for Langflow using structlog."""
 
+import contextlib
 import json
 import logging
 import logging.handlers
@@ -13,6 +14,7 @@ from typing import Any, TypedDict
 
 import orjson
 import structlog
+from loguru import logger as loguru_logger
 from platformdirs import user_cache_dir
 from typing_extensions import NotRequired
 
@@ -158,6 +160,8 @@ class SizedLogBuffer:
 
 # log buffer for capturing log messages
 log_buffer = SizedLogBuffer()
+_file_handler: logging.handlers.RotatingFileHandler | None = None
+_loguru_handler_id: int | None = None
 
 
 def add_serialized(_logger: Any, _method_name: str, event_dict: dict[str, Any]) -> dict[str, Any]:
@@ -190,6 +194,54 @@ def buffer_writer(_logger: Any, _method_name: str, event_dict: dict[str, Any]) -
         serialized_bytes = event_dict["serialized"]
         log_buffer.write(serialized_bytes.decode("utf-8"))
     return event_dict
+
+
+def _forward_loguru_message(message) -> None:
+    """Forward Loguru messages through Langflow's configured structlog pipeline."""
+    record = message.record
+    structlog_logger = structlog.get_logger(record["name"])
+    level_name = record["level"].name.lower()
+    log_method = getattr(structlog_logger, level_name, structlog_logger.info)
+    if record["exception"]:
+        log_method(record["message"], exc_info=record["exception"])
+    else:
+        log_method(record["message"])
+
+
+def setup_loguru_logger(log_level: str, *, enqueue: bool = False) -> None:
+    """Route Loguru's default logger through Langflow logging."""
+    global _loguru_handler_id  # noqa: PLW0603
+
+    if _loguru_handler_id is not None:
+        with contextlib.suppress(ValueError):
+            loguru_logger.remove(_loguru_handler_id)
+    else:
+        with contextlib.suppress(ValueError):
+            loguru_logger.remove(0)
+
+    _loguru_handler_id = loguru_logger.add(
+        _forward_loguru_message,
+        level=log_level.upper(),
+        enqueue=enqueue,
+        format="{message}",
+    )
+
+
+def setup_log_file(log_file: Path, *, max_bytes: int) -> None:
+    """Set up Langflow's rotating file handler."""
+    global _file_handler  # noqa: PLW0603
+
+    if _file_handler is not None:
+        logging.root.removeHandler(_file_handler)
+        _file_handler.close()
+
+    _file_handler = logging.handlers.RotatingFileHandler(
+        log_file,
+        maxBytes=max_bytes,
+        backupCount=5,
+    )
+    _file_handler.setFormatter(logging.Formatter("%(message)s"))
+    logging.root.addHandler(_file_handler)
 
 
 class LogConfig(TypedDict):
@@ -229,7 +281,7 @@ def configure(
     if current_min_level == requested_min_level:
         return
 
-    if log_level is None:
+    if log_level is None or log_level.upper() not in LOG_LEVEL_MAP:
         log_level = "ERROR"
 
     if log_file is None:
@@ -338,15 +390,7 @@ def configure(
             max_bytes = 10 * 1024 * 1024  # Default 10MB
 
         # Since structlog doesn't have built-in rotation, we'll use stdlib logging for file output
-        file_handler = logging.handlers.RotatingFileHandler(
-            log_file,
-            maxBytes=max_bytes,
-            backupCount=5,
-        )
-        file_handler.setFormatter(logging.Formatter("%(message)s"))
-
-        # Add file handler to root logger
-        logging.root.addHandler(file_handler)
+        setup_log_file(log_file, max_bytes=max_bytes)
         logging.root.setLevel(numeric_level)
 
     # Set up interceptors for uvicorn and gunicorn
@@ -356,6 +400,7 @@ def configure(
     # Create the global logger instance
     global logger  # noqa: PLW0603
     logger = structlog.get_logger()
+    setup_loguru_logger(log_level)
 
     if disable:
         # In structlog, we can set a very high filter level to effectively disable logging


### PR DESCRIPTION
## Summary

Fixes https://github.com/langflow-ai/langflow/issues/12805.

Custom components that import `logger` directly from Loguru were bypassing Langflow's configured logging pipeline. As a result, messages such as `logger.info(f"Processing {file_path}")` could appear on stderr but not in the configured `LANGFLOW_LOG_FILE`, even when `LANGFLOW_LOG_LEVEL=DEBUG` and log retrieval/file logging were enabled.

This PR routes Loguru's default logger through Langflow's structlog configuration so those custom component messages reach the same sinks as the rest of Langflow logging. It also keeps repeated `configure(...)` calls from stacking duplicate rotating file handlers.

## Root Cause

`configure()` configured Langflow's structlog logger and stdlib file handlers, but plain `from loguru import logger` usage kept Loguru's default sink. Custom component logs emitted through Loguru therefore skipped Langflow's configured file handler.

## Changes

- Add a small Loguru bridge that forwards Loguru records into the configured structlog pipeline.
- Normalize invalid log levels before configuring Loguru, matching the existing structlog fallback behavior.
- Track and replace Langflow's rotating file handler on reconfiguration to avoid duplicate file writes.
- Add a regression test proving Loguru messages are written to the configured log file.

## Validation

- `uv run ruff check src/lfx/src/lfx/log/logger.py src/backend/tests/unit/test_logger.py`
- `uv run pytest src/backend/tests/unit/test_logger.py`
- Manual reproduction of the issue pattern confirmed `loguru.logger.info("Processing /tmp/example.png")` lands in `LANGFLOW_LOG_FILE`.