### PR TITLE
chore: enable CodeRabbit auto-review on release-* branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -36,7 +36,8 @@ reviews:
     ignore_title_keywords: []
     labels: []
     drafts: false
-    base_branches: []
+    base_branches:
+      - "release-.*"
   finishing_touches:
     docstrings:
       enabled: true


### PR DESCRIPTION
## Summary
- Adds `release-.*` to `reviews.auto_review.base_branches` in `.coderabbit.yaml` so PRs targeting release branches (e.g. `release-1.9.2`) receive the same auto-review as PRs targeting `main`.
- Currently CodeRabbit skips review on those PRs with the message "Auto reviews are disabled on base/target branches other than the default branch."

## Notes
CodeRabbit reads its config from the default branch, so this PR targets `main`. The change takes effect for new PRs (and re-pushes to existing ones) opened against any `release-*` branch after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal auto-review configuration settings to refine branch targeting for automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->