### PR TITLE
fix(ui): Hide native Edge password reveal icon on desktop

### DIFF
--- a/src/frontend/src/style/applies.css
+++ b/src/frontend/src/style/applies.css
@@ -16,6 +16,14 @@
   }
 }
 
+input[type="password"]::-ms-reveal,
+input[type="password"]::-ms-clear {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
+  visibility: hidden !important;
+}
+
 @keyframes slideDown {
   from {
     height: 0;


### PR DESCRIPTION
## Objective                                                                                                                                
Prevent Microsoft Edge / IE from rendering its native eye/clear icons on password inputs, which were overlapping the app's own reveal button on Windows desktop.