### PR TITLE
fix(security): ignore inputs.session in build_public_tmp (CVE-2026-33017 follow-up)

### DIFF
--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -661,6 +661,9 @@ async def build_public_tmp(
     - The 'data' parameter is NOT accepted to prevent flow definition tampering
     - Public flows must execute the stored flow definition only
     - The flow definition is always loaded from the database
+    - The 'inputs.session' field is ignored: public flows always use the per-user
+      virtual session ID derived from client_id and flow_id, so unauthenticated
+      callers cannot read chat history for arbitrary sessions
 
     The endpoint:
     1. Verifies the requested flow is marked as public in the database
@@ -702,6 +705,15 @@ async def build_public_tmp(
             client_id=client_id,
             authenticated_user_id=authenticated_user_id,
         )
+
+        # Security: drop attacker-controlled session selection on the public path.
+        # An unauthenticated caller could otherwise pass inputs.session to read chat
+        # history for any session, including authenticated /api/v1/run sessions whose
+        # IDs default to the flow UUID. With session=None, downstream falls back to
+        # the per-user virtual flow ID derived from client_id + flow_id.
+        # (CVE-2026-33017 follow-up / H1-3682787)
+        if inputs is not None and inputs.session is not None:
+            inputs = inputs.model_copy(update={"session": None})
 
         # Validate the stored flow data after the public-access boundary.
         # Public flows never accept client-supplied data.

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -591,6 +591,59 @@ async def test_build_public_tmp_checks_public_access_before_validation(
 
 @pytest.mark.benchmark
 @pytest.mark.security
+async def test_build_public_tmp_strips_attacker_controlled_session(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    """Security (CVE-2026-33017 follow-up / H1-3682787): inputs.session is dropped on the public path.
+
+    Regression guard: an unauthenticated caller could otherwise pass
+    inputs.session to read chat history for any session (e.g. an authenticated
+    /api/v1/run session whose ID defaults to the flow UUID). Verify that
+    build_public_tmp forwards inputs with session=None to start_flow_build,
+    forcing fallback to the per-user virtual flow ID derived from
+    client_id + flow_id.
+    """
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+
+    # Publish the flow.
+    response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == codes.OK
+
+    captured: dict = {}
+
+    async def fake_start_flow_build(**kwargs):
+        captured.update(kwargs)
+        return "test-job-id"
+
+    monkeypatch.setattr("langflow.api.v1.chat.start_flow_build", fake_start_flow_build)
+
+    client.cookies.set("client_id", "test-session-strip-client")
+
+    attacker_session = "victim-session-id-from-authenticated-run"
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={"inputs": {"session": attacker_session, "input_value": "hi"}},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == codes.OK
+    assert response.json() == {"job_id": "test-job-id"}
+
+    forwarded_inputs = captured.get("inputs")
+    assert forwarded_inputs is not None, "start_flow_build should have been called with inputs"
+    assert forwarded_inputs.session is None, (
+        "build_public_tmp must drop attacker-controlled inputs.session before forwarding"
+    )
+    # Unrelated fields must be preserved (only `session` is stripped).
+    assert forwarded_inputs.input_value == "hi"
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
 async def test_build_flow_cross_user_blocked(client, json_memory_chatbot_no_llm, logged_in_headers, user_two):
     """Security (GHSA-qj98-rhf8-v93f): authenticated user cannot build another user's private flow.
 


### PR DESCRIPTION
## Summary

Fixes an unauthenticated cross-session chat history disclosure on the public
build endpoint (PVR0759710 / H1-3682787 — reported as an incomplete fix for
CVE-2026-33017).

\`POST /api/v1/build_public_tmp/{flow_id}/flow\` accepted an \`inputs.session\`
parameter and forwarded it to the graph build, where it overrode the per-user
virtual session ID derived from \`client_id + flow_id\` ([api/build.py:307-310](https://github.com/langflow-ai/langflow/blob/main/src/backend/base/langflow/api/build.py#L307-L310)).
A Memory component with an empty \`session_id\` then loaded chat history for
the attacker-supplied session — no ownership check.

Sessions created via the authenticated \`/api/v1/run/{flow_id}\` path default
to \`session_id == flow_id\` (the flow UUID, visible in the flow URL), so
target session IDs are predictable. In multi-user deployments
(\`LANGFLOW_AUTO_LOGIN=false\`) where a public flow contains a Memory component,
an unauthenticated caller could read another user's stored chat history,
sender metadata, and timestamps.

## Fix

Strip \`inputs.session\` at the public-path trust boundary in \`build_public_tmp\`
before forwarding to \`start_flow_build\`. Downstream code already falls back to
the per-user virtual flow ID, restoring intended isolation. Mirrors the
boundary pattern used by the original CVE-2026-33017 fix (73b6612e), which
hardcoded \`data=None\` rather than accepting and validating it. Authenticated
\`/api/v1/build\` and \`/api/v1/run\` paths are unchanged.

- \`src/backend/base/langflow/api/v1/chat.py\` — strip \`inputs.session\` and
  extend the handler's Security Note docstring.

## Test plan

- [x] New regression test \`test_build_public_tmp_strips_attacker_controlled_session\`
      monkeypatches \`start_flow_build\` and asserts \`inputs.session is None\`
      on the forwarded call regardless of what the unauthenticated caller
      supplies; \`inputs.input_value\` is preserved.
- [x] Verified the test FAILS on unpatched code (confirms it catches the
      vulnerability) and PASSES with the patch.
- [x] Existing public_tmp tests still pass:
      \`test_build_public_tmp_ignores_data_parameter\`,
      \`test_build_public_tmp_without_data_parameter\`,
      \`test_build_public_tmp_checks_public_access_before_validation\`.
- [ ] Manual replay of the reporter's PoC against a patched build with
      \`LANGFLOW_AUTO_LOGIN=false\`: confirm the Memory component returns no
      messages from the targeted authenticated session.

## Reference

- PVR0759710 / H1-3682787
- CVE-2026-33017 (original fix: 73b6612e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for public flows by blocking attacker-supplied session parameters. The system now prevents unauthorized manipulation of user sessions through malicious inputs, ensuring proper session isolation and protecting session history access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->