### PR TITLE
fix: pin postgres image to bookworm in docker_example

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -237,7 +237,7 @@
         "filename": "docker_example/docker-compose.yml",
         "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 24,
         "is_secret": false
       }
     ],
@@ -247,7 +247,7 @@
         "filename": "docker_example/pre.docker-compose.yml",
         "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 25,
         "is_secret": false
       }
     ],
@@ -8253,5 +8253,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-07T18:00:42Z"
+  "generated_at": "2026-05-07T19:13:33Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -237,7 +237,7 @@
         "filename": "docker_example/docker-compose.yml",
         "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 22,
         "is_secret": false
       }
     ],
@@ -247,7 +247,7 @@
         "filename": "docker_example/pre.docker-compose.yml",
         "hashed_secret": "e80c4f90316c87b6b24d03890493c8d1c7c1c99d",
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 23,
         "is_secret": false
       }
     ],
@@ -8253,5 +8253,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-05T19:37:49Z"
+  "generated_at": "2026-05-07T18:00:42Z"
 }

--- a/docker_example/README.md
+++ b/docker_example/README.md
@@ -48,7 +48,7 @@ Volumes:
 
 ### PostgreSQL Service
 
-The `postgres` service uses the `postgres:16` Docker image and exposes port 5432.
+The `postgres` service uses the `postgres:16-bookworm` Docker image and exposes port 5432. The image is pinned to the `bookworm` (Debian 12, glibc 2.36) base to keep the OS-level locale data stable across rebuilds and avoid collation version mismatch warnings on existing data volumes.
 
 Environment variables:
 

--- a/docker_example/README.md
+++ b/docker_example/README.md
@@ -48,7 +48,7 @@ Volumes:
 
 ### PostgreSQL Service
 
-The `postgres` service uses the `postgres:16-bookworm` Docker image and exposes port 5432. The image is pinned to the `bookworm` (Debian 12, glibc 2.36) base to keep the OS-level locale data stable across rebuilds and avoid collation version mismatch warnings on existing data volumes.
+The `postgres` service uses the `postgres:16-trixie` Docker image and exposes port 5432. The image is pinned to a specific Debian base (`trixie`, Debian 13) so the `postgres:16` tag cannot silently roll its underlying OS, which would otherwise produce a glibc collation version mismatch warning on existing data volumes.
 
 Environment variables:
 
@@ -59,6 +59,26 @@ Environment variables:
 Volumes:
 
 - `langflow-postgres`: This volume is mapped to `/var/lib/postgresql/data` in the container.
+
+### Upgrading from a `bookworm`-initialized volume
+
+Earlier versions of this example used `postgres:16`, which initially shipped on Debian Bookworm (glibc 2.36). The pinned image now uses Trixie (glibc 2.41). On the first start against a volume that was initialized under Bookworm, PostgreSQL logs a one-time warning:
+
+```
+WARNING: database "langflow" has a collation version mismatch
+DETAIL: The database was created using collation version 2.36, but the operating system provides version 2.41.
+```
+
+To clear it, refresh the collation version against the running database (one-off, takes seconds on a typical Langflow database):
+
+```sh
+docker compose exec postgres \
+  psql -U langflow -d langflow \
+  -c "REINDEX DATABASE langflow;" \
+  -c "ALTER DATABASE langflow REFRESH COLLATION VERSION;"
+```
+
+Fresh installs are unaffected.
 
 ## Switching to a Specific LangFlow Version
 

--- a/docker_example/docker-compose.yml
+++ b/docker_example/docker-compose.yml
@@ -14,9 +14,11 @@ services:
       - langflow-data:/app/langflow
 
   postgres:
-    # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
-    # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
-    image: postgres:16-bookworm
+    # Pinned to a specific Debian base (trixie) so the postgres:16 tag does not
+    # silently roll its OS underneath us — that roll causes a glibc collation
+    # version mismatch warning on existing volumes. Matches the langflow image
+    # base. See https://github.com/langflow-ai/langflow/issues/9608
+    image: postgres:16-trixie
     environment:
       POSTGRES_USER: langflow
       POSTGRES_PASSWORD: langflow

