### PR TITLE
fix: force pull latest base images in Docker nightly builds

### DIFF
--- a/.github/workflows/docker-nightly-build.yml
+++ b/.github/workflows/docker-nightly-build.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_base.Dockerfile
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -129,6 +130,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_base.Dockerfile
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -210,6 +212,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push.Dockerfile
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -222,6 +225,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push.Dockerfile
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -303,6 +307,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_with_extras.Dockerfile
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -315,6 +320,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_with_extras.Dockerfile
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}


### PR DESCRIPTION
- Add pull: true to all docker build steps in nightly workflow
- Forces Docker to pull latest python:3.12-slim-trixie instead of using cached layers
- Ensures Debian Trixie base images are used instead of cached Bookworm layers
- Resolves issue where Docker layer caching prevented CVE fixes from taking effect