### PR TITLE
fix: exclude component error messages from MemoryBase ingestion

### DIFF
--- a/src/backend/base/langflow/services/memory_base/task.py
+++ b/src/backend/base/langflow/services/memory_base/task.py
@@ -334,13 +334,21 @@ async def _fetch_pending_messages(
     session_id: str,
     cursor_id: uuid.UUID | None,
 ) -> list[MessageTable]:
-    """Fetch all messages for this session that come after cursor_id using shared session."""
+    """Fetch all messages for this session that come after cursor_id using shared session.
+
+    Excludes component error/exception messages (``error=True`` or ``category='error'``)
+    so error text emitted by failing components is never indexed as legitimate
+    conversation content. The cursor still advances past any newer non-error messages,
+    so skipped error rows will not be reconsidered on subsequent runs.
+    """
     from sqlalchemy import and_, or_
 
     stmt = (
         select(MessageTable)
         .where(MessageTable.flow_id == flow_id)
         .where(MessageTable.session_id == session_id)
+        .where(MessageTable.error == False)  # noqa: E712
+        .where(MessageTable.category != "error")
         .order_by(col(MessageTable.timestamp).asc(), col(MessageTable.id).asc())
     )
     if cursor_id is not None:

--- a/src/backend/tests/unit/test_memory_base_task.py
+++ b/src/backend/tests/unit/test_memory_base_task.py
@@ -1016,3 +1016,180 @@ class TestIngestionLocking:
 
         assert result == {"message": "No pending messages", "ingested": 0}
         advance_cursor_mock.assert_not_awaited()
