### PR TITLE
fix(frontend): paginator empty state shows "0 items" instead of "1-0 of 0 items"

### DIFF
--- a/src/frontend/src/components/common/paginatorComponent/__tests__/PaginatorComponent.test.tsx
+++ b/src/frontend/src/components/common/paginatorComponent/__tests__/PaginatorComponent.test.tsx
@@ -1,0 +1,174 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import PaginatorComponent from "../index";
+
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name, className }: { name: string; className?: string }) => (
+    <span data-testid={`icon-${name}`} className={className}>
+      {name}
+    </span>
+  ),
+}));
+
+jest.mock("../../../ui/select", () => {
+  const React = require("react");
+  return {
+    Select: ({
+      children,
+      value,
+      onValueChange,
+    }: {
+      children: React.ReactNode;
+      value: string;
+      onValueChange: (value: string) => void;
+    }) => (
+      <select
+        data-testid="page-select"
+        value={value}
+        onChange={(e) => onValueChange(e.target.value)}
+      >
+        {children}
+      </select>
+    ),
+    SelectContent: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    SelectItem: ({
+      children,
+      value,
+    }: {
+      children: React.ReactNode;
+      value: string;
+    }) => <option value={value}>{children}</option>,
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    SelectValue: () => null,
+  };
+});
+
+const renderPaginator = (
+  overrides: Partial<React.ComponentProps<typeof PaginatorComponent>> = {},
+) => {
+  const paginate = jest.fn();
+  const utils = render(
+    <PaginatorComponent
+      pageSize={20}
+      pageIndex={1}
+      totalRowsCount={0}
+      paginate={paginate}
+      {...overrides}
+    />,
+  );
+  return { paginate, ...utils };
+};
+
+describe("PaginatorComponent", () => {
+  describe("empty state", () => {
+    it("renders '0 items' instead of '1-0 of 0 items' when there are no rows", () => {
+      renderPaginator({ totalRowsCount: 0 });
+
+      expect(screen.getByText("0 items")).toBeInTheDocument();
+      expect(screen.queryByText(/1-0/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/of 0 items/)).not.toBeInTheDocument();
+    });
+
+    it("uses 'flows' label when isComponent is false", () => {
+      renderPaginator({ totalRowsCount: 0, isComponent: false });
+      expect(screen.getByText("0 flows")).toBeInTheDocument();
+    });
+
+    it("uses 'components' label when isComponent is true", () => {
+      renderPaginator({ totalRowsCount: 0, isComponent: true });
+      expect(screen.getByText("0 components")).toBeInTheDocument();
+    });
+
+    it("renders 'of 1 pages' instead of 'of 0 pages' when empty", () => {
+      renderPaginator({ totalRowsCount: 0 });
+      expect(screen.getByText("of 1 pages")).toBeInTheDocument();
+    });
+
+    it("disables both prev and next when there are no rows", () => {
+      renderPaginator({ totalRowsCount: 0 });
+      const prev = screen.getByRole("button", { name: /previous page/i });
+      const next = screen.getByRole("button", { name: /next page/i });
+      expect(prev).toBeDisabled();
+      expect(next).toBeDisabled();
+    });
+  });
+
+  describe("populated state", () => {
+    it("renders the correct range on the first page", () => {
+      renderPaginator({ totalRowsCount: 45, pageSize: 20, pageIndex: 1 });
+      expect(screen.getByText(/1-20/)).toBeInTheDocument();
+      expect(screen.getByText(/of 45 items/)).toBeInTheDocument();
+    });
+
+    it("clamps the range end to totalRowsCount on the last page", () => {
+      renderPaginator({ totalRowsCount: 45, pageSize: 20, pageIndex: 3 });
+      expect(screen.getByText(/41-45/)).toBeInTheDocument();
+    });
+
+    it("renders the correct page count", () => {
+      renderPaginator({ totalRowsCount: 45, pageSize: 20, pageIndex: 1 });
+      expect(screen.getByText("of 3 pages")).toBeInTheDocument();
+    });
+
+    it("respects an explicit pages prop", () => {
+      renderPaginator({
+        totalRowsCount: 45,
+        pageSize: 20,
+        pageIndex: 1,
+        pages: 7,
+      });
+      expect(screen.getByText("of 7 pages")).toBeInTheDocument();
+    });
+
+    it("disables prev on the first page and next on the last page", () => {
+      const { rerender, paginate } = renderPaginator({
+        totalRowsCount: 45,
+        pageSize: 20,
+        pageIndex: 1,
+      });
+      expect(
+        screen.getByRole("button", { name: /previous page/i }),
+      ).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /next page/i }),
+      ).not.toBeDisabled();
+
+      rerender(
+        <PaginatorComponent
+          pageSize={20}
+          pageIndex={3}
+          totalRowsCount={45}
+          paginate={paginate}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: /previous page/i }),
+      ).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: /next page/i })).toBeDisabled();
+    });
+
+    it("calls paginate with the next page when next is clicked", () => {
+      const { paginate } = renderPaginator({
+        totalRowsCount: 45,
+        pageSize: 20,
+        pageIndex: 1,
+      });
+      fireEvent.click(screen.getByRole("button", { name: /next page/i }));
+      expect(paginate).toHaveBeenCalledWith(2, 20);
+    });
+
+    it("calls paginate with the previous page when prev is clicked", () => {
+      const { paginate } = renderPaginator({
+        totalRowsCount: 45,
+        pageSize: 20,
+        pageIndex: 2,
+      });
+      fireEvent.click(screen.getByRole("button", { name: /previous page/i }));
+      expect(paginate).toHaveBeenCalledWith(1, 20);
+    });
+  });
+});

