### PR TITLE
fix(flows): escape wildcard endpoint names when deduplicating

### DIFF
--- a/src/backend/base/langflow/api/v1/flows_helpers.py
+++ b/src/backend/base/langflow/api/v1/flows_helpers.py
@@ -211,10 +211,13 @@ async def _deduplicate_endpoint_name(
     if fail_on_conflict:
         raise HTTPException(status_code=409, detail="Endpoint name must be unique")
 
+    escaped_endpoint_name = (
+        endpoint_name.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    )
     flows = (
         await session.exec(
             select(Flow)
-            .where(Flow.endpoint_name.like(f"{endpoint_name}-%"))  # type: ignore[union-attr]
+            .where(Flow.endpoint_name.like(f"{escaped_endpoint_name}-%", escape="\\"))  # type: ignore[union-attr]
             .where(Flow.user_id == user_id)
         )
     ).all()

--- a/src/backend/tests/unit/api/v1/test_flows.py
+++ b/src/backend/tests/unit/api/v1/test_flows.py
@@ -823,6 +823,39 @@ async def test_upsert_flow_auto_renames_name_on_create_conflict(client: AsyncCli
     assert result["name"] == "duplicate_name (1)"  # Auto-renamed
 
 
+async def test_create_flow_auto_renames_endpoint_with_like_wildcards(
+    client: AsyncClient, logged_in_headers
+):
+    """Test that endpoint_name deduplication escapes SQL LIKE wildcards."""
+    first_flow = {
+        "name": "wildcard_endpoint_flow",
+        "endpoint_name": "dup_name",
+        "data": {},
+    }
+    unrelated_flow = {
+        "name": "wildcard_endpoint_unrelated",
+        "endpoint_name": "dupa_name-7",
+        "data": {},
+    }
+
+    response = await client.post("api/v1/flows/", json=first_flow, headers=logged_in_headers)
+    assert response.status_code == status.HTTP_201_CREATED
+
+    response = await client.post("api/v1/flows/", json=unrelated_flow, headers=logged_in_headers)
+    assert response.status_code == status.HTTP_201_CREATED
+
+    second_flow = {
+        "name": "wildcard_endpoint_flow_copy",
+        "endpoint_name": "dup_name",
+        "data": {},
+    }
+
+    response = await client.post("api/v1/flows/", json=second_flow, headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["endpoint_name"] == "dup_name-1"
+
+
 async def test_upsert_flow_returns_409_for_name_conflict_on_update(client: AsyncClient, logged_in_headers):
     """Test that PUT returns 409 when name conflicts with another flow during UPDATE."""
     # Create two flows


### PR DESCRIPTION
## Summary

- escape SQL `LIKE` wildcard characters before scanning existing endpoint-name suffixes
- keep the exact endpoint-name equality check unchanged
- add a regression test for endpoint names containing `_`

## Why

`_deduplicate_endpoint_name()` first checks for an exact endpoint-name conflict, then scans existing names with `LIKE '<endpoint_name>-%'` to choose the next numeric suffix.

When the endpoint name itself contains SQL `LIKE` wildcard characters, that suffix scan can match unrelated endpoint names. For example, `dup_name` can match `dupa_name-7`, causing the next duplicate of `dup_name` to be renamed to a later suffix instead of `dup_name-1`.

Escaping `%`, `_`, and `\` in the `LIKE` pattern keeps the suffix scan scoped to the literal endpoint name.

## Tests

- `python3 -m py_compile src/backend/base/langflow/api/v1/flows_helpers.py`
- `python3 -m py_compile src/backend/tests/unit/api/v1/test_flows.py`

Note: I also started the focused pytest command, but local dependency sync for this repository pulled a very large fresh environment and did not finish in a reasonable time on my machine.
