### PR TITLE
feat(mcp): Auto-install default MCP servers per OS at startup

### DIFF
--- a/src/backend/base/langflow/api/utils/mcp/default_servers.py
+++ b/src/backend/base/langflow/api/utils/mcp/default_servers.py
@@ -1,0 +1,127 @@
+"""Orchestrator that auto-installs the default MCP servers (registry-driven) for every user."""
+
+import platform
+from typing import Literal
+
+from fastapi import HTTPException
+from lfx.log.logger import logger
+from lfx.services.deps import get_settings_service
+from sqlalchemy import exc as sqlalchemy_exc
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from langflow.api.utils.mcp.default_servers_specs import (
+    DEFAULT_MCP_SERVERS,
+    DefaultMcpServerConfig,
+    DefaultMcpServerSpec,
+)
+from langflow.api.v2.mcp import get_server_list, update_server
+from langflow.api.v2.schemas import MCPServerConfig
+from langflow.services.database.models.user.model import User
+from langflow.services.deps import get_service
+from langflow.services.schema import ServiceType
+
+OsKind = Literal["unix", "windows"]
+
+
+def _detect_os_kind() -> OsKind:
+    """Collapse platform.system() into the two buckets we ship configs for.
+
+    Why: WSL reports Linux and *BSD reports its own name; mcp-shell-server runs
+    POSIX-style via uvx in all of those. Only Windows needs the `cmd /c` wrapper.
+    """
+    return "windows" if platform.system() == "Windows" else "unix"
+
+
+def _select_os_config(spec: DefaultMcpServerSpec, os_kind: OsKind) -> DefaultMcpServerConfig:
+    return spec.windows if os_kind == "windows" else spec.unix
+
+
+def _build_server_payload(
+    spec: DefaultMcpServerSpec,
+    os_kind: OsKind,
+) -> dict:
+    """Build the persisted payload, re-validating via MCPServerConfig.
+
+    Why re-validate something we authored: defense in depth. If a future commit
+    drops a forbidden command, env var, or arg into the registry, this fails
+    fast at startup instead of silently installing a backdoor.
+    """
+    cfg = _select_os_config(spec, os_kind)
+    payload = {
+        "command": cfg.command,
+        "args": list(cfg.args),
+        "env": dict(cfg.env),
+        "metadata": {
+            "description": spec.description,
+            "auto_configured": True,
+            "langflow_internal": True,
+            "platform": os_kind,
+        },
+    }
+    MCPServerConfig.model_validate(payload)
+    return payload
+
+
+async def auto_configure_default_mcp_servers(session: AsyncSession) -> None:
+    """Install the curated default MCP servers for every existing user.
+
+    Idempotent: if a user already has a server with the same name (whether we created
+    it or they did), the entry is preserved. Errors per-user are logged and the loop
+    continues — one bad user must never break others.
+    """
+    settings_service = get_settings_service()
+    if not settings_service.settings.enable_default_mcp_servers:
+        await logger.adebug("default_mcp_servers_disabled")
+        return
+
+    users = (await session.exec(select(User))).all()
+    if not users:
+        return
+
+    storage_service = get_service(ServiceType.STORAGE_SERVICE)
+    os_kind = _detect_os_kind()
+
+    for server_name, spec in DEFAULT_MCP_SERVERS.items():
+        payload = _build_server_payload(spec, os_kind)
+        for user in users:
+            try:
+                existing = await get_server_list(user, session, storage_service, settings_service)
+                if server_name in existing.get("mcpServers", {}):
+                    await logger.adebug(
+                        "default_mcp_server_skipped",
+                        user_id=str(user.id),
+                        server_name=server_name,
+                        reason="already_exists",
+                    )
+                    continue
+                await update_server(
+                    server_name=server_name,
+                    server_config=payload,
+                    current_user=user,
+                    session=session,
+                    storage_service=storage_service,
+                    settings_service=settings_service,
+                )
+                await logger.ainfo(
+                    "default_mcp_server_added",
+                    user_id=str(user.id),
+                    server_name=server_name,
+                    os_kind=os_kind,
+                )
+            except (
+                HTTPException,
+                sqlalchemy_exc.SQLAlchemyError,
+                OSError,
+                PermissionError,
+                FileNotFoundError,
+                RuntimeError,
+                ValueError,
+                AttributeError,
+            ):
+                await logger.aexception(
+                    "default_mcp_server_failed",
+                    user_id=str(user.id),
+                    server_name=server_name,
+                )
+                continue

--- a/src/backend/base/langflow/api/utils/mcp/default_servers.py
+++ b/src/backend/base/langflow/api/utils/mcp/default_servers.py
@@ -105,6 +105,7 @@ async def auto_configure_default_mcp_servers(session: AsyncSession) -> None:
                     "mcpServers", {}
                 )
                 persisted = existing_servers.get(server_name)
+                is_reconcile = False
                 if persisted is not None:
                     persisted_meta = persisted.get("metadata") or {}
                     if not persisted_meta.get("auto_configured"):
@@ -124,18 +125,10 @@ async def auto_configure_default_mcp_servers(session: AsyncSession) -> None:
                             reason="already_in_sync",
                         )
                         continue
-                    # Spec drifted (e.g. user upgraded across a commit that changed the
-                    # canonical payload). Reconcile by overwriting with the new spec —
-                    # `auto_configured: True` was our marker that the entry is ours.
-                    # Platform context lets ops correlate reconciliations against the
-                    # reported OS when the prior version's payload is too short for
-                    # that OS (notably first-run npx timeouts on Windows).
-                    await logger.ainfo(
-                        "default_mcp_server_reconciled",
-                        user_id=str(user.id),
-                        server_name=server_name,
-                        platform=platform.system(),
-                    )
+                    # Spec drifted (e.g. user upgraded across a commit that changed
+                    # the canonical payload). `auto_configured: True` was our marker
+                    # that the entry is ours, so overwriting is safe.
+                    is_reconcile = True
                 await update_server(
                     server_name=server_name,
                     server_config=payload,
@@ -144,11 +137,23 @@ async def auto_configure_default_mcp_servers(session: AsyncSession) -> None:
                     storage_service=storage_service,
                     settings_service=settings_service,
                 )
