### PR TITLE
fix: update Docker base images to Trixie and force pull latest images in nightly builds

### DIFF
--- a/.github/workflows/docker-nightly-build.yml
+++ b/.github/workflows/docker-nightly-build.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_base.Dockerfile
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -129,6 +130,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_base.Dockerfile
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -210,6 +212,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push.Dockerfile
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -222,6 +225,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push.Dockerfile
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -303,6 +307,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_with_extras.Dockerfile
           tags: ${{ steps.tags.outputs.docker_tags }}
           platforms: linux/${{ matrix.arch }}
@@ -315,6 +320,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.push_to_registry }}
+          pull: true
           file: ./docker/build_and_push_with_extras.Dockerfile
           tags: ${{ steps.tags.outputs.ghcr_tags }}
           platforms: linux/${{ matrix.arch }}

--- a/docker/build_and_push.Dockerfile
+++ b/docker/build_and_push.Dockerfile
@@ -9,7 +9,7 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 
 # Install the project into `/app`
 WORKDIR /app
@@ -75,7 +75,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.13-slim-trixie AS runtime
+FROM python:3.12-slim-trixie AS runtime
 
 
 RUN apt-get update \

--- a/docker/build_and_push_backend.Dockerfile
+++ b/docker/build_and_push_backend.Dockerfile
@@ -8,7 +8,7 @@
 ################################
 # BUILDER
 ################################
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 
 WORKDIR /app
 
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ################################
 # RUNTIME
 ################################
-FROM python:3.12.13-slim-trixie AS runtime
+FROM python:3.12-slim-trixie AS runtime
 
 # Install minimal runtime dependencies
 RUN apt-get update \

--- a/docker/build_and_push_base.Dockerfile
+++ b/docker/build_and_push_base.Dockerfile
@@ -10,7 +10,7 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 
 # Install the project into `/app`
 WORKDIR /app
@@ -77,7 +77,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.13-slim-trixie AS runtime
+FROM python:3.12-slim-trixie AS runtime
 
 
 RUN apt-get update \

--- a/docker/build_and_push_ep.Dockerfile
+++ b/docker/build_and_push_ep.Dockerfile
@@ -9,7 +9,7 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 
 # Install the project into `/app`
 WORKDIR /app
@@ -72,7 +72,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.13-slim-trixie AS runtime
+FROM python:3.12-slim-trixie AS runtime
 
 RUN apt-get update \
     && apt-get upgrade -y \

--- a/docker/build_and_push_with_extras.Dockerfile
+++ b/docker/build_and_push_with_extras.Dockerfile
@@ -9,7 +9,7 @@
 # 1. use python:3.12.3-slim as the base image until https://github.com/pydantic/pydantic-core/issues/1292 gets resolved
 # 2. do not add --platform=$BUILDPLATFORM because the pydantic binaries must be resolved for the final architecture
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim AS builder
 
 # Install the project into `/app`
 WORKDIR /app
@@ -72,7 +72,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # RUNTIME
 # Setup user, utilities and copy the virtual environment only
 ################################
-FROM python:3.12.13-slim-trixie AS runtime
+FROM python:3.12-slim-trixie AS runtime
 
 
 RUN apt-get update \


### PR DESCRIPTION
## Description

Updates Docker base images to Debian Trixie and adds `pull: true` to nightly build workflow to resolve CVE vulnerabilities.

**This PR is created directly from `main` branch (not cherry-picked) to avoid future merge conflicts.**

## Changes

### 1. Dockerfile Updates (5 files)
- **Builder stage**: `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` → `ghcr.io/astral-sh/uv:python3.12-trixie-slim`
- **Runtime stage**: `python:3.12.13-slim-trixie` → `python:3.12-slim-trixie` (unpinned for latest patches)

Files updated:
- `docker/build_and_push_base.Dockerfile`
- `docker/build_and_push.Dockerfile`
- `docker/build_and_push_backend.Dockerfile`
- `docker/build_and_push_with_extras.Dockerfile`
- `docker/build_and_push_ep.Dockerfile`

### 2. Workflow Update
- Added `pull: true` to 6 Docker build steps in `.github/workflows/docker-nightly-build.yml`
- Forces Docker to pull latest base images instead of using cached layers
- Ensures Trixie images are used even if Bookworm layers are cached

## Why Both Changes Are Needed

1. **Dockerfiles**: Update references from Bookworm to Trixie (newer Debian stable)
2. **Workflow**: Force pull ensures we get latest Trixie images, not cached Bookworm layers
3. **Main branch**: Scheduled nightly builds run from `main`, so changes must be here

## Testing

- Wait for tonight's scheduled nightly build (00:00 UTC)
- Verify CVE count reduction via Docker Scout scan
- Expected: ~124 CVEs → ~40-60 CVEs

## Future Work (Phase 2)

As noted by @jordanrfrazier in #13014, we should eventually:

1. **Pin to specific Python patch version** (e.g., `python:3.12.15-slim-trixie`)
2. **Remove `pull: true`** from workflow (makes builds faster and more predictable)
3. **Update pinned versions quarterly** as part of maintenance

This PR is **Phase 1** (temporary fix with `pull: true`). Phase 2 will come ~2 weeks after CVEs are confirmed fixed.

## Related

- Similar changes on `release-1.10.0`: #12990, #13014
- This PR created fresh from `main` to avoid merge conflicts when `release-1.10.0` merges back


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated container runtime environments and build images to the latest stable versions for enhanced reliability, security, and deployment consistency
  * Optimized the automated build and deployment process with improved image layer caching, resulting in faster build times and more efficient deployments
  * Modernized underlying system and Python dependencies across containerized environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->