### PR TITLE
feat(assistant): Add Refresh List and Manage Model Providers to model selector

### DIFF
--- a/src/frontend/src/components/core/assistantPanel/components/__tests__/model-selector.test.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/__tests__/model-selector.test.tsx
@@ -11,6 +11,24 @@ jest.mock("@/components/common/genericIconComponent", () => {
   };
 });
 
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: "3rdParty", init: jest.fn() },
+}));
+
+jest.mock("@/hooks/use-refresh-model-inputs", () => ({
+  useRefreshModelInputs: () => ({
+    refresh: jest.fn(),
+    refreshAllModelInputs: jest.fn(),
+  }),
+}));
+
+jest.mock("@/modals/modelProviderModal", () => {
+  return function MockModelProviderModal({ open }: { open: boolean }) {
+    return open ? <div data-testid="mock-model-provider-modal" /> : null;
+  };
+});
+
 let mockFilteredProviders = [
   {
     provider: "Anthropic",

--- a/src/frontend/src/components/core/assistantPanel/components/model-selector.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/model-selector.tsx
@@ -124,125 +124,125 @@ export function ModelSelector({
 
   return (
     <>
-    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          data-testid="assistant-model-selector"
-          className="h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground active:!scale-100"
-        >
-          <span className="flex items-center gap-1.5">
+      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            data-testid="assistant-model-selector"
+            className="h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground active:!scale-100"
+          >
+            <span className="flex items-center gap-1.5">
+              <ForwardedIconComponent
+                name={currentProviderIcon}
+                className="h-4 w-4 shrink-0"
+              />
+            </span>
+            <span>{currentModel?.displayName || "Select model"}</span>
             <ForwardedIconComponent
-              name={currentProviderIcon}
-              className="h-4 w-4 shrink-0"
+              name={isOpen ? "ChevronUp" : "ChevronDown"}
+              className="h-3 w-3"
             />
-          </span>
-          <span>{currentModel?.displayName || "Select model"}</span>
-          <ForwardedIconComponent
-            name={isOpen ? "ChevronUp" : "ChevronDown"}
-            className="h-3 w-3"
-          />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="start"
-        className="z-[70] max-h-96 w-72 overflow-y-auto p-2"
-      >
-        {enabledProviders.map((provider, index) => (
-          <div key={provider.provider}>
-            {index > 0 && <DropdownMenuSeparator className="my-2" />}
-            <DropdownMenuLabel className="text-xs font-semibold my-2 ml-2 text-muted-foreground">
-              {provider.provider}
-            </DropdownMenuLabel>
-            <div className="flex flex-col gap-1">
-              {provider.models.map((model) => {
-                const modelId = `${provider.provider}-${model.model_name}`;
-                const isSelected = currentModel?.id === modelId;
-                return (
-                  <DropdownMenuItem
-                    key={modelId}
-                    onClick={() =>
-                      handleModelSelect({
-                        id: modelId,
-                        name: model.model_name,
-                        provider: provider.provider,
-                        displayName: model.model_name,
-                        icon: provider.icon,
-                      })
-                    }
-                    className="flex w-full cursor-pointer items-center rounded-md px-3 py-2"
-                  >
-                    <div className="flex w-full items-center gap-2">
-                      <ForwardedIconComponent
-                        name={provider.icon}
-                        className="h-4 w-4 shrink-0 text-primary ml-2"
-                      />
-                      <div className="truncate text-[13px]">
-                        {model.model_name}
-                      </div>
-                      <div className="pl-2 ml-auto">
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="z-[70] max-h-96 w-72 overflow-y-auto p-2"
+        >
+          {enabledProviders.map((provider, index) => (
+            <div key={provider.provider}>
+              {index > 0 && <DropdownMenuSeparator className="my-2" />}
+              <DropdownMenuLabel className="text-xs font-semibold my-2 ml-2 text-muted-foreground">
+                {provider.provider}
+              </DropdownMenuLabel>
+              <div className="flex flex-col gap-1">
+                {provider.models.map((model) => {
+                  const modelId = `${provider.provider}-${model.model_name}`;
+                  const isSelected = currentModel?.id === modelId;
+                  return (
+                    <DropdownMenuItem
+                      key={modelId}
+                      onClick={() =>
+                        handleModelSelect({
+                          id: modelId,
+                          name: model.model_name,
+                          provider: provider.provider,
+                          displayName: model.model_name,
+                          icon: provider.icon,
+                        })
+                      }
+                      className="flex w-full cursor-pointer items-center rounded-md px-3 py-2"
+                    >
+                      <div className="flex w-full items-center gap-2">
                         <ForwardedIconComponent
-                          name="Check"
-                          className={cn(
-                            "h-4 w-4 shrink-0 text-primary",
-                            isSelected ? "opacity-100" : "opacity-0",
-                          )}
+                          name={provider.icon}
+                          className="h-4 w-4 shrink-0 text-primary ml-2"
                         />
+                        <div className="truncate text-[13px]">
+                          {model.model_name}
+                        </div>
+                        <div className="pl-2 ml-auto">
+                          <ForwardedIconComponent
+                            name="Check"
+                            className={cn(
+                              "h-4 w-4 shrink-0 text-primary",
+                              isSelected ? "opacity-100" : "opacity-0",
+                            )}
+                          />
+                        </div>
                       </div>
-                    </div>
-                  </DropdownMenuItem>
-                );
-              })}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        ))}
-        <DropdownMenuSeparator className="my-2" />
-        <DropdownMenuItem
-          onClick={(e) => {
-            e.preventDefault();
-            handleRefreshList();
-          }}
-          data-testid="assistant-refresh-model-list"
-          className="flex w-full cursor-pointer items-center rounded-md px-3 py-2 text-muted-foreground hover:text-foreground"
-        >
-          <div className="flex w-full items-center gap-2">
-            <span className="ml-2 text-[13px]">
-              {t("modelInput.refreshList")}
-            </span>
-            <ForwardedIconComponent
-              name="RotateCw"
-              className="ml-auto h-4 w-4 shrink-0"
-            />
-          </div>
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={(e) => {
-            e.preventDefault();
-            handleOpenManageProviders();
-          }}
-          data-testid="assistant-manage-model-providers"
-          className="flex w-full cursor-pointer items-center rounded-md px-3 py-2 text-muted-foreground hover:text-foreground"
-        >
-          <div className="flex w-full items-center gap-2">
-            <span className="ml-2 text-[13px]">
-              {t("modelInput.manageProviders")}
-            </span>
-            <ForwardedIconComponent
-              name="Settings"
-              className="ml-auto h-4 w-4 shrink-0"
-            />
-          </div>
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-    {isManageProvidersOpen && (
-      <ModelProviderModal
-        open={isManageProvidersOpen}
-        onClose={() => setIsManageProvidersOpen(false)}
-        modelType="llm"
-      />
-    )}
+          ))}
+          <DropdownMenuSeparator className="my-2" />
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.preventDefault();
+              handleRefreshList();
+            }}
+            data-testid="assistant-refresh-model-list"
+            className="flex w-full cursor-pointer items-center rounded-md px-3 py-2 text-muted-foreground hover:text-foreground"
+          >
+            <div className="flex w-full items-center gap-2">
+              <span className="ml-2 text-[13px]">
+                {t("modelInput.refreshList")}
+              </span>
+              <ForwardedIconComponent
+                name="RotateCw"
+                className="ml-auto h-4 w-4 shrink-0"
+              />
+            </div>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.preventDefault();
+              handleOpenManageProviders();
+            }}
+            data-testid="assistant-manage-model-providers"
+            className="flex w-full cursor-pointer items-center rounded-md px-3 py-2 text-muted-foreground hover:text-foreground"
+          >
+            <div className="flex w-full items-center gap-2">
+              <span className="ml-2 text-[13px]">
+                {t("modelInput.manageProviders")}
+              </span>
+              <ForwardedIconComponent
+                name="Settings"
+                className="ml-auto h-4 w-4 shrink-0"
+              />
+            </div>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {isManageProvidersOpen && (
+        <ModelProviderModal
+          open={isManageProvidersOpen}
+          onClose={() => setIsManageProvidersOpen(false)}
+          modelType="llm"
+        />
+      )}
     </>
   );
 }

--- a/src/frontend/src/components/core/assistantPanel/components/model-selector.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/model-selector.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/utils/utils";
@@ -10,6 +11,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useRefreshModelInputs } from "@/hooks/use-refresh-model-inputs";
+import ModelProviderModal from "@/modals/modelProviderModal";
 import type { AssistantModel } from "../assistant-panel.types";
 import { useEnabledModels } from "../hooks";
 
@@ -22,8 +25,21 @@ export function ModelSelector({
   selectedModel,
   onModelChange,
 }: ModelSelectorProps) {
+  const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
+  const [isManageProvidersOpen, setIsManageProvidersOpen] = useState(false);
   const { filteredProviders: enabledProviders, isLoading } = useEnabledModels();
+  const { refresh: refreshAllModelInputs } = useRefreshModelInputs();
+
+  const handleRefreshList = async () => {
+    setIsOpen(false);
+    await refreshAllModelInputs({ silent: true });
+  };
+
+  const handleOpenManageProviders = () => {
+    setIsOpen(false);
+    setIsManageProvidersOpen(true);
+  };
 
   // Flatten all models for easy selection
   const allModels = useMemo(() => {
@@ -107,6 +123,7 @@ export function ModelSelector({
   }
 
   return (
+    <>
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger asChild>
         <Button
@@ -180,7 +197,52 @@ export function ModelSelector({
             </div>
           </div>
         ))}
+        <DropdownMenuSeparator className="my-2" />
+        <DropdownMenuItem
+          onClick={(e) => {
+            e.preventDefault();
+            handleRefreshList();
+          }}
+          data-testid="assistant-refresh-model-list"
+          className="flex w-full cursor-pointer items-center rounded-md px-3 py-2 text-muted-foreground hover:text-foreground"
+        >
+          <div className="flex w-full items-center gap-2">
+            <span className="ml-2 text-[13px]">
+              {t("modelInput.refreshList")}
+            </span>
+            <ForwardedIconComponent
+              name="RotateCw"
+              className="ml-auto h-4 w-4 shrink-0"
+            />
+          </div>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={(e) => {
+            e.preventDefault();
+            handleOpenManageProviders();
+          }}
+          data-testid="assistant-manage-model-providers"
+          className="flex w-full cursor-pointer items-center rounded-md px-3 py-2 text-muted-foreground hover:text-foreground"
+        >
+          <div className="flex w-full items-center gap-2">
+            <span className="ml-2 text-[13px]">
+              {t("modelInput.manageProviders")}
+            </span>
+            <ForwardedIconComponent
+              name="Settings"
+              className="ml-auto h-4 w-4 shrink-0"
+            />
+          </div>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+    {isManageProvidersOpen && (
+      <ModelProviderModal
+        open={isManageProvidersOpen}
+        onClose={() => setIsManageProvidersOpen(false)}
+        modelType="llm"
+      />
+    )}
+    </>
   );
 }

--- a/src/frontend/tests/core/integrations/starter-projects-shard1.spec.ts
+++ b/src/frontend/tests/core/integrations/starter-projects-shard1.spec.ts
@@ -11,7 +11,10 @@ test(
     let numberOfOutdatedComponents = 0;
 
     await page.getByTestId("side_nav_options_all-templates").click();
-    await page.waitForLoadState("networkidle", { timeout: 30000 });
+    // Avoid waitForLoadState("networkidle"): persistent connections
+    // (MCP refresh, websockets) keep network busy and force the full 30s
+    // timeout on every iteration. The toBeVisible() below already
+    // auto-waits for actual readiness.
     await expect(page.getByTestId("text_card_container").first()).toBeVisible({
       timeout: 20000,
     });
@@ -42,7 +45,7 @@ test(
     for (const template of templatesData) {
       console.log(`Testing template ${template.index}: ${template.name}`);
 
-      await page.goto("/", { waitUntil: "networkidle", timeout: 30000 });
+      await page.goto("/", { waitUntil: "domcontentloaded", timeout: 30000 });
       await expect(page.getByTestId("mainpage_title")).toBeVisible({
         timeout: 30000,
       });
@@ -51,7 +54,6 @@ test(
       await page.waitForLoadState("domcontentloaded");
 
       await page.getByTestId("side_nav_options_all-templates").click();
-      await page.waitForLoadState("networkidle", { timeout: 30000 });
       await expect(page.getByTestId("text_card_container").first()).toBeVisible(
         { timeout: 20000 },
       );
@@ -62,7 +64,6 @@ test(
       await expect(targetTemplate).toBeVisible({ timeout: 15000 });
       await targetTemplate.click();
 
-      await page.waitForLoadState("networkidle", { timeout: 30000 });
       await expect(
         page.locator('[data-testid="div-generic-node"]').first(),
       ).toBeVisible({ timeout: 25000 });

--- a/src/frontend/tests/core/integrations/starter-projects-shard2.spec.ts
+++ b/src/frontend/tests/core/integrations/starter-projects-shard2.spec.ts
@@ -11,7 +11,10 @@ test(
     let numberOfOutdatedComponents = 0;
 
     await page.getByTestId("side_nav_options_all-templates").click();
-    await page.waitForLoadState("networkidle", { timeout: 30000 });
+    // Avoid waitForLoadState("networkidle"): persistent connections
+    // (MCP refresh, websockets) keep network busy and force the full 30s
+    // timeout on every iteration. The toBeVisible() below already
+    // auto-waits for actual readiness.
     await expect(page.getByTestId("text_card_container").first()).toBeVisible({
       timeout: 20000,
     });
@@ -41,7 +44,7 @@ test(
     for (const template of templatesData) {
       console.log(`Testing template ${template.index}: ${template.name}`);
 
-      await page.goto("/", { waitUntil: "networkidle", timeout: 30000 });
+      await page.goto("/", { waitUntil: "domcontentloaded", timeout: 30000 });
       await expect(page.getByTestId("mainpage_title")).toBeVisible({
         timeout: 30000,
       });
@@ -50,7 +53,6 @@ test(
       await page.waitForLoadState("domcontentloaded");
 
       await page.getByTestId("side_nav_options_all-templates").click();
-      await page.waitForLoadState("networkidle", { timeout: 30000 });
       await expect(page.getByTestId("text_card_container").first()).toBeVisible(
         { timeout: 20000 },
       );
@@ -61,7 +63,6 @@ test(
       await expect(targetTemplate).toBeVisible({ timeout: 15000 });
       await targetTemplate.click();
 
-      await page.waitForLoadState("networkidle", { timeout: 30000 });
       await expect(
         page.locator('[data-testid="div-generic-node"]').first(),
       ).toBeVisible({ timeout: 25000 });

--- a/src/frontend/tests/core/integrations/starter-projects-shard3.spec.ts
+++ b/src/frontend/tests/core/integrations/starter-projects-shard3.spec.ts
@@ -11,7 +11,10 @@ test(
     let numberOfOutdatedComponents = 0;
 
     await page.getByTestId("side_nav_options_all-templates").click();
-    await page.waitForLoadState("networkidle", { timeout: 30000 });
+    // Avoid waitForLoadState("networkidle"): persistent connections
+    // (MCP refresh, websockets) keep network busy and force the full 30s
+    // timeout on every iteration. The toBeVisible() below already
+    // auto-waits for actual readiness.
     await expect(page.getByTestId("text_card_container").first()).toBeVisible({
       timeout: 20000,
     });
@@ -42,7 +45,7 @@ test(
     for (const template of templatesData) {
       console.log(`Testing template ${template.index}: ${template.name}`);
 
-      await page.goto("/", { waitUntil: "networkidle", timeout: 30000 });
+      await page.goto("/", { waitUntil: "domcontentloaded", timeout: 30000 });
       await expect(page.getByTestId("mainpage_title")).toBeVisible({
         timeout: 30000,
       });
@@ -51,7 +54,6 @@ test(
       await page.waitForLoadState("domcontentloaded");
 
       await page.getByTestId("side_nav_options_all-templates").click();
-      await page.waitForLoadState("networkidle", { timeout: 30000 });
       await expect(page.getByTestId("text_card_container").first()).toBeVisible(
         { timeout: 20000 },
       );
@@ -62,7 +64,6 @@ test(
       await expect(targetTemplate).toBeVisible({ timeout: 15000 });
       await targetTemplate.click();
 
-      await page.waitForLoadState("networkidle", { timeout: 30000 });
       await expect(
         page.locator('[data-testid="div-generic-node"]').first(),
       ).toBeVisible({ timeout: 25000 });

--- a/src/frontend/tests/core/integrations/starter-projects-shard4.spec.ts
+++ b/src/frontend/tests/core/integrations/starter-projects-shard4.spec.ts
@@ -11,7 +11,10 @@ test(
     let numberOfOutdatedComponents = 0;
 
     await page.getByTestId("side_nav_options_all-templates").click();
-    await page.waitForLoadState("networkidle", { timeout: 30000 });
+    // Avoid waitForLoadState("networkidle"): persistent connections
+    // (MCP refresh, websockets) keep network busy and force the full 30s
+    // timeout on every iteration. The toBeVisible() below already
+    // auto-waits for actual readiness.
     await expect(page.getByTestId("text_card_container").first()).toBeVisible({
       timeout: 20000,
     });
@@ -41,7 +44,7 @@ test(
     for (const template of templatesData) {
       console.log(`Testing template ${template.index}: ${template.name}`);
 
-      await page.goto("/", { waitUntil: "networkidle", timeout: 30000 });
+      await page.goto("/", { waitUntil: "domcontentloaded", timeout: 30000 });
       await expect(page.getByTestId("mainpage_title")).toBeVisible({
         timeout: 30000,
       });
@@ -50,7 +53,6 @@ test(
       await page.waitForLoadState("domcontentloaded");
 
       await page.getByTestId("side_nav_options_all-templates").click();
-      await page.waitForLoadState("networkidle", { timeout: 30000 });
       await expect(page.getByTestId("text_card_container").first()).toBeVisible(
         { timeout: 20000 },
       );
@@ -61,7 +63,6 @@ test(
       await expect(targetTemplate).toBeVisible({ timeout: 15000 });
       await targetTemplate.click();
 
-      await page.waitForLoadState("networkidle", { timeout: 30000 });
       await expect(
         page.locator('[data-testid="div-generic-node"]').first(),
       ).toBeVisible({ timeout: 25000 });


### PR DESCRIPTION
## Objective                                                                                                                                           
Bring the Langflow Assistant model selector to parity with the canvas model input by adding "Refresh List" and "Manage Model Providers" footer options. 

<img width="765" height="539" alt="image" src="https://github.com/user-attachments/assets/a6c02110-647c-43c7-a459-61b241613b27" />