-                await logger.ainfo(
-                    "default_mcp_server_added",
-                    user_id=str(user.id),
-                    server_name=server_name,
-                )
+                # Distinct event names so Sentry/Datadog filtering can separate
+                # fresh installs from upgrade-driven reconciliations. Platform is
+                # included on reconcile because the bug that motivated this path
+                # (first-run `npx -y` timeouts on Windows) is OS-correlated.
+                if is_reconcile:
+                    await logger.ainfo(
+                        "default_mcp_server_reconciled",
+                        user_id=str(user.id),
+                        server_name=server_name,
+                        platform=platform.system(),
+                    )
+                else:
+                    await logger.ainfo(
+                        "default_mcp_server_added",
+                        user_id=str(user.id),
+                        server_name=server_name,
+                    )
             except (
                 HTTPException,
                 sqlalchemy_exc.SQLAlchemyError,

--- a/src/backend/base/langflow/api/utils/mcp/default_servers.py
+++ b/src/backend/base/langflow/api/utils/mcp/default_servers.py
@@ -1,5 +1,7 @@
 """Orchestrator that auto-installs the default MCP servers (registry-driven) for every user."""
 
+import platform
+
 from fastapi import HTTPException
 from lfx.log.logger import logger
 from lfx.services.deps import get_settings_service
@@ -16,6 +18,35 @@ from langflow.api.v2.schemas import MCPServerConfig
 from langflow.services.database.models.user.model import User
 from langflow.services.deps import get_service
 from langflow.services.schema import ServiceType
+
+# Metadata fields the spec authors. We compare these (and only these) when
+# deciding whether a persisted auto-configured entry has drifted from the
+# canonical spec — extra metadata keys (added by future API extensions or
+# user tooling) must not trigger spurious reconciliations.
+_SPEC_OWNED_METADATA_KEYS: tuple[str, ...] = (
+    "description",
+    "auto_configured",
+    "langflow_internal",
+    "startup_timeout_seconds",
+)
+
+
+def _is_persisted_payload_in_sync(persisted: dict, canonical: dict) -> bool:
+    """Return True iff the persisted MCP entry already matches the canonical spec.
+
+    Compares only the fields the spec controls (command, args, env, and the
+    spec-owned metadata keys). Extra fields on either side are ignored so we
+    don't thrash on derived / user-added properties.
+    """
+    if persisted.get("command") != canonical["command"]:
+        return False
+    if list(persisted.get("args") or []) != list(canonical["args"]):
+        return False
+    if dict(persisted.get("env") or {}) != dict(canonical["env"]):
+        return False
+    persisted_meta = persisted.get("metadata") or {}
+    canonical_meta = canonical["metadata"]
+    return all(persisted_meta.get(key) == canonical_meta.get(key) for key in _SPEC_OWNED_METADATA_KEYS)
 
 
 def _build_server_payload(spec: DefaultMcpServerSpec) -> dict:
@@ -70,15 +101,41 @@ async def auto_configure_default_mcp_servers(session: AsyncSession) -> None:
         payload = _build_server_payload(spec)
         for user in users:
             try:
-                existing = await get_server_list(user, session, storage_service, settings_service)
-                if server_name in existing.get("mcpServers", {}):
-                    await logger.adebug(
-                        "default_mcp_server_skipped",
+                existing_servers = (await get_server_list(user, session, storage_service, settings_service)).get(
+                    "mcpServers", {}
+                )
+                persisted = existing_servers.get(server_name)
+                if persisted is not None:
+                    persisted_meta = persisted.get("metadata") or {}
+                    if not persisted_meta.get("auto_configured"):
+                        # User-owned entry (no `auto_configured` flag): never overwrite.
+                        await logger.adebug(
+                            "default_mcp_server_skipped",
+                            user_id=str(user.id),
+                            server_name=server_name,
+                            reason="user_owned",
+                        )
+                        continue
+                    if _is_persisted_payload_in_sync(persisted, payload):
+                        await logger.adebug(
+                            "default_mcp_server_skipped",
+                            user_id=str(user.id),
+                            server_name=server_name,
+                            reason="already_in_sync",
+                        )
+                        continue
+                    # Spec drifted (e.g. user upgraded across a commit that changed the
+                    # canonical payload). Reconcile by overwriting with the new spec —
+                    # `auto_configured: True` was our marker that the entry is ours.
+                    # Platform context lets ops correlate reconciliations against the
+                    # reported OS when the prior version's payload is too short for
+                    # that OS (notably first-run npx timeouts on Windows).
+                    await logger.ainfo(
+                        "default_mcp_server_reconciled",
                         user_id=str(user.id),
                         server_name=server_name,
-                        reason="already_exists",
+                        platform=platform.system(),
                     )
-                    continue
                 await update_server(
                     server_name=server_name,
                     server_config=payload,

--- a/src/backend/base/langflow/api/utils/mcp/default_servers.py
+++ b/src/backend/base/langflow/api/utils/mcp/default_servers.py
@@ -1,8 +1,5 @@
 """Orchestrator that auto-installs the default MCP servers (registry-driven) for every user."""
 
-import platform
-from typing import Literal
-
 from fastapi import HTTPException
 from lfx.log.logger import logger
 from lfx.services.deps import get_settings_service
@@ -12,7 +9,6 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from langflow.api.utils.mcp.default_servers_specs import (
     DEFAULT_MCP_SERVERS,
-    DefaultMcpServerConfig,
     DefaultMcpServerSpec,
 )
 from langflow.api.v2.mcp import get_server_list, update_server
@@ -21,43 +17,32 @@ from langflow.services.database.models.user.model import User
 from langflow.services.deps import get_service
 from langflow.services.schema import ServiceType
 
-OsKind = Literal["unix", "windows"]
 
-
-def _detect_os_kind() -> OsKind:
-    """Collapse platform.system() into the two buckets we ship configs for.
-
-    Why: WSL reports Linux and *BSD reports its own name; mcp-shell-server runs
-    POSIX-style via uvx in all of those. Only Windows needs the `cmd /c` wrapper.
-    """
-    return "windows" if platform.system() == "Windows" else "unix"
-
-
-def _select_os_config(spec: DefaultMcpServerSpec, os_kind: OsKind) -> DefaultMcpServerConfig:
-    return spec.windows if os_kind == "windows" else spec.unix
-
-
-def _build_server_payload(
-    spec: DefaultMcpServerSpec,
-    os_kind: OsKind,
-) -> dict:
+def _build_server_payload(spec: DefaultMcpServerSpec) -> dict:
     """Build the persisted payload, re-validating via MCPServerConfig.
 
     Why re-validate something we authored: defense in depth. If a future commit
     drops a forbidden command, env var, or arg into the registry, this fails
     fast at startup instead of silently installing a backdoor.
+
+    When ``spec.startup_timeout_seconds`` is set, it surfaces as
+    ``metadata.startup_timeout_seconds`` for ``update_tools`` to pick up and
+    override the global ``mcp_server_timeout`` for this server only.
     """
-    cfg = _select_os_config(spec, os_kind)
+    cfg = spec.config
+    metadata: dict = {
+        "description": spec.description,
+        "auto_configured": True,
+        "langflow_internal": True,
+    }
+    if spec.startup_timeout_seconds is not None:
+        metadata["startup_timeout_seconds"] = spec.startup_timeout_seconds
+
     payload = {
         "command": cfg.command,
         "args": list(cfg.args),
         "env": dict(cfg.env),
-        "metadata": {
-            "description": spec.description,
-            "auto_configured": True,
-            "langflow_internal": True,
-            "platform": os_kind,
-        },
+        "metadata": metadata,
     }
     MCPServerConfig.model_validate(payload)
     return payload
@@ -80,10 +65,9 @@ async def auto_configure_default_mcp_servers(session: AsyncSession) -> None:
         return
 
     storage_service = get_service(ServiceType.STORAGE_SERVICE)
-    os_kind = _detect_os_kind()
 
     for server_name, spec in DEFAULT_MCP_SERVERS.items():
-        payload = _build_server_payload(spec, os_kind)
+        payload = _build_server_payload(spec)
         for user in users:
             try:
                 existing = await get_server_list(user, session, storage_service, settings_service)
@@ -107,7 +91,6 @@ async def auto_configure_default_mcp_servers(session: AsyncSession) -> None:
                     "default_mcp_server_added",
                     user_id=str(user.id),
                     server_name=server_name,
-                    os_kind=os_kind,
                 )
             except (
                 HTTPException,

--- a/src/backend/base/langflow/api/utils/mcp/default_servers_specs.py
+++ b/src/backend/base/langflow/api/utils/mcp/default_servers_specs.py
@@ -1,0 +1,47 @@
+"""Registry of default MCP servers auto-installed for every Langflow user on startup.
+
+Why this lives in its own module: the orchestrator (default_servers.py) MUST stay agnostic
+to which servers exist. To register a new default server, append a single entry to
+DEFAULT_MCP_SERVERS — no changes to the orchestrator are required.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DefaultMcpServerConfig:
+    """Per-OS configuration for a single default MCP server."""
+
+    command: str
+    args: tuple[str, ...]
+    env: dict[str, str]
+
+
+@dataclass(frozen=True)
+class DefaultMcpServerSpec:
+    """An entry in the default MCP servers registry. Keyed by server name."""
+
+    description: str
+    unix: DefaultMcpServerConfig
+    windows: DefaultMcpServerConfig
+
+
+UNIX_SHELL_ALLOWED_COMMANDS = "ls,cat,pwd,grep,wc,find,echo,head,tail,date,whoami,uname,which,df,ps"
+WINDOWS_SHELL_ALLOWED_COMMANDS = "dir,type,echo,where,whoami,hostname,findstr,systeminfo,ver"
+
+
+DEFAULT_MCP_SERVERS: dict[str, DefaultMcpServerSpec] = {
+    "shell-execution": DefaultMcpServerSpec(
+        description=("Secure shell execution server (tumf/mcp-shell-server) — whitelisted commands only."),
+        unix=DefaultMcpServerConfig(
+            command="uvx",
+            args=("mcp-shell-server",),
+            env={"ALLOW_COMMANDS": UNIX_SHELL_ALLOWED_COMMANDS},
+        ),
+        windows=DefaultMcpServerConfig(
+            command="cmd",
+            args=("/c", "uvx", "mcp-shell-server"),
+            env={"ALLOW_COMMANDS": WINDOWS_SHELL_ALLOWED_COMMANDS},
+        ),
+    ),
+}

--- a/src/backend/base/langflow/api/utils/mcp/default_servers_specs.py
+++ b/src/backend/base/langflow/api/utils/mcp/default_servers_specs.py
@@ -10,7 +10,11 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class DefaultMcpServerConfig:
-    """Per-OS configuration for a single default MCP server."""
+    """Launch configuration for a single default MCP server.
+
+    Cross-platform — the chosen providers run identically on macOS/Linux/Windows.
+    If a future server requires per-OS variation, extend this dataclass then.
+    """
 
     command: str
     args: tuple[str, ...]
@@ -22,26 +26,36 @@ class DefaultMcpServerSpec:
     """An entry in the default MCP servers registry. Keyed by server name."""
 
     description: str
-    unix: DefaultMcpServerConfig
-    windows: DefaultMcpServerConfig
+    config: DefaultMcpServerConfig
+    # Optional per-server startup timeout (seconds). When set, surfaces in the
+    # persisted payload as ``metadata.startup_timeout_seconds`` and overrides
+    # the global ``mcp_server_timeout`` for THIS server only.
+    # Use this for servers whose first run is legitimately slow (e.g. ``npx -y``
+    # downloading a large package on first launch).
+    startup_timeout_seconds: int | None = None
 
 
-UNIX_SHELL_ALLOWED_COMMANDS = "ls,cat,pwd,grep,wc,find,echo,head,tail,date,whoami,uname,which,df,ps"
-WINDOWS_SHELL_ALLOWED_COMMANDS = "dir,type,echo,where,whoami,hostname,findstr,systeminfo,ver"
+# Cross-platform shell-execution config.
+# Why DesktopCommander instead of tumf/mcp-shell-server: the previous provider
+# imports `pwd` at module load and crashes on Windows. DesktopCommander uses Node
+# `child_process.spawn` and runs identically on macOS/Linux/Windows. The launch
+# command requires `-y` to skip npx's interactive prompt; this is allowed by
+# MCPServerConfig.validate_yes_flag_pattern via the package-pinned allowlist
+# ALLOWED_NPX_YES_PACKAGES (see api/v2/schemas.py).
+_SHELL_EXECUTION_CONFIG = DefaultMcpServerConfig(
+    command="npx",
+    args=("-y", "@wonderwhy-er/desktop-commander@latest"),
+    env={},
+)
 
 
 DEFAULT_MCP_SERVERS: dict[str, DefaultMcpServerSpec] = {
     "shell-execution": DefaultMcpServerSpec(
-        description=("Secure shell execution server (tumf/mcp-shell-server) — whitelisted commands only."),
-        unix=DefaultMcpServerConfig(
-            command="uvx",
-            args=("mcp-shell-server",),
-            env={"ALLOW_COMMANDS": UNIX_SHELL_ALLOWED_COMMANDS},
-        ),
-        windows=DefaultMcpServerConfig(
-            command="cmd",
-            args=("/c", "uvx", "mcp-shell-server"),
-            env={"ALLOW_COMMANDS": WINDOWS_SHELL_ALLOWED_COMMANDS},
-        ),
+        description=("Cross-platform shell execution + filesystem control (wonderwhy-er/desktop-commander)."),
+        config=_SHELL_EXECUTION_CONFIG,
+        # First run of `npx -y @wonderwhy-er/desktop-commander@latest` can take
+        # 30-90s while npm downloads the package + dependencies (Tiptap, sharp,
+        # etc.). 60s comfortably covers that without raising the global default.
+        startup_timeout_seconds=60,
     ),
 }

--- a/src/backend/base/langflow/api/v2/schemas.py
+++ b/src/backend/base/langflow/api/v2/schemas.py
@@ -1,5 +1,6 @@
 """Pydantic schemas for v2 API endpoints."""
 
+import shlex
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
@@ -28,12 +29,12 @@ ALLOWED_MCP_COMMANDS = frozenset(
 DANGEROUS_SHELL_CHARS = frozenset({";", "|", "&", "$", "`", "<", ">", "(", ")", "\n", "\r"})
 
 # SECURITY: Keywords that enable code execution or package installation
+# Note: -y/--yes is intentionally NOT here. It is governed by validate_yes_flag_pattern
+# below, which permits it only inside the package-allowlisted `npx -y <pkg>` pattern.
 DANGEROUS_KEYWORDS = frozenset(
     {
         "-c",
         "-e",
-        "-y",
-        "--yes",
         "pip",
         "install",
         "npm",
@@ -41,6 +42,21 @@ DANGEROUS_KEYWORDS = frozenset(
         "pnpm",
         "eval",
         "exec",
+    }
+)
+
+# SECURITY: -y / --yes flags. These are blocked by default and only allowed
+# in the strict pattern `npx -y <pkg>` where <pkg> is explicitly listed in
+# ALLOWED_NPX_YES_PACKAGES. See validate_yes_flag_pattern.
+YES_FLAGS = frozenset({"-y", "--yes"})
+
+# SECURITY: Per-package allowlist for the `npx -y <pkg>` pattern.
+# Adding a package here is a code-review touchpoint: each entry must be justified
+# (the package is a default MCP server we ship; npm publish is the trust boundary).
+ALLOWED_NPX_YES_PACKAGES = frozenset(
+    {
+        "@wonderwhy-er/desktop-commander",
+        "@wonderwhy-er/desktop-commander@latest",
     }
 )
 
@@ -207,6 +223,80 @@ class MCPServerConfig(BaseModel):
 
         return self
 
+    @model_validator(mode="after")
+    def validate_yes_flag_pattern(self) -> "MCPServerConfig":
+        """Restrict ``-y`` / ``--yes`` to the package-allowlisted ``npx -y <pkg>`` pattern.
+
+        Why: most npm-distributed MCP servers (notably ``@wonderwhy-er/desktop-commander``)
+        require ``npx -y <pkg>`` to skip the interactive install prompt — without ``-y``
+        the stdio MCP server hangs at startup. Generically allowing ``-y`` after ``npx``
+        is rejected by policy: each package gets vetted explicitly via
+        ``ALLOWED_NPX_YES_PACKAGES``. Direct and shell-wrapper invocations are both
+        validated; the historical loophole of putting ``-y`` inside a quoted shell
+        argument (e.g. ``sh -c "npx -y any-pkg"``) is closed here too via shlex
+        tokenization of the wrapped command.
+        """
+        if not self.args:
+            return self
+
+        base_command = _extract_base_command(self.command) if self.command else None
+
+        # Direct case: command is npx, args contains a yes-flag.
+        if base_command == "npx" and any(a.lower() in YES_FLAGS for a in self.args):
+            tokens = ["npx", *self.args]
+            if not _is_allowed_npx_yes_invocation(tokens):
+                msg = (
+                    "Argument '-y'/'--yes' is only allowed with command 'npx' followed "
+                    "by an approved package. "
+                    f"Got: npx {' '.join(self.args)}. "
+                    f"Approved packages: {sorted(ALLOWED_NPX_YES_PACKAGES)}"
+                )
+                logger.warning("MCP -y rejected (direct): npx args={}", self.args)
+                raise ValueError(msg)
+            return self
+
+        # Shell-wrapper case: tokenize the wrapped command and re-apply the pattern check.
+        if base_command in SHELL_WRAPPERS:
+            wrapped = _find_wrapped_command(self.args)
+            if wrapped is not None:
+                try:
+                    wrapped_tokens = shlex.split(wrapped)
+                except ValueError as e:
+                    # Unbalanced quotes etc. — refuse rather than guess.
+                    msg = f"Could not parse shell-wrapper command: {wrapped!r} ({e})"
+                    raise ValueError(msg) from e
+                if any(t.lower() in YES_FLAGS for t in wrapped_tokens) and not _is_allowed_npx_yes_invocation(
+                    wrapped_tokens
+                ):
+                    msg = (
+                        "Argument '-y'/'--yes' inside a shell wrapper is only allowed "
+                        "in the pattern `npx -y <approved-package>`. "
+                        f"Got wrapped command: {wrapped!r}. "
+                        f"Approved packages: {sorted(ALLOWED_NPX_YES_PACKAGES)}"
+                    )
+                    logger.warning("MCP -y rejected (wrapper): {}", wrapped)
+                    raise ValueError(msg)
+
+        # Anywhere else: -y/--yes must NOT appear as a top-level arg.
+        # This catches the stray-flag case in shell-wrapper args (e.g. `sh -c "npx X" -y`)
+        # where the flag sits OUTSIDE the wrapped command. The wrapped string is the only
+        # legitimate place for -y, and only when it matches the npx-yes pattern above.
+        if any(a.lower() in YES_FLAGS for a in self.args):
+            msg = (
+                "Argument '-y'/'--yes' is only allowed in the strict pattern "
+                "`npx -y <approved-package>`, either as direct args of `npx` "
+                "or inside a single shell-wrapper -c/'/c' argument. "
+                f"Got: command='{self.command}' args={self.args}"
+            )
+            logger.warning(
+                "MCP -y rejected (top-level): command={}, args={}",
+                self.command,
+                self.args,
+            )
+            raise ValueError(msg)
+
+        return self
+
     @field_validator("args")
     @classmethod
     def validate_args(cls, v: list[str] | None) -> list[str] | None:
@@ -303,6 +393,32 @@ class MCPServerConfig(BaseModel):
                 raise ValueError(msg)
 
         return self
+
+
+def _find_wrapped_command(args: list[str]) -> str | None:
+    """Return the single string immediately following the first SHELL_EXEC_FLAG, or None."""
+    for i, arg in enumerate(args):
+        if arg in SHELL_EXEC_FLAGS and i + 1 < len(args):
+            return args[i + 1]
+    return None
+
+
+def _is_allowed_npx_yes_invocation(tokens: list[str]) -> bool:
+    """Strictly match the pattern: ['npx', '-y'|'--yes', <pkg-on-allowlist>].
+
+    Used by both the direct-args and shell-wrapper paths in validate_yes_flag_pattern.
+    Strict on length (exactly 3) so trailing junk like ['npx','-y','pkg',';rm'] never
+    sneaks through. Case sensitive on the package name (npm package names are case
+    sensitive on the registry).
+    """
+    expected_token_count = 3
+    if len(tokens) != expected_token_count:
+        return False
+    if tokens[0] != "npx":
+        return False
+    if tokens[1].lower() not in YES_FLAGS:
+        return False
+    return tokens[2] in ALLOWED_NPX_YES_PACKAGES
 
 
 def _extract_base_command(command: str) -> str:

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -353,6 +353,27 @@ def get_lifespan(*, fix_migration=False, version=None):
                     except Exception as e:  # noqa: BLE001
                         await logger.awarning(f"Failed to configure agentic MCP server: {e}")
 
+            # Gate: Auto-configure default MCP servers (shell-execution, ...) for every user
+            if get_settings_service().settings.enable_default_mcp_servers:
+                if is_step_complete(PreloadStep.DEFAULT_MCP_SERVERS):
+                    await logger.adebug(
+                        "Skipping default MCP servers config: master already completed it during preload"
+                    )
+                else:
+                    from langflow.api.utils.mcp.default_servers import (
+                        auto_configure_default_mcp_servers,
+                    )
+
+                    current_time = asyncio.get_event_loop().time()
+                    await logger.ainfo("Configuring default MCP servers...")
+                    try:
+                        async with session_scope() as session:
+                            await auto_configure_default_mcp_servers(session)
+                        elapsed = asyncio.get_event_loop().time() - current_time
+                        await logger.adebug(f"Default MCP servers configured in {elapsed:.2f}s")
+                    except Exception as e:  # noqa: BLE001
+                        await logger.awarning(f"Failed to configure default MCP servers: {e}")
+
             # Gate: Load flows from directory
             current_time = asyncio.get_event_loop().time()
             if is_step_complete(PreloadStep.FLOWS):

--- a/src/backend/base/langflow/preload.py
+++ b/src/backend/base/langflow/preload.py
@@ -62,6 +62,7 @@ class PreloadStep(Enum):
     STARTER_PROJECTS = "starter_projects"
     AGENTIC_GLOBALS = "agentic_globals"
     AGENTIC_MCP = "agentic_mcp"
+    DEFAULT_MCP_SERVERS = "default_mcp_servers"
     FLOWS = "flows"
 
 
@@ -72,6 +73,7 @@ _STEP_ATTR: Final[dict[PreloadStep, str]] = {
     PreloadStep.STARTER_PROJECTS: "starter_projects_created",
     PreloadStep.AGENTIC_GLOBALS: "agentic_globals_initialized",
     PreloadStep.AGENTIC_MCP: "agentic_mcp_configured",
+    PreloadStep.DEFAULT_MCP_SERVERS: "default_mcp_servers_configured",
     PreloadStep.FLOWS: "flows_loaded",
 }
 
@@ -84,6 +86,7 @@ _STEP_PREREQUISITES: Final[dict[PreloadStep, tuple[PreloadStep, ...]]] = {
     PreloadStep.AGENTIC_GLOBALS: (PreloadStep.TYPES_CACHED,),
     # MCP config may succeed even when globals failed (separate try/except in preload).
     PreloadStep.AGENTIC_MCP: (PreloadStep.TYPES_CACHED,),
+    PreloadStep.DEFAULT_MCP_SERVERS: (PreloadStep.TYPES_CACHED,),
     PreloadStep.FLOWS: (PreloadStep.TYPES_CACHED,),
 }
 
@@ -116,6 +119,7 @@ class _PreloadState:
     starter_projects_created: bool = False
     agentic_globals_initialized: bool = False
     agentic_mcp_configured: bool = False
+    default_mcp_servers_configured: bool = False
     flows_loaded: bool = False
 
     def reset(self) -> None:
@@ -144,6 +148,7 @@ class _PreloadState:
         self.starter_projects_created = False
         self.agentic_globals_initialized = False
         self.agentic_mcp_configured = False
+        self.default_mcp_servers_configured = False
         self.flows_loaded = False
 
 
@@ -279,6 +284,21 @@ async def _run_master_preload() -> None:
                 PreloadStep.AGENTIC_MCP,
                 "auto-configure agentic MCP server failed",
                 _run_agentic_mcp(),
+            )
+
+        if settings_service.settings.enable_default_mcp_servers:
+            from langflow.api.utils.mcp.default_servers import auto_configure_default_mcp_servers
+
+            await logger.adebug("[preload] auto-configuring default MCP servers")
+
+            async def _run_default_mcp_servers() -> None:
+                async with session_scope() as session:
+                    await auto_configure_default_mcp_servers(session)
+
+            await _best_effort(
+                PreloadStep.DEFAULT_MCP_SERVERS,
+                "auto-configure default MCP servers failed",
+                _run_default_mcp_servers(),
             )
 
         await logger.adebug("[preload] loading flows from directory")

--- a/src/backend/tests/unit/api/utils/mcp/test_default_servers_orchestrator.py
+++ b/src/backend/tests/unit/api/utils/mcp/test_default_servers_orchestrator.py
@@ -257,7 +257,7 @@ class TestLoggingHygiene:
     async def test_should_not_log_username_or_email_when_configuring_default_servers(
         self,
         patched_orchestrator_deps,
-        monkeypatch,  # noqa: ARG002 — fixture wires deps for this test too
+        monkeypatch,
     ):
         """Logs may contain user_id (UUID) and server_name; never PII (username/email)."""
         user_a = SimpleNamespace(id=uuid4(), username="alice-secret", email="alice@example.com")

--- a/src/backend/tests/unit/api/utils/mcp/test_default_servers_orchestrator.py
+++ b/src/backend/tests/unit/api/utils/mcp/test_default_servers_orchestrator.py
@@ -72,7 +72,6 @@ def patched_orchestrator_deps(monkeypatch):
     monkeypatch.setattr(orchestrator_module, "get_service", lambda _t: storage_sentinel)
     monkeypatch.setattr(orchestrator_module, "update_server", update_server_mock)
     monkeypatch.setattr(orchestrator_module, "get_server_list", get_server_list_mock)
-    monkeypatch.setattr("platform.system", lambda: "Linux")
 
     return SimpleNamespace(
         settings=settings_ns,
@@ -103,25 +102,25 @@ class TestRespectsFlag:
         patched_orchestrator_deps.get_server_list.assert_not_called()
 
 
-class TestInstallsUnixShellServer:
-    async def test_should_install_unix_shell_server_for_each_user_when_running_on_linux(
+class TestInstallsShellExecution:
+    async def test_should_install_shell_execution_for_each_user(
         self, fake_session_with_users, patched_orchestrator_deps, fake_user
     ):
-        # Arrange — flag on (default), Linux (default), user has no existing MCP servers
+        """Cross-platform: same payload regardless of host OS (DesktopCommander via npx)."""
         update_server = patched_orchestrator_deps.update_server
 
-        # Act
         await auto_configure_default_mcp_servers(fake_session_with_users)
 
-        # Assert — one call per (user, default-server) pair
         assert update_server.await_count == 1
         call_kwargs = update_server.await_args.kwargs
         assert call_kwargs["server_name"] == "shell-execution"
         assert call_kwargs["current_user"] is fake_user
         cfg = call_kwargs["server_config"]
-        assert cfg["command"] == "uvx"
-        assert cfg["args"] == ["mcp-shell-server"]
-        assert "ALLOW_COMMANDS" in cfg["env"]
+        assert cfg["command"] == "npx"
+        assert cfg["args"] == ["-y", "@wonderwhy-er/desktop-commander@latest"]
+        assert cfg["env"] == {}
+        assert cfg["metadata"]["auto_configured"] is True
+        assert cfg["metadata"]["langflow_internal"] is True
 
 
 class TestIdempotency:
@@ -132,9 +131,8 @@ class TestIdempotency:
         patched_orchestrator_deps.get_server_list.return_value = {
             "mcpServers": {
                 "shell-execution": {
-                    "command": "uvx",
-                    "args": ["mcp-shell-server"],
-                    "env": {"ALLOW_COMMANDS": "ls,echo"},  # user-customized whitelist
+                    "command": "npx",
+                    "args": ["-y", "@some/user-replacement"],
                 }
             }
         }
@@ -142,22 +140,6 @@ class TestIdempotency:
         await auto_configure_default_mcp_servers(fake_session_with_users)
 
         patched_orchestrator_deps.update_server.assert_not_called()
-
-
-class TestInstallsWindowsShellServer:
-    async def test_should_install_windows_shell_server_when_running_on_windows(
-        self, fake_session_with_users, patched_orchestrator_deps, monkeypatch
-    ):
-        monkeypatch.setattr("platform.system", lambda: "Windows")
-
-        await auto_configure_default_mcp_servers(fake_session_with_users)
-
-        update_server = patched_orchestrator_deps.update_server
-        assert update_server.await_count == 1
-        cfg = update_server.await_args.kwargs["server_config"]
-        assert cfg["command"] == "cmd"
-        assert cfg["args"] == ["/c", "uvx", "mcp-shell-server"]
-        assert cfg["metadata"]["platform"] == "windows"
 
 
 class TestRegistryRevalidation:
@@ -179,8 +161,7 @@ class TestRegistryRevalidation:
 
         bad_spec = DefaultMcpServerSpec(
             description="evil",
-            unix=DefaultMcpServerConfig(command="rm", args=("-rf", "x"), env={}),
-            windows=DefaultMcpServerConfig(command="rm", args=("-rf", "x"), env={}),
+            config=DefaultMcpServerConfig(command="rm", args=("-rf", "x"), env={}),
         )
         monkeypatch.setattr(
             orchestrator_module,
@@ -204,9 +185,10 @@ class TestRegistryRevalidation:
 
         bad_spec = DefaultMcpServerSpec(
             description="leak via LD_PRELOAD",
-            unix=DefaultMcpServerConfig(command="uvx", args=("mcp-shell-server",), env={"LD_PRELOAD": "evil.so"}),
-            windows=DefaultMcpServerConfig(
-                command="cmd", args=("/c", "uvx", "mcp-shell-server"), env={"LD_PRELOAD": "x"}
+            config=DefaultMcpServerConfig(
+                command="npx",
+                args=("-y", "@wonderwhy-er/desktop-commander@latest"),
+                env={"LD_PRELOAD": "evil.so"},
             ),
         )
         monkeypatch.setattr(
@@ -239,8 +221,7 @@ class TestRegistryExtensibility:
 
         extra_spec = DefaultMcpServerSpec(
             description="Hypothetical fetch server",
-            unix=DefaultMcpServerConfig(command="uvx", args=("mcp-fetch",), env={}),
-            windows=DefaultMcpServerConfig(command="cmd", args=("/c", "uvx", "mcp-fetch"), env={}),
+            config=DefaultMcpServerConfig(command="uvx", args=("mcp-fetch",), env={}),
         )
         extended = {**DEFAULT_MCP_SERVERS, "fetch": extra_spec}
         monkeypatch.setattr(orchestrator_module, "DEFAULT_MCP_SERVERS", extended)
@@ -256,8 +237,8 @@ class TestRegistryExtensibility:
 class TestLoggingHygiene:
     async def test_should_not_log_username_or_email_when_configuring_default_servers(
         self,
-        patched_orchestrator_deps,
-        monkeypatch,  # noqa: ARG002 — fixture wires deps for this test too
+        patched_orchestrator_deps,  # noqa: ARG002 — fixture wires deps for this test too
+        monkeypatch,
     ):
         """Logs may contain user_id (UUID) and server_name; never PII (username/email)."""
         user_a = SimpleNamespace(id=uuid4(), username="alice-secret", email="alice@example.com")

--- a/src/backend/tests/unit/api/utils/mcp/test_default_servers_orchestrator.py
+++ b/src/backend/tests/unit/api/utils/mcp/test_default_servers_orchestrator.py
@@ -1,0 +1,316 @@
+"""Tests for the auto_configure_default_mcp_servers orchestrator.
+
+The orchestrator is the only caller of update_server() for this feature.
+We fake every external dependency (storage, settings, DB session, update_server,
+get_server_list, platform.system) so tests are pure-unit and deterministic.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from langflow.api.utils.mcp import default_servers as orchestrator_module
+from langflow.api.utils.mcp.default_servers import auto_configure_default_mcp_servers
+
+
+@pytest.fixture
+def fake_user():
+    return SimpleNamespace(id=uuid4(), username="user-one", email="user-one@example.com")
+
+
+@pytest.fixture
+def fake_session_with_users(fake_user):
+    """Fake AsyncSession whose `exec(select(User))` returns a fixed user list."""
+
+    class _ExecResult:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def all(self):
+            return self._rows
+
+    async def _exec(_query):
+        return _ExecResult([fake_user])
+
+    session = MagicMock()
+    session.exec = _exec
+    return session
+
+
+def _make_session_with(users):
+    class _ExecResult:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def all(self):
+            return self._rows
+
+    async def _exec(_query):
+        return _ExecResult(users)
+
+    session = MagicMock()
+    session.exec = _exec
+    return session
+
+
+@pytest.fixture
+def patched_orchestrator_deps(monkeypatch):
+    """Replace external deps the orchestrator pulls via get_settings_service / get_service.
+
+    Returns the (settings_namespace, update_server_mock, get_server_list_mock,
+    storage_service_sentinel) tuple so individual tests can configure behavior.
+    """
+    settings_ns = SimpleNamespace(enable_default_mcp_servers=True)
+    settings_service = SimpleNamespace(settings=settings_ns)
+    storage_sentinel = object()
+
+    update_server_mock = AsyncMock(return_value=None)
+    get_server_list_mock = AsyncMock(return_value={"mcpServers": {}})
+
+    monkeypatch.setattr(orchestrator_module, "get_settings_service", lambda: settings_service)
+    monkeypatch.setattr(orchestrator_module, "get_service", lambda _t: storage_sentinel)
+    monkeypatch.setattr(orchestrator_module, "update_server", update_server_mock)
+    monkeypatch.setattr(orchestrator_module, "get_server_list", get_server_list_mock)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    return SimpleNamespace(
+        settings=settings_ns,
+        update_server=update_server_mock,
+        get_server_list=get_server_list_mock,
+        storage=storage_sentinel,
+    )
+
+
+class TestRespectsFlag:
+    async def test_should_skip_when_enable_default_mcp_servers_is_false(
+        self, fake_session_with_users, patched_orchestrator_deps
+    ):
+        patched_orchestrator_deps.settings.enable_default_mcp_servers = False
+
+        await auto_configure_default_mcp_servers(fake_session_with_users)
+
+        patched_orchestrator_deps.update_server.assert_not_called()
+        patched_orchestrator_deps.get_server_list.assert_not_called()
+
+    async def test_should_skip_when_no_users_exist(self, patched_orchestrator_deps):
+        """Fresh DB / pre-onboarding state — nothing to install yet, no error either."""
+        empty_session = _make_session_with([])
+
+        await auto_configure_default_mcp_servers(empty_session)
+
+        patched_orchestrator_deps.update_server.assert_not_called()
+        patched_orchestrator_deps.get_server_list.assert_not_called()
+
+
+class TestInstallsUnixShellServer:
+    async def test_should_install_unix_shell_server_for_each_user_when_running_on_linux(
+        self, fake_session_with_users, patched_orchestrator_deps, fake_user
+    ):
+        # Arrange — flag on (default), Linux (default), user has no existing MCP servers
+        update_server = patched_orchestrator_deps.update_server
+
+        # Act
+        await auto_configure_default_mcp_servers(fake_session_with_users)
+
+        # Assert — one call per (user, default-server) pair
+        assert update_server.await_count == 1
+        call_kwargs = update_server.await_args.kwargs
+        assert call_kwargs["server_name"] == "shell-execution"
+        assert call_kwargs["current_user"] is fake_user
+        cfg = call_kwargs["server_config"]
+        assert cfg["command"] == "uvx"
+        assert cfg["args"] == ["mcp-shell-server"]
+        assert "ALLOW_COMMANDS" in cfg["env"]
+
+
+class TestIdempotency:
+    async def test_should_skip_when_server_already_exists_for_user(
+        self, fake_session_with_users, patched_orchestrator_deps
+    ):
+        """User already has a `shell-execution` entry — possibly customized; never overwrite."""
+        patched_orchestrator_deps.get_server_list.return_value = {
+            "mcpServers": {
+                "shell-execution": {
+                    "command": "uvx",
+                    "args": ["mcp-shell-server"],
+                    "env": {"ALLOW_COMMANDS": "ls,echo"},  # user-customized whitelist
+                }
+            }
+        }
+
+        await auto_configure_default_mcp_servers(fake_session_with_users)
+
+        patched_orchestrator_deps.update_server.assert_not_called()
+
+
+class TestInstallsWindowsShellServer:
+    async def test_should_install_windows_shell_server_when_running_on_windows(
+        self, fake_session_with_users, patched_orchestrator_deps, monkeypatch
+    ):
+        monkeypatch.setattr("platform.system", lambda: "Windows")
+
+        await auto_configure_default_mcp_servers(fake_session_with_users)
+
+        update_server = patched_orchestrator_deps.update_server
+        assert update_server.await_count == 1
+        cfg = update_server.await_args.kwargs["server_config"]
+        assert cfg["command"] == "cmd"
+        assert cfg["args"] == ["/c", "uvx", "mcp-shell-server"]
+        assert cfg["metadata"]["platform"] == "windows"
+
+
+class TestRegistryRevalidation:
+    """Defense-in-depth on the registry.
+
+    Even if a future commit drops a forbidden command into the registry, the
+    orchestrator must re-validate via MCPServerConfig BEFORE touching storage.
+    Failure must fail loud (raise) — not silently install the bad spec.
+    """
+
+    async def test_should_raise_when_default_spec_uses_command_outside_allowlist(
+        self, fake_session_with_users, patched_orchestrator_deps, monkeypatch
+    ):
+        from langflow.api.utils.mcp.default_servers_specs import (
+            DefaultMcpServerConfig,
+            DefaultMcpServerSpec,
+        )
+        from pydantic import ValidationError
+
+        bad_spec = DefaultMcpServerSpec(
+            description="evil",
+            unix=DefaultMcpServerConfig(command="rm", args=("-rf", "x"), env={}),
+            windows=DefaultMcpServerConfig(command="rm", args=("-rf", "x"), env={}),
+        )
+        monkeypatch.setattr(
+            orchestrator_module,
+            "DEFAULT_MCP_SERVERS",
+            {"evil": bad_spec},
+        )
+
+        with pytest.raises(ValidationError):
+            await auto_configure_default_mcp_servers(fake_session_with_users)
+
+        patched_orchestrator_deps.update_server.assert_not_called()
+
+    async def test_should_raise_when_default_spec_includes_blocked_env_var(
+        self, fake_session_with_users, patched_orchestrator_deps, monkeypatch
+    ):
+        from langflow.api.utils.mcp.default_servers_specs import (
+            DefaultMcpServerConfig,
+            DefaultMcpServerSpec,
+        )
+        from pydantic import ValidationError
+
+        bad_spec = DefaultMcpServerSpec(
+            description="leak via LD_PRELOAD",
+            unix=DefaultMcpServerConfig(command="uvx", args=("mcp-shell-server",), env={"LD_PRELOAD": "evil.so"}),
+            windows=DefaultMcpServerConfig(
+                command="cmd", args=("/c", "uvx", "mcp-shell-server"), env={"LD_PRELOAD": "x"}
+            ),
+        )
+        monkeypatch.setattr(
+            orchestrator_module,
+            "DEFAULT_MCP_SERVERS",
+            {"leaky": bad_spec},
+        )
+
+        with pytest.raises(ValidationError):
+            await auto_configure_default_mcp_servers(fake_session_with_users)
+
+        patched_orchestrator_deps.update_server.assert_not_called()
+
+
+class TestRegistryExtensibility:
+    """Adding a new default server must require no orchestrator changes.
+
+    The orchestrator iterates DEFAULT_MCP_SERVERS and treats every entry uniformly,
+    so registering a new default is a one-line change to the registry.
+    """
+
+    async def test_should_install_additional_servers_added_to_registry(
+        self, fake_session_with_users, patched_orchestrator_deps, monkeypatch
+    ):
+        from langflow.api.utils.mcp.default_servers_specs import (
+            DEFAULT_MCP_SERVERS,
+            DefaultMcpServerConfig,
+            DefaultMcpServerSpec,
+        )
+
+        extra_spec = DefaultMcpServerSpec(
+            description="Hypothetical fetch server",
+            unix=DefaultMcpServerConfig(command="uvx", args=("mcp-fetch",), env={}),
+            windows=DefaultMcpServerConfig(command="cmd", args=("/c", "uvx", "mcp-fetch"), env={}),
+        )
+        extended = {**DEFAULT_MCP_SERVERS, "fetch": extra_spec}
+        monkeypatch.setattr(orchestrator_module, "DEFAULT_MCP_SERVERS", extended)
+
+        await auto_configure_default_mcp_servers(fake_session_with_users)
+
+        installed_names = {
+            call.kwargs["server_name"] for call in patched_orchestrator_deps.update_server.await_args_list
+        }
+        assert installed_names == {"shell-execution", "fetch"}
+
+
+class TestLoggingHygiene:
+    async def test_should_not_log_username_or_email_when_configuring_default_servers(
+        self,
+        patched_orchestrator_deps,
+        monkeypatch,  # noqa: ARG002 — fixture wires deps for this test too
+    ):
+        """Logs may contain user_id (UUID) and server_name; never PII (username/email)."""
+        user_a = SimpleNamespace(id=uuid4(), username="alice-secret", email="alice@example.com")
+        user_b = SimpleNamespace(id=uuid4(), username="bob-secret", email="bob@example.com")
+        session = _make_session_with([user_a, user_b])
+
+        captured = []
+
+        class _SpyLogger:
+            async def adebug(self, msg, **kwargs):
+                captured.append((msg, kwargs))
+
+            async def ainfo(self, msg, **kwargs):
+                captured.append((msg, kwargs))
+
+            async def aexception(self, msg, **kwargs):
+                captured.append((msg, kwargs))
+
+        monkeypatch.setattr(orchestrator_module, "logger", _SpyLogger())
+
+        await auto_configure_default_mcp_servers(session)
+
+        flattened: list[str] = []
+        for msg, kwargs in captured:
+            flattened.append(str(msg))
+            flattened.extend(str(value) for value in kwargs.values())
+        rendered = " | ".join(flattened)
+
+        for forbidden in ("alice-secret", "bob-secret", "alice@example.com", "bob@example.com"):
+            assert forbidden not in rendered, f"PII leaked into logs: {forbidden!r} in {rendered!r}"
+
+
+class TestPerUserFailureIsolation:
+    async def test_should_continue_processing_other_users_when_one_user_storage_fails(self, patched_orchestrator_deps):
+        """A single user's storage error must not abort the loop for the rest."""
+        from fastapi import HTTPException
+
+        user_a = SimpleNamespace(id=uuid4(), username="a", email="a@example.com")
+        user_b = SimpleNamespace(id=uuid4(), username="b", email="b@example.com")
+        user_c = SimpleNamespace(id=uuid4(), username="c", email="c@example.com")
+        session = _make_session_with([user_a, user_b, user_c])
+
+        # First user's update_server raises; the other two must still be attempted.
+        patched_orchestrator_deps.update_server.side_effect = [
+            HTTPException(status_code=500, detail="storage down"),
+            None,
+            None,
+        ]
+
+        await auto_configure_default_mcp_servers(session)
+
+        assert patched_orchestrator_deps.update_server.await_count == 3
+        attempted_users = [
+            call.kwargs["current_user"] for call in patched_orchestrator_deps.update_server.await_args_list
+        ]
+        assert attempted_users == [user_a, user_b, user_c]

--- a/src/backend/tests/unit/api/utils/mcp/test_default_servers_orchestrator.py
+++ b/src/backend/tests/unit/api/utils/mcp/test_default_servers_orchestrator.py
@@ -142,6 +142,99 @@ class TestIdempotency:
         patched_orchestrator_deps.update_server.assert_not_called()
 
 
+class TestReconcileAutoConfiguredEntries:
+    """Reconcile auto-configured entries when the canonical spec drifts.
+
+    When the canonical spec evolves (e.g. a new `metadata.startup_timeout_seconds`
+    field is added), users who installed Langflow on an earlier build keep a
+    stale persisted payload — the orchestrator's old skip-if-exists behavior
+    would lock them out of fixes forever (notably: the 60s opt-in needed to
+    survive the first `npx -y @wonderwhy-er/desktop-commander@latest` download
+    on Windows + slow networks).
+
+    Reconciliation is gated on `metadata.auto_configured == True`: only entries
+    that we wrote can be overwritten. Anything missing the flag (e.g. the user
+    swapped in their own server) is preserved unconditionally.
+    """
+
+    async def test_should_reconcile_auto_configured_entry_when_persisted_payload_diverges_from_spec(
+        self, fake_session_with_users, patched_orchestrator_deps
+    ):
+        """Stale entry from a pre-`startup_timeout_seconds` build must be updated."""
+        patched_orchestrator_deps.get_server_list.return_value = {
+            "mcpServers": {
+                "shell-execution": {
+                    "command": "npx",
+                    "args": ["-y", "@wonderwhy-er/desktop-commander@latest"],
+                    "env": {},
+                    "metadata": {
+                        "description": (
+                            "Cross-platform shell execution + filesystem control (wonderwhy-er/desktop-commander)."
+                        ),
+                        "auto_configured": True,
+                        "langflow_internal": True,
+                        # NOTE: no startup_timeout_seconds — this is the stale field.
+                    },
+                }
+            }
+        }
+
+        await auto_configure_default_mcp_servers(fake_session_with_users)
+
+        patched_orchestrator_deps.update_server.assert_awaited_once()
+        cfg = patched_orchestrator_deps.update_server.await_args.kwargs["server_config"]
+        assert cfg["metadata"].get("startup_timeout_seconds") == 60
+
+    async def test_should_not_overwrite_entry_lacking_auto_configured_flag(
+        self, fake_session_with_users, patched_orchestrator_deps
+    ):
+        """User-owned entry (no `auto_configured` flag) must be preserved."""
+        patched_orchestrator_deps.get_server_list.return_value = {
+            "mcpServers": {
+                "shell-execution": {
+                    "command": "npx",
+                    "args": ["-y", "@user/custom-fork"],
+                    "env": {},
+                    "metadata": {"description": "user-owned override"},
+                }
+            }
+        }
+
+        await auto_configure_default_mcp_servers(fake_session_with_users)
+
+        patched_orchestrator_deps.update_server.assert_not_called()
+
+    async def test_should_skip_when_auto_configured_entry_payload_already_matches_spec(
+        self, fake_session_with_users, patched_orchestrator_deps
+    ):
+        """No-op when the persisted payload already matches the canonical spec.
+
+        Avoids needless disk writes and noisy logs on every Langflow startup.
+        """
+        from langflow.api.utils.mcp.default_servers_specs import DEFAULT_MCP_SERVERS
+
+        spec = DEFAULT_MCP_SERVERS["shell-execution"]
+        patched_orchestrator_deps.get_server_list.return_value = {
+            "mcpServers": {
+                "shell-execution": {
+                    "command": spec.config.command,
+                    "args": list(spec.config.args),
+                    "env": dict(spec.config.env),
+                    "metadata": {
+                        "description": spec.description,
+                        "auto_configured": True,
+                        "langflow_internal": True,
+                        "startup_timeout_seconds": spec.startup_timeout_seconds,
+                    },
+                }
+            }
+        }
+
+        await auto_configure_default_mcp_servers(fake_session_with_users)
+
+        patched_orchestrator_deps.update_server.assert_not_called()
+
+
 class TestRegistryRevalidation:
     """Defense-in-depth on the registry.
 

--- a/src/backend/tests/unit/api/utils/mcp/test_default_servers_preload.py
+++ b/src/backend/tests/unit/api/utils/mcp/test_default_servers_preload.py
@@ -1,0 +1,70 @@
+"""Tests for the PreloadStep gating of default MCP server installation.
+
+Why this exists: in multi-worker (gunicorn) mode, every worker would otherwise
+re-run auto_configure_default_mcp_servers for every user, causing wasted writes
+and contention. The PreloadStep enum is the master-once / worker-skip mechanism
+shared with AGENTIC_MCP and other heavy boot steps.
+"""
+
+import pytest
+from langflow.preload import (
+    PreloadStep,
+    _PreloadState,
+    is_step_complete,
+    mark_step_complete,
+)
+
+
+class TestPreloadStepEnumIncludesDefaultMcpServers:
+    def test_should_define_default_mcp_servers_step(self):
+        assert PreloadStep.DEFAULT_MCP_SERVERS.value == "default_mcp_servers"
+
+
+class TestPreloadStateTracksDefaultMcpServers:
+    def test_should_default_to_not_configured(self):
+        state = _PreloadState()
+
+        assert state.default_mcp_servers_configured is False
+
+    def test_should_clear_flag_on_reset(self):
+        state = _PreloadState()
+        state.default_mcp_servers_configured = True
+
+        state.reset()
+
+        assert state.default_mcp_servers_configured is False
+
+
+class TestMarkAndIsStepComplete:
+    @pytest.fixture(autouse=True)
+    def _reset_module_state(self):
+        """Each test gets a clean preload state — module-level _STATE is shared."""
+        from langflow.preload import _STATE
+
+        snapshot = {
+            "types_cached": _STATE.types_cached,
+            "default_mcp_servers_configured": _STATE.default_mcp_servers_configured,
+        }
+        try:
+            yield
+        finally:
+            _STATE.types_cached = snapshot["types_cached"]
+            _STATE.default_mcp_servers_configured = snapshot["default_mcp_servers_configured"]
+
+    def test_should_report_complete_after_mark_when_prereqs_met(self):
+        from langflow.preload import _STATE
+
+        _STATE.types_cached = True  # prereq
+
+        mark_step_complete(PreloadStep.DEFAULT_MCP_SERVERS)
+
+        assert is_step_complete(PreloadStep.DEFAULT_MCP_SERVERS) is True
+
+    def test_should_raise_when_marking_complete_without_types_cached_prereq(self):
+        from langflow.preload import _STATE
+
+        _STATE.types_cached = False
+        _STATE.default_mcp_servers_configured = False
+
+        with pytest.raises(RuntimeError, match="incomplete prerequisites"):
+            mark_step_complete(PreloadStep.DEFAULT_MCP_SERVERS)

--- a/src/backend/tests/unit/api/utils/mcp/test_default_servers_registry.py
+++ b/src/backend/tests/unit/api/utils/mcp/test_default_servers_registry.py
@@ -1,0 +1,137 @@
+"""Tests for the default MCP servers registry (specs and per-OS configurations)."""
+
+import pytest
+from langflow.api.utils.mcp.default_servers import _detect_os_kind
+from langflow.api.utils.mcp.default_servers_specs import (
+    DEFAULT_MCP_SERVERS,
+    UNIX_SHELL_ALLOWED_COMMANDS,
+    WINDOWS_SHELL_ALLOWED_COMMANDS,
+)
+from langflow.api.v2.schemas import MCPServerConfig
+
+# Commands that, if reachable from the shell server's whitelist, would defeat the
+# purpose of having a whitelist (they let the caller execute anything else).
+DANGEROUS_SHELL_WHITELIST_COMMANDS = frozenset(
+    {
+        "bash",
+        "sh",
+        "zsh",
+        "fish",
+        "ksh",
+        "csh",
+        "tcsh",
+        "python",
+        "python3",
+        "node",
+        "perl",
+        "ruby",
+        "php",
+        "eval",
+        "exec",
+        "sudo",
+        "su",
+        "doas",
+        "curl",
+        "wget",
+        "ssh",
+        "scp",
+        "rsync",
+        "rm",
+        "mv",
+        "dd",
+        "chmod",
+        "chown",
+        "kill",
+        "pkill",
+        "killall",
+        "powershell",
+        "pwsh",
+        "cmd",
+        "cscript",
+        "wscript",
+        "regedit",
+        "reg",
+    }
+)
+
+
+class TestUnixShellDefaultSpec:
+    def test_unix_shell_default_spec_passes_mcp_server_config_validation(self):
+        """The Unix shell-execution spec must satisfy the production Pydantic validator.
+
+        Why: defends against a future commit dropping a forbidden command/arg/env into
+        the registry — the registry is internal but still re-validated as defense in depth.
+        """
+        spec = DEFAULT_MCP_SERVERS["shell-execution"]
+        payload = {
+            "command": spec.unix.command,
+            "args": list(spec.unix.args),
+            "env": dict(spec.unix.env),
+        }
+
+        MCPServerConfig.model_validate(payload)
+
+
+class TestWindowsShellDefaultSpec:
+    def test_windows_shell_default_spec_passes_mcp_server_config_validation(self):
+        """The Windows shell-execution spec must satisfy the production Pydantic validator.
+
+        Why: Windows requires the `cmd /c uvx ...` wrapper pattern; that wrapper must
+        survive validate_command + validate_shell_wrapper_args without raising.
+        """
+        spec = DEFAULT_MCP_SERVERS["shell-execution"]
+        payload = {
+            "command": spec.windows.command,
+            "args": list(spec.windows.args),
+            "env": dict(spec.windows.env),
+        }
+
+        MCPServerConfig.model_validate(payload)
+
+
+class TestShellWhitelistsAreSafe:
+    """Audits the shell server's per-OS allowed-commands list.
+
+    The mcp-shell-server enforces ALLOW_COMMANDS at runtime; if we ship a whitelist
+    that reintroduces a shell or interpreter, the user effectively gets arbitrary
+    execution. These tests are the durable spec of "what may never be in defaults".
+    """
+
+    def test_unix_allow_commands_does_not_contain_shell_or_eval(self):
+        cmds = {c.strip() for c in UNIX_SHELL_ALLOWED_COMMANDS.split(",") if c.strip()}
+        forbidden = cmds & DANGEROUS_SHELL_WHITELIST_COMMANDS
+        assert not forbidden, (
+            f"Unix shell-execution whitelist contains forbidden commands: {sorted(forbidden)}. "
+            "These would let the caller bypass the whitelist."
+        )
+
+    def test_windows_allow_commands_does_not_contain_shell_or_eval(self):
+        cmds = {c.strip() for c in WINDOWS_SHELL_ALLOWED_COMMANDS.split(",") if c.strip()}
+        forbidden = cmds & DANGEROUS_SHELL_WHITELIST_COMMANDS
+        assert not forbidden, (
+            f"Windows shell-execution whitelist contains forbidden commands: {sorted(forbidden)}. "
+            "These would let the caller bypass the whitelist."
+        )
+
+
+class TestDetectOsKind:
+    """`_detect_os_kind()` collapses platform.system() into the two buckets we ship for.
+
+    Why: WSL reports Linux, *BSD reports its own name; mcp-shell-server runs on POSIX
+    via uvx in all of those. Only Windows truly needs the cmd /c wrapper.
+    """
+
+    @pytest.mark.parametrize(
+        ("system_value", "expected"),
+        [
+            ("Linux", "unix"),
+            ("Darwin", "unix"),
+            ("FreeBSD", "unix"),
+            ("OpenBSD", "unix"),
+            ("Windows", "windows"),
+        ],
+    )
+    def test_should_return_expected_kind_when_platform_system_returns(self, monkeypatch, system_value, expected):
+        monkeypatch.setattr("platform.system", lambda: system_value)
+
+        assert _detect_os_kind() == expected

--- a/src/backend/tests/unit/api/utils/mcp/test_default_servers_registry.py
+++ b/src/backend/tests/unit/api/utils/mcp/test_default_servers_registry.py
@@ -1,137 +1,45 @@
-"""Tests for the default MCP servers registry (specs and per-OS configurations)."""
+"""Tests for the default MCP servers registry."""
 
-import pytest
-from langflow.api.utils.mcp.default_servers import _detect_os_kind
-from langflow.api.utils.mcp.default_servers_specs import (
-    DEFAULT_MCP_SERVERS,
-    UNIX_SHELL_ALLOWED_COMMANDS,
-    WINDOWS_SHELL_ALLOWED_COMMANDS,
-)
+from langflow.api.utils.mcp.default_servers_specs import DEFAULT_MCP_SERVERS
 from langflow.api.v2.schemas import MCPServerConfig
 
-# Commands that, if reachable from the shell server's whitelist, would defeat the
-# purpose of having a whitelist (they let the caller execute anything else).
-DANGEROUS_SHELL_WHITELIST_COMMANDS = frozenset(
-    {
-        "bash",
-        "sh",
-        "zsh",
-        "fish",
-        "ksh",
-        "csh",
-        "tcsh",
-        "python",
-        "python3",
-        "node",
-        "perl",
-        "ruby",
-        "php",
-        "eval",
-        "exec",
-        "sudo",
-        "su",
-        "doas",
-        "curl",
-        "wget",
-        "ssh",
-        "scp",
-        "rsync",
-        "rm",
-        "mv",
-        "dd",
-        "chmod",
-        "chown",
-        "kill",
-        "pkill",
-        "killall",
-        "powershell",
-        "pwsh",
-        "cmd",
-        "cscript",
-        "wscript",
-        "regedit",
-        "reg",
-    }
-)
 
+class TestShellExecutionUsesDesktopCommander:
+    """The `shell-execution` slot is backed by wonderwhy-er/desktop-commander.
 
-class TestUnixShellDefaultSpec:
-    def test_unix_shell_default_spec_passes_mcp_server_config_validation(self):
-        """The Unix shell-execution spec must satisfy the production Pydantic validator.
+    Why: the previous provider (tumf/mcp-shell-server) was POSIX-only via `import pwd`
+    and silently broke on Windows even though our config validator accepted the spec.
+    DesktopCommander is cross-platform via `npx`, with explicit Windows support. The
+    slot name remains `shell-execution` — capability stays stable, provider can swap.
+    """
 
-        Why: defends against a future commit dropping a forbidden command/arg/env into
-        the registry — the registry is internal but still re-validated as defense in depth.
+    def test_shell_execution_spec_launches_desktop_commander_via_npx_yes(self):
+        spec = DEFAULT_MCP_SERVERS["shell-execution"]
+
+        assert spec.config.command == "npx"
+        assert list(spec.config.args) == ["-y", "@wonderwhy-er/desktop-commander@latest"]
+        assert spec.config.env == {}
+
+    def test_shell_execution_spec_passes_mcp_server_config_validation(self):
+        """Defense-in-depth: registry payload must clear the production Pydantic validator.
+
+        Exercises the package-allowlisted -y exception in validate_yes_flag_pattern.
         """
         spec = DEFAULT_MCP_SERVERS["shell-execution"]
         payload = {
-            "command": spec.unix.command,
-            "args": list(spec.unix.args),
-            "env": dict(spec.unix.env),
+            "command": spec.config.command,
+            "args": list(spec.config.args),
+            "env": dict(spec.config.env),
         }
 
         MCPServerConfig.model_validate(payload)
 
-
-class TestWindowsShellDefaultSpec:
-    def test_windows_shell_default_spec_passes_mcp_server_config_validation(self):
-        """The Windows shell-execution spec must satisfy the production Pydantic validator.
-
-        Why: Windows requires the `cmd /c uvx ...` wrapper pattern; that wrapper must
-        survive validate_command + validate_shell_wrapper_args without raising.
+    def test_shell_execution_spec_declares_60s_startup_timeout(self):
+        """Slice E5: first-run of `npx -y @wonderwhy-er/desktop-commander@latest` can
+        take 30–90s while npm downloads the package + deps. The global default is
+        20s; the spec opts into a 60s startup timeout so the first user click
+        doesn't time out.
         """
         spec = DEFAULT_MCP_SERVERS["shell-execution"]
-        payload = {
-            "command": spec.windows.command,
-            "args": list(spec.windows.args),
-            "env": dict(spec.windows.env),
-        }
 
-        MCPServerConfig.model_validate(payload)
-
-
-class TestShellWhitelistsAreSafe:
-    """Audits the shell server's per-OS allowed-commands list.
-
-    The mcp-shell-server enforces ALLOW_COMMANDS at runtime; if we ship a whitelist
-    that reintroduces a shell or interpreter, the user effectively gets arbitrary
-    execution. These tests are the durable spec of "what may never be in defaults".
-    """
-
-    def test_unix_allow_commands_does_not_contain_shell_or_eval(self):
-        cmds = {c.strip() for c in UNIX_SHELL_ALLOWED_COMMANDS.split(",") if c.strip()}
-        forbidden = cmds & DANGEROUS_SHELL_WHITELIST_COMMANDS
-        assert not forbidden, (
-            f"Unix shell-execution whitelist contains forbidden commands: {sorted(forbidden)}. "
-            "These would let the caller bypass the whitelist."
-        )
-
-    def test_windows_allow_commands_does_not_contain_shell_or_eval(self):
-        cmds = {c.strip() for c in WINDOWS_SHELL_ALLOWED_COMMANDS.split(",") if c.strip()}
-        forbidden = cmds & DANGEROUS_SHELL_WHITELIST_COMMANDS
-        assert not forbidden, (
-            f"Windows shell-execution whitelist contains forbidden commands: {sorted(forbidden)}. "
-            "These would let the caller bypass the whitelist."
-        )
-
-
-class TestDetectOsKind:
-    """`_detect_os_kind()` collapses platform.system() into the two buckets we ship for.
-
-    Why: WSL reports Linux, *BSD reports its own name; mcp-shell-server runs on POSIX
-    via uvx in all of those. Only Windows truly needs the cmd /c wrapper.
-    """
-
-    @pytest.mark.parametrize(
-        ("system_value", "expected"),
-        [
-            ("Linux", "unix"),
-            ("Darwin", "unix"),
-            ("FreeBSD", "unix"),
-            ("OpenBSD", "unix"),
-            ("Windows", "windows"),
-        ],
-    )
-    def test_should_return_expected_kind_when_platform_system_returns(self, monkeypatch, system_value, expected):
-        monkeypatch.setattr("platform.system", lambda: system_value)
-
-        assert _detect_os_kind() == expected
+        assert spec.startup_timeout_seconds == 60

--- a/src/backend/tests/unit/api/utils/mcp/test_default_servers_registry.py
+++ b/src/backend/tests/unit/api/utils/mcp/test_default_servers_registry.py
@@ -35,10 +35,12 @@ class TestShellExecutionUsesDesktopCommander:
         MCPServerConfig.model_validate(payload)
 
     def test_shell_execution_spec_declares_60s_startup_timeout(self):
-        """Slice E5: first-run of `npx -y @wonderwhy-er/desktop-commander@latest` can
-        take 30–90s while npm downloads the package + deps. The global default is
-        20s; the spec opts into a 60s startup timeout so the first user click
-        doesn't time out.
+        """Slice E5: spec opts into a 60s startup timeout for first-run.
+
+        First-run of `npx -y @wonderwhy-er/desktop-commander@latest` can take
+        30-90s while npm downloads the package + deps. The global default is
+        20s; the per-spec override avoids first-click timeouts without raising
+        the global default for every other server.
         """
         spec = DEFAULT_MCP_SERVERS["shell-execution"]
 

--- a/src/backend/tests/unit/api/v2/test_mcp_server_config_npx_yes.py
+++ b/src/backend/tests/unit/api/v2/test_mcp_server_config_npx_yes.py
@@ -1,0 +1,154 @@
+"""Validator behavior around `npx -y <package>` patterns.
+
+Why this exists: the default `shell-execution` MCP server is now backed by
+`wonderwhy-er/desktop-commander`, which is an npm package distributed via npx.
+Launching it requires `npx -y @wonderwhy-er/desktop-commander@latest` — but
+`-y`/`--yes` was previously rejected by the validator as a dangerous keyword.
+
+We replace that blanket rejection with a strict, package-allowlisted exception:
+`-y`/`--yes` is allowed iff the rest of the invocation matches
+`npx -y <pkg-on-allowlist>`, either directly or inside an approved shell-wrapper.
+
+Every other usage of `-y`/`--yes` MUST continue to be rejected. These tests
+cover both the new accepts and every regression vector we audited.
+"""
+
+import pytest
+from langflow.api.v2.schemas import MCPServerConfig
+from pydantic import ValidationError
+
+# Pinned name strings of the only npm packages we ship as default MCP servers
+# that legitimately require `npx -y` to launch.
+APPROVED_PKG = "@wonderwhy-er/desktop-commander@latest"
+APPROVED_PKG_NO_TAG = "@wonderwhy-er/desktop-commander"
+DISALLOWED_PKG = "@evil/random-pkg"
+
+
+class TestAcceptsApprovedNpxYesPattern:
+    def test_should_accept_npx_yes_with_allowed_package(self):
+        """Slice A1: the canonical launch path for desktop-commander must validate."""
+        MCPServerConfig.model_validate({"command": "npx", "args": ["-y", APPROVED_PKG]})
+
+
+class TestRejectsDisallowedPackage:
+    def test_should_reject_when_npx_yes_targets_disallowed_package(self):
+        """Slice A2 / Threat T1: bypass via arbitrary npm package must fail.
+
+        The whole point of the allowlist is that `-y` is meaningful only for the
+        specific packages we ship — never as a generic escape hatch.
+        """
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "npx", "args": ["-y", DISALLOWED_PKG]})
+
+
+class TestAcceptsDoubleDashYesVariant:
+    def test_should_accept_npx_double_dash_yes_with_allowed_package(self):
+        """Slice A3: --yes is the long-form alias of -y; must be treated identically."""
+        MCPServerConfig.model_validate({"command": "npx", "args": ["--yes", APPROVED_PKG]})
+
+    def test_should_reject_npx_double_dash_yes_with_disallowed_package(self):
+        """Slice A3 / Threat T1: same allowlist enforcement applies to --yes."""
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "npx", "args": ["--yes", DISALLOWED_PKG]})
+
+
+class TestRejectsYesFlagOutsideNpx:
+    def test_should_reject_yes_flag_with_python_command(self):
+        """Slice A4 / Threat T3: -y must never be allowed for Python (or any non-npx)."""
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "python", "args": ["-y", "anything"]})
+
+    def test_should_reject_yes_flag_with_bash_command_no_dash_c(self):
+        """Slice A5 / Threat T3: bare -y rejected on bash without -c.
+
+        Bash without -c is not a shell-wrapper context; a bare -y in args is
+        rejected the same as for python.
+        """
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "bash", "args": ["-y", "anything"]})
+
+
+class TestRejectsBareYesFlag:
+    def test_should_reject_bare_yes_flag_with_npx(self):
+        """Slice A6 / Threat T9: 'npx -y' alone (no package) must fail."""
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "npx", "args": ["-y"]})
+
+
+class TestRejectsWrongOrder:
+    def test_should_reject_when_yes_flag_does_not_precede_package(self):
+        """Slice A7 / Threat T4: ['<pkg>', '-y'] must fail — strict ordering."""
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "npx", "args": [APPROVED_PKG, "-y"]})
+
+    def test_should_reject_when_extra_args_follow_npx_yes_pkg(self):
+        """Slice A7 / Threat T8: trailing args must be rejected (length must be exactly 2)."""
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "npx", "args": ["-y", APPROVED_PKG, "--extra"]})
+
+
+class TestShellWrapperAcceptsApprovedNpxYes:
+    """Shell-wrapper variants must work too — Windows uses cmd /c, Unix uses sh -c.
+
+    The wrapped command is a single quoted string carrying `npx -y <approved-pkg>`.
+    """
+
+    def test_should_accept_sh_dash_c_with_npx_yes_approved_package(self):
+        """Slice A8: legitimate Unix-style wrapper invocation."""
+        MCPServerConfig.model_validate({"command": "sh", "args": ["-c", f"npx -y {APPROVED_PKG}"]})
+
+    def test_should_accept_bash_dash_c_with_npx_yes_approved_package(self):
+        """Slice A8: bash flavor of the same."""
+        MCPServerConfig.model_validate({"command": "bash", "args": ["-c", f"npx -y {APPROVED_PKG}"]})
+
+    def test_should_accept_cmd_slash_c_with_npx_yes_approved_package(self):
+        """Slice A10: Windows-style wrapper invocation."""
+        MCPServerConfig.model_validate({"command": "cmd", "args": ["/c", f"npx -y {APPROVED_PKG}"]})
+
+
+class TestShellWrapperRejectsLoophole:
+    """Closes the historical shell-wrapper loophole.
+
+    The previous validator inspected wrapper args as a single string and never
+    tokenized the wrapped command. Threat T2: attacker chooses any npm package
+    and quotes it inside the wrapped string. Current behavior: passes because
+    the whole string '-y <pkg>' is one arg and never matches DANGEROUS_KEYWORDS
+    by exact equality. After fix: tokenize the wrapped string with shlex and
+    re-apply the npx-yes pattern check.
+    """
+
+    def test_should_reject_sh_dash_c_with_npx_yes_disallowed_package(self):
+        """Slice A9: the canonical loophole — wrapped npx -y of any package."""
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "sh", "args": ["-c", f"npx -y {DISALLOWED_PKG}"]})
+
+    def test_should_reject_bash_dash_c_with_npx_yes_disallowed_package(self):
+        """Slice A9: bash variant."""
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "bash", "args": ["-c", f"npx -y {DISALLOWED_PKG}"]})
+
+    def test_should_reject_cmd_slash_c_with_npx_yes_disallowed_package(self):
+        """Slice A9: Windows variant."""
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "cmd", "args": ["/c", f"npx -y {DISALLOWED_PKG}"]})
+
+
+class TestRejectsStrayYesFlagInShellWrapper:
+    """Threat T5: -y must not appear loose in shell-wrapper args.
+
+    The wrapped command (single string after -c/'/c') is the ONLY place where
+    -y can legitimately appear, and only when it sits inside the approved npx
+    pattern. Tests use a wrapped command that itself passes existing checks
+    (`npx <pkg>`) so the rejection must come from the new top-level guard,
+    not from collateral protection.
+    """
+
+    def test_should_reject_stray_yes_flag_after_wrapped_command(self):
+        """Slice A11: -y is the third arg, outside the wrapped command string."""
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "sh", "args": ["-c", f"npx {APPROVED_PKG}", "-y"]})
+
+    def test_should_reject_stray_double_dash_yes_after_wrapped_command(self):
+        """Slice A11: same with --yes."""
+        with pytest.raises(ValidationError):
+            MCPServerConfig.model_validate({"command": "cmd", "args": ["/c", f"npx {APPROVED_PKG}", "--yes"]})

