### PR TITLE
fix(tests): Stabilize traces and user-flow-cleanup e2e on Windows CI                                                                                

### DIFF
--- a/src/frontend/tests/core/features/traces.spec.ts
+++ b/src/frontend/tests/core/features/traces.spec.ts
@@ -21,8 +21,11 @@ test(
 
     await page.getByTestId("side_nav_options_all-templates").click();
     await page.getByRole("heading", { name: "Basic Prompting" }).click();
+    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+      timeout: 100000,
+    });
     await expect(page.getByTestId(/.*rf__node.*/).first()).toBeVisible({
-      timeout: 3000,
+      timeout: 30000,
     });
     let outdatedComponents = await page.getByTestId("update-button").count();
     const maxUpdateIterations = 20;
@@ -74,8 +77,11 @@ test.skip(
 
     await page.getByTestId("side_nav_options_all-templates").click();
     await page.getByRole("heading", { name: "Basic Prompting" }).click();
+    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+      timeout: 100000,
+    });
     await expect(page.getByTestId(/.*rf__node.*/).first()).toBeVisible({
-      timeout: 3000,
+      timeout: 30000,
     });
     let outdatedComponents = await page.getByTestId("update-button").count();
     const maxUpdateIterations = 20;

--- a/src/frontend/tests/core/features/user-flow-state-cleanup.spec.ts
+++ b/src/frontend/tests/core/features/user-flow-state-cleanup.spec.ts
@@ -54,7 +54,7 @@ test(
       timeout: 60000,
     });
     await page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
+      timeout: 60000,
     });
     await page.getByTestId("user-profile-settings").click();
     await page.getByText("Admin Page", { exact: true }).click();
@@ -129,7 +129,7 @@ test(
       await basicPromptingHeading.click();
       try {
         await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-          timeout: attempt === maxClickAttempts ? 100000 : 45000,
+          timeout: attempt === maxClickAttempts ? 180000 : 45000,
         });
         canvasMounted = true;
         break;


### PR DESCRIPTION
OBJECTIVE: Eliminate Playwright timeouts in shard 21 caused by slow canvas mounts and homepage data loads on Windows CI.                          
                                                                                                                                                             
CHANGES:                                                                                                                                                   
  - Wait for `canvas_controls_dropdown` (100s) before asserting `rf__node` in `traces.spec.ts`, replacing the brittle 3s visibility check
  - Bump `rf__node` visibility timeout from 3s to 30s in both traces test bodies                                                                             
  - Increase admin-login `mainpage_title` timeout from 30s to 60s in `user-flow-state-cleanup.spec.ts` (Loading already grants 60s, but the post-Loading data
   render can outlast 30s)                                                                                                                                   
  - Bump final canvas-mount retry timeout from 100s to 180s for the Basic Prompting flow 