### PR TITLE
fix: namespace inputs.session on build_public_tmp

### DIFF
--- a/src/backend/base/langflow/api/utils/__init__.py
+++ b/src/backend/base/langflow/api/utils/__init__.py
@@ -43,6 +43,7 @@ from langflow.api.utils.flow_utils import (
     build_graph_from_db,
     build_graph_from_db_no_cache,
     cascade_delete_flow,
+    scope_session_to_namespace,
     verify_public_flow_and_get_user,
 )
 
@@ -85,6 +86,7 @@ __all__ = [
     "parse_value",
     "raise_error_if_astra_cloud_env",
     "remove_api_keys",
+    "scope_session_to_namespace",
     "validate_is_component",
     "verify_public_flow_and_get_user",
 ]

--- a/src/backend/base/langflow/api/utils/flow_utils.py
+++ b/src/backend/base/langflow/api/utils/flow_utils.py
@@ -135,6 +135,26 @@ def compute_virtual_flow_id(identifier: str | uuid.UUID, flow_id: uuid.UUID) -> 
     return uuid.uuid5(uuid.NAMESPACE_DNS, f"{identifier}_{flow_id}")
 
 
+def scope_session_to_namespace(session: str | None, namespace: str) -> str | None:
+    """Wrap a caller-supplied session ID under a (client_id, flow_id) namespace.
+
+    Mitigates CVE-2026-33017: an unauthenticated public-flow caller cannot
+    address a session that lives outside its own namespace through a Memory
+    component, regardless of whether the caller supplies a non-empty,
+    pre-prefixed, or empty string.
+
+    Returns ``None`` unchanged. Returns the value unchanged when it equals the
+    namespace or already starts with ``f"{namespace}:"``. Otherwise prefixes
+    it -- including the empty-string case, which becomes ``f"{namespace}:"``.
+    """
+    if session is None:
+        return session
+    prefix = f"{namespace}:"
+    if session == namespace or session.startswith(prefix):
+        return session
+    return f"{prefix}{session}"
+
+
 async def verify_public_flow_and_get_user(
     flow_id: uuid.UUID,
     client_id: str | None,

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -31,6 +31,7 @@ from langflow.api.utils import (
     format_exception_message,
     get_top_level_vertices,
     parse_exception,
+    scope_session_to_namespace,
     verify_public_flow_and_get_user,
 )
 from langflow.api.v1.schemas import (
@@ -661,6 +662,9 @@ async def build_public_tmp(
     - The 'data' parameter is NOT accepted to prevent flow definition tampering
     - Public flows must execute the stored flow definition only
     - The flow definition is always loaded from the database
+    - Caller-supplied 'inputs.session' is namespaced under the (client_id,
+      flow_id) virtual flow ID so an unauthenticated caller cannot address a
+      session that lives outside its own namespace (CVE-2026-33017)
 
     The endpoint:
     1. Verifies the requested flow is marked as public in the database
@@ -702,6 +706,12 @@ async def build_public_tmp(
             client_id=client_id,
             authenticated_user_id=authenticated_user_id,
         )
+
+        # Defends CVE-2026-33017: scope caller session into the (client_id, flow_id) namespace.
+        if inputs is not None and inputs.session is not None:
+            scoped_session = scope_session_to_namespace(inputs.session, str(new_flow_id))
+            if scoped_session != inputs.session:
+                inputs = inputs.model_copy(update={"session": scoped_session})
 
         # Validate the stored flow data after the public-access boundary.
         # Public flows never accept client-supplied data.

--- a/src/backend/tests/unit/test_chat_endpoint.py
+++ b/src/backend/tests/unit/test_chat_endpoint.py
@@ -849,3 +849,313 @@ async def test_job_owner_cleaned_up_after_cleanup_job():
             service._cleanup_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await service._cleanup_task
+
+
+# ---------------------------------------------------------------------------
+# CVE-2026-33017: session-id namespacing on build_public_tmp
+# ---------------------------------------------------------------------------
+
+
+def _stub_start_flow_build(monkeypatch, captured: dict) -> None:
+    """Capture the kwargs that would be dispatched to start_flow_build without running the build."""
+    import langflow.api.v1.chat as chat_module
+
+    async def _fake_start_flow_build(**kwargs):
+        captured.update(kwargs)
+        return "00000000-0000-0000-0000-00000000ffff"
+
+    monkeypatch.setattr(chat_module, "start_flow_build", _fake_start_flow_build)
+
+
+def _send_unauthenticated(client, client_id: str) -> None:
+    """Drop login cookies and set the public client_id cookie.
+
+    The shared AsyncClient persists access-token cookies from logged_in_headers
+    that would otherwise let get_current_user_optional resolve a user and
+    namespace under user_id -- not the unauthenticated shape the CVE targets.
+    """
+    client.cookies.clear()
+    client.cookies.set("client_id", client_id)
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
+async def test_build_public_tmp_namespaces_caller_session(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    """Caller-supplied session equal to the real flow UUID is wrapped under the namespace.
+
+    The threat: /api/v1/run hands out session_id == flow_id by default, and the
+    flow UUID is visible in URLs. Without namespacing, an unauthenticated caller
+    can pass that UUID as inputs.session and a Memory component reads its history.
+    """
+    from langflow.api.utils.flow_utils import compute_virtual_flow_id
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    patch_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert patch_response.status_code == codes.OK
+
+    captured: dict = {}
+    _stub_start_flow_build(monkeypatch, captured)
+
+    client_id = "ns-test-client"
+    _send_unauthenticated(client, client_id)
+    victim_session = str(flow_id)
+
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={"inputs": {"session": victim_session}},
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == codes.OK
+
+    expected_namespace = str(compute_virtual_flow_id(client_id, flow_id))
+    sent_inputs = captured["inputs"]
+    assert sent_inputs is not None
+    assert sent_inputs.session == f"{expected_namespace}:{victim_session}"
+    assert sent_inputs.session != victim_session
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
+async def test_build_public_tmp_session_already_namespaced_unchanged(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    """Idempotency: a value already in-namespace is forwarded as-is, not double-wrapped."""
+    from langflow.api.utils.flow_utils import compute_virtual_flow_id
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    patch_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert patch_response.status_code == codes.OK
+
+    captured: dict = {}
+    _stub_start_flow_build(monkeypatch, captured)
+
+    client_id = "ns-passthrough-client"
+    _send_unauthenticated(client, client_id)
+    namespace = str(compute_virtual_flow_id(client_id, flow_id))
+    already_scoped = f"{namespace}:thread-1"
+
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={"inputs": {"session": already_scoped}},
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == codes.OK
+    assert captured["inputs"].session == already_scoped
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
+async def test_build_public_tmp_isolates_disjoint_clients(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    """Different client_ids submitting the same session string land in disjoint namespaces."""
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    patch_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert patch_response.status_code == codes.OK
+
+    captured: dict = {}
+    _stub_start_flow_build(monkeypatch, captured)
+
+    shared_session = "shared-session-name"
+
+    _send_unauthenticated(client, "client-A")
+    response_a = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={"inputs": {"session": shared_session}},
+        headers={"Content-Type": "application/json"},
+    )
+    assert response_a.status_code == codes.OK
+    session_a = captured["inputs"].session
+
+    captured.clear()
+    _send_unauthenticated(client, "client-B")
+    response_b = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={"inputs": {"session": shared_session}},
+        headers={"Content-Type": "application/json"},
+    )
+    assert response_b.status_code == codes.OK
+    session_b = captured["inputs"].session
+
+    assert session_a != session_b
+    assert session_a.endswith(f":{shared_session}")
+    assert session_b.endswith(f":{shared_session}")
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
+async def test_build_public_tmp_no_session_passthrough(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    """No inputs supplied: namespacing is skipped; downstream falls back to the virtual flow ID."""
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    patch_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert patch_response.status_code == codes.OK
+
+    captured: dict = {}
+    _stub_start_flow_build(monkeypatch, captured)
+
+    _send_unauthenticated(client, "ns-default-client")
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={"inputs": None},
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == codes.OK
+    assert captured["inputs"] is None
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
+async def test_build_public_tmp_empty_session_is_namespaced(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    """An empty-string session is scoped, not forwarded as-is.
+
+    Empty string is currently *coincidentally* safe (downstream `or virtual_id`
+    fallbacks save it), but a refactor of either branch would silently regress.
+    Pin the contract here: empty becomes ``f"{namespace}:"``.
+    """
+    from langflow.api.utils.flow_utils import compute_virtual_flow_id
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    patch_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert patch_response.status_code == codes.OK
+
+    captured: dict = {}
+    _stub_start_flow_build(monkeypatch, captured)
+
+    client_id = "ns-empty-client"
+    _send_unauthenticated(client, client_id)
+
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={"inputs": {"session": ""}},
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == codes.OK
+
+    expected_namespace = str(compute_virtual_flow_id(client_id, flow_id))
+    sent_session = captured["inputs"].session
+    assert sent_session != ""
+    assert sent_session == f"{expected_namespace}:"
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
+async def test_build_public_tmp_authenticated_namespace_uses_user_id(
+    client, json_memory_chatbot_no_llm, logged_in_headers, active_user, monkeypatch
+):
+    """AUTO_LOGIN=False (prod-like) + valid bearer: the namespace is derived from user.id."""
+    from langflow.api.utils.flow_utils import compute_virtual_flow_id
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    patch_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert patch_response.status_code == codes.OK
+
+    captured: dict = {}
+    _stub_start_flow_build(monkeypatch, captured)
+
+    client.cookies.set("client_id", "should-be-ignored")
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={"inputs": {"session": "thread-A"}},
+        headers={**logged_in_headers, "Content-Type": "application/json"},
+    )
+    assert response.status_code == codes.OK
+
+    expected_namespace = str(compute_virtual_flow_id(active_user.id, flow_id))
+    assert captured["inputs"].session == f"{expected_namespace}:thread-A"
+
+
+@pytest.mark.benchmark
+@pytest.mark.security
+async def test_build_public_tmp_namespacing_blocks_memory_query_collision(
+    client, json_memory_chatbot_no_llm, logged_in_headers, monkeypatch
+):
+    """End-to-end proof that namespacing prevents Memory query collision.
+
+    A victim message stored under ``session_id == flow_id`` is unreachable via a
+    Memory query keyed on the namespaced session that build_public_tmp forwards.
+    This is the test that catches a regression in either the endpoint guard or
+    the helper -- the shape-only tests above would still pass if the rewrite
+    was applied but the downstream query stopped honoring it.
+    """
+    from lfx.memory import aadd_messages, aget_messages
+    from lfx.schema.message import Message
+
+    flow_id = await create_flow(client, json_memory_chatbot_no_llm, logged_in_headers)
+    patch_response = await client.patch(
+        f"api/v1/flows/{flow_id}",
+        json={"access_type": "PUBLIC"},
+        headers=logged_in_headers,
+    )
+    assert patch_response.status_code == codes.OK
+
+    victim_session = str(flow_id)
+    await aadd_messages(
+        Message(text="victim-secret", sender="User", sender_name="User", session_id=victim_session),
+        flow_id=flow_id,
+    )
+    seeded = await aget_messages(session_id=victim_session)
+    assert any(m.text == "victim-secret" for m in seeded)
+
+    captured: dict = {}
+    _stub_start_flow_build(monkeypatch, captured)
+    _send_unauthenticated(client, "leak-test-client")
+
+    response = await client.post(
+        f"api/v1/build_public_tmp/{flow_id}/flow",
+        json={"inputs": {"session": victim_session}},
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == codes.OK
+
+    namespaced_session = captured["inputs"].session
+    assert namespaced_session != victim_session
+
+    leaked = await aget_messages(session_id=namespaced_session)
+    assert all(m.text != "victim-secret" for m in leaked)
+
+    still_seeded = await aget_messages(session_id=victim_session)
+    assert any(m.text == "victim-secret" for m in still_seeded)
+
+
+def test_scope_session_to_namespace_helper():
+    from langflow.api.utils import scope_session_to_namespace
+
+    ns = "namespace-A"
+    assert scope_session_to_namespace(None, ns) is None
+    assert scope_session_to_namespace("", ns) == f"{ns}:"
+    assert scope_session_to_namespace(ns, ns) == ns
+    assert scope_session_to_namespace(f"{ns}:thread-1", ns) == f"{ns}:thread-1"
+    assert scope_session_to_namespace("victim-session", ns) == f"{ns}:victim-session"
+    assert scope_session_to_namespace("victim-session", "namespace-B") == "namespace-B:victim-session"
+    # A foreign-namespace prefix is treated as out-of-namespace and gets re-wrapped.
+    assert scope_session_to_namespace("namespace-B:victim", "namespace-A") == "namespace-A:namespace-B:victim"

--- a/src/lfx/src/lfx/cli/_running_commands.py
+++ b/src/lfx/src/lfx/cli/_running_commands.py
@@ -64,7 +64,8 @@ def register(app: typer.Typer) -> None:
             None,
             "--session-id",
             help=(
-                "Session ID to attach to the run. Agent and Memory Components will use this to track conversation history."
+                "Session ID to attach to the run. "
+                "Agent and Memory Components will use this to track conversation history."
             ),
         ),
     ) -> None:


### PR DESCRIPTION
## Summary
- Wrap any non-None `inputs.session` on `POST /api/v1/build_public_tmp/{flow_id}/flow` under the per-(client_id, flow_id) virtual flow ID, so an unauthenticated caller cannot select an arbitrary session and read another session's chat history through a Memory component.
- Empty strings, in-namespace values, and pre-prefixed values are handled idempotently. `None` passes through unchanged; downstream falls back to the virtual flow ID.
- Adds `@pytest.mark.security` regression tests covering shape, idempotency, cross-client isolation, empty-string scoping, the authenticated-user namespace path, an end-to-end Memory query collision check, and the helper unit cases.

## Background
Follow-up to the prior CVE-2026-33017 fix (#12160), which removed the attacker-controlled `data` parameter but left `inputs.session` accepted. Sessions created via the authenticated `/api/v1/run` path use `session_id == flow_id` by default, so the flow UUID visible in URLs becomes a predictable target. With a public flow whose Memory component has an empty `session_id` field, an unauthenticated caller could pass that UUID as `inputs.session` and the Memory retrieve query would return the victim's history.

## Notes
Targeting `release-1.9.2` (1.9.2 is not yet released).