--- a/src/backend/tests/unit/base/mcp/test_mcp_per_server_timeout.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_per_server_timeout.py
@@ -1,0 +1,103 @@
+"""Tests for per-server startup timeout in MCP stdio connections.
+
+Why this exists: some MCP servers we ship as defaults (notably
+`@wonderwhy-er/desktop-commander` via `npx -y`) take 30-90s on the very first
+launch because npm has to download the package + dependencies. The global
+`mcp_server_timeout` (default 20s) is too tight for first-run, but we don't
+want to raise it globally — that would degrade UX for legitimate failures.
+
+The fix: `MCPStdioClient.connect_to_server` accepts an optional `timeout=`
+override; `update_tools` reads `server_config["metadata"]["startup_timeout_seconds"]`
+and passes it. Default-server registry entries can opt in via a spec field.
+
+This file covers the wiring; the registry side lives in
+`tests/unit/api/utils/mcp/test_default_servers_registry.py`.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from lfx.base.mcp.util import MCPStdioClient, update_tools
+
+
+class TestMcpStdioClientAcceptsCustomTimeout:
+    async def test_should_use_custom_timeout_when_provided(self):
+        """Slice E1: explicit timeout= overrides the global setting."""
+        client = MCPStdioClient()
+
+        captured: dict[str, float | None] = {"timeout": None}
+
+        async def _capturing_wait_for(coro, *, timeout):
+            captured["timeout"] = timeout
+            # Drain the coroutine so we don't leak a warning.
+            coro.close()
+            return []
+
+        with (
+            patch("lfx.base.mcp.util.asyncio.wait_for", new=_capturing_wait_for),
+            patch.object(client, "_connect_to_server", new=AsyncMock(return_value=[])),
+        ):
+            await client.connect_to_server("echo hi", timeout=2.5)
+
+        assert captured["timeout"] == pytest.approx(2.5)
+
+    async def test_should_fall_back_to_global_when_timeout_none(self):
+        """Slice E3 / regression: omitting timeout preserves the historical default."""
+        from lfx.services.deps import get_settings_service
+
+        client = MCPStdioClient()
+        global_timeout = float(get_settings_service().settings.mcp_server_timeout)
+
+        captured: dict[str, float | None] = {"timeout": None}
+
+        async def _capturing_wait_for(coro, *, timeout):
+            captured["timeout"] = timeout
+            coro.close()
+            return []
+
+        with (
+            patch("lfx.base.mcp.util.asyncio.wait_for", new=_capturing_wait_for),
+            patch.object(client, "_connect_to_server", new=AsyncMock(return_value=[])),
+        ):
+            await client.connect_to_server("echo hi")
+
+        assert captured["timeout"] == pytest.approx(global_timeout)
+
+
+class TestUpdateToolsPropagatesPerServerTimeout:
+    async def test_should_pass_metadata_startup_timeout_to_connect(self):
+        """Slice E2: the orchestrator stamps timeout in metadata; update_tools forwards it."""
+        mock_stdio = AsyncMock(spec=MCPStdioClient)
+        mock_stdio.connect_to_server.return_value = []
+        mock_stdio._connected = True
+
+        server_config = {
+            "command": "npx",
+            "args": ["-y", "@wonderwhy-er/desktop-commander@latest"],
+            "env": {},
+            "metadata": {"startup_timeout_seconds": 60},
+        }
+
+        await update_tools("test-server", server_config, mcp_stdio_client=mock_stdio)
+
+        # connect_to_server should have been called with timeout=60 (kwarg).
+        kwargs = mock_stdio.connect_to_server.call_args.kwargs
+        assert kwargs.get("timeout") == 60
+
+    async def test_should_omit_timeout_when_metadata_field_absent(self):
+        """Slice E3: legacy server configs without metadata stay on the global default."""
+        mock_stdio = AsyncMock(spec=MCPStdioClient)
+        mock_stdio.connect_to_server.return_value = []
+        mock_stdio._connected = True
+
+        server_config = {
+            "command": "uvx",
+            "args": ["mcp-proxy", "http://localhost:7860/api/v1/mcp/sse"],
+            "env": {},
+        }
+
+        await update_tools("legacy-server", server_config, mcp_stdio_client=mock_stdio)
+
+        kwargs = mock_stdio.connect_to_server.call_args.kwargs
+        # Either omitted entirely or explicitly None — both mean "fall back to global".
+        assert kwargs.get("timeout") is None

--- a/src/backend/tests/unit/base/mcp/test_mcp_stdio_env_passthrough.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_stdio_env_passthrough.py
@@ -1,0 +1,198 @@
+"""Tests for OS-essential env var passthrough in MCP stdio connections.
+
+Why this exists: child MCP servers (notably `@wonderwhy-er/desktop-commander`)
+call Node's `os.homedir()` at module load. On Windows, `os.homedir()` reads
+`USERPROFILE` (or `HOMEDRIVE`+`HOMEPATH`); on Unix it reads `HOME` first and
+only then falls back to a `getpwuid()` lookup.
+
+Before this fix, `MCPStdioClient._connect_to_server` passed only `{DEBUG, PATH}`
+into the subprocess env. On Windows that left `os.homedir()` returning `null`,
+which then crashed any server that built paths from `path.join(USER_HOME, ...)`.
+The MCP SDK then surfaced the crash as an opaque "Connection closed" /
+TaskGroup sub-exception — same error users saw for the shell-execution server.
+
+This file pins the curated passthrough so the next person who tightens the env
+list doesn't accidentally re-strip `USERPROFILE` / `HOME` and resurrect the
+Windows bug.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from lfx.base.mcp.util import MCPStdioClient
+
+
+@pytest.fixture
+def stdio_client():
+    return MCPStdioClient()
+
+
+async def _connect_capturing_env(client: MCPStdioClient, *, command: str = "echo hi") -> dict[str, str]:
+    """Capture the env dict the StdioServerParameters was built with.
+
+    Drives `_connect_to_server` far enough that StdioServerParameters is built,
+    then returns the env dict — without launching a subprocess.
+    """
+    with patch.object(
+        client,
+        "_get_or_create_session",
+        new=AsyncMock(return_value=SimpleNamespace(list_tools=AsyncMock(return_value=SimpleNamespace(tools=[])))),
+    ):
+        await client._connect_to_server(command)
+    return dict(client._connection_params.env)
+
+
+class TestWindowsEnvPassthrough:
+    """When the host is Windows, `USERPROFILE` etc must reach the child."""
+
+    async def test_should_pass_userprofile_when_present_on_windows(self, stdio_client):
+        with (
+            patch("lfx.base.mcp.util.platform.system", return_value="Windows"),
+            patch.dict(
+                "os.environ",
+                {"PATH": "C:/Windows", "USERPROFILE": r"C:\Users\test"},
+                clear=True,
+            ),
+        ):
+            env = await _connect_capturing_env(stdio_client)
+        assert env.get("USERPROFILE") == r"C:\Users\test"
+
+    async def test_should_pass_homedrive_and_homepath_fallbacks_on_windows(self, stdio_client):
+        """`os.homedir()` falls back to HOMEDRIVE+HOMEPATH when USERPROFILE is absent."""
+        with (
+            patch("lfx.base.mcp.util.platform.system", return_value="Windows"),
+            patch.dict(
+                "os.environ",
+                {"PATH": "C:/Windows", "HOMEDRIVE": "C:", "HOMEPATH": r"\Users\test"},
+                clear=True,
+            ),
+        ):
+            env = await _connect_capturing_env(stdio_client)
+        assert env.get("HOMEDRIVE") == "C:"
+        assert env.get("HOMEPATH") == r"\Users\test"
+
+    async def test_should_pass_appdata_and_temp_on_windows(self, stdio_client):
+        with (
+            patch("lfx.base.mcp.util.platform.system", return_value="Windows"),
+            patch.dict(
+                "os.environ",
+                {
+                    "PATH": "C:/Windows",
+                    "APPDATA": r"C:\Users\test\AppData\Roaming",
+                    "LOCALAPPDATA": r"C:\Users\test\AppData\Local",
+                    "TEMP": r"C:\Users\test\AppData\Local\Temp",
+                    "TMP": r"C:\Users\test\AppData\Local\Temp",
+                },
+                clear=True,
+            ),
+        ):
+            env = await _connect_capturing_env(stdio_client)
+        assert env.get("APPDATA", "").endswith("Roaming")
+        assert env.get("LOCALAPPDATA", "").endswith("Local")
+        assert env.get("TEMP", "").endswith("Temp")
+        assert env.get("TMP", "").endswith("Temp")
+
+    async def test_should_pass_pathext_so_cmd_resolves_npx_cmd_on_windows(self, stdio_client):
+        """Without PATHEXT, `cmd /c npx ...` can't find `npx.cmd` in PATH."""
+        with (
+            patch("lfx.base.mcp.util.platform.system", return_value="Windows"),
+            patch.dict(
+                "os.environ",
+                {"PATH": "C:/Windows", "PATHEXT": ".COM;.EXE;.BAT;.CMD"},
+                clear=True,
+            ),
+        ):
+            env = await _connect_capturing_env(stdio_client)
+        assert ".CMD" in env.get("PATHEXT", "")
+
+    async def test_should_omit_windows_vars_when_absent_from_host_environ(self, stdio_client):
+        """Only forward what's actually present.
+
+        If the host doesn't have a Windows var (e.g. running tests on Unix),
+        we don't fabricate one.
+        """
+        with (
+            patch("lfx.base.mcp.util.platform.system", return_value="Windows"),
+            patch.dict("os.environ", {"PATH": "C:/Windows"}, clear=True),
+        ):
+            env = await _connect_capturing_env(stdio_client)
+        assert "USERPROFILE" not in env
+        assert "APPDATA" not in env
+
+
+class TestUnixEnvPassthrough:
+    """Forward Unix-essential env vars to the subprocess.
+
+    On Unix, `HOME` falls back to `getpwuid()` but many tools still read it
+    from env first. Forwarding it avoids per-tool quirks.
+    """
+
+    async def test_should_pass_home_when_present_on_unix(self, stdio_client):
+        with (
+            patch("lfx.base.mcp.util.platform.system", return_value="Linux"),
+            patch.dict("os.environ", {"PATH": "/usr/bin", "HOME": "/home/test"}, clear=True),
+        ):
+            env = await _connect_capturing_env(stdio_client)
+        assert env.get("HOME") == "/home/test"
+
+    async def test_should_pass_lang_for_locale_aware_tools_on_unix(self, stdio_client):
+        with (
+            patch("lfx.base.mcp.util.platform.system", return_value="Darwin"),
+            patch.dict(
+                "os.environ",
+                {"PATH": "/usr/bin", "HOME": "/Users/test", "LANG": "en_US.UTF-8"},
+                clear=True,
+            ),
+        ):
+            env = await _connect_capturing_env(stdio_client)
+        assert env.get("LANG") == "en_US.UTF-8"
+
+    async def test_should_not_pass_windows_vars_when_running_on_unix(self, stdio_client):
+        """Windows-only vars must not bleed through on Unix hosts."""
+        with (
+            patch("lfx.base.mcp.util.platform.system", return_value="Linux"),
+            patch.dict(
+                "os.environ",
+                {"PATH": "/usr/bin", "HOME": "/h", "USERPROFILE": "should-not-leak"},
+                clear=True,
+            ),
+        ):
+            env = await _connect_capturing_env(stdio_client)
+        assert "USERPROFILE" not in env
+
+
+class TestUserSuppliedEnvWins:
+    """User-supplied env (from server config) must override host passthrough."""
+
+    async def test_should_let_user_env_override_passthrough_value(self, stdio_client):
+        with (
+            patch("lfx.base.mcp.util.platform.system", return_value="Linux"),
+            patch.dict(
+                "os.environ",
+                {"PATH": "/usr/bin", "HOME": "/host/home"},
+                clear=True,
+            ),
+            patch.object(
+                stdio_client,
+                "_get_or_create_session",
+                new=AsyncMock(
+                    return_value=SimpleNamespace(list_tools=AsyncMock(return_value=SimpleNamespace(tools=[])))
+                ),
+            ),
+        ):
+            await stdio_client._connect_to_server("echo hi", env={"HOME": "/user/override"})
+        assert dict(stdio_client._connection_params.env).get("HOME") == "/user/override"
+
+
+class TestLegacyEnvKeysPreserved:
+    """Don't drop keys the previous behavior guaranteed (avoids silent regressions)."""
+
+    async def test_should_still_pass_path_and_debug(self, stdio_client):
+        with (
+            patch("lfx.base.mcp.util.platform.system", return_value="Linux"),
+            patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
+        ):
+            env = await _connect_capturing_env(stdio_client)
+        assert env.get("PATH") == "/usr/bin"
+        assert env.get("DEBUG") == "true"

