### PR TITLE
fix: avoid leaking raw exception details to HTTP clients

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import tempfile
+import uuid
 import warnings
 from contextlib import asynccontextmanager, suppress
 from http import HTTPStatus
@@ -576,13 +577,18 @@ def create_app():
                 status_code=exc.status_code,
                 content={"message": str(exc.detail)},
             )
-        await logger.aerror(f"unhandled error: {exc}", exc_info=exc)
+        # Generate a correlation id so operators can match the client-facing
+        # response to the full traceback in server logs without exposing the
+        # raw exception (which often contains file paths, SQL, or other
+        # internal details).
+        error_id = uuid.uuid4().hex
+        await logger.aerror(f"unhandled error [{error_id}]: {exc}", exc_info=exc)
 
         await log_exception_to_telemetry(exc, "handler")
 
         return JSONResponse(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            content={"message": str(exc)},
+            content={"message": "Internal server error", "error_id": error_id},
         )
 
     FastAPIInstrumentor.instrument_app(app)

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -80,6 +80,30 @@ async def log_exception_to_telemetry(exc: Exception, context: str) -> None:
         await logger.awarning(f"Failed to log {context} exception to telemetry")
 
 
+async def default_exception_handler(_request: Request, exc: Exception) -> JSONResponse:
+    """Catch-all exception handler.
+
+    For ``HTTPException`` we propagate ``exc.detail`` since callers raise it
+    intentionally as user-facing copy. For everything else we return a
+    generic message and a correlation id; the raw exception (which may
+    contain file paths, SQL fragments, internal hostnames, etc.) is only
+    written to server logs, not to the response body.
+    """
+    if isinstance(exc, HTTPException):
+        await logger.aerror(f"HTTPException: {exc}", exc_info=exc)
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"message": str(exc.detail)},
+        )
+    error_id = uuid.uuid4().hex
+    await logger.aerror(f"unhandled error [{error_id}]: {exc}", exc_info=exc)
+    await log_exception_to_telemetry(exc, "handler")
+    return JSONResponse(
+        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        content={"message": "Internal server error", "error_id": error_id},
+    )
+
+
 class RequestCancelledMiddleware(BaseHTTPMiddleware):
     def __init__(self, app) -> None:
         super().__init__(app)
@@ -569,27 +593,7 @@ def create_app():
             content={"detail": exc.detail},
         )
 
-    @app.exception_handler(Exception)
-    async def exception_handler(_request: Request, exc: Exception):
-        if isinstance(exc, HTTPException):
-            await logger.aerror(f"HTTPException: {exc}", exc_info=exc)
-            return JSONResponse(
-                status_code=exc.status_code,
-                content={"message": str(exc.detail)},
-            )
-        # Generate a correlation id so operators can match the client-facing
-        # response to the full traceback in server logs without exposing the
-        # raw exception (which often contains file paths, SQL, or other
-        # internal details).
-        error_id = uuid.uuid4().hex
-        await logger.aerror(f"unhandled error [{error_id}]: {exc}", exc_info=exc)
-
-        await log_exception_to_telemetry(exc, "handler")
-
-        return JSONResponse(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            content={"message": "Internal server error", "error_id": error_id},
-        )
+    app.add_exception_handler(Exception, default_exception_handler)
 
     FastAPIInstrumentor.instrument_app(app)
 

