### PR TITLE
fix: update Docker base images to latest Python 3.12 and Debian Trixie to resolve CVEs

### DIFF
--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -9,7 +9,7 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 
 # Install the project into `/app`
 WORKDIR /app

--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -75,7 +75,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.13-slim-trixie AS runtime
+FROM python:3.12-slim-trixie AS runtime
 
 
 RUN apt-get update \

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ################################
 # RUNTIME
 ################################
-FROM python:3.12.13-slim-trixie AS runtime
+FROM python:3.12-slim-trixie AS runtime
 
 # Install minimal runtime dependencies
 RUN apt-get update \

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -8,7 +8,7 @@
 ################################
 # BUILDER
 ################################
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 
 WORKDIR /app
 

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -77,7 +77,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.13-slim-trixie AS runtime
+FROM python:3.12-slim-trixie AS runtime
 
 
 RUN apt-get update \

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -10,7 +10,7 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 
 # Install the project into `/app`
 WORKDIR /app

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -9,7 +9,7 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 
 # Install the project into `/app`
 WORKDIR /app

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -72,7 +72,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.13-slim-trixie AS runtime
+FROM python:3.12-slim-trixie AS runtime
 
 RUN apt-get update \
     && apt-get upgrade -y \

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -9,7 +9,7 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 
 # Install the project into `/app`
 WORKDIR /app

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -72,7 +72,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.13-slim-trixie AS runtime
+FROM python:3.12-slim-trixie AS runtime
 
 
 RUN apt-get update \


### PR DESCRIPTION
## Summary
Updates all Docker base images to use the latest Debian Trixie and Python 3.12 to resolve CVE vulnerabilities in both builder and runtime stages.

## Changes
### Runtime Stage (Commit 1)
- Updated from `python:3.12.13-slim-trixie` to `python:3.12-slim-trixie`
- Ensures automatic security patches for runtime images

### Builder Stage (Commit 2)
- Updated from `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` to `ghcr.io/astral-sh/uv:python3.12-trixie-slim`
- Ensures consistency between builder and runtime (both now use Debian Trixie)
- Eliminates CVEs in build environment

## Why
- Addresses CVE vulnerabilities in Debian base images (Bookworm → Trixie)
- Using unpinned patch versions follows security best practices
- Ensures automatic security updates without manual intervention
- Maintains consistency between build and runtime environments

## Testing
- Nightly builds will validate these changes automatically
- No functional changes expected, only security patches
- All 5 Dockerfiles updated for consistency

## Affected Builds
- Nightly: base, main, main-all
- Release: backend, entrypoint
