### PR TITLE
fix: remove stepper modal close button

### DIFF
--- a/src/frontend/src/components/ui/__tests__/dialog.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/dialog.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import type { ReactElement } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import {
   Dialog,
@@ -59,5 +58,21 @@ describe("DialogContent", () => {
 
     // Assert — custom handler was called
     expect(customHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("should_hide_close_button_when_requested", () => {
+    renderWithProviders(
+      <Dialog open>
+        <DialogContent hideCloseButton>
+          <DialogTitle>Test Dialog</DialogTitle>
+          <DialogDescription>Test description</DialogDescription>
+          <p>Content</p>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /close/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/ui/dialog.tsx
+++ b/src/frontend/src/components/ui/dialog.tsx
@@ -54,6 +54,7 @@ const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     hideTitle?: boolean;
+    hideCloseButton?: boolean;
     closeButtonClassName?: string;
     overlayClassName?: string;
   }
@@ -63,6 +64,7 @@ const DialogContent = React.forwardRef<
       className,
       children,
       hideTitle = false,
+      hideCloseButton = false,
       closeButtonClassName,
       overlayClassName,
       onOpenAutoFocus,
@@ -108,22 +110,24 @@ const DialogContent = React.forwardRef<
             </VisuallyHidden>
           )}
           {children}
-          <ShadTooltip
-            styleClasses="z-50"
-            content="Close"
-            side="bottom"
-            avoidCollisions
-          >
-            <DialogPrimitive.Close
-              className={cn(
-                "absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-sm ring-offset-background transition-opacity hover:bg-secondary-hover hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
-                closeButtonClassName,
-              )}
+          {!hideCloseButton && (
+            <ShadTooltip
+              styleClasses="z-50"
+              content="Close"
+              side="bottom"
+              avoidCollisions
             >
-              <Cross2Icon className="h-[18px] w-[18px]" />
-              <span className="sr-only">Close</span>
-            </DialogPrimitive.Close>
-          </ShadTooltip>
+              <DialogPrimitive.Close
+                className={cn(
+                  "absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-sm ring-offset-background transition-opacity hover:bg-secondary-hover hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
+                  closeButtonClassName,
+                )}
+              >
+                <Cross2Icon className="h-[18px] w-[18px]" />
+                <span className="sr-only">Close</span>
+              </DialogPrimitive.Close>
+            </ShadTooltip>
+          )}
         </DialogPrimitive.Content>
       </DialogPortal>
     );

--- a/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-stepper-modal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/deploymentsPage/components/deployment-stepper-modal.tsx
@@ -135,7 +135,7 @@ export default function DeploymentStepperModal({
     >
       <DialogContent
         className="flex h-[85vh] w-[900px] !max-w-none flex-col gap-0 overflow-hidden border-none bg-transparent p-0 shadow-none"
-        closeButtonClassName="top-5 right-4"
+        hideCloseButton
         overlayClassName="bg-black/30 dark:bg-black/50 backdrop-blur"
       >
         {isLoadingEditData ? (


### PR DESCRIPTION
## Summary
- add opt-out support for shared dialog close button
- hide floating close button in deployment stepper modal
- cover hidden close button behavior with dialog test

BEFORE:
<img width="780" height="550" alt="image" src="https://github.com/user-attachments/assets/732817f7-5047-47ff-9e1e-26d6d5be4bf1" />


AFTER:
<img width="985" height="279" alt="image" src="https://github.com/user-attachments/assets/11313552-d5a1-4799-ab52-c3ba7c50441a" />