--- a/docker_example/docker-compose.yml
+++ b/docker_example/docker-compose.yml
@@ -14,7 +14,9 @@ services:
       - langflow-data:/app/langflow
 
   postgres:
-    image: postgres:16
+    # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
+    # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
+    image: postgres:16-bookworm
     environment:
       POSTGRES_USER: langflow
       POSTGRES_PASSWORD: langflow

--- a/docker_example/pre.docker-compose.yml
+++ b/docker_example/pre.docker-compose.yml
@@ -15,7 +15,9 @@ services:
       - langflow-data:/app/langflow
 
   postgres:
-    image: postgres:16
+    # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
+    # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
+    image: postgres:16-bookworm
     environment:
       POSTGRES_USER: langflow
       POSTGRES_PASSWORD: langflow

--- a/docker_example/pre.docker-compose.yml
+++ b/docker_example/pre.docker-compose.yml
@@ -15,9 +15,11 @@ services:
       - langflow-data:/app/langflow
 
   postgres:
-    # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
-    # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
-    image: postgres:16-bookworm
+    # Pinned to a specific Debian base (trixie) so the postgres:16 tag does not
+    # silently roll its OS underneath us — that roll causes a glibc collation
+    # version mismatch warning on existing volumes. Matches the langflow image
+    # base. See https://github.com/langflow-ai/langflow/issues/9608
+    image: postgres:16-trixie
     environment:
       POSTGRES_USER: langflow
       POSTGRES_PASSWORD: langflow

--- a/docs/docs/Deployment/deployment-docker.mdx
+++ b/docs/docs/Deployment/deployment-docker.mdx
@@ -232,7 +232,9 @@ For example, this Docker Compose file uses a bind mount for Langflow data (`./la
         volumes:
           - ./langflow-data:/app/langflow
       postgres:
-        image: postgres:16
+        # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
+        # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
+        image: postgres:16-bookworm
         volumes:
           - langflow-postgres:/var/lib/postgresql/data
 

--- a/docs/docs/Deployment/deployment-docker.mdx
+++ b/docs/docs/Deployment/deployment-docker.mdx
@@ -232,9 +232,10 @@ For example, this Docker Compose file uses a bind mount for Langflow data (`./la
         volumes:
           - ./langflow-data:/app/langflow
       postgres:
-        # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
-        # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
-        image: postgres:16-bookworm
+        # Pinned to a specific Debian base (trixie) so the postgres:16 tag does
+        # not silently roll its OS, which triggers a glibc collation mismatch
+        # warning on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
+        image: postgres:16-trixie
         volumes:
           - langflow-postgres:/var/lib/postgresql/data
 

--- a/docs/docs/Develop/configuration-custom-database.mdx
+++ b/docs/docs/Develop/configuration-custom-database.mdx
@@ -124,7 +124,9 @@ For example:
     ```yaml
     services:
       postgres:
-        image: postgres:16
+        # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
+        # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
+        image: postgres:16-bookworm
         environment:
           - POSTGRES_USER=${POSTGRES_USER}
           - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}

--- a/docs/docs/Develop/configuration-custom-database.mdx
+++ b/docs/docs/Develop/configuration-custom-database.mdx
@@ -124,9 +124,10 @@ For example:
     ```yaml
     services:
       postgres:
-        # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
-        # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
-        image: postgres:16-bookworm
+        # Pinned to a specific Debian base (trixie) so the postgres:16 tag does
+        # not silently roll its OS, which triggers a glibc collation mismatch
+        # warning on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
+        image: postgres:16-trixie
         environment:
           - POSTGRES_USER=${POSTGRES_USER}
           - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}