+
+
+# ------------------------------------------------------------------ #
+#  _fetch_pending_messages — error-message filtering                  #
+# ------------------------------------------------------------------ #
+
+
+class TestFetchPendingMessagesFiltersErrors:
+    """Regression: component error/exception messages must never be ingested.
+
+    See bug report: "[Memory Base] Error messages from components are indexed as
+    valid chunks in Chroma".  The fetch must skip messages where ``error=True``
+    or ``category='error'`` so failure output (e.g. an embedder API error) is
+    never embedded as legitimate conversation context.
+    """
+
+    @staticmethod
+    def _engine():
+        from sqlalchemy.ext.asyncio import create_async_engine
+        from sqlmodel.pool import StaticPool
+
+        return create_async_engine(
+            "sqlite+aiosqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+
+    @pytest.mark.asyncio
+    async def test_excludes_messages_with_error_flag_or_error_category(self):
+        from langflow.services.database.models.message.model import MessageTable
+        from langflow.services.memory_base.task import _fetch_pending_messages
+        from sqlmodel import SQLModel
+        from sqlmodel.ext.asyncio.session import AsyncSession
+
+        engine = self._engine()
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(SQLModel.metadata.create_all)
+
+            flow_id = uuid.uuid4()
+            session_id = "sess-error-filter"
+            base_ts = datetime.now(timezone.utc)
+
+            good_user = MessageTable(
+                id=uuid.uuid4(),
+                sender="User",
+                sender_name="User",
+                session_id=session_id,
+                text="What is the weather?",
+                flow_id=flow_id,
+                timestamp=base_ts,
+                error=False,
+                category="message",
+            )
+            error_flag_only = MessageTable(
+                id=uuid.uuid4(),
+                sender="Knowledge Base",
+                sender_name="Knowledge Base",
+                session_id=session_id,
+                text="[Knowledge Base] Error embedding content (INVALID_ARGUMENT): 400.",
+                flow_id=flow_id,
+                timestamp=base_ts.replace(microsecond=base_ts.microsecond + 1),
+                error=True,
+                category="message",  # category may not always be "error"
+            )
+            error_category = MessageTable(
+                id=uuid.uuid4(),
+                sender="Knowledge Base",
+                sender_name="Knowledge Base",
+                session_id=session_id,
+                text="EmbedContentRequest.content contains an empty Part.",
+                flow_id=flow_id,
+                timestamp=base_ts.replace(microsecond=base_ts.microsecond + 2),
+                error=False,  # legacy rows may have error=False but category="error"
+                category="error",
+            )
+            good_ai = MessageTable(
+                id=uuid.uuid4(),
+                sender="Machine",
+                sender_name="AI",
+                session_id=session_id,
+                text="The weather is sunny.",
+                flow_id=flow_id,
+                timestamp=base_ts.replace(microsecond=base_ts.microsecond + 3),
+                error=False,
+                category="message",
+            )
+
+            async with AsyncSession(engine, expire_on_commit=False) as db:
+                db.add_all([good_user, error_flag_only, error_category, good_ai])
+                await db.commit()
+
+                fetched = await _fetch_pending_messages(
+                    db,
+                    flow_id=flow_id,
+                    session_id=session_id,
+                    cursor_id=None,
+                )
+
+            fetched_ids = {m.id for m in fetched}
+            assert good_user.id in fetched_ids
+            assert good_ai.id in fetched_ids
+            assert error_flag_only.id not in fetched_ids, "error=True message must be filtered"
+            assert error_category.id not in fetched_ids, "category='error' message must be filtered"
+        finally:
+            await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_other_session_or_flow_messages_still_excluded_even_when_error(self):
+        """Sanity check: error filter does not accidentally pull in cross-session rows."""
+        from langflow.services.database.models.message.model import MessageTable
+        from langflow.services.memory_base.task import _fetch_pending_messages
+        from sqlmodel import SQLModel
+        from sqlmodel.ext.asyncio.session import AsyncSession
+
+        engine = self._engine()
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(SQLModel.metadata.create_all)
+
+            flow_id = uuid.uuid4()
+            other_flow_id = uuid.uuid4()
+            session_id = "sess-A"
+            other_session_id = "sess-B"
+            ts = datetime.now(timezone.utc)
+
+            # Good message in *another* session — must not be returned.
+            other_session_msg = MessageTable(
+                id=uuid.uuid4(),
+                sender="User",
+                sender_name="User",
+                session_id=other_session_id,
+                text="cross-session leak attempt",
+                flow_id=flow_id,
+                timestamp=ts,
+                error=False,
+                category="message",
+            )
+            # Good message in another flow — must not be returned either.
+            other_flow_msg = MessageTable(
+                id=uuid.uuid4(),
+                sender="User",
+                sender_name="User",
+                session_id=session_id,
+                text="cross-flow leak attempt",
+                flow_id=other_flow_id,
+                timestamp=ts,
+                error=False,
+                category="message",
+            )
+            good = MessageTable(
+                id=uuid.uuid4(),
+                sender="User",
+                sender_name="User",
+                session_id=session_id,
+                text="kept",
+                flow_id=flow_id,
+                timestamp=ts.replace(microsecond=ts.microsecond + 1),
+                error=False,
+                category="message",
+            )
+
+            async with AsyncSession(engine, expire_on_commit=False) as db:
+                db.add_all([other_session_msg, other_flow_msg, good])
+                await db.commit()
+
+                fetched = await _fetch_pending_messages(
+                    db,
+                    flow_id=flow_id,
+                    session_id=session_id,
+                    cursor_id=None,
+                )
+
+            fetched_ids = {m.id for m in fetched}
+            assert fetched_ids == {good.id}
+        finally:
+            await engine.dispose()


### PR DESCRIPTION
## Summary

When a component inside a Memory-Base–watched flow emits an error message (for example, a Gemini embedder returning `EmbedContentRequest.content contains an empty Part`), Langflow persists that error to the message table with `error=True` and `category='error'`, and the component's `display_name` (e.g. `Knowledge Base`) as `sender`.

The MemoryBase ingestion task fetched **all** session messages after the cursor without any error filter, so the failure text was chunked, embedded, and written to Chroma — indistinguishable from legitimate User/AI turns at retrieval time. Top-k results then returned the error string as context.

This PR filters error rows out at the SQL fetch boundary in `_fetch_pending_messages` so they never reach the document builder or the Chroma write path. The cursor still advances past any later non-error message, so skipped error rows are not reconsidered on subsequent runs.

- Filter `WHERE error = false AND category != 'error'` covers both the boolean flag set by `ErrorMessage` and the legacy `category='error'` rows.
- No change to cursor advancement semantics — when only error messages are pending, the fetch returns empty and the cursor stays put until a real message arrives.

## Test plan

- [x] New regression tests in `test_memory_base_task.py::TestFetchPendingMessagesFiltersErrors` exercise the real SQL filter against an in-memory SQLite database:
  - `test_excludes_messages_with_error_flag_or_error_category` — seeds a User/AI pair plus two error rows (one with `error=True`, one with `category='error'`) and asserts only the User and AI messages are returned.
  - `test_other_session_or_flow_messages_still_excluded_even_when_error` — sanity-checks that the new predicate does not loosen the existing session/flow scoping.
- [x] Full local run of the existing memory-base test suites passes:
  ```
  uv run --frozen python -m pytest \
    src/backend/tests/unit/test_memory_base_task.py \
    src/backend/tests/unit/test_memory_bases.py
  # 123 passed
  ```
- [ ] Manual reproduction of the reported scenario (Chat Input → Knowledge Base → Parser → Prompt Template → Agent → Chat Output, KB component fails on empty query, MB threshold reached) — error chunk should no longer appear in the Chroma collection or in retrieval results.

Closes the bug report titled *"[Memory Base] Error messages from components are indexed as valid chunks in Chroma"*.