### PR TITLE
fix(kb): align OpenSearch KB default vector field with canvas component

### DIFF
--- a/src/backend/tests/unit/base/knowledge_bases/test_opensearch_backend.py
+++ b/src/backend/tests/unit/base/knowledge_bases/test_opensearch_backend.py
@@ -1,0 +1,120 @@
+"""Unit tests for ``OpenSearchBackend`` defaults.
+
+Pins the default vector-field name to ``chunk_embedding`` so the KB
+backend stays aligned with the canvas OpenSearch component, which
+defaults to the same field. A regression here re-introduces the
+``Field 'chunk_embedding' is not knn_vector type`` failure when a
+KB-ingested index is wired into the canvas component without a
+manual ``Vector Field Name`` override.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from lfx.base.knowledge_bases.backends import OpenSearchBackend
+from lfx.base.knowledge_bases.backends.opensearch import (
+    DEFAULT_TEXT_FIELD,
+    DEFAULT_VECTOR_FIELD,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_backend(
+    kb_path: Path,
+    backend_config: dict | None = None,
+) -> OpenSearchBackend:
+    backend = OpenSearchBackend(
+        kb_name="kb_os_defaults",
+        kb_path=kb_path,
+        backend_config=backend_config or {"index_name": "test_index"},
+    )
+    # Pre-populate resolved secrets so ``ensure_ready`` is a no-op and
+    # ``_build_vector_store`` can run without touching variable_service.
+    backend._resolved_url = "https://example.local:9200"
+    backend._resolved_username = "admin"
+    backend._resolved_password = "secret"  # noqa: S105 — test fixture  # pragma: allowlist secret
+    backend._secrets_resolved = True
+    return backend
+
+
+class TestOpenSearchBackendVectorFieldDefault:
+    """Default field names must match the canvas OpenSearch component."""
+
+    def test_default_vector_field_is_chunk_embedding(self) -> None:
+        # The canvas OpenSearch component defaults to ``chunk_embedding``;
+        # the KB backend must agree so a KB-ingested index queries cleanly
+        # from the canvas component without a manual override.
+        assert DEFAULT_VECTOR_FIELD == "chunk_embedding"
+
+    def test_build_vector_store_uses_chunk_embedding_by_default(self, tmp_path: Path) -> None:
+        backend = _make_backend(tmp_path)
+        fake_wrapper = MagicMock(name="OpenSearchVectorSearch")
+        with (
+            patch("opensearchpy.OpenSearch", return_value=MagicMock()),
+            patch(
+                "langchain_community.vectorstores.OpenSearchVectorSearch",
+                fake_wrapper,
+            ),
+        ):
+            _ = backend.vector_store
+
+        fake_wrapper.assert_called_once()
+        kwargs = fake_wrapper.call_args.kwargs
+        assert kwargs["vector_field"] == "chunk_embedding"
+        assert kwargs["text_field"] == DEFAULT_TEXT_FIELD
+        # Sanity-check the field the backend stashes for iter/count helpers
+        # so the in-memory state agrees with what was sent to LangChain.
+        assert backend._os_vector_field == "chunk_embedding"
+
+    def test_build_vector_store_honours_backend_config_override(self, tmp_path: Path) -> None:
+        # Operators with a legacy ``vector_field`` index (or any custom
+        # name) must still be able to override via backend_config.
+        backend = _make_backend(
+            tmp_path,
+            backend_config={"index_name": "test_index", "vector_field": "embedding"},
+        )
+        fake_wrapper = MagicMock(name="OpenSearchVectorSearch")
+        with (
+            patch("opensearchpy.OpenSearch", return_value=MagicMock()),
+            patch(
+                "langchain_community.vectorstores.OpenSearchVectorSearch",
+                fake_wrapper,
+            ),
+        ):
+            _ = backend.vector_store
+
+        kwargs = fake_wrapper.call_args.kwargs
+        assert kwargs["vector_field"] == "embedding"
+        assert backend._os_vector_field == "embedding"
+
+
+@pytest.mark.parametrize(
+    ("config_value", "expected"),
+    [
+        (None, "chunk_embedding"),
+        ("", "chunk_embedding"),
+        ("custom_vec", "custom_vec"),
+    ],
+)
+def test_vector_field_resolution_table(tmp_path: Path, config_value: str | None, expected: str) -> None:
+    """Empty / missing config falls back to the default; truthy wins."""
+    cfg: dict = {"index_name": "test_index"}
+    if config_value is not None:
+        cfg["vector_field"] = config_value
+    backend = _make_backend(tmp_path, backend_config=cfg)
+    fake_wrapper = MagicMock(name="OpenSearchVectorSearch")
+    with (
+        patch("opensearchpy.OpenSearch", return_value=MagicMock()),
+        patch(
+            "langchain_community.vectorstores.OpenSearchVectorSearch",
+            fake_wrapper,
+        ),
+    ):
+        _ = backend.vector_store
+
+    assert fake_wrapper.call_args.kwargs["vector_field"] == expected

--- a/src/frontend/src/constants/dbProviderConstants.ts
+++ b/src/frontend/src/constants/dbProviderConstants.ts
@@ -115,8 +115,8 @@ export const DB_PROVIDER_OPTIONS: DBProviderOption[] = [
         variableKey: OPENSEARCH_VARIABLES.VECTOR_FIELD,
         required: false,
         isSecret: false,
-        placeholder: "vector_field",
-        defaultValue: "vector_field",
+        placeholder: "chunk_embedding",
+        defaultValue: "chunk_embedding",
       },
       {
         label: "Text field",
@@ -246,7 +246,7 @@ export function getDBProviderConfig(
       getGlobalVariableValue(variables, OPENSEARCH_VARIABLES.INDEX_NAME) ?? "",
     vector_field:
       getGlobalVariableValue(variables, OPENSEARCH_VARIABLES.VECTOR_FIELD) ??
-      "vector_field",
+      "chunk_embedding",
     text_field:
       getGlobalVariableValue(variables, OPENSEARCH_VARIABLES.TEXT_FIELD) ??
       "text",

--- a/src/frontend/src/pages/SettingsPage/pages/DBProvidersPage/index.tsx
+++ b/src/frontend/src/pages/SettingsPage/pages/DBProvidersPage/index.tsx
@@ -450,7 +450,7 @@ function buildBackendConfigPayload(
     password_variable: OPENSEARCH_VARIABLES.PASSWORD,
     index_name: literalFields[OPENSEARCH_VARIABLES.INDEX_NAME] || "",
     vector_field:
-      literalFields[OPENSEARCH_VARIABLES.VECTOR_FIELD] || "vector_field",
+      literalFields[OPENSEARCH_VARIABLES.VECTOR_FIELD] || "chunk_embedding",
     text_field: literalFields[OPENSEARCH_VARIABLES.TEXT_FIELD] || "text",
     use_ssl: booleanFields[OPENSEARCH_VARIABLES.USE_SSL] ?? true,
     verify_certs: booleanFields[OPENSEARCH_VARIABLES.VERIFY_CERTS] ?? true,

--- a/src/lfx/src/lfx/base/knowledge_bases/backends/opensearch.py
+++ b/src/lfx/src/lfx/base/knowledge_bases/backends/opensearch.py
@@ -20,7 +20,9 @@ secrets — and round-trips cleanly through the UI.
   the raw credential.
 * ``index_name`` — OpenSearch index this KB writes / reads. Required.
 * ``vector_field`` — document field for the embedding vector.
-  Defaults to ``vector_field``.
+  Defaults to ``chunk_embedding`` to match the canvas OpenSearch
+  component's default, so KB ingestion and the canvas component
+  can target the same index without manual overrides.
 * ``text_field`` — document field for the chunk text. Defaults to
   ``text``.
 * ``engine`` — k-NN engine (``jvector``, ``nmslib``, ``faiss``,
@@ -59,7 +61,7 @@ if TYPE_CHECKING:
 DEFAULT_URL_VARIABLE = "OPENSEARCH_URL"
 DEFAULT_USERNAME_VARIABLE = "OPENSEARCH_USERNAME"
 DEFAULT_PASSWORD_VARIABLE = "OPENSEARCH_PASSWORD"  # noqa: S105 — variable name, not a secret  # pragma: allowlist secret
-DEFAULT_VECTOR_FIELD = "vector_field"
+DEFAULT_VECTOR_FIELD = "chunk_embedding"
 DEFAULT_TEXT_FIELD = "text"
 # ``faiss`` is part of the core OpenSearch k-NN plugin on every
 # released version (1.x → 3.x) and works without extra cluster setup.


### PR DESCRIPTION
## Summary

- Change the KB OpenSearch backend's default ``vector_field`` from ``vector_field`` to ``chunk_embedding`` so it matches the canvas OpenSearch component's default.
- Update the DB Providers settings page (placeholder, default, and config-build fallbacks) so the UI agrees with the backend default.
- Update the backend's docstring to explain the rationale.

### Why

KB ingestion creates indices with a knn_vector field named ``vector_field``, while the canvas OpenSearch component reads from ``chunk_embedding``. Wiring an ingested KB index into the canvas component fails with:

```
RequestError(400, 'search_phase_execution_exception',
  "failed to create query: Field 'chunk_embedding' is not knn_vector type.")
```

The natural workflow (ingest with KB, query with the canvas component) shouldn't require a manual override. Aligning the KB default to ``chunk_embedding`` (the canvas component's default) makes the two layers compatible out of the box.

Operators who already ingested into ``vector_field`` can still override via ``backend_config["vector_field"]`` or the ``OPENSEARCH_VECTOR_FIELD`` global variable.

## Test plan

- [ ] Create a fresh KB with the OpenSearch backend (default config) and ingest a file — index uses ``chunk_embedding`` as the knn_vector field.
- [ ] Add an OpenSearch canvas component pointed at the same index — search returns results without changing ``Vector Field Name``.
- [ ] Existing KBs with an explicit ``vector_field`` override (e.g. ``"embedding"``, or the legacy ``"vector_field"``) still work — no regression on overrides.
- [ ] Frontend ``dbProviderConstants`` test suite still passes; the existing case that overrides ``VECTOR_FIELD`` is unaffected.