### PR TITLE
feat: preconfigured Ollama provider with granite4:350m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all init format_backend format lint build run_backend dev help tests coverage clean_python_cache clean_npm_cache clean_frontend_build clean_all run_clic load_test_setup load_test_setup_basic load_test_list_flows load_test_run load_test_langflow_quick load_test_stress load_test_example load_test_clean load_test_remote_setup load_test_remote_run load_test_help docs docs_build docs_install api_examples_local api_examples_local_syntax
+.PHONY: all init format_backend format lint build run_backend dev help tests coverage clean_python_cache clean_npm_cache clean_frontend_build clean_all run_clic ollama_up ollama_down load_test_setup load_test_setup_basic load_test_list_flows load_test_run load_test_langflow_quick load_test_stress load_test_example load_test_clean load_test_remote_setup load_test_remote_run load_test_help docs docs_build docs_install api_examples_local api_examples_local_syntax
 
 # Configurations
 VERSION=$(shell grep "^version" pyproject.toml | sed 's/.*\"\(.*\)\"$$/\1/')
@@ -233,9 +233,21 @@ lint: install_backend ## run linters
 
 
 
-run_clic: clean_frontend_build install_frontend install_backend build_frontend ## run the CLI with fresh frontend build
+ollama_up: ## start a local Ollama with granite3.3:2b for the bundled model provider
+	@bash scripts/setup/ollama_bootstrap.sh
+
+ollama_down: ## stop and remove the bundled Ollama container (keeps the model volume)
+	@if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -Fxq langflow-ollama; then \
+		echo 'Stopping langflow-ollama container...'; \
+		docker rm -f langflow-ollama >/dev/null; \
+	else \
+		echo 'No langflow-ollama container found.'; \
+	fi
+
+run_clic: clean_frontend_build install_frontend install_backend build_frontend ollama_up ## run the CLI with fresh frontend build
 	@echo 'Running the CLI with fresh frontend build'
