### PR TITLE
fix: mask MCP auth_settings ciphertext in folder responses

### DIFF
--- a/src/backend/base/langflow/api/v1/auth_helpers.py
+++ b/src/backend/base/langflow/api/v1/auth_helpers.py
@@ -2,7 +2,12 @@ from typing import Any
 
 from pydantic import SecretStr
 
-from langflow.services.auth.mcp_encryption import decrypt_auth_settings, encrypt_auth_settings
+from langflow.services.auth.mcp_encryption import (
+    SENSITIVE_FIELD_MASK,
+    SENSITIVE_FIELDS,
+    decrypt_auth_settings,
+    encrypt_auth_settings,
+)
 from langflow.services.database.models.folder.model import Folder
 
 
@@ -52,12 +57,13 @@ def handle_auth_settings_update(
 
     new_auth_type = auth_dict.get("auth_type")
 
-    # Handle masked secret fields from frontend
-    # If frontend sends back "*******" for a secret field, preserve the existing value
+    # Handle masked secret fields from frontend.
+    # If the frontend sends back the SENSITIVE_FIELD_MASK sentinel for a secret
+    # field, preserve the previously stored (decrypted) value instead of writing
+    # the placeholder to disk.
     if decrypted_current:
-        secret_fields = ["oauth_client_secret", "api_key"]
-        for field in secret_fields:
-            if field in auth_dict and auth_dict[field] == "*******" and field in decrypted_current:
+        for field in SENSITIVE_FIELDS:
+            if field in auth_dict and auth_dict[field] == SENSITIVE_FIELD_MASK and field in decrypted_current:
                 auth_dict[field] = decrypted_current[field]
 
     # Encrypt and store the auth settings

--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -63,7 +63,7 @@ from langflow.api.v1.schemas import (
     MCPSettings,
 )
 from langflow.services.auth.constants import AUTO_LOGIN_WARNING
-from langflow.services.auth.mcp_encryption import decrypt_auth_settings, encrypt_auth_settings
+from langflow.services.auth.mcp_encryption import decrypt_auth_settings, encrypt_auth_settings, mask_auth_settings
 from langflow.services.database.models import Flow, Folder
 from langflow.services.database.models.api_key.crud import check_key, create_api_key
 from langflow.services.database.models.api_key.model import ApiKey, ApiKeyCreate
@@ -273,16 +273,11 @@ async def _build_project_tools_response(
             # Get project-level auth settings but mask sensitive fields for security
             auth_settings = None
             if project.auth_settings:
-                # Decrypt to get the settings structure
+                # Decrypt to get the settings structure, then mask sensitive fields
+                # before constructing the response model.
                 decrypted_settings = decrypt_auth_settings(project.auth_settings)
                 if decrypted_settings:
-                    # Mask sensitive fields before sending to frontend
-                    masked_settings = decrypted_settings.copy()
-                    if masked_settings.get("oauth_client_secret"):
-                        masked_settings["oauth_client_secret"] = "*******"  # noqa: S105
-                    if masked_settings.get("api_key"):
-                        masked_settings["api_key"] = "*******"
-                    auth_settings = AuthSettings(**masked_settings)
+                    auth_settings = AuthSettings(**mask_auth_settings(decrypted_settings))
 
     except Exception as e:
         msg = f"Error listing project tools: {e!s}"

--- a/src/backend/base/langflow/services/auth/mcp_encryption.py
+++ b/src/backend/base/langflow/services/auth/mcp_encryption.py
@@ -13,6 +13,29 @@ SENSITIVE_FIELDS = [
     "api_key",
 ]
 
+# Placeholder shown to clients in place of stored ciphertext for any field in
+# SENSITIVE_FIELDS. The frontend round-trips this exact value back on PATCH and
+# `langflow.api.v1.auth_helpers.handle_auth_settings_update` treats it as a
+# sentinel meaning "keep the previously stored value", so changing this string
+# silently breaks the round-trip — keep all three call sites in sync.
+SENSITIVE_FIELD_MASK = "*******"
+
+
+def mask_auth_settings(auth_settings: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return a copy of ``auth_settings`` with SENSITIVE_FIELDS replaced by SENSITIVE_FIELD_MASK.
+
+    ``None`` and empty dicts pass through unchanged. Empty-string values are
+    left alone so the frontend can still distinguish "never set" from
+    "currently set but masked".
+    """
+    if not auth_settings:
+        return auth_settings
+    masked = dict(auth_settings)
+    for field in SENSITIVE_FIELDS:
+        if masked.get(field):
+            masked[field] = SENSITIVE_FIELD_MASK
+    return masked
+
 
 def encrypt_auth_settings(auth_settings: dict[str, Any] | None) -> dict[str, Any] | None:
     """Encrypt sensitive fields in auth_settings dictionary.

--- a/src/backend/base/langflow/services/database/models/folder/model.py
+++ b/src/backend/base/langflow/services/database/models/folder/model.py
@@ -1,12 +1,29 @@
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID, uuid4
 
+from pydantic import field_serializer
 from sqlalchemy import Text, UniqueConstraint
 from sqlmodel import JSON, Column, Field, Relationship, SQLModel
 
 from langflow.services.database.models.deployment.model import Deployment
 from langflow.services.database.models.flow.model import Flow, FlowRead
 from langflow.services.database.models.user.model import User
+
+# Keep in sync with SENSITIVE_FIELDS in
+# langflow.services.auth.mcp_encryption — these field names are encrypted at
+# rest and must never leave the server, even as ciphertext, in API responses.
+_AUTH_SECRET_FIELDS = ("oauth_client_secret", "api_key")
+_MASK = "*******"  # noqa: S105  # placeholder; matches frontend round-trip in auth_helpers.py
+
+
+def _mask_auth_settings(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not value:
+        return value
+    masked = dict(value)
+    for field in _AUTH_SECRET_FIELDS:
+        if masked.get(field):
+            masked[field] = _MASK
+    return masked
 
 
 class FolderBase(SQLModel):
@@ -49,11 +66,19 @@ class FolderRead(FolderBase):
     id: UUID
     parent_id: UUID | None = Field()
 
+    @field_serializer("auth_settings")
+    def _serialize_auth_settings(self, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        return _mask_auth_settings(value)
+
 
 class FolderReadWithFlows(FolderBase):
     id: UUID
     parent_id: UUID | None = Field()
     flows: list[FlowRead] = Field(default=[])
+
+    @field_serializer("auth_settings")
+    def _serialize_auth_settings(self, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        return _mask_auth_settings(value)
 
 
 class FolderUpdate(SQLModel):

--- a/src/backend/base/langflow/services/database/models/folder/model.py
+++ b/src/backend/base/langflow/services/database/models/folder/model.py
@@ -5,25 +5,10 @@ from pydantic import field_serializer
 from sqlalchemy import Text, UniqueConstraint
 from sqlmodel import JSON, Column, Field, Relationship, SQLModel
 
+from langflow.services.auth.mcp_encryption import mask_auth_settings
 from langflow.services.database.models.deployment.model import Deployment
 from langflow.services.database.models.flow.model import Flow, FlowRead
 from langflow.services.database.models.user.model import User
-
-# Keep in sync with SENSITIVE_FIELDS in
-# langflow.services.auth.mcp_encryption — these field names are encrypted at
-# rest and must never leave the server, even as ciphertext, in API responses.
-_AUTH_SECRET_FIELDS = ("oauth_client_secret", "api_key")
-_MASK = "*******"  # placeholder; matches frontend round-trip in auth_helpers.py
-
-
-def _mask_auth_settings(value: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not value:
-        return value
-    masked = dict(value)
-    for field in _AUTH_SECRET_FIELDS:
-        if masked.get(field):
-            masked[field] = _MASK
-    return masked
 
 
 class FolderBase(SQLModel):
@@ -68,7 +53,7 @@ class FolderRead(FolderBase):
 
     @field_serializer("auth_settings")
     def _serialize_auth_settings(self, value: dict[str, Any] | None) -> dict[str, Any] | None:
-        return _mask_auth_settings(value)
+        return mask_auth_settings(value)
 
 
 class FolderReadWithFlows(FolderBase):
@@ -78,7 +63,7 @@ class FolderReadWithFlows(FolderBase):
 
     @field_serializer("auth_settings")
     def _serialize_auth_settings(self, value: dict[str, Any] | None) -> dict[str, Any] | None:
-        return _mask_auth_settings(value)
+        return mask_auth_settings(value)
 
 
 class FolderUpdate(SQLModel):

--- a/src/backend/base/langflow/services/database/models/folder/model.py
+++ b/src/backend/base/langflow/services/database/models/folder/model.py
@@ -13,7 +13,7 @@ from langflow.services.database.models.user.model import User
 # langflow.services.auth.mcp_encryption — these field names are encrypted at
 # rest and must never leave the server, even as ciphertext, in API responses.
 _AUTH_SECRET_FIELDS = ("oauth_client_secret", "api_key")
-_MASK = "*******"  # noqa: S105  # placeholder; matches frontend round-trip in auth_helpers.py
+_MASK = "*******"  # placeholder; matches frontend round-trip in auth_helpers.py
 
 
 def _mask_auth_settings(value: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/src/backend/tests/unit/services/auth/test_mcp_encryption.py
+++ b/src/backend/tests/unit/services/auth/test_mcp_encryption.py
@@ -6,9 +6,12 @@ from unittest.mock import patch
 import pytest
 from cryptography.fernet import Fernet
 from langflow.services.auth.mcp_encryption import (
+    SENSITIVE_FIELD_MASK,
+    SENSITIVE_FIELDS,
     decrypt_auth_settings,
     encrypt_auth_settings,
     is_encrypted,
+    mask_auth_settings,
 )
 from langflow.services.auth.service import AuthService
 from lfx.services.settings.auth import AuthSettings
@@ -164,3 +167,64 @@ class TestMCPEncryption:
         # Test with encrypted value
         encrypted_value = mock_auth_service.encrypt_api_key("secret-value")
         assert is_encrypted(encrypted_value)
+
+
+class TestMaskAuthSettings:
+    """Coverage for the shared masker used in folder + MCP project responses.
+
+    The masker is consumed by ``FolderRead`` / ``FolderReadWithFlows``
+    serializers and by ``_build_project_tools_response`` in
+    ``api/v1/mcp_projects.py``. The mask string ``SENSITIVE_FIELD_MASK`` is
+    also a sentinel that the frontend round-trips on PATCH;
+    ``handle_auth_settings_update`` swaps it back to the stored ciphertext
+    before re-encrypting. Keep that contract pinned so changing the
+    constant fails loudly here.
+    """
+
+    def test_mask_constant_is_seven_asterisks(self):
+        # Pinned to the value the frontend already sends back on PATCH.
+        assert SENSITIVE_FIELD_MASK == "*******"
+
+    def test_sensitive_fields_pinned(self):
+        # Any addition here MUST be reflected in mask_auth_settings, the
+        # SENSITIVE_FIELDS list, and the frontend round-trip in
+        # api/v1/auth_helpers.py — pin it here so additions surface in review.
+        assert SENSITIVE_FIELDS == ["oauth_client_secret", "api_key"]
+
+    def test_none_passthrough(self):
+        assert mask_auth_settings(None) is None
+
+    def test_empty_dict_passthrough(self):
+        assert mask_auth_settings({}) == {}
+
+    def test_masks_oauth_client_secret(self):
+        result = mask_auth_settings({"auth_type": "oauth", "oauth_client_secret": "ciphertext-blob"})
+        assert result == {"auth_type": "oauth", "oauth_client_secret": SENSITIVE_FIELD_MASK}
+
+    def test_masks_api_key(self):
+        result = mask_auth_settings({"auth_type": "apikey", "api_key": "ciphertext-blob"})
+        assert result == {"auth_type": "apikey", "api_key": SENSITIVE_FIELD_MASK}
+
+    def test_preserves_non_secret_fields(self):
+        result = mask_auth_settings(
+            {
+                "auth_type": "oauth",
+                "oauth_client_id": "public-client-id",
+                "oauth_client_secret": "ciphertext-blob",
+                "oauth_server_url": "https://oauth.example.com",
+            }
+        )
+        assert result["oauth_client_id"] == "public-client-id"
+        assert result["oauth_server_url"] == "https://oauth.example.com"
+        assert result["oauth_client_secret"] == SENSITIVE_FIELD_MASK
+
+    def test_does_not_mutate_input(self):
+        original = {"auth_type": "apikey", "api_key": "ciphertext-blob"}
+        mask_auth_settings(original)
+        assert original == {"auth_type": "apikey", "api_key": "ciphertext-blob"}
+
+    def test_empty_secret_value_is_left_alone(self):
+        # Empty string is falsy, so we don't replace it with a mask — this lets
+        # the frontend still distinguish "never set" from "currently set but masked".
+        result = mask_auth_settings({"auth_type": "apikey", "api_key": ""})
+        assert result == {"auth_type": "apikey", "api_key": ""}

--- a/src/backend/tests/unit/services/database/models/folder/test_auth_settings_masking.py
+++ b/src/backend/tests/unit/services/database/models/folder/test_auth_settings_masking.py
@@ -1,0 +1,161 @@
+"""Tests for masking of MCP auth_settings ciphertext in folder response schemas.
+
+`FolderRead` / `FolderReadWithFlows` are returned by `/api/v1/projects/`
+and `/api/v1/projects/{id}`. They must not leak the encrypted
+`oauth_client_secret` / `api_key` blobs to clients — even as ciphertext —
+because the listing endpoint returns globally-shared folders to every
+authenticated user, and shipping secret material off the server is a
+defense-in-depth failure on its own.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from langflow.services.database.models.folder.model import (
+    Folder,
+    FolderRead,
+    FolderReadWithFlows,
+    _mask_auth_settings,
+)
+
+_FOLDER_ID = UUID("00000000-0000-0000-0000-000000000001")
+_CIPHER_OAUTH = "gAAAAABoauth-ciphertext-blob-XXXX"  # noqa: S105  # pragma: allowlist secret
+_CIPHER_APIKEY = "gAAAAABapikey-ciphertext-blob-XXXX"  # noqa: S105  # pragma: allowlist secret
+_MASK = "*******"
+
+
+class TestMaskAuthSettingsHelper:
+    def test_none_passthrough(self):
+        assert _mask_auth_settings(None) is None
+
+    def test_empty_dict_passthrough(self):
+        assert _mask_auth_settings({}) == {}
+
+    def test_masks_oauth_client_secret(self):
+        result = _mask_auth_settings({"auth_type": "oauth", "oauth_client_secret": _CIPHER_OAUTH})
+        assert result == {"auth_type": "oauth", "oauth_client_secret": _MASK}
+
+    def test_masks_api_key(self):
+        result = _mask_auth_settings({"auth_type": "apikey", "api_key": _CIPHER_APIKEY})
+        assert result == {"auth_type": "apikey", "api_key": _MASK}
+
+    def test_preserves_non_secret_fields(self):
+        result = _mask_auth_settings(
+            {
+                "auth_type": "oauth",
+                "oauth_client_id": "public-client-id",
+                "oauth_client_secret": _CIPHER_OAUTH,
+                "oauth_server_url": "https://oauth.example.com",
+            }
+        )
+        assert result["oauth_client_id"] == "public-client-id"
+        assert result["oauth_server_url"] == "https://oauth.example.com"
+        assert result["oauth_client_secret"] == _MASK
+
+    def test_does_not_mutate_input(self):
+        original = {"auth_type": "apikey", "api_key": _CIPHER_APIKEY}
+        _mask_auth_settings(original)
+        assert original == {"auth_type": "apikey", "api_key": _CIPHER_APIKEY}
+
+    def test_empty_secret_value_is_left_alone(self):
+        # Empty string is falsy, so we don't replace it with a mask.
+        result = _mask_auth_settings({"auth_type": "apikey", "api_key": ""})
+        assert result == {"auth_type": "apikey", "api_key": ""}
+
+
+class TestFolderReadSerializer:
+    def _make(self, **overrides):
+        kwargs = {
+            "id": _FOLDER_ID,
+            "parent_id": None,
+            "name": "Project",
+            "description": "desc",
+        }
+        kwargs.update(overrides)
+        return FolderRead(**kwargs)
+
+    def test_masks_both_secret_fields_when_present(self):
+        folder = self._make(
+            auth_settings={
+                "auth_type": "oauth",
+                "oauth_client_id": "id-public",
+                "oauth_client_secret": _CIPHER_OAUTH,
+                "api_key": _CIPHER_APIKEY,
+            }
+        )
+        dumped = folder.model_dump()
+        assert dumped["auth_settings"]["oauth_client_secret"] == _MASK
+        assert dumped["auth_settings"]["api_key"] == _MASK
+        assert dumped["auth_settings"]["oauth_client_id"] == "id-public"
+
+    def test_none_auth_settings_serializes_as_none(self):
+        folder = self._make(auth_settings=None)
+        assert folder.model_dump()["auth_settings"] is None
+
+    def test_secrets_masked_in_json_output(self):
+        folder = self._make(
+            auth_settings={
+                "auth_type": "apikey",
+                "api_key": _CIPHER_APIKEY,
+            }
+        )
+        # `model_dump_json` is the path FastAPI takes for response bodies.
+        payload = folder.model_dump_json()
+        assert _CIPHER_APIKEY not in payload
+        assert _MASK in payload
+
+
+class TestFolderReadWithFlowsSerializer:
+    def test_masks_secrets(self):
+        folder = FolderReadWithFlows(
+            id=_FOLDER_ID,
+            parent_id=None,
+            name="Project",
+            description="desc",
+            auth_settings={
+                "auth_type": "oauth",
+                "oauth_client_secret": _CIPHER_OAUTH,
+            },
+            flows=[],
+        )
+        dumped = folder.model_dump()
+        assert dumped["auth_settings"]["oauth_client_secret"] == _MASK
+        assert dumped["flows"] == []
+
+
+class TestFolderOrmModelUnaffected:
+    """The encrypt/decrypt code paths read `Folder.auth_settings` as a dict via
+    attribute access. We must not mask values when the table model is dumped,
+    or those code paths break. Only the response schemas should mask.
+    """
+
+    def test_orm_folder_dump_keeps_ciphertext(self):
+        folder = Folder(
+            name="Project",
+            description="desc",
+            auth_settings={
+                "auth_type": "oauth",
+                "oauth_client_secret": _CIPHER_OAUTH,
+                "api_key": _CIPHER_APIKEY,
+            },
+        )
+        dumped = folder.model_dump()
+        assert dumped["auth_settings"]["oauth_client_secret"] == _CIPHER_OAUTH
+        assert dumped["auth_settings"]["api_key"] == _CIPHER_APIKEY
+
+    def test_attribute_access_returns_real_dict(self):
+        folder = Folder(
+            name="Project",
+            description="desc",
+            auth_settings={
+                "auth_type": "apikey",
+                "api_key": _CIPHER_APIKEY,
+            },
+        )
+        # `auth_helpers.handle_auth_settings_update` and friends rely on this:
+        # `existing_project.auth_settings.get("auth_type")`,
+        # `existing_project.auth_settings.copy()`, etc.
+        assert folder.auth_settings is not None
+        assert folder.auth_settings["api_key"] == _CIPHER_APIKEY
+        assert folder.auth_settings.get("auth_type") == "apikey"

--- a/src/backend/tests/unit/services/database/models/folder/test_auth_settings_masking.py
+++ b/src/backend/tests/unit/services/database/models/folder/test_auth_settings_masking.py
@@ -6,62 +6,25 @@ and `/api/v1/projects/{id}`. They must not leak the encrypted
 because the listing endpoint returns globally-shared folders to every
 authenticated user, and shipping secret material off the server is a
 defense-in-depth failure on its own.
+
+Helper-level coverage of `mask_auth_settings` lives in
+`tests/unit/services/auth/test_mcp_encryption_mask.py`.
 """
 
 from __future__ import annotations
 
 from uuid import UUID
 
+from langflow.services.auth.mcp_encryption import SENSITIVE_FIELD_MASK
 from langflow.services.database.models.folder.model import (
     Folder,
     FolderRead,
     FolderReadWithFlows,
-    _mask_auth_settings,
 )
 
 _FOLDER_ID = UUID("00000000-0000-0000-0000-000000000001")
 _CIPHER_OAUTH = "gAAAAABoauth-ciphertext-blob-XXXX"  # pragma: allowlist secret
 _CIPHER_APIKEY = "gAAAAABapikey-ciphertext-blob-XXXX"  # pragma: allowlist secret
-_MASK = "*******"
-
-
-class TestMaskAuthSettingsHelper:
-    def test_none_passthrough(self):
-        assert _mask_auth_settings(None) is None
-
-    def test_empty_dict_passthrough(self):
-        assert _mask_auth_settings({}) == {}
-
-    def test_masks_oauth_client_secret(self):
-        result = _mask_auth_settings({"auth_type": "oauth", "oauth_client_secret": _CIPHER_OAUTH})
-        assert result == {"auth_type": "oauth", "oauth_client_secret": _MASK}
-
-    def test_masks_api_key(self):
-        result = _mask_auth_settings({"auth_type": "apikey", "api_key": _CIPHER_APIKEY})
-        assert result == {"auth_type": "apikey", "api_key": _MASK}
-
-    def test_preserves_non_secret_fields(self):
-        result = _mask_auth_settings(
-            {
-                "auth_type": "oauth",
-                "oauth_client_id": "public-client-id",
-                "oauth_client_secret": _CIPHER_OAUTH,
-                "oauth_server_url": "https://oauth.example.com",
-            }
-        )
-        assert result["oauth_client_id"] == "public-client-id"
-        assert result["oauth_server_url"] == "https://oauth.example.com"
-        assert result["oauth_client_secret"] == _MASK
-
-    def test_does_not_mutate_input(self):
-        original = {"auth_type": "apikey", "api_key": _CIPHER_APIKEY}
-        _mask_auth_settings(original)
-        assert original == {"auth_type": "apikey", "api_key": _CIPHER_APIKEY}
-
-    def test_empty_secret_value_is_left_alone(self):
-        # Empty string is falsy, so we don't replace it with a mask.
-        result = _mask_auth_settings({"auth_type": "apikey", "api_key": ""})
-        assert result == {"auth_type": "apikey", "api_key": ""}
 
 
 class TestFolderReadSerializer:
@@ -85,8 +48,8 @@ class TestFolderReadSerializer:
             }
         )
         dumped = folder.model_dump()
-        assert dumped["auth_settings"]["oauth_client_secret"] == _MASK
-        assert dumped["auth_settings"]["api_key"] == _MASK
+        assert dumped["auth_settings"]["oauth_client_secret"] == SENSITIVE_FIELD_MASK
+        assert dumped["auth_settings"]["api_key"] == SENSITIVE_FIELD_MASK
         assert dumped["auth_settings"]["oauth_client_id"] == "id-public"
 
     def test_none_auth_settings_serializes_as_none(self):
@@ -103,7 +66,7 @@ class TestFolderReadSerializer:
         # `model_dump_json` is the path FastAPI takes for response bodies.
         payload = folder.model_dump_json()
         assert _CIPHER_APIKEY not in payload
-        assert _MASK in payload
+        assert SENSITIVE_FIELD_MASK in payload
 
 
 class TestFolderReadWithFlowsSerializer:
@@ -120,7 +83,7 @@ class TestFolderReadWithFlowsSerializer:
             flows=[],
         )
         dumped = folder.model_dump()
-        assert dumped["auth_settings"]["oauth_client_secret"] == _MASK
+        assert dumped["auth_settings"]["oauth_client_secret"] == SENSITIVE_FIELD_MASK
         assert dumped["flows"] == []
 
 

--- a/src/backend/tests/unit/services/database/models/folder/test_auth_settings_masking.py
+++ b/src/backend/tests/unit/services/database/models/folder/test_auth_settings_masking.py
@@ -125,7 +125,9 @@ class TestFolderReadWithFlowsSerializer:
 
 
 class TestFolderOrmModelUnaffected:
-    """The encrypt/decrypt code paths read `Folder.auth_settings` as a dict via
+    """ORM model must keep raw ciphertext, only response schemas mask.
+
+    The encrypt/decrypt code paths read `Folder.auth_settings` as a dict via
     attribute access. We must not mask values when the table model is dumped,
     or those code paths break. Only the response schemas should mask.
     """

--- a/src/backend/tests/unit/services/database/models/folder/test_auth_settings_masking.py
+++ b/src/backend/tests/unit/services/database/models/folder/test_auth_settings_masking.py
@@ -20,8 +20,8 @@ from langflow.services.database.models.folder.model import (
 )
 
 _FOLDER_ID = UUID("00000000-0000-0000-0000-000000000001")
-_CIPHER_OAUTH = "gAAAAABoauth-ciphertext-blob-XXXX"  # noqa: S105  # pragma: allowlist secret
-_CIPHER_APIKEY = "gAAAAABapikey-ciphertext-blob-XXXX"  # noqa: S105  # pragma: allowlist secret
+_CIPHER_OAUTH = "gAAAAABoauth-ciphertext-blob-XXXX"  # pragma: allowlist secret
+_CIPHER_APIKEY = "gAAAAABapikey-ciphertext-blob-XXXX"  # pragma: allowlist secret
 _MASK = "*******"
 
 


### PR DESCRIPTION
## Summary
- `FolderRead` and `FolderReadWithFlows` returned `auth_settings` verbatim from the database, including the encrypted `oauth_client_secret` and `api_key` blobs.
- `GET /api/v1/projects/` returns the caller's folders **and every globally-shared folder** (`user_id IS NULL`), so any authenticated user received ciphertext for those credentials. Even with owner-only access the response still ships secret material to the client, which is a defense-in-depth failure on its own — secrets should never leave the server post-write.
- Mask the two sensitive fields in the response with the existing `\"*******\"` placeholder the frontend already round-trips for these values (see [api/v1/auth_helpers.py L60](https://github.com/langflow-ai/langflow/blob/main/src/backend/base/langflow/api/v1/auth_helpers.py#L60)).

## Why this is the right shape
- `field_serializer` only fires on response serialization, so the encrypt/decrypt code paths (which read `existing_project.auth_settings` as a dict via attribute access — see `api/v1/projects.py` and `api/v1/auth_helpers.py`) are unaffected.
- The ORM `Folder` table model is intentionally unchanged. Only `FolderRead` and `FolderReadWithFlows` carry the serializer, so internal code that dumps a `Folder` model still sees real values.
- The frontend already treats `\"*******\"` as a sentinel meaning \"keep the existing encrypted value\" on PATCH (`auth_helpers.py` line 60), so the round-trip is non-breaking.

## Test plan
- [ ] `GET /api/v1/projects/{id}` and `GET /api/v1/projects/` return `oauth_client_secret`/`api_key` as `\"*******\"` instead of `gAAAAAB...` ciphertext.
- [ ] Patching a project with `\"*******\"` in those fields preserves the previously stored value (existing flow, exercised by `test_mcp_projects.py`).
- [ ] The existing `mcp_projects.py` GET path (`/api/v1/mcp/project/{id}`) is unaffected — it uses its own `MCPProjectResponse`/`AuthSettings` (with pydantic `SecretStr`) and does not touch `FolderRead*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive credential fields such as API keys and OAuth secrets are now masked with placeholder values when folder configurations are retrieved.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13058)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->