--- a/src/backend/tests/unit/test_mcp_command_injection_security.py
+++ b/src/backend/tests/unit/test_mcp_command_injection_security.py
@@ -396,20 +396,25 @@ class TestMCPCommandInjectionSecurity:
     # ==================== Npx/Uvx Auto-Install Prevention ====================
 
     def test_npx_auto_install_flag_rejected(self):
-        """Test that npx -y (auto-install) flag is rejected."""
+        """Test that npx -y is rejected for packages outside the explicit allowlist.
+
+        Note: -y is now governed by ALLOWED_NPX_YES_PACKAGES (see schemas.py).
+        The behavior — reject malicious package — is preserved; the error message
+        wording changed to be more specific about the allowlist.
+        """
         with pytest.raises(ValidationError) as exc_info:
             MCPServerConfig(command="npx", args=["-y", "@malicious/package"])
 
-        error_msg = str(exc_info.value)
-        assert "not allowed" in error_msg.lower()
+        error_msg = str(exc_info.value).lower()
+        assert "only allowed" in error_msg or "not allowed" in error_msg
 
     def test_npx_yes_flag_rejected(self):
-        """Test that npx --yes (auto-install) flag is rejected."""
+        """Test that npx --yes is rejected for packages outside the explicit allowlist."""
         with pytest.raises(ValidationError) as exc_info:
             MCPServerConfig(command="npx", args=["--yes", "@malicious/package"])
 
