### PR TITLE
refactor: refine MCP Server tab layout and alignment

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/ToolsComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/ToolsComponent/index.tsx
@@ -24,8 +24,13 @@ export default function ToolsComponent({
   disabled = false,
   template,
   showParameter = true,
+  hideButton = false,
+  open,
+  setOpen,
 }: InputProps<any[] | undefined, ToolsComponentType>): JSX.Element | null {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isModalOpen = open ?? internalOpen;
+  const setIsModalOpen = setOpen ?? setInternalOpen;
   const actions = value
     ?.filter((action) => action.status === true)
     .map((action) => {
@@ -69,7 +74,7 @@ export default function ToolsComponent({
         className="relative flex items-center w-full gap-3"
         data-testid={"div-" + id}
       >
-        {(visibleActions.length > 0 || isAction) && (
+        {!hideButton && (visibleActions.length > 0 || isAction) && (
           <Button
             variant={
               ENABLE_MCP_COMPOSER && button_description ? "outline" : "ghost"
@@ -103,7 +108,12 @@ export default function ToolsComponent({
             ))}
           </div>
         ) : visibleActions.length > 0 ? (
-          <div className="flex w-full flex-wrap gap-1 overflow-hidden py-1.5">
+          <div
+            className={cn(
+              "flex w-full flex-wrap gap-1 overflow-hidden pb-1.5",
+              hideButton ? "pt-0" : "pt-3",
+            )}
+          >
             {visibleActions.map((action, index) => (
               <Badge
                 key={index}
@@ -125,16 +135,21 @@ export default function ToolsComponent({
           </div>
         ) : (
           visibleActions.length === 0 &&
-          isAction && (
+          isAction &&
+          (hideButton ? (
+            <span className="py-1.5 text-sm text-muted-foreground">
+              No tools added to this server
+            </span>
+          ) : (
             <div className="mt-2 flex w-full flex-col items-center gap-2 rounded-md border border-dashed p-8">
               <span className="text-sm text-muted-foreground">
-                No actions added to this server
+                No tools added to this server
               </span>
               <Button size={"sm"} onClick={() => setIsModalOpen(true)}>
-                <span>Add actions</span>
+                <span>Add tools</span>
               </Button>
             </div>
-          )
+          ))
         )}
 
         {visibleActions.length === 0 && !isAction && value && (

--- a/src/frontend/src/components/core/parameterRenderComponent/types.ts
+++ b/src/frontend/src/components/core/parameterRenderComponent/types.ts
@@ -59,6 +59,9 @@ export type ToolsComponentType = {
   button_description?: string;
   isAction?: boolean;
   template?: APITemplateType;
+  hideButton?: boolean;
+  open?: boolean;
+  setOpen?: (open: boolean) => void;
 };
 
 export type FloatComponentType = {

--- a/src/frontend/src/pages/MainPage/pages/homePage/components/McpAuthSection.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/components/McpAuthSection.tsx
@@ -23,7 +23,7 @@ export const McpAuthSection = ({
 }: McpAuthSectionProps) => {
   const { t } = useTranslation();
   return (
-    <div className="flex justify-between">
+    <div className="flex items-center justify-between">
       <span className="flex gap-2 items-center text-sm cursor-default">
         <span className=" font-medium">{t("mcp.auth")}</span>
         {!hasAuthentication ? (

--- a/src/frontend/src/pages/MainPage/pages/homePage/components/McpAutoInstallContent.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/components/McpAutoInstallContent.tsx
@@ -25,7 +25,7 @@ export const McpAutoInstallContent = ({
   installClient,
   installedClients,
 }: McpAutoInstallContentProps) => (
-  <div className="flex flex-col gap-1 mt-4">
+  <div className="flex flex-col gap-1">
     {!isLocalConnection && (
       <div className="mb-2 rounded-md bg-accent-amber px-3 py-2 text-sm text-accent-amber-foreground">
         <div className="flex items-center gap-3">

--- a/src/frontend/src/pages/MainPage/pages/homePage/components/McpFlowsSection.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/components/McpFlowsSection.tsx
@@ -1,7 +1,11 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ForwardedIconComponent } from "@/components/common/genericIconComponent";
 import ShadTooltip from "@/components/common/shadTooltipComponent";
 import ToolsComponent from "@/components/core/parameterRenderComponent/components/ToolsComponent";
+import { Button } from "@/components/ui/button";
+import { ICON_STROKE_WIDTH } from "@/constants/constants";
+import { ENABLE_MCP_COMPOSER } from "@/customization/feature-flags";
 import type { InputFieldType } from "@/types/api";
 import type { ToolFlow } from "../utils/mcpServerUtils";
 
@@ -15,9 +19,11 @@ export const McpFlowsSection = ({
   handleOnNewValue,
 }: McpFlowsSectionProps) => {
   const { t } = useTranslation();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   return (
-    <div className="w-full xl:w-2/5">
-      <div className="flex flex-row justify-between pt-1">
+    <div className="w-full pr-4 xl:w-2/5">
+      <div className="flex flex-row items-center justify-between">
         <ShadTooltip content={t("mcp.flowsTooltip")} side="right">
           <div className="flex items-center text-sm font-medium hover:cursor-help">
             {t("mcp.flowsTools")}
@@ -28,8 +34,22 @@ export const McpFlowsSection = ({
             />
           </div>
         </ShadTooltip>
+        <Button
+          variant={ENABLE_MCP_COMPOSER ? "outline" : "ghost"}
+          size="sm"
+          data-testid="button_open_actions"
+          onClick={() => setIsModalOpen(true)}
+          className="!text-mmd font-normal"
+        >
+          <ForwardedIconComponent
+            name={ENABLE_MCP_COMPOSER ? "wrench" : "Settings2"}
+            className="icon-size"
+            strokeWidth={ICON_STROKE_WIDTH}
+          />
+          {t("mcp.editTools")}
+        </Button>
       </div>
-      <div className="flex flex-row flex-wrap gap-2 pt-2">
+      <div className="flex flex-row flex-wrap gap-2 pt-4">
         <ToolsComponent
           value={flowsMCPData}
           title={t("mcp.toolsTitle")}
@@ -40,6 +60,9 @@ export const McpFlowsSection = ({
           editNode={false}
           isAction
           disabled={false}
+          hideButton
+          open={isModalOpen}
+          setOpen={setIsModalOpen}
         />
       </div>
     </div>

--- a/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
+++ b/src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx
@@ -126,7 +126,7 @@ const McpServerTab = ({ folderName }: { folderName: string }) => {
             </div>
           </div>
 
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-4 rounded-md border border-dashed border-border p-4">
             {hasOAuthError ? (
               <div className="p-4 bg-accent-red-subtle border border-accent-red-border rounded-lg">
                 <div className="flex items-center gap-2 mb-2">


### PR DESCRIPTION
## Summary

Refines the MCP Server tab layout in the home page so the two halves are visually aligned and the install content area is delimited:

- Wraps the install/JSON content in a dashed bordered container (mirrors the empty-state pattern used elsewhere)
- Moves the Edit Tools button next to the Flows/Tools label
- Aligns the first chip row vertically with the Auto install / JSON tabs
- Centers the Auth row vertically
- Drops a redundant `mt-4` in `McpAutoInstallContent` that was making the dashed box's top padding visually larger than its bottom padding

## ToolsComponent change

To let `McpFlowsSection` render its own Edit Tools button (next to the section label) while still triggering the same modal, `ToolsComponent` now accepts:

- `hideButton?: boolean` — skips rendering its internal absolute-positioned Edit button
- `open?: boolean` / `setOpen?: (open: boolean) => void` — optional controlled modal state

When the new props are omitted, behavior is unchanged. The node parameter renderer (the other consumer) is untouched.