### PR TITLE
fix(memory-base): resolve embeddings from static registry, fix Google Gemini provider inference

### DIFF
--- a/src/backend/base/langflow/api/utils/kb_helpers.py
+++ b/src/backend/base/langflow/api/utils/kb_helpers.py
@@ -37,7 +37,6 @@ from lfx.base.knowledge_bases.ingestion_sources import (
     KBIngestionSource,
 )
 from lfx.base.knowledge_bases.ingestion_sources.base import IngestionItemStatus, IngestionRunStatus
-from lfx.base.models.unified_models import get_embedding_model_options
 from lfx.components.models_and_agents.embedding_model import EmbeddingModelComponent
 from lfx.log import logger
 
@@ -1017,17 +1016,49 @@ class KBIngestionHelper:
 
     @staticmethod
     async def build_embeddings(provider: str, model: str, current_user):
-        """Internal helper to build embeddings object."""
-        options = get_embedding_model_options(user_id=current_user.id)
-        selected_option = next((o for o in options if o["provider"] == provider and o["name"] == model), None)
+        """Build a LangChain embeddings instance for a stored KB.
 
-        if not selected_option:
-            all_options = get_embedding_model_options()
-            selected_option = next((o for o in all_options if o["provider"] == provider and o["name"] == model), None)
+        The provider/model pair is the source of truth recorded in the KB's
+        ``embedding_metadata.json`` at creation time. We resolve the embedding
+        class and parameter mapping straight from the static registry rather
+        than the user-filtered catalog, so retrieval keeps working when:
 
-            if not selected_option:
-                msg = f"Embedding model '{model}' for provider '{provider}' not found."
-                raise ValueError(msg)
+        - the call originates from a context where the credential lookup
+          inside ``get_embedding_model_options`` silently returns an empty
+          set of enabled providers (e.g. a thread-bridged async hop), or
+        - the user has since disabled the model in their settings.
+
+        The runtime credential is still resolved by ``get_embeddings`` via
+        ``get_api_key_for_provider``, so a missing API key still raises a
+        clear, user-actionable error at instantiation time.
+        """
+        from lfx.base.models.unified_models.class_registry import (
+            EMBEDDING_PARAM_MAPPINGS,
+            EMBEDDING_PROVIDER_CLASS_MAPPING,
+        )
+
+        embedding_class = EMBEDDING_PROVIDER_CLASS_MAPPING.get(provider)
+        param_mapping = EMBEDDING_PARAM_MAPPINGS.get(provider)
+        if not embedding_class or not param_mapping:
+            supported = ", ".join(sorted(EMBEDDING_PROVIDER_CLASS_MAPPING))
+            msg = (
+                f"Embedding model '{model}' for provider '{provider}' could not be "
+                f"resolved: provider '{provider}' is not registered. Supported "
+                f"providers: {supported}."
+            )
+            raise ValueError(msg)
+
+        selected_option = {
+            "name": model,
+            "provider": provider,
+            "category": provider,
+            "icon": provider,
+            "metadata": {
+                "embedding_class": embedding_class,
+                "param_mapping": param_mapping,
+                "model_type": "embeddings",
+            },
+        }
 
         embedding_model = EmbeddingModelComponent(model=[selected_option], _user_id=current_user.id)
         return embedding_model.build_embeddings()

--- a/src/backend/base/langflow/services/memory_base/embedding_helpers.py
+++ b/src/backend/base/langflow/services/memory_base/embedding_helpers.py
@@ -5,22 +5,71 @@ Extracted from MemoryBaseService to keep single-responsibility per file.
 
 from __future__ import annotations
 
