### PR TITLE
Add user scoping to voice mode flow description lookup

### DIFF
--- a/src/backend/base/langflow/api/v1/voice_mode.py
+++ b/src/backend/base/langflow/api/v1/voice_mode.py
@@ -521,9 +521,7 @@ async def get_flow_desc_from_db(flow_id: str, user_id: UUID | None = None) -> Fl
     async with session_scope() as session:
         stmt = select(Flow).where(Flow.id == UUID(flow_id))
         if user_id is not None:
-            stmt = stmt.where(
-                (Flow.user_id == user_id) | (Flow.access_type == AccessTypeEnum.PUBLIC)
-            )
+            stmt = stmt.where((Flow.user_id == user_id) | (Flow.access_type == AccessTypeEnum.PUBLIC))
         result = await session.exec(stmt)
         flow = result.scalar_one_or_none()
         if not flow:

--- a/src/backend/base/langflow/api/v1/voice_mode.py
+++ b/src/backend/base/langflow/api/v1/voice_mode.py
@@ -29,7 +29,7 @@ from langflow.api.v1.chat import build_flow_and_stream
 from langflow.memory import aadd_messagetables
 from langflow.schema.properties import Properties
 from langflow.services.auth.utils import get_current_user_for_websocket
-from langflow.services.database.models.flow.model import Flow
+from langflow.services.database.models.flow.model import AccessTypeEnum, Flow
 from langflow.services.database.models.message.model import MessageTable
 from langflow.services.database.models.user.model import User
 from langflow.services.deps import get_variable_service, session_scope
@@ -517,9 +517,13 @@ message_tasks: dict[str, asyncio.Task] = {}
 last_sender_by_session: defaultdict[str, str | None] = defaultdict(lambda: None)
 
 
-async def get_flow_desc_from_db(flow_id: str) -> Flow:
+async def get_flow_desc_from_db(flow_id: str, user_id: UUID | None = None) -> Flow:
     async with session_scope() as session:
         stmt = select(Flow).where(Flow.id == UUID(flow_id))
+        if user_id is not None:
+            stmt = stmt.where(
+                (Flow.user_id == user_id) | (Flow.access_type == AccessTypeEnum.PUBLIC)
+            )
         result = await session.exec(stmt)
         flow = result.scalar_one_or_none()
         if not flow:
@@ -733,7 +737,7 @@ async def flow_as_tool_websocket(
         if current_user is None or openai_key is None:
             return
         try:
-            flow_description = await get_flow_desc_from_db(flow_id)
+            flow_description = await get_flow_desc_from_db(flow_id, user_id=current_user.id)
             flow_tool = {
                 "name": "execute_flow",
                 "type": "function",

--- a/src/backend/base/langflow/api/v1/voice_mode.py
+++ b/src/backend/base/langflow/api/v1/voice_mode.py
@@ -517,7 +517,7 @@ message_tasks: dict[str, asyncio.Task] = {}
 last_sender_by_session: defaultdict[str, str | None] = defaultdict(lambda: None)
 
 
-async def get_flow_desc_from_db(flow_id: str, user_id: UUID | None = None) -> Flow:
+async def get_flow_desc_from_db(flow_id: str, user_id: UUID | None = None) -> str | None:
     async with session_scope() as session:
         stmt = select(Flow).where(Flow.id == UUID(flow_id))
         if user_id is not None:


### PR DESCRIPTION
## What

Add ownership check to `get_flow_desc_from_db` in voice mode WebSocket handler.

## Why

The `get_flow_desc_from_db` helper fetches flow descriptions without scoping to the requesting user. This brings it in line with the authorization pattern used by other flow endpoints (e.g., `chat.py`, `flows.py`) which filter by `user_id` or allow public access.

## How

- Added optional `user_id` parameter to `get_flow_desc_from_db`
- When provided, queries are scoped to flows owned by the user OR marked as PUBLIC
- Updated the call site in `flow_as_tool_websocket` to pass `current_user.id`
- Imported `AccessTypeEnum` for the public flow check

## Testing

```bash
# Verify voice mode WebSocket only returns descriptions for owned/public flows
pytest tests/unit/test_voice_mode.py -v
```

## Breaking Changes

None. The `user_id` parameter defaults to `None` for backward compatibility in any other call sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flows used as tools in voice mode now respect user authorization, displaying only flows owned by the current user or marked as public.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->