### PR TITLE
feat(i18n): translate default node titles on language change, preserve user-customized names

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -124,10 +124,7 @@ async def get_all(request: Request):
         all_types_en = await get_and_cache_all_types_dict(settings_service=get_settings_service())
 
         locale = getattr(request.state, "locale", "en")
-        if locale != "en":
-            all_types = translate_component_dict(all_types_en, locale)
-        else:
-            all_types = all_types_en
+        all_types = translate_component_dict(all_types_en, locale) if locale != "en" else all_types_en
 
         component_display_names = build_component_display_names(all_types_en)
         return compress_response({**all_types, "component_display_names": component_display_names})

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -118,16 +118,19 @@ async def get_all(request: Request):
     with display_names translated to the locale indicated by Accept-Language.
     """
     from langflow.interface.components import get_and_cache_all_types_dict
-    from langflow.utils.i18n import translate_component_dict
+    from langflow.utils.i18n import build_component_display_names, translate_component_dict
 
     try:
-        all_types = await get_and_cache_all_types_dict(settings_service=get_settings_service())
+        all_types_en = await get_and_cache_all_types_dict(settings_service=get_settings_service())
 
         locale = getattr(request.state, "locale", "en")
         if locale != "en":
-            all_types = translate_component_dict(all_types, locale)
+            all_types = translate_component_dict(all_types_en, locale)
+        else:
+            all_types = all_types_en
 
-        return compress_response(all_types)
+        component_display_names = build_component_display_names(all_types_en)
+        return compress_response({**all_types, "component_display_names": component_display_names})
 
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/src/backend/base/langflow/utils/i18n.py
+++ b/src/backend/base/langflow/utils/i18n.py
@@ -155,7 +155,7 @@ def build_component_display_names(all_types_en: dict[str, Any]) -> dict[str, dic
 
     result: dict[str, dict[str, set[str]]] = {}
 
-    for category, components in all_types_en.items():
+    for components in all_types_en.values():
         for name, data in components.items():
             norm = normalize_component_key(name)
             if norm not in result:

--- a/src/backend/base/langflow/utils/i18n.py
+++ b/src/backend/base/langflow/utils/i18n.py
@@ -181,8 +181,7 @@ def build_component_display_names(all_types_en: dict[str, Any]) -> dict[str, dic
                         result[norm]["description"].add(val)
 
     return {
-        k: {"display_name": list(v["display_name"]), "description": list(v["description"])}
-        for k, v in result.items()
+        k: {"display_name": list(v["display_name"]), "description": list(v["description"])} for k, v in result.items()
     }
 
 

--- a/src/backend/base/langflow/utils/i18n.py
+++ b/src/backend/base/langflow/utils/i18n.py
@@ -140,6 +140,52 @@ def translate_flow_notes(nodes: list[dict], locale: str) -> list[dict]:
     return result
 
 
+def build_component_display_names(all_types_en: dict[str, Any]) -> dict[str, dict[str, list[str]]]:
+    """Build the set of all known translations for display_name and description per component.
+
+    Iterates every loaded locale and looks up each component's display_name / description key
+    directly in the locale dicts (one key lookup per locale, not a full translate_component_dict
+    pass).  The English value is always included as the baseline.
+
+    Returns a dict keyed by normalized component key (e.g. "textinput") where each value is:
+        {"display_name": [...all locale values...], "description": [...all locale values...]}
+    """
+    if not _translations:
+        _load_translations()
+
+    result: dict[str, dict[str, set[str]]] = {}
+
+    for category, components in all_types_en.items():
+        for name, data in components.items():
+            norm = normalize_component_key(name)
+            if norm not in result:
+                result[norm] = {"display_name": set(), "description": set()}
+
+            dn_en = data.get("display_name", "")
+            desc_en = data.get("description", "")
+
+            if dn_en:
+                key = component_field_key(norm, "display_name", dn_en)
+                result[norm]["display_name"].add(dn_en)
+                for locale_dict in _translations.values():
+                    val = locale_dict.get(key)
+                    if val:
+                        result[norm]["display_name"].add(val)
+
+            if desc_en:
+                key = component_field_key(norm, "description", desc_en)
+                result[norm]["description"].add(desc_en)
+                for locale_dict in _translations.values():
+                    val = locale_dict.get(key)
+                    if val:
+                        result[norm]["description"].add(val)
+
+    return {
+        k: {"display_name": list(v["display_name"]), "description": list(v["description"])}
+        for k, v in result.items()
+    }
+
+
 def translate_component_dict(all_types: dict[str, Any], locale: str) -> dict[str, Any]:
     """Return a copy of all_types with display_names substituted for locale.
 

--- a/src/backend/tests/unit/test_endpoints.py
+++ b/src/backend/tests/unit/test_endpoints.py
@@ -144,7 +144,12 @@ async def test_get_all(client: AsyncClient, logged_in_headers):
     dir_reader = DirectoryReader(BASE_COMPONENTS_PATH)
     files = dir_reader.get_files()
     # json_response is a dict of dicts