-# Provider inference map — mirrors provider_patterns in KBAnalysisHelper._detect_embedding_provider
-# so we can derive the provider from a model name string without filesystem access.
+import contextlib
+
+# Provider inference patterns. Order matters: more specific patterns first.
+# The provider names must match the keys in
+# ``lfx.base.models.unified_models.class_registry.EMBEDDING_PROVIDER_CLASS_MAPPING``
+# so the inferred provider can be used to instantiate the matching embedding
+# class without further translation.
 _MODEL_TO_PROVIDER: list[tuple[list[str], str]] = [
-    (["text-embedding", "ada-", "gpt-"], "OpenAI"),
+    # Google Generative AI uses a "models/" prefix for every embedding name.
+    # Matched first so it doesn't get caught by the OpenAI "text-embedding-"
+    # rule below (Google has "models/text-embedding-004").
+    (
+        [
+            "models/gemini-embedding",
+            "models/text-embedding",
+            "models/embedding-",
+            "gemini-embedding",
+        ],
+        "Google Generative AI",
+    ),
+    (["text-embedding-", "ada-", "gpt-"], "OpenAI"),
     (["embed-english", "embed-multilingual"], "Cohere"),
     (["sentence-transformers", "bert-", "huggingface"], "HuggingFace"),
-    (["palm", "gecko", "google"], "Google"),
+    # Other Google models (PaLM/Gecko legacy names).
+    (["palm", "gecko"], "Google Generative AI"),
     (["ollama"], "Ollama"),
     (["azure"], "Azure OpenAI"),
 ]
 
 
 def infer_embedding_provider(embedding_model: str) -> str:
-    """Derive embedding provider name from a model string."""
+    """Derive embedding provider name from a model string.
+
+    Looks up the model in the unified models catalog first so the answer
+    matches what the UI dropdown shows; falls back to pattern-based
+    inference for legacy/edge cases.
+    """
+    if not embedding_model:
+        return "OpenAI"  # Safe default — matches _resolve_embedding fallback
+
+    catalog_provider = _lookup_provider_in_catalog(embedding_model)
+    if catalog_provider:
+        return catalog_provider
+
     lower = embedding_model.lower()
     for patterns, provider in _MODEL_TO_PROVIDER:
         if any(p in lower for p in patterns):
             return provider
     return "OpenAI"  # Safe default — matches _resolve_embedding fallback
+
+
+def _lookup_provider_in_catalog(embedding_model: str) -> str | None:
+    """Return the provider for ``embedding_model`` from the unified catalog, if known."""
+    with contextlib.suppress(Exception):
+        # Imported lazily so the helper has no hard dependency on the
+        # unified_models package at import time (keeps test imports cheap).
+        from lfx.base.models.unified_models.model_catalog import get_unified_models_detailed
+
+        all_providers = get_unified_models_detailed(
+            model_type="embeddings",
+            include_deprecated=True,
+            include_unsupported=True,
+        )
+        for provider_data in all_providers:
+            for model_data in provider_data.get("models", []):
+                if model_data.get("model_name") == embedding_model:
+                    return provider_data.get("provider")
+    return None

