### PR TITLE
fix(frontend): render node dropdowns above build/notification overlays

### DIFF
--- a/src/frontend/src/components/core/dropdownComponent/index.tsx
+++ b/src/frontend/src/components/core/dropdownComponent/index.tsx
@@ -31,7 +31,13 @@ import {
   CommandList,
   CommandSeparator,
 } from "../../ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "../../ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverContentWithoutPortal,
+  PopoverTrigger,
+} from "../../ui/popover";
+import { BUILD_PANEL_COLLISION_PADDING_PX } from "@/constants/constants";
 import type { BaseInputProps } from "../parameterRenderComponent/types";
 
 export default function Dropdown({
@@ -69,6 +75,10 @@ export default function Dropdown({
   const [waitingForResponse, setWaitingForResponse] = useState(false);
   const [customValue, setCustomValue] = useState("");
   const nodes = useFlowStore((state) => state.nodes);
+  const isBuilding = useFlowStore((state) => state.isBuilding);
+  const buildInfo = useFlowStore((state) => state.buildInfo);
+  const showingBuildPanel =
+    isBuilding || !!buildInfo?.error || !!buildInfo?.success;
 
   const [filteredOptions, setFilteredOptions] = useState(() => {
     // Include the current value in filteredOptions if it's a custom value not in validOptions
@@ -100,6 +110,10 @@ export default function Dropdown({
   const sourceOptions = dialogInputs?.fields ? dialogInputs : externalOptions;
   const { firstWord } = formatName(name);
   const fuse = new Fuse(validOptions, { keys: ["name", "value"] });
+  const PopoverContentDropdown =
+    children || editNode || inspectionPanel
+      ? PopoverContent
+      : PopoverContentWithoutPortal;
   const { helperText, hasRefreshButton } = baseInputProps;
 
   // API and store hooks
@@ -630,10 +644,13 @@ export default function Dropdown({
   );
 
   const renderPopoverContent = () => (
-    <PopoverContent
+    <PopoverContentDropdown
       side="bottom"
-      avoidCollisions={!!children || inspectionPanel}
-      className="noflow nowheel nopan nodelete nodrag z-[60] p-0"
+      avoidCollisions
+      collisionPadding={{
+        bottom: showingBuildPanel ? BUILD_PANEL_COLLISION_PADDING_PX : 0,
+      }}
+      className="noflow nowheel nopan nodelete nodrag p-0"
       style={
         children ? {} : { minWidth: refButton?.current?.clientWidth ?? "200px" }
       }
@@ -664,7 +681,7 @@ export default function Dropdown({
           </div>
         )}
       </Command>
-    </PopoverContent>
+    </PopoverContentDropdown>
   );
 
   // Loading state

--- a/src/frontend/src/components/core/dropdownComponent/index.tsx
+++ b/src/frontend/src/components/core/dropdownComponent/index.tsx
@@ -31,12 +31,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "../../ui/command";
-import {
-  Popover,
-  PopoverContent,
-  PopoverContentWithoutPortal,
-  PopoverTrigger,
-} from "../../ui/popover";
+import { Popover, PopoverContent, PopoverTrigger } from "../../ui/popover";
 import type { BaseInputProps } from "../parameterRenderComponent/types";
 
 export default function Dropdown({
@@ -105,10 +100,6 @@ export default function Dropdown({
   const sourceOptions = dialogInputs?.fields ? dialogInputs : externalOptions;
   const { firstWord } = formatName(name);
   const fuse = new Fuse(validOptions, { keys: ["name", "value"] });
-  const PopoverContentDropdown =
-    children || editNode || inspectionPanel
-      ? PopoverContent
-      : PopoverContentWithoutPortal;
   const { helperText, hasRefreshButton } = baseInputProps;
 
   // API and store hooks
@@ -639,10 +630,10 @@ export default function Dropdown({
   );
 
   const renderPopoverContent = () => (
-    <PopoverContentDropdown
+    <PopoverContent
       side="bottom"
       avoidCollisions={!!children || inspectionPanel}
-      className="noflow nowheel nopan nodelete nodrag p-0"
+      className="noflow nowheel nopan nodelete nodrag z-[60] p-0"
       style={
         children ? {} : { minWidth: refButton?.current?.clientWidth ?? "200px" }
       }
@@ -673,7 +664,7 @@ export default function Dropdown({
           </div>
         )}
       </Command>
-    </PopoverContentDropdown>
+    </PopoverContent>
   );
 
   // Loading state

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
@@ -14,11 +14,7 @@ import type { NodeDataType } from "@/types/flow";
 import ForwardedIconComponent from "../../../../common/genericIconComponent";
 import { Button } from "../../../../ui/button";
 import { Command } from "../../../../ui/command";
-import {
-  Popover,
-  PopoverContent,
-  PopoverContentWithoutPortal,
-} from "../../../../ui/popover";
+import { Popover, PopoverContent } from "../../../../ui/popover";
 import type { BaseInputProps } from "../../types";
 import ModelList from "./components/ModelList";
 import ModelTrigger from "./components/ModelTrigger";
@@ -41,8 +37,6 @@ export default function ModelInputComponent({
   handleNodeClass,
   externalOptions,
   showParameter = true,
-  editNode,
-  inspectionPanel,
   showEmptyState = false,
 }: BaseInputProps<any> & ModelInputComponentType): JSX.Element | null {
   const { t } = useTranslation();
@@ -473,15 +467,11 @@ export default function ModelInputComponent({
   );
 
   const renderPopoverContent = () => {
-    const PopoverContentInput =
-      editNode || inspectionPanel
-        ? PopoverContent
-        : PopoverContentWithoutPortal;
     return (
-      <PopoverContentInput
+      <PopoverContent
         side="bottom"
         avoidCollisions={true}
-        className="noflow nowheel nopan nodelete nodrag p-0"
+        className="noflow nowheel nopan nodelete nodrag z-[60] p-0"
         style={{ minWidth: refButton?.current?.clientWidth ?? "200px" }}
       >
         <Command className="flex flex-col">
@@ -509,7 +499,7 @@ export default function ModelInputComponent({
             </div>
           )}
         </Command>
-      </PopoverContentInput>
+      </PopoverContent>
     );
   };
 

--- a/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import LoadingTextComponent from "@/components/common/loadingTextComponent";
+import { BUILD_PANEL_COLLISION_PADDING_PX } from "@/constants/constants";
 import { useGetEnabledModels } from "@/controllers/API/queries/models/use-get-enabled-models";
 import { useGetModelProviders } from "@/controllers/API/queries/models/use-get-model-providers";
 import { usePostTemplateValue } from "@/controllers/API/queries/nodes/use-post-template-value";
@@ -14,7 +15,11 @@ import type { NodeDataType } from "@/types/flow";
 import ForwardedIconComponent from "../../../../common/genericIconComponent";
 import { Button } from "../../../../ui/button";
 import { Command } from "../../../../ui/command";
-import { Popover, PopoverContent } from "../../../../ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverContentWithoutPortal,
+} from "../../../../ui/popover";
 import type { BaseInputProps } from "../../types";
 import ModelList from "./components/ModelList";
 import ModelTrigger from "./components/ModelTrigger";
@@ -37,6 +42,8 @@ export default function ModelInputComponent({
   handleNodeClass,
   externalOptions,
   showParameter = true,
+  editNode,
+  inspectionPanel,
   showEmptyState = false,
 }: BaseInputProps<any> & ModelInputComponentType): JSX.Element | null {
   const { t } = useTranslation();
@@ -47,6 +54,10 @@ export default function ModelInputComponent({
     useState(false);
   const [isRefreshingAfterClose, setIsRefreshingAfterClose] = useState(false);
   const [refreshOptions, setRefreshOptions] = useState(false);
+  const isBuilding = useFlowStore((state) => state.isBuilding);
+  const buildInfo = useFlowStore((state) => state.buildInfo);
+  const showingBuildPanel =
+    isBuilding || !!buildInfo?.error || !!buildInfo?.success;
 
   // Connection mode: local state for reactivity, persisted in node data for reload
   const [isConnectionMode, setIsConnectionMode] = useState(() => {
@@ -467,11 +478,18 @@ export default function ModelInputComponent({
   );
 
   const renderPopoverContent = () => {
+    const PopoverContentInput =
+      editNode || inspectionPanel
+        ? PopoverContent
+        : PopoverContentWithoutPortal;
     return (
-      <PopoverContent
+      <PopoverContentInput
         side="bottom"
-        avoidCollisions={true}
-        className="noflow nowheel nopan nodelete nodrag z-[60] p-0"
+        avoidCollisions
+        collisionPadding={{
+          bottom: showingBuildPanel ? BUILD_PANEL_COLLISION_PADDING_PX : 0,
+        }}
+        className="noflow nowheel nopan nodelete nodrag p-0"
         style={{ minWidth: refButton?.current?.clientWidth ?? "200px" }}
       >
         <Command className="flex flex-col">
@@ -499,7 +517,7 @@ export default function ModelInputComponent({
             </div>
           )}
         </Command>
-      </PopoverContent>
+      </PopoverContentInput>
     );
   };
 

--- a/src/frontend/src/constants/constants.ts
+++ b/src/frontend/src/constants/constants.ts
@@ -896,6 +896,13 @@ export const DEFAULT_NOTE_SIZE = 324;
 export const CHAT_INPUT_MIN_HEIGHT = 24;
 export const CHAT_INPUT_MAX_HEIGHT = 200;
 
+/**
+ * Collision padding (px) reserved at the bottom of the canvas viewport for
+ * node popovers (dropdowns) when the build status / error notification panel
+ * is visible. Keeps Radix popovers from opening over the panel.
+ */
+export const BUILD_PANEL_COLLISION_PADDING_PX = 160;
+
 export const COLOR_OPTIONS = {
   amber: "hsl(var(--note-amber))",
   neutral: "hsl(var(--note-neutral))",


### PR DESCRIPTION
## Summary

Node dropdowns (the model selector and the generic dropdown) used to be clipped by the **build status / error notification panel** at the bottom of the canvas. The dropdown items were unreachable while a build error toast was visible — users had to drag the component upward to read the options.

## Root cause

- ReactFlow nodes apply `transform: translate3d(...)` plus a CSS scale on `.react-flow__viewport` (the canvas zoom). The popover ships rendered **inline** inside the node so it inherits that scale and looks "right" at any zoom level.
- Living inside a node also creates a stacking-context trap: the popover's internal `z-50` cannot escape the node, and the build/notification panel (`FlowBuildingComponent`, `z-50`, sibling of the canvas) wins the stacking order, so the popover gets visually covered.

## Changes

- `src/frontend/src/components/core/dropdownComponent/index.tsx`
- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/index.tsx`
- `src/frontend/src/constants/constants.ts`

In both popover components:

1. Restored the original `PopoverContentWithoutPortal` selector so node-level usage stays inline (children / editNode / inspectionPanel still use the portaled `PopoverContent` as before).
2. Subscribed to `useFlowStore` for `isBuilding` and `buildInfo`, deriving `showingBuildPanel = isBuilding || !!buildInfo?.error || !!buildInfo?.success`.
3. Always pass `avoidCollisions` and a dynamic `collisionPadding={{ bottom: showingBuildPanel ? BUILD_PANEL_COLLISION_PADDING_PX : 0 }}`. When the build panel is on screen, Radix treats the bottom 160px as off-limits and flips the popover above the trigger.

`constants/constants.ts` exports `BUILD_PANEL_COLLISION_PADDING_PX = 160` with a JSDoc comment so the magic number lives in one place.

## Why not Portal + scale

We considered portaling the popover and re-applying the canvas zoom transform manually, but that fights Radix's positioning (Radix already uses `transform: translate3d(...)` for placement) and creates layout sizing issues on the wrapper. The collision-padding approach is much simpler and stays within Radix's documented APIs.

## Test plan

- [x] Manual: open a flow with a `LanguageModelComponent`, force a build failure (invalid API key), open the model dropdown — popover flips above the trigger; no overlap with the red "Flow build failed" panel.
- [x] Manual: zoom canvas in and out with dropdown open — popover scales with the rest of the node (not native size).
- [x] Manual: dismiss the notification — popover opens downward again as before.
- [x] `tsc --noEmit` — no new TypeScript errors introduced (only pre-existing errors on `release-1.10.0`).
- [x] `make format_frontend` clean.
- [ ] Manual: pan the canvas with dropdown open — popover follows the trigger.
- [ ] Manual: open dropdown inside Inspection Panel and Edit Node modal — still works (these already use the portaled path).

## Screen shots
Before
<img width="617" height="651" alt="image" src="https://github.com/user-attachments/assets/7c46850a-eb0f-42fd-b1fa-8f0c742c634b" />


After
<img width="769" height="613" alt="image" src="https://github.com/user-attachments/assets/fb0b78a0-c736-4bac-8130-5528424a8a24" />
