### PR TITLE
fix(knowledge-base): surface metadata on chunk cards and make filter self-documenting

### DIFF
--- a/src/backend/base/langflow/api/v1/knowledge_bases.py
+++ b/src/backend/base/langflow/api/v1/knowledge_bases.py
@@ -37,6 +37,7 @@ from langflow.schema.knowledge_base import (
     IngestionRunDetail,
     IngestionRunInfo,
     IngestionRunItemInfo,
+    KbMetadataKeysResponse,
     KnowledgeBaseInfo,
     PaginatedChunkResponse,
     PaginatedIngestionRunResponse,
@@ -51,6 +52,7 @@ from langflow.services.memory_base.kb_path_helpers import validate_kb_path
 from langflow.services.task.service import TaskService
 from langflow.utils.kb_constants import (
     CHUNK_PREVIEW_MULTIPLIER,
+    KB_METADATA_RESERVED_KEYS,
     MAX_CHUNK_OVERLAP,
     MAX_CHUNK_SIZE,
     MAX_MAX_CHUNKS,
@@ -59,6 +61,12 @@ from langflow.utils.kb_constants import (
     MIN_KB_NAME_LENGTH,
     MIN_MAX_CHUNKS,
 )
+
+# Cap on distinct values per metadata key returned by ``/metadata/keys``.
+# Distinct value sets in the wild can be unbounded (free-form strings),
+# so the endpoint truncates and signals the cap via the ``truncated`` flag
+# on its response. Keep small enough to keep the popover dropdown usable.
+KB_METADATA_KEYS_VALUES_CAP = 50
 
 router = APIRouter(tags=["Knowledge Bases"], prefix="/knowledge_bases", include_in_schema=False)
 
@@ -1398,6 +1406,117 @@ async def get_knowledge_base_chunks(
         # ``SharedSystemClient`` registry entry. Calling it for a
         # MongoDB/Astra/Postgres-backed KB would mutate that registry
         # for unrelated Chroma KBs served from the same path.
+        if kb_path is not None and backend_type_value == BackendType.CHROMA.value:
+            KBStorageHelper.release_chroma_resources(kb_path)
+
+
+@router.get(
+    "/{kb_name}/metadata/keys",
+    status_code=HTTPStatus.OK,
+    dependencies=[Depends(_check_memory_base_association)],
+)
+async def get_knowledge_base_metadata_keys(
+    kb_name: str,
+    current_user: CurrentActiveUser,
+) -> KbMetadataKeysResponse:
+    """List distinct user-supplied metadata keys (and a sample of values) for a KB.
+
+    Powers the chunks-browser filter popover so users can pick from keys
+    that actually exist in the KB instead of typing blind.
+
+    Reserved ingestion-internal keys (``file_name``, ``source``, ``job_id``,
+    etc.) are excluded — those have dedicated filters on the chunks endpoint
+    and would clutter the user-tag dropdown.
+
+    Iterates the chunk stream once and dedupes per key. Distinct value sets
+    are capped at ``KB_METADATA_KEYS_VALUES_CAP`` per key to keep the popover
+    dropdown usable when a key has unbounded free-form values; the response
+    sets ``truncated=true`` so the UI can surface a "showing first N values"
+    hint. Native distinct queries are deferred to backend-specific work
+    (same trade-off as the chunks-endpoint post-filter pass).
+    """
+    kb_path: Path | None = None
+    backend = None
+    backend_type_value: str = BackendType.CHROMA.value
+    try:
+        kb_path = _resolve_kb_path(kb_name, current_user)
+
+        backend_type_value, backend_config = await _resolve_backend_selection(
+            kb_name=kb_name,
+            kb_path=kb_path,
+            current_user=current_user,
+        )
+
+        # Local-Chroma short-circuit: empty KB without a Chroma store on
+        # disk would otherwise hit 'readonly database' on the empty dir.
+        if backend_type_value == BackendType.CHROMA.value:
+            has_data = any((kb_path / m).exists() for m in ["chroma", "chroma.sqlite3", "index"])
+            if not has_data:
+                return KbMetadataKeysResponse(keys={}, truncated=False)
+
+        backend = create_backend(
+            backend_type_value,
+            kb_name=kb_name,
+            kb_path=kb_path,
+            backend_config=backend_config,
+            user_id=current_user.id,
+        )
+
+        # Per-key ordered set of stringified distinct values. Insertion
+        # order is preserved so the UI dropdown shows values in the order
+        # they were first ingested rather than a hash-shuffled order.
+        distinct: dict[str, dict[str, None]] = {}
+        truncated = False
+        try:
+            async for batch in backend.iter_documents(batch_size=1000):
+                for entry in batch:
+                    raw = (entry.metadata or {}).get("source_metadata")
+                    if not raw:
+                        continue
+                    try:
+                        stored = json.loads(raw) if isinstance(raw, str) else raw
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(stored, dict):
+                        continue
+                    for key, value in stored.items():
+                        if key in KB_METADATA_RESERVED_KEYS:
+                            continue
+                        bucket = distinct.setdefault(key, {})
+                        # Array-valued metadata expands into one distinct value
+                        # per array entry so the popover dropdown shows every
+                        # tag that could be filtered on.
+                        candidates = value if isinstance(value, list) else [value]
+                        for candidate in candidates:
+                            if candidate is None:
+                                continue
+                            stringified = str(candidate)
+                            if stringified in bucket:
+                                continue
+                            if len(bucket) >= KB_METADATA_KEYS_VALUES_CAP:
+                                truncated = True
+                                break
+                            bucket[stringified] = None
+        except Exception as iter_error:
+            await logger.aerror("iter_documents failed while listing metadata keys for '%s': %s", kb_name, iter_error)
+            raise HTTPException(status_code=500, detail="Error listing metadata keys.") from iter_error
+
+        return KbMetadataKeysResponse(
+            keys={key: list(values.keys()) for key, values in sorted(distinct.items())},
+            truncated=truncated,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        await logger.aerror("Error listing metadata keys for '%s': %s", kb_name, e)
+        raise HTTPException(status_code=500, detail="Error listing metadata keys.") from e
+    finally:
+        if backend is not None:
+            try:
+                await backend.teardown()
+            except Exception as teardown_exc:  # noqa: BLE001
+                await logger.adebug("Backend teardown failed: %s", teardown_exc)
         if kb_path is not None and backend_type_value == BackendType.CHROMA.value:
             KBStorageHelper.release_chroma_resources(kb_path)
 

--- a/src/backend/base/langflow/schema/knowledge_base.py
+++ b/src/backend/base/langflow/schema/knowledge_base.py
@@ -162,6 +162,20 @@ class PaginatedChunkResponse(BaseModel):
     total_pages: int
 
 
+class KbMetadataKeysResponse(BaseModel):
+    """Distinct user-supplied metadata keys (and a sample of values) for a KB.
+
+    Powers the chunks-browser filter popover so users can pick from keys
+    that actually exist in the KB instead of typing blind. Reserved
+    ingestion-internal keys (``file_name``, ``source``, ``chunk_index``,
+    etc.) are excluded — those have dedicated filters in the chunks
+    endpoint and would clutter the user-tag dropdown.
+    """
+
+    keys: dict[str, list[str]]
+    truncated: bool = False
+
+
 class IngestionRunItemInfo(BaseModel):
     """Per-item outcome inside a run (``ingestion_run.items`` row shape)."""
 

--- a/src/backend/tests/unit/test_knowledge_bases_api.py
+++ b/src/backend/tests/unit/test_knowledge_bases_api.py
@@ -1310,6 +1310,134 @@ class TestKnowledgeBaseAPI:
         data = response.json()
         assert sorted(chunk["id"] for chunk in data["chunks"]) == ["2", "3"]
 
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
+    @patch("langflow.api.v1.knowledge_bases.create_backend")
+    async def test_get_metadata_keys_returns_distinct_user_keys(
+        self, mock_create_backend, mock_root, client: AsyncClient, logged_in_headers, tmp_path
+    ):
+        """``/metadata/keys`` returns distinct user keys + sample values, hides reserved."""
+        import json as _json
+
+        from lfx.base.knowledge_bases.backends.base import IngestedDocument
+
+        mock_root.return_value = tmp_path
+        kb_dir = tmp_path / "activeuser" / "KB1"
+        kb_dir.mkdir(parents=True, exist_ok=True)
+        (kb_dir / "chroma.sqlite3").write_text("dummy")
+
+        documents = [
+            IngestedDocument(
+                content="doc",
+                metadata={
+                    "_id": "1",
+                    "source_metadata": _json.dumps(
+                        {
+                            # Reserved keys must be excluded from the response.
+                            "file_name": "report.pdf",
+                            "source": "file_upload",
+                            "chunk_index": 0,
+                            # User keys.
+                            "year": "2020",
+                            "dept": "engineering",
+                            "tags": ["urgent", "review"],
+                        }
+                    ),
+                },
+            ),
+            IngestedDocument(
+                content="doc 2",
+                metadata={
+                    "_id": "2",
+                    "source_metadata": _json.dumps({"file_name": "doc2.pdf", "year": "2021", "tags": "audit"}),
+                },
+            ),
+            IngestedDocument(
+                content="legacy",
+                metadata={"_id": "3"},  # pre-metadata era — should be ignored
+            ),
+        ]
+
+        async def _iter_documents(*, batch_size: int = 1000, include_embeddings: bool = False):  # noqa: ARG001
+            yield documents
+
+        backend = MagicMock()
+        backend.iter_documents = _iter_documents
+        backend.teardown = AsyncMock()
+        mock_create_backend.return_value = backend
+
+        response = await client.get(
+            "api/v1/knowledge_bases/KB1/metadata/keys",
+            headers=logged_in_headers,
+        )
+        assert response.status_code == 200, response.json()
+        data = response.json()
+        # Reserved keys hidden; user keys surface with insertion-ordered values.
+        assert set(data["keys"].keys()) == {"year", "dept", "tags"}
+        assert data["keys"]["year"] == ["2020", "2021"]
+        assert data["keys"]["dept"] == ["engineering"]
+        # Array-valued metadata expands one distinct value per array entry,
+        # union-ed with the second doc's "audit" string.
+        assert sorted(data["keys"]["tags"]) == ["audit", "review", "urgent"]
+        assert data["truncated"] is False
+
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
+    @patch("langflow.api.v1.knowledge_bases.create_backend")
+    async def test_get_metadata_keys_caps_distinct_values_per_key(
+        self, mock_create_backend, mock_root, client: AsyncClient, logged_in_headers, tmp_path
+    ):
+        """Distinct values per key are capped — response sets ``truncated=true``."""
+        import json as _json
+
+        from langflow.api.v1.knowledge_bases import KB_METADATA_KEYS_VALUES_CAP
+        from lfx.base.knowledge_bases.backends.base import IngestedDocument
+
+        mock_root.return_value = tmp_path
+        kb_dir = tmp_path / "activeuser" / "KB1"
+        kb_dir.mkdir(parents=True, exist_ok=True)
+        (kb_dir / "chroma.sqlite3").write_text("dummy")
+
+        documents = [
+            IngestedDocument(
+                content=f"doc {idx}",
+                metadata={"_id": str(idx), "source_metadata": _json.dumps({"variant": str(idx)})},
+            )
+            for idx in range(KB_METADATA_KEYS_VALUES_CAP + 5)
+        ]
+
+        async def _iter_documents(*, batch_size: int = 1000, include_embeddings: bool = False):  # noqa: ARG001
+            yield documents
+
+        backend = MagicMock()
+        backend.iter_documents = _iter_documents
+        backend.teardown = AsyncMock()
+        mock_create_backend.return_value = backend
+
+        response = await client.get(
+            "api/v1/knowledge_bases/KB1/metadata/keys",
+            headers=logged_in_headers,
+        )
+        assert response.status_code == 200, response.json()
+        data = response.json()
+        assert len(data["keys"]["variant"]) == KB_METADATA_KEYS_VALUES_CAP
+        assert data["truncated"] is True
+
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
+    async def test_get_metadata_keys_empty_kb_returns_empty_response(
+        self, mock_root, client: AsyncClient, logged_in_headers, tmp_path
+    ):
+        """Empty Chroma KB short-circuits before booting the backend client."""
+        mock_root.return_value = tmp_path
+        kb_dir = tmp_path / "activeuser" / "KB1"
+        kb_dir.mkdir(parents=True, exist_ok=True)
+        # No chroma.sqlite3 / chroma / index files → short-circuit path.
+
+        response = await client.get(
+            "api/v1/knowledge_bases/KB1/metadata/keys",
+            headers=logged_in_headers,
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json() == {"keys": {}, "truncated": False}
+
 
 class TestPerformIngestionTask:
     """Tests for the internal KBIngestionHelper.perform_ingestion background task."""

--- a/src/frontend/src/controllers/API/queries/knowledge-bases/use-get-kb-metadata-keys.ts
+++ b/src/frontend/src/controllers/API/queries/knowledge-bases/use-get-kb-metadata-keys.ts
@@ -1,0 +1,55 @@
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { useQueryFunctionType } from "@/types/api";
+import { api } from "../../api";
+import { getURL } from "../../helpers/constants";
+import { UseRequestProcessor } from "../../services/request-processor";
+
+export interface KbMetadataKeysResponse {
+  /**
+   * Map of distinct user-supplied metadata keys to a sample of their
+   * stringified distinct values. Reserved ingestion-internal keys
+   * (`file_name`, `source`, etc.) are excluded server-side.
+   */
+  keys: Record<string, string[]>;
+  /**
+   * True when at least one key's distinct-value list hit the server-side
+   * cap. UI uses this to surface a "showing first N values" hint.
+   */
+  truncated: boolean;
+}
+
+interface GetKbMetadataKeysParams {
+  kb_name: string;
+}
+
+export const useGetKbMetadataKeys: useQueryFunctionType<
+  GetKbMetadataKeysParams,
+  KbMetadataKeysResponse
+> = (params, options?) => {
+  const { query } = UseRequestProcessor();
+
+  const getKeysFn = async (): Promise<KbMetadataKeysResponse> => {
+    const url = `${getURL("KNOWLEDGE_BASES")}/${params?.kb_name}/metadata/keys`;
+    const res = await api.get<KbMetadataKeysResponse>(url);
+    return res.data;
+  };
+
+  const queryResult: UseQueryResult<KbMetadataKeysResponse, Error> = query(
+    ["useGetKbMetadataKeys", params?.kb_name],
+    getKeysFn,
+    {
+      enabled: !!params?.kb_name,
+      // Always refetch on mount / when the popover re-enables this hook so
+      // metadata added by a fresh ingestion shows up in the dropdown without
+      // a hard refresh. The endpoint scans chunks server-side so a per-open
+      // refetch is the safest invalidation path — cheaper than wiring an
+      // ingestion-completion event into this hook from another component.
+      staleTime: 0,
+      refetchOnMount: "always",
+      refetchOnWindowFocus: false,
+      ...options,
+    },
+  );
+
+  return queryResult;
+};

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/SourceChunksPage.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/SourceChunksPage.tsx
@@ -191,6 +191,7 @@ export const SourceChunksPage = () => {
                 </SelectContent>
               </Select>
               <ChunksMetadataFilter
+                kbName={sourceId || ""}
                 onAdd={(key, value) =>
                   setMetadataFilter((prev) => {
                     const existing = prev[key] ?? [];

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/__tests__/SourceChunksPage.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/__tests__/SourceChunksPage.test.tsx
@@ -27,6 +27,17 @@ jest.mock(
   }),
 );
 
+jest.mock(
+  "@/controllers/API/queries/knowledge-bases/use-get-kb-metadata-keys",
+  () => ({
+    useGetKbMetadataKeys: () => ({
+      data: { keys: {}, truncated: false },
+      isLoading: false,
+      refetch: jest.fn(),
+    }),
+  }),
+);
+
 jest.mock("@/components/common/genericIconComponent", () => ({
   __esModule: true,
   default: ({ name }: { name: string }) => (

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/ChunkCard.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/ChunkCard.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { ChunkInfo } from "@/controllers/API/queries/knowledge-bases/use-get-knowledge-base-chunks";
+import { isReservedKbMetadataKey } from "@/utils/kbReservedKeys";
 import { cn } from "@/utils/utils";
 
 interface ChunkCardProps {
@@ -11,11 +12,68 @@ interface ChunkCardProps {
   onCopy: (content: string) => void;
 }
 
+interface ParsedChunkMetadata {
+  fileName: string | null;
+  userTags: Array<{ key: string; value: string }>;
+}
+
+const formatTagValue = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => String(entry)).join(", ");
+  }
+  if (value === null || value === undefined) return "";
+  return String(value);
+};
+
+// `source_metadata` is stored as a JSON string on each chunk so the value
+// space stays portable across vector stores (see
+// `knowledge_bases.py::get_knowledge_base_chunks`). Parse it once per render
+// and split into the file-name surface + user-supplied tags so the card can
+// show both without leaking ingestion-internal keys.
+const parseChunkMetadata = (
+  metadata: Record<string, unknown> | null,
+): ParsedChunkMetadata => {
+  const empty: ParsedChunkMetadata = { fileName: null, userTags: [] };
+  if (!metadata) return empty;
+
+  const fileName =
+    typeof metadata.file_name === "string" ? metadata.file_name : null;
+
+  const raw = metadata.source_metadata;
+  let parsed: Record<string, unknown> | null = null;
+  if (typeof raw === "string" && raw.length > 0) {
+    try {
+      const decoded = JSON.parse(raw);
+      if (decoded && typeof decoded === "object" && !Array.isArray(decoded)) {
+        parsed = decoded as Record<string, unknown>;
+      }
+    } catch {
+      parsed = null;
+    }
+  } else if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    parsed = raw as Record<string, unknown>;
+  }
+
+  if (!parsed) return { fileName, userTags: [] };
+
+  const userTags = Object.entries(parsed)
+    .filter(([key]) => !isReservedKbMetadataKey(key))
+    .map(([key, value]) => ({ key, value: formatTagValue(value) }))
+    .filter((entry) => entry.value !== "");
+
+  return { fileName, userTags };
+};
+
 const ChunkCard = ({ chunk, index, onCopy }: ChunkCardProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const contentRef = useRef<HTMLParagraphElement>(null);
+
+  const { fileName, userTags } = useMemo(
+    () => parseChunkMetadata(chunk.metadata),
+    [chunk.metadata],
+  );
 
   useEffect(() => {
     const el = contentRef.current;
@@ -80,6 +138,15 @@ const ChunkCard = ({ chunk, index, onCopy }: ChunkCardProps) => {
           </div>
         </div>
       </div>
+      {fileName && (
+        <div
+          className="mb-1.5 flex items-center gap-1 text-xs text-muted-foreground"
+          data-testid="chunk-card-file-name"
+        >
+          <ForwardedIconComponent name="File" className="h-3 w-3" />
+          <span className="truncate">{fileName}</span>
+        </div>
+      )}
       <p
         ref={contentRef}
         className={cn(
@@ -89,6 +156,23 @@ const ChunkCard = ({ chunk, index, onCopy }: ChunkCardProps) => {
       >
         {chunk.content}
       </p>
+      {userTags.length > 0 && (
+        <div
+          className="mt-2 flex flex-wrap gap-1"
+          data-testid="chunk-card-metadata-tags"
+        >
+          {userTags.map(({ key, value }) => (
+            <span
+              key={`${key}=${value}`}
+              className="inline-flex items-center gap-1 rounded-full bg-background px-2 py-0.5 text-[11px]"
+              data-testid={`chunk-card-metadata-tag-${key}`}
+            >
+              <span className="font-medium text-muted-foreground">{key}:</span>
+              <span className="text-foreground">{value}</span>
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/ChunksMetadataFilter.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/ChunksMetadataFilter.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useMemo, useState } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -7,27 +7,59 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { useGetKbMetadataKeys } from "@/controllers/API/queries/knowledge-bases/use-get-kb-metadata-keys";
 
 const KEY_PATTERN = /^[a-z0-9_]{1,32}$/;
 
 interface ChunksMetadataFilterProps {
+  /** Knowledge base name — used to fetch the available metadata keys. */
+  kbName: string;
   /** Called when the user submits a key/value pair. */
   onAdd: (key: string, value: string) => void;
 }
 
 /**
- * Compact "+ Add filter" popover for the chunks-browser metadata chips.
+ * "+ Filter by metadata" popover for the chunks-browser metadata chips.
+ *
+ * Both inputs are bound to a `<datalist>` populated from the new
+ * `/metadata/keys` endpoint so the user gets self-documenting key + value
+ * suggestions on click and free-text typing for keys not in the list.
  *
  * Validation mirrors the backend rules so an obviously malformed key (e.g.
  * uppercase or punctuation) is rejected before it would 422 server-side.
  * Submitting closes the popover and clears the inputs so the user can chain
  * multiple chips without re-opening it manually.
  */
-export const ChunksMetadataFilter = ({ onAdd }: ChunksMetadataFilterProps) => {
+export const ChunksMetadataFilter = ({
+  kbName,
+  onAdd,
+}: ChunksMetadataFilterProps) => {
   const [open, setOpen] = useState(false);
   const [key, setKey] = useState("");
   const [value, setValue] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const keyListId = useId();
+  const valueListId = useId();
+
+  const {
+    data: metadataKeys,
+    isLoading,
+    refetch: refetchMetadataKeys,
+  } = useGetKbMetadataKeys({ kb_name: kbName }, { enabled: open && !!kbName });
+
+  const availableKeys = useMemo(
+    () => Object.keys(metadataKeys?.keys ?? {}).sort(),
+    [metadataKeys],
+  );
+
+  // Distinct values for the currently typed key, when that key matches one
+  // of the keys returned from the server. Falls back to no suggestions for
+  // free-typed keys.
+  const valueSuggestions = useMemo(() => {
+    const trimmed = key.trim();
+    if (!trimmed) return [];
+    return metadataKeys?.keys?.[trimmed] ?? [];
+  }, [key, metadataKeys]);
 
   const submit = () => {
     const trimmedKey = key.trim();
@@ -47,8 +79,23 @@ export const ChunksMetadataFilter = ({ onAdd }: ChunksMetadataFilterProps) => {
     setOpen(false);
   };
 
+  const hasKeys = availableKeys.length > 0;
+
+  // Refetch on every popover open so a fresh ingestion's new keys/values
+  // surface without a hard page refresh. The `enabled` flag re-arms the
+  // query when the popover opens; calling `refetch` here forces a network
+  // round-trip even when React Query already has cached data, which is the
+  // case after the user closes and re-opens the popover within the same
+  // browser session.
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next && kbName) {
+      void refetchMetadataKeys();
+    }
+  };
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"
@@ -63,14 +110,32 @@ export const ChunksMetadataFilter = ({ onAdd }: ChunksMetadataFilterProps) => {
       <PopoverContent className="w-72" align="end">
         <div className="flex flex-col gap-2">
           <Input
-            placeholder="key"
+            list={keyListId}
+            placeholder={
+              isLoading
+                ? "Loading keys..."
+                : hasKeys
+                  ? "Pick or type a key"
+                  : "key"
+            }
             value={key}
             onChange={(e) => setKey(e.target.value)}
             data-testid="chunks-metadata-filter-key"
             autoFocus
           />
+          <datalist
+            id={keyListId}
+            data-testid="chunks-metadata-filter-key-options"
+          >
+            {availableKeys.map((option) => (
+              <option key={option} value={option} />
+            ))}
+          </datalist>
           <Input
-            placeholder="value"
+            list={valueListId}
+            placeholder={
+              valueSuggestions.length > 0 ? "Pick or type a value" : "value"
+            }
             value={value}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => {
@@ -81,6 +146,30 @@ export const ChunksMetadataFilter = ({ onAdd }: ChunksMetadataFilterProps) => {
             }}
             data-testid="chunks-metadata-filter-value"
           />
+          <datalist
+            id={valueListId}
+            data-testid="chunks-metadata-filter-value-options"
+          >
+            {valueSuggestions.map((option) => (
+              <option key={option} value={option} />
+            ))}
+          </datalist>
+          {!isLoading && !hasKeys && (
+            <span
+              className="text-xs text-muted-foreground"
+              data-testid="chunks-metadata-filter-empty"
+            >
+              No metadata keys found in this KB. Type a key to filter anyway.
+            </span>
+          )}
+          {metadataKeys?.truncated && (
+            <span
+              className="text-xs text-muted-foreground"
+              data-testid="chunks-metadata-filter-truncated"
+            >
+              Showing first 50 values per key.
+            </span>
+          )}
           {error && <span className="text-xs text-destructive">{error}</span>}
           <Button
             onClick={submit}

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/__tests__/ChunkCard.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/__tests__/ChunkCard.test.tsx
@@ -84,4 +84,121 @@ describe("ChunkCard", () => {
       jest.useRealTimers();
     });
   });
+
+  describe("Metadata rendering", () => {
+    it("renders the file_name from metadata", () => {
+      render(
+        <ChunkCard
+          chunk={makeChunk({ metadata: { file_name: "Desktop Guide.pdf" } })}
+          index={1}
+          onCopy={jest.fn()}
+        />,
+      );
+      expect(screen.getByTestId("chunk-card-file-name")).toHaveTextContent(
+        "Desktop Guide.pdf",
+      );
+    });
+
+    it("renders user-supplied tags from source_metadata as chips", () => {
+      const metadata = {
+        file_name: "doc.pdf",
+        source_metadata: JSON.stringify({
+          file_name: "doc.pdf",
+          chunk_index: 0,
+          year: "2020",
+          dept: "engineering",
+        }),
+      };
+      render(
+        <ChunkCard
+          chunk={makeChunk({ metadata })}
+          index={1}
+          onCopy={jest.fn()}
+        />,
+      );
+      expect(
+        screen.getByTestId("chunk-card-metadata-tag-year"),
+      ).toHaveTextContent("year:");
+      expect(
+        screen.getByTestId("chunk-card-metadata-tag-year"),
+      ).toHaveTextContent("2020");
+      expect(
+        screen.getByTestId("chunk-card-metadata-tag-dept"),
+      ).toHaveTextContent("engineering");
+    });
+
+    it("hides reserved ingestion-internal keys from the tag chips", () => {
+      const metadata = {
+        source_metadata: JSON.stringify({
+          file_name: "doc.pdf",
+          chunk_index: 5,
+          source: "file_upload",
+          job_id: "abc-123",
+        }),
+      };
+      render(
+        <ChunkCard
+          chunk={makeChunk({ metadata })}
+          index={1}
+          onCopy={jest.fn()}
+        />,
+      );
+      expect(
+        screen.queryByTestId("chunk-card-metadata-tags"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("joins array-valued tags with commas in a single chip", () => {
+      const metadata = {
+        source_metadata: JSON.stringify({
+          tags: ["urgent", "review"],
+        }),
+      };
+      render(
+        <ChunkCard
+          chunk={makeChunk({ metadata })}
+          index={1}
+          onCopy={jest.fn()}
+        />,
+      );
+      expect(
+        screen.getByTestId("chunk-card-metadata-tag-tags"),
+      ).toHaveTextContent("urgent, review");
+    });
+
+    it("handles malformed source_metadata JSON without crashing", () => {
+      const metadata = {
+        file_name: "doc.pdf",
+        source_metadata: "{not-json",
+      };
+      render(
+        <ChunkCard
+          chunk={makeChunk({ metadata })}
+          index={1}
+          onCopy={jest.fn()}
+        />,
+      );
+      // file_name still renders from the top-level metadata; tag list is empty.
+      expect(screen.getByTestId("chunk-card-file-name")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chunk-card-metadata-tags"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders nothing metadata-related when metadata is null", () => {
+      render(
+        <ChunkCard
+          chunk={makeChunk({ metadata: null })}
+          index={1}
+          onCopy={jest.fn()}
+        />,
+      );
+      expect(
+        screen.queryByTestId("chunk-card-file-name"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chunk-card-metadata-tags"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/__tests__/ChunksMetadataFilter.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/__tests__/ChunksMetadataFilter.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name }: { name: string }) => (
+    <span data-testid={`icon-${name}`}>{name}</span>
+  ),
+}));
+
+const mockUseGetKbMetadataKeys = jest.fn();
+jest.mock(
+  "@/controllers/API/queries/knowledge-bases/use-get-kb-metadata-keys",
+  () => ({
+    useGetKbMetadataKeys: (params: any, options?: any) =>
+      mockUseGetKbMetadataKeys(params, options),
+  }),
+);
+
+import { ChunksMetadataFilter } from "../ChunksMetadataFilter";
+
+const mockRefetch = jest.fn();
+const setHookData = (data: any, isLoading = false) => {
+  mockUseGetKbMetadataKeys.mockReturnValue({
+    data,
+    isLoading,
+    refetch: mockRefetch,
+  });
+};
+
+beforeEach(() => {
+  mockUseGetKbMetadataKeys.mockReset();
+  mockRefetch.mockReset();
+  setHookData({ keys: {}, truncated: false });
+});
+
+describe("ChunksMetadataFilter", () => {
+  it("renders the popover trigger labelled 'Filter by metadata'", () => {
+    render(<ChunksMetadataFilter kbName="kb1" onAdd={jest.fn()} />);
+    expect(screen.getByTestId("chunks-metadata-add-filter")).toHaveTextContent(
+      "Filter by metadata",
+    );
+  });
+
+  it("populates the key datalist with available keys when popover opens", async () => {
+    setHookData({
+      keys: { year: ["2020", "2021"], dept: ["eng", "qa"] },
+      truncated: false,
+    });
+    const user = userEvent.setup();
+    render(<ChunksMetadataFilter kbName="kb1" onAdd={jest.fn()} />);
+
+    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("chunks-metadata-filter-key-options"),
+      ).toBeInTheDocument(),
+    );
+    const options = screen
+      .getByTestId("chunks-metadata-filter-key-options")
+      .querySelectorAll("option");
+    expect(
+      Array.from(options)
+        .map((o) => o.value)
+        .sort(),
+    ).toEqual(["dept", "year"]);
+  });
+
+  it("populates the value datalist with distinct values for the typed key", async () => {
+    setHookData({
+      keys: { year: ["2020", "2021"], dept: ["eng"] },
+      truncated: false,
+    });
+    const user = userEvent.setup();
+    render(<ChunksMetadataFilter kbName="kb1" onAdd={jest.fn()} />);
+
+    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+    await user.type(screen.getByTestId("chunks-metadata-filter-key"), "year");
+
+    await waitFor(() =>
+      expect(
+        screen
+          .getByTestId("chunks-metadata-filter-value-options")
+          .querySelectorAll("option").length,
+      ).toBe(2),
+    );
+    const values = Array.from(
+      screen
+        .getByTestId("chunks-metadata-filter-value-options")
+        .querySelectorAll("option"),
+    ).map((o) => o.value);
+    expect(values).toEqual(["2020", "2021"]);
+  });
+
+  it("renders the empty-state hint when no keys are available", async () => {
+    setHookData({ keys: {}, truncated: false });
+    const user = userEvent.setup();
+    render(<ChunksMetadataFilter kbName="kb1" onAdd={jest.fn()} />);
+    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+    expect(
+      await screen.findByTestId("chunks-metadata-filter-empty"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the truncated hint when the server caps any value list", async () => {
+    setHookData({ keys: { tag: ["a"] }, truncated: true });
+    const user = userEvent.setup();
+    render(<ChunksMetadataFilter kbName="kb1" onAdd={jest.fn()} />);
+    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+    expect(
+      await screen.findByTestId("chunks-metadata-filter-truncated"),
+    ).toBeInTheDocument();
+  });
+
+  it("rejects an uppercase key with the validation message", async () => {
+    const onAdd = jest.fn();
+    const user = userEvent.setup();
+    render(<ChunksMetadataFilter kbName="kb1" onAdd={onAdd} />);
+    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+    await user.type(screen.getByTestId("chunks-metadata-filter-key"), "Year");
+    await user.type(screen.getByTestId("chunks-metadata-filter-value"), "2020");
+    await user.click(screen.getByTestId("chunks-metadata-filter-submit"));
+    expect(onAdd).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/1-32 lowercase letters, digits, or underscores/i),
+    ).toBeInTheDocument();
+  });
+
+  it("refetches metadata keys every time the popover is opened", async () => {
+    setHookData({ keys: { year: ["2020"] }, truncated: false });
+    const user = userEvent.setup();
+    render(<ChunksMetadataFilter kbName="kb1" onAdd={jest.fn()} />);
+
+    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+    // Close the popover by triggering the trigger again.
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+    expect(mockRefetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls onAdd with trimmed key/value on valid submit and clears inputs", async () => {
+    const onAdd = jest.fn();
+    const user = userEvent.setup();
+    render(<ChunksMetadataFilter kbName="kb1" onAdd={onAdd} />);
+    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+    await user.type(screen.getByTestId("chunks-metadata-filter-key"), "year");
+    await user.type(screen.getByTestId("chunks-metadata-filter-value"), "2020");
+    await user.click(screen.getByTestId("chunks-metadata-filter-submit"));
+    expect(onAdd).toHaveBeenCalledWith("year", "2020");
+  });
+});

--- a/src/frontend/src/utils/kbReservedKeys.ts
+++ b/src/frontend/src/utils/kbReservedKeys.ts
@@ -1,0 +1,17 @@
+// Mirrors `KB_METADATA_RESERVED_KEYS` in
+// `src/backend/base/langflow/utils/kb_constants.py`. Keep both lists in sync —
+// this set is used to hide ingestion-internal keys when rendering chunk
+// metadata in the UI so that user-facing chips only show user-supplied tags.
+export const KB_METADATA_RESERVED_KEYS = new Set<string>([
+  "source",
+  "file_name",
+  "chunk_index",
+  "total_chunks",
+  "ingested_at",
+  "job_id",
+  "source_type",
+  "source_metadata",
+]);
+
+export const isReservedKbMetadataKey = (key: string): boolean =>
+  KB_METADATA_RESERVED_KEYS.has(key);


### PR DESCRIPTION
## Summary

Closes the QA-flagged UX gap where the Knowledge Base chunks-browser metadata feature was effectively only usable by users with direct API access. Two fixes bundled because they share the reserved-keys constant + the new metadata-keys endpoint, and ship as one consistent surface to QA.

**Chunk card metadata audit** — each chunk card now renders the source `file_name` + user-supplied tag chips below the content, so users can verify at-a-glance which metadata was applied at ingestion time. Reserved ingestion-internal keys (`chunk_index`, `job_id`, `total_chunks`, etc.) stay hidden via a frontend mirror of `KB_METADATA_RESERVED_KEYS`.

**Self-documenting filter popover** — the "Filter by metadata" popover no longer asks the user to type blind. A new `GET /knowledge_bases/{kb_name}/metadata/keys` endpoint scans chunks server-side and returns distinct user keys mapped to a sample of their values. The popover binds both inputs to a `<datalist>` so users get native browser suggestions on click while keeping free-text typing for keys not yet ingested. Cache refetches on every popover open so freshly-ingested metadata surfaces without a hard page refresh.


## What changed for users

### Chunk cards now show metadata

Before: each chunk card showed only `Chunk N` + char-count + content. Users had no way to verify which file a chunk came from or which user-tags were applied without going through the API.

After:
- File-name row above the chunk content (icon + truncated name).
- User-tag chips below the chunk content (`year: 2020`, `dept: engineering`).
- Array-valued tags render in a single chip (`tags: urgent, review`).
- Empty/malformed metadata renders nothing — no broken chips, no crashes.

### Filter popover dropdown

Before: free-text key/value inputs. A user who didn't personally configure ingestion had no way to know what to type.

After:
- Clicking the key field surfaces a dropdown of distinct user-supplied keys present in the KB (reserved keys hidden).
- Typing a key narrows to matches; selecting a known key surfaces a dropdown of distinct values for that key.
- Free-text typing still works for keys not yet seen, so a user pre-staging filters before an ingest run still has an escape hatch.
- Empty-state hint when KB has no user metadata yet ("No metadata keys found in this KB. Type a key to filter anyway.").
- Truncated hint when any key has more than 50 distinct values ("Showing first 50 values per key.").
- Validation regex (`^[a-z0-9_]{1,32}$`) preserved — uppercase/punctuation still rejected inline before hitting the 422 from the API.

## Architecture notes

- **New endpoint scans chunks once and dedupes per key.** Same trade-off as the chunks-endpoint post-filter pass — vector stores have incompatible distinct DSLs, so a uniform Python pass is the only path that works across Chroma / OpenSearch / Mongo / Astra. Distinct values per key are capped at `KB_METADATA_KEYS_VALUES_CAP = 50` to keep the popover dropdown usable when a key has unbounded free-form values; the response sets `truncated=true` so the UI can surface the cap. Backend-native distinct queries are deferred to the same follow-up that owns native filter push-down.
- **Reserved keys are excluded server-side.** `source`, `file_name`, `chunk_index`, `total_chunks`, `ingested_at`, `job_id`, `source_type`, `source_metadata` are written by the ingestion pipeline itself and have dedicated filters on the chunks endpoint. Including them in the user-tag dropdown would clutter the UX and let users build filters that double-up on existing ones.
- **Frontend mirrors the reserved-keys list** in `src/frontend/src/utils/kbReservedKeys.ts`. Source of truth stays backend (`langflow.utils.kb_constants.KB_METADATA_RESERVED_KEYS`); the frontend mirror is documented as such with a pointer comment so future readers know to update both. Used by `ChunkCard` to filter chips and structurally by the popover via the server response (the server is the gate, the frontend mirror only serves rendering).
- **`source_metadata` is parsed JSON-string at the chunk-card boundary.** Same as the chunks endpoint's filter logic — the value is stored as a JSON string for cross-vector-store portability. Malformed JSON falls through to "no chips" without crashing.
- **`<datalist>` over a custom Combobox** to keep the diff small, get free-text-with-suggestions UX from the browser, and avoid pulling cmdk into this surface. Native styling differences are acceptable for a power-user filter — point of this PR is discoverability, not eye-candy. Can upgrade to a richer Combobox later if QA pushes back.
- **Refetch on every popover open** — `staleTime: 0` + `refetchOnMount: "always"` + an explicit `refetch()` call inside `onOpenChange`. Cheaper than wiring an ingestion-completion event into this hook from another component, and the request is small (one GET per popover open).

## Files

### Backend
- `src/backend/base/langflow/api/v1/knowledge_bases.py` — new `GET /{kb_name}/metadata/keys` route + `KB_METADATA_KEYS_VALUES_CAP` constant.
- `src/backend/base/langflow/schema/knowledge_base.py` — new `KbMetadataKeysResponse` model.
- `src/backend/tests/unit/test_knowledge_bases_api.py` — 3 new tests (distinct keys + reserved-key exclusion, value-cap enforcement + `truncated`, empty-KB short-circuit).

### Frontend
- `src/frontend/src/controllers/API/queries/knowledge-bases/use-get-kb-metadata-keys.ts` — new React Query hook.
- `src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/ChunkCard.tsx` — file-name row + user-tag chips.
- `src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/ChunksMetadataFilter.tsx` — datalist-driven dropdowns + empty/truncated hints + refetch on open. New `kbName` prop wired through `SourceChunksPage`.
- `src/frontend/src/utils/kbReservedKeys.ts` — frontend mirror of `KB_METADATA_RESERVED_KEYS`.
- Test coverage extended: `ChunkCard.test.tsx` (5 new metadata-rendering cases), new `ChunksMetadataFilter.test.tsx` (7 cases incl. refetch-on-open), `SourceChunksPage.test.tsx` updated to mock the new hook.

## Test plan

- [x] `uv run --frozen pytest src/backend/tests/unit/test_knowledge_bases_api.py::TestKnowledgeBaseAPI` — 41 passed.
- [x] `npx jest src/pages/MainPage/pages/knowledgePage/sourceChunksPage` — 30 passed across 3 suites.
- [x] `npx jest src/modals/knowledgeBaseUploadModal` — 71 passed (no regression on related KB upload modal surface).
- [x] `make backend` boots clean against `feat/kb-v1-db-connectors` (`Application startup complete.`, no errors, only pre-existing benign SQLite warnings).
- [x] `ruff format` + `ruff check` clean on touched files.
- [x] Biome format clean on touched frontend files.
- [ ] Manual smoke (recommended for QA):
  - [ ] Ingest a batch with run-level `{"year":"2020","dept":"engineering"}`. Verify chunk cards render the file name + both chips. Verify "Filter by metadata" popover key dropdown shows `dept`, `year` (no `source`/`file_name`/etc.). Selecting `year` shows `2020` in the value dropdown.
  - [ ] Ingest a second batch with `{"year":"2021","dept":"qa"}`. Reopen the popover (without page refresh). Verify the new keys/values appear in the dropdowns immediately.
  - [ ] Ingest a per-file override (one file `confidential=true`). Verify card chips reflect the override on that file's chunks only.
  - [ ] Try filtering with a key that doesn't exist in the KB — popover still accepts free-text input, query returns 0 chunks (not an error).
  - [ ] Try filtering an empty KB — popover shows the empty-state hint.
  - [ ] Ingest >50 distinct values for one key — popover shows the truncated hint.


## Notes for reviewers

- **Stacked on #12802** — review against `feat/kb-v1-db-connectors`.
- **Mirror of `KB_METADATA_RESERVED_KEYS`** in the frontend duplicates the backend list. Single source of truth stays backend; frontend mirror is for rendering only and is documented with a pointer comment. If the backend list grows, update both files.
- **`<datalist>` rendering** is browser-native — visual treatment differs slightly between Chrome / Firefox / Safari / Edge. All four show a clickable dropdown of suggestions and accept free-text. Keyboard navigation is native. If QA wants a uniform look, follow-up would swap in a cmdk Combobox.
- **Refetch on popover open** uses both `staleTime: 0` + `refetchOnMount: "always"` + an explicit `refetch()` call. Belt-and-suspenders — `enabled` flips don't trigger refetch on the same observer, so the explicit `refetch()` is the load-bearing piece.

