### PR TITLE
feat(knowledge-base): KB row settings shortcut + ingestion history in Update modal

### DIFF
--- a/src/backend/base/langflow/api/v1/knowledge_bases.py
+++ b/src/backend/base/langflow/api/v1/knowledge_bases.py
@@ -1716,12 +1716,16 @@ def _run_row_to_info(row) -> IngestionRunInfo:
     key on their ``job_metadata`` blob.
     """
     user_metadata = getattr(row, "user_metadata", None) or {}
+    source_config = getattr(row, "source_config", None) or {}
+    raw_source_name = source_config.get("source_name")
+    source_name = raw_source_name.strip() if isinstance(raw_source_name, str) and raw_source_name.strip() else None
     return IngestionRunInfo(
         id=str(row.id),
         kb_name=row.kb_name,
         kb_id=str(row.kb_id) if row.kb_id else None,
         job_id=str(row.job_id) if row.job_id else None,
         source_type=row.source_type,
+        source_name=source_name,
         status=row.status,
         error_message=row.error_message,
         total_items=row.total_items,

--- a/src/backend/base/langflow/schema/knowledge_base.py
+++ b/src/backend/base/langflow/schema/knowledge_base.py
@@ -199,6 +199,9 @@ class IngestionRunInfo(BaseModel):
     kb_id: str | None = None
     job_id: str | None = None
     source_type: str
+    # User-supplied name typed at upload (or connector source_name).
+    # ``None`` for legacy runs that pre-date source_name capture.
+    source_name: str | None = None
     status: str
     error_message: str | None = None
     total_items: int = 0

--- a/src/backend/tests/unit/base/knowledge_bases/test_ingestion_run_endpoints.py
+++ b/src/backend/tests/unit/base/knowledge_bases/test_ingestion_run_endpoints.py
@@ -77,6 +77,7 @@ async def _insert_run(
     items: list[dict] | None = None,
     succeeded: int = 1,
     failed: int = 0,
+    source_config: dict | None = None,
 ) -> uuid.UUID:
     """Seed a ``Job`` row carrying KB ingestion-run data on its metadata.
 