-	@uv run langflow run \
+	@OLLAMA_BASE_URL=$${OLLAMA_BASE_URL:-http://localhost:11434} \
+	uv run langflow run \
 		--frontend-path $(path) \
 		--log-level $(log_level) \
 		--host $(host) \
@@ -243,9 +255,10 @@ run_clic: clean_frontend_build install_frontend install_backend build_frontend #
 		$(if $(env),--env-file $(env),) \
 		$(if $(filter false,$(open_browser)),--no-open-browser)
 
-run_cli: install_frontend install_backend build_frontend ## run the CLI quickly (without cleaning build cache)
+run_cli: install_frontend install_backend build_frontend ollama_up ## run the CLI quickly (without cleaning build cache)
 	@echo 'Running the CLI quickly (reusing existing build cache if available)'
-	@uv run langflow run \
+	@OLLAMA_BASE_URL=$${OLLAMA_BASE_URL:-http://localhost:11434} \
+	uv run langflow run \
 		--frontend-path $(path) \
 		--log-level $(log_level) \
 		--host $(host) \

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ lint: install_backend ## run linters
 
 
 
-ollama_up: ## start a local Ollama with granite3.3:2b for the bundled model provider
+ollama_up: ## start a local Ollama with granite4:350m for the bundled model provider
 	@bash scripts/setup/ollama_bootstrap.sh
 
 ollama_down: ## stop and remove the bundled Ollama container (keeps the model volume)

--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,14 @@ ollama_up: ## start a local Ollama with granite3.3:2b for the bundled model prov
 	@bash scripts/setup/ollama_bootstrap.sh
 
 ollama_down: ## stop and remove the bundled Ollama container (keeps the model volume)
-	@if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -Fxq langflow-ollama; then \
-		echo 'Stopping langflow-ollama container...'; \
-		docker rm -f langflow-ollama >/dev/null; \
+	@engine=""; \
+	for c in docker podman; do \
+		if command -v $$c >/dev/null 2>&1 && $$c info >/dev/null 2>&1; then engine=$$c; break; fi; \
+	done; \
+	if [ -z "$$engine" ]; then echo 'No usable container engine (docker/podman) found.'; exit 0; fi; \
+	if $$engine ps -a --format '{{.Names}}' 2>/dev/null | grep -Fxq langflow-ollama; then \
+		echo "Stopping langflow-ollama container ($$engine)..."; \
+		$$engine rm -f langflow-ollama >/dev/null; \
 	else \
 		echo 'No langflow-ollama container found.'; \
 	fi

--- a/docker_example/ollama-granite/README.md
+++ b/docker_example/ollama-granite/README.md
@@ -8,6 +8,12 @@ Turnkey stack: Langflow, Postgres, and an Ollama server with `granite3.3:2b` pre
 docker compose up
 ```
 
+Or, with Podman:
+
+```bash
+podman compose up        # podman-compose / podman compose plugin
+```
+
 Open http://localhost:7860. The first start downloads the model (~1.5 GB), so allow a few minutes.
 
 ## Services

--- a/docker_example/ollama-granite/README.md
+++ b/docker_example/ollama-granite/README.md
@@ -1,0 +1,29 @@
+# Langflow + Ollama (granite3.3:2b) preset
+
+Turnkey stack: Langflow, Postgres, and an Ollama server with `granite3.3:2b` pre-pulled. The Langflow service sees `OLLAMA_BASE_URL=http://ollama:11434`, so the Ollama provider is auto-enabled in **Model Providers** on first login.
+
+## Run
+
+```bash
+docker compose up
+```
+
+Open http://localhost:7860. The first start downloads the model (~1.5 GB), so allow a few minutes.
+
+## Services
+
+- **langflow** — `localhost:7860`, with `OLLAMA_BASE_URL` already set
+- **postgres** — `localhost:5432` (`langflow/langflow`)
+- **ollama** — `localhost:11434`
+- **ollama-init** — one-shot, pulls `granite3.3:2b` then exits
+
+## GPU
+
+Uncomment the `deploy.resources` block on the `ollama` service in `docker-compose.yml`. Requires the NVIDIA Container Toolkit on the host.
+
+## Tear down
+
+```bash
+docker compose down            # keep volumes (model + DB persist)
+docker compose down -v         # also wipe volumes
+```

--- a/docker_example/ollama-granite/README.md
+++ b/docker_example/ollama-granite/README.md
@@ -1,6 +1,6 @@
-# Langflow + Ollama (granite3.3:2b) preset
+# Langflow + Ollama (granite4:350m) preset
 
-Turnkey stack: Langflow, Postgres, and an Ollama server with `granite3.3:2b` pre-pulled. The Langflow service sees `OLLAMA_BASE_URL=http://ollama:11434`, so the Ollama provider is auto-enabled in **Model Providers** on first login.
+Turnkey stack: Langflow, Postgres, and an Ollama server with `granite4:350m` pre-pulled. The Langflow service sees `OLLAMA_BASE_URL=http://ollama:11434`, so the Ollama provider is auto-enabled in **Model Providers** on first login.
 
 ## Run
 
@@ -14,14 +14,14 @@ Or, with Podman:
 podman compose up        # podman-compose / podman compose plugin
 ```
 
-Open http://localhost:7860. The first start downloads the model (~1.5 GB), so allow a few minutes.
+Open http://localhost:7860. The first start downloads the model (a few hundred MB for `granite4:350m`).
 
 ## Services
 
 - **langflow** — `localhost:7860`, with `OLLAMA_BASE_URL` already set
 - **postgres** — `localhost:5432` (`langflow/langflow`)
 - **ollama** — `localhost:11434`
-- **ollama-init** — one-shot, pulls `granite3.3:2b` then exits
+- **ollama-init** — one-shot, pulls `granite4:350m` then exits
 
 ## GPU
 

--- a/docker_example/ollama-granite/docker-compose.yml
+++ b/docker_example/ollama-granite/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     environment:
       - OLLAMA_HOST=http://ollama:11434
     command: >
-      "ollama pull granite3.3:2b && echo 'granite3.3:2b ready'"
+      "ollama pull granite4:350m && echo 'granite4:350m ready'"
     restart: "no"
 
 volumes:

--- a/docker_example/ollama-granite/docker-compose.yml
+++ b/docker_example/ollama-granite/docker-compose.yml
@@ -1,0 +1,67 @@
+services:
+  langflow:
+    image: langflowai/langflow:latest
+    pull_policy: always
+    ports:
+      - "7860:7860"
+    depends_on:
+      postgres:
+        condition: service_started
+      ollama-init:
+        condition: service_completed_successfully
+    environment:
+      - LANGFLOW_DATABASE_URL=postgresql://langflow:langflow@postgres:5432/langflow
+      - LANGFLOW_CONFIG_DIR=/app/langflow
+      # Pre-configures the Ollama provider in Model Providers on first user login.
+      - OLLAMA_BASE_URL=http://ollama:11434
+    volumes:
+      - langflow-data:/app/langflow
+
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: langflow
+      POSTGRES_PASSWORD: langflow
+      POSTGRES_DB: langflow
+    ports:
+      - "5432:5432"
+    volumes:
+      - langflow-postgres:/var/lib/postgresql/data
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+    # Uncomment the block below to enable NVIDIA GPU acceleration
+    # (requires the NVIDIA Container Toolkit on the host).
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+
+  ollama-init:
+    image: ollama/ollama:latest
+    depends_on:
+      ollama:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    environment:
+      - OLLAMA_HOST=http://ollama:11434
+    command: >
+      "ollama pull granite3.3:2b && echo 'granite3.3:2b ready'"
+    restart: "no"
+
+volumes:
+  langflow-postgres:
+  langflow-data:
+  ollama-data:

--- a/scripts/setup/ollama_bootstrap.sh
+++ b/scripts/setup/ollama_bootstrap.sh
@@ -2,16 +2,27 @@
 # Bootstrap a local Ollama server with the granite3.3:2b model so that
 # `make run_cli` exposes a pre-configured Ollama provider in Langflow.
 #
-# Behavior:
-#   - If something is already responding on $OLLAMA_PORT, do nothing.
-#   - Else if `docker` is available, start (or restart) a container named
-#     `langflow-ollama` and pull granite3.3:2b on it.
-#   - Else if the `ollama` CLI is installed locally, start `ollama serve`
-#     in the background and pull the model.
-#   - Else print a warning and exit 0 (Langflow still starts; Ollama provider
-#     just won't be reachable).
+# Resolution order:
+#   1. If something already responds on $OLLAMA_PORT, use it.
+#   2. Else if a container engine (docker or podman) is available with a
+#      running daemon, start (or restart) a container named `langflow-ollama`
+#      and pull the model.
+#   3. Else if the `ollama` CLI is installed, start `ollama serve` in the
+#      background and pull the model.
+#   4. Else, on macOS with Homebrew, install Ollama via `brew install ollama`,
+#      then go to step 3. Skip this with LANGFLOW_OLLAMA_NO_INSTALL=1.
+#   5. Else, fail with explicit installation instructions.
 #
-# Exits non-zero only when an explicit step fails (docker run/exec, ollama pull).
+# Environment variables:
+#   OLLAMA_PORT                 default 11434
+#   OLLAMA_HOST                 default 127.0.0.1
+#   LANGFLOW_OLLAMA_MODEL       default granite3.3:2b
+#   LANGFLOW_OLLAMA_ENGINE      override container engine: docker | podman
+#                               (auto-detected when unset)
+#   LANGFLOW_OLLAMA_NO_INSTALL  set to 1 to disable brew autoinstall
+#   LANGFLOW_OLLAMA_OPTIONAL    set to 1 to make this script never exit non-zero
+#                               (useful for CI / contributors who do not need
+#                                the bundled provider)
 
 set -euo pipefail
 
@@ -22,9 +33,21 @@ CONTAINER_NAME="langflow-ollama"
 VOLUME_NAME="langflow-ollama-data"
 HEALTH_TIMEOUT_S=60
 
+# Resolved container engine (docker | podman). Empty means "no engine usable".
+ENGINE=""
+
 log()  { printf '\033[1;36m[ollama-bootstrap]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[ollama-bootstrap]\033[0m %s\n' "$*" >&2; }
 err()  { printf '\033[1;31m[ollama-bootstrap]\033[0m %s\n' "$*" >&2; }
+
+abort() {
+  err "$*"
+  if [ "${LANGFLOW_OLLAMA_OPTIONAL:-0}" = "1" ]; then
+    warn "LANGFLOW_OLLAMA_OPTIONAL=1 — continuing without Ollama (provider will be unreachable)."
+    exit 0
+  fi
+  exit 1
+}
 
 is_server_up() {
   curl -fsS --max-time 2 "http://${OLLAMA_HOST}:${OLLAMA_PORT}/api/tags" >/dev/null 2>&1
@@ -34,7 +57,6 @@ wait_for_server() {
   local elapsed=0
   while ! is_server_up; do
     if [ "$elapsed" -ge "$HEALTH_TIMEOUT_S" ]; then
-      err "Ollama did not become healthy within ${HEALTH_TIMEOUT_S}s"
       return 1
     fi
     sleep 2
@@ -42,13 +64,36 @@ wait_for_server() {
   done
 }
 
-ensure_model_docker() {
-  log "Ensuring model '${OLLAMA_MODEL}' is pulled (docker exec)..."
-  if docker exec "$CONTAINER_NAME" ollama list 2>/dev/null | awk 'NR>1 {print $1}' | grep -Fxq "$OLLAMA_MODEL"; then
+engine_is_usable() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 && "$cmd" info >/dev/null 2>&1
+}
+
+resolve_engine() {
+  if [ -n "${LANGFLOW_OLLAMA_ENGINE:-}" ]; then
+    if engine_is_usable "$LANGFLOW_OLLAMA_ENGINE"; then
+      ENGINE="$LANGFLOW_OLLAMA_ENGINE"
+      return 0
+    fi
+    warn "LANGFLOW_OLLAMA_ENGINE='${LANGFLOW_OLLAMA_ENGINE}' is not usable — falling back to auto-detect."
+  fi
+  for candidate in docker podman; do
+    if engine_is_usable "$candidate"; then
+      ENGINE="$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+ensure_model_engine() {
+  log "Ensuring model '${OLLAMA_MODEL}' is pulled (${ENGINE} exec)..."
+  if "$ENGINE" exec "$CONTAINER_NAME" ollama list 2>/dev/null \
+      | awk 'NR>1 {print $1}' | grep -Fxq "$OLLAMA_MODEL"; then
     log "Model '${OLLAMA_MODEL}' already present."
     return 0
   fi
-  docker exec "$CONTAINER_NAME" ollama pull "$OLLAMA_MODEL"
+  "$ENGINE" exec "$CONTAINER_NAME" ollama pull "$OLLAMA_MODEL"
 }
 
 ensure_model_local() {
@@ -60,49 +105,74 @@ ensure_model_local() {
   ollama pull "$OLLAMA_MODEL"
 }
 
-start_with_docker() {
-  log "Starting Ollama container '${CONTAINER_NAME}' on port ${OLLAMA_PORT}..."
-  if docker ps --format '{{.Names}}' | grep -Fxq "$CONTAINER_NAME"; then
+start_with_engine() {
+  log "Starting Ollama container '${CONTAINER_NAME}' on port ${OLLAMA_PORT} (engine: ${ENGINE})..."
+  if "$ENGINE" ps --format '{{.Names}}' | grep -Fxq "$CONTAINER_NAME"; then
     log "Container already running."
-  elif docker ps -a --format '{{.Names}}' | grep -Fxq "$CONTAINER_NAME"; then
+  elif "$ENGINE" ps -a --format '{{.Names}}' | grep -Fxq "$CONTAINER_NAME"; then
     log "Container exists but is stopped — restarting."
-    docker start "$CONTAINER_NAME" >/dev/null
+    "$ENGINE" start "$CONTAINER_NAME" >/dev/null
   else
-    docker volume create "$VOLUME_NAME" >/dev/null
-    docker run -d \
+    "$ENGINE" volume create "$VOLUME_NAME" >/dev/null 2>&1 || true
+    "$ENGINE" run -d \
       --name "$CONTAINER_NAME" \
       --restart unless-stopped \
       -p "${OLLAMA_PORT}:11434" \
       -v "${VOLUME_NAME}:/root/.ollama" \
-      ollama/ollama >/dev/null
+      docker.io/ollama/ollama:latest >/dev/null
   fi
-  wait_for_server
-  ensure_model_docker
+  if ! wait_for_server; then
+    abort "Ollama container did not become healthy within ${HEALTH_TIMEOUT_S}s. Inspect with: ${ENGINE} logs ${CONTAINER_NAME}"
+  fi
+  ensure_model_engine
 }
 
 start_with_local_cli() {
-  log "Starting local 'ollama serve' on port ${OLLAMA_PORT}..."
+  log "Starting local 'ollama serve' on port ${OLLAMA_PORT} (logs: /tmp/langflow-ollama.log)..."
   OLLAMA_HOST="${OLLAMA_HOST}:${OLLAMA_PORT}" nohup ollama serve >/tmp/langflow-ollama.log 2>&1 &
-  wait_for_server
+  if ! wait_for_server; then
+    abort "Local 'ollama serve' did not become healthy within ${HEALTH_TIMEOUT_S}s. Tail /tmp/langflow-ollama.log for details."
+  fi
   ensure_model_local
+}
+
+try_install_ollama() {
+  if [ "${LANGFLOW_OLLAMA_NO_INSTALL:-0}" = "1" ]; then
+    return 1
+  fi
+  case "$(uname -s)" in
+    Darwin)
+      if command -v brew >/dev/null 2>&1; then
+        log "Ollama not found — installing via Homebrew (brew install ollama)..."
+        brew install ollama
+        return 0
+      fi
+      ;;
+  esac
+  return 1
 }
 
 main() {
   if is_server_up; then
     log "Ollama already responding at http://${OLLAMA_HOST}:${OLLAMA_PORT} — skipping bootstrap."
-    log "(If granite3.3:2b is not installed, run: ollama pull ${OLLAMA_MODEL})"
+    log "(If '${OLLAMA_MODEL}' is not installed, run: ollama pull ${OLLAMA_MODEL})"
     return 0
   fi
 
-  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-    start_with_docker
+  if resolve_engine; then
+    start_with_engine
   elif command -v ollama >/dev/null 2>&1; then
     start_with_local_cli
+  elif try_install_ollama && command -v ollama >/dev/null 2>&1; then
+    start_with_local_cli
   else
-    warn "Neither Docker nor the 'ollama' CLI is available."
-    warn "Langflow will start, but the Ollama provider won't be reachable."
-    warn "Install Docker (https://docs.docker.com/get-docker/) or Ollama (https://ollama.com/download) and re-run."
-    return 0
+    abort "Cannot start Ollama: no usable container engine (docker / podman) and no 'ollama' CLI.
+       Install one of:
+         - Podman:          https://podman.io/docs/installation  (then 'podman machine start')
+         - Docker Desktop:  https://docs.docker.com/get-docker/
+         - Ollama:          https://ollama.com/download           (or 'brew install ollama')
+       Then re-run 'make run_cli'.
+       To skip this bootstrap on this machine, run:  LANGFLOW_OLLAMA_OPTIONAL=1 make run_cli"
   fi
 
   log "Ollama is up at http://${OLLAMA_HOST}:${OLLAMA_PORT} with model '${OLLAMA_MODEL}'."

--- a/scripts/setup/ollama_bootstrap.sh
+++ b/scripts/setup/ollama_bootstrap.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Bootstrap a local Ollama server with the granite3.3:2b model so that
+# Bootstrap a local Ollama server with the granite4:350m model so that
 # `make run_cli` exposes a pre-configured Ollama provider in Langflow.
 #
 # Resolution order:
@@ -16,7 +16,7 @@
 # Environment variables:
 #   OLLAMA_PORT                 default 11434
 #   OLLAMA_HOST                 default 127.0.0.1
-#   LANGFLOW_OLLAMA_MODEL       default granite3.3:2b
+#   LANGFLOW_OLLAMA_MODEL       default granite4:350m
 #   LANGFLOW_OLLAMA_ENGINE      override container engine: docker | podman
 #                               (auto-detected when unset)
 #   LANGFLOW_OLLAMA_NO_INSTALL  set to 1 to disable brew autoinstall
@@ -28,7 +28,7 @@ set -euo pipefail
 
 OLLAMA_PORT="${OLLAMA_PORT:-11434}"
 OLLAMA_HOST="${OLLAMA_HOST:-127.0.0.1}"
-OLLAMA_MODEL="${LANGFLOW_OLLAMA_MODEL:-granite3.3:2b}"
+OLLAMA_MODEL="${LANGFLOW_OLLAMA_MODEL:-granite4:350m}"
 CONTAINER_NAME="langflow-ollama"
 VOLUME_NAME="langflow-ollama-data"
 HEALTH_TIMEOUT_S=60

--- a/scripts/setup/ollama_bootstrap.sh
+++ b/scripts/setup/ollama_bootstrap.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Bootstrap a local Ollama server with the granite3.3:2b model so that
+# `make run_cli` exposes a pre-configured Ollama provider in Langflow.
+#
+# Behavior:
+#   - If something is already responding on $OLLAMA_PORT, do nothing.
+#   - Else if `docker` is available, start (or restart) a container named
+#     `langflow-ollama` and pull granite3.3:2b on it.
+#   - Else if the `ollama` CLI is installed locally, start `ollama serve`
+#     in the background and pull the model.
+#   - Else print a warning and exit 0 (Langflow still starts; Ollama provider
+#     just won't be reachable).
+#
+# Exits non-zero only when an explicit step fails (docker run/exec, ollama pull).
+
+set -euo pipefail
+
+OLLAMA_PORT="${OLLAMA_PORT:-11434}"
+OLLAMA_HOST="${OLLAMA_HOST:-127.0.0.1}"
+OLLAMA_MODEL="${LANGFLOW_OLLAMA_MODEL:-granite3.3:2b}"
+CONTAINER_NAME="langflow-ollama"
+VOLUME_NAME="langflow-ollama-data"
+HEALTH_TIMEOUT_S=60
+
+log()  { printf '\033[1;36m[ollama-bootstrap]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[ollama-bootstrap]\033[0m %s\n' "$*" >&2; }
+err()  { printf '\033[1;31m[ollama-bootstrap]\033[0m %s\n' "$*" >&2; }
+
+is_server_up() {
+  curl -fsS --max-time 2 "http://${OLLAMA_HOST}:${OLLAMA_PORT}/api/tags" >/dev/null 2>&1
+}
+
+wait_for_server() {
+  local elapsed=0
+  while ! is_server_up; do
+    if [ "$elapsed" -ge "$HEALTH_TIMEOUT_S" ]; then
+      err "Ollama did not become healthy within ${HEALTH_TIMEOUT_S}s"
+      return 1
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+}
+
+ensure_model_docker() {
+  log "Ensuring model '${OLLAMA_MODEL}' is pulled (docker exec)..."
+  if docker exec "$CONTAINER_NAME" ollama list 2>/dev/null | awk 'NR>1 {print $1}' | grep -Fxq "$OLLAMA_MODEL"; then
+    log "Model '${OLLAMA_MODEL}' already present."
+    return 0
+  fi
+  docker exec "$CONTAINER_NAME" ollama pull "$OLLAMA_MODEL"
+}
+
+ensure_model_local() {
+  log "Ensuring model '${OLLAMA_MODEL}' is pulled (local ollama CLI)..."
+  if ollama list 2>/dev/null | awk 'NR>1 {print $1}' | grep -Fxq "$OLLAMA_MODEL"; then
+    log "Model '${OLLAMA_MODEL}' already present."
+    return 0
+  fi
+  ollama pull "$OLLAMA_MODEL"
+}
+
+start_with_docker() {
+  log "Starting Ollama container '${CONTAINER_NAME}' on port ${OLLAMA_PORT}..."
+  if docker ps --format '{{.Names}}' | grep -Fxq "$CONTAINER_NAME"; then
+    log "Container already running."
+  elif docker ps -a --format '{{.Names}}' | grep -Fxq "$CONTAINER_NAME"; then
+    log "Container exists but is stopped — restarting."
+    docker start "$CONTAINER_NAME" >/dev/null
+  else
+    docker volume create "$VOLUME_NAME" >/dev/null
+    docker run -d \
+      --name "$CONTAINER_NAME" \
+      --restart unless-stopped \
+      -p "${OLLAMA_PORT}:11434" \
+      -v "${VOLUME_NAME}:/root/.ollama" \
+      ollama/ollama >/dev/null
+  fi
+  wait_for_server
+  ensure_model_docker
+}
+
+start_with_local_cli() {
+  log "Starting local 'ollama serve' on port ${OLLAMA_PORT}..."
+  OLLAMA_HOST="${OLLAMA_HOST}:${OLLAMA_PORT}" nohup ollama serve >/tmp/langflow-ollama.log 2>&1 &
+  wait_for_server
+  ensure_model_local
+}
+
+main() {
+  if is_server_up; then
+    log "Ollama already responding at http://${OLLAMA_HOST}:${OLLAMA_PORT} — skipping bootstrap."
+    log "(If granite3.3:2b is not installed, run: ollama pull ${OLLAMA_MODEL})"
+    return 0
+  fi
+
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    start_with_docker
+  elif command -v ollama >/dev/null 2>&1; then
+    start_with_local_cli
+  else
+    warn "Neither Docker nor the 'ollama' CLI is available."
+    warn "Langflow will start, but the Ollama provider won't be reachable."
+    warn "Install Docker (https://docs.docker.com/get-docker/) or Ollama (https://ollama.com/download) and re-run."
+    return 0
+  fi
+
+  log "Ollama is up at http://${OLLAMA_HOST}:${OLLAMA_PORT} with model '${OLLAMA_MODEL}'."
+}
+
+main "$@"

--- a/src/lfx/src/lfx/base/models/ollama_constants.py
+++ b/src/lfx/src/lfx/base/models/ollama_constants.py
@@ -137,6 +137,12 @@ OLLAMA_MODELS_DETAILED = [
     ),
     create_model_metadata(
         provider="Ollama",
+        name="granite3.3:2b",
+        icon="Ollama",
+        tool_calling=True,
+    ),
+    create_model_metadata(
+        provider="Ollama",
         name="aya-expanse",
         icon="Ollama",
         tool_calling=True,

--- a/src/lfx/src/lfx/base/models/ollama_constants.py
+++ b/src/lfx/src/lfx/base/models/ollama_constants.py
@@ -137,7 +137,7 @@ OLLAMA_MODELS_DETAILED = [
     ),
     create_model_metadata(
         provider="Ollama",
-        name="granite3.3:2b",
+        name="granite4:350m",
         icon="Ollama",
         tool_calling=True,
     ),

--- a/src/lfx/src/lfx/services/settings/constants.py
+++ b/src/lfx/src/lfx/services/settings/constants.py
@@ -36,6 +36,8 @@ VARIABLES_TO_GET_FROM_ENVIRONMENT = [
     "WATSONX_APIKEY",
     "WATSONX_PROJECT_ID",
     "WATSONX_URL",
+    # Ollama base URL — when set, the Ollama provider is auto-enabled in Model Providers
+    "OLLAMA_BASE_URL",
 ]
 
 # Agentic experience specific variables


### PR DESCRIPTION
## Summary

Turnkey Ollama experience: starting Langflow auto-configures the **Ollama** provider in **Model Providers** with `granite4:350m` ready to use. Works for both `make run_cli` (using `docker` or `podman`, with optional Homebrew autoinstall fallback) and a new dedicated Compose stack.

`granite4:350m` is the bundled default — ~676 MB on disk, supports tool calling, much quicker to bootstrap on a fresh machine than the 2 B variants. The model name is configurable via `LANGFLOW_OLLAMA_MODEL`.

### Wiring (so the provider shows up in the UI)
- Add `OLLAMA_BASE_URL` to `VARIABLES_TO_GET_FROM_ENVIRONMENT` so it gets promoted to a per-user `Variable` on first login — this is what marks the provider as enabled in the Model Providers UI.
- Register `granite4:350m` in the Ollama catalog (`tool_calling=True`) so it appears in the dropdown.
- `run_cli` and `run_clic` export `OLLAMA_BASE_URL=http://localhost:11434` for the Langflow process.

### Bootstrap script (`scripts/setup/ollama_bootstrap.sh`)
Idempotent. Resolution order:

1. Something already responds on `:11434` → use it.
2. A container engine is available — **`docker` OR `podman`**, autodetected — start (or restart) `langflow-ollama` and `<engine> exec` an `ollama pull granite4:350m`. The Ollama image is pinned to `docker.io/ollama/ollama:latest` so it resolves under Podman's default registry policy. Engine can be forced with `LANGFLOW_OLLAMA_ENGINE=docker|podman`.
3. Local `ollama` CLI installed → `ollama serve` in the background, then `ollama pull`.
4. macOS + Homebrew → `brew install ollama`, then go to step 3. Skippable with `LANGFLOW_OLLAMA_NO_INSTALL=1`.
5. None of the above → **fail loudly** with concrete install instructions (Podman / Docker / Ollama) instead of silently letting Langflow start with a dead `OLLAMA_BASE_URL`. Escape hatch: `LANGFLOW_OLLAMA_OPTIONAL=1 make run_cli` (warns and continues).

### Make targets
- `make ollama_up` — runs the bootstrap. Listed as a dependency of `run_cli` / `run_clic`.
- `make ollama_down` — stops/removes the `langflow-ollama` container (engine-agnostic — works with podman too). Keeps the model volume.

### Compose stack — `docker_example/ollama-granite/`
Standalone, runs end-to-end with one command:

```bash
docker compose up      # or: podman compose up
```

Services: `langflow + postgres + ollama + ollama-init` (one-shot sidecar that pulls `granite4:350m` then exits). NVIDIA GPU block included but commented.

## How a user runs it

**Local (Podman / Docker / no engine all handled):**
```bash
make run_cli
```

**Compose:**
```bash
cd docker_example/ollama-granite && docker compose up
```

Open http://localhost:7860. First start downloads `granite4:350m` (~676 MB). Ollama appears in Model Providers already enabled.

## Verified on a dev machine (macOS + Podman)

- `podman ps` → container `langflow-ollama` `Up`
- `GET http://127.0.0.1:11434/api/tags` lists `granite4:350m` (676 MB)
- `POST /api/generate` to `granite4:350m` returns a real completion
- After first login on a fresh DB, the **Ollama** card in **Model Providers** is enabled and the model is selectable
- `make run_cli` exports `OLLAMA_BASE_URL` and Langflow log confirms `Set default_fields for non-secret variable OLLAMA_BASE_URL`

## Test plan

- [x] `make run_cli` on a Podman host → container created, model pulled, Langflow starts wired up
- [ ] `make run_cli` on a Docker-only host → same path, engine auto-detected as docker
- [ ] `make run_cli` with `ollama serve` already on `:11434` → bootstrap detects it and skips the engine path
- [ ] `make run_cli` on macOS without Docker/Podman/Ollama → autoinstalls Ollama via Homebrew, then starts `ollama serve`
- [ ] `make run_cli` on Linux without Docker/Podman/Ollama → fails loudly with install instructions (no silent pass-through)
- [ ] `LANGFLOW_OLLAMA_OPTIONAL=1 make run_cli` on a host without anything → warns and continues
- [ ] After first login on a fresh DB, the **Ollama** card in **Model Providers** is enabled and `granite4:350m` is available
- [ ] `docker compose up` and `podman compose up` in `docker_example/ollama-granite/` both bring the stack up end-to-end
- [ ] `make ollama_down` cleans up the container under both docker and podman (without wiping the model volume)
- [x] Backend variable-service seed tests still pass (`test_initialize_user_variables__create_and_update`, etc.)

## Files

- `src/lfx/src/lfx/services/settings/constants.py` — adds `OLLAMA_BASE_URL` to env-seed list
- `src/lfx/src/lfx/base/models/ollama_constants.py` — registers `granite4:350m`
- `Makefile` — `ollama_up` / `ollama_down` targets, wires into `run_cli` / `run_clic`
- `scripts/setup/ollama_bootstrap.sh` — engine-agnostic bootstrap
- `docker_example/ollama-granite/{docker-compose.yml,README.md}` — turnkey stack

## Configuration knobs (env vars)

| Variable | Default | Purpose |
|---|---|---|
| `OLLAMA_PORT` | `11434` | Port to expose Ollama on |
| `OLLAMA_HOST` | `127.0.0.1` | Host the script probes |
| `LANGFLOW_OLLAMA_MODEL` | `granite4:350m` | Model to ensure-pull |
| `LANGFLOW_OLLAMA_ENGINE` | _(auto)_ | Force `docker` or `podman` |
| `LANGFLOW_OLLAMA_NO_INSTALL` | `0` | Disable Homebrew autoinstall fallback |
| `LANGFLOW_OLLAMA_OPTIONAL` | `0` | Never exit non-zero (warn-and-continue) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)