-        error_msg = str(exc_info.value)
-        assert "not allowed" in error_msg.lower()
+        error_msg = str(exc_info.value).lower()
+        assert "only allowed" in error_msg or "not allowed" in error_msg
 
     # ==================== Subshell Metacharacter Tests ====================
 

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1547,6 +1547,73 @@ class MCPSessionManager:
                 self._context_to_session.pop(context_id, None)
 
 
+# OS-essential env vars to forward into MCP stdio subprocesses.
+#
+# Why this list exists: Node-based MCP servers (e.g. `@wonderwhy-er/desktop-commander`)
+# call `os.homedir()` at module load. On Windows that reads `USERPROFILE` (or the
+# `HOMEDRIVE`+`HOMEPATH` fallback); when the var is missing the call returns
+# `null` and any `path.join(homedir, ...)` blows up — surfacing to MCP clients
+# as an opaque "Connection closed" / TaskGroup sub-exception. The same is true
+# of locale, temp-dir, and shell-related vars for other server families.
+#
+# Why not pass `os.environ` wholesale: the parent Langflow process may carry
+# secrets (AWS_*, GITHUB_TOKEN, OPENAI_API_KEY, ...) that have no business
+# being inherited by an arbitrary MCP server subprocess. We curate.
+#
+# User-supplied env (from server config) still wins via merge order.
+_PASSTHROUGH_ENV_VARS_WINDOWS: tuple[str, ...] = (
+    # `os.homedir()` lookup chain on Windows.
+    "USERPROFILE",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    # Per-user app data directories — many MCP servers store config here.
+    "APPDATA",
+    "LOCALAPPDATA",
+    # Temp dirs — required by tools that spawn helper subprocesses.
+    "TEMP",
+    "TMP",
+    # Required for `cmd /c` and child Win32 APIs.
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "WINDIR",
+    "COMSPEC",
+    # Without PATHEXT, `cmd /c npx ...` cannot resolve `npx.cmd` from PATH.
+    "PATHEXT",
+)
+_PASSTHROUGH_ENV_VARS_UNIX: tuple[str, ...] = (
+    # `os.homedir()` reads HOME first; getpwuid() is only the fallback.
+    "HOME",
+    "USER",
+    "LOGNAME",
+    # Shell-aware tools.
+    "SHELL",
+    "TERM",
+    "TMPDIR",
+    # Locale — affects text encoding, sort order, error messages.
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+)
+
+
+def _build_subprocess_env(user_env: dict[str, str] | None) -> dict[str, str]:
+    """Build the env dict passed to MCP stdio subprocesses.
+
+    Always-set keys: ``DEBUG=true`` (legacy) and ``PATH`` (so tools resolve).
+    Forwarded if present in the parent env: a curated list of OS-essential
+    vars (``USERPROFILE`` etc on Windows, ``HOME`` etc on Unix). Anything in
+    ``user_env`` overrides everything else.
+    """
+    passthrough = _PASSTHROUGH_ENV_VARS_WINDOWS if platform.system() == "Windows" else _PASSTHROUGH_ENV_VARS_UNIX
+    env: dict[str, str] = {"DEBUG": "true", "PATH": os.environ.get("PATH", "")}
+    for var in passthrough:
+        if var in os.environ:
+            env[var] = os.environ[var]
+    if user_env:
+        env.update(user_env)
+    return env
+
+
 class MCPStdioClient:
     def __init__(self, component_cache=None):
         self.session: ClientSession | None = None