@@ -115,7 +116,7 @@ async def _insert_run(
                 "kb_name": kb_name,
                 "kb_id": str(kb_id) if kb_id is not None else None,
                 "source_type": source_type,
-                "source_config": {"source_name": "demo"},
+                "source_config": {"source_name": "demo"} if source_config is None else source_config,
                 "status": status.value,
                 "error_message": None,
                 "total_items": succeeded + failed,
@@ -189,6 +190,41 @@ class TestListIngestionRuns:
         assert str(mine) in ids
         # Must not leak the other user's run even though kb_name matches
         assert str(foreign_run_id) not in ids
+
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
+    async def test_exposes_source_name_from_source_config(
+        self, mock_root, client: AsyncClient, logged_in_headers, active_user, tmp_path
+    ):
+        mock_root.return_value = tmp_path
+        kb_dir = tmp_path / active_user.username / "named_kb"
+        kb_dir.mkdir(parents=True)
+
+        await _insert_run(
+            user_id=active_user.id,
+            kb_name="named_kb",
+            source_config={"source_name": "Test6"},
+        )
+        await _insert_run(
+            user_id=active_user.id,
+            kb_name="named_kb",
+            source_config={},
+        )
+        await _insert_run(
+            user_id=active_user.id,
+            kb_name="named_kb",
+            source_config={"source_name": "   "},
+        )
+
+        response = await client.get(
+            "api/v1/knowledge_bases/named_kb/runs",
+            headers=logged_in_headers,
+        )
+        assert response.status_code == 200
+        names = [r["source_name"] for r in response.json()["runs"]]
+        # Order is newest-first: whitespace, missing, then "Test6".
+        assert "Test6" in names
+        # Whitespace-only collapses to ``None``.
+        assert names.count(None) == 2
 
     @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
     async def test_pagination(self, mock_root, client: AsyncClient, logged_in_headers, active_user, tmp_path):

--- a/src/frontend/src/controllers/API/queries/knowledge-bases/use-get-ingestion-runs.ts
+++ b/src/frontend/src/controllers/API/queries/knowledge-bases/use-get-ingestion-runs.ts
@@ -10,6 +10,7 @@ export interface IngestionRunInfo {
   kb_id: string | null;
   job_id: string | null;
   source_type: string;
+  source_name: string | null;
   status: string;
   error_message: string | null;
   total_items: number;

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/KnowledgeBaseUploadModal.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/KnowledgeBaseUploadModal.tsx
@@ -47,6 +47,7 @@ export default function KnowledgeBaseUploadModal({
         return (
           <StepConfiguration
             isAddSourcesMode={form.isAddSourcesMode}
+            kbName={existingKnowledgeBase?.name}
             sourceName={form.sourceName}
             onSourceNameChange={form.setSourceName}
             selectedEmbeddingModel={form.selectedEmbeddingModel}

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/__tests__/KnowledgeBaseUploadModal.test.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/__tests__/KnowledgeBaseUploadModal.test.tsx
@@ -24,6 +24,17 @@ jest.mock(
   }),
 );
 
+jest.mock(
+  "@/controllers/API/queries/knowledge-bases/use-get-ingestion-runs",
+  () => ({
+    useGetIngestionRuns: () => ({
+      data: { runs: [], total: 0, page: 1, limit: 10, total_pages: 0 },
+      isLoading: false,
+      isError: false,
+    }),
+  }),
+);
+
 const mockApiPost = jest.fn();
 jest.mock("@/controllers/API/api", () => ({
   api: { post: mockApiPost, get: jest.fn() },

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/IngestionHistoryPanel.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/IngestionHistoryPanel.tsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { useGetIngestionRuns } from "@/controllers/API/queries/knowledge-bases/use-get-ingestion-runs";
+import { cn } from "@/utils/utils";
+
+interface IngestionHistoryPanelProps {
+  kbName: string;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  succeeded: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  partial: "bg-amber-50 text-amber-700 border-amber-200",
+  failed: "bg-rose-50 text-rose-700 border-rose-200",
+  cancelled: "bg-slate-50 text-slate-600 border-slate-200",
+  running: "bg-sky-50 text-sky-700 border-sky-200",
+  pending: "bg-slate-50 text-slate-600 border-slate-200",
+};
+
+const SOURCE_TYPE_LABELS: Record<string, string> = {
+  file_upload: "File Upload",
+  folder: "Folder",
+  template: "Flow Template",
+  google_drive: "Google Drive",
+  s3: "AWS S3",
+  onedrive: "OneDrive",
+  sharepoint: "SharePoint",
+};
+
+const HISTORY_LIMIT = 10;
+
+function formatRelativeTime(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  const diffSec = Math.max(0, Math.floor((now - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
+  return `${Math.floor(diffSec / 86400)}d ago`;
+}
+
+export function IngestionHistoryPanel({ kbName }: IngestionHistoryPanelProps) {
+  const [expanded, setExpanded] = useState(true);
+  const { data, isLoading, isError } = useGetIngestionRuns(
+    { kb_name: kbName, page: 1, limit: HISTORY_LIMIT },
+    { staleTime: 0, refetchOnMount: "always" },
+  );
+
+  const total = data?.total ?? 0;
+  const runs = data?.runs ?? [];
+
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-md border border-border bg-muted/40 p-3"
+      data-testid="kb-ingestion-history-panel"
+    >
+      <button
+        type="button"
+        className="flex w-full items-center justify-between text-left"
+        onClick={() => setExpanded((v) => !v)}
+        data-testid="kb-ingestion-history-toggle"
+      >
+        <div className="flex items-center gap-2">
+          <ForwardedIconComponent
+            name="History"
+            className="h-4 w-4 text-muted-foreground"
+          />
+          <span className="text-sm font-medium">Previously ingested</span>
+          {total > 0 && (
+            <span className="text-xs text-muted-foreground">({total})</span>
+          )}
+        </div>
+        <ForwardedIconComponent
+          name={expanded ? "ChevronUp" : "ChevronDown"}
+          className="h-4 w-4 text-muted-foreground"
+        />
+      </button>
+
+      {expanded && (
+        <div
+          className={cn(
+            "flex flex-col gap-2",
+            runs.length > 0 && "max-h-[200px] overflow-y-auto pr-1",
+          )}
+        >
+          {isLoading && (
+            <div
+              className="text-xs text-muted-foreground"
+              data-testid="kb-ingestion-history-loading"
+            >
+              Loading history…
+            </div>
+          )}
+          {isError && !isLoading && (
+            <div className="text-xs text-rose-600">
+              Unable to load ingestion history.
+            </div>
+          )}
+          {!isLoading && !isError && runs.length === 0 && (
+            <div
+              className="text-xs text-muted-foreground"
+              data-testid="kb-ingestion-history-empty"
+            >
+              No sources ingested yet. The first upload will appear here.
+            </div>
+          )}
+          {runs.map((run) => {
+            const statusClass =
+              STATUS_STYLES[run.status] ?? STATUS_STYLES.pending;
+            const typeLabel =
+              SOURCE_TYPE_LABELS[run.source_type] ?? run.source_type;
+            const primaryLabel = run.source_name?.trim() || typeLabel;
+            const showTypeSubtitle = !!run.source_name?.trim();
+            return (
+              <div
+                key={run.id}
+                className="flex flex-col gap-1 rounded-md border border-border bg-background p-2"
+                data-testid="kb-ingestion-history-row"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 truncate">
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${statusClass}`}
+                    >
+                      {run.status}
+                    </span>
+                    <span
+                      className="truncate text-xs font-medium"
+                      data-testid="kb-ingestion-history-source-name"
+                    >
+                      {primaryLabel}
+                    </span>
+                    {showTypeSubtitle && (
+                      <span className="truncate text-[10px] text-muted-foreground">
+                        · {typeLabel}
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    {formatRelativeTime(run.started_at)}
+                  </span>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <ForwardedIconComponent
+                      name="CircleCheck"
+                      className="h-3 w-3 text-emerald-600"
+                    />
+                    {run.succeeded}
+                  </span>
+                  {run.failed > 0 && (
+                    <span className="flex items-center gap-1">
+                      <ForwardedIconComponent
+                        name="CircleAlert"
+                        className="h-3 w-3 text-rose-600"
+                      />
+                      {run.failed}
+                    </span>
+                  )}
+                  {run.skipped > 0 && (
+                    <span className="flex items-center gap-1">
+                      <ForwardedIconComponent
+                        name="CircleMinus"
+                        className="h-3 w-3 text-slate-500"
+                      />
+                      {run.skipped}
+                    </span>
+                  )}
+                  <span>·</span>
+                  <span>{run.chunks_created} chunks</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default IngestionHistoryPanel;

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
@@ -28,10 +28,12 @@ import type { GlobalVariable } from "@/types/global_variables";
 import { cn } from "@/utils/utils";
 import { ACCEPTED_FILE_TYPES } from "../constants";
 import type { ColumnConfigRow } from "../types";
+import { IngestionHistoryPanel } from "./IngestionHistoryPanel";
 import { MetadataEditor, type MetadataPair } from "./MetadataEditor";
 
 interface StepConfigurationProps {
   isAddSourcesMode: boolean;
+  kbName?: string;
   sourceName: string;
   onSourceNameChange: (value: string) => void;
   selectedEmbeddingModel: ModelOption[];
@@ -63,6 +65,7 @@ interface StepConfigurationProps {
 
 export function StepConfiguration({
   isAddSourcesMode,
+  kbName,
   sourceName,
   onSourceNameChange,
   selectedEmbeddingModel,
@@ -95,6 +98,11 @@ export function StepConfiguration({
   return (
     <div className="relative">
       <div className="flex flex-col">
+        {isAddSourcesMode && kbName && (
+          <div className="pb-4">
+            <IngestionHistoryPanel kbName={kbName} />
+          </div>
+        )}
         {/* Name */}
         <div className="flex flex-col gap-2">
           <Label htmlFor="source-name" className="text-sm font-medium">

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/__tests__/IngestionHistoryPanel.test.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/__tests__/IngestionHistoryPanel.test.tsx
@@ -1,0 +1,202 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name }: { name: string }) => (
+    <span data-testid={`icon-${name}`}>{name}</span>
+  ),
+}));
+
+const mockUseGetIngestionRuns = jest.fn();
+jest.mock(
+  "@/controllers/API/queries/knowledge-bases/use-get-ingestion-runs",
+  () => ({
+    useGetIngestionRuns: (...args: unknown[]) =>
+      mockUseGetIngestionRuns(...args),
+  }),
+);
+
+import { IngestionHistoryPanel } from "../IngestionHistoryPanel";
+
+const makeRun = (overrides = {}) => ({
+  id: "run-1",
+  kb_name: "my_kb",
+  kb_id: null,
+  job_id: null,
+  source_type: "file_upload",
+  source_name: null as string | null,
+  status: "succeeded",
+  error_message: null,
+  total_items: 3,
+  succeeded: 3,
+  failed: 0,
+  skipped: 0,
+  total_bytes: 1024,
+  chunks_created: 12,
+  started_at: new Date(Date.now() - 60_000).toISOString(),
+  finished_at: null,
+  ...overrides,
+});
+
+describe("IngestionHistoryPanel", () => {
+  beforeEach(() => {
+    mockUseGetIngestionRuns.mockReset();
+  });
+
+  it("shows empty state when no runs exist", () => {
+    mockUseGetIngestionRuns.mockReturnValue({
+      data: { runs: [], total: 0, page: 1, limit: 10, total_pages: 0 },
+      isLoading: false,
+      isError: false,
+    });
+    render(<IngestionHistoryPanel kbName="my_kb" />);
+    expect(
+      screen.getByTestId("kb-ingestion-history-empty"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockUseGetIngestionRuns.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+    render(<IngestionHistoryPanel kbName="my_kb" />);
+    expect(
+      screen.getByTestId("kb-ingestion-history-loading"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error state when fetch fails", () => {
+    mockUseGetIngestionRuns.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    render(<IngestionHistoryPanel kbName="my_kb" />);
+    expect(
+      screen.getByText("Unable to load ingestion history."),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to type label when source_name missing", () => {
+    mockUseGetIngestionRuns.mockReturnValue({
+      data: {
+        runs: [
+          makeRun({
+            id: "r1",
+            status: "succeeded",
+            source_type: "file_upload",
+            source_name: null,
+          }),
+          makeRun({
+            id: "r2",
+            status: "partial",
+            source_type: "google_drive",
+            source_name: null,
+          }),
+        ],
+        total: 2,
+        page: 1,
+        limit: 10,
+        total_pages: 1,
+      },
+      isLoading: false,
+      isError: false,
+    });
+    render(<IngestionHistoryPanel kbName="my_kb" />);
+    const rows = screen.getAllByTestId("kb-ingestion-history-row");
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText("File Upload")).toBeInTheDocument();
+    expect(screen.getByText("Google Drive")).toBeInTheDocument();
+    expect(screen.getByText("succeeded")).toBeInTheDocument();
+    expect(screen.getByText("partial")).toBeInTheDocument();
+  });
+
+  it("prefers user-typed source_name over type label, with type as subtitle", () => {
+    mockUseGetIngestionRuns.mockReturnValue({
+      data: {
+        runs: [
+          makeRun({
+            id: "r1",
+            source_type: "file_upload",
+            source_name: "Test6",
+          }),
+        ],
+        total: 1,
+        page: 1,
+        limit: 10,
+        total_pages: 1,
+      },
+      isLoading: false,
+      isError: false,
+    });
+    render(<IngestionHistoryPanel kbName="my_kb" />);
+    const sourceLabel = screen.getByTestId("kb-ingestion-history-source-name");
+    expect(sourceLabel).toHaveTextContent("Test6");
+    expect(screen.getByText("· File Upload")).toBeInTheDocument();
+  });
+
+  it("treats whitespace-only source_name as missing", () => {
+    mockUseGetIngestionRuns.mockReturnValue({
+      data: {
+        runs: [
+          makeRun({
+            id: "r1",
+            source_type: "file_upload",
+            source_name: "   ",
+          }),
+        ],
+        total: 1,
+        page: 1,
+        limit: 10,
+        total_pages: 1,
+      },
+      isLoading: false,
+      isError: false,
+    });
+    render(<IngestionHistoryPanel kbName="my_kb" />);
+    const sourceLabel = screen.getByTestId("kb-ingestion-history-source-name");
+    expect(sourceLabel).toHaveTextContent("File Upload");
+    expect(screen.queryByText("· File Upload")).not.toBeInTheDocument();
+  });
+
+  it("collapses and expands when header is toggled", async () => {
+    mockUseGetIngestionRuns.mockReturnValue({
+      data: {
+        runs: [makeRun()],
+        total: 1,
+        page: 1,
+        limit: 10,
+        total_pages: 1,
+      },
+      isLoading: false,
+      isError: false,
+    });
+    const user = userEvent.setup();
+    render(<IngestionHistoryPanel kbName="my_kb" />);
+
+    expect(screen.getByTestId("kb-ingestion-history-row")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("kb-ingestion-history-toggle"));
+
+    expect(
+      screen.queryByTestId("kb-ingestion-history-row"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls useGetIngestionRuns with kbName + fresh-data options", () => {
+    mockUseGetIngestionRuns.mockReturnValue({
+      data: { runs: [], total: 0, page: 1, limit: 10, total_pages: 0 },
+      isLoading: false,
+      isError: false,
+    });
+    render(<IngestionHistoryPanel kbName="my_kb" />);
+    expect(mockUseGetIngestionRuns).toHaveBeenCalledWith(
+      expect.objectContaining({ kb_name: "my_kb", page: 1, limit: 10 }),
+      expect.objectContaining({ staleTime: 0, refetchOnMount: "always" }),
+    );
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/config/__tests__/knowledgeBaseColumns.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/config/__tests__/knowledgeBaseColumns.test.tsx
@@ -160,7 +160,7 @@ describe("createKnowledgeBaseColumns", () => {
       const CellRenderer = getActionsRenderer({ onDelete });
       render(<CellRenderer data={makeKb({ status: "ready" })} />);
 
-      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByTestId("kb-row-actions-trigger"));
       await user.click(screen.getByText("Delete"));
       expect(onDelete).toHaveBeenCalledWith(
         expect.objectContaining({ dir_name: "my_kb" }),
@@ -173,7 +173,7 @@ describe("createKnowledgeBaseColumns", () => {
       const CellRenderer = getActionsRenderer({ onAddSources });
       render(<CellRenderer data={makeKb({ status: "ready" })} />);
 
-      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByTestId("kb-row-actions-trigger"));
       await user.click(screen.getByText("Update Knowledge"));
       expect(onAddSources).toHaveBeenCalledWith(
         expect.objectContaining({ dir_name: "my_kb" }),
@@ -186,7 +186,7 @@ describe("createKnowledgeBaseColumns", () => {
       const CellRenderer = getActionsRenderer({ onViewChunks });
       render(<CellRenderer data={makeKb({ status: "ready" })} />);
 
-      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByTestId("kb-row-actions-trigger"));
       await user.click(screen.getByText("View Chunks"));
       expect(onViewChunks).toHaveBeenCalledWith(
         expect.objectContaining({ dir_name: "my_kb" }),
@@ -198,7 +198,7 @@ describe("createKnowledgeBaseColumns", () => {
       const CellRenderer = getActionsRenderer({});
       render(<CellRenderer data={makeKb({ status: "ingesting" })} />);
 
-      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByTestId("kb-row-actions-trigger"));
       expect(screen.getByText("Stop Ingestion")).toBeInTheDocument();
       expect(screen.queryByText("Delete")).not.toBeInTheDocument();
     });
@@ -209,7 +209,7 @@ describe("createKnowledgeBaseColumns", () => {
       const CellRenderer = getActionsRenderer({ onStopIngestion });
       render(<CellRenderer data={makeKb({ status: "ingesting" })} />);
 
-      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByTestId("kb-row-actions-trigger"));
       await user.click(screen.getByText("Stop Ingestion"));
       expect(onStopIngestion).toHaveBeenCalledWith(
         expect.objectContaining({ dir_name: "my_kb" }),
@@ -221,11 +221,43 @@ describe("createKnowledgeBaseColumns", () => {
       const CellRenderer = getActionsRenderer({});
       render(<CellRenderer data={makeKb({ status: "ingesting" })} />);
 
-      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByTestId("kb-row-actions-trigger"));
       const updateItem = screen
         .getByText("Update Knowledge")
         .closest('[role="menuitem"]');
       expect(updateItem).toHaveAttribute("data-disabled");
+    });
+  });
+
+  describe("Row settings icon shortcut", () => {
+    const getActionsRenderer = (callbacks = {}) => {
+      const cols = createKnowledgeBaseColumns(callbacks);
+      return cols.find((c) => c.headerName === "")!
+        .cellRenderer as React.ComponentType<StatusCellRendererProps>;
+    };
+
+    it("renders the settings icon button on each row", () => {
+      const CellRenderer = getActionsRenderer({});
+      render(<CellRenderer data={makeKb({ status: "ready" })} />);
+      expect(screen.getByTestId("kb-row-update-button")).toBeInTheDocument();
+    });
+
+    it("calls onAddSources directly when settings icon is clicked", async () => {
+      const onAddSources = jest.fn();
+      const user = userEvent.setup();
+      const CellRenderer = getActionsRenderer({ onAddSources });
+      render(<CellRenderer data={makeKb({ status: "ready" })} />);
+
+      await user.click(screen.getByTestId("kb-row-update-button"));
+      expect(onAddSources).toHaveBeenCalledWith(
+        expect.objectContaining({ dir_name: "my_kb" }),
+      );
+    });
+
+    it("disables the settings icon button while KB is ingesting", () => {
+      const CellRenderer = getActionsRenderer({});
+      render(<CellRenderer data={makeKb({ status: "ingesting" })} />);
+      expect(screen.getByTestId("kb-row-update-button")).toBeDisabled();
     });
   });
 });

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/config/knowledgeBaseColumns.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/config/knowledgeBaseColumns.tsx
@@ -8,6 +8,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { KnowledgeBaseInfo } from "@/controllers/API/queries/knowledge-bases/use-get-knowledge-bases";
 import { formatFileSize } from "@/utils/stringManipulation";
 import { FILE_ICONS } from "@/utils/styleUtils";
@@ -176,8 +182,8 @@ export const createKnowledgeBaseColumns = (
     {
       headerName: "",
       field: "actions",
-      width: 65,
-      minWidth: 65,
+      width: 110,
+      minWidth: 110,
       sortable: false,
       editable: false,
       resizable: false,
@@ -188,77 +194,103 @@ export const createKnowledgeBaseColumns = (
         const isBusy = isBusyStatus(status);
         const isCancelling = status === "cancelling";
         return (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <ForwardedIconComponent
-                  name="EllipsisVertical"
-                  className="h-4 w-4 text-primary"
-                />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                disabled={isBusy}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  callbacks?.onAddSources?.(params.data);
-                }}
-              >
-                <ForwardedIconComponent
-                  name="RefreshCw"
-                  className="mr-2 h-4 w-4"
-                />
-                Update Knowledge
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={(e) => {
-                  e.stopPropagation();
-                  callbacks?.onViewChunks?.(params.data);
-                }}
-              >
-                <ForwardedIconComponent
-                  name="Layers"
-                  className="mr-2 h-4 w-4"
-                />
-                View Chunks
-              </DropdownMenuItem>
-              {isBusy ? (
-                <DropdownMenuItem
-                  disabled={isCancelling}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    callbacks?.onStopIngestion?.(params.data);
-                  }}
-                  className="text-destructive focus:text-destructive"
+          <div className="flex items-center justify-center gap-1">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    disabled={isBusy}
+                    data-testid="kb-row-update-button"
+                    aria-label="Update Knowledge"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      callbacks?.onAddSources?.(params.data);
+                    }}
+                  >
+                    <ForwardedIconComponent
+                      name="Settings"
+                      className="h-4 w-4 text-primary"
+                    />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Update Knowledge</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  data-testid="kb-row-actions-trigger"
+                  onClick={(e) => e.stopPropagation()}
                 >
                   <ForwardedIconComponent
-                    name="Square"
+                    name="EllipsisVertical"
+                    className="h-4 w-4 text-primary"
+                  />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  disabled={isBusy}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    callbacks?.onAddSources?.(params.data);
+                  }}
+                >
+                  <ForwardedIconComponent
+                    name="RefreshCw"
                     className="mr-2 h-4 w-4"
                   />
-                  Stop Ingestion
+                  Update Knowledge
                 </DropdownMenuItem>
-              ) : (
                 <DropdownMenuItem
                   onClick={(e) => {
                     e.stopPropagation();
-                    callbacks?.onDelete?.(params.data);
+                    callbacks?.onViewChunks?.(params.data);
                   }}
-                  className="text-destructive focus:text-destructive"
                 >
                   <ForwardedIconComponent
-                    name="Trash2"
+                    name="Layers"
                     className="mr-2 h-4 w-4"
                   />
-                  Delete
+                  View Chunks
                 </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                {isBusy ? (
+                  <DropdownMenuItem
+                    disabled={isCancelling}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      callbacks?.onStopIngestion?.(params.data);
+                    }}
+                    className="text-destructive focus:text-destructive"
+                  >
+                    <ForwardedIconComponent
+                      name="Square"
+                      className="mr-2 h-4 w-4"
+                    />
+                    Stop Ingestion
+                  </DropdownMenuItem>
+                ) : (
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      callbacks?.onDelete?.(params.data);
+                    }}
+                    className="text-destructive focus:text-destructive"
+                  >
+                    <ForwardedIconComponent
+                      name="Trash2"
+                      className="mr-2 h-4 w-4"
+                    />
+                    Delete
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         );
       },
     },


### PR DESCRIPTION
## Summary

Closes two QA-flagged UX gaps on the Knowledge Bases tab.

**Gap 1 — settings buried in dropdown.** "Update Knowledge" was only reachable via the row's overflow menu (⋮). Now there's a dedicated settings icon directly on each row, one click to open the Update modal. The dropdown is preserved for the rest of the row actions.

**Gap 2 — Update modal showed no history.** Opening "Update Knowledge" gave the user no visibility into what was already ingested into the KB, so they couldn't tell if a file had been added before. The modal's Step 1 now shows a collapsible **"Previously ingested"** panel above the upload fields, listing each prior ingestion run with the user-typed source name, source type, relative date, status badge, and counts.

## Changes

### Backend
- `schema/knowledge_base.py` — `IngestionRunInfo.source_name: str | None = None` (new field on the run-list response).
- `api/v1/knowledge_bases.py::_run_row_to_info` — populates `source_name` from `RunRow.source_config["source_name"]`. Whitespace-only collapses to `None` so the frontend renders the type label as a clean fallback. Backward-compatible: legacy runs without `source_name` in `source_config` simply return `null`.

### Frontend
- **New:** `modals/knowledgeBaseUploadModal/components/IngestionHistoryPanel.tsx`
  - Uses `useGetIngestionRuns` with `staleTime: 0` + `refetchOnMount: "always"` so the list is fresh immediately after an ingest (mirrors the cache fix from #12993).
  - Empty / loading / error states.
  - Run row prefers `source_name` (e.g. `"Test6"`) with the type label (`"File Upload"`) as a small subtitle when both are present.
  - Collapsible header with total count badge.
- `modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx` — accepts `kbName?: string` and renders the panel only when `isAddSourcesMode && kbName`.
- `modals/knowledgeBaseUploadModal/KnowledgeBaseUploadModal.tsx` — threads `kbName` from `existingKnowledgeBase.name`.
- `controllers/API/queries/knowledge-bases/use-get-ingestion-runs.ts` — adds `source_name: string | null` to the TS interface.
- `pages/MainPage/pages/knowledgePage/config/knowledgeBaseColumns.tsx` — settings icon button rendered alongside the existing dropdown in the actions cell. `data-testid="kb-row-update-button"`, tooltip "Update Knowledge", disabled when KB is busy. Dropdown trigger gets a stable `data-testid="kb-row-actions-trigger"`. Column widened from 65 → 110.

### Tests (all green)
- **Backend** — new `test_exposes_source_name_from_source_config` covers populated, missing, and whitespace-only cases. `_insert_run` helper gains a `source_config` parameter. **11/11 ingestion-run-endpoint tests pass.**
- **Frontend** —
  - 6 new `IngestionHistoryPanel.test.tsx` tests: empty / loading / error states, type-label fallback, source_name preference with type subtitle, whitespace-only handling, collapse/expand, hook args.
  - 3 new column tests: settings icon present, click → `onAddSources`, disabled while ingesting.
  - Existing column tests migrated to `kb-row-actions-trigger` testid (was `getByRole("button")`, now ambiguous with two buttons in the cell).
  - `KnowledgeBaseUploadModal.test.tsx` mocks `useGetIngestionRuns` for the new render path.
  - **79/79 knowledgeBaseUploadModal tests pass, 18/18 column tests pass, 121/121 knowledgePage tests pass.**

## Test plan

- [x] `cd src/frontend && npm start` (or your usual dev command), open Knowledge Bases tab.
- [x] Settings icon visible on each row, left of the ⋮ dropdown. Click → opens Update modal directly.
- [x] Settings icon disabled (greyed) while a KB is ingesting; ⋮ stays clickable.
- [x] Open the Update modal on a KB with prior runs → "Previously ingested (N)" panel appears above name field, expanded by default.
- [x] Each row shows: status badge · source name (or type label fallback) · "·  type label" subtitle when both present · relative time · succeeded / failed / skipped counts · chunk count.
- [x] Toggle the panel header → list collapses/expands.
- [x] Open Update modal on a brand-new KB with no runs → empty state "No sources ingested yet…".
- [x] Upload a file with a typed source name (e.g. `Test6`), close modal, reopen → new row appears at top with the typed name, no stale cache.
- [x] Old runs with no `source_name` in `source_config` still render correctly using the type label.

## Screen shots

<img width="1547" height="301" alt="image" src="https://github.com/user-attachments/assets/242e7830-5a38-481b-829c-84fff3d88470" />

<img width="754" height="820" alt="image" src="https://github.com/user-attachments/assets/dc1830a8-448f-489e-b4e3-baf9e5a0ab18" />

