### PR TITLE
feat(flow): add per-flow toggle for Flow Activity/Tracing recording

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3582,7 +3582,7 @@
         "filename": "src/backend/tests/unit/services/tracing/test_tracing_service.py",
         "hashed_secret": "1230f71eec8a61a625a18b6fa03b9bdd046a8931",
         "is_verified": false,
-        "line_number": 371,
+        "line_number": 394,
         "is_secret": false
       },
       {
@@ -3590,7 +3590,7 @@
         "filename": "src/backend/tests/unit/services/tracing/test_tracing_service.py",
         "hashed_secret": "2d63069839e1cab99da0a0bbbbeb8f2ceb455cc8",
         "is_verified": false,
-        "line_number": 372,
+        "line_number": 395,
         "is_secret": false
       },
       {
@@ -3598,7 +3598,7 @@
         "filename": "src/backend/tests/unit/services/tracing/test_tracing_service.py",
         "hashed_secret": "3b96880b8e11758bbf9796b9cd90aaa3ab4bab6e",
         "is_verified": false,
-        "line_number": 373,
+        "line_number": 396,
         "is_secret": false
       }
     ],
@@ -8198,5 +8198,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-27T15:53:27Z"
+  "generated_at": "2026-04-29T17:56:21Z"
 }

--- a/src/backend/base/langflow/alembic/versions/fe2a9108c_flow_activity_enabled.py
+++ b/src/backend/base/langflow/alembic/versions/fe2a9108c_flow_activity_enabled.py
@@ -1,0 +1,41 @@
+"""add flow_activity_enabled column to flow
+
+Phase: EXPAND
+
+Revision ID: fe2a9108c1fb
+Revises: mb00a1b2c3d4
+Create Date: 2026-04-29 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+
+# revision identifiers, used by Alembic.
+revision: str = "fe2a9108c1fb"  # pragma: allowlist secret
+down_revision: str | None = "mb00a1b2c3d4"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    with op.batch_alter_table("flow", schema=None) as batch_op:
+        if not migration.column_exists(table_name="flow", column_name="flow_activity_enabled", conn=conn):
+            batch_op.add_column(
+                sa.Column(
+                    "flow_activity_enabled",
+                    sa.Boolean(),
+                    nullable=False,
+                    server_default=sa.text("true"),
+                )
+            )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    with op.batch_alter_table("flow", schema=None) as batch_op:
+        if migration.column_exists(table_name="flow", column_name="flow_activity_enabled", conn=conn):
+            batch_op.drop_column("flow_activity_enabled")

--- a/src/backend/base/langflow/api/utils/flow_utils.py
+++ b/src/backend/base/langflow/api/utils/flow_utils.py
@@ -86,9 +86,18 @@ async def build_and_cache_graph_from_data(
     graph_data: dict,
 ):  # -> Graph | Any:
     """Build and cache the graph."""
-    # Convert flow_id to str if it's UUID
+    flow_uuid = flow_id if isinstance(flow_id, uuid.UUID) else uuid.UUID(str(flow_id))
     str_flow_id = str(flow_id) if isinstance(flow_id, uuid.UUID) else flow_id
+
+    async with session_scope_readonly() as session:
+        flow_row = await session.get(Flow, flow_uuid)
+        if flow_row is None:
+            msg = f"Flow {flow_id} not found"
+            raise ValueError(msg)
+        flow_activity_enabled = flow_row.flow_activity_enabled
+
     graph = Graph.from_payload(graph_data, str_flow_id)
+    graph.flow_activity_enabled = flow_activity_enabled
     await chat_service.set_cache(str_flow_id, graph)
     return graph
 

--- a/src/backend/base/langflow/api/utils/flow_utils.py
+++ b/src/backend/base/langflow/api/utils/flow_utils.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from fastapi import HTTPException
 from lfx.graph.graph.base import Graph
 from lfx.log.logger import logger
-from lfx.services.deps import session_scope
+from lfx.services.deps import session_scope, session_scope_readonly
 from sqlalchemy import delete
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -29,26 +29,27 @@ if TYPE_CHECKING:
     from langflow.services.chat.service import ChatService
 
 
-async def _get_flow_name(flow_id: uuid.UUID) -> str:
-    async with session_scope() as session:
-        flow = await session.get(Flow, flow_id)
-        if flow is None:
-            msg = f"Flow {flow_id} not found"
-            raise ValueError(msg)
-    return flow.name
-
-
 async def build_graph_from_data(flow_id: uuid.UUID | str, payload: dict, **kwargs):
     """Build and cache the graph."""
-    # Get flow name
-    if "flow_name" not in kwargs:
-        flow_name = await _get_flow_name(flow_id if isinstance(flow_id, uuid.UUID) else uuid.UUID(flow_id))
-    else:
-        flow_name = kwargs["flow_name"]
+    flow_uuid = flow_id if isinstance(flow_id, uuid.UUID) else uuid.UUID(str(flow_id))
     str_flow_id = str(flow_id)
     session_id = kwargs.get("session_id") or str_flow_id
 
+    flow_name = kwargs.get("flow_name")
+    flow_activity_enabled = kwargs.get("flow_activity_enabled")
+    if flow_name is None or flow_activity_enabled is None:
+        async with session_scope_readonly() as session:
+            flow_row = await session.get(Flow, flow_uuid)
+            if flow_row is None:
+                msg = f"Flow {flow_id} not found"
+                raise ValueError(msg)
+            if flow_name is None:
+                flow_name = flow_row.name
+            if flow_activity_enabled is None:
+                flow_activity_enabled = flow_row.flow_activity_enabled
+
     graph = Graph.from_payload(payload, str_flow_id, flow_name, kwargs.get("user_id"))
+    graph.flow_activity_enabled = flow_activity_enabled
     for vertex_id in graph.has_session_id_vertices:
         vertex = graph.get_vertex(vertex_id)
         if vertex is None:
@@ -69,6 +70,7 @@ async def build_graph_from_db_no_cache(flow_id: uuid.UUID, session: AsyncSession
         msg = "Invalid flow ID"
         raise ValueError(msg)
     kwargs["user_id"] = kwargs.get("user_id") or str(flow.user_id)
+    kwargs["flow_activity_enabled"] = flow.flow_activity_enabled
     return await build_graph_from_data(flow_id, flow.data, flow_name=flow.name, **kwargs)
 
 

--- a/src/backend/base/langflow/api/v1/flows_helpers.py
+++ b/src/backend/base/langflow/api/v1/flows_helpers.py
@@ -127,6 +127,7 @@ _UPDATABLE_FLOW_FIELDS: frozenset[str] = frozenset(
         "action_description",
         "access_type",
         "fs_path",
+        "flow_activity_enabled",
     }
 )
 

--- a/src/backend/base/langflow/services/database/models/flow/model.py
+++ b/src/backend/base/langflow/services/database/models/flow/model.py
@@ -63,6 +63,10 @@ class FlowBase(SQLModel):
     tags: list[str] | None = None
     locked: bool | None = Field(default=False, nullable=True)
     mcp_enabled: bool | None = Field(default=False, nullable=True, description="Can be exposed in the MCP server")
+    flow_activity_enabled: bool = Field(
+        default=True,
+        description="When True, flow runs persist traces shown in Flow Activity",
+    )
     action_name: str | None = Field(
         default=None, nullable=True, description="The name of the action associated with the flow"
     )
@@ -254,6 +258,10 @@ class FlowHeader(BaseModel):
     mcp_enabled: bool | None = Field(None, description="Flag indicating whether the flow is exposed in the MCP server")
     action_name: str | None = Field(None, description="The name of the action associated with the flow")
     action_description: str | None = Field(None, description="The description of the action associated with the flow")
+    flow_activity_enabled: bool = Field(
+        default=True,
+        description="When True, flow runs persist traces shown in Flow Activity",
+    )
 
     @field_validator("data", mode="before")
     @classmethod
@@ -275,6 +283,7 @@ class FlowUpdate(SQLModel):
     action_description: str | None = None
     access_type: AccessTypeEnum | None = None
     fs_path: str | None = None
+    flow_activity_enabled: bool | None = None
 
     @field_validator("endpoint_name")
     @classmethod

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -84,6 +84,8 @@ class TraceContext:
         user_id: str | None,
         session_id: str | None,
         flow_id: str | None = None,
+        *,
+        collect_flow_activity: bool = True,
     ):
         self.run_id: UUID | None = run_id
         self.run_name: str | None = run_name
@@ -91,6 +93,7 @@ class TraceContext:
         self.user_id: str | None = user_id
         self.session_id: str | None = session_id
         self.flow_id: str | None = flow_id
+        self.collect_flow_activity: bool = collect_flow_activity
         self.tracers: dict[str, BaseTracer] = {}
         self.all_inputs: dict[str, dict] = defaultdict(dict)
         self.all_outputs: dict[str, dict] = defaultdict(dict)
@@ -235,7 +238,7 @@ class TracingService(Service):
         )
 
     def _initialize_native_tracer(self, trace_context: TraceContext) -> None:
-        if self.deactivated:
+        if self.deactivated or not trace_context.collect_flow_activity:
             return
         native_tracer = _get_native_tracer()
         trace_context.tracers["native"] = native_tracer(
@@ -269,6 +272,8 @@ class TracingService(Service):
         session_id: str | None,
         project_name: str | None = None,
         flow_id: str | None = None,
+        *,
+        collect_flow_activity: bool = True,
     ) -> None:
         """Start a trace for a graph run.
 
