### PR TITLE
chore: improve AI-agent context (CLAUDE.md auto-load + AGENTS.md tweaks)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ Required fixtures: `component_class`, `default_kwargs`, `file_names_mapping`
 - Database tests may fail in batch but pass individually
 - Pre-commit hooks require `uv run git commit`
 - Always use `uv run` when running Python commands
+- When running tests inside a sub-package (e.g. `langflow-base`, `lfx`), sync that package's dev group first: `uv sync --group dev --package langflow-base`. The default `uv sync` only resolves the top-level workspace and may leave dev-only test deps (e.g. `fakeredis`) uninstalled.
 
 ### Graph Testing Pattern
 
@@ -178,11 +179,13 @@ This updates: `pyproject.toml`, `src/backend/base/pyproject.toml`, `src/frontend
 
 ## Pre-commit Workflow
 
-1. Run `make format_backend` (FIRST - saves time on lint fixes)
-2. Run `make format_frontend`
-3. Run `make lint`
-4. Run `make unit_tests`
-5. Commit changes (use `uv run git commit` if pre-commit hooks are enabled)
+Pre-commit hooks run ruff and biome automatically on `git commit`, so manual
+formatting is not required. To avoid an extra commit cycle when you have many
+changes:
+
+1. Run `make format_backend` once before staging - fixes most ruff issues up front.
+2. Run `uv run git commit` (the `uv run` ensures pre-commit finds the right Python).
+3. If you touched backend code, run `make unit_tests` locally for faster feedback than CI.
 
 ## Pull Request Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # CLAUDE.md
 
-See [AGENTS.md](./AGENTS.md) for project instructions.
+@AGENTS.md
 
-This project uses [AGENTS.md](https://agents.md/) as the standard for providing context to AI coding agents. The AGENTS.md file contains all the information needed to understand and contribute to this codebase.
+This project uses [AGENTS.md](https://agents.md/) as the standard for providing context to AI coding agents. The `@AGENTS.md` import above tells Claude Code to load `AGENTS.md` automatically; other tools that natively support `AGENTS.md` will pick it up directly.


### PR DESCRIPTION
## Summary

Two small improvements to make this repo work better with AI coding agents.

### 1. Auto-load AGENTS.md via CLAUDE.md

The previous `CLAUDE.md` was a human-readable redirect to `AGENTS.md`, but Claude Code does not yet natively read `AGENTS.md` (tracked upstream in [anthropics/claude-code#6235](https://github.com/anthropics/claude-code/issues/6235), [#31005](https://github.com/anthropics/claude-code/issues/31005), [#34235](https://github.com/anthropics/claude-code/issues/34235)). The agent silently missed our project instructions.

Fix: replace the redirect text with an `@AGENTS.md` import directive. Claude Code does support this and will load `AGENTS.md` content into context. Other agents (Codex, Cursor, Copilot, etc.) already read `AGENTS.md` directly. Verified with a fresh `claude -p` subprocess that the import resolves.

### 2. AGENTS.md content tweaks

- **Sub-package dev deps**: noted that running tests inside `langflow-base` or `lfx` requires `uv sync --group dev --package <name>` because the default sync leaves sub-package dev deps (e.g. `fakeredis`) uninstalled. Tripped me up while testing #12588.
- **Pre-commit Workflow**: tightened the 5-step manual sequence into a 3-step note that acknowledges pre-commit hooks already run ruff/biome automatically on commit.