--- a/src/frontend/src/components/common/paginatorComponent/__tests__/index.test.tsx
+++ b/src/frontend/src/components/common/paginatorComponent/__tests__/index.test.tsx
@@ -42,17 +42,17 @@ function renderPaginator(
 // ---------------------------------------------------------------------------
 
 describe("empty state", () => {
-  it("shows 0-0 of 0 items when totalRowsCount is 0", () => {
+  it("shows '0 items' when totalRowsCount is 0", () => {
     renderPaginator({ totalRowsCount: 0, pageIndex: 1, pageSize: 20 });
-    expect(screen.getByText(/^0-0$/)).toBeInTheDocument();
-    expect(screen.getByText(/of 0 items/)).toBeInTheDocument();
+    expect(screen.getByText(/^0 items$/)).toBeInTheDocument();
+    expect(screen.queryByText(/of 0 items/)).not.toBeInTheDocument();
   });
 
   it("does not show a negative start when pageIndex is 0 and totalRowsCount is 0", () => {
     // pageIndex=0 would previously produce (0-1)*20+1 = -19
     renderPaginator({ totalRowsCount: 0, pageIndex: 0, pageSize: 20 });
     expect(screen.queryByText(/-19/)).not.toBeInTheDocument();
-    expect(screen.getByText(/^0-0$/)).toBeInTheDocument();
+    expect(screen.getByText(/^0 items$/)).toBeInTheDocument();
   });
 });
 

--- a/src/frontend/src/components/common/paginatorComponent/index.tsx
+++ b/src/frontend/src/components/common/paginatorComponent/index.tsx
@@ -26,35 +26,46 @@ export default function PaginatorComponent({
 }: PaginatorComponentType) {
   const [size, setPageSize] = useState(pageSize);
   const [maxIndex, setMaxPageIndex] = useState(
-    Math.ceil(totalRowsCount / pageSize),
+    Math.max(1, Math.ceil(totalRowsCount / pageSize)),
   );
 
   useEffect(() => {
-    setMaxPageIndex(pages ?? Math.ceil(totalRowsCount / size));
+    setMaxPageIndex(pages ?? Math.max(1, Math.ceil(totalRowsCount / size)));
   }, [totalRowsCount]);
 
   const disableFirstPage = pageIndex <= 1;
-  const disableLastPage = pageIndex === maxIndex;
+  const disableLastPage = pageIndex >= maxIndex;
 
   const _handleValueChange = (pageSize: string) => {
     setPageSize(Number(pageSize));
-    setMaxPageIndex(pages ?? Math.ceil(totalRowsCount / Number(pageSize)));
+    setMaxPageIndex(
+      pages ?? Math.max(1, Math.ceil(totalRowsCount / Number(pageSize))),
+    );
     paginate(1, Number(pageSize));
   };
+
+  const itemLabel =
+    isComponent === undefined ? "items" : isComponent ? "components" : "flows";
+  const isEmpty = totalRowsCount === 0;
+  const rangeStart = (pageIndex - 1) * pageSize + 1;
+  const rangeEnd = Math.min(
+    totalRowsCount,
+    (pageIndex - 1) * pageSize + pageSize,
+  );
 
   return (
     <div className="flex flex-1 items-center justify-between px-6">
       <div className="flex items-center justify-end gap-1 text-mmd text-secondary-foreground">
-        {totalRowsCount === 0 ? 0 : (pageIndex - 1) * pageSize + 1}-
-        {Math.min(totalRowsCount, (pageIndex - 1) * pageSize + pageSize)}{" "}
-        <span className="text-muted-foreground">
-          of {totalRowsCount}{" "}
-          {isComponent === undefined
-            ? "items"
-            : isComponent
-              ? "components"
-              : "flows"}
-        </span>
+        {isEmpty ? (
+          <span className="text-muted-foreground">0 {itemLabel}</span>
+        ) : (
+          <>
+            {rangeStart}-{rangeEnd}{" "}
+            <span className="text-muted-foreground">
+              of {totalRowsCount} {itemLabel}
+            </span>
+          </>
+        )}
       </div>
       <div className={"flex items-center gap-2"}>
         <div className="flex items-center gap-1 text-mmd text-secondary-foreground">


### PR DESCRIPTION
## Summary

When `totalRowsCount` is 0 the paginator rendered `1-0 of 0 items` and `of 0 pages`, with the next button still enabled because `pageIndex (1) !== maxIndex (0)`.

This is visible on any empty list that uses `PaginatorComponent`. It's most obvious right now under the new Flow Activity panel (PR #12932), but the bug pre-dates that work.

## Changes

- Hide the range when empty and render `0 items` (or `0 flows` / `0 components` depending on `isComponent`)
- Floor `maxIndex` to 1 so the page selector reads `of 1 pages` instead of `of 0 pages`
- Switch `disableLastPage` from `===` to `>=` so both prev and next are disabled when there is nowhere to go
- Add `PaginatorComponent.test.tsx` covering empty-state labels, range clamping, page count, and prev/next button enablement (12 tests)

## Screenshot context

Before: `1-0 of 0 items` / `of 0 pages` / next button enabled
After: `0 items` / `of 1 pages` / both nav buttons disabled