@@ -280,7 +285,15 @@ class TracingService(Service):
             return
         try:
             project_name = project_name or os.getenv("LANGCHAIN_PROJECT", "Langflow")
-            trace_context = TraceContext(run_id, run_name, project_name, user_id, session_id, flow_id)
+            trace_context = TraceContext(
+                run_id,
+                run_name,
+                project_name,
+                user_id,
+                session_id,
+                flow_id,
+                collect_flow_activity=collect_flow_activity,
+            )
             trace_context_var.set(trace_context)
             await self._start(trace_context)
             self._initialize_langsmith_tracer(trace_context)
@@ -337,7 +350,7 @@ class TracingService(Service):
         self._end_all_tracers(trace_context, outputs, error)
 
         native_tracer = trace_context.tracers.get("native")
-        if native_tracer:
+        if native_tracer is not None:
             # Deferred import breaks the circular dependency between service.py and native.py.
             from langflow.services.tracing.native import NativeTracer
 

--- a/src/backend/tests/unit/services/tracing/test_tracing_service.py
+++ b/src/backend/tests/unit/services/tracing/test_tracing_service.py
@@ -207,6 +207,29 @@ async def test_start_end_tracers(tracing_service):
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_tracers")
+async def test_collect_flow_activity_false_skips_native_tracer(tracing_service):
+    """When disabled, Langflow skips the native tracer used for Flow Activity storage."""
+    run_id = uuid.uuid4()
+    run_name = "test_run"
+    user_id = "test_user"
+    session_id = "test_session"
+
+    await tracing_service.start_tracers(
+        run_id,
+        run_name,
+        user_id,
+        session_id,
+        collect_flow_activity=False,
+    )
+    trace_context = trace_context_var.get()
+    assert trace_context is not None
+    assert trace_context.collect_flow_activity is False
+    assert "native" not in trace_context.tracers
+    assert "langsmith" in trace_context.tracers
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_tracers")
 async def test_trace_component(tracing_service, mock_component):
     """Test component tracing context manager."""
     run_id = uuid.uuid4()