--- a/src/backend/tests/unit/test_memory_bases.py
+++ b/src/backend/tests/unit/test_memory_bases.py
@@ -95,6 +95,143 @@ def _make_message(
 # ------------------------------------------------------------------ #
 
 
+class TestInferEmbeddingProvider:
+    """Provider inference regression tests.
+
+    The returned provider name must be a canonical key registered in
+    ``EMBEDDING_PROVIDER_CLASS_MAPPING`` so the result can be round-tripped
+    through ``KBIngestionHelper.build_embeddings`` without translation.
+    """
+
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            # Google Generative AI — the original bug: gemini-embedding was
+            # being misclassified as OpenAI because no Google pattern matched.
+            ("models/gemini-embedding-001", "Google Generative AI"),
+            ("models/text-embedding-004", "Google Generative AI"),
+            ("models/embedding-001", "Google Generative AI"),
+            # OpenAI — must NOT be caught by the Google "models/text-embedding"
+            # pattern, since OpenAI names don't carry the "models/" prefix.
+            ("text-embedding-3-small", "OpenAI"),
+            ("text-embedding-3-large", "OpenAI"),
+            ("text-embedding-ada-002", "OpenAI"),
+            # Other providers
+            ("nomic-embed-text", "Ollama"),
+            ("embed-english-v3.0", "Cohere"),
+            # Unknown / empty fall back to the safe default.
+            ("unknown-model", "OpenAI"),
+            ("", "OpenAI"),
+        ],
+    )
+    def test_provider_inferred_correctly(self, model, expected):
+        from langflow.services.memory_base.embedding_helpers import infer_embedding_provider
+
+        assert infer_embedding_provider(model) == expected
+
+    def test_inferred_provider_is_in_class_mapping(self):
+        """Inferred provider must be a registered embedding-class mapping key.
+
+        Otherwise the downstream ``KBIngestionHelper.build_embeddings`` call
+        will reject it.
+        """
+        from langflow.services.memory_base.embedding_helpers import infer_embedding_provider
+        from lfx.base.models.unified_models.class_registry import EMBEDDING_PROVIDER_CLASS_MAPPING
+
+        for model in (
+            "models/gemini-embedding-001",
+            "text-embedding-3-small",
+            "text-embedding-3-large",
+            "nomic-embed-text",
+            "unknown-model",
+        ):
+            assert infer_embedding_provider(model) in EMBEDDING_PROVIDER_CLASS_MAPPING
+
+
+class TestKBIngestionHelperBuildEmbeddings:
+    """Regression tests for the Memory Base retrieval bug.
+
+    ``build_embeddings`` must not depend on the user-filtered catalog
+    returned by ``get_embedding_model_options``: that catalog is empty
+    whenever the per-user credential lookup fails (which can happen
+    transparently when the helper runs in a thread bridged from an async
+    event loop). The KB's ``embedding_metadata.json`` is the source of
+    truth — we resolve the embedding class from the static registry.
+    """
+
+    @pytest.mark.asyncio
+    async def test_builds_embeddings_for_openai_default_model(self):
+        from langflow.api.utils.kb_helpers import KBIngestionHelper
+
+        sentinel = object()
+        with patch("langflow.api.utils.kb_helpers.EmbeddingModelComponent") as mock_component_cls:
+            instance = mock_component_cls.return_value
+            instance.build_embeddings.return_value = sentinel
+            user = MagicMock(id=uuid.uuid4())
+
+            result = await KBIngestionHelper.build_embeddings("OpenAI", "text-embedding-3-small", user)
+
+        assert result is sentinel
+        kwargs = mock_component_cls.call_args.kwargs
+        selected = kwargs["model"][0]
+        assert selected["provider"] == "OpenAI"
+        assert selected["name"] == "text-embedding-3-small"
+        assert selected["metadata"]["embedding_class"] == "OpenAIEmbeddings"
+        assert selected["metadata"]["model_type"] == "embeddings"
+        assert "param_mapping" in selected["metadata"]
+
+    @pytest.mark.asyncio
+    async def test_builds_embeddings_for_google_gemini_model(self):
+        """Google-side regression coverage.
+
+        ``gemini-embedding-001`` must resolve to
+        ``GoogleGenerativeAIEmbeddings`` rather than blowing up.
+        """
+        from langflow.api.utils.kb_helpers import KBIngestionHelper
+
+        with patch("langflow.api.utils.kb_helpers.EmbeddingModelComponent") as mock_component_cls:
+            mock_component_cls.return_value.build_embeddings.return_value = MagicMock()
+            user = MagicMock(id=uuid.uuid4())
+
+            await KBIngestionHelper.build_embeddings("Google Generative AI", "models/gemini-embedding-001", user)
+
+        selected = mock_component_cls.call_args.kwargs["model"][0]
+        assert selected["provider"] == "Google Generative AI"
+        assert selected["metadata"]["embedding_class"] == "GoogleGenerativeAIEmbeddings"
+
+    @pytest.mark.asyncio
+    async def test_unregistered_provider_raises_with_helpful_message(self):
+        from langflow.api.utils.kb_helpers import KBIngestionHelper
+
+        user = MagicMock(id=uuid.uuid4())
+        with pytest.raises(ValueError, match="not registered"):
+            await KBIngestionHelper.build_embeddings("MadeUpProvider", "some-model", user)
+
+    @pytest.mark.asyncio
+    async def test_does_not_consult_user_filtered_catalog(self):
+        """Helper must resolve from the static registry, not the user catalog.
+
+        Even if ``get_embedding_model_options`` would return an empty list
+        (e.g. the per-user credential lookup silently failed), the helper
+        must still resolve the model from the static registry.
+        """
+        from langflow.api.utils import kb_helpers as kb_helpers_module
+        from langflow.api.utils.kb_helpers import KBIngestionHelper
+
+        # The helper used to call ``get_embedding_model_options`` and raise
+        # when the result was empty. Make sure that name is no longer wired
+        # into the helper's module — otherwise the bug can silently regress.
+        assert not hasattr(kb_helpers_module, "get_embedding_model_options")
+
+        with patch("langflow.api.utils.kb_helpers.EmbeddingModelComponent") as mock_component_cls:
+            mock_component_cls.return_value.build_embeddings.return_value = MagicMock()
+            user = MagicMock(id=uuid.uuid4())
+
+            await KBIngestionHelper.build_embeddings("OpenAI", "text-embedding-3-large", user)
+
+        assert mock_component_cls.called
+
+
 class TestMemoryBaseModel:
     def test_defaults(self):
         mb = MemoryBase(


### PR DESCRIPTION
## Summary

Memory Base retrieval was failing on every flow run with:

> ComponentBuildError: Embedding model 'text-embedding-3-small' for provider 'OpenAI' not found.

Confirmed for `text-embedding-3-small`, `text-embedding-3-large`, and `models/gemini-embedding-001`. Two interacting bugs:

1. **`KBIngestionHelper.build_embeddings` consulted the user-filtered catalog.** It looked the (provider, model) pair up via `get_embedding_model_options(user_id=…)`, which returns an empty list whenever `_fetch_enabled_providers_for_user` silently fails (happens when the call is bridged from an async event loop into a worker thread via `run_until_complete`). Result: even a default-listed model like `text-embedding-3-small` couldn't be resolved at retrieval time. The fallback `get_embedding_model_options()` (no `user_id`) is also empty, because that helper requires `enabled_providers` to be non-empty before yielding anything. Now we resolve straight from the static `EMBEDDING_PROVIDER_CLASS_MAPPING` / `EMBEDDING_PARAM_MAPPINGS` registry — the persisted `embedding_metadata.json` is the source of truth, and the runtime API key is still resolved later via `get_embeddings`.

2. **`infer_embedding_provider` misclassified Google Gemini embeddings.** `models/gemini-embedding-001` matched none of the Google patterns (`palm`, `gecko`, `google`) and fell through to the `"OpenAI"` default. The Google patterns also returned `"Google"`, but the canonical name registered in `EMBEDDING_PROVIDER_CLASS_MAPPING` is `"Google Generative AI"`, so even when inference matched it produced an unusable provider. Fixed by:
   - Looking the model up in the unified catalog first (single source of truth for provider names).
   - Updating the pattern table to recognize the `models/…` prefix Google uses and to return `"Google Generative AI"`.

## Files changed

- [embedding_helpers.py](src/backend/base/langflow/services/memory_base/embedding_helpers.py) — catalog lookup + corrected pattern table.
- [kb_helpers.py](src/backend/base/langflow/api/utils/kb_helpers.py) — `build_embeddings` now constructs the embedding option from the static registry; drops the now-unused `get_embedding_model_options` import.
- [test_memory_bases.py](src/backend/tests/unit/test_memory_bases.py) — adds `TestInferEmbeddingProvider` and `TestKBIngestionHelperBuildEmbeddings` regression suites.

## Test plan

- [x] `pytest src/backend/tests/unit/test_memory_bases.py` — 136 passed (was 121, +15 new).
- [x] `pytest src/backend/tests/unit/test_memory_base_task.py` — passing.
- [x] `pytest src/backend/tests/unit/test_knowledge_bases_api.py` — passing.
- [x] `pytest src/backend/tests/unit/components/files_and_knowledge/test_memory_retrieval.py` — passing.
- [x] `ruff check` clean on touched files.
- [ ] Manual smoke test: configure OpenAI in Settings, create a Memory Base with `text-embedding-3-small`, drop the Memory Base component on a flow, run it. Should no longer raise `ComponentBuildError`.
- [ ] Manual smoke test: same flow with `models/gemini-embedding-001` and a Google Generative AI key.