### PR TITLE
fix(frontend): stop empty-state splash from flashing after login

### DIFF
--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -102,11 +102,14 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
   }, []);
 
   useEffect(() => {
-    // Wait until both the global flows store and the folder query have
-    // resolved at least once before deciding whether the folder is empty.
-    // This avoids a one-frame flash of <EmptyFolder> on initial mount and
-    // right after login, when the store is briefly stale.
-    if (flows === undefined || folderData === undefined) return;
+    // Wait until both the global flows store has populated and the folder
+    // query has settled (success or error) before deciding whether the
+    // folder is empty. This avoids a one-frame flash of <EmptyFolder> on
+    // initial mount and right after login, when the store is briefly
+    // stale. Gating on isLoading instead of folderData lets us still
+    // resolve when the query errors out (e.g. when there is no valid
+    // folder id to query, after deleting all folders).
+    if (flows === undefined || isLoading) return;
     setIsEmptyFolder(
       isFolderEmpty({
         flows,
@@ -115,7 +118,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
         enableMcp: ENABLE_MCP,
       }),
     );
-  }, [flows, folderId, myCollectionId, folderData]);
+  }, [flows, folderId, myCollectionId, folderData, isLoading]);
 
   const handleFileDrop = useFileDrop(isEmptyFolder ? undefined : flowType);
 

--- a/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/index.tsx
@@ -36,7 +36,7 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
   const [pageIndex, setPageIndex] = useState(1);
   const [pageSize, setPageSize] = useState(12);
   const [search, setSearch] = useState("");
-  const [isEmptyFolder, setIsEmptyFolder] = useState(true);
+  const [isEmptyFolder, setIsEmptyFolder] = useState<boolean | null>(null);
   const navigate = useCustomNavigate();
 
   const [flowType, setFlowType] = useState<FlowTabType>(
@@ -102,6 +102,11 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
   }, []);
 
   useEffect(() => {
+    // Wait until both the global flows store and the folder query have
+    // resolved at least once before deciding whether the folder is empty.
+    // This avoids a one-frame flash of <EmptyFolder> on initial mount and
+    // right after login, when the store is briefly stale.
+    if (flows === undefined || folderData === undefined) return;
     setIsEmptyFolder(
       isFolderEmpty({
         flows,
@@ -278,14 +283,14 @@ const HomePage = ({ type }: { type: "flows" | "components" | "mcp" }) => {
                 setView={setView}
                 setNewProjectModal={setNewProjectModal}
                 setSearch={onSearch}
-                isEmptyFolder={isEmptyFolder}
+                isEmptyFolder={isEmptyFolder === true}
                 selectedFlows={selectedFlows}
               />
-              {isEmptyFolder ? (
+              {isEmptyFolder === true ? (
                 <EmptyFolder setOpenModal={setNewProjectModal} />
               ) : (
                 <div className="flex h-full flex-col">
-                  {isLoading ? (
+                  {isLoading || isEmptyFolder === null ? (
                     view === "grid" ? (
                       <div className="mt-4 grid grid-cols-1 gap-1 md:grid-cols-2 lg:grid-cols-3">
                         <ListSkeleton />

--- a/src/frontend/src/stores/__tests__/flowsManagerStore.test.ts
+++ b/src/frontend/src/stores/__tests__/flowsManagerStore.test.ts
@@ -461,7 +461,10 @@ describe("useFlowsManagerStore", () => {
         result.current.resetStore();
       });
 
-      expect(result.current.flows).toEqual([]);
+      // flows must be undefined (not []) so consumers gating on
+      // `flows && ...` correctly show a loader after logout instead of
+      // briefly rendering the empty-state splash with stale empty data.
+      expect(result.current.flows).toBeUndefined();
       expect(result.current.currentFlow).toBeUndefined();
       expect(result.current.currentFlowId).toBe("");
       expect(result.current.searchFlowsComponents).toBe("");

--- a/src/frontend/src/stores/flowsManagerStore.ts
+++ b/src/frontend/src/stores/flowsManagerStore.ts
@@ -135,7 +135,7 @@ const useFlowsManagerStore = create<FlowsManagerStoreType>((set, get) => ({
   },
   resetStore: () => {
     set({
-      flows: [],
+      flows: undefined,
       currentFlow: undefined,
       currentFlowId: "",
       searchFlowsComponents: "",


### PR DESCRIPTION
## Summary

After signing in, the empty-state splash (\"create your first flow\") rendered for one frame even when the user already had flows. Two stacked bugs:

1. \`flowsManagerStore.resetStore()\` set \`flows: []\` on logout. After logout → login, the truthy gate in \`main-page.tsx\` (\`flows && examples && folders\`) passed immediately with stale empty values, \`shouldShowMainContent\` returned false, and \`EmptyPageCommunity\` rendered until the new flows query resolved.
2. \`homePage/index.tsx\` initialized \`isEmptyFolder = true\` and only flipped it inside a \`useEffect\`, so the first render of \`HomePage\` always rendered \`EmptyFolder\` regardless of actual state.

## Changes

- \`flowsManagerStore.resetStore\`: \`flows: []\` → \`flows: undefined\`. Matches the initial state and lets the gate correctly wait for the next fetch.
- \`homePage/index.tsx\`: \`isEmptyFolder\` is now \`boolean | null\`, starting at \`null\` and only resolving once both the global flows store and the folder query have data. While \`null\`, the existing \`ListSkeleton\` renders instead of \`EmptyFolder\`.
- Updated \`flowsManagerStore.test.ts\` to assert the new \`undefined\` reset value.

## Verification

Captured with a \`MutationObserver\` watching the empty-state \`data-testid\`s during a real post-login transition.

Before the fix, four insertions in the same paint window:
\`\`\`
EmptyFolder splash       (data-testid=\"new_project_btn_empty_page\")
EmptyPageCommunity       (data-testid=\"empty_page_github_button\")
EmptyPage logo light     (data-testid=\"empty_page_logo_light\")
EmptyPage logo dark      (data-testid=\"empty_page_logo_dark\")
\`\`\`
After the fix: zero insertions.