--- a/src/frontend/src/controllers/API/queries/flows/use-patch-update-flow.ts
+++ b/src/frontend/src/controllers/API/queries/flows/use-patch-update-flow.ts
@@ -1,6 +1,7 @@
 import type { UseMutationResult } from "@tanstack/react-query";
 import type { ReactFlowJsonObject } from "@xyflow/react";
 import type { useMutationFunctionType } from "@/types/api";
+import type { FlowType } from "@/types/flow";
 import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import { UseRequestProcessor } from "../../services/request-processor";
@@ -14,6 +15,7 @@ interface IPatchUpdateFlow {
   endpoint_name?: string | null | undefined;
   locked?: boolean | null | undefined;
   access_type?: "PUBLIC" | "PRIVATE" | "PROTECTED";
+  flow_activity_enabled?: boolean;
 }
 
 export const usePatchUpdateFlow: useMutationFunctionType<
@@ -25,13 +27,13 @@ export const usePatchUpdateFlow: useMutationFunctionType<
   const PatchUpdateFlowFn = async ({
     id,
     ...payload
-  }: IPatchUpdateFlow): Promise<any> => {
+  }: IPatchUpdateFlow): Promise<FlowType> => {
     const response = await api.patch(`${getURL("FLOWS")}/${id}`, payload);
 
     return response.data;
   };
 