@@ -1576,7 +1643,7 @@ class MCPStdioClient:
         from mcp import StdioServerParameters
 
         command = shlex.split(command_str)
-        env_data: dict[str, str] = {"DEBUG": "true", "PATH": os.environ["PATH"], **(env or {})}
+        env_data: dict[str, str] = _build_subprocess_env(env)
 
         if platform.system() == "Windows":
             server_params = StdioServerParameters(

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1611,11 +1611,31 @@ class MCPStdioClient:
         self._connected = True
         return response.tools
 
-    async def connect_to_server(self, command_str: str, env: dict[str, str] | None = None) -> list[StructuredTool]:
-        """Connect to MCP server using stdio transport (SDK style)."""
-        return await asyncio.wait_for(
-            self._connect_to_server(command_str, env), timeout=get_settings_service().settings.mcp_server_timeout
-        )
+    async def connect_to_server(
+        self,
+        command_str: str,
+        env: dict[str, str] | None = None,
+        *,
+        timeout: float | None = None,  # noqa: ASYNC109
+    ) -> list[StructuredTool]:
+        """Connect to MCP server using stdio transport (SDK style).
+
+        Args:
+            command_str: shell-quoted command line for the server process.
+            env: environment overrides forwarded to the subprocess.
+            timeout: optional per-server startup timeout in seconds. When ``None``
+                (the default) we fall back to ``settings.mcp_server_timeout``.
+                Used by default-server entries that legitimately need more than
+                the global default for first-run cases (e.g. ``npx -y`` packages
+                that download on first launch).
+
+        Why ``# noqa: ASYNC109``: ASYNC109 recommends ``anyio.fail_after`` over
+        a ``timeout`` parameter, but the rest of this module already uses
+        ``asyncio.wait_for(..., timeout=...)``; staying consistent matters more
+        than complying with that lint here.
+        """
+        resolved_timeout = float(timeout) if timeout is not None else get_settings_service().settings.mcp_server_timeout
+        return await asyncio.wait_for(self._connect_to_server(command_str, env), timeout=resolved_timeout)
 
     def set_session_context(self, context_id: str):
         """Set the session context (e.g., flow_id + user_id + session_id)."""
@@ -2153,7 +2173,11 @@ async def update_tools(
                 else:
                     args.extend(extra_args)
         full_command = shlex.join([*shlex.split(command), *args])
-        tools = await mcp_stdio_client.connect_to_server(full_command, env)
+        # Per-server startup-timeout opt-in via metadata.startup_timeout_seconds.
+        # When absent, connect_to_server falls back to the global setting.
+        metadata = server_config.get("metadata") or {}
+        startup_timeout = metadata.get("startup_timeout_seconds")
+        tools = await mcp_stdio_client.connect_to_server(full_command, env, timeout=startup_timeout)
         client = mcp_stdio_client
     elif mode in ["Streamable_HTTP", "SSE"]:
         # Streamable HTTP connection with SSE fallback

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -356,6 +356,11 @@ class Settings(BaseSettings):
     mcp_composer_version: str = "==0.1.0.8.10"
     """Version constraint for mcp-composer when using uvx. Uses PEP 440 syntax."""
 
+    # Default MCP servers (shell-execution, ...) auto-installed for every user on startup.
+    enable_default_mcp_servers: bool = True
+    """If True, Langflow auto-configures a curated set of default MCP servers
+    (shell-execution, ...) for every user on startup. Set to False to opt-out."""
+
     # Agentic Experience
     agentic_experience: bool = False
     """If set to True, Langflow will start the agentic MCP server that provides tools for


### PR DESCRIPTION
## Objective                                                                                                                                        
Ship Langflow with a curated, registry-driven default MCP server (shell-execution) auto-configured for every user on startup, with per-OS command whitelists.                                                                                                                                         
   
## Changes                                                                                                                                          
  - Add `DEFAULT_MCP_SERVERS` registry and `auto_configure_default_mcp_servers` orchestrator with per-user idempotency, OS detection (unix vs
  windows), and Pydantic re-validation as defense-in-depth                                                                                            
  - Add `enable_default_mcp_servers` setting (env `LANGFLOW_ENABLE_DEFAULT_MCP_SERVERS`, default `true`) for opt-out
  - Add `enable_default_mcp_servers` setting (env `LANGFLOW_ENABLE_DEFAULT_MCP_SERVERS`, default `true`) for opt-out
  - Add `PreloadStep.DEFAULT_MCP_SERVERS` so multi-worker boots run the install once in master and skip in workers
  - Wire orchestrator into `main.py` lifespan and `preload._run_master_preload` mirroring the agentic MCP pattern
  - Add 24 unit tests (registry, orchestrator, preload) at 100% coverage on new files