-    all_names = [component_name for _, components in response.json().items() for component_name in components]
+    all_names = [
+        component_name
+        for key, components in response.json().items()
+        if key != "component_display_names"
+        for component_name in components
+    ]
     json_response = response.json()
     # We need to test the custom nodes
     assert len(all_names) <= len(

--- a/src/frontend/src/controllers/API/queries/flows/use-get-types.ts
+++ b/src/frontend/src/controllers/API/queries/flows/use-get-types.ts
@@ -7,6 +7,7 @@ import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { useTypesStore } from "@/stores/typesStore";
 import type {
   APIObjectType,
+  ComponentDisplayNamesType,
   useQueryFunctionType,
 } from "../../../../types/api";
 import { api } from "../../api";
@@ -21,6 +22,9 @@ export const useGetTypes: useQueryFunctionType<
   const { query } = UseRequestProcessor();
   const setLoading = useFlowsManagerStore((state) => state.setIsLoading);
   const setTypes = useTypesStore((state) => state.setTypes);
+  const setComponentDisplayNames = useTypesStore(
+    (state) => state.setComponentDisplayNames,
+  );
 
   const getTypesFn = async (checkCache = false) => {
     try {
@@ -34,12 +38,20 @@ export const useGetTypes: useQueryFunctionType<
       const response = await api.get<APIObjectType>(
         `${getURL("ALL")}?force_refresh=true`,
       );
-      const data = response?.data;
+      const raw = response?.data as Record<string, unknown>;
+
+      const componentDisplayNames =
+        raw?.component_display_names as ComponentDisplayNamesType | undefined;
+      delete raw.component_display_names;
+      const data = raw as APIObjectType;
 
       if (!ENABLE_KNOWLEDGE_BASES) {
         delete data.knowledge_bases;
       }
 
+      if (componentDisplayNames) {
+        setComponentDisplayNames(componentDisplayNames);
+      }
       setTypes(data);
       syncNodeTranslations();
       recomputeComponentsToUpdateIfNeeded();

--- a/src/frontend/src/controllers/API/queries/flows/use-get-types.ts
+++ b/src/frontend/src/controllers/API/queries/flows/use-get-types.ts
@@ -40,8 +40,9 @@ export const useGetTypes: useQueryFunctionType<
       );
       const raw = response?.data as Record<string, unknown>;
 
-      const componentDisplayNames =
-        raw?.component_display_names as ComponentDisplayNamesType | undefined;
+      const componentDisplayNames = raw?.component_display_names as
+        | ComponentDisplayNamesType
+        | undefined;
       delete raw.component_display_names;
       const data = raw as APIObjectType;
 

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -1352,7 +1352,12 @@ export function syncNodeTranslations(): void {
   const { nodes } = useFlowStore.getState();
   if (nodes.length === 0) return;
 
-  const { data: typesData, types, templates } = useTypesStore.getState();
+  const {
+    data: typesData,
+    types,
+    templates,
+    componentDisplayNames,
+  } = useTypesStore.getState();
 
   // Build normalized lookup: normalize(registryKey) → registryKey
   // This lets us find "Prompt Template" in the registry when nodeType is "PromptTemplate".
@@ -1397,6 +1402,15 @@ export function syncNodeTranslations(): void {
 
     if (!freshDef) return node;
 
+    // Determine whether display_name / description are default (safe to translate)
+    // or user-customized (leave alone). A value is "default" if it appears in the
+    // known-translations set for this component type across any supported locale.
+    const normKey = normalizeComponentKey(nodeType);
+    const knownNames = componentDisplayNames[normKey]?.display_name ?? [];
+    const knownDescs = componentDisplayNames[normKey]?.description ?? [];
+    const shouldTranslateName = knownNames.includes(node.data.node!.display_name);
+    const shouldTranslateDesc = knownDescs.includes(node.data.node!.description);
+
     // Update input field display_names, info (tooltips), and placeholders
     const updatedTemplate = { ...node.data.node!.template };
     for (const fieldName of Object.keys(updatedTemplate)) {
@@ -1433,6 +1447,8 @@ export function syncNodeTranslations(): void {
         ...node.data,
         node: {
           ...node.data.node!,
+          ...(shouldTranslateName && { display_name: freshDef.display_name }),
+          ...(shouldTranslateDesc && { description: freshDef.description }),
           template: updatedTemplate,
           ...(updatedOutputs && { outputs: updatedOutputs }),
         },

--- a/src/frontend/src/stores/flowStore.ts
+++ b/src/frontend/src/stores/flowStore.ts
@@ -1408,8 +1408,12 @@ export function syncNodeTranslations(): void {
     const normKey = normalizeComponentKey(nodeType);
     const knownNames = componentDisplayNames[normKey]?.display_name ?? [];
     const knownDescs = componentDisplayNames[normKey]?.description ?? [];
-    const shouldTranslateName = knownNames.includes(node.data.node!.display_name);
-    const shouldTranslateDesc = knownDescs.includes(node.data.node!.description);
+    const shouldTranslateName = knownNames.includes(
+      node.data.node!.display_name,
+    );
+    const shouldTranslateDesc = knownDescs.includes(
+      node.data.node!.description,
+    );
 
     // Update input field display_names, info (tooltips), and placeholders
     const updatedTemplate = { ...node.data.node!.template };

--- a/src/frontend/src/stores/typesStore.ts
+++ b/src/frontend/src/stores/typesStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { APIDataType } from "../types/api";
+import type { APIDataType, ComponentDisplayNamesType } from "../types/api";
 import type { TypesStoreType } from "../types/zustand/types";
 import {
   extractSecretFieldsFromComponents,
@@ -37,5 +37,9 @@ export const useTypesStore = create<TypesStoreType>((set, get) => ({
       typeof change === "function" ? change(get().data) : change;
     set({ data: newChange });
     get().setComponentFields(extractSecretFieldsFromComponents(newChange));
+  },
+  componentDisplayNames: {} as ComponentDisplayNamesType,
+  setComponentDisplayNames: (data: ComponentDisplayNamesType) => {
+    set({ componentDisplayNames: data });
   },
 }));

--- a/src/frontend/src/types/api/index.ts
+++ b/src/frontend/src/types/api/index.ts
@@ -14,6 +14,11 @@ export type APITemplateType = {
   [key: string]: InputFieldType;
 };
 
+export type ComponentDisplayNamesType = Record<
+  string,
+  { display_name: string[]; description: string[] }
+>;
+
 export type APICodeValidateType = {
   imports: { errors: Array<string> };
   function: { errors: Array<string> };

--- a/src/frontend/src/types/zustand/types/index.ts
+++ b/src/frontend/src/types/zustand/types/index.ts
@@ -1,4 +1,8 @@
-import type { APIClassType, APIDataType, ComponentDisplayNamesType } from "../../api";
+import type {
+  APIClassType,
+  APIDataType,
+  ComponentDisplayNamesType,
+} from "../../api";
 
 export type TypesStoreType = {
   types: { [char: string]: string };

--- a/src/frontend/src/types/zustand/types/index.ts
+++ b/src/frontend/src/types/zustand/types/index.ts
@@ -1,4 +1,4 @@
-import type { APIClassType, APIDataType } from "../../api";
+import type { APIClassType, APIDataType, ComponentDisplayNamesType } from "../../api";
 
 export type TypesStoreType = {
   types: { [char: string]: string };
@@ -10,4 +10,6 @@ export type TypesStoreType = {
   ComponentFields: Set<string>;
   setComponentFields: (fields: Set<string>) => void;
   addComponentField: (field: string) => void;
+  componentDisplayNames: ComponentDisplayNamesType;
+  setComponentDisplayNames: (data: ComponentDisplayNamesType) => void;
 };


### PR DESCRIPTION
## Summary

- Adds `build_component_display_names()` to the backend i18n module — collects all known translations (across every supported locale) for each component's `display_name` and `description`, keyed by normalized component type
- Appends this map to the `/api/v1/all` response under `component_display_names`
- Frontend stores the map in `typesStore` and extracts it from the API response before passing the rest to `setTypes`
- `syncNodeTranslations` checks if a node's current `display_name`/`description` appears in the known-translations set before overwriting — values in the set are defaults (safe to translate), values not in the set are user-customized and left alone

## Motivation

Commit `5dae32a1ef` removed node-level `display_name`/`description` from `syncNodeTranslations` to avoid clobbering user-renamed nodes (e.g. "Instructions" → "Text Input"). This preserved custom names but broke i18n: default node titles no longer translated on language switch.

The known-translations set fixes both sides: default names translate, custom names are untouched.

## How the set-membership check works

```
component_display_names["textinput"] = {
  "display_name": ["Text Input", "Saisie de texte", "Texteingabe", "テキスト入力", ...],
  "description": [...]
}
```

Before overwriting `node.data.node.display_name`, `syncNodeTranslations` checks:
- **In set** → it's a default name (possibly in another language) → replace with current locale value
- **Not in set** → user customized it → leave alone

## Test plan

- [ ] Default-named node ("Text Input") → switch to French → title translates to "Saisie de texte"
- [ ] Custom-named node (e.g. "Instructions") → switch to French → stays "Instructions"
- [ ] Switch back to English → default node returns to "Text Input"
- [ ] TypeScript build: `cd src/frontend && npx tsc --noEmit` — no new errors
- [ ] Blog Writer spec: node titled "Instructions" survives language switch