-  const mutation: UseMutationResult<IPatchUpdateFlow, any, IPatchUpdateFlow> =
+  const mutation: UseMutationResult<IPatchUpdateFlow, Error, IPatchUpdateFlow> =
     mutate(["usePatchUpdateFlow"], PatchUpdateFlowFn, {
       onSettled: () => {
         queryClient.invalidateQueries({

--- a/src/frontend/src/pages/FlowPage/components/TraceComponent/FlowInsightsContent.tsx
+++ b/src/frontend/src/pages/FlowPage/components/TraceComponent/FlowInsightsContent.tsx
@@ -32,6 +32,7 @@ import {
 import { usePatchUpdateFlow } from "@/controllers/API/queries/flows/use-patch-update-flow";
 import { useGetTracesQuery } from "@/controllers/API/queries/traces";
 import { TraceListItem } from "@/controllers/API/queries/traces/types";
+import useAlertStore from "@/stores/alertStore";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { cn } from "@/utils/utils";
 import { createFlowTracesColumns } from "./config/flowTraceColumns";
@@ -88,6 +89,7 @@ export function FlowInsightsContent({
 
   const { mutate: patchFlow, isPending: isPatchingFlow } = usePatchUpdateFlow();
   const patchFlowField = useFlowsManagerStore((state) => state.patchFlowField);
+  const setErrorData = useAlertStore((state) => state.setErrorData);
 
   const handleRecordingCheckedChange = useCallback(
     (checked: boolean) => {
@@ -96,13 +98,25 @@ export function FlowInsightsContent({
         { id: resolvedFlowId, flow_activity_enabled: checked },
         {
           onSuccess: (updated) => {
-            const newVal = updated?.flow_activity_enabled ?? checked;
-            patchFlowField(resolvedFlowId, { flow_activity_enabled: newVal });
+            if (typeof updated?.flow_activity_enabled !== "boolean") {
+              return;
+            }
+            patchFlowField(resolvedFlowId, {
+              flow_activity_enabled: updated.flow_activity_enabled,
+            });
+          },
+          onError: () => {
+            setErrorData({
+              title: "Failed to update Flow Activity recording",
+              list: [
+                "Please try again. If the problem persists, reload the page.",
+              ],
+            });
           },
         },
       );
     },
-    [resolvedFlowId, isPatchingFlow, patchFlow, patchFlowField],
+    [resolvedFlowId, isPatchingFlow, patchFlow, patchFlowField, setErrorData],
   );
 
   const columns = useMemo(

--- a/src/frontend/src/pages/FlowPage/components/TraceComponent/FlowInsightsContent.tsx
+++ b/src/frontend/src/pages/FlowPage/components/TraceComponent/FlowInsightsContent.tsx
@@ -22,6 +22,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { usePatchUpdateFlow } from "@/controllers/API/queries/flows/use-patch-update-flow";
 import { useGetTracesQuery } from "@/controllers/API/queries/traces";
 import { TraceListItem } from "@/controllers/API/queries/traces/types";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
@@ -65,6 +73,37 @@ export function FlowInsightsContent({
     if (!resolvedFlowId) return state.currentFlow?.name;
     return state.getFlowById(resolvedFlowId)?.name ?? state.currentFlow?.name;
   });
+
+  // Derive recording state from the store without requiring currentFlow to match.
+  // We look at currentFlow first (most up-to-date) then fall back to the flows list.
+  // Default to true (enabled) when the field is absent or the flow isn't loaded yet.
+  const recordingEnabled = useFlowsManagerStore((state) => {
+    if (!resolvedFlowId) return true;
+    const target =
+      state.currentFlow?.id === resolvedFlowId
+        ? state.currentFlow
+        : (state.flows?.find((f) => f.id === resolvedFlowId) ?? null);
+    return target ? target.flow_activity_enabled !== false : true;
+  });
+
+  const { mutate: patchFlow, isPending: isPatchingFlow } = usePatchUpdateFlow();
+  const patchFlowField = useFlowsManagerStore((state) => state.patchFlowField);
+
+  const handleRecordingCheckedChange = useCallback(
+    (checked: boolean) => {
+      if (!resolvedFlowId || isPatchingFlow) return;
+      patchFlow(
+        { id: resolvedFlowId, flow_activity_enabled: checked },
+        {
+          onSuccess: (updated) => {
+            const newVal = updated?.flow_activity_enabled ?? checked;
+            patchFlowField(resolvedFlowId, { flow_activity_enabled: newVal });
+          },
+        },
+      );
+    },
+    [resolvedFlowId, isPatchingFlow, patchFlow, patchFlowField],
+  );
 
   const columns = useMemo(
     () =>
@@ -225,10 +264,36 @@ export function FlowInsightsContent({
       <div className="flex flex-1 flex-col overflow-hidden">
         {showFlowActivityHeader && (
           <div
-            className="border-b border-border px-4 py-3"
+            className="flex flex-nowrap items-center justify-between gap-3 border-b border-border px-4 py-3"
             data-testid="flow-activity-header"
           >
             <h2 className="text-base font-semibold">Flow Activity</h2>
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex shrink-0 items-center">
+                    <Switch
+                      id="flow-activity-recording"
+                      checked={recordingEnabled}
+                      disabled={isPatchingFlow}
+                      onCheckedChange={handleRecordingCheckedChange}
+                      aria-label={
+                        recordingEnabled
+                          ? "Flow Activity recording on"
+                          : "Flow Activity recording off"
+                      }
+                      data-testid="flow-activity-recording-toggle"
+                      className="data-[state=checked]:bg-status-green"
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-[220px]">
+                  {recordingEnabled
+                    ? "Flow Activity is recording runs for this flow. Turn off to stop storing new traces."
+                    : "Flow Activity recording is off for this flow. Turn on to store traces for new runs."}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         )}
         <div className="flex flex-nowrap items-center justify-between gap-2 border-b px-4 py-2">

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarSegmentedNav.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarSegmentedNav.tsx
@@ -8,6 +8,7 @@ import {
   type SidebarSection,
   useSidebar,
 } from "@/components/ui/sidebar";
+import useFlowsManagerStore from "@/stores/flowsManagerStore";
 import { usePlaygroundStore } from "@/stores/playgroundStore";
 import { cn } from "@/utils/utils";
 import { useSearchContext } from "../index";
@@ -68,6 +69,9 @@ const SidebarSegmentedNav = () => {
   const setPlaygroundFullscreen = usePlaygroundStore(
     (state) => state.setIsFullscreen,
   );
+  const currentFlow = useFlowsManagerStore((state) => state.currentFlow);
+  const flowActivityRecordingEnabled =
+    currentFlow != null && currentFlow.flow_activity_enabled !== false;
 
   return (
     <div className="flex h-full flex-col border-r border-border bg-background">
@@ -112,7 +116,17 @@ const SidebarSegmentedNav = () => {
                 >
                   <ForwardedIconComponent
                     name={item.icon}
-                    className="h-5 w-5"
+                    strokeWidth={
+                      item.id === "traces" && flowActivityRecordingEnabled
+                        ? 2
+                        : undefined
+                    }
+                    className={cn(
+                      "h-5 w-5",
+                      item.id === "traces" &&
+                        flowActivityRecordingEnabled &&
+                        "text-status-green",
+                    )}
                   />
                   <span className="sr-only">{t(item.label)}</span>
                 </SidebarMenuButton>

--- a/src/frontend/src/stores/flowsManagerStore.ts
+++ b/src/frontend/src/stores/flowsManagerStore.ts
@@ -142,6 +142,17 @@ const useFlowsManagerStore = create<FlowsManagerStoreType>((set, get) => ({
       selectedFlowsComponentsCards: [],
     });
   },
+  patchFlowField: (flowId: string, patch: Partial<FlowType>) => {
+    set((state) => ({
+      currentFlow:
+        state.currentFlow?.id === flowId
+          ? { ...state.currentFlow, ...patch }
+          : state.currentFlow,
+      flows: state.flows?.map((f) =>
+        f.id === flowId ? { ...f, ...patch } : f,
+      ),
+    }));
+  },
 }));
 
 export default useFlowsManagerStore;

--- a/src/frontend/src/types/flow/index.ts
+++ b/src/frontend/src/types/flow/index.ts
@@ -1,6 +1,10 @@
 import type { Edge, Node, ReactFlowJsonObject } from "@xyflow/react";
 import type { BuildStatus } from "../../constants/enums";
-import type { APIClassType, OutputFieldType } from "../api/index";
+import type {
+  APIClassType,
+  APITemplateType,
+  OutputFieldType,
+} from "../api/index";
 
 export type PaginatedFlowsType = {
   items: FlowType[];
@@ -34,6 +38,7 @@ export type FlowType = {
   public?: boolean;
   access_type?: "PUBLIC" | "PRIVATE" | "PROTECTED";
   mcp_enabled?: boolean;
+  flow_activity_enabled?: boolean;
 };
 
 export type GenericNodeType = Node<NodeDataType, "genericNode">;
@@ -47,10 +52,7 @@ export type noteClassType = Pick<
   APIClassType,
   "description" | "display_name" | "documentation" | "tool_mode" | "frozen"
 > & {
-  template: {
-    backgroundColor?: string;
-    [key: string]: any;
-  };
+  template: APITemplateType;
   outputs?: OutputFieldType[];
 };
 

--- a/src/frontend/src/types/zustand/flowsManager/index.ts
+++ b/src/frontend/src/types/zustand/flowsManager/index.ts
@@ -29,6 +29,7 @@ export type FlowsManagerStoreType = {
   IOModalOpen: boolean;
   setIOModalOpen: (IOModalOpen: boolean) => void;
   resetStore: () => void;
+  patchFlowField: (flowId: string, patch: Partial<FlowType>) => void;
 };
 
 export type UseUndoRedoOptions = {

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -2415,6 +2415,7 @@ class Graph:
         subgraph._run_id = self._run_id
         subgraph.session_id = self.session_id
         subgraph._is_subgraph = True
+        subgraph.flow_activity_enabled = self.flow_activity_enabled
 
         # Add the filtered nodes and edges
         subgraph.add_nodes_and_edges(subgraph_nodes, subgraph_edges)

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -132,6 +132,8 @@ class Graph:
         self._end_trace_tasks: set[asyncio.Task] = set()
         self._is_subgraph = False
 
+        self.flow_activity_enabled = True
+
         if context and not isinstance(context, dict):
             msg = "Context must be a dictionary"
             raise TypeError(msg)
@@ -672,6 +674,7 @@ class Graph:
                 user_id=self.user_id,
                 session_id=self.session_id,
                 flow_id=self.flow_id,
+                collect_flow_activity=self.flow_activity_enabled,
             )
 
     def _end_all_traces_async(self, outputs: dict[str, Any] | None = None, error: Exception | None = None) -> None:
@@ -1136,6 +1139,8 @@ class Graph:
             )
             # Deep copy vertices and edges
             new_graph.add_nodes_and_edges(copy.deepcopy(self._vertices, memo), copy.deepcopy(self._edges, memo))
+
+        new_graph.flow_activity_enabled = getattr(self, "flow_activity_enabled", True)
 
         # Store the newly created object in memo
         memo[id(self)] = new_graph

--- a/src/lfx/src/lfx/services/tracing/base.py
+++ b/src/lfx/src/lfx/services/tracing/base.py
@@ -37,6 +37,8 @@ class BaseTracingService(Service, ABC):
         session_id: str | None,
         project_name: str | None = None,
         flow_id: str | None = None,
+        *,
+        collect_flow_activity: bool = True,
     ) -> None:
         """Start tracers for a graph run.
 
@@ -47,6 +49,7 @@ class BaseTracingService(Service, ABC):
             session_id: Session identifier (optional)
             project_name: Project name (optional)
             flow_id: Flow identifier (optional)
+            collect_flow_activity: When False, Langflow may skip storing native Flow Activity traces
         """
 
     @abstractmethod

--- a/src/lfx/src/lfx/services/tracing/service.py
+++ b/src/lfx/src/lfx/services/tracing/service.py
@@ -49,6 +49,8 @@ class TracingService(BaseTracingService):
         session_id: str | None,
         project_name: str | None = None,
         flow_id: str | None = None,
+        *,
+        collect_flow_activity: bool = True,
     ) -> None:
         """Start tracers (minimal implementation - just logs).
 
@@ -59,6 +61,7 @@ class TracingService(BaseTracingService):
             user_id: User identifier
             session_id: Session identifier
             project_name: Project name
+            collect_flow_activity: Unused in minimal LFX (native Flow Activity is Langflow-specific)
         """
         logger.debug(f"Trace started: {run_name}")
 


### PR DESCRIPTION
### Summary

Adds a **per-flow setting** (`flow_activity_enabled`) so teams can **enable or disable** persistence of traces used by **Flow Activity**. When off, new runs do not use the native Flow Activity tracer; existing UI can still show history, while the sidebar reflects whether recording is active.

### What changed

- **Database:** New boolean column `flow_activity_enabled` on `flow`, default `true`, with Alembic migration.
- **API & models:** Field on flow read/update models; included in allowed PATCH fields so the UI can persist the toggle.
- **Execution:** Graph build loads the flag from the flow row; `Graph` exposes `flow_activity_enabled` and passes `collect_flow_activity` into trace startup; deep copy keeps the same value.
- **Tracing:** `TraceContext` / `start_trace` accept `collect_flow_activity`; native Flow Activity tracer is not initialized when collection is disabled.
- **LFX:** Graph and tracing service signatures aligned with the Langflow backend (minimal LFX tracer documents the unused parameter).
- **Frontend:** Toggle in the Flow Activity panel (with tooltips and test id), optimistic store updates via `patchFlowField`, traces item in the sidebar uses green styling when recording is enabled; `FlowType` and patch mutation updated.
- **Tests:** Unit coverage for tracing service when `collect_flow_activity` is false.