--- a/docs/docs/Develop/enterprise-database-guide.mdx
+++ b/docs/docs/Develop/enterprise-database-guide.mdx
@@ -67,7 +67,9 @@ For more information, see [Configure an external PostgreSQL database](/configura
         environment:
           - LANGFLOW_DATABASE_URL=postgresql://langflow:langflow@postgres:5432/langflow
       postgres:
-        image: postgres:16
+        # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
+        # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
+        image: postgres:16-bookworm
         ports:
           - "5432:5432"
         environment:

--- a/docs/docs/Develop/enterprise-database-guide.mdx
+++ b/docs/docs/Develop/enterprise-database-guide.mdx
@@ -67,9 +67,10 @@ For more information, see [Configure an external PostgreSQL database](/configura
         environment:
           - LANGFLOW_DATABASE_URL=postgresql://langflow:langflow@postgres:5432/langflow
       postgres:
-        # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
-        # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
-        image: postgres:16-bookworm
+        # Pinned to a specific Debian base (trixie) so the postgres:16 tag does
+        # not silently roll its OS, which triggers a glibc collation mismatch
+        # warning on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
+        image: postgres:16-trixie
         ports:
           - "5432:5432"
         environment:

--- a/docs/docs/Develop/integrations-langfuse.mdx
+++ b/docs/docs/Develop/integrations-langfuse.mdx
@@ -107,7 +107,9 @@ As an alternative to the previous setup, particularly for self-hosted Langfuse, 
           - langflow-data:/app/langflow
 
       postgres:
-        image: postgres:16
+        # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
+        # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
+        image: postgres:16-bookworm
         environment:
           POSTGRES_USER: langflow
           POSTGRES_PASSWORD: langflow

--- a/docs/docs/Develop/integrations-langfuse.mdx
+++ b/docs/docs/Develop/integrations-langfuse.mdx
@@ -107,9 +107,10 @@ As an alternative to the previous setup, particularly for self-hosted Langfuse, 
           - langflow-data:/app/langflow
 
       postgres:
-        # Pinned to bookworm (glibc 2.36) to prevent collation version mismatch
-        # warnings on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
-        image: postgres:16-bookworm
+        # Pinned to a specific Debian base (trixie) so the postgres:16 tag does
+        # not silently roll its OS, which triggers a glibc collation mismatch
+        # warning on existing volumes. See https://github.com/langflow-ai/langflow/issues/9608
+        image: postgres:16-trixie
         environment:
           POSTGRES_USER: langflow
           POSTGRES_PASSWORD: langflow


### PR DESCRIPTION
## Summary

Pin the PostgreSQL image in `docker_example/` from `postgres:16` to `postgres:16-bookworm` to prevent a recurring collation version mismatch warning on existing `langflow-postgres` volumes.

## Background

Users running Langflow with the example `docker-compose.yml` and `pull_policy: always` see this warning after Docker Hub silently rolled the `postgres:16` tag from Debian Bookworm (glibc 2.36) to Debian Trixie (glibc 2.41):

```
WARNING: database "langflow" has a collation version mismatch
DETAIL: The database was created using collation version 2.36, but the
operating system provides version 2.41.
```

The warning is harmless in most cases but floods logs and creates user confusion. Reported in [#9608](https://github.com/langflow-ai/langflow/issues/9608).

## Root cause

`docker_example/docker-compose.yml` used `postgres:16` without a base-OS qualifier. When Docker Hub updated `postgres:16` from a Bookworm-based build to a Trixie-based build, any user with `pull_policy: always` pulled the new image and started it against a data directory initialized under the older glibc collation version.

## Fix

- Pin to `postgres:16-bookworm` in [docker_example/docker-compose.yml](https://github.com/langflow-ai/langflow/blob/fix/postgres-version/docker_example/docker-compose.yml) and [docker_example/pre.docker-compose.yml](https://github.com/langflow-ai/langflow/blob/fix/postgres-version/docker_example/pre.docker-compose.yml).
- Add inline comments explaining the pin and linking to issue #9608.
- Update [docker_example/README.md](https://github.com/langflow-ai/langflow/blob/fix/postgres-version/docker_example/README.md) so the documented image tag matches.

Bookworm specifically (vs. Trixie) keeps the OS locale data stable for users with pre-existing volumes initialized under glibc 2.36, while still receiving 16.x patch updates.

## Test plan

- [ ] `docker compose -f docker_example/docker-compose.yml up` starts cleanly
- [ ] No `collation version mismatch` warning on container startup
- [ ] Existing `langflow-postgres` volumes (initialized under glibc 2.36) start without the warning
- [ ] `langflow` service can still connect to the pinned postgres