### PR TITLE
test: fix flow state clean test on windows

### DIFF
--- a/src/frontend/tests/core/features/user-flow-state-cleanup.spec.ts
+++ b/src/frontend/tests/core/features/user-flow-state-cleanup.spec.ts
@@ -44,17 +44,19 @@ test(
     await page.evaluate(() => {
       sessionStorage.removeItem("testMockAutoLogin");
     });
-    await page.getByRole("button", { name: "Sign In" }).click();
+    await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.url().includes("/api/v1/login") && response.status() === 200,
+        { timeout: 60000 },
+      ),
+      page.getByRole("button", { name: "Sign In" }).click(),
+    ]);
 
-    // Create User A — wait for the homepage Loading state to clear before
-    // checking mainpage_title (mainpage_title only renders after data load,
-    // which can outlast a 30s wait on slower runners like Windows CI).
-    await page.waitForSelector('text="Loading"', {
-      state: "hidden",
-      timeout: 60000,
-    });
+    // mainpage_title only renders after the homepage data finishes loading,
+    // and on slower runners (Windows CI) this can outlast a 60s wait.
     await page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 60000,
+      timeout: 90000,
     });
     await page.getByTestId("user-profile-settings").click();
     await page.getByText("Admin Page", { exact: true }).click();
@@ -88,10 +90,17 @@ test(
     await page.evaluate(() => {
       sessionStorage.removeItem("testMockAutoLogin");
     });
-    await page.getByRole("button", { name: "Sign In" }).click();
+    await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.url().includes("/api/v1/login") && response.status() === 200,
+        { timeout: 60000 },
+      ),
+      page.getByRole("button", { name: "Sign In" }).click(),
+    ]);
 
     // Create a flow for User A
-    await page.waitForSelector('[id="new-project-btn"]', { timeout: 30000 });
+    await page.waitForSelector('[id="new-project-btn"]', { timeout: 60000 });
     // Check that User A starts with an empty flows list
     expect(
       (
@@ -129,7 +138,7 @@ test(
       await basicPromptingHeading.click();
       try {
         await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-          timeout: attempt === maxClickAttempts ? 180000 : 45000,
+          timeout: attempt === maxClickAttempts ? 240000 : 60000,
         });
         canvasMounted = true;
         break;
@@ -172,7 +181,14 @@ test(
     await page.evaluate(() => {
       sessionStorage.removeItem("testMockAutoLogin");
     });
-    await page.getByRole("button", { name: "Sign In" }).click();
+    await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.url().includes("/api/v1/login") && response.status() === 200,
+        { timeout: 60000 },
+      ),
+      page.getByRole("button", { name: "Sign In" }).click(),
+    ]);
 
     // Verify admin can't see User A's flow
     await expect(page.getByText(userAFlowName, { exact: true })).toBeVisible({


### PR DESCRIPTION
This pull request updates the user flow state cleanup end-to-end tests to improve reliability, especially on slower environments like Windows CI. The main changes focus on making the login and loading steps more robust by synchronizing on specific network responses and increasing timeouts for slow operations.

**Test reliability and robustness improvements:**

* Replaced simple "Sign In" button clicks with a `Promise.all` that waits for both the button click and the corresponding `/api/v1/login` network response, ensuring the login process completes before proceeding. [[1]](diffhunk://#diff-87a1826663c0a4c88bcd20a8e87b7b102e35fa9bbc70b3d32a28eef440f949d0L47-R59) [[2]](diffhunk://#diff-87a1826663c0a4c88bcd20a8e87b7b102e35fa9bbc70b3d32a28eef440f949d0L91-R103) [[3]](diffhunk://#diff-87a1826663c0a4c88bcd20a8e87b7b102e35fa9bbc70b3d32a28eef440f949d0L175-R191)
* Increased timeouts for waiting on selectors that are slow to appear in CI environments, such as `mainpage_title`, `new-project-btn`, and `canvas_controls_dropdown`, to reduce test flakiness. [[1]](diffhunk://#diff-87a1826663c0a4c88bcd20a8e87b7b102e35fa9bbc70b3d32a28eef440f949d0L47-R59) [[2]](diffhunk://#diff-87a1826663c0a4c88bcd20a8e87b7b102e35fa9bbc70b3d32a28eef440f949d0L91-R103) [[3]](diffhunk://#diff-87a1826663c0a4c88bcd20a8e87b7b102e35fa9bbc70b3d32a28eef440f949d0L132-R141)