--- a/src/backend/tests/unit/test_default_exception_handler.py
+++ b/src/backend/tests/unit/test_default_exception_handler.py
@@ -1,0 +1,113 @@
+"""Tests for the catch-all exception handler.
+
+The handler must NOT echo unhandled exception messages back to the client —
+those routinely embed filesystem paths, SQL fragments, internal hostnames,
+and library versions, which are useful reconnaissance for an attacker.
+HTTPException detail strings, on the other hand, are intentionally
+caller-facing and should be preserved verbatim.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+from fastapi import HTTPException
+from langflow.main import default_exception_handler
+
+_HEX32 = re.compile(r"^[0-9a-f]{32}$")
+_SECRET_PATH = "/var/lib/langflow/secret/flows.db"
+
+
+@pytest.fixture(autouse=True)
+def _silence_side_effects(monkeypatch):
+    """Stub out the I/O the handler does so the unit test stays hermetic."""
+    import langflow.main as main_module
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(main_module, "log_exception_to_telemetry", _noop)
+    # Replace logger methods used by the handler.
+    monkeypatch.setattr(main_module.logger, "aerror", _noop)
+
+
+def _body(response) -> dict:
+    return json.loads(bytes(response.body).decode())
+
+
+@pytest.mark.asyncio
+async def test_unhandled_exception_returns_generic_message_with_error_id():
+    exc = RuntimeError(f"connection refused to {_SECRET_PATH}")
+    response = await default_exception_handler(None, exc)
+
+    assert response.status_code == 500
+    body = _body(response)
+    assert body["message"] == "Internal server error"
+    assert _HEX32.match(body["error_id"]), f"error_id should be a 32-char hex token, got {body['error_id']!r}"
+
+
+@pytest.mark.asyncio
+async def test_unhandled_exception_does_not_leak_str_exc():
+    """Regression guard: the previous handler returned ``str(exc)`` directly."""
+    exc = RuntimeError(f"sqlalchemy: column users.foo missing at {_SECRET_PATH}")
+    response = await default_exception_handler(None, exc)
+
+    body = _body(response)
+    raw = json.dumps(body)
+    # Neither the path, the SQL-ish fragment, nor the library hint may appear.
+    assert _SECRET_PATH not in raw
+    assert "sqlalchemy" not in raw
+    assert "column users.foo" not in raw
+
+
+@pytest.mark.asyncio
+async def test_each_call_produces_unique_error_id():
+    exc = ValueError("boom")
+    r1 = _body(await default_exception_handler(None, exc))
+    r2 = _body(await default_exception_handler(None, exc))
+    assert r1["error_id"] != r2["error_id"]
+
+
+@pytest.mark.asyncio
+async def test_http_exception_passes_detail_through_unchanged():
+    exc = HTTPException(status_code=404, detail="Project not found")
+    response = await default_exception_handler(None, exc)
+
+    assert response.status_code == 404
+    assert _body(response) == {"message": "Project not found"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 409, 422])
+async def test_http_exception_preserves_status_code(status_code):
+    exc = HTTPException(status_code=status_code, detail="msg")
+    response = await default_exception_handler(None, exc)
+    assert response.status_code == status_code
+
+
+@pytest.mark.asyncio
+async def test_http_exception_with_dict_detail_is_stringified():
+    """The legacy contract was ``str(exc.detail)``; preserve it for HTTPException."""
+    exc = HTTPException(status_code=400, detail={"field": "bad"})
+    response = await default_exception_handler(None, exc)
+    body = _body(response)
+    assert body["message"] == str({"field": "bad"})
+
+
+@pytest.mark.asyncio
+async def test_long_exception_chain_does_not_leak():
+    """Chained exceptions can stash the original message in __context__."""
+    try:
+        try:
+            msg = f"opening {_SECRET_PATH}"
+            raise FileNotFoundError(msg)
+        except FileNotFoundError as inner:
+            raise RuntimeError("wrapper") from inner
+    except RuntimeError as exc:
+        response = await default_exception_handler(None, exc)
+
+    raw = json.dumps(_body(response))
+    assert _SECRET_PATH not in raw
+    assert "FileNotFoundError" not in raw

--- a/src/backend/tests/unit/test_default_exception_handler.py
+++ b/src/backend/tests/unit/test_default_exception_handler.py
@@ -17,7 +17,7 @@ from fastapi import HTTPException
 from langflow.main import default_exception_handler
 
 _HEX32 = re.compile(r"^[0-9a-f]{32}$")
-_SECRET_PATH = "/var/lib/langflow/secret/flows.db"
+_LEAKY_PATH = "/var/lib/langflow/internal/flows.db"
 
 
 @pytest.fixture(autouse=True)
@@ -39,7 +39,7 @@ def _body(response) -> dict:
 
 @pytest.mark.asyncio
 async def test_unhandled_exception_returns_generic_message_with_error_id():
-    exc = RuntimeError(f"connection refused to {_SECRET_PATH}")
+    exc = RuntimeError(f"connection refused to {_LEAKY_PATH}")
     response = await default_exception_handler(None, exc)
 
     assert response.status_code == 500
@@ -51,13 +51,13 @@ async def test_unhandled_exception_returns_generic_message_with_error_id():
 @pytest.mark.asyncio
 async def test_unhandled_exception_does_not_leak_str_exc():
     """Regression guard: the previous handler returned ``str(exc)`` directly."""
-    exc = RuntimeError(f"sqlalchemy: column users.foo missing at {_SECRET_PATH}")
+    exc = RuntimeError(f"sqlalchemy: column users.foo missing at {_LEAKY_PATH}")
     response = await default_exception_handler(None, exc)
 
     body = _body(response)
     raw = json.dumps(body)
     # Neither the path, the SQL-ish fragment, nor the library hint may appear.
-    assert _SECRET_PATH not in raw
+    assert _LEAKY_PATH not in raw
     assert "sqlalchemy" not in raw
     assert "column users.foo" not in raw
 
@@ -101,13 +101,14 @@ async def test_long_exception_chain_does_not_leak():
     """Chained exceptions can stash the original message in __context__."""
     try:
         try:
-            msg = f"opening {_SECRET_PATH}"
+            msg = f"opening {_LEAKY_PATH}"
             raise FileNotFoundError(msg)
         except FileNotFoundError as inner:
-            raise RuntimeError("wrapper") from inner
+            wrap_msg = "wrapper"
+            raise RuntimeError(wrap_msg) from inner
     except RuntimeError as exc:
         response = await default_exception_handler(None, exc)
 
     raw = json.dumps(_body(response))
-    assert _SECRET_PATH not in raw
+    assert _LEAKY_PATH not in raw
     assert "FileNotFoundError" not in raw


### PR DESCRIPTION
## Summary
- The global `Exception` handler in `create_app()` returned `{\"message\": str(exc)}` for any unhandled error. Exception messages often embed filesystem paths, SQL fragments, internal hostnames, and library versions — useful reconnaissance for an attacker probing endpoints with crafted input.
- Return a generic message and a correlation id instead; keep the full traceback in server logs (already emitted via `logger.aerror(..., exc_info=exc)`).
- `HTTPException` handling is unchanged — those carry intentional, caller-facing detail.

## Why this matters
Any reachable endpoint can be made to raise non-`HTTPException` errors (e.g. `ValueError`, `OSError`, `sqlalchemy.exc.OperationalError`, `KeyError`, `FileNotFoundError`) by sending malformed inputs or referencing non-existent resources. Today those errors are reflected verbatim to the client at `INTERNAL_SERVER_ERROR`, leaking internal details.

## Behavior change
Before:
```json
{ \"message\": \"(asyncpg.UndefinedColumnError) column users.foo does not exist\\n[SQL: SELECT ... ]\" }
```
After:
```json
{ \"message\": \"Internal server error\", \"error_id\": \"a1b2c3...\" }
```
The `error_id` is also logged alongside the full traceback so operators can correlate a client report to the server log.

## Test plan
- [ ] Existing tests still pass (HTTPException paths are untouched).
- [ ] Trigger an unhandled exception in development and confirm: client sees `{\"message\": \"Internal server error\", \"error_id\": ...}`; server logs include the same `error_id` plus the traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server errors now include unique correlation IDs in responses, enabling users and support teams to efficiently link error reports with corresponding server logs for faster resolution.
  * Generic error messages are now returned to clients while maintaining complete traceability through unique identifiers logged server-side for improved security and debugging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13056)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->