### PR TITLE
fix(deployments): rename env labels

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployment-info-grid.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployment-info-grid.test.tsx
@@ -52,6 +52,12 @@ function renderGrid(
 // ---------------------------------------------------------------------------
 
 describe("DeploymentInfoGrid", () => {
+  it("renders environment label and selected environment name", () => {
+    renderGrid(makeDeployment(), "Production");
+    expect(screen.getByText("Environment")).toBeInTheDocument();
+    expect(screen.getByText("Production")).toBeInTheDocument();
+  });
+
   describe("date formatting", () => {
     it("formats ISO date strings to a localized date", () => {
       const iso = "2025-05-15T12:00:00Z";

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployments-table.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/__tests__/deployments-table.test.tsx
@@ -273,7 +273,7 @@ describe("Column headers", () => {
       "Name",
       "Type",
       "Attached",
-      "Provider",
+      "Environment",
       "Last Modified",
       "Test",
     ]) {

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-info-grid.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-details-modal/deployment-info-grid.tsx
@@ -62,7 +62,7 @@ export default function DeploymentInfoGrid({
         </>
       )}
 
-      <span className="text-xs text-muted-foreground">Provider</span>
+      <span className="text-xs text-muted-foreground">Environment</span>
       <span className="col-span-3 text-sm text-foreground">
         {providerName || "—"}
       </span>

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-table.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployments-table.tsx
@@ -99,7 +99,7 @@ export default function DeploymentsTable({
           <TableHead>Name</TableHead>
           <TableHead>Type</TableHead>
           <TableHead>Attached</TableHead>
-          <TableHead>Provider</TableHead>
+          <TableHead>Environment</TableHead>
           <TableHead>Last Modified</TableHead>
           <TableHead>Test</TableHead>
           <TableHead className="w-10" />


### PR DESCRIPTION
## Summary
- rename deployments table column from Provider to Environment
- rename deployment details modal label from Provider to Environment
- update frontend tests for the new terminology

<img width="763" height="522" alt="Screenshot 2026-04-30 at 2 17 19 PM" src="https://github.com/user-attachments/assets/26152edf-e53b-42c1-b70d-f43e766b6734" />
<img width="1492" height="1042" alt="Screenshot 2026-04-30 at 2 17 16 PM" src="https://github.com/user-attachments/assets/cb63f960-a418-4a34-a10b-066570c2f6c0" />

