### PR TITLE
ci: block PR titles ending in ellipsis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,22 @@ jobs:
           echo "  run-all-tests: ${{ inputs.run-all-tests }}"
           echo "  runs-on: ${{ inputs.runs-on }}"
 
+  validate-pr-title:
+    name: Validate PR Title
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: Reject titles ending in ellipsis
+        run: |
+          echo "PR title: $PR_TITLE"
+          if [[ "$PR_TITLE" == *"..." || "$PR_TITLE" == *"…" ]]; then
+            echo "❌ PR title ends with ellipsis. Please write a complete, descriptive title."
+            exit 1
+          fi
+          echo "✅ PR title is complete."
+
   check-nightly-status:
     name: Check PyPI Version Update
     runs-on: ubuntu-latest
@@ -427,6 +443,7 @@ jobs:
     name: "CI Success"
     needs:
       [
+        validate-pr-title,
         test-backend,
         test-frontend-unit,
         test-frontend,
@@ -476,7 +493,9 @@ jobs:
               to_entries[]
               | select(.value.result=="failure")
               | .key as $job
-              | if $job == "test-backend" then
+              | if $job == "validate-pr-title" then
+                  "  - PR Title Validation: Title ends with ellipsis (...). Use a complete, descriptive title."
+                elif $job == "test-backend" then
                   "  - Backend Tests: Check Python code, tests, and dependencies"
                 elif $job == "test-frontend-unit" then
                   "  - Frontend Unit Tests: Check React components and unit test logic"


### PR DESCRIPTION
## Summary

Adds a `validate-pr-title` job to `.github/workflows/ci.yml` that fails when a PR title ends with `...` or `…` (Unicode ellipsis). The job is added to the `CI Success` aggregate's `needs` list so the rule blocks merges via the existing required-check protection.

## Why this lives in `ci.yml`

`conventional-labels.yml` already validates titles, but it runs on `pull_request_target` (it needs write access to apply labels) and isn't part of the `CI Success` aggregator branch protection consumes. The new job has to live inside `ci.yml` to actually block merges, and it's gated on `github.event_name == 'pull_request'` so `merge_group` / `workflow_dispatch` / `workflow_call` runs (which have no PR title) cleanly skip it.

## Notes

- Title is read via `env: PR_TITLE` to avoid shell-escape issues if a title contains quotes or backticks.
- Failure surfaces in the existing `CI Success` job's diagnostic summary with a friendly message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow to enforce more descriptive pull request titles.
  * Improved CI diagnostic logging for better visibility into test execution parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->