### PR TITLE
fix(kb): require OpenSearch username/password in DB Provider settings

### DIFF
--- a/src/frontend/src/constants/__tests__/dbProviderConstants.test.ts
+++ b/src/frontend/src/constants/__tests__/dbProviderConstants.test.ts
@@ -88,11 +88,39 @@ describe("dbProviderConstants", () => {
       ]),
     ).toBe(false);
 
+    // URL + index alone is no longer enough — basic-auth credentials
+    // are required so the settings UI matches the runtime contract
+    // (the OpenSearch components default to basic auth and reject a
+    // run with empty username/password).
     expect(
       isDBProviderConfigured("opensearch", [
         variable(OPENSEARCH_VARIABLES.URL, "https://search.example.com:9200"),
         variable(OPENSEARCH_VARIABLES.INDEX_NAME, "kb-index"),
       ]),
+    ).toBe(false);
+
+    expect(
+      isDBProviderConfigured("opensearch", [
+        variable(OPENSEARCH_VARIABLES.URL, "https://search.example.com:9200"),
+        variable(OPENSEARCH_VARIABLES.USERNAME, "admin"),
+        variable(OPENSEARCH_VARIABLES.PASSWORD, "secret"),
+        variable(OPENSEARCH_VARIABLES.INDEX_NAME, "kb-index"),
+      ]),
     ).toBe(true);
+  });
+
+  it("flags OpenSearch as not-configured when only one of username/password is set", () => {
+    // Asymmetric credentials are a footgun: the backend treats
+    // ``http_auth`` as a tuple of (username, password) and falls back
+    // to no-auth when only one is set, which silently masquerades as
+    // success against auth-disabled clusters but fails against real
+    // ones. Force both fields to be present.
+    expect(
+      isDBProviderConfigured("opensearch", [
+        variable(OPENSEARCH_VARIABLES.URL, "https://search.example.com:9200"),
+        variable(OPENSEARCH_VARIABLES.USERNAME, "admin"),
+        variable(OPENSEARCH_VARIABLES.INDEX_NAME, "kb-index"),
+      ]),
+    ).toBe(false);
   });
 });

--- a/src/frontend/src/constants/dbProviderConstants.ts
+++ b/src/frontend/src/constants/dbProviderConstants.ts
@@ -90,16 +90,24 @@ export const DB_PROVIDER_OPTIONS: DBProviderOption[] = [
         placeholder: "https://search.example.com:9200",
       },
       {
+        // Required because the runtime OpenSearch components (KB +
+        // canvas vector-store) default to basic auth and surface a
+        // confusing "Auth Mode is 'basic' but username/password are
+        // missing" error when the global variables aren't populated.
+        // Operators with auth-less clusters or external auth (sigv4 /
+        // upstream proxy) can set these env vars to a placeholder
+        // value; OpenSearch ignores the credentials when auth is not
+        // enforced.
         label: "Username",
         variableKey: OPENSEARCH_VARIABLES.USERNAME,
-        required: false,
+        required: true,
         isSecret: false,
         placeholder: "admin",
       },
       {
         label: "Password",
         variableKey: OPENSEARCH_VARIABLES.PASSWORD,
-        required: false,
+        required: true,
         isSecret: true,
         placeholder: "Enter OpenSearch password",
       },


### PR DESCRIPTION
## Summary

The DB Providers settings panel marks `Username` and `Password` as optional, but the OpenSearch runtime components (canvas vector-store node + KB ingestion path) default to basic auth and raise:

> Auth Mode is 'basic' but username/password are missing.

…when the global variables aren't populated. Operators who fill in only the cluster URL save the form successfully, then hit this confusing error far downstream when their first flow runs. The bug report ([reproducer in this issue's body](#)) traces the inconsistency to the optional/required mismatch between the settings UI and the runtime contract.

This PR aligns the settings UI with the runtime by marking the two fields required, so [DBProvidersPage's existing `canSave` and `handleSave` validation](src/frontend/src/pages/SettingsPage/pages/DBProvidersPage/index.tsx) blocks the save up-front with the standard "Missing required configuration" toast. The credential variables remain backed by Langflow's secrets store — only the variable names live in `backend_config`.

### Why required vs. an "Auth = None" mode

The bug report offered two fixes: (1) mark them required, or (2) add an "Auth Mode = None" toggle. We chose (1) because:
- Almost every production OpenSearch cluster needs auth, and "Test Connection" already lets users validate before activation.
- Auth-less clusters / sigv4 / upstream-proxy setups can still satisfy the form with placeholder values — `OpenSearchVectorSearch` ignores `http_auth` when the cluster doesn't enforce auth.
- Adding a real "no-auth" mode is a larger UX change that should land alongside a matching `auth_mode` field on the standalone OpenSearch component (`src/lfx/src/lfx/components/elastic/opensearch.py`) for consistency. That can be a follow-up.

## Files changed

- `src/frontend/src/constants/dbProviderConstants.ts` — flip `OPENSEARCH_USERNAME` / `OPENSEARCH_PASSWORD` `required` from `false` → `true`, with a comment explaining the runtime contract.
- `src/frontend/src/constants/__tests__/dbProviderConstants.test.ts` — update the existing `isDBProviderConfigured` assertion (URL + index alone is no longer "configured") and add a new test for the asymmetric (one-credential-only) case.

## Test plan

- [x] `npx jest src/constants/__tests__/dbProviderConstants.test.ts` — 7 tests pass.
- [ ] Manual: Settings → DB Providers → OpenSearch with only Cluster URL filled in. The Save button is disabled and shows the existing "Missing required configuration" message listing the missing fields.
- [ ] Manual: Same screen with all required fields populated saves successfully and activates OpenSearch as the active provider.
- [ ] Manual: Existing users who had a working OpenSearch config without saved credentials see the unconfigured indicator on the DB Providers list and are prompted to fill in the missing fields on next save.