### PR TITLE
feat(stepflow): add executor backend MVP

### DIFF
--- a/src/backend/base/langflow/agentic/services/flow_executor.py
+++ b/src/backend/base/langflow/agentic/services/flow_executor.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from fastapi import HTTPException
 from lfx.cli.script_loader import extract_structured_result
 from lfx.events.event_manager import EventManager, create_default_event_manager
+from lfx.execution import StepResult, get_default_coordinator
 from lfx.log.logger import logger
 from lfx.schema.schema import InputValueRequest
 from lfx.utils.flow_validation import CustomComponentValidationError
@@ -59,7 +60,13 @@ async def _run_graph_with_events(
         graph.prepare()
         inputs = InputValueRequest(input_value=input_value) if input_value else None
 
-        results = [result async for result in graph.async_start(inputs=inputs, event_manager=event_manager)]
+        results = [
+            item.payload
+            async for item in get_default_coordinator().run(
+                graph, inputs=[], initial_inputs=inputs, event_manager=event_manager
+            )
+            if isinstance(item, StepResult)
+        ]
         execution_result.result = extract_structured_result(results)
     except Exception as e:  # noqa: BLE001
         execution_result.error = e
@@ -131,7 +138,11 @@ async def execute_flow_file(
         graph.prepare()
         inputs = InputValueRequest(input_value=input_value) if input_value else None
 
-        results = [result async for result in graph.async_start(inputs=inputs)]
+        results = [
+            item.payload
+            async for item in get_default_coordinator().run(graph, inputs=[], initial_inputs=inputs)
+            if isinstance(item, StepResult)
+        ]
         flow_result = extract_structured_result(results)
     except HTTPException:
         raise

--- a/src/backend/base/langflow/agentic/services/flow_executor.py
+++ b/src/backend/base/langflow/agentic/services/flow_executor.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from fastapi import HTTPException
 from lfx.cli.script_loader import extract_structured_result
 from lfx.events.event_manager import EventManager, create_default_event_manager
-from lfx.execution import StepResult, get_default_coordinator
+from lfx.execution import get_default_coordinator
 from lfx.log.logger import logger
 from lfx.schema.schema import InputValueRequest
 from lfx.utils.flow_validation import CustomComponentValidationError
@@ -61,11 +61,10 @@ async def _run_graph_with_events(
         inputs = InputValueRequest(input_value=input_value) if input_value else None
 
         results = [
-            item.payload
-            async for item in get_default_coordinator().run(
-                graph, inputs=[], initial_inputs=inputs, event_manager=event_manager
+            payload
+            async for payload in get_default_coordinator().stream(
+                graph, initial_inputs=inputs, event_manager=event_manager
             )
-            if isinstance(item, StepResult)
         ]
         execution_result.result = extract_structured_result(results)
     except Exception as e:  # noqa: BLE001
@@ -138,11 +137,7 @@ async def execute_flow_file(
         graph.prepare()
         inputs = InputValueRequest(input_value=input_value) if input_value else None
 
-        results = [
-            item.payload
-            async for item in get_default_coordinator().run(graph, inputs=[], initial_inputs=inputs)
-            if isinstance(item, StepResult)
-        ]
+        results = [payload async for payload in get_default_coordinator().stream(graph, initial_inputs=inputs)]
         flow_result = extract_structured_result(results)
     except HTTPException:
         raise

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -487,6 +487,7 @@ def register_all_service_factories() -> None:
     from lfx.services.schema import ServiceType
 
     service_manager = get_service_manager()
+    from lfx.services.executor import factory as executor_factory
     from lfx.services.mcp_composer import factory as mcp_composer_factory
     from lfx.services.settings import factory as settings_factory
 
@@ -542,6 +543,7 @@ def register_all_service_factories() -> None:
     )
     service_manager.register_factory(authorization_factory.AuthorizationServiceFactory())
     service_manager.register_factory(mcp_composer_factory.MCPComposerServiceFactory())
+    service_manager.register_factory(executor_factory.ExecutorServiceFactory())
     service_manager.set_factory_registered()
 
 

--- a/src/backend/tests/unit/agentic/services/test_flow_executor_uses_coordinator.py
+++ b/src/backend/tests/unit/agentic/services/test_flow_executor_uses_coordinator.py
@@ -9,6 +9,7 @@ import pytest
 from lfx.execution import (
     Coordinator,
     ExecutorRegistry,
+    reset_default_coordinator,
     set_default_coordinator,
 )
 from lfx.execution.executor import Executor
@@ -23,26 +24,21 @@ class _Recording(Executor):
 
     async def execute(self, unit):
         self.units_seen.append(unit)
-        # Yield a fake vertex result with no .vertex attr so extract_structured_result
-        # falls through to the default "no response" branch (still a dict).
         yield StepResult(payload=object())
         yield RunComplete(outputs=[])
 
 
 @pytest.fixture(autouse=True)
 def _reset_singleton():
-    from lfx import execution
-
-    execution._default_registry = None
-    execution._default_coordinator = None
+    reset_default_coordinator()
     yield
-    execution._default_registry = None
-    execution._default_coordinator = None
+    reset_default_coordinator()
 
 
 @pytest.mark.asyncio
 async def test_run_graph_uses_default_coordinator():
-    """Coordinator dispatch on _run_graph_with_events."""
+    from dataclasses import dataclass, field
+
     from langflow.agentic.services.flow_executor import _run_graph_with_events
     from langflow.agentic.services.flow_types import FlowExecutionResult
 
@@ -51,12 +47,13 @@ async def test_run_graph_uses_default_coordinator():
     registry.register(recording)
     set_default_coordinator(Coordinator(registry=registry))
 
+    @dataclass
     class _FakeGraph:
         flow_id: str | None = None
         flow_name: str | None = None
         user_id: str | None = None
         session_id: str | None = None
-        context: dict = {}
+        context: dict = field(default_factory=dict)
 
         def prepare(self):
             pass

--- a/src/backend/tests/unit/agentic/services/test_flow_executor_uses_coordinator.py
+++ b/src/backend/tests/unit/agentic/services/test_flow_executor_uses_coordinator.py
@@ -1,0 +1,81 @@
+"""Verify flow_executor.py routes through the executor coordinator."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from lfx.execution import (
+    Coordinator,
+    ExecutorRegistry,
+    set_default_coordinator,
+)
+from lfx.execution.executor import Executor
+from lfx.execution.types import RunComplete, StepResult
+
+
+class _Recording(Executor):
+    kind = "in-process"
+
+    def __init__(self) -> None:
+        self.units_seen: list[Any] = []
+
+    async def execute(self, unit):
+        self.units_seen.append(unit)
+        # Yield a fake vertex result with no .vertex attr so extract_structured_result
+        # falls through to the default "no response" branch (still a dict).
+        yield StepResult(payload=object())
+        yield RunComplete(outputs=[])
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    from lfx import execution
+
+    execution._default_registry = None
+    execution._default_coordinator = None
+    yield
+    execution._default_registry = None
+    execution._default_coordinator = None
+
+
+@pytest.mark.asyncio
+async def test_run_graph_uses_default_coordinator():
+    """Coordinator dispatch on _run_graph_with_events."""
+    from langflow.agentic.services.flow_executor import _run_graph_with_events
+    from langflow.agentic.services.flow_types import FlowExecutionResult
+
+    recording = _Recording()
+    registry = ExecutorRegistry()
+    registry.register(recording)
+    set_default_coordinator(Coordinator(registry=registry))
+
+    class _FakeGraph:
+        flow_id: str | None = None
+        flow_name: str | None = None
+        user_id: str | None = None
+        session_id: str | None = None
+        context: dict = {}
+
+        def prepare(self):
+            pass
+
+    queue: asyncio.Queue = asyncio.Queue()
+    execution_result = FlowExecutionResult()
+
+    from lfx.events.event_manager import create_default_event_manager
+
+    em = create_default_event_manager(asyncio.Queue())
+    await _run_graph_with_events(
+        graph=_FakeGraph(),
+        input_value="hi",
+        global_variables=None,
+        user_id=None,
+        session_id=None,
+        event_manager=em,
+        event_queue=queue,
+        execution_result=execution_result,
+    )
+
+    assert len(recording.units_seen) == 1

--- a/src/backend/tests/unit/components/flow_controls/test_loop.py
+++ b/src/backend/tests/unit/components/flow_controls/test_loop.py
@@ -389,7 +389,7 @@ class TestLoopComponentSubgraphExecution:
         event_manager_received = []
 
         # Create an async generator that yields mock results
-        async def mock_async_start(event_manager=None):
+        async def mock_async_start(event_manager=None, **_kwargs):
             event_manager_received.append(event_manager)
             yield MagicMock(valid=True, result_dict={"outputs": {}})
 

--- a/src/langflow-stepflow/pyproject.toml
+++ b/src/langflow-stepflow/pyproject.toml
@@ -55,6 +55,9 @@ dev = [
     "httpx>=0.25.0",
 ]
 
+[project.entry-points."lfx.executors"]
+stepflow = "langflow_stepflow.executor:StepflowExecutor"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/langflow-stepflow/src/langflow_stepflow/__init__.py
+++ b/src/langflow-stepflow/src/langflow_stepflow/__init__.py
@@ -4,9 +4,11 @@ A Python package for integrating Langflow workflows with Stepflow,
 providing translation and execution capabilities.
 """
 
+from .executor import StepflowExecutor
 from .translation.translator import LangflowConverter
 
 __version__ = "0.1.0"
 __all__ = [
     "LangflowConverter",
+    "StepflowExecutor",
 ]

--- a/src/langflow-stepflow/src/langflow_stepflow/executor.py
+++ b/src/langflow-stepflow/src/langflow_stepflow/executor.py
@@ -1,0 +1,286 @@
+"""StepflowExecutor: bridge between the lfx execution seam and a Stepflow orchestrator.
+
+The lfx ``Executor`` ABC accepts a ``Unit`` (graph + inputs + runtime options) and yields
+``StepResult`` items terminated by a ``RunComplete``. This adapter:
+
+1. Translates the Langflow flow into a Stepflow ``Flow`` (preferred input:
+   ``runtime_options['langflow_json']``; fallback: ``graph.dump()``/``to_dict()``).
+2. Boots a local Stepflow orchestrator (default) or talks to one at ``STEPFLOW_ENDPOINT``,
+   stores the translated flow, kicks off a run, and streams status events back as
+   ``StepResult`` payloads.
+3. Yields a final ``RunComplete`` with whatever the orchestrator considered the run's
+   outputs.
+
+The default orchestrator config wires ``/builtin`` to the in-process builtin plugin and
+``/langflow`` to a gRPC worker launched as ``python -m langflow_stepflow.worker``. Both
+are overridable: pass a prebuilt ``StepflowConfig`` to ``__init__`` if you want a
+different topology (e.g. an externally managed worker pool).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from typing import TYPE_CHECKING, Any
+
+from lfx.execution.executor import Executor
+from lfx.execution.types import RunComplete, StepResult
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from lfx.execution.types import Unit
+
+logger = logging.getLogger(__name__)
+
+
+def _value_to_python(result_value: Any) -> Any:
+    """Convert a protobuf Struct ``Value`` (or already-native value) to a plain object."""
+    if result_value is None:
+        return None
+    if isinstance(result_value, str | int | float | bool | dict | list):
+        return result_value
+    try:
+        from google.protobuf.json_format import MessageToDict
+
+        return MessageToDict(result_value)
+    except Exception:  # noqa: BLE001 - any non-Value payload degrades to its repr below
+        return result_value
+
+
+def _coerce_text(output: Any) -> str:
+    """Best-effort extraction of a chat message string from a flow output blob."""
+    if output is None:
+        return ""
+    if isinstance(output, str):
+        return output
+    if isinstance(output, dict):
+        for key in ("text", "message", "result"):
+            value = output.get(key)
+            if isinstance(value, str):
+                return value
+    return str(output)
+
+
+def _build_messages(text: str) -> list[Any]:
+    """Wrap extracted text in a ChatOutputResponse so text-extraction paths find it."""
+    if not text:
+        return []
+    from lfx.utils.schemas import ChatOutputResponse
+
+    return [ChatOutputResponse(message=text, type="text")]
+
+
+class StepflowExecutor(Executor):
+    """Execute a Langflow flow by translating it to Stepflow and running it via stepflow_py.
+
+    Args:
+        endpoint: If set, connect to an already-running orchestrator at this address.
+            Otherwise boot a local orchestrator via ``StepflowClient.local`` using
+            ``config`` (or the default config below).
+        config: Optional ``StepflowConfig`` controlling plugins/routes for local mode.
+            If omitted, a default is built that registers the langflow worker.
+        worker_command: Command used by the default config to launch the worker.
+            Defaults to ``[sys.executable, "-m", "langflow_stepflow.worker"]``.
+    """
+
+    kind = "stepflow"
+
+    def __init__(
+        self,
+        *,
+        endpoint: str | None = None,
+        config: Any = None,
+        worker_command: list[str] | None = None,
+    ) -> None:
+        self._endpoint = endpoint or os.environ.get("STEPFLOW_ENDPOINT")
+        self._config = config
+        self._worker_command = worker_command
+
+    async def execute(self, unit: Unit) -> AsyncIterator[StepResult | RunComplete]:
+        flow_dict = self._translate_to_dict(unit)
+        # The seam delivers inputs in the lfx run-path shape ({INPUT_FIELD_NAME: ...});
+        # the translated flow reads $.message / $.session_id, so map before submitting.
+        # The original lfx input is preserved separately for RunOutputs.inputs.
+        run_input = self._build_run_input(unit, 0)
+        original_input = unit.inputs[0] if unit.inputs else {}
+
+        if self._endpoint:
+            # Remote-orchestrator path. Kept narrow on purpose: the connect/auth surface
+            # is still moving upstream, so this hands off to whatever ``connect`` looks
+            # like at runtime rather than baking in assumptions.
+            from stepflow_py.client import StepflowClient
+
+            async with await StepflowClient.connect(self._endpoint) as client:
+                async for item in self._run_through(client, flow_dict, run_input, original_input):
+                    yield item
+            return
+
+        from stepflow_py.client import StepflowClient
+
+        config = self._config or self._default_config()
+        async with StepflowClient.local(config) as client:
+            async for item in self._run_through(client, flow_dict, run_input, original_input):
+                yield item
+
+    def _build_run_input(self, unit: Unit, index: int = 0) -> dict[str, Any]:
+        """Map an lfx run-path input dict to the Stepflow run input the flow expects.
+
+        The seam delivers inputs as ``[{INPUT_FIELD_NAME: <value>}]`` and carries
+        ``session_id`` separately in ``runtime_options`` (set by ``Graph.arun``). The
+        translated flow reads ``$.message`` (ChatInput/passthrough) and ``$.session_id``
+        (Memory/Agent), so both must be surfaced at the top level of the submitted input.
+        """
+        from lfx.schema.schema import INPUT_FIELD_NAME
+
+        raw = unit.inputs[index] if unit.inputs and index < len(unit.inputs) else {}
+        payload = {key: value for key, value in raw.items() if key != INPUT_FIELD_NAME}
+        if INPUT_FIELD_NAME in raw:
+            payload["message"] = raw[INPUT_FIELD_NAME]
+        # Mirror process.py's effective_session_id semantics: always present, "" when unset.
+        payload["session_id"] = unit.runtime_options.get("session_id") or ""
+        return payload
+
+    def translate(self, unit: Unit) -> Any:
+        """Public translation hook so callers (and tests) can drive the converter alone."""
+        return self._translate(unit)
+
+    def _translate(self, unit: Unit) -> Any:
+        from langflow_stepflow.translation.translator import LangflowConverter
+
+        langflow_json = unit.runtime_options.get("langflow_json")
+        if langflow_json is None:
+            langflow_json = self._dump_graph(unit.graph)
+        if isinstance(langflow_json, str):
+            langflow_json = json.loads(langflow_json)
+        return LangflowConverter().convert(langflow_json)
+
+    def _translate_to_dict(self, unit: Unit) -> dict[str, Any]:
+        import msgspec
+
+        return msgspec.to_builtins(self._translate(unit))
+
+    async def _run_through(
+        self,
+        client: Any,
+        flow_dict: dict[str, Any],
+        run_input: dict[str, Any],
+        original_input: dict[str, Any],
+    ) -> AsyncIterator[StepResult | RunComplete]:
+        store_resp = await client.store_flow(flow_dict)
+        run_resp = await client.submit(store_resp.flow_id, run_input)
+        run_id = run_resp.summary.run_id
+
+        # Raw events are streamed as StepResult for the event_manager/streaming path; we
+        # only need the terminal status here to decide success vs failure.
+        status: Any = None
+        async for event in client.status_events(run_id, include_results=True):
+            yield StepResult(payload=event)
+            if event.HasField("run_completed"):
+                status = event.run_completed.status
+                break
+
+        # A failed/cancelled run must fail loud, like the in-process seam; otherwise the
+        # caller can't tell an empty success from a failure.
+        self._raise_for_failed_status(status, run_id)
+
+        # The run's output rides on the per-item results, not the status stream: a single
+        # submit() run emits no item_completed event, so fetch the results explicitly once
+        # the run is terminal (see StepflowClient.submit / get_run_items). get_run_items
+        # already returns native dicts (MessageToDict), so each item's "output" is plain.
+        items = await client.get_run_items(run_id)
+        if len(items) > 1:
+            # execute() submits a single input today, so only item 0 is expected. Surface
+            # the drop rather than silently swallowing extra items if that ever changes.
+            logger.warning(
+                "Stepflow run %s produced %d item results; only index 0 is mapped "
+                "(multi-item submission is not yet supported).",
+                run_id,
+                len(items),
+            )
+
+        result_value = items[0].get("output") if items else None
+        yield RunComplete(outputs=[self._to_run_outputs(result_value, original_input)])
+
+    @staticmethod
+    def _raise_for_failed_status(status: Any, run_id: str) -> None:
+        """Raise if the run reached a terminal non-success state.
+
+        ``Graph.arun`` is expected to fail loud on a failed run; the stepflow backend must
+        match that rather than returning a success-shaped empty ``RunOutputs``. A ``None``
+        status (stream ended without a terminal event) is left to the coordinator.
+        """
+        from stepflow_py.proto import common_pb2
+
+        completed = common_pb2.ExecutionStatus.EXECUTION_STATUS_COMPLETED
+        if status is not None and status != completed:
+            from langflow_stepflow.exceptions import ExecutionError
+
+            name = common_pb2.ExecutionStatus.Name(status)
+            msg = f"Stepflow run {run_id} ended with non-success status: {name}"
+            raise ExecutionError(msg)
+
+    @staticmethod
+    def _to_run_outputs(result_value: Any, run_input: dict[str, Any]) -> Any:
+        """Map a Stepflow item result (protobuf Value) into the lfx RunOutputs contract.
+
+        ``Graph.arun`` returns ``list[RunOutputs]`` and downstream /run serializers read
+        ``RunOutputs.outputs[i]`` as ``ResultData``. We surface the run's output value
+        under the ChatOutput "message" output so the existing extraction finds it, and keep
+        the original lfx input dict on ``RunOutputs.inputs`` (matching _arun_legacy).
+        """
+        from lfx.graph.schema import ResultData, RunOutputs
+        from lfx.schema.schema import OutputValue
+
+        output = _value_to_python(result_value)
+        text = _coerce_text(output)
+        message = output if isinstance(output, dict | list | str) else text
+
+        result_data = ResultData(
+            results={"message": output},
+            outputs={"message": OutputValue(message=message, type="text")},
+            messages=_build_messages(text),
+        )
+        return RunOutputs(inputs=run_input, outputs=[result_data])
+
+    def _default_config(self) -> Any:
+        from stepflow_py.config import (
+            BuiltinPluginConfig,
+            GrpcPluginConfig,
+            InMemoryStoreConfig,
+            RouteRule,
+            StepflowConfig,
+        )
+
+        command, args = self._worker_invocation()
+        return StepflowConfig(
+            plugins={
+                "builtin": BuiltinPluginConfig(),
+                "langflow": GrpcPluginConfig(command=command, args=args, queueName="langflow"),
+            },
+            routes={
+                "/builtin": [RouteRule(plugin="builtin")],
+                "/langflow": [RouteRule(plugin="langflow")],
+            },
+            storageConfig=InMemoryStoreConfig(),
+        )
+
+    def _worker_invocation(self) -> tuple[str, list[str]]:
+        if self._worker_command:
+            return self._worker_command[0], list(self._worker_command[1:])
+        return sys.executable, ["-m", "langflow_stepflow.worker"]
+
+    @staticmethod
+    def _dump_graph(graph: Any) -> dict[str, Any]:
+        for attr in ("dump", "to_dict", "to_json"):
+            fn = getattr(graph, attr, None)
+            if callable(fn):
+                result = fn()
+                return json.loads(result) if isinstance(result, str) else result
+        msg = (
+            "StepflowExecutor needs a Langflow JSON workflow. Pass it explicitly via "
+            "runtime_options['langflow_json'] or expose dump()/to_dict() on the graph."
+        )
+        raise TypeError(msg)

--- a/src/langflow-stepflow/src/langflow_stepflow/worker/handlers/base_model.py
+++ b/src/langflow-stepflow/src/langflow_stepflow/worker/handlers/base_model.py
@@ -1,7 +1,9 @@
 """Handlers for Pydantic BaseModel serialization and deserialization.
 
 Input: reconstruct BaseModel instances from dicts with ``__class_name__`` markers.
-Output: serialize BaseModel instances with class metadata and SecretStr handling.
+Output: serialize BaseModel instances with class metadata. ``SecretStr`` fields are left
+masked by Pydantic's ``model_dump`` -- secrets are never unwrapped onto this serialized
+output edge (the orchestrator routes it between steps and may stream it back).
 """
 
 from __future__ import annotations
@@ -84,75 +86,14 @@ def _is_secret_str_type(field_type: Any) -> bool:
         return False
 
 
-def _looks_like_env_var_name(value: str) -> bool:
-    """Check if a string looks like an environment variable name.
-
-    Matches strings that are all uppercase letters/digits/underscores and
-    contain at least one underscore, like ``OPENAI_API_KEY`` or
-    ``AWS_SECRET_KEY``. The underscore requirement avoids matching short
-    names like ``PATH`` or ``HOME``.
-    """
-    return value.isupper() and "_" in value
-
-
-def _resolve_secret_value(secret_value: Any) -> Any:
-    """Resolve a SecretStr value, attempting env var lookup if it looks like one.
-
-    Only attempts resolution when the value looks like an env var name
-    (all uppercase with underscores) to avoid accidentally matching
-    unrelated environment variables.
-    """
-    if not isinstance(secret_value, str) or not secret_value:
-        return secret_value
-
-    if not _looks_like_env_var_name(secret_value):
-        return secret_value
-
-    import os
-
-    resolved = os.getenv(secret_value)
-    return resolved if resolved is not None else secret_value
-
-
-def _handle_special_pydantic_types(obj: Any, serialized: dict[str, Any]) -> dict[str, Any]:
-    """Handle SecretStr and other special Pydantic types during serialization."""
-    try:
-        if hasattr(obj, "model_fields"):
-            fields = obj.model_fields
-            for field_name, field_info in fields.items():
-                if hasattr(field_info, "annotation"):
-                    field_type = field_info.annotation
-                    if _is_secret_str_type(field_type):
-                        field_value = getattr(obj, field_name, None)
-                        if field_value is not None:
-                            try:
-                                secret_value = field_value.get_secret_value()
-                                serialized[field_name] = _resolve_secret_value(secret_value)
-                            except Exception:
-                                pass
-        elif hasattr(obj, "__fields__"):
-            fields = obj.__fields__
-            for field_name, field_info in fields.items():
-                field_type = field_info.type_
-                if _is_secret_str_type(field_type):
-                    field_value = getattr(obj, field_name, None)
-                    if field_value is not None:
-                        try:
-                            secret_value = field_value.get_secret_value()
-                            serialized[field_name] = _resolve_secret_value(secret_value)
-                        except Exception:
-                            pass
-    except Exception:
-        pass
-
-    return serialized
-
-
 class BaseModelOutputHandler(OutputHandler):
     """Serialize Pydantic BaseModel instances with class metadata.
 
-    Produces dicts with ``__class_name__`` and ``__module_name__`` markers.
-    Includes special handling for SecretStr fields (resolves env vars).
+    Produces dicts with ``__class_name__`` and ``__module_name__`` markers. ``SecretStr``
+    fields stay masked: ``model_dump(mode="json")`` renders them as ``'**********'`` and we
+    never unwrap them onto the serialized output. If a downstream component needs the real
+    value, it must be resolved on that component's input/config edge inside the worker, not
+    carried through the orchestrator (see follow-up for real component execution).
     """
 
     def matches(self, *, value: Any) -> bool:
@@ -182,8 +123,6 @@ class BaseModelOutputHandler(OutputHandler):
             serialized = value.model_dump(mode="json", warnings=False)
         except Exception:
             serialized = value.model_dump(mode="json")
-
-        serialized = _handle_special_pydantic_types(value, serialized)
 
         serialized["__class_name__"] = value.__class__.__name__
         serialized["__module_name__"] = value.__class__.__module__

--- a/src/langflow-stepflow/src/langflow_stepflow/worker/handlers/tool_wrapper.py
+++ b/src/langflow-stepflow/src/langflow_stepflow/worker/handlers/tool_wrapper.py
@@ -1,7 +1,7 @@
 """Input handler for tool wrapper deserialization.
 
 Converts serialized tool wrapper dicts into callable LangChain StructuredTool
-objects.
+objects whose invocation executes the wrapped Langflow component.
 """
 
 from __future__ import annotations
@@ -57,84 +57,127 @@ def _eval_expr(node: ast.AST) -> float:
     raise TypeError(f"Unsupported operation or expression type: {type(node).__name__}")
 
 
-def _create_tool_from_wrapper(tool_wrapper: dict[str, Any]) -> Any:
-    """Create a LangChain StructuredTool from a tool wrapper."""
+def _build_blob_data(component_code: dict[str, Any], component_type: str) -> dict[str, Any]:
+    """Reshape a raw component definition into the executor's enhanced blob shape.
+
+    ``component_tool`` stores the raw component node (``node["data"]["node"]``) as
+    the tool blob: the Python source lives under ``template.code.value`` and the
+    declared outputs under ``outputs``. ``CustomCodeExecutor._compile_component``
+    instead expects ``code`` and the ``template`` (sans code) at the top level, so
+    reshape here, mirroring ``NodeProcessor._prepare_udf_blob``. The tool runs the
+    component's first declared output.
+    """
+    template = component_code.get("template", {})
+    code = template.get("code", {}).get("value", "")
+    outputs = component_code.get("outputs", [])
+    selected_output = outputs[0].get("name") if outputs else None
+    prepared_template = {name: cfg for name, cfg in template.items() if name != "code"}
+    return {
+        "code": code,
+        "template": prepared_template,
+        "component_type": component_type,
+        "outputs": outputs,
+        "selected_output": selected_output,
+        "base_classes": component_code.get("base_classes", []),
+        "display_name": component_code.get("display_name", component_type),
+        "description": component_code.get("description", ""),
+        "documentation": component_code.get("documentation", ""),
+        "metadata": component_code.get("metadata", {}),
+        "field_order": component_code.get("field_order", []),
+        "icon": component_code.get("icon", ""),
+    }
+
+
+def _build_input_schema(tool_input_schema: dict[str, Any]) -> Any:
+    """Build the StructuredTool args schema from the tool's input schema."""
+    from pydantic import BaseModel, create_model
+
+    properties = tool_input_schema.get("properties", {})
+    field_definitions: dict[str, tuple[type, Any]] = {}
+    for field_name, field_def in properties.items():
+        field_definitions[field_name] = (str, field_def.get("default", ""))
+
+    if field_definitions:
+        return create_model("ToolInputSchema", **field_definitions)  # type: ignore[call-overload]
+
+    class EmptySchema(BaseModel):
+        pass
+
+    return EmptySchema
+
+
+async def _create_tool_from_wrapper(tool_wrapper: dict[str, Any], context: Any = None) -> Any:
+    """Create a LangChain StructuredTool from a tool wrapper.
+
+    The returned tool executes the wrapped Langflow component on invocation. The
+    component is compiled once here, where the Stepflow ``context`` is available to
+    fetch its code blob, then executed without context on each call, matching the
+    custom-code executor's pre-compile-then-execute design.
+    """
     try:
         from langchain_core.tools import StructuredTool
-        from pydantic import BaseModel, create_model
 
         tool_metadata = tool_wrapper.get("tool_metadata", {})
-        tool_input_schema = tool_wrapper.get("tool_input_schema", {})
         static_inputs = tool_wrapper.get("static_inputs", {})
         component_type = tool_wrapper.get("component_type", "unknown")
         session_id = tool_wrapper.get("session_id", "default_session")
 
+        input_schema = _build_input_schema(tool_wrapper.get("tool_input_schema", {}))
+
+        # Calculator fast-path: the CalculatorComponent's expression evaluator is
+        # pure and self-contained, so run it directly without compiling a component.
+        if tool_metadata.get("name") == "evaluate_expression":
+
+            def calculator_func(**kwargs) -> dict[str, Any]:
+                return {"result": _execute_calculator_tool(kwargs.get("expression", ""))}
+
+            return StructuredTool.from_function(
+                func=calculator_func,
+                name=tool_metadata.get("name", "unknown_tool"),
+                description=tool_metadata.get("description", ""),
+                args_schema=input_schema,
+            )
+
         component_code = tool_wrapper.get("component_code")
         code_blob_id = tool_wrapper.get("code_blob_id")
-
         if component_code is None and code_blob_id is None:
             raise ValueError("Tool wrapper missing both component_code and code_blob_id")
 
-        properties = tool_input_schema.get("properties", {})
-
-        field_definitions: dict[str, tuple[type, Any]] = {}
-        for field_name, field_def in properties.items():
-            field_type: type = str
-            default_value = field_def.get("default", "")
-            field_definitions[field_name] = (field_type, default_value)
-
-        input_schema: type[BaseModel]
-        if field_definitions:
-            input_schema = create_model("ToolInputSchema", **field_definitions)  # type: ignore[call-overload]
+        # Resolve the raw component definition: component_tool stores it as a blob
+        # and references it by id; an inline component_code dict is also accepted.
+        if code_blob_id is not None:
+            if context is None:
+                raise ValueError("code_blob_id requires a Stepflow context to fetch the component blob")
+            raw_component = await context.get_blob(code_blob_id)
         else:
+            raw_component = component_code
+        if not isinstance(raw_component, dict):
+            raise TypeError(f"Component code must be a component definition dict, got {type(raw_component).__name__}")
 
-            class EmptySchema(BaseModel):
-                pass
+        # Imported lazily: custom_code_executor imports this handler, so a top-level
+        # import would be circular.
+        from ..custom_code_executor import CustomCodeExecutor
 
-            input_schema = EmptySchema
+        executor = CustomCodeExecutor()
+        blob_data = _build_blob_data(raw_component, component_type)
+        compiled_component = await executor._compile_component(blob_data, code_blob_id)
 
-        def tool_func(**kwargs) -> dict[str, Any]:
-            """Execute the tool by running the component."""
+        async def tool_func(**kwargs) -> Any:
+            """Execute the wrapped component with the tool's merged inputs."""
             try:
-                if tool_metadata.get("name") == "evaluate_expression" and "expression" in kwargs:
-                    result = _execute_calculator_tool(kwargs["expression"])
-                    return {"result": result}
-
-                merged_inputs = {
-                    **static_inputs,
-                    **kwargs,
-                    "session_id": session_id,
-                }
-
-                tool_name = tool_metadata.get("name", "unknown")
-                result_data = {
-                    "result": (f"Tool {tool_name} executed with inputs: {merged_inputs}"),
-                    "component_type": component_type,
-                    "inputs": merged_inputs,
-                    "status": "tool_wrapper_execution",
-                }
-
-                if code_blob_id:
-                    result_data["code_blob_id"] = code_blob_id
-                elif component_code:
-                    result_data["has_component_code"] = True
-
-                return result_data
-
-            except Exception as e:
-                return {
-                    "error": f"Tool execution failed: {str(e)}",
-                    "component_type": component_type,
-                }
+                runtime_inputs = {**static_inputs, **kwargs, "session_id": session_id}
+                return await executor._execute_compiled_component(compiled_component, runtime_inputs)
+            except Exception as e:  # noqa: BLE001 - surface a tool-shaped error to the agent
+                return {"error": f"Tool execution failed: {str(e)}", "component_type": component_type}
 
         return StructuredTool.from_function(
-            func=tool_func,
+            coroutine=tool_func,
             name=tool_metadata.get("name", "unknown_tool"),
             description=tool_metadata.get("description", ""),
             args_schema=input_schema,
         )
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - any wrapper-build failure degrades to a failed tool
 
         class FailedToolWrapper:
             def __init__(self, tool_wrapper, error):
@@ -167,11 +210,14 @@ class ToolWrapperInputHandler(InputHandler):
 
         for key, (value, _template_field) in fields.items():
             if isinstance(value, dict) and value.get("__tool_wrapper__"):
-                result[key] = _create_tool_from_wrapper(value)
+                result[key] = await _create_tool_from_wrapper(value, context)
             elif isinstance(value, list):
-                result[key] = [
-                    _create_tool_from_wrapper(item) if isinstance(item, dict) and item.get("__tool_wrapper__") else item
-                    for item in value
-                ]
+                resolved: list[Any] = []
+                for item in value:
+                    if isinstance(item, dict) and item.get("__tool_wrapper__"):
+                        resolved.append(await _create_tool_from_wrapper(item, context))
+                    else:
+                        resolved.append(item)
+                result[key] = resolved
 
         return result

--- a/src/langflow-stepflow/tests/helpers/tool_components.py
+++ b/src/langflow-stepflow/tests/helpers/tool_components.py
@@ -1,0 +1,103 @@
+"""Shared helpers for tool-wrapper tests.
+
+A real (non-mock) in-memory Stepflow context and a real, executable component
+definition in the shape ``component_tool`` stores as the tool blob.
+"""
+
+from typing import Any
+
+
+class InMemoryContext:
+    """Minimal in-memory StepflowContext stand-in (a real object, not a mock).
+
+    ``put_blob`` stores and returns a stable id; ``get_blob`` reads it back.
+    Enough for the handler to resolve a tool's component code the way the worker
+    does at runtime.
+    """
+
+    def __init__(self) -> None:
+        self._blobs: dict[str, Any] = {}
+        self._counter = 0
+
+    async def put_blob(self, data: Any, *_args: Any, **_kwargs: Any) -> str:
+        self._counter += 1
+        blob_id = f"blob_{self._counter}"
+        self._blobs[blob_id] = data
+        return blob_id
+
+    async def get_blob(self, blob_id: str) -> Any:
+        return self._blobs[blob_id]
+
+
+SIMPLE_COMPONENT_CODE = """
+from langflow.custom.custom_component.component import Component
+from langflow.io import MessageTextInput, Output
+from langflow.schema.message import Message
+
+
+class SimpleTestComponent(Component):
+    display_name = "Simple Test"
+    description = "A simple test component"
+
+    inputs = [
+        MessageTextInput(name="text_input", display_name="Text Input", info="Text input for testing")
+    ]
+
+    outputs = [
+        Output(display_name="Output", name="result", method="process_text")
+    ]
+
+    async def process_text(self) -> Message:
+        input_text = self.text_input or "No input provided"
+        return Message(text=f"Processed: {input_text}", sender="SimpleTestComponent")
+"""
+
+
+def simple_component_node_info() -> dict[str, Any]:
+    """Raw component definition as stored in the tool blob by ``component_tool``.
+
+    This is ``node["data"]["node"]``: the Python source under ``template.code.value``
+    plus the declared outputs.
+    """
+    return {
+        "template": {
+            "code": {"value": SIMPLE_COMPONENT_CODE},
+            "text_input": {
+                "type": "str",
+                "value": "",
+                "info": "Text input for testing",
+                "required": False,
+                "tool_mode": True,
+            },
+        },
+        "outputs": [{"name": "result", "method": "process_text", "types": ["Message"]}],
+        "display_name": "Simple Test",
+        "description": "A simple test component",
+        "base_classes": ["Message"],
+    }
+
+
+def make_real_tool_wrapper(
+    blob_id: str,
+    *,
+    name: str = "simple_test",
+    description: str = "Runs the simple test component",
+    static_inputs: dict[str, Any] | None = None,
+    properties: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a tool wrapper backed by a real component blob.
+
+    ``properties`` defaults to exposing ``text_input`` as the single tool param;
+    pass ``{}`` to expose no tool params (so ``static_inputs`` drive the component).
+    """
+    if properties is None:
+        properties = {"text_input": {"type": "string", "default": ""}}
+    return {
+        "__tool_wrapper__": True,
+        "code_blob_id": blob_id,
+        "static_inputs": static_inputs or {},
+        "component_type": "SimpleTestComponent",
+        "tool_metadata": {"name": name, "description": description},
+        "tool_input_schema": {"properties": properties},
+        "session_id": "test_session",
+    }

--- a/src/langflow-stepflow/tests/integration/test_stepflow_executor_runs_passthrough.py
+++ b/src/langflow-stepflow/tests/integration/test_stepflow_executor_runs_passthrough.py
@@ -1,0 +1,92 @@
+"""End-to-end integration test for StepflowExecutor.
+
+Boots a local Stepflow orchestrator, spawns the langflow worker, dispatches a
+ChatInput->ChatOutput passthrough flow through the executor, and verifies the run
+reaches a terminal SUCCEEDED status.
+
+Skipped unless ``stepflow-py[local]`` and ``stepflow-orchestrator`` are installed --
+this test depends on running a separate subprocess (the Rust orchestrator) and a
+gRPC worker.
+"""
+
+from __future__ import annotations
+
+import pytest
+from lfx.execution.types import RunComplete, StepResult, Unit
+from lfx.graph.schema import RunOutputs
+
+from langflow_stepflow.executor import StepflowExecutor
+
+pytestmark = pytest.mark.integration
+
+# Skip the whole module if the local-orchestrator extra isn't installed.
+pytest.importorskip("stepflow_py.config")
+
+
+def _passthrough_flow() -> dict:
+    return {
+        "name": "passthrough",
+        "data": {
+            "nodes": [
+                {
+                    "id": "ChatInput-1",
+                    "data": {
+                        "type": "ChatInput",
+                        "node": {"template": {"input_value": {"value": "hi"}}},
+                    },
+                },
+                {
+                    "id": "ChatOutput-1",
+                    "data": {
+                        "type": "ChatOutput",
+                        "node": {"template": {"input_value": {}}},
+                    },
+                },
+            ],
+            "edges": [
+                {
+                    "source": "ChatInput-1",
+                    "target": "ChatOutput-1",
+                    "data": {
+                        "sourceHandle": {"name": "message"},
+                        "targetHandle": {"fieldName": "input_value"},
+                    },
+                }
+            ],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_executor_runs_passthrough_end_to_end():
+    executor = StepflowExecutor()
+    # Feed the real run-path input shape ({INPUT_FIELD_NAME: ...}), not the stepflow-native
+    # {"message": ...}, so the executor's contract adapter (input mapping + output mapping) is
+    # exercised the way Graph.arun drives it.
+    unit = Unit(
+        graph=None,
+        inputs=[{"input_value": "hello world"}],
+        runtime_options={"langflow_json": _passthrough_flow(), "session_id": "test-session"},
+    )
+
+    events: list[object] = []
+    completion: RunComplete | None = None
+    async for item in executor.execute(unit):
+        if isinstance(item, StepResult):
+            events.append(item.payload)
+        elif isinstance(item, RunComplete):
+            completion = item
+
+    assert completion is not None, "executor never yielded RunComplete"
+    assert events, "executor yielded no step events"
+
+    # The seam contract: RunComplete.outputs is list[RunOutputs], not raw stepflow events.
+    assert completion.outputs, "RunComplete carried no outputs"
+    assert all(isinstance(out, RunOutputs) for out in completion.outputs)
+    run_outputs = completion.outputs[0]
+    # The original lfx input is preserved on RunOutputs.inputs (matches _arun_legacy).
+    assert run_outputs.inputs == {"input_value": "hello world"}
+    # The passthrough echoes the input message back through to the terminal output.
+    result_data = run_outputs.outputs[0]
+    assert result_data is not None
+    assert result_data.messages[0].message == "hello world"

--- a/src/langflow-stepflow/tests/integration/test_tool_wrapper_roundtrip.py
+++ b/src/langflow-stepflow/tests/integration/test_tool_wrapper_roundtrip.py
@@ -1,0 +1,51 @@
+"""Integration test: tool wrapper producer -> consumer roundtrip.
+
+``component_tool_executor`` (the producer) stores a tool-mode component as a blob
+and emits a tool wrapper; ``ToolWrapperInputHandler`` (the consumer) resolves that
+same blob and builds a tool that executes the real component. This proves the
+blob-shape contract between the two ends end-to-end, with a real component but no
+LLM (a full agent-driven tool call needs a live model and is out of scope here).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from tests.helpers.tool_components import InMemoryContext, simple_component_node_info
+
+from langflow_stepflow.worker.component_tool import component_tool_executor
+from langflow_stepflow.worker.handlers.tool_wrapper import ToolWrapperInputHandler
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_component_tool_to_execution_roundtrip():
+    context = InMemoryContext()
+    node_info = simple_component_node_info()
+
+    # Producer: component_tool stores the component blob and builds the wrapper.
+    produced = await component_tool_executor(
+        {
+            "code": node_info,
+            "inputs": {},
+            "component_type": "SimpleTestComponent",
+            "session_id": "session_roundtrip",
+        },
+        context,
+    )
+    wrapper = produced["result"]
+    assert wrapper["__tool_wrapper__"] is True
+    assert "code_blob_id" in wrapper
+    # text_input is tool_mode=True, so the producer exposes it as a tool param.
+    assert "text_input" in wrapper["tool_input_schema"]["properties"]
+
+    # Consumer: the handler resolves the same blob and builds an executing tool.
+    handler = ToolWrapperInputHandler()
+    prepared = await handler.prepare({"tools": (wrapper, {})}, context)
+    tool = prepared["tools"]
+
+    output = await tool.ainvoke({"text_input": "roundtrip"})
+
+    assert "Processed: roundtrip" in json.dumps(output, default=str)

--- a/src/langflow-stepflow/tests/unit/test_stepflow_executor.py
+++ b/src/langflow-stepflow/tests/unit/test_stepflow_executor.py
@@ -1,0 +1,202 @@
+"""Unit smoke tests for the StepflowExecutor adapter.
+
+Covers wiring against the lfx execution seam: ABC conformance, registration, default
+config shape, and translation. The actual orchestrator run is exercised by the
+integration test in ``tests/integration/test_stepflow_executor_runs_passthrough.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from lfx.execution.coordinator import Coordinator
+from lfx.execution.registry import ExecutorRegistry
+from lfx.execution.types import RunComplete, StepResult, Unit
+
+from langflow_stepflow.executor import StepflowExecutor
+
+
+def _minimal_chat_passthrough() -> dict:
+    """Smallest Langflow JSON the converter will accept end-to-end."""
+    return {
+        "name": "passthrough",
+        "data": {
+            "nodes": [
+                {
+                    "id": "ChatInput-1",
+                    "data": {
+                        "type": "ChatInput",
+                        "node": {"template": {"input_value": {"value": "hi"}}},
+                    },
+                },
+                {
+                    "id": "ChatOutput-1",
+                    "data": {
+                        "type": "ChatOutput",
+                        "node": {"template": {"input_value": {}}},
+                    },
+                },
+            ],
+            "edges": [
+                {
+                    "source": "ChatInput-1",
+                    "target": "ChatOutput-1",
+                    "data": {
+                        "sourceHandle": {"name": "message"},
+                        "targetHandle": {"fieldName": "input_value"},
+                    },
+                }
+            ],
+        },
+    }
+
+
+def test_kind_is_stepflow():
+    assert StepflowExecutor.kind == "stepflow"
+
+
+def test_translate_produces_a_flow():
+    executor = StepflowExecutor()
+    unit = Unit(graph=None, runtime_options={"langflow_json": _minimal_chat_passthrough()})
+    flow = executor.translate(unit)
+    assert flow is not None
+
+
+def test_executor_registers_and_routes_through_coordinator():
+    registry = ExecutorRegistry()
+    registry.register(StepflowExecutor())
+    coordinator = Coordinator(registry=registry, executor_kind="stepflow")
+    assert registry.has("stepflow")
+    assert coordinator._registry.get("stepflow").kind == "stepflow"  # noqa: SLF001
+
+
+def test_default_config_registers_langflow_worker():
+    # Verifies the default StepflowConfig is the one we'd need to actually route
+    # /langflow/* steps to a worker -- the routing miss I hit during the first manual
+    # run attempt should now be impossible with the defaults.
+    executor = StepflowExecutor()
+    config = executor._default_config()  # noqa: SLF001
+    assert "langflow" in config.plugins
+    assert "/langflow" in config.routes
+    plugin_for_langflow = config.routes["/langflow"][0].plugin
+    assert plugin_for_langflow == "langflow"
+    # Default worker command should be invokable as a python module path.
+    cmd, args = executor._worker_invocation()  # noqa: SLF001
+    assert "langflow_stepflow.worker" in " ".join([cmd, *args])
+
+
+def test_value_types_are_lfx_seam_types():
+    assert StepResult.__module__.startswith("lfx.execution")
+    assert RunComplete.__module__.startswith("lfx.execution")
+
+
+# --- P1-a / P1-c: run-input mapping (lfx contract shape -> stepflow $.message/$.session_id) ---
+
+
+def test_build_run_input_maps_input_field_to_message():
+    executor = StepflowExecutor()
+    unit = Unit(graph=None, inputs=[{"input_value": "hello"}], runtime_options={"session_id": "s1"})
+    payload = executor._build_run_input(unit, 0)  # noqa: SLF001
+    assert payload["message"] == "hello"
+    assert payload["session_id"] == "s1"
+    assert "input_value" not in payload
+
+
+def test_build_run_input_defaults_session_id_to_empty_string():
+    executor = StepflowExecutor()
+    unit = Unit(graph=None, inputs=[{"input_value": "hi"}], runtime_options={})
+    payload = executor._build_run_input(unit, 0)  # noqa: SLF001
+    assert payload["session_id"] == ""
+
+
+def test_build_run_input_preserves_extra_keys():
+    executor = StepflowExecutor()
+    unit = Unit(graph=None, inputs=[{"input_value": "hi", "foo": "bar"}], runtime_options={})
+    payload = executor._build_run_input(unit, 0)  # noqa: SLF001
+    assert payload["foo"] == "bar"
+    assert payload["message"] == "hi"
+
+
+def test_build_run_input_handles_no_inputs():
+    executor = StepflowExecutor()
+    unit = Unit(graph=None, inputs=[], runtime_options={})
+    payload = executor._build_run_input(unit, 0)  # noqa: SLF001
+    assert payload == {"session_id": ""}
+
+
+# --- P1-b: terminal item result (protobuf Value) -> list[RunOutputs] ---
+
+
+def _string_value(text: str):
+    from google.protobuf import struct_pb2
+
+    return struct_pb2.Value(string_value=text)
+
+
+def _struct_value(data: dict):
+    from google.protobuf import struct_pb2
+
+    struct = struct_pb2.Struct()
+    struct.update(data)
+    return struct_pb2.Value(struct_value=struct)
+
+
+def test_to_run_outputs_returns_run_outputs_contract():
+    from lfx.graph.schema import ResultData, RunOutputs
+
+    run_outputs = StepflowExecutor._to_run_outputs(_string_value("hello world"), {"input_value": "hello world"})  # noqa: SLF001
+    assert isinstance(run_outputs, RunOutputs)
+    assert run_outputs.inputs == {"input_value": "hello world"}
+    assert len(run_outputs.outputs) == 1
+    assert isinstance(run_outputs.outputs[0], ResultData)
+
+
+def test_to_run_outputs_surfaces_string_message():
+    run_outputs = StepflowExecutor._to_run_outputs(_string_value("hello world"), {"input_value": "x"})  # noqa: SLF001
+    result_data = run_outputs.outputs[0]
+    assert result_data.outputs["message"].message == "hello world"
+    assert result_data.messages[0].message == "hello world"
+
+
+def test_to_run_outputs_extracts_text_from_struct():
+    run_outputs = StepflowExecutor._to_run_outputs(_struct_value({"text": "hi there", "sender": "AI"}), {})  # noqa: SLF001
+    result_data = run_outputs.outputs[0]
+    assert result_data.messages[0].message == "hi there"
+    assert result_data.results["message"] == {"text": "hi there", "sender": "AI"}
+
+
+def test_to_run_outputs_handles_missing_result():
+    run_outputs = StepflowExecutor._to_run_outputs(None, {"input_value": "x"})  # noqa: SLF001
+    assert run_outputs.outputs[0].messages == []
+
+
+# --- terminal run status handling: a failed/cancelled run must fail loud, not look empty ---
+
+
+def _status(name: str) -> int:
+    from stepflow_py.proto import common_pb2
+
+    return common_pb2.ExecutionStatus.Value(name)
+
+
+def test_raise_for_failed_status_allows_completed():
+    # Should not raise on a successful run.
+    StepflowExecutor._raise_for_failed_status(_status("EXECUTION_STATUS_COMPLETED"), "run-1")  # noqa: SLF001
+
+
+def test_raise_for_failed_status_allows_none():
+    # A stream that ended without a terminal status is left to the coordinator, not raised here.
+    StepflowExecutor._raise_for_failed_status(None, "run-1")  # noqa: SLF001
+
+
+def test_raise_for_failed_status_raises_on_failed():
+    from langflow_stepflow.exceptions import ExecutionError
+
+    with pytest.raises(ExecutionError, match="non-success status: EXECUTION_STATUS_FAILED"):
+        StepflowExecutor._raise_for_failed_status(_status("EXECUTION_STATUS_FAILED"), "run-1")  # noqa: SLF001
+
+
+def test_raise_for_failed_status_raises_on_cancelled():
+    from langflow_stepflow.exceptions import ExecutionError
+
+    with pytest.raises(ExecutionError):
+        StepflowExecutor._raise_for_failed_status(_status("EXECUTION_STATUS_CANCELLED"), "run-1")  # noqa: SLF001

--- a/src/langflow-stepflow/tests/unit/test_tool_wrapper_execution.py
+++ b/src/langflow-stepflow/tests/unit/test_tool_wrapper_execution.py
@@ -1,0 +1,103 @@
+"""Real-component execution tests for tool-mode wrappers.
+
+These assert that a tool wrapping a real component actually runs that component
+when the agent invokes it, rather than returning a synthetic placeholder.
+"""
+
+import json
+
+import pytest
+from langchain_core.tools import StructuredTool
+
+from langflow_stepflow.worker.handlers.tool_wrapper import ToolWrapperInputHandler
+from tests.helpers.tool_components import (
+    InMemoryContext,
+    make_real_tool_wrapper,
+    simple_component_node_info,
+)
+
+
+class TestToolExecutesRealComponent:
+    @pytest.mark.asyncio
+    async def test_tool_invocation_runs_wrapped_component(self):
+        context = InMemoryContext()
+        blob_id = await context.put_blob(simple_component_node_info())
+        wrapper = make_real_tool_wrapper(blob_id)
+
+        handler = ToolWrapperInputHandler()
+        prepared = await handler.prepare({"tools": (wrapper, {})}, context)
+        tool = prepared["tools"]
+
+        assert isinstance(tool, StructuredTool)
+        assert tool.name == "simple_test"
+        assert tool.description == "Runs the simple test component"
+
+        output = await tool.ainvoke({"text_input": "Hello World"})
+
+        dumped = json.dumps(output, default=str)
+        assert "Processed: Hello World" in dumped
+        # The old synthetic placeholder must be gone.
+        assert "executed with inputs" not in dumped
+
+    @pytest.mark.asyncio
+    async def test_static_inputs_flow_into_component(self):
+        """Static inputs (wired component values) reach the component at execution."""
+        context = InMemoryContext()
+        blob_id = await context.put_blob(simple_component_node_info())
+        # No tool params: the agent passes nothing, so the static input drives it.
+        wrapper = make_real_tool_wrapper(
+            blob_id,
+            static_inputs={"text_input": "Static Value"},
+            properties={},
+        )
+
+        handler = ToolWrapperInputHandler()
+        prepared = await handler.prepare({"tools": (wrapper, {})}, context)
+
+        output = await prepared["tools"].ainvoke({})
+
+        assert "Processed: Static Value" in json.dumps(output, default=str)
+
+    @pytest.mark.asyncio
+    async def test_prepare_list_of_real_tools(self):
+        context = InMemoryContext()
+        blob_id = await context.put_blob(simple_component_node_info())
+        wrapper_a = make_real_tool_wrapper(blob_id, name="tool_a")
+        wrapper_b = make_real_tool_wrapper(blob_id, name="tool_b")
+
+        handler = ToolWrapperInputHandler()
+        result = await handler.prepare({"tools": ([wrapper_a, wrapper_b], {})}, context)
+
+        tools = result["tools"]
+        assert [t.name for t in tools] == ["tool_a", "tool_b"]
+        assert all(isinstance(t, StructuredTool) for t in tools)
+
+    @pytest.mark.asyncio
+    async def test_prepare_mixed_list_keeps_non_wrappers(self):
+        context = InMemoryContext()
+        blob_id = await context.put_blob(simple_component_node_info())
+        wrapper = make_real_tool_wrapper(blob_id, name="real_tool")
+
+        handler = ToolWrapperInputHandler()
+        result = await handler.prepare({"tools": ([wrapper, "not_a_wrapper", 42], {})}, context)
+
+        tools = result["tools"]
+        assert isinstance(tools[0], StructuredTool)
+        assert tools[1] == "not_a_wrapper"
+        assert tools[2] == 42
+
+    @pytest.mark.asyncio
+    async def test_prepare_multiple_fields(self):
+        context = InMemoryContext()
+        blob_id = await context.put_blob(simple_component_node_info())
+        wrapper_a = make_real_tool_wrapper(blob_id, name="tool_a")
+        wrapper_b = make_real_tool_wrapper(blob_id, name="tool_b")
+
+        handler = ToolWrapperInputHandler()
+        result = await handler.prepare(
+            {"primary_tool": (wrapper_a, {}), "secondary_tool": (wrapper_b, {})},
+            context,
+        )
+
+        assert result["primary_tool"].name == "tool_a"
+        assert result["secondary_tool"].name == "tool_b"

--- a/src/langflow-stepflow/tests/unit/test_tool_wrapper_handler.py
+++ b/src/langflow-stepflow/tests/unit/test_tool_wrapper_handler.py
@@ -1,10 +1,17 @@
-"""Unit tests for ToolWrapperInputHandler."""
+"""Unit tests for ToolWrapperInputHandler and its pure helpers.
+
+Real-component execution is covered in ``test_tool_wrapper_execution.py``; this
+file covers the calculator fast-path, schema/blob reshaping helpers, ``matches``,
+and failed-wrapper handling, none of which need a running component.
+"""
 
 import pytest
 from langchain_core.tools import StructuredTool
 
 from langflow_stepflow.worker.handlers.tool_wrapper import (
     ToolWrapperInputHandler,
+    _build_blob_data,
+    _build_input_schema,
     _create_tool_from_wrapper,
     _execute_calculator_tool,
 )
@@ -37,6 +44,13 @@ def _make_tool_wrapper(
     return wrapper
 
 
+def _calculator_wrapper() -> dict:
+    return _make_tool_wrapper(
+        name="evaluate_expression",
+        properties={"expression": {"type": "string", "default": ""}},
+    )
+
+
 # ---------------------------------------------------------------------------
 # _execute_calculator_tool
 # ---------------------------------------------------------------------------
@@ -62,12 +76,65 @@ class TestExecuteCalculatorTool:
         assert _execute_calculator_tool("1 / 3") == "0.333333"
 
     def test_invalid_expression(self):
-        result = _execute_calculator_tool("not_valid")
-        assert "Calculator error" in result
+        assert "Calculator error" in _execute_calculator_tool("not_valid")
 
     def test_division_by_zero(self):
-        result = _execute_calculator_tool("1 / 0")
-        assert "Calculator error" in result
+        assert "Calculator error" in _execute_calculator_tool("1 / 0")
+
+
+# ---------------------------------------------------------------------------
+# _build_blob_data
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBlobData:
+    def test_reshapes_raw_component_into_enhanced_blob(self):
+        node_info = {
+            "template": {
+                "code": {"value": "print('x')"},
+                "text_input": {"type": "str", "value": "hi"},
+            },
+            "outputs": [{"name": "result", "method": "process_text"}],
+            "display_name": "My Comp",
+        }
+
+        blob = _build_blob_data(node_info, "MyComponent")
+
+        assert blob["code"] == "print('x')"
+        # Code is lifted to the top level and dropped from the template.
+        assert "code" not in blob["template"]
+        assert blob["template"]["text_input"]["value"] == "hi"
+        assert blob["component_type"] == "MyComponent"
+        assert blob["outputs"] == [{"name": "result", "method": "process_text"}]
+        assert blob["selected_output"] == "result"
+        assert blob["display_name"] == "My Comp"
+
+    def test_no_outputs_yields_none_selected_output(self):
+        blob = _build_blob_data({"template": {"code": {"value": "x"}}}, "C")
+        assert blob["selected_output"] is None
+        # component_type is the display_name fallback.
+        assert blob["display_name"] == "C"
+
+
+# ---------------------------------------------------------------------------
+# _build_input_schema
+# ---------------------------------------------------------------------------
+
+
+class TestBuildInputSchema:
+    def test_builds_model_with_declared_properties(self):
+        schema = _build_input_schema({"properties": {"query": {"default": ""}, "limit": {"default": "10"}}})
+        instance = schema(query="a", limit="b")
+        assert instance.query == "a"
+        assert instance.limit == "b"
+
+    def test_default_values_applied(self):
+        schema = _build_input_schema({"properties": {"limit": {"default": "10"}}})
+        assert schema().limit == "10"
+
+    def test_empty_properties_yields_constructible_schema(self):
+        schema = _build_input_schema({})
+        assert schema() is not None
 
 
 # ---------------------------------------------------------------------------
@@ -76,87 +143,37 @@ class TestExecuteCalculatorTool:
 
 
 class TestCreateToolFromWrapper:
-    def test_creates_structured_tool(self):
-        wrapper = _make_tool_wrapper(name="my_tool", description="does stuff")
-        tool = _create_tool_from_wrapper(wrapper)
-
+    @pytest.mark.asyncio
+    async def test_calculator_tool_creates_structured_tool(self):
+        tool = await _create_tool_from_wrapper(_calculator_wrapper())
         assert isinstance(tool, StructuredTool)
-        assert tool.name == "my_tool"
-        assert tool.description == "does stuff"
+        assert tool.name == "evaluate_expression"
 
-    def test_creates_tool_with_code_blob_id(self):
-        wrapper = _make_tool_wrapper(
-            component_code=None,
-            code_blob_id="abc123",
-        )
-        tool = _create_tool_from_wrapper(wrapper)
-        assert isinstance(tool, StructuredTool)
-
-    def test_tool_with_input_schema(self):
-        wrapper = _make_tool_wrapper(
-            properties={
-                "query": {"type": "string", "default": ""},
-                "limit": {"type": "integer", "default": "10"},
-            },
-        )
-        tool = _create_tool_from_wrapper(wrapper)
-        assert isinstance(tool, StructuredTool)
-
-    def test_calculator_tool_execution(self):
-        wrapper = _make_tool_wrapper(
-            name="evaluate_expression",
-            properties={"expression": {"type": "string", "default": ""}},
-        )
-        tool = _create_tool_from_wrapper(wrapper)
-        result = tool.invoke({"expression": "2 + 3"})
+    @pytest.mark.asyncio
+    async def test_calculator_tool_execution(self):
+        tool = await _create_tool_from_wrapper(_calculator_wrapper())
+        result = await tool.ainvoke({"expression": "2 + 3"})
         assert result == {"result": "5"}
 
-    def test_non_calculator_tool_execution(self):
-        wrapper = _make_tool_wrapper(
-            name="search_tool",
-            properties={"query": {"type": "string", "default": ""}},
-            static_inputs={"api_key": "test_key"},  # pragma: allowlist secret
-            component_type="SearchComponent",
-            session_id="sess_1",
-        )
-        tool = _create_tool_from_wrapper(wrapper)
-        result = tool.invoke({"query": "hello"})
-
-        assert result["component_type"] == "SearchComponent"
-        assert result["inputs"]["query"] == "hello"
-        assert result["inputs"]["api_key"] == "test_key"  # pragma: allowlist secret
-        assert result["inputs"]["session_id"] == "sess_1"
-        assert result["status"] == "tool_wrapper_execution"
-
-    def test_tool_with_code_blob_id_in_result(self):
-        wrapper = _make_tool_wrapper(
-            name="blob_tool",
-            component_code=None,
-            code_blob_id="blob_abc",
-        )
-        tool = _create_tool_from_wrapper(wrapper)
-        result = tool.invoke({})
-        assert result["code_blob_id"] == "blob_abc"
-
-    def test_tool_with_component_code_in_result(self):
-        wrapper = _make_tool_wrapper(
-            name="code_tool",
-            component_code="def run(): pass",
-        )
-        tool = _create_tool_from_wrapper(wrapper)
-        result = tool.invoke({})
-        assert result["has_component_code"] is True
-
-    def test_missing_both_code_sources_returns_failed_wrapper(self):
+    @pytest.mark.asyncio
+    async def test_missing_both_code_sources_returns_failed_wrapper(self):
         wrapper = _make_tool_wrapper(component_code=None, code_blob_id=None)
-        tool = _create_tool_from_wrapper(wrapper)
+        tool = await _create_tool_from_wrapper(wrapper)
 
-        # Should be a FailedToolWrapper, not a StructuredTool
         assert not isinstance(tool, StructuredTool)
-        assert hasattr(tool, "name")
         assert tool.name == "test_tool"
         result = tool.invoke({})
-        assert "error" in result
+        assert "Tool creation failed" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_code_blob_id_without_context_returns_failed_wrapper(self):
+        # The real-execution path needs a context to fetch the component blob;
+        # without one the wrapper degrades to a failed tool rather than faking a result.
+        wrapper = _make_tool_wrapper(component_code=None, code_blob_id="abc123")
+        tool = await _create_tool_from_wrapper(wrapper, context=None)
+
+        assert not isinstance(tool, StructuredTool)
+        result = tool.invoke({})
         assert "Tool creation failed" in result["error"]
 
 
@@ -170,16 +187,13 @@ class TestToolWrapperInputHandlerMatches:
         self.handler = ToolWrapperInputHandler()
 
     def test_matches_dict_with_tool_wrapper_marker(self):
-        wrapper = _make_tool_wrapper()
-        assert self.handler.matches(template_field={}, value=wrapper) is True
+        assert self.handler.matches(template_field={}, value=_make_tool_wrapper()) is True
 
     def test_matches_list_with_tool_wrapper(self):
-        wrapper = _make_tool_wrapper()
-        assert self.handler.matches(template_field={}, value=[wrapper]) is True
+        assert self.handler.matches(template_field={}, value=[_make_tool_wrapper()]) is True
 
     def test_matches_list_with_mixed_items(self):
-        wrapper = _make_tool_wrapper()
-        assert self.handler.matches(template_field={}, value=[wrapper, "other"]) is True
+        assert self.handler.matches(template_field={}, value=[_make_tool_wrapper(), "other"]) is True
 
     def test_no_match_plain_dict(self):
         assert self.handler.matches(template_field={}, value={"key": "value"}) is False
@@ -201,7 +215,7 @@ class TestToolWrapperInputHandlerMatches:
 
 
 # ---------------------------------------------------------------------------
-# ToolWrapperInputHandler.prepare
+# ToolWrapperInputHandler.prepare (no-context paths)
 # ---------------------------------------------------------------------------
 
 
@@ -210,64 +224,17 @@ class TestToolWrapperInputHandlerPrepare:
         self.handler = ToolWrapperInputHandler()
 
     @pytest.mark.asyncio
-    async def test_prepare_single_wrapper(self):
-        wrapper = _make_tool_wrapper(name="my_tool")
-        fields = {"tools": (wrapper, {})}
-        result = await self.handler.prepare(fields, None)
-
-        assert "tools" in result
+    async def test_prepare_calculator_wrapper_without_context(self):
+        result = await self.handler.prepare({"tools": (_calculator_wrapper(), {})}, None)
         assert isinstance(result["tools"], StructuredTool)
-        assert result["tools"].name == "my_tool"
-
-    @pytest.mark.asyncio
-    async def test_prepare_list_of_wrappers(self):
-        wrapper_a = _make_tool_wrapper(name="tool_a")
-        wrapper_b = _make_tool_wrapper(name="tool_b")
-        fields = {"tools": ([wrapper_a, wrapper_b], {})}
-        result = await self.handler.prepare(fields, None)
-
-        assert "tools" in result
-        assert len(result["tools"]) == 2
-        assert isinstance(result["tools"][0], StructuredTool)
-        assert isinstance(result["tools"][1], StructuredTool)
-        assert result["tools"][0].name == "tool_a"
-        assert result["tools"][1].name == "tool_b"
-
-    @pytest.mark.asyncio
-    async def test_prepare_mixed_list(self):
-        wrapper = _make_tool_wrapper(name="real_tool")
-        fields = {"tools": ([wrapper, "not_a_wrapper", 42], {})}
-        result = await self.handler.prepare(fields, None)
-
-        assert "tools" in result
-        assert len(result["tools"]) == 3
-        assert isinstance(result["tools"][0], StructuredTool)
-        assert result["tools"][1] == "not_a_wrapper"
-        assert result["tools"][2] == 42
-
-    @pytest.mark.asyncio
-    async def test_prepare_multiple_fields(self):
-        wrapper_a = _make_tool_wrapper(name="tool_a")
-        wrapper_b = _make_tool_wrapper(name="tool_b")
-        fields = {
-            "primary_tool": (wrapper_a, {}),
-            "secondary_tool": (wrapper_b, {}),
-        }
-        result = await self.handler.prepare(fields, None)
-
-        assert isinstance(result["primary_tool"], StructuredTool)
-        assert isinstance(result["secondary_tool"], StructuredTool)
-        assert result["primary_tool"].name == "tool_a"
-        assert result["secondary_tool"].name == "tool_b"
+        assert result["tools"].name == "evaluate_expression"
 
     @pytest.mark.asyncio
     async def test_prepare_failed_wrapper_in_list(self):
-        good_wrapper = _make_tool_wrapper(name="good_tool")
-        bad_wrapper = _make_tool_wrapper(name="bad_tool", component_code=None, code_blob_id=None)
-        fields = {"tools": ([good_wrapper, bad_wrapper], {})}
-        result = await self.handler.prepare(fields, None)
+        good = _calculator_wrapper()
+        bad = _make_tool_wrapper(name="bad_tool", component_code=None, code_blob_id=None)
+        result = await self.handler.prepare({"tools": ([good, bad], {})}, None)
 
         assert isinstance(result["tools"][0], StructuredTool)
-        # Bad wrapper becomes FailedToolWrapper
         assert not isinstance(result["tools"][1], StructuredTool)
         assert result["tools"][1].name == "bad_tool"

--- a/src/langflow-stepflow/tests/unit/test_type_converter.py
+++ b/src/langflow-stepflow/tests/unit/test_type_converter.py
@@ -51,6 +51,10 @@ class ConcreteTestExecutor(BaseExecutor):
         return component_info.get("instance"), component_info.get("name", "test")
 
 
+# Pydantic renders a non-empty SecretStr field as this mask under model_dump(mode="json").
+MASKED_SECRET = "**********"  # pragma: allowlist secret
+
+
 class TestBaseModelOutputHandler:
     """Test cases for BaseModelOutputHandler serialization."""
 
@@ -84,8 +88,8 @@ class TestBaseModelOutputHandler:
         assert serialized["__module_name__"] == "tests.unit.test_type_converter"
 
     @pytest.mark.asyncio
-    async def test_secret_str_serialization_with_actual_secret(self):
-        """Test that SecretStr fields are properly serialized with actual values."""
+    async def test_secret_str_fields_are_masked(self):
+        """SecretStr fields serialize masked -- the plaintext value is never emitted."""
         secret_value = "test-api-key-12345"  # pragma: allowlist secret
         model = SecretTestModel(
             name="test",
@@ -95,49 +99,32 @@ class TestBaseModelOutputHandler:
 
         serialized = await self.handler.process(model)
 
-        # Check that secret values are properly extracted
         assert serialized["name"] == "test"
-        assert serialized["api_key"] == secret_value  # pragma: allowlist secret
-        assert serialized["optional_secret"] == "optional-secret-value"  # pragma: allowlist secret
+        assert serialized["api_key"] == MASKED_SECRET
+        assert serialized["optional_secret"] == MASKED_SECRET
+        assert secret_value not in serialized.values()
 
-        # Check class metadata
         assert serialized["__class_name__"] == "SecretTestModel"
         assert serialized["__module_name__"] == "tests.unit.test_type_converter"
 
     @pytest.mark.asyncio
-    async def test_secret_str_serialization_with_env_var_resolution(self):
-        """Test that SecretStr fields with environment variable names are resolved."""
-        # Set up environment variable
+    async def test_env_var_name_secret_is_not_resolved(self):
+        """A SecretStr holding an env var name must NOT be resolved onto the output edge."""
         test_api_key = "actual-api-key-from-env"  # pragma: allowlist secret
 
         with patch.dict(os.environ, {"TEST_API_KEY": test_api_key}):
-            # Create model with environment variable name as secret
-            model = SecretTestModel(
-                name="test",
-                api_key=SecretStr("TEST_API_KEY"),  # Environment variable name
-            )
+            model = SecretTestModel(name="test", api_key=SecretStr("TEST_API_KEY"))
 
             serialized = await self.handler.process(model)
 
-            # Check that environment variable was resolved
-            assert serialized["api_key"] == test_api_key
+            # Neither the env var value nor its name should leak; the field stays masked.
+            assert serialized["api_key"] == MASKED_SECRET
+            assert test_api_key not in serialized.values()
             assert serialized["name"] == "test"
 
     @pytest.mark.asyncio
-    async def test_secret_str_serialization_no_env_var_fallback(self):
-        """Test SecretStr serialization when environment variable doesn't exist."""
-        # Create model with non-existent environment variable name
-        model = SecretTestModel(name="test", api_key=SecretStr("NON_EXISTENT_ENV_VAR"))
-
-        serialized = await self.handler.process(model)
-
-        # Should keep the original value if env var doesn't exist
-        assert serialized["api_key"] == "NON_EXISTENT_ENV_VAR"  # pragma: allowlist secret
-        assert serialized["name"] == "test"
-
-    @pytest.mark.asyncio
-    async def test_openai_embeddings_like_serialization(self):
-        """Test serialization of OpenAI-like embeddings model."""
+    async def test_openai_embeddings_like_serialization_masks_key(self):
+        """OpenAI-like embeddings model serializes with its api key masked, others intact."""
         api_key = "real-openai-key-12345"  # pragma: allowlist secret
         model = MockOpenAIEmbeddings(
             model="text-embedding-3-small",
@@ -148,33 +135,19 @@ class TestBaseModelOutputHandler:
 
         serialized = await self.handler.process(model)
 
-        # Check all fields are properly serialized
         assert serialized["model"] == "text-embedding-3-small"
-        assert serialized["openai_api_key"] == api_key  # SecretStr unwrapped
+        assert serialized["openai_api_key"] == MASKED_SECRET
+        assert api_key not in serialized.values()
         assert serialized["chunk_size"] == 500
         assert serialized["max_retries"] == 3  # Default value
         assert serialized["dimensions"] == 1536
 
-        # Check class metadata for reconstruction
         assert serialized["__class_name__"] == "MockOpenAIEmbeddings"
         assert serialized["__module_name__"] == "tests.unit.test_type_converter"
 
     @pytest.mark.asyncio
-    async def test_openai_api_key_env_var_resolution(self):
-        """Test that OPENAI_API_KEY environment variable is properly resolved."""
-        real_api_key = "proj-real-openai-key-from-environment"  # pragma: allowlist secret
-
-        with patch.dict(os.environ, {"OPENAI_API_KEY": real_api_key}):
-            model = MockOpenAIEmbeddings(openai_api_key=SecretStr("OPENAI_API_KEY"))
-
-            serialized = await self.handler.process(model)
-
-            # Verify the actual API key value is serialized, not the env var name
-            assert serialized["openai_api_key"] == real_api_key
-
-    @pytest.mark.asyncio
     async def test_mixed_secret_and_regular_fields(self):
-        """Test model with both secret and regular fields."""
+        """Model with both secret and regular fields: secret masked, regular fields intact."""
         api_key = "secret-key-value"  # pragma: allowlist secret
         model = SecretTestModel(
             name="production-model",
@@ -184,37 +157,11 @@ class TestBaseModelOutputHandler:
 
         serialized = await self.handler.process(model)
 
-        # Regular field should be unchanged
         assert serialized["name"] == "production-model"
-        # Secret field should be unwrapped
-        assert serialized["api_key"] == api_key
+        assert serialized["api_key"] == MASKED_SECRET
+        assert api_key not in serialized.values()
         # None secret field should remain None
         assert serialized["optional_secret"] is None
-
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {}, clear=True)  # Clear environment
-    async def test_secret_str_with_no_env_vars(self):
-        """Test SecretStr serialization when no environment variables are set."""
-        model = SecretTestModel(name="test", api_key=SecretStr("MISSING_API_KEY"))
-
-        serialized = await self.handler.process(model)
-
-        # Should keep original value if env var resolution fails
-        assert serialized["api_key"] == "MISSING_API_KEY"  # pragma: allowlist secret
-
-    @pytest.mark.asyncio
-    async def test_serialized_data_structure_debugging(self):
-        """Test to show what serialized data looks like for debugging."""
-        api_key = "debug-key-12345"  # pragma: allowlist secret
-        model = MockOpenAIEmbeddings(model="test-model", openai_api_key=SecretStr(api_key), chunk_size=123)
-
-        serialized = await self.handler.process(model)
-
-        # Verify the structure
-        assert "openai_api_key" in serialized
-        assert serialized["openai_api_key"] == api_key
-        assert "__class_name__" in serialized
-        assert "__module_name__" in serialized
 
 
 class TestBaseModelInputHandler:
@@ -241,8 +188,13 @@ class TestBaseModelInputHandler:
         assert deserialized.enabled is False
 
     @pytest.mark.asyncio
-    async def test_openai_embeddings_like_deserialization(self):
-        """Test deserialization of OpenAI-like embeddings model."""
+    async def test_secret_round_trip_stays_masked(self):
+        """Across the worker boundary a secret survives only as its mask, not the real value.
+
+        Masking on the output edge is intentional (see BaseModelOutputHandler): the plaintext
+        is never serialized, so a serialize->deserialize round trip reconstructs the masked
+        SecretStr. A component needing the real value must resolve it on its own input edge.
+        """
         api_key = "real-openai-key-12345"  # pragma: allowlist secret
         model = MockOpenAIEmbeddings(
             model="text-embedding-ada-002",
@@ -261,27 +213,10 @@ class TestBaseModelInputHandler:
         assert deserialized.chunk_size == 750
         assert deserialized.max_retries == 3  # Default
 
-        # Check that SecretStr field is reconstructed properly
+        # The real key never crossed the boundary; only the mask round-trips.
         assert isinstance(deserialized.openai_api_key, SecretStr)
-        assert deserialized.openai_api_key.get_secret_value() == api_key
-
-    @pytest.mark.asyncio
-    async def test_openai_api_key_env_var_round_trip(self):
-        """Test that OPENAI_API_KEY environment variable is properly resolved."""
-        real_api_key = "proj-real-openai-key-from-environment"  # pragma: allowlist secret
-
-        with patch.dict(os.environ, {"OPENAI_API_KEY": real_api_key}):
-            model = MockOpenAIEmbeddings(openai_api_key=SecretStr("OPENAI_API_KEY"))
-
-            serialized = await self.output_handler.process(model)
-
-            # Test full round-trip
-            fields = {"param": (serialized, {})}
-            result = await self.input_handler.prepare(fields, None)
-
-            deserialized = result["param"]
-            assert isinstance(deserialized.openai_api_key, SecretStr)
-            assert deserialized.openai_api_key.get_secret_value() == real_api_key
+        assert deserialized.openai_api_key.get_secret_value() == MASKED_SECRET
+        assert deserialized.openai_api_key.get_secret_value() != api_key
 
     def test_deserialization_without_class_metadata(self):
         """Test that regular dicts without markers don't match."""
@@ -377,8 +312,8 @@ class TestOutputTreeWalker:
             pytest.skip("Langflow not available for testing")
 
     @pytest.mark.asyncio
-    async def test_real_openai_embeddings_serialization(self):
-        """Test with actual OpenAI embeddings class if available."""
+    async def test_real_openai_embeddings_serialization_masks_key(self):
+        """Real OpenAIEmbeddings serializes with its api key masked, not unwrapped."""
         try:
             from langchain_openai import OpenAIEmbeddings
             from pydantic import SecretStr
@@ -394,9 +329,10 @@ class TestOutputTreeWalker:
             # Serialize
             serialized = await self.executor._apply_output_handlers(embeddings, self.handlers)
 
-            # Check that API key is properly extracted
+            # The plaintext key must never reach the serialized output edge.
             assert "openai_api_key" in serialized
-            assert serialized["openai_api_key"] == api_key
+            assert serialized["openai_api_key"] == MASKED_SECRET
+            assert api_key not in serialized.values()
             assert serialized["model"] == "text-embedding-3-small"
             assert serialized["chunk_size"] == 500
 
@@ -404,7 +340,7 @@ class TestOutputTreeWalker:
             assert serialized["__class_name__"] == "OpenAIEmbeddings"
             assert "langchain_openai" in serialized["__module_name__"]
 
-            # Test deserialization
+            # Round-trips as the mask, never the real key.
             input_handler = BaseModelInputHandler()
             fields = {"param": (serialized, {})}
             result = await input_handler.prepare(fields, None)
@@ -414,13 +350,12 @@ class TestOutputTreeWalker:
             assert deserialized.model == "text-embedding-3-small"
             assert deserialized.chunk_size == 500
 
-            # Check that SecretStr is properly reconstructed
             assert hasattr(deserialized, "openai_api_key")
             if isinstance(deserialized.openai_api_key, SecretStr):
-                assert deserialized.openai_api_key.get_secret_value() == api_key
+                assert deserialized.openai_api_key.get_secret_value() == MASKED_SECRET
+                assert deserialized.openai_api_key.get_secret_value() != api_key
             else:
-                # In some versions, it might be a string after deserialization
-                assert deserialized.openai_api_key == api_key
+                assert deserialized.openai_api_key == MASKED_SECRET
 
         except ImportError:
             pytest.skip("langchain_openai not available for real OpenAI embeddings test")

--- a/src/lfx/src/lfx/base/flow_controls/loop_utils.py
+++ b/src/lfx/src/lfx/base/flow_controls/loop_utils.py
@@ -1,6 +1,7 @@
 """Utility functions for loop component execution."""
 
 from collections import deque
+from contextlib import aclosing
 from typing import TYPE_CHECKING
 
 from lfx.execution import get_default_coordinator
@@ -267,12 +268,17 @@ async def execute_loop_body(
             # Execute subgraph and collect results
             # Pass event_manager so UI receives events from subgraph execution
             results = []
-            async for result in get_default_coordinator().stream(iteration_subgraph, event_manager=event_manager):
-                results.append(result)
-                # Stop all on error (as per design decision)
-                if hasattr(result, "valid") and not result.valid:
-                    msg = f"Error in loop iteration: {result}"
-                    raise RuntimeError(msg)
+            # aclosing guarantees the stream is finalized even when we raise mid-iteration
+            # on an invalid result, so the underlying subgraph generator's cleanup runs.
+            async with aclosing(
+                get_default_coordinator().stream(iteration_subgraph, event_manager=event_manager)
+            ) as stream:
+                async for result in stream:
+                    results.append(result)
+                    # Stop all on error (as per design decision)
+                    if hasattr(result, "valid") and not result.valid:
+                        msg = f"Error in loop iteration: {result}"
+                        raise RuntimeError(msg)
 
             # Extract output from final result
             output = extract_loop_output(results, end_vertex_id)

--- a/src/lfx/src/lfx/base/flow_controls/loop_utils.py
+++ b/src/lfx/src/lfx/base/flow_controls/loop_utils.py
@@ -265,8 +265,13 @@ async def execute_loop_body(
 
             # Execute subgraph and collect results
             # Pass event_manager so UI receives events from subgraph execution
+            from lfx.execution import StepResult, get_default_coordinator
+
             results = []
-            async for result in iteration_subgraph.async_start(event_manager=event_manager):
+            async for step in get_default_coordinator().run(iteration_subgraph, inputs=[], event_manager=event_manager):
+                if not isinstance(step, StepResult):
+                    continue
+                result = step.payload
                 results.append(result)
                 # Stop all on error (as per design decision)
                 if hasattr(result, "valid") and not result.valid:

--- a/src/lfx/src/lfx/base/flow_controls/loop_utils.py
+++ b/src/lfx/src/lfx/base/flow_controls/loop_utils.py
@@ -3,6 +3,7 @@
 from collections import deque
 from typing import TYPE_CHECKING
 
+from lfx.execution import get_default_coordinator
 from lfx.schema.data import Data
 
 if TYPE_CHECKING:
@@ -265,13 +266,8 @@ async def execute_loop_body(
 
             # Execute subgraph and collect results
             # Pass event_manager so UI receives events from subgraph execution
-            from lfx.execution import StepResult, get_default_coordinator
-
             results = []
-            async for step in get_default_coordinator().run(iteration_subgraph, inputs=[], event_manager=event_manager):
-                if not isinstance(step, StepResult):
-                    continue
-                result = step.payload
+            async for result in get_default_coordinator().stream(iteration_subgraph, event_manager=event_manager):
                 results.append(result)
                 # Stop all on error (as per design decision)
                 if hasattr(result, "valid") and not result.valid:

--- a/src/lfx/src/lfx/cli/common.py
+++ b/src/lfx/src/lfx/cli/common.py
@@ -29,6 +29,7 @@ from lfx.cli.script_loader import (
     find_graph_variable,
     load_graph_from_script,
 )
+from lfx.execution import get_default_coordinator
 from lfx.load import load_flow_from_json
 from lfx.run._defaults import apply_run_defaults, resolve_fallback_to_env_vars
 from lfx.schema.schema import InputValueRequest
@@ -349,14 +350,11 @@ async def execute_graph_with_capture(graph, input_value: str | None, session_id:
     try:
         sys.stdout = captured_stdout
         sys.stderr = captured_stderr
-        from lfx.execution import StepResult, get_default_coordinator
-
         results = [
-            item.payload
-            async for item in get_default_coordinator().run(
-                graph, inputs=[], initial_inputs=inputs, fallback_to_env_vars=fallback_to_env_vars
+            payload
+            async for payload in get_default_coordinator().stream(
+                graph, initial_inputs=inputs, fallback_to_env_vars=fallback_to_env_vars
             )
-            if isinstance(item, StepResult)
         ]
     except Exception as exc:
         # Capture any error output that was written to stderr

--- a/src/lfx/src/lfx/cli/common.py
+++ b/src/lfx/src/lfx/cli/common.py
@@ -349,7 +349,15 @@ async def execute_graph_with_capture(graph, input_value: str | None, session_id:
     try:
         sys.stdout = captured_stdout
         sys.stderr = captured_stderr
-        results = [result async for result in graph.async_start(inputs, fallback_to_env_vars=fallback_to_env_vars)]
+        from lfx.execution import StepResult, get_default_coordinator
+
+        results = [
+            item.payload
+            async for item in get_default_coordinator().run(
+                graph, inputs=[], initial_inputs=inputs, fallback_to_env_vars=fallback_to_env_vars
+            )
+            if isinstance(item, StepResult)
+        ]
     except Exception as exc:
         # Capture any error output that was written to stderr
         error_output = captured_stderr.getvalue()

--- a/src/lfx/src/lfx/execution/__init__.py
+++ b/src/lfx/src/lfx/execution/__init__.py
@@ -34,6 +34,13 @@ def set_default_coordinator(coordinator: Coordinator) -> None:
     _default_coordinator = coordinator
 
 
+def reset_default_coordinator() -> None:
+    """Drop the module-level singletons; next access rebuilds them. For tests."""
+    global _default_registry, _default_coordinator  # noqa: PLW0603
+    _default_registry = None
+    _default_coordinator = None
+
+
 __all__ = [
     "Coordinator",
     "Executor",
@@ -45,5 +52,6 @@ __all__ = [
     "get_default_coordinator",
     "get_default_registry",
     "identity_partition",
+    "reset_default_coordinator",
     "set_default_coordinator",
 ]

--- a/src/lfx/src/lfx/execution/__init__.py
+++ b/src/lfx/src/lfx/execution/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from lfx.execution.backends.in_process import InProcessExecutor
 from lfx.execution.coordinator import Coordinator
 from lfx.execution.executor import Executor
@@ -9,36 +11,38 @@ from lfx.execution.partitioner import identity_partition
 from lfx.execution.registry import ExecutorNotFoundError, ExecutorRegistry
 from lfx.execution.types import RunComplete, StepResult, Unit
 
-_default_registry: ExecutorRegistry | None = None
-_default_coordinator: Coordinator | None = None
+
+@dataclass
+class _Defaults:
+    registry: ExecutorRegistry | None = None
+    coordinator: Coordinator | None = None
+
+
+_defaults = _Defaults()
 
 
 def get_default_registry() -> ExecutorRegistry:
-    global _default_registry  # noqa: PLW0603
-    if _default_registry is None:
+    if _defaults.registry is None:
         registry = ExecutorRegistry()
         registry.register(InProcessExecutor())
-        _default_registry = registry
-    return _default_registry
+        _defaults.registry = registry
+    return _defaults.registry
 
 
 def get_default_coordinator() -> Coordinator:
-    global _default_coordinator  # noqa: PLW0603
-    if _default_coordinator is None:
-        _default_coordinator = Coordinator(registry=get_default_registry())
-    return _default_coordinator
+    if _defaults.coordinator is None:
+        _defaults.coordinator = Coordinator(registry=get_default_registry())
+    return _defaults.coordinator
 
 
 def set_default_coordinator(coordinator: Coordinator) -> None:
-    global _default_coordinator  # noqa: PLW0603
-    _default_coordinator = coordinator
+    _defaults.coordinator = coordinator
 
 
 def reset_default_coordinator() -> None:
     """Drop the module-level singletons; next access rebuilds them. For tests."""
-    global _default_registry, _default_coordinator  # noqa: PLW0603
-    _default_registry = None
-    _default_coordinator = None
+    _defaults.registry = None
+    _defaults.coordinator = None
 
 
 __all__ = [

--- a/src/lfx/src/lfx/execution/__init__.py
+++ b/src/lfx/src/lfx/execution/__init__.py
@@ -1,0 +1,49 @@
+"""Public entry points for the execution layer."""
+
+from __future__ import annotations
+
+from lfx.execution.backends.in_process import InProcessExecutor
+from lfx.execution.coordinator import Coordinator
+from lfx.execution.executor import Executor
+from lfx.execution.partitioner import identity_partition
+from lfx.execution.registry import ExecutorNotFoundError, ExecutorRegistry
+from lfx.execution.types import RunComplete, StepResult, Unit
+
+_default_registry: ExecutorRegistry | None = None
+_default_coordinator: Coordinator | None = None
+
+
+def get_default_registry() -> ExecutorRegistry:
+    global _default_registry  # noqa: PLW0603
+    if _default_registry is None:
+        registry = ExecutorRegistry()
+        registry.register(InProcessExecutor())
+        _default_registry = registry
+    return _default_registry
+
+
+def get_default_coordinator() -> Coordinator:
+    global _default_coordinator  # noqa: PLW0603
+    if _default_coordinator is None:
+        _default_coordinator = Coordinator(registry=get_default_registry())
+    return _default_coordinator
+
+
+def set_default_coordinator(coordinator: Coordinator) -> None:
+    global _default_coordinator  # noqa: PLW0603
+    _default_coordinator = coordinator
+
+
+__all__ = [
+    "Coordinator",
+    "Executor",
+    "ExecutorNotFoundError",
+    "ExecutorRegistry",
+    "RunComplete",
+    "StepResult",
+    "Unit",
+    "get_default_coordinator",
+    "get_default_registry",
+    "identity_partition",
+    "set_default_coordinator",
+]

--- a/src/lfx/src/lfx/execution/__init__.py
+++ b/src/lfx/src/lfx/execution/__init__.py
@@ -1,8 +1,12 @@
-"""Public entry points for the execution layer."""
+"""Public entry points for the execution layer.
+
+The execution coordinator and registry are owned by the :class:`ExecutorService`
+(``lfx.services.executor``). The helpers below are thin convenience wrappers that
+resolve the service through the standard service manager so callers do not need to
+know about the service plumbing.
+"""
 
 from __future__ import annotations
-
-from dataclasses import dataclass
 
 from lfx.execution.backends.in_process import InProcessExecutor
 from lfx.execution.coordinator import Coordinator
@@ -12,37 +16,35 @@ from lfx.execution.registry import ExecutorNotFoundError, ExecutorRegistry
 from lfx.execution.types import RunComplete, StepResult, Unit
 
 
-@dataclass
-class _Defaults:
-    registry: ExecutorRegistry | None = None
-    coordinator: Coordinator | None = None
+def _get_executor_service():
+    from lfx.services.deps import get_service
+    from lfx.services.schema import ServiceType
 
-
-_defaults = _Defaults()
+    service = get_service(ServiceType.EXECUTOR_SERVICE)
+    if service is None:
+        msg = "ExecutorService is not available; check earlier logs for the underlying init failure."
+        raise RuntimeError(msg)
+    return service
 
 
 def get_default_registry() -> ExecutorRegistry:
-    if _defaults.registry is None:
-        registry = ExecutorRegistry()
-        registry.register(InProcessExecutor())
-        _defaults.registry = registry
-    return _defaults.registry
+    return _get_executor_service().registry
 
 
 def get_default_coordinator() -> Coordinator:
-    if _defaults.coordinator is None:
-        _defaults.coordinator = Coordinator(registry=get_default_registry())
-    return _defaults.coordinator
+    return _get_executor_service().coordinator
 
 
 def set_default_coordinator(coordinator: Coordinator) -> None:
-    _defaults.coordinator = coordinator
+    _get_executor_service().set_coordinator(coordinator)
 
 
 def reset_default_coordinator() -> None:
-    """Drop the module-level singletons; next access rebuilds them. For tests."""
-    _defaults.registry = None
-    _defaults.coordinator = None
+    """Drop the executor service so the next access rebuilds registry + coordinator. For tests."""
+    from lfx.services.manager import get_service_manager
+    from lfx.services.schema import ServiceType
+
+    get_service_manager().update(ServiceType.EXECUTOR_SERVICE)
 
 
 __all__ = [
@@ -50,6 +52,7 @@ __all__ = [
     "Executor",
     "ExecutorNotFoundError",
     "ExecutorRegistry",
+    "InProcessExecutor",
     "RunComplete",
     "StepResult",
     "Unit",

--- a/src/lfx/src/lfx/execution/backends/in_process.py
+++ b/src/lfx/src/lfx/execution/backends/in_process.py
@@ -1,4 +1,4 @@
-"""In-process executor — wraps today's graph runner."""
+"""In-process executor: wraps today's graph runner."""
 
 from __future__ import annotations
 
@@ -21,9 +21,9 @@ class InProcessExecutor(Executor):
         graph = unit.graph
         opts = unit.runtime_options
 
-        legacy = getattr(graph, "_arun_legacy", None)
-        if legacy is not None and unit.inputs and isinstance(unit.inputs[0], dict):
-            outputs = await legacy(inputs=unit.inputs, **opts)
+        if opts.get("_use_arun_legacy") and hasattr(graph, "_arun_legacy"):
+            legacy_kwargs = {k: v for k, v in opts.items() if not k.startswith("_")}
+            outputs = await graph._arun_legacy(inputs=unit.inputs, **legacy_kwargs)  # noqa: SLF001
             yield RunComplete(outputs=list(outputs))
             return
 
@@ -33,18 +33,10 @@ class InProcessExecutor(Executor):
             config=opts.get("config"),
             event_manager=opts.get("event_manager"),
             reset_output_values=opts.get("reset_output_values", True),
+            fallback_to_env_vars=opts.get("fallback_to_env_vars", False),
         ):
             yield StepResult(payload=result)
             if isinstance(result, Finish):
                 break
 
-        outputs_filter = opts.get("outputs") or []
-        final = []
-        for vertex in graph.vertices:
-            if not vertex.built:
-                continue
-            if (not outputs_filter and vertex.is_output) or (
-                vertex.display_name in outputs_filter or vertex.id in outputs_filter
-            ):
-                final.append(vertex.result)
-        yield RunComplete(outputs=final)
+        yield RunComplete(outputs=[])

--- a/src/lfx/src/lfx/execution/backends/in_process.py
+++ b/src/lfx/src/lfx/execution/backends/in_process.py
@@ -1,0 +1,50 @@
+"""In-process executor — wraps today's graph runner."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from lfx.execution.executor import Executor
+from lfx.execution.types import RunComplete, StepResult
+from lfx.graph.graph.constants import Finish
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from lfx.execution.types import Unit
+
+
+class InProcessExecutor(Executor):
+    kind = "in-process"
+
+    async def execute(self, unit: Unit) -> AsyncIterator[StepResult | RunComplete]:
+        graph = unit.graph
+        opts = unit.runtime_options
+
+        legacy = getattr(graph, "_arun_legacy", None)
+        if legacy is not None and unit.inputs and isinstance(unit.inputs[0], dict):
+            outputs = await legacy(inputs=unit.inputs, **opts)
+            yield RunComplete(outputs=list(outputs))
+            return
+
+        async for result in graph.async_start(
+            inputs=opts.get("initial_inputs"),
+            max_iterations=opts.get("max_iterations"),
+            config=opts.get("config"),
+            event_manager=opts.get("event_manager"),
+            reset_output_values=opts.get("reset_output_values", True),
+        ):
+            yield StepResult(payload=result)
+            if isinstance(result, Finish):
+                break
+
+        outputs_filter = opts.get("outputs") or []
+        final = []
+        for vertex in graph.vertices:
+            if not vertex.built:
+                continue
+            if (not outputs_filter and vertex.is_output) or (
+                vertex.display_name in outputs_filter or vertex.id in outputs_filter
+            ):
+                final.append(vertex.result)
+        yield RunComplete(outputs=final)

--- a/src/lfx/src/lfx/execution/backends/in_process.py
+++ b/src/lfx/src/lfx/execution/backends/in_process.py
@@ -27,16 +27,32 @@ class InProcessExecutor(Executor):
             yield RunComplete(outputs=list(outputs))
             return
 
-        async for result in graph.async_start(
+        # Hold a reference to the inner async iterator so we can guarantee
+        # finalization on consumer cancellation. ``async for`` does NOT call
+        # ``aclose()`` on its iterator when the loop is interrupted by an exception
+        # (e.g. ``GeneratorExit`` from this generator being closed). Without the
+        # explicit try/finally below, the inner generator's ``finally:`` block --
+        # which is where event managers, connections, or vertex finalizers run --
+        # would only execute on GC, leaking resources for an unpredictable window.
+        inner = graph.async_start(
             inputs=opts.get("initial_inputs"),
             max_iterations=opts.get("max_iterations"),
             config=opts.get("config"),
             event_manager=opts.get("event_manager"),
             reset_output_values=opts.get("reset_output_values", True),
             fallback_to_env_vars=opts.get("fallback_to_env_vars", False),
-        ):
-            yield StepResult(payload=result)
-            if isinstance(result, Finish):
-                break
+        )
+        try:
+            async for result in inner:
+                yield StepResult(payload=result)
+                if isinstance(result, Finish):
+                    break
 
-        yield RunComplete(outputs=[])
+            yield RunComplete(outputs=[])
+        finally:
+            # ``aclose`` is a no-op if the generator already completed. Async
+            # iterables that aren't generators (test stubs, custom iterators) may
+            # not implement aclose, so guard with hasattr.
+            aclose = getattr(inner, "aclose", None)
+            if aclose is not None:
+                await aclose()

--- a/src/lfx/src/lfx/execution/coordinator.py
+++ b/src/lfx/src/lfx/execution/coordinator.py
@@ -19,6 +19,7 @@ Callers pick the view they want:
 
 from __future__ import annotations
 
+from contextlib import aclosing
 from typing import TYPE_CHECKING, Any
 
 from lfx.execution.partitioner import identity_partition
@@ -91,17 +92,16 @@ class Coordinator:
         empty list here; callers that want final outputs from the streaming path
         should use ``stream()`` and collect what they need from payloads.
         """
-        async for item in self.run(graph, inputs=inputs, **runtime_options):
-            if isinstance(item, RunComplete):
-                return item.outputs
+        async with aclosing(self.run(graph, inputs=inputs, **runtime_options)) as stream:
+            async for item in stream:
+                if isinstance(item, RunComplete):
+                    return item.outputs
         msg = "Executor stream ended without a RunComplete"
         raise RuntimeError(msg)
 
     async def stream(
         self,
         graph: Any,
-        *,
-        inputs: list[dict[str, Any]] | None = None,
         **runtime_options: Any,
     ) -> AsyncIterator[Any]:
         """Yield ``StepResult.payload`` values only.
@@ -110,11 +110,14 @@ class Coordinator:
         exists for consumers that process events incrementally and have no use for
         the end-of-run envelope. If you need to know when the run ends, use
         ``run()`` directly.
+
+        Note there is no ``inputs`` parameter here. The in-process executor's
+        streaming path reads its inputs from ``runtime_options["initial_inputs"]``,
+        not from the seam-level ``inputs`` list (which only the legacy passthrough
+        in ``run_to_completion`` consumes). Pass ``initial_inputs=...`` to feed a
+        streaming run.
         """
-        inner = self.run(graph, inputs=inputs or [], **runtime_options)
-        try:
+        async with aclosing(self.run(graph, inputs=[], **runtime_options)) as inner:
             async for item in inner:
                 if isinstance(item, StepResult):
                     yield item.payload
-        finally:
-            await inner.aclose()

--- a/src/lfx/src/lfx/execution/coordinator.py
+++ b/src/lfx/src/lfx/execution/coordinator.py
@@ -1,4 +1,21 @@
-"""Coordinator: graph in, streaming step results out."""
+"""Coordinator: graph in, streaming step results out.
+
+The ``Coordinator`` is the single dispatch point between callers and executors. It
+looks up the registered ``Executor`` for the configured ``kind``, partitions the
+input graph into ``Unit`` value objects, and forwards each unit's event stream.
+
+Callers pick the view they want:
+
+- ``run()``: full seam stream (``StepResult`` + terminal ``RunComplete``). Use when
+  you need the terminal signal -- e.g. ``run_to_completion``.
+- ``stream()``: payloads only. Drops the terminal ``RunComplete`` silently because
+  every existing payload-consumer in the codebase (``flow_executor``, the CLI,
+  ``Loop``, ``run/base``) processes events incrementally and has no use for the
+  terminal envelope.
+- ``run_to_completion()``: drains the stream and returns ``RunComplete.outputs``.
+  Practically useful only with the in-process executor's legacy passthrough; see
+  the docstring on ``RunComplete.outputs`` for the full semantics.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +31,8 @@ if TYPE_CHECKING:
 
 
 class Coordinator:
+    """Routes graph runs through a registered ``Executor`` of the configured kind."""
+
     def __init__(
         self,
         *,
@@ -30,11 +49,30 @@ class Coordinator:
         inputs: list[dict[str, Any]],
         **runtime_options: Any,
     ) -> AsyncIterator[StepResult | RunComplete]:
+        """Stream the seam-typed event sequence for ``graph``.
+
+        Yields the executor's ``StepResult`` items in order followed by the
+        terminal ``RunComplete``. If you only need payloads, use ``stream()``;
+        if you only need the final ``outputs`` list, use ``run_to_completion()``.
+
+        ``runtime_options`` are forwarded as-is into ``Unit.runtime_options``;
+        consult the active executor's documentation for which keys it honors.
+        """
         units = identity_partition(graph, inputs=inputs, runtime_options=runtime_options)
         executor = self._registry.get(self._executor_kind)
         for unit in units:
-            async for item in executor.execute(unit):
-                yield item
+            # Cascade cleanup: if our consumer aclose()s us, we aclose the executor
+            # stream, which lets InProcessExecutor's try/finally aclose the underlying
+            # graph generator. Without this, the executor stream is abandoned on
+            # consumer aclose and only finalizes when CPython gets around to GC.
+            inner = executor.execute(unit)
+            try:
+                async for item in inner:
+                    yield item
+            finally:
+                aclose = getattr(inner, "aclose", None)
+                if aclose is not None:
+                    await aclose()
 
     async def run_to_completion(
         self,
@@ -43,6 +81,16 @@ class Coordinator:
         inputs: list[dict[str, Any]],
         **runtime_options: Any,
     ) -> list[Any]:
+        """Drain the stream and return ``RunComplete.outputs``.
+
+        Raises ``RuntimeError`` if the executor's stream ends without a terminal
+        ``RunComplete`` -- a contract violation that every executor must avoid.
+
+        See ``RunComplete.outputs`` for the per-executor semantics of the returned
+        list. In particular, the in-process executor's streaming path returns an
+        empty list here; callers that want final outputs from the streaming path
+        should use ``stream()`` and collect what they need from payloads.
+        """
         async for item in self.run(graph, inputs=inputs, **runtime_options):
             if isinstance(item, RunComplete):
                 return item.outputs
@@ -56,6 +104,17 @@ class Coordinator:
         inputs: list[dict[str, Any]] | None = None,
         **runtime_options: Any,
     ) -> AsyncIterator[Any]:
-        async for item in self.run(graph, inputs=inputs or [], **runtime_options):
-            if isinstance(item, StepResult):
-                yield item.payload
+        """Yield ``StepResult.payload`` values only.
+
+        The terminal ``RunComplete`` is intentionally NOT yielded -- this helper
+        exists for consumers that process events incrementally and have no use for
+        the end-of-run envelope. If you need to know when the run ends, use
+        ``run()`` directly.
+        """
+        inner = self.run(graph, inputs=inputs or [], **runtime_options)
+        try:
+            async for item in inner:
+                if isinstance(item, StepResult):
+                    yield item.payload
+        finally:
+            await inner.aclose()

--- a/src/lfx/src/lfx/execution/coordinator.py
+++ b/src/lfx/src/lfx/execution/coordinator.py
@@ -1,0 +1,51 @@
+"""Coordinator: graph in, streaming step results out."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from lfx.execution.partitioner import identity_partition
+from lfx.execution.types import RunComplete
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from lfx.execution.registry import ExecutorRegistry
+    from lfx.execution.types import StepResult
+
+
+class Coordinator:
+    def __init__(
+        self,
+        *,
+        registry: ExecutorRegistry,
+        executor_kind: str = "in-process",
+    ) -> None:
+        self._registry = registry
+        self._executor_kind = executor_kind
+
+    async def run(
+        self,
+        graph: Any,
+        *,
+        inputs: list[dict[str, Any]],
+        **runtime_options: Any,
+    ) -> AsyncIterator[StepResult | RunComplete]:
+        units = identity_partition(graph, inputs=inputs, runtime_options=runtime_options)
+        executor = self._registry.get(self._executor_kind)
+        for unit in units:
+            async for item in executor.execute(unit):
+                yield item
+
+    async def run_to_completion(
+        self,
+        graph: Any,
+        *,
+        inputs: list[dict[str, Any]],
+        **runtime_options: Any,
+    ) -> list[Any]:
+        async for item in self.run(graph, inputs=inputs, **runtime_options):
+            if isinstance(item, RunComplete):
+                return item.outputs
+        msg = "Executor stream ended without a RunComplete"
+        raise RuntimeError(msg)

--- a/src/lfx/src/lfx/execution/coordinator.py
+++ b/src/lfx/src/lfx/execution/coordinator.py
@@ -58,6 +58,11 @@ class Coordinator:
 
         ``runtime_options`` are forwarded as-is into ``Unit.runtime_options``;
         consult the active executor's documentation for which keys it honors.
+
+        ``identity_partition`` currently yields exactly one ``Unit``, so this emits a
+        single terminal ``RunComplete``. A future partitioner returning multiple units
+        would emit one ``RunComplete`` per unit; consumers relying on a single terminal
+        envelope (notably ``run_to_completion``) would need updating first.
         """
         units = identity_partition(graph, inputs=inputs, runtime_options=runtime_options)
         executor = self._registry.get(self._executor_kind)

--- a/src/lfx/src/lfx/execution/coordinator.py
+++ b/src/lfx/src/lfx/execution/coordinator.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from lfx.execution.partitioner import identity_partition
-from lfx.execution.types import RunComplete
+from lfx.execution.types import RunComplete, StepResult
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
     from lfx.execution.registry import ExecutorRegistry
-    from lfx.execution.types import StepResult
 
 
 class Coordinator:
@@ -49,3 +48,14 @@ class Coordinator:
                 return item.outputs
         msg = "Executor stream ended without a RunComplete"
         raise RuntimeError(msg)
+
+    async def stream(
+        self,
+        graph: Any,
+        *,
+        inputs: list[dict[str, Any]] | None = None,
+        **runtime_options: Any,
+    ) -> AsyncIterator[Any]:
+        async for item in self.run(graph, inputs=inputs or [], **runtime_options):
+            if isinstance(item, StepResult):
+                yield item.payload

--- a/src/lfx/src/lfx/execution/executor.py
+++ b/src/lfx/src/lfx/execution/executor.py
@@ -1,0 +1,19 @@
+"""Executor abstract base class."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from lfx.execution.types import RunComplete, StepResult, Unit
+
+
+class Executor(ABC):
+    kind: ClassVar[str]
+
+    @abstractmethod
+    def execute(self, unit: Unit) -> AsyncIterator[StepResult | RunComplete]:
+        """Yield StepResult items, end with a RunComplete."""

--- a/src/lfx/src/lfx/execution/executor.py
+++ b/src/lfx/src/lfx/execution/executor.py
@@ -1,4 +1,23 @@
-"""Executor abstract base class."""
+"""Executor abstract base class.
+
+An ``Executor`` is the pluggable backend that turns a ``Unit`` into a stream of
+``StepResult`` events terminated by a single ``RunComplete``. The ``Coordinator``
+holds at most one instance per ``kind`` and dispatches every ``run()`` against it,
+so implementations must observe the lifecycle contract documented below.
+
+Authoring a new executor:
+
+1. Subclass ``Executor`` and set ``kind`` to a unique, stable string.
+2. Implement ``execute`` as an ``async def`` generator. Yield zero or more
+   ``StepResult`` items, then exactly one ``RunComplete``.
+3. Register through one of three paths (all equivalent at runtime):
+   - Explicit: ``get_service(ServiceType.EXECUTOR_SERVICE).register(MyExecutor())``
+   - Plugin: ``[project.entry-points."lfx.executors"] my_kind = "pkg.mod:MyExecutor"``
+   - Service replacement: ``@register_service(ServiceType.EXECUTOR_SERVICE)``
+4. Validate with the shared contract suite: subclass
+   ``tests.unit.execution.test_executor_contract.ExecutorContract`` in your tests
+   and provide the two fixtures. All universal seam guarantees are checked there.
+"""
 
 from __future__ import annotations
 
@@ -12,8 +31,46 @@ if TYPE_CHECKING:
 
 
 class Executor(ABC):
+    """Pluggable execution backend for the seam.
+
+    Class attributes:
+        kind: Unique stable identifier used by ``ExecutorRegistry`` and by
+            ``settings.executor_kind``. Two executors with the same ``kind`` cannot
+            coexist in a single registry; entry-point discovery refuses collisions.
+
+    Lifecycle contract:
+        - A single instance is shared across all runs of its ``kind``. The same
+          instance may receive concurrent ``execute()`` calls (e.g. parallel API
+          requests, ``Loop`` subgraphs). Implementations MUST be safe under
+          concurrent calls and MUST NOT carry per-run state on ``self``.
+        - ``execute()`` is called once per ``Unit``. Each call MUST return a fresh
+          async iterator; reusing/caching a generator across calls is a bug.
+        - The stream MUST emit zero or more ``StepResult`` followed by exactly one
+          terminal ``RunComplete``. ``Coordinator.run_to_completion`` raises if the
+          terminal item is missing.
+        - Exceptions raised inside the generator propagate to the consumer. The
+          generator's finalizer runs as usual, so any ``async with`` / cleanup code
+          will execute. Consumers MAY drop the iterator mid-stream (``aclose``);
+          implementations MUST tolerate this without hanging or leaking external
+          resources (subprocesses, sockets, locks, file handles).
+        - ``execute()`` MUST be tolerant of arbitrary keys in ``unit.runtime_options``:
+          ignore keys the executor doesn't recognize. Keys prefixed with ``_`` are
+          reserved for executor-internal flags; non-owning executors must ignore them.
+    """
+
     kind: ClassVar[str]
 
     @abstractmethod
     def execute(self, unit: Unit) -> AsyncIterator[StepResult | RunComplete]:
-        """Yield StepResult items, end with a RunComplete."""
+        """Run ``unit`` and yield the seam-typed event stream.
+
+        Args:
+            unit: The work item. ``unit.graph`` is executor-defined (an in-memory
+                ``Graph`` for in-process; whatever shape a remote/sandboxed executor
+                expects). ``unit.inputs`` and ``unit.runtime_options`` carry per-run
+                state.
+
+        Yields:
+            ``StepResult`` items for mid-run events (executor-defined payloads),
+            terminated by exactly one ``RunComplete``.
+        """

--- a/src/lfx/src/lfx/execution/partitioner.py
+++ b/src/lfx/src/lfx/execution/partitioner.py
@@ -1,0 +1,16 @@
+"""Identity partitioner — one unit per graph."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lfx.execution.types import Unit
+
+
+def identity_partition(
+    graph: Any,
+    *,
+    inputs: list[dict[str, Any]],
+    runtime_options: dict[str, Any] | None = None,
+) -> list[Unit]:
+    return [Unit(graph=graph, inputs=inputs, runtime_options=runtime_options or {})]

--- a/src/lfx/src/lfx/execution/partitioner.py
+++ b/src/lfx/src/lfx/execution/partitioner.py
@@ -1,4 +1,4 @@
-"""Identity partitioner — one unit per graph."""
+"""Identity partitioner: one unit per graph."""
 
 from __future__ import annotations
 

--- a/src/lfx/src/lfx/execution/registry.py
+++ b/src/lfx/src/lfx/execution/registry.py
@@ -1,0 +1,27 @@
+"""Executor registry."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lfx.execution.executor import Executor
+
+
+class ExecutorNotFoundError(LookupError):
+    pass
+
+
+class ExecutorRegistry:
+    def __init__(self) -> None:
+        self._by_kind: dict[str, Executor] = {}
+
+    def register(self, executor: Executor) -> None:
+        self._by_kind[executor.kind] = executor
+
+    def get(self, kind: str) -> Executor:
+        try:
+            return self._by_kind[kind]
+        except KeyError as exc:
+            msg = f"No executor registered for kind={kind!r}"
+            raise ExecutorNotFoundError(msg) from exc

--- a/src/lfx/src/lfx/execution/registry.py
+++ b/src/lfx/src/lfx/execution/registry.py
@@ -12,12 +12,31 @@ class ExecutorNotFoundError(LookupError):
     pass
 
 
+class ExecutorKindCollisionError(ValueError):
+    """Raised when registering an executor whose kind is already registered and replace=False."""
+
+
 class ExecutorRegistry:
     def __init__(self) -> None:
         self._by_kind: dict[str, Executor] = {}
 
-    def register(self, executor: Executor) -> None:
+    def register(self, executor: Executor, *, replace: bool = True) -> None:
+        """Register an executor by its kind.
+
+        Args:
+            executor: The executor to register.
+            replace: If True (default), overwrite any existing executor with the same kind.
+                If False, raise :class:`ExecutorKindCollisionError` instead. Discovery paths
+                pass ``replace=False`` so an installed package cannot silently replace a
+                pre-registered executor (notably the built-in ``in-process``).
+        """
+        if not replace and executor.kind in self._by_kind:
+            msg = f"Executor kind={executor.kind!r} is already registered"
+            raise ExecutorKindCollisionError(msg)
         self._by_kind[executor.kind] = executor
+
+    def has(self, kind: str) -> bool:
+        return kind in self._by_kind
 
     def get(self, kind: str) -> Executor:
         try:

--- a/src/lfx/src/lfx/execution/types.py
+++ b/src/lfx/src/lfx/execution/types.py
@@ -1,4 +1,11 @@
-"""Value objects for the execution layer."""
+"""Value objects for the execution layer.
+
+These three dataclasses are the entire vocabulary of the seam: a ``Unit`` flows from
+``Coordinator`` into ``Executor.execute()``, which yields a stream of ``StepResult``
+items terminated by a single ``RunComplete``. Every consumer downstream of the
+coordinator (``run_to_completion``, ``stream``, ``flow_executor``, the CLI, ``Loop``
+subgraphs) reads only these types, so changes here ripple widely. Keep them small.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +15,30 @@ from typing import Any
 
 @dataclass
 class Unit:
+    """A self-contained slice of work handed to an ``Executor``.
+
+    Attributes:
+        graph: The graph (or graph-shaped object) the executor should run. Executors
+            decide what they can accept here -- the in-process executor wants a real
+            ``lfx.Graph``; a remote executor may want a serialized form. There is no
+            seam-level constraint other than "the executor knows what to do with it."
+        inputs: Per-run input dicts. Shape is consumer-defined.
+        runtime_options: A free-form bag of run-scoped options. Stringly typed on
+            purpose: the seam can't enumerate every option every executor might want
+            (event managers, session IDs, fallback flags, executor-specific tokens),
+            and pinning a schema here would force every change into this module.
+            Conventions worth knowing:
+
+            - Keys starting with ``_`` are reserved for executor-internal flags
+              (e.g. ``_use_arun_legacy`` selects the legacy passthrough in the
+              in-process executor). Other executors MUST ignore unknown keys.
+            - Common keys recognized by the in-process executor:
+              ``initial_inputs``, ``max_iterations``, ``config``, ``event_manager``,
+              ``reset_output_values``, ``fallback_to_env_vars``, ``session_id``.
+            - Other executors are free to define their own keys; document them in
+              the executor module.
+    """
+
     graph: Any
     inputs: list[dict[str, Any]] = field(default_factory=list)
     runtime_options: dict[str, Any] = field(default_factory=dict)
@@ -15,9 +46,54 @@ class Unit:
 
 @dataclass
 class StepResult:
+    """A single mid-run event from an executor.
+
+    ``payload`` is intentionally untyped at the seam level. Each executor decides
+    what mid-run events look like for its backend:
+
+    - ``InProcessExecutor`` yields ``Vertex`` / ``Finish`` instances from
+      ``Graph.async_start``.
+    - A remote executor (e.g. stepflow) might yield protobuf status events.
+    - A sandboxed executor might yield structured ``StepStarted`` / ``StepCompleted``
+      records.
+
+    Consumers that need a uniform shape across executors should normalize at the
+    consumer site (or wrap an executor with an adapter), not push a structured event
+    type down through the seam. Doing the latter would force every executor to
+    translate its native event vocabulary into a synthetic one and would mask
+    information the native vocabulary carries.
+
+    ``Coordinator.stream()`` unwraps ``StepResult.payload`` for callers that want a
+    raw event stream; ``Coordinator.run()`` yields the full ``StepResult``/``
+    RunComplete`` union for callers that want the seam shape.
+    """
+
     payload: Any
 
 
 @dataclass
 class RunComplete:
+    """Terminal item in an executor stream.
+
+    ``outputs`` is populated only by executors / paths that have a meaningful notion
+    of "final outputs of the run." In particular:
+
+    - The in-process executor's *legacy* path (selected via
+      ``runtime_options["_use_arun_legacy"]``) populates ``outputs`` with the
+      ``list[RunOutputs]`` returned by ``Graph._arun_legacy``. ``Graph.arun`` reads
+      this via ``Coordinator.run_to_completion``.
+    - The in-process executor's *streaming* path yields ``RunComplete(outputs=[])``;
+      consumers of the streaming path are expected to collect what they need from
+      ``StepResult.payload`` events along the way (this is what ``flow_executor``,
+      the CLI, ``Loop``, and ``run/base`` already do via ``Coordinator.stream``).
+    - Other executors MAY populate ``outputs`` with whatever terminal-status event
+      their backend provides (e.g. a stepflow ``RunCompletedEvent``).
+
+    Bottom line: the *only* universal contract on ``outputs`` is that it is a list.
+    If you need final values across all executors, collect them from the stream;
+    if you specifically need the legacy ``list[RunOutputs]`` shape, use
+    ``Coordinator.run_to_completion`` with ``_use_arun_legacy=True`` against the
+    in-process executor.
+    """
+
     outputs: list[Any]

--- a/src/lfx/src/lfx/execution/types.py
+++ b/src/lfx/src/lfx/execution/types.py
@@ -34,7 +34,8 @@ class Unit:
               in-process executor). Other executors MUST ignore unknown keys.
             - Common keys recognized by the in-process executor:
               ``initial_inputs``, ``max_iterations``, ``config``, ``event_manager``,
-              ``reset_output_values``, ``fallback_to_env_vars``, ``session_id``.
+              ``reset_output_values``, ``fallback_to_env_vars``. ``session_id`` is
+              honored only by the legacy passthrough path; the streaming path drops it.
             - Other executors are free to define their own keys; document them in
               the executor module.
     """

--- a/src/lfx/src/lfx/execution/types.py
+++ b/src/lfx/src/lfx/execution/types.py
@@ -1,0 +1,23 @@
+"""Value objects for the execution layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Unit:
+    graph: Any
+    inputs: list[dict[str, Any]] = field(default_factory=list)
+    runtime_options: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class StepResult:
+    payload: Any
+
+
+@dataclass
+class RunComplete:
+    outputs: list[Any]

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -878,25 +878,33 @@ class Graph:
         fallback_to_env_vars: bool = False,
         event_manager: EventManager | None = None,
     ) -> list[RunOutputs]:
-        """Runs the graph with the given inputs.
+        """Runs the graph with the given inputs via the configured executor."""
+        from lfx.execution import get_default_coordinator
 
-        Args:
-            inputs (list[Dict[str, str]]): The input values for the graph.
-            inputs_components (Optional[list[list[str]]], optional): Components to run for the inputs. Defaults to None.
-            types (Optional[list[Optional[InputType]]], optional): The types of the inputs. Defaults to None.
-            outputs (Optional[list[str]], optional): The outputs to retrieve from the graph. Defaults to None.
-            session_id (Optional[str], optional): The session ID for the graph. Defaults to None.
-            stream (bool, optional): Whether to stream the results or not. Defaults to False.
-            fallback_to_env_vars (bool, optional): Whether to fallback to environment variables. Defaults to False.
-            event_manager (EventManager | None): The event manager for the graph.
+        return await get_default_coordinator().run_to_completion(
+            self,
+            inputs=inputs,
+            inputs_components=inputs_components,
+            types=types,
+            outputs=outputs,
+            session_id=session_id,
+            stream=stream,
+            fallback_to_env_vars=fallback_to_env_vars,
+            event_manager=event_manager,
+        )
 
-        Returns:
-            List[RunOutputs]: The outputs of the graph.
-        """
-        # inputs is {"message": "Hello, world!"}
-        # we need to go through self.inputs and update the self.raw_params
-        # of the vertices that are inputs
-        # if the value is a list, we need to run multiple times
+    async def _arun_legacy(
+        self,
+        inputs: list[dict[str, str]],
+        *,
+        inputs_components: list[list[str]] | None = None,
+        types: list[InputType | None] | None = None,
+        outputs: list[str] | None = None,
+        session_id: str | None = None,
+        stream: bool = False,
+        fallback_to_env_vars: bool = False,
+        event_manager: EventManager | None = None,
+    ) -> list[RunOutputs]:
         vertex_outputs = []
         if not isinstance(inputs, list):
             inputs = [inputs]

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -891,6 +891,7 @@ class Graph:
             stream=stream,
             fallback_to_env_vars=fallback_to_env_vars,
             event_manager=event_manager,
+            _use_arun_legacy=True,
         )
 
     async def _arun_legacy(

--- a/src/lfx/src/lfx/run/base.py
+++ b/src/lfx/src/lfx/run/base.py
@@ -443,9 +443,18 @@ async def run_flow(
         # fall through to os.environ on miss instead of erroring the build).
         fallback_to_env_vars = resolve_fallback_to_env_vars()
 
-        async for result in graph.async_start(
-            inputs, event_manager=event_manager, fallback_to_env_vars=fallback_to_env_vars
+        from lfx.execution import StepResult, get_default_coordinator
+
+        async for _item in get_default_coordinator().run(
+            graph,
+            inputs=[],
+            initial_inputs=inputs,
+            event_manager=event_manager,
+            fallback_to_env_vars=fallback_to_env_vars,
         ):
+            if not isinstance(_item, StepResult):
+                continue
+            result = _item.payload
             result_count += 1
             if verbosity > 0:
                 logger.debug(f"Processing result #{result_count}")

--- a/src/lfx/src/lfx/run/base.py
+++ b/src/lfx/src/lfx/run/base.py
@@ -15,6 +15,7 @@ from lfx.cli.script_loader import (
     load_graph_from_script,
 )
 from lfx.cli.validation import validate_global_variables_for_env
+from lfx.execution import get_default_coordinator
 from lfx.log.logger import logger
 from lfx.run._defaults import apply_run_defaults, resolve_fallback_to_env_vars, validate_provided_id
 from lfx.schema.schema import InputValueRequest
@@ -443,18 +444,12 @@ async def run_flow(
         # fall through to os.environ on miss instead of erroring the build).
         fallback_to_env_vars = resolve_fallback_to_env_vars()
 
-        from lfx.execution import StepResult, get_default_coordinator
-
-        async for _item in get_default_coordinator().run(
+        async for result in get_default_coordinator().stream(
             graph,
-            inputs=[],
             initial_inputs=inputs,
             event_manager=event_manager,
             fallback_to_env_vars=fallback_to_env_vars,
         ):
-            if not isinstance(_item, StepResult):
-                continue
-            result = _item.payload
             result_count += 1
             if verbosity > 0:
                 logger.debug(f"Processing result #{result_count}")

--- a/src/lfx/src/lfx/services/deps.py
+++ b/src/lfx/src/lfx/services/deps.py
@@ -61,6 +61,10 @@ def get_service(service_type: ServiceType, default=None):
     try:
         return service_manager.get(service_type, default)
     except Exception:  # noqa: BLE001
+        # Preserve the traceback in logs so callers seeing a None return have something to grep
+        # for. Returning None remains the contract because several callers (e.g. get_db_service)
+        # treat absence as "not configured" and substitute a noop implementation.
+        logger.exception("Failed to resolve service %s", service_type)
         return None
 
 

--- a/src/lfx/src/lfx/services/executor/__init__.py
+++ b/src/lfx/src/lfx/services/executor/__init__.py
@@ -1,0 +1,1 @@
+"""Executor service module."""

--- a/src/lfx/src/lfx/services/executor/factory.py
+++ b/src/lfx/src/lfx/services/executor/factory.py
@@ -1,0 +1,24 @@
+"""Factory for the executor service."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from lfx.services.executor.service import ExecutorService
+from lfx.services.factory import ServiceFactory
+from lfx.services.schema import ServiceType
+
+if TYPE_CHECKING:
+    from lfx.services.settings.service import SettingsService
+
+
+class ExecutorServiceFactory(ServiceFactory):
+    """Factory for creating ExecutorService instances."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.service_class = ExecutorService
+        self.dependencies = [ServiceType.SETTINGS_SERVICE]
+
+    def create(self, settings_service: SettingsService) -> ExecutorService:
+        return ExecutorService(settings_service=settings_service)

--- a/src/lfx/src/lfx/services/executor/service.py
+++ b/src/lfx/src/lfx/services/executor/service.py
@@ -1,0 +1,118 @@
+"""Executor service: owns the executor registry and the default coordinator."""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING
+
+from lfx.execution.backends.in_process import InProcessExecutor
+from lfx.execution.coordinator import Coordinator
+from lfx.execution.registry import ExecutorKindCollisionError, ExecutorRegistry
+from lfx.log.logger import logger
+from lfx.services.base import Service
+
+if TYPE_CHECKING:
+    from lfx.execution.executor import Executor
+    from lfx.services.settings.service import SettingsService
+
+
+ENTRY_POINT_GROUP = "lfx.executors"
+
+
+class ExecutorService(Service):
+    """Service that holds the executor registry and the default coordinator."""
+
+    name = "executor_service"
+
+    def __init__(self, settings_service: SettingsService) -> None:
+        super().__init__()
+        self._settings_service = settings_service
+        self._registry = ExecutorRegistry()
+        self._coordinator: Coordinator | None = None
+        self._populate_registry()
+
+    def register(self, executor: Executor) -> None:
+        """Register an executor; replaces any prior registration for the same kind.
+
+        Invalidates the cached coordinator so the next access rebuilds against the new
+        registry contents. Direct mutation of the registry through other paths bypasses
+        this invalidation -- always go through this method to register or replace.
+        """
+        self._registry.register(executor)
+        self._coordinator = None
+
+    def has(self, kind: str) -> bool:
+        """Return True if an executor with the given kind is registered."""
+        return self._registry.has(kind)
+
+    def get(self, kind: str) -> Executor:
+        """Return the executor registered under the given kind."""
+        return self._registry.get(kind)
+
+    @property
+    def registry(self) -> ExecutorRegistry:
+        """Return the underlying registry.
+
+        Read access only. Mutating the registry directly (e.g. ``service.registry.register(...)``)
+        bypasses the cached-coordinator invalidation done by :meth:`register`; always go through
+        :meth:`register` for mutations.
+        """
+        return self._registry
+
+    @property
+    def coordinator(self) -> Coordinator:
+        if self._coordinator is None:
+            kind = self._settings_service.settings.executor_kind
+            self._coordinator = Coordinator(registry=self._registry, executor_kind=kind)
+        return self._coordinator
+
+    def set_coordinator(self, coordinator: Coordinator) -> None:
+        """Override the default coordinator (test/extension hook)."""
+        self._coordinator = coordinator
+
+    def _populate_registry(self) -> None:
+        """Register the built-in executor and run plugin discovery."""
+        self._registry.register(InProcessExecutor())
+        self._discover_entry_points()
+
+    def _discover_entry_points(self) -> None:
+        try:
+            eps = entry_points(group=ENTRY_POINT_GROUP)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Failed to enumerate entry points for group=%r. Executor plugin discovery skipped.",
+                ENTRY_POINT_GROUP,
+            )
+            return
+        for ep in eps:
+            kind: str = "<unknown>"
+            try:
+                obj = ep.load()
+                executor = obj() if isinstance(obj, type) else obj
+                kind = getattr(executor, "kind", "<unknown>")
+                self._registry.register(executor, replace=False)
+                logger.debug("Loaded executor from entry point: %s -> %s", ep.name, kind)
+            except ExecutorKindCollisionError:
+                logger.warning(
+                    "Skipping entry point %r: an executor with kind=%r is already registered. "
+                    "Entry-point discovery cannot replace existing executors; register the "
+                    "executor explicitly via ExecutorService.register() if replacement is intended.",
+                    ep.name,
+                    kind,
+                )
+            except Exception:  # noqa: BLE001
+                # Broad catch is intentional: a single broken plugin must not break discovery
+                # of others. The full traceback is preserved via logger.exception.
+                logger.exception("Failed to load executor entry point %s", ep.name)
+
+    async def teardown(self) -> None:
+        """Reset the service to its post-init state.
+
+        ServiceManager.teardown() does not evict the cached service instance, so we must
+        leave the registry usable: the built-in InProcessExecutor is re-registered and
+        plugin discovery re-runs so a post-teardown access still returns a working
+        coordinator.
+        """
+        self._coordinator = None
+        self._registry = ExecutorRegistry()
+        self._populate_registry()

--- a/src/lfx/src/lfx/services/executor/service.py
+++ b/src/lfx/src/lfx/services/executor/service.py
@@ -7,12 +7,12 @@ from typing import TYPE_CHECKING
 
 from lfx.execution.backends.in_process import InProcessExecutor
 from lfx.execution.coordinator import Coordinator
+from lfx.execution.executor import Executor
 from lfx.execution.registry import ExecutorKindCollisionError, ExecutorRegistry
 from lfx.log.logger import logger
 from lfx.services.base import Service
 
 if TYPE_CHECKING:
-    from lfx.execution.executor import Executor
     from lfx.services.settings.service import SettingsService
 
 
@@ -89,6 +89,13 @@ class ExecutorService(Service):
             try:
                 obj = ep.load()
                 executor = obj() if isinstance(obj, type) else obj
+                if not isinstance(executor, Executor):
+                    logger.warning(
+                        "Skipping entry point %r: loaded object of type %r is not an Executor.",
+                        ep.name,
+                        type(executor).__name__,
+                    )
+                    continue
                 kind = getattr(executor, "kind", "<unknown>")
                 self._registry.register(executor, replace=False)
                 logger.debug("Loaded executor from entry point: %s -> %s", ep.name, kind)
@@ -108,10 +115,9 @@ class ExecutorService(Service):
     async def teardown(self) -> None:
         """Reset the service to its post-init state.
 
-        ServiceManager.teardown() does not evict the cached service instance, so we must
-        leave the registry usable: the built-in InProcessExecutor is re-registered and
-        plugin discovery re-runs so a post-teardown access still returns a working
-        coordinator.
+        Rebuilds the registry (built-in InProcessExecutor + plugin discovery) and clears
+        the cached coordinator, so the service stays usable if it is accessed again before
+        the service manager evicts it.
         """
         self._coordinator = None
         self._registry = ExecutorRegistry()

--- a/src/lfx/src/lfx/services/manager.py
+++ b/src/lfx/src/lfx/services/manager.py
@@ -306,6 +306,12 @@ class ServiceManager:
 
         self.services = {}
         self.factories = {}
+        # ``teardown`` empties the factory registry, so the "registered" flag has
+        # to drop too: get_service() re-registers factories only when
+        # are_factories_registered() is False. Leaving it set after a teardown
+        # makes the next lookup skip re-registration and raise
+        # NoFactoryRegisteredError.
+        self.factory_registered = False
 
     @classmethod
     def get_factories(cls) -> list[ServiceFactory]:

--- a/src/lfx/src/lfx/services/schema.py
+++ b/src/lfx/src/lfx/services/schema.py
@@ -27,3 +27,4 @@ class ServiceType(str, Enum):
     FLOW_EVENTS_SERVICE = "flow_events_service"
     TELEMETRY_WRITER_SERVICE = "telemetry_writer_service"
     EXTENSION_EVENTS_SERVICE = "extension_events_service"
+    EXECUTOR_SERVICE = "executor_service"

--- a/src/lfx/src/lfx/services/settings/groups/runtime.py
+++ b/src/lfx/src/lfx/services/settings/groups/runtime.py
@@ -85,6 +85,14 @@ class RuntimeSettings(BaseModel):
 
     celery_enabled: bool = False
 
+    executor_kind: str = "in-process"
+    """The default executor kind used by the execution coordinator.
+
+    Must match the `kind` of an Executor registered with the executor service. The built-in
+    `in-process` executor runs graphs in the current process; third-party executors registered
+    via the `lfx.executors` entry-point group can be selected by setting this to their kind.
+    """
+
     @field_validator("event_delivery", mode="before")
     @classmethod
     def set_event_delivery(cls, value, info):

--- a/src/lfx/tests/unit/components/flow_controls/test_loop_events.py
+++ b/src/lfx/tests/unit/components/flow_controls/test_loop_events.py
@@ -82,7 +82,7 @@ class TestEventManagerPropagation:
         received_event_manager = None
 
         # Create a mock subgraph that captures the event_manager
-        async def mock_async_start(event_manager=None):
+        async def mock_async_start(event_manager=None, **kwargs):  # noqa: ARG001
             nonlocal received_event_manager
             received_event_manager = event_manager
             yield MagicMock(valid=True, result_dict=MagicMock(outputs={}))
@@ -119,7 +119,7 @@ class TestEventManagerPropagation:
         mock_event_manager = MagicMock()
         event_manager_calls = []
 
-        async def mock_async_start(event_manager=None):
+        async def mock_async_start(event_manager=None, **kwargs):  # noqa: ARG001
             event_manager_calls.append(event_manager)
             yield MagicMock(valid=True, result_dict=MagicMock(outputs={}))
 

--- a/src/lfx/tests/unit/components/flow_controls/test_loop_events.py
+++ b/src/lfx/tests/unit/components/flow_controls/test_loop_events.py
@@ -77,79 +77,107 @@ class TestEventManagerPropagation:
 
     @pytest.mark.asyncio
     async def test_event_manager_passed_to_subgraph_async_start(self):
-        """Test that event_manager is passed to subgraph's async_start method."""
-        mock_event_manager = MagicMock()
-        received_event_manager = None
-
-        # Create a mock subgraph that captures the event_manager
-        async def mock_async_start(event_manager=None, **kwargs):  # noqa: ARG001
-            nonlocal received_event_manager
-            received_event_manager = event_manager
-            yield MagicMock(valid=True, result_dict=MagicMock(outputs={}))
-
-        def create_mock_subgraph(_vertex_ids):
-            mock_subgraph = MagicMock()
-            mock_subgraph._vertices = []
-            mock_subgraph.prepare = MagicMock()
-            mock_subgraph.async_start = mock_async_start
-            mock_subgraph.get_vertex = MagicMock(return_value=MagicMock(custom_component=MagicMock()))
-            return mock_subgraph
-
-        mock_graph = MagicMock()
-        mock_graph.create_subgraph = create_subgraph_context_manager_mock(create_mock_subgraph)
-
-        data_list = [Data(text="item1")]
-
-        await execute_loop_body(
-            graph=mock_graph,
-            data_list=data_list,
-            loop_body_vertex_ids={"vertex1"},
-            start_vertex_id="vertex1",
-            start_edge=MagicMock(target_handle=MagicMock(field_name="data")),
-            end_vertex_id="vertex1",
-            event_manager=mock_event_manager,
+        """The loop body's runner must forward event_manager into the executor's runtime_options."""
+        from lfx.execution import (
+            Coordinator,
+            ExecutorRegistry,
+            reset_default_coordinator,
+            set_default_coordinator,
         )
+        from lfx.execution.executor import Executor
+        from lfx.execution.types import RunComplete
 
-        # Verify event_manager was passed to async_start
-        assert received_event_manager is mock_event_manager
+        try:
+            mock_event_manager = MagicMock()
+            seen: list = []
+
+            class _Recorder(Executor):
+                kind = "in-process"
+
+                async def execute(self, unit):
+                    seen.append(unit.runtime_options.get("event_manager"))
+                    yield RunComplete(outputs=[])
+
+            registry = ExecutorRegistry()
+            registry.register(_Recorder())
+            set_default_coordinator(Coordinator(registry=registry))
+
+            def create_mock_subgraph(_vertex_ids):
+                mock_subgraph = MagicMock()
+                mock_subgraph._vertices = []
+                mock_subgraph.prepare = MagicMock()
+                mock_subgraph.get_vertex = MagicMock(return_value=MagicMock(custom_component=MagicMock()))
+                return mock_subgraph
+
+            mock_graph = MagicMock()
+            mock_graph.create_subgraph = create_subgraph_context_manager_mock(create_mock_subgraph)
+
+            await execute_loop_body(
+                graph=mock_graph,
+                data_list=[Data(text="item1")],
+                loop_body_vertex_ids={"vertex1"},
+                start_vertex_id="vertex1",
+                start_edge=MagicMock(target_handle=MagicMock(field_name="data")),
+                end_vertex_id="vertex1",
+                event_manager=mock_event_manager,
+            )
+
+            assert len(seen) == 1
+            assert seen[0] is mock_event_manager
+        finally:
+            reset_default_coordinator()
 
     @pytest.mark.asyncio
     async def test_event_manager_passed_for_each_iteration(self):
-        """Test that event_manager is passed to async_start for each loop iteration."""
-        mock_event_manager = MagicMock()
-        event_manager_calls = []
-
-        async def mock_async_start(event_manager=None, **kwargs):  # noqa: ARG001
-            event_manager_calls.append(event_manager)
-            yield MagicMock(valid=True, result_dict=MagicMock(outputs={}))
-
-        def create_mock_subgraph(_vertex_ids):
-            mock_subgraph = MagicMock()
-            mock_subgraph._vertices = []
-            mock_subgraph.prepare = MagicMock()
-            mock_subgraph.async_start = mock_async_start
-            mock_subgraph.get_vertex = MagicMock(return_value=MagicMock(custom_component=MagicMock()))
-            return mock_subgraph
-
-        mock_graph = MagicMock()
-        mock_graph.create_subgraph = create_subgraph_context_manager_mock(create_mock_subgraph)
-
-        # 3 items = 3 iterations
-        data_list = [Data(text="item1"), Data(text="item2"), Data(text="item3")]
-
-        await execute_loop_body(
-            graph=mock_graph,
-            data_list=data_list,
-            loop_body_vertex_ids={"vertex1"},
-            start_vertex_id="vertex1",
-            start_edge=MagicMock(target_handle=MagicMock(field_name="data")),
-            end_vertex_id="vertex1",
-            event_manager=mock_event_manager,
+        """Every loop iteration runs through the executor with the same event_manager."""
+        from lfx.execution import (
+            Coordinator,
+            ExecutorRegistry,
+            reset_default_coordinator,
+            set_default_coordinator,
         )
+        from lfx.execution.executor import Executor
+        from lfx.execution.types import RunComplete
 
-        # Verify event_manager was passed for each iteration
-        assert len(event_manager_calls) == 3
-        assert all(em is mock_event_manager for em in event_manager_calls)
+        try:
+            mock_event_manager = MagicMock()
+            seen: list = []
+
+            class _Recorder(Executor):
+                kind = "in-process"
+
+                async def execute(self, unit):
+                    seen.append(unit.runtime_options.get("event_manager"))
+                    yield RunComplete(outputs=[])
+
+            registry = ExecutorRegistry()
+            registry.register(_Recorder())
+            set_default_coordinator(Coordinator(registry=registry))
+
+            def create_mock_subgraph(_vertex_ids):
+                mock_subgraph = MagicMock()
+                mock_subgraph._vertices = []
+                mock_subgraph.prepare = MagicMock()
+                mock_subgraph.get_vertex = MagicMock(return_value=MagicMock(custom_component=MagicMock()))
+                return mock_subgraph
+
+            mock_graph = MagicMock()
+            mock_graph.create_subgraph = create_subgraph_context_manager_mock(create_mock_subgraph)
+
+            await execute_loop_body(
+                graph=mock_graph,
+                data_list=[Data(text="item1"), Data(text="item2"), Data(text="item3")],
+                loop_body_vertex_ids={"vertex1"},
+                start_vertex_id="vertex1",
+                start_edge=MagicMock(target_handle=MagicMock(field_name="data")),
+                end_vertex_id="vertex1",
+                event_manager=mock_event_manager,
+            )
+
+            assert len(seen) == 3
+            assert all(em is mock_event_manager for em in seen)
+        finally:
+            reset_default_coordinator()
 
     def test_subgraph_preserves_vertex_ids(self):
         """Test that subgraph vertices maintain original IDs.

--- a/src/lfx/tests/unit/execution/conftest.py
+++ b/src/lfx/tests/unit/execution/conftest.py
@@ -1,22 +1,24 @@
-"""Reset the module-level singletons between every test in this folder.
-
-The default coordinator and registry are import-time singletons so that
-production callers can use them without DI. Tests that mutate them
-(register a new backend, swap the default, etc.) must not bleed state
-into the next test.
-"""
+"""Shared fixtures for execution tests."""
 
 from __future__ import annotations
 
 import pytest
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.execution import reset_default_coordinator
+from lfx.graph import Graph
 
 
 @pytest.fixture(autouse=True)
 def _reset_execution_singletons():
-    from lfx import execution
-
-    execution._default_registry = None
-    execution._default_coordinator = None
+    reset_default_coordinator()
     yield
-    execution._default_registry = None
-    execution._default_coordinator = None
+    reset_default_coordinator()
+
+
+@pytest.fixture
+def simple_graph():
+    chat_input = ChatInput(_id="chat_input")
+    chat_input.set(should_store_message=False)
+    chat_output = ChatOutput(input_value="test", _id="chat_output")
+    chat_output.set(sender_name=chat_input.message_response)
+    return Graph(chat_input, chat_output)

--- a/src/lfx/tests/unit/execution/conftest.py
+++ b/src/lfx/tests/unit/execution/conftest.py
@@ -1,0 +1,22 @@
+"""Reset the module-level singletons between every test in this folder.
+
+The default coordinator and registry are import-time singletons so that
+production callers can use them without DI. Tests that mutate them
+(register a new backend, swap the default, etc.) must not bleed state
+into the next test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_execution_singletons():
+    from lfx import execution
+
+    execution._default_registry = None
+    execution._default_coordinator = None
+    yield
+    execution._default_registry = None
+    execution._default_coordinator = None

--- a/src/lfx/tests/unit/execution/test_cancellation.py
+++ b/src/lfx/tests/unit/execution/test_cancellation.py
@@ -1,0 +1,187 @@
+"""Cancellation and cleanup tests for the execution seam.
+
+The contract suite covers the bare-minimum ``aclose()`` shape via
+``test_consumer_cancellation_does_not_hang_or_leak``. This module exercises the
+stricter behaviour the seam needs in production: explicit cleanup at the top of
+the consumer chain MUST cascade all the way down to the underlying graph iterator.
+
+What we deliberately do NOT test here:
+
+- Implicit GC-based finalization (``async for ... break`` without ``aclosing``,
+  ``task.cancel()`` then immediate assert). CPython finalizes abandoned async
+  generators on a GC pass; asyncio runs the registered finalizer on event-loop
+  shutdown. Neither is observable inside a single test, and asserting either
+  would test CPython, not us. Consumers that need deterministic cleanup MUST
+  use ``contextlib.aclosing`` or call ``aclose()`` explicitly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import aclosing
+
+import pytest
+from lfx.execution.backends.in_process import InProcessExecutor
+from lfx.execution.coordinator import Coordinator
+from lfx.execution.registry import ExecutorRegistry
+from lfx.execution.types import StepResult, Unit
+
+
+class _InstrumentedGraph:
+    """Minimal graph stub whose ``async_start`` runs forever until closed.
+
+    We track entry, items yielded, and finalizer invocation so tests can assert
+    the iterator was properly closed rather than abandoned.
+    """
+
+    def __init__(self) -> None:
+        self.entered: bool = False
+        self.finalized: bool = False
+        self.items_yielded: int = 0
+
+    async def async_start(self, **_kwargs):
+        self.entered = True
+        try:
+            for i in range(10_000):
+                self.items_yielded += 1
+                yield f"item-{i}"
+                await asyncio.sleep(0)
+        finally:
+            self.finalized = True
+
+
+def _unit(graph: _InstrumentedGraph) -> Unit:
+    return Unit(graph=graph, inputs=[], runtime_options={})
+
+
+@pytest.mark.asyncio
+async def test_aclose_on_executor_finalizes_underlying_graph_iteration():
+    """``aclose()`` on the executor's generator MUST run the underlying graph's finalizer.
+
+    Without the explicit try/finally inside ``InProcessExecutor.execute``, the inner
+    generator is abandoned and the graph's ``finally:`` block (event managers,
+    connections, vertex teardown) only runs on a future GC pass.
+    """
+    graph = _InstrumentedGraph()
+    executor = InProcessExecutor()
+    stream = executor.execute(_unit(graph))
+
+    first = await anext(stream)
+    assert isinstance(first, StepResult)
+    assert graph.entered
+    assert not graph.finalized
+
+    await stream.aclose()
+    assert graph.finalized, "underlying async generator was not finalized on aclose()"
+
+
+@pytest.mark.asyncio
+async def test_aclosing_helper_chains_cleanup_through_executor():
+    """``contextlib.aclosing`` MUST trigger the same cascade as explicit ``aclose``."""
+    graph = _InstrumentedGraph()
+    executor = InProcessExecutor()
+
+    async with aclosing(executor.execute(_unit(graph))) as stream:
+        async for _ in stream:
+            break
+
+    assert graph.finalized
+
+
+@pytest.mark.asyncio
+async def test_coordinator_run_cascades_aclose_to_executor_and_graph():
+    """Cleanup must propagate through every seam layer.
+
+    Consumer aclose -> Coordinator.run -> Executor.execute -> graph.async_start.
+    A regression at any layer would leave the graph generator hanging.
+    """
+    graph = _InstrumentedGraph()
+    registry = ExecutorRegistry()
+    registry.register(InProcessExecutor())
+    coordinator = Coordinator(registry=registry)
+
+    async with aclosing(coordinator.run(graph, inputs=[])) as stream:
+        first = await anext(stream)
+        assert first is not None
+
+    assert graph.finalized, "Coordinator.run did not cascade aclose to the graph"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_stream_cascades_aclose_to_graph():
+    """``Coordinator.stream`` must cascade cleanup the same way ``Coordinator.run`` does."""
+    graph = _InstrumentedGraph()
+    registry = ExecutorRegistry()
+    registry.register(InProcessExecutor())
+    coordinator = Coordinator(registry=registry)
+
+    async with aclosing(coordinator.stream(graph)) as stream:
+        async for _ in stream:
+            break
+
+    assert graph.finalized
+
+
+@pytest.mark.asyncio
+async def test_cleanup_bounded_by_timeout():
+    """Finalization must complete within a bounded window even on a slow CI box.
+
+    A regression that swaps in a non-cancellable resource (blocking subprocess
+    wait, sync lock) would hang here rather than slow.
+    """
+    graph = _InstrumentedGraph()
+    executor = InProcessExecutor()
+
+    async def drive():
+        gen = executor.execute(_unit(graph))
+        await anext(gen)
+        await gen.aclose()
+
+    await asyncio.wait_for(drive(), timeout=2.0)
+    assert graph.finalized
+
+
+@pytest.mark.asyncio
+async def test_exception_in_consumer_still_finalizes_graph():
+    """An exception inside the consumer MUST still trigger cleanup via ``aclosing``."""
+    graph = _InstrumentedGraph()
+    executor = InProcessExecutor()
+
+    class _ConsumerError(RuntimeError):
+        pass
+
+    async def consume_then_raise() -> None:
+        async with aclosing(executor.execute(_unit(graph))) as stream:
+            async for _ in stream:
+                msg = "downstream bug"
+                raise _ConsumerError(msg)
+
+    with pytest.raises(_ConsumerError):
+        await consume_then_raise()
+
+    assert graph.finalized
+
+
+@pytest.mark.asyncio
+async def test_concurrent_consumers_each_clean_up_independently():
+    """Concurrent runs on one executor instance must clean up independently.
+
+    Regression guard for any future change that introduces shared cleanup state
+    on the executor (which would couple unrelated consumers).
+    """
+    graph_a = _InstrumentedGraph()
+    graph_b = _InstrumentedGraph()
+    executor = InProcessExecutor()
+
+    async def drive(graph: _InstrumentedGraph, items_before_stop: int) -> None:
+        async with aclosing(executor.execute(_unit(graph))) as stream:
+            count = 0
+            async for _ in stream:
+                count += 1
+                if count >= items_before_stop:
+                    break
+
+    await asyncio.gather(drive(graph_a, 1), drive(graph_b, 3))
+
+    assert graph_a.finalized
+    assert graph_b.finalized

--- a/src/lfx/tests/unit/execution/test_coordinator.py
+++ b/src/lfx/tests/unit/execution/test_coordinator.py
@@ -1,0 +1,62 @@
+import pytest
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.execution.coordinator import Coordinator
+from lfx.execution.registry import ExecutorRegistry
+from lfx.execution.types import RunComplete, StepResult
+from lfx.graph import Graph
+
+
+def _simple_graph():
+    chat_input = ChatInput(_id="chat_input")
+    chat_input.set(should_store_message=False)
+    chat_output = ChatOutput(input_value="test", _id="chat_output")
+    chat_output.set(sender_name=chat_input.message_response)
+    return Graph(chat_input, chat_output)
+
+
+def _make_coordinator():
+    from lfx.execution.backends.in_process import InProcessExecutor
+
+    registry = ExecutorRegistry()
+    registry.register(InProcessExecutor())
+    return Coordinator(registry=registry)
+
+
+@pytest.mark.asyncio
+async def test_run_yields_streaming_step_results_ending_in_run_complete():
+    coordinator = _make_coordinator()
+    items = [item async for item in coordinator.run(_simple_graph(), inputs=[{"input_value": "hi"}])]
+    assert isinstance(items[-1], RunComplete)
+    assert all(isinstance(i, StepResult) for i in items[:-1])
+
+
+@pytest.mark.asyncio
+async def test_run_to_completion_drains_and_returns_outputs():
+    coordinator = _make_coordinator()
+    outputs = await coordinator.run_to_completion(_simple_graph(), inputs=[{"input_value": "hi"}])
+    assert isinstance(outputs, list)
+
+
+@pytest.mark.asyncio
+async def test_run_to_completion_propagates_executor_errors():
+    coordinator = _make_coordinator()
+    graph = _simple_graph()
+
+    async def boom(*args, **kwargs):  # noqa: ARG001
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    graph._arun_legacy = boom
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await coordinator.run_to_completion(graph, inputs=[{"input_value": "hi"}])
+
+
+@pytest.mark.asyncio
+async def test_run_with_no_executor_registered_raises():
+    from lfx.execution.registry import ExecutorNotFoundError
+
+    coordinator = Coordinator(registry=ExecutorRegistry())
+    with pytest.raises(ExecutorNotFoundError):
+        async for _ in coordinator.run(_simple_graph(), inputs=[]):
+            pass

--- a/src/lfx/tests/unit/execution/test_coordinator.py
+++ b/src/lfx/tests/unit/execution/test_coordinator.py
@@ -49,7 +49,7 @@ async def test_run_to_completion_propagates_executor_errors():
     graph._arun_legacy = boom
 
     with pytest.raises(RuntimeError, match="boom"):
-        await coordinator.run_to_completion(graph, inputs=[{"input_value": "hi"}])
+        await coordinator.run_to_completion(graph, inputs=[{"input_value": "hi"}], _use_arun_legacy=True)
 
 
 @pytest.mark.asyncio

--- a/src/lfx/tests/unit/execution/test_coordinator.py
+++ b/src/lfx/tests/unit/execution/test_coordinator.py
@@ -1,17 +1,7 @@
 import pytest
-from lfx.components.input_output import ChatInput, ChatOutput
 from lfx.execution.coordinator import Coordinator
 from lfx.execution.registry import ExecutorRegistry
 from lfx.execution.types import RunComplete, StepResult
-from lfx.graph import Graph
-
-
-def _simple_graph():
-    chat_input = ChatInput(_id="chat_input")
-    chat_input.set(should_store_message=False)
-    chat_output = ChatOutput(input_value="test", _id="chat_output")
-    chat_output.set(sender_name=chat_input.message_response)
-    return Graph(chat_input, chat_output)
 
 
 def _make_coordinator():
@@ -23,40 +13,47 @@ def _make_coordinator():
 
 
 @pytest.mark.asyncio
-async def test_run_yields_streaming_step_results_ending_in_run_complete():
+async def test_run_yields_streaming_step_results_ending_in_run_complete(simple_graph):
     coordinator = _make_coordinator()
-    items = [item async for item in coordinator.run(_simple_graph(), inputs=[{"input_value": "hi"}])]
+    items = [item async for item in coordinator.run(simple_graph, inputs=[{"input_value": "hi"}])]
     assert isinstance(items[-1], RunComplete)
     assert all(isinstance(i, StepResult) for i in items[:-1])
 
 
 @pytest.mark.asyncio
-async def test_run_to_completion_drains_and_returns_outputs():
+async def test_run_to_completion_drains_and_returns_outputs(simple_graph):
     coordinator = _make_coordinator()
-    outputs = await coordinator.run_to_completion(_simple_graph(), inputs=[{"input_value": "hi"}])
+    outputs = await coordinator.run_to_completion(simple_graph, inputs=[{"input_value": "hi"}])
     assert isinstance(outputs, list)
 
 
 @pytest.mark.asyncio
-async def test_run_to_completion_propagates_executor_errors():
+async def test_run_to_completion_propagates_executor_errors(simple_graph):
     coordinator = _make_coordinator()
-    graph = _simple_graph()
 
     async def boom(*args, **kwargs):  # noqa: ARG001
         msg = "boom"
         raise RuntimeError(msg)
 
-    graph._arun_legacy = boom
+    simple_graph._arun_legacy = boom
 
     with pytest.raises(RuntimeError, match="boom"):
-        await coordinator.run_to_completion(graph, inputs=[{"input_value": "hi"}], _use_arun_legacy=True)
+        await coordinator.run_to_completion(simple_graph, inputs=[{"input_value": "hi"}], _use_arun_legacy=True)
 
 
 @pytest.mark.asyncio
-async def test_run_with_no_executor_registered_raises():
+async def test_run_with_no_executor_registered_raises(simple_graph):
     from lfx.execution.registry import ExecutorNotFoundError
 
     coordinator = Coordinator(registry=ExecutorRegistry())
     with pytest.raises(ExecutorNotFoundError):
-        async for _ in coordinator.run(_simple_graph(), inputs=[]):
+        async for _ in coordinator.run(simple_graph, inputs=[]):
             pass
+
+
+@pytest.mark.asyncio
+async def test_stream_helper_yields_payloads_directly(simple_graph):
+    coordinator = _make_coordinator()
+    payloads = [p async for p in coordinator.stream(simple_graph, initial_inputs=None)]
+    assert payloads
+    assert any(hasattr(p, "vertex") for p in payloads)

--- a/src/lfx/tests/unit/execution/test_coordinator_e2e.py
+++ b/src/lfx/tests/unit/execution/test_coordinator_e2e.py
@@ -1,0 +1,156 @@
+"""End-to-end seam tests: a real Graph driven through Coordinator.
+
+Tests in ``test_coordinator.py`` check Coordinator behaviour at a behavioural level
+but defer most of the heavy lifting to the executor or graph layer. This module
+verifies the seam contract by running a real ``lfx.Graph`` through the full
+``Coordinator -> ExecutorRegistry -> InProcessExecutor -> graph.async_start``
+chain and asserting the event stream looks like what consumers actually receive:
+
+- ``stream()`` payloads are vertex-shaped (not the seam envelopes).
+- ``run()`` yields ``StepResult`` items in order then exactly one ``RunComplete``.
+- ``stream()`` never leaks ``RunComplete`` through the payload channel.
+- Switching the registered executor changes what runs (the dispatch is real, not
+  hard-wired to ``InProcessExecutor``).
+- Lifecycle: registry get() returns the same instance for repeated calls.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from lfx.execution.backends.in_process import InProcessExecutor
+from lfx.execution.coordinator import Coordinator
+from lfx.execution.executor import Executor
+from lfx.execution.registry import ExecutorRegistry
+from lfx.execution.types import RunComplete, StepResult, Unit
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+def _make_coordinator() -> Coordinator:
+    registry = ExecutorRegistry()
+    registry.register(InProcessExecutor())
+    return Coordinator(registry=registry)
+
+
+@pytest.mark.asyncio
+async def test_run_yields_step_results_then_terminal_run_complete(simple_graph):
+    coordinator = _make_coordinator()
+    items = [item async for item in coordinator.run(simple_graph, inputs=[{"input_value": "hi"}])]
+
+    assert items, "real Graph drove zero events through Coordinator"
+    assert isinstance(items[-1], RunComplete), "stream must end with RunComplete"
+    assert sum(isinstance(i, RunComplete) for i in items) == 1, "exactly one RunComplete expected"
+    assert all(isinstance(i, StepResult) for i in items[:-1]), "pre-terminal items must all be StepResult"
+
+
+@pytest.mark.asyncio
+async def test_stream_yields_payloads_only_no_run_complete_leak(simple_graph):
+    """``Coordinator.stream`` MUST NOT yield ``RunComplete`` instances.
+
+    It is the payload-only helper; the terminal envelope from the executor must
+    be stripped before reaching the consumer.
+    """
+    coordinator = _make_coordinator()
+    payloads = [p async for p in coordinator.stream(simple_graph, initial_inputs=None)]
+
+    assert payloads, "stream produced no payloads from a real graph"
+    assert not any(isinstance(p, RunComplete) for p in payloads), (
+        "Coordinator.stream() leaked RunComplete into the payload channel"
+    )
+    assert not any(isinstance(p, StepResult) for p in payloads), (
+        "Coordinator.stream() leaked StepResult envelopes; payloads should be unwrapped"
+    )
+
+
+@pytest.mark.asyncio
+async def test_payload_shape_is_vertex_or_finish_for_in_process(simple_graph):
+    """Pin the in-process payload contract.
+
+    Changes to graph.async_start can't silently rename or restructure the
+    events consumers depend on without breaking this test.
+    """
+    from lfx.graph.graph.constants import Finish
+
+    coordinator = _make_coordinator()
+    payloads = [p async for p in coordinator.stream(simple_graph, initial_inputs=None)]
+
+    vertex_ids = [getattr(p, "vertex", None) and p.vertex.id for p in payloads]
+    assert "chat_input" in vertex_ids
+    assert "chat_output" in vertex_ids
+    assert any(isinstance(p, Finish) for p in payloads), "expected a terminal Finish payload"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_to_configured_kind(simple_graph):
+    """Changing ``executor_kind`` changes where execution lands.
+
+    Proves the registry lookup is the real dispatch, not a hard-coded reference.
+    """
+
+    class _Marker(Executor):
+        kind = "marker"
+        ran: bool = False
+
+        async def execute(self, unit: Unit) -> AsyncIterator[StepResult | RunComplete]:  # noqa: ARG002
+            type(self).ran = True
+            yield StepResult(payload="sentinel")
+            yield RunComplete(outputs=["sentinel"])
+
+    registry = ExecutorRegistry()
+    registry.register(InProcessExecutor())
+    registry.register(_Marker())
+    coordinator = Coordinator(registry=registry, executor_kind="marker")
+
+    items = [item async for item in coordinator.run(simple_graph, inputs=[])]
+    assert _Marker.ran is True
+    assert items[0].payload == "sentinel"
+    assert isinstance(items[-1], RunComplete)
+    assert items[-1].outputs == ["sentinel"]
+
+
+@pytest.mark.asyncio
+async def test_run_to_completion_returns_outputs_from_legacy_path(simple_graph):
+    """``run_to_completion`` with the legacy flag returns populated outputs.
+
+    This is the only path through the seam where ``RunComplete.outputs`` carries
+    a meaningful value (see ``RunComplete`` docstring).
+    """
+    coordinator = _make_coordinator()
+    outputs = await coordinator.run_to_completion(
+        simple_graph,
+        inputs=[{"input_value": "hi"}],
+        _use_arun_legacy=True,
+    )
+    assert isinstance(outputs, list)
+
+
+@pytest.mark.asyncio
+async def test_registry_returns_same_executor_instance_across_runs(simple_graph):
+    """The seam shares one executor instance per kind across all runs.
+
+    Two sequential ``coordinator.run`` calls MUST resolve to the same instance;
+    otherwise executor authors couldn't rely on instance-level setup.
+    """
+    instances: list[Executor] = []
+    real_inprocess = InProcessExecutor()
+
+    class _Recorder(Executor):
+        kind = "recorder"
+
+        async def execute(self, unit: Unit) -> AsyncIterator[StepResult | RunComplete]:
+            instances.append(self)
+            async for item in real_inprocess.execute(unit):
+                yield item
+
+    registry = ExecutorRegistry()
+    registry.register(_Recorder())
+    coordinator = Coordinator(registry=registry, executor_kind="recorder")
+
+    [_ async for _ in coordinator.run(simple_graph, inputs=[{"input_value": "a"}])]
+    [_ async for _ in coordinator.run(simple_graph, inputs=[{"input_value": "b"}])]
+
+    assert len(instances) == 2
+    assert instances[0] is instances[1], "registry must return the same instance per kind"

--- a/src/lfx/tests/unit/execution/test_coordinator_e2e.py
+++ b/src/lfx/tests/unit/execution/test_coordinator_e2e.py
@@ -35,6 +35,22 @@ def _make_coordinator() -> Coordinator:
     return Coordinator(registry=registry)
 
 
+def _build_simple_graph():
+    """Build a fresh single-use graph (mirror of the ``simple_graph`` fixture).
+
+    Tests that drive more than one run need a new graph each time, since a Graph
+    can't be re-driven after it finishes.
+    """
+    from lfx.components.input_output import ChatInput, ChatOutput
+    from lfx.graph import Graph
+
+    chat_input = ChatInput(_id="chat_input")
+    chat_input.set(should_store_message=False)
+    chat_output = ChatOutput(input_value="test", _id="chat_output")
+    chat_output.set(sender_name=chat_input.message_response)
+    return Graph(chat_input, chat_output)
+
+
 @pytest.mark.asyncio
 async def test_run_yields_step_results_then_terminal_run_complete(simple_graph):
     coordinator = _make_coordinator()
@@ -128,7 +144,7 @@ async def test_run_to_completion_returns_outputs_from_legacy_path(simple_graph):
 
 
 @pytest.mark.asyncio
-async def test_registry_returns_same_executor_instance_across_runs(simple_graph):
+async def test_registry_returns_same_executor_instance_across_runs():
     """The seam shares one executor instance per kind across all runs.
 
     Two sequential ``coordinator.run`` calls MUST resolve to the same instance;
@@ -149,8 +165,10 @@ async def test_registry_returns_same_executor_instance_across_runs(simple_graph)
     registry.register(_Recorder())
     coordinator = Coordinator(registry=registry, executor_kind="recorder")
 
-    [_ async for _ in coordinator.run(simple_graph, inputs=[{"input_value": "a"}])]
-    [_ async for _ in coordinator.run(simple_graph, inputs=[{"input_value": "b"}])]
+    # Build a fresh graph per run; a Graph is single-use once driven to completion,
+    # so reusing one across both runs would couple the second run to the first's state.
+    [_ async for _ in coordinator.run(_build_simple_graph(), inputs=[{"input_value": "a"}])]
+    [_ async for _ in coordinator.run(_build_simple_graph(), inputs=[{"input_value": "b"}])]
 
     assert len(instances) == 2
     assert instances[0] is instances[1], "registry must return the same instance per kind"

--- a/src/lfx/tests/unit/execution/test_default_registry.py
+++ b/src/lfx/tests/unit/execution/test_default_registry.py
@@ -1,0 +1,27 @@
+from lfx.execution import (
+    Coordinator,
+    get_default_coordinator,
+    get_default_registry,
+    set_default_coordinator,
+)
+
+
+def test_default_registry_has_in_process():
+    assert get_default_registry().get("in-process").kind == "in-process"
+
+
+def test_default_coordinator_uses_default_registry():
+    c = get_default_coordinator()
+    assert isinstance(c, Coordinator)
+
+
+def test_set_default_coordinator_overrides_singleton():
+    custom = Coordinator(registry=get_default_registry())
+    set_default_coordinator(custom)
+    assert get_default_coordinator() is custom
+
+
+def test_default_coordinator_is_idempotent_within_a_test():
+    a = get_default_coordinator()
+    b = get_default_coordinator()
+    assert a is b

--- a/src/lfx/tests/unit/execution/test_default_registry.py
+++ b/src/lfx/tests/unit/execution/test_default_registry.py
@@ -16,9 +16,14 @@ def test_default_coordinator_uses_default_registry():
 
 
 def test_set_default_coordinator_overrides_singleton():
+    original = get_default_coordinator()
     custom = Coordinator(registry=get_default_registry())
     set_default_coordinator(custom)
-    assert get_default_coordinator() is custom
+    try:
+        assert get_default_coordinator() is custom
+    finally:
+        # Restore the singleton so this override doesn't bleed into later tests.
+        set_default_coordinator(original)
 
 
 def test_default_coordinator_is_idempotent_within_a_test():

--- a/src/lfx/tests/unit/execution/test_executor.py
+++ b/src/lfx/tests/unit/execution/test_executor.py
@@ -1,0 +1,37 @@
+import pytest
+from lfx.execution.executor import Executor
+from lfx.execution.types import RunComplete, StepResult, Unit
+
+
+def test_executor_is_abstract():
+    with pytest.raises(TypeError, match="abstract"):
+        Executor()
+
+
+@pytest.mark.asyncio
+async def test_concrete_executor_yields_steps_then_run_complete():
+    class Toy(Executor):
+        kind = "toy"
+
+        async def execute(self, unit):  # noqa: ARG002
+            yield StepResult(payload={"vertex_id": "a"})
+            yield StepResult(payload={"vertex_id": "b"})
+            yield RunComplete(outputs=["done"])
+
+    items = [item async for item in Toy().execute(Unit(graph=object(), inputs=[]))]
+    assert len(items) == 3
+    assert isinstance(items[-1], RunComplete)
+    assert items[-1].outputs == ["done"]
+
+
+@pytest.mark.asyncio
+async def test_executor_must_yield_run_complete_last():
+    class Toy(Executor):
+        kind = "toy"
+
+        async def execute(self, unit):  # noqa: ARG002
+            yield StepResult(payload={})
+            yield RunComplete(outputs=[])
+
+    items = [item async for item in Toy().execute(Unit(graph=object(), inputs=[]))]
+    assert isinstance(items[-1], RunComplete)

--- a/src/lfx/tests/unit/execution/test_executor_contract.py
+++ b/src/lfx/tests/unit/execution/test_executor_contract.py
@@ -1,0 +1,228 @@
+"""Reusable contract test suite for any ``lfx.execution.Executor`` implementation.
+
+The seam has a small but load-bearing set of behaviors that any executor MUST satisfy
+to be safely swappable behind ``Coordinator``. This module spells them out as a
+parametrizable suite so:
+
+- The built-in ``InProcessExecutor`` is checked here against the same suite the
+  external executors (stepflow, future remote/sandbox, etc.) will be checked against.
+- Authors of new executors can subclass ``ExecutorContract`` in their own project,
+  override the two fixtures, and inherit the full battery of behavioural assertions
+  rather than re-deriving them from the docstring of the ABC.
+
+The contract intentionally does NOT pin executor-specific event shapes -- only the
+universal seam guarantees. If a future executor needs to add stricter checks for its
+own payloads, those go in an executor-specific test file, not here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import AsyncIterator, Callable
+from typing import TYPE_CHECKING
+
+import pytest
+from lfx.execution.types import RunComplete, StepResult, Unit
+
+if TYPE_CHECKING:
+    from lfx.execution.executor import Executor
+
+
+class ExecutorContract:
+    """Base class of behavioural assertions every Executor must satisfy.
+
+    Subclasses MUST override two fixtures:
+
+    - ``contract_executor``: returns a freshly constructed ``Executor`` instance.
+    - ``contract_unit_factory``: returns a callable ``() -> Unit`` that produces a
+      fresh, runnable ``Unit`` each call. The unit should drive a minimal but real
+      execution -- not a stub -- so the test actually exercises the executor's
+      end-to-end path.
+
+    Tests are designed to be independent: each test creates its own unit through
+    the factory so subclasses don't have to worry about state bleed between cases.
+    """
+
+    @pytest.fixture
+    def contract_executor(self) -> Executor:
+        msg = "Subclasses must override the contract_executor fixture"
+        raise NotImplementedError(msg)
+
+    @pytest.fixture
+    def contract_unit_factory(self) -> Callable[[], Unit]:
+        msg = "Subclasses must override the contract_unit_factory fixture"
+        raise NotImplementedError(msg)
+
+    # --- Universal seam guarantees ----------------------------------------------------
+
+    def test_kind_is_a_non_empty_string(self, contract_executor: Executor) -> None:
+        """``kind`` is a ClassVar on the ABC; it must be set and non-empty."""
+        assert isinstance(contract_executor.kind, str)
+        assert contract_executor.kind, "Executor.kind must be a non-empty string"
+
+    def test_execute_returns_async_iterator(
+        self,
+        contract_executor: Executor,
+        contract_unit_factory: Callable[[], Unit],
+    ) -> None:
+        """``execute(unit)`` MUST return an async iterator.
+
+        The ABC types it as such; consumers (Coordinator.run, Coordinator.stream,
+        run_to_completion) rely on it.
+        """
+        stream = contract_executor.execute(contract_unit_factory())
+        assert isinstance(stream, AsyncIterator), (
+            f"{type(contract_executor).__name__}.execute() returned a "
+            f"{type(stream).__name__}, expected AsyncIterator. Consumers can't iterate "
+            "this. Common cause: forgetting to make the method an `async def` "
+            "generator."
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_ends_with_exactly_one_run_complete(
+        self,
+        contract_executor: Executor,
+        contract_unit_factory: Callable[[], Unit],
+    ) -> None:
+        """Streams emit zero-or-more ``StepResult`` items terminated by one ``RunComplete``."""
+        items = [item async for item in contract_executor.execute(contract_unit_factory())]
+
+        assert items, "executor yielded nothing -- a RunComplete is mandatory"
+        assert isinstance(items[-1], RunComplete), (
+            f"final item was {type(items[-1]).__name__}; the seam requires a terminal "
+            "RunComplete so run_to_completion() and downstream collectors can detect end-of-run."
+        )
+
+        run_completes = [i for i in items if isinstance(i, RunComplete)]
+        assert len(run_completes) == 1, (
+            f"executor yielded {len(run_completes)} RunComplete items; the seam allows "
+            "at most one (and requires exactly one)."
+        )
+
+        non_terminal = items[:-1]
+        bad = [i for i in non_terminal if not isinstance(i, StepResult)]
+        assert not bad, (
+            f"all pre-terminal items must be StepResult; got: {[type(i).__name__ for i in bad]}. "
+            "Coordinator.stream() relies on this to filter; mixing other types makes "
+            "the stream untyped at the seam boundary."
+        )
+
+    @pytest.mark.asyncio
+    async def test_executor_is_reusable_across_runs(
+        self,
+        contract_executor: Executor,
+        contract_unit_factory: Callable[[], Unit],
+    ) -> None:
+        """An Executor MUST be reusable: state that carries between runs is a bug.
+
+        The registry returns the same instance for every ``coordinator.run()`` call,
+        so any internal state pinned to ``self`` will silently corrupt later runs.
+        """
+        first = [item async for item in contract_executor.execute(contract_unit_factory())]
+        second = [item async for item in contract_executor.execute(contract_unit_factory())]
+
+        assert isinstance(first[-1], RunComplete)
+        assert isinstance(second[-1], RunComplete)
+        # Same shape across runs proves no carry-over short-circuit. We don't assert
+        # equality of payloads because some executors include timestamps / run IDs.
+        assert len(first) >= 1
+        assert len(second) >= 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_runs_on_one_instance_are_isolated(
+        self,
+        contract_executor: Executor,
+        contract_unit_factory: Callable[[], Unit],
+    ) -> None:
+        """Concurrent runs on one executor instance MUST be isolated.
+
+        Coordinator may launch concurrent runs (Loop subgraphs, parallel API
+        requests). An executor that crosses state between them is broken.
+        """
+
+        async def drain() -> list[object]:
+            return [item async for item in contract_executor.execute(contract_unit_factory())]
+
+        a, b = await asyncio.gather(drain(), drain())
+        assert isinstance(a[-1], RunComplete)
+        assert isinstance(b[-1], RunComplete)
+
+    @pytest.mark.asyncio
+    async def test_consumer_cancellation_does_not_hang_or_leak(
+        self,
+        contract_executor: Executor,
+        contract_unit_factory: Callable[[], Unit],
+    ) -> None:
+        """Consumer cancellation via ``aclose()`` MUST finalize within a bounded window.
+
+        The executor's async generator is closed by the consumer; any internal
+        context managers, subprocesses, or sockets MUST be released. A strict
+        timeout surfaces regressions as test failures rather than CI hangs.
+        """
+        gen = contract_executor.execute(contract_unit_factory())
+
+        try:
+            first = await asyncio.wait_for(anext(gen), timeout=10.0)
+        except StopAsyncIteration:
+            # Executor produced no items at all -- still a valid stream (just an empty one).
+            return
+
+        assert isinstance(first, (StepResult, RunComplete)), (
+            f"first yielded item was {type(first).__name__}; seam requires StepResult or RunComplete"
+        )
+
+        # Drop the iterator. If the executor holds a subprocess / network / lock, this
+        # is the moment of truth: aclose() must finalize without blocking forever.
+        await asyncio.wait_for(gen.aclose(), timeout=10.0)
+
+    @pytest.mark.asyncio
+    async def test_execute_signature_takes_exactly_one_unit(self, contract_executor: Executor) -> None:
+        """Pin the ABC signature so executors don't drift away from a single ``Unit`` parameter.
+
+        ``execute(*args, **kwargs)`` shapes bypass the ``Unit`` value object and
+        make the seam opaque to introspection.
+        """
+        sig = inspect.signature(contract_executor.execute)
+        params = [p for p in sig.parameters.values() if p.name != "self"]
+        assert len(params) == 1, (
+            f"{type(contract_executor).__name__}.execute must accept exactly one positional "
+            f"Unit argument; got signature: {sig}"
+        )
+
+
+class TestInProcessExecutorContract(ExecutorContract):
+    """Run the contract suite against the built-in InProcessExecutor.
+
+    This is the reference implementation: if the contract suite is wrong, this is
+    where it will fail first. Stepflow / remote / sandbox executors are exercised
+    against the same suite in their own test files.
+    """
+
+    @pytest.fixture
+    def contract_executor(self) -> Executor:
+        from lfx.execution.backends.in_process import InProcessExecutor
+
+        return InProcessExecutor()
+
+    @pytest.fixture
+    def contract_unit_factory(self, simple_graph) -> Callable[[], Unit]:  # noqa: ARG002
+        # ``simple_graph`` is a pytest fixture from conftest.py. We don't capture it
+        # by closure across runs because Graph instances accumulate state; instead we
+        # rebuild on every call so each unit is fresh.
+        from lfx.components.input_output import ChatInput, ChatOutput
+        from lfx.graph import Graph
+        from lfx.schema.schema import InputValueRequest
+
+        def factory() -> Unit:
+            ci = ChatInput(_id="chat_input")
+            ci.set(should_store_message=False)
+            co = ChatOutput(input_value="test", _id="chat_output")
+            co.set(sender_name=ci.message_response)
+            return Unit(
+                graph=Graph(ci, co),
+                inputs=[],
+                runtime_options={"initial_inputs": InputValueRequest(input_value="hi")},
+            )
+
+        return factory

--- a/src/lfx/tests/unit/execution/test_executor_service.py
+++ b/src/lfx/tests/unit/execution/test_executor_service.py
@@ -1,0 +1,220 @@
+"""Service-level contract tests for the ExecutorService."""
+
+from __future__ import annotations
+
+import pytest
+from lfx.execution.executor import Executor
+from lfx.execution.types import RunComplete
+from lfx.services.deps import get_service
+from lfx.services.executor.service import ExecutorService
+from lfx.services.manager import get_service_manager
+from lfx.services.schema import ServiceType
+
+
+def _get_service() -> ExecutorService:
+    service = get_service(ServiceType.EXECUTOR_SERVICE)
+    assert service is not None
+    return service
+
+
+def test_executor_service_is_resolvable_via_service_manager():
+    service = _get_service()
+    assert isinstance(service, ExecutorService)
+
+
+def test_executor_service_preregisters_in_process():
+    service = _get_service()
+    assert service.has("in-process")
+    assert service.get("in-process").kind == "in-process"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_uses_settings_executor_kind():
+    """Behavioral assertion: coordinator dispatches to whichever kind the settings select."""
+    settings_service = get_service(ServiceType.SETTINGS_SERVICE)
+    settings_service.settings.executor_kind = "kind-from-settings"
+
+    seen: list[str] = []
+
+    class Sentinel(Executor):
+        kind = "kind-from-settings"
+
+        async def execute(self, unit):  # noqa: ARG002
+            seen.append(self.kind)
+            yield RunComplete(outputs=["ok"])
+
+    get_service_manager().update(ServiceType.EXECUTOR_SERVICE)
+    service = _get_service()
+    service.register(Sentinel())
+
+    outputs = await service.coordinator.run_to_completion(graph=object(), inputs=[])
+
+    assert seen == ["kind-from-settings"]
+    assert outputs == ["ok"]
+
+    settings_service.settings.executor_kind = "in-process"
+    get_service_manager().update(ServiceType.EXECUTOR_SERVICE)
+
+
+def test_register_replaces_and_invalidates_cached_coordinator():
+    service = _get_service()
+    first = service.coordinator
+
+    class Other(Executor):
+        kind = "in-process"
+
+        async def execute(self, unit):  # noqa: ARG002
+            yield RunComplete(outputs=[])
+
+    service.register(Other())
+    assert service.coordinator is not first
+    assert isinstance(service.get("in-process"), Other)
+
+
+@pytest.mark.asyncio
+async def test_teardown_preserves_builtin_in_process():
+    """teardown() must leave the service usable: the built-in must still be registered.
+
+    ServiceManager.teardown() does not evict the cached service instance, so any code
+    that resolves the service after teardown (e.g. background tasks racing app shutdown)
+    must still get a working coordinator.
+    """
+    service = _get_service()
+
+    custom_kinds_before = service.has("in-process")
+    assert custom_kinds_before
+
+    await service.teardown()
+
+    assert service.has("in-process")
+    assert service.coordinator is not None  # rebuilds lazily over the fresh registry
+
+
+def test_entry_point_cannot_replace_builtin_in_process(monkeypatch):
+    """A package exposing an executor with kind="in-process" must not silently replace the built-in."""
+    from lfx.execution.backends.in_process import InProcessExecutor
+    from lfx.services.executor import service as service_module
+
+    class Hijacker(Executor):
+        kind = "in-process"
+
+        async def execute(self, unit):  # noqa: ARG002
+            yield RunComplete(outputs=[])
+
+    class _FakeEntryPoint:
+        name = "hijacker"
+
+        def load(self):
+            return Hijacker
+
+    monkeypatch.setattr(
+        service_module,
+        "entry_points",
+        lambda group: [_FakeEntryPoint()] if group == service_module.ENTRY_POINT_GROUP else [],
+    )
+
+    settings_service = get_service(ServiceType.SETTINGS_SERVICE)
+    fresh = ExecutorService(settings_service=settings_service)
+
+    assert isinstance(fresh.get("in-process"), InProcessExecutor)
+
+
+def test_entry_point_with_unique_kind_is_registered(monkeypatch):
+    """Entry points with non-colliding kinds are still loaded."""
+    from lfx.services.executor import service as service_module
+
+    class RemoteStub(Executor):
+        kind = "remote-stub"
+
+        async def execute(self, unit):  # noqa: ARG002
+            yield RunComplete(outputs=[])
+
+    class _FakeEntryPoint:
+        name = "remote_stub"
+
+        def load(self):
+            return RemoteStub
+
+    monkeypatch.setattr(
+        service_module,
+        "entry_points",
+        lambda group: [_FakeEntryPoint()] if group == service_module.ENTRY_POINT_GROUP else [],
+    )
+
+    settings_service = get_service(ServiceType.SETTINGS_SERVICE)
+    fresh = ExecutorService(settings_service=settings_service)
+
+    assert fresh.has("remote-stub")
+    assert isinstance(fresh.get("remote-stub"), RemoteStub)
+
+
+def test_entry_point_load_failure_does_not_break_discovery(monkeypatch):
+    """A single broken entry point must not prevent the built-in or other plugins from loading."""
+    from lfx.execution.backends.in_process import InProcessExecutor
+    from lfx.services.executor import service as service_module
+
+    class GoodStub(Executor):
+        kind = "good-stub"
+
+        async def execute(self, unit):  # noqa: ARG002
+            yield RunComplete(outputs=[])
+
+    class _BrokenEntryPoint:
+        name = "broken"
+
+        def load(self):
+            msg = "simulated import failure"
+            raise ImportError(msg)
+
+    class _GoodEntryPoint:
+        name = "good_stub"
+
+        def load(self):
+            return GoodStub
+
+    monkeypatch.setattr(
+        service_module,
+        "entry_points",
+        lambda group: [_BrokenEntryPoint(), _GoodEntryPoint()] if group == service_module.ENTRY_POINT_GROUP else [],
+    )
+
+    settings_service = get_service(ServiceType.SETTINGS_SERVICE)
+    fresh = ExecutorService(settings_service=settings_service)
+
+    assert isinstance(fresh.get("in-process"), InProcessExecutor)
+    assert isinstance(fresh.get("good-stub"), GoodStub)
+
+
+def test_entry_point_returning_non_executor_is_skipped(monkeypatch):
+    """An entry point whose loaded object lacks `kind` must not crash discovery."""
+    from lfx.execution.backends.in_process import InProcessExecutor
+    from lfx.services.executor import service as service_module
+
+    class NotAnExecutor:
+        pass
+
+    class _BadEntryPoint:
+        name = "bad"
+
+        def load(self):
+            return NotAnExecutor
+
+    monkeypatch.setattr(
+        service_module,
+        "entry_points",
+        lambda group: [_BadEntryPoint()] if group == service_module.ENTRY_POINT_GROUP else [],
+    )
+
+    settings_service = get_service(ServiceType.SETTINGS_SERVICE)
+    fresh = ExecutorService(settings_service=settings_service)
+
+    assert isinstance(fresh.get("in-process"), InProcessExecutor)
+
+
+def test_factory_declares_settings_dependency():
+    """Pin the factory contract: ExecutorService depends on settings_service only."""
+    from lfx.services.executor.factory import ExecutorServiceFactory
+
+    factory = ExecutorServiceFactory()
+    assert factory.service_class is ExecutorService
+    assert factory.dependencies == [ServiceType.SETTINGS_SERVICE]

--- a/src/lfx/tests/unit/execution/test_executor_service.py
+++ b/src/lfx/tests/unit/execution/test_executor_service.py
@@ -188,12 +188,15 @@ def test_entry_point_load_failure_does_not_break_discovery(monkeypatch):
 
 
 def test_entry_point_returning_non_executor_is_skipped(monkeypatch):
-    """An entry point whose loaded object lacks `kind` must not crash discovery."""
+    """An entry point whose loaded object is not an Executor must be skipped, not registered."""
     from lfx.execution.backends.in_process import InProcessExecutor
     from lfx.services.executor import service as service_module
 
     class NotAnExecutor:
-        pass
+        # Carries a `kind` (so it would survive registry.register's attribute read) but is
+        # not an Executor. Without the isinstance guard it would register and only blow up
+        # later at execute() time; discovery must reject it up front.
+        kind = "not-really"
 
     class _BadEntryPoint:
         name = "bad"
@@ -210,6 +213,9 @@ def test_entry_point_returning_non_executor_is_skipped(monkeypatch):
     settings_service = get_service(ServiceType.SETTINGS_SERVICE)
     fresh = ExecutorService(settings_service=settings_service)
 
+    # The bad plugin is rejected outright...
+    assert not fresh.has("not-really")
+    # ...and the built-in executor still works.
     assert isinstance(fresh.get("in-process"), InProcessExecutor)
 
 

--- a/src/lfx/tests/unit/execution/test_executor_service.py
+++ b/src/lfx/tests/unit/execution/test_executor_service.py
@@ -29,10 +29,15 @@ def test_executor_service_preregisters_in_process():
 
 
 @pytest.mark.asyncio
-async def test_coordinator_uses_settings_executor_kind():
+async def test_coordinator_uses_settings_executor_kind(monkeypatch, request):
     """Behavioral assertion: coordinator dispatches to whichever kind the settings select."""
     settings_service = get_service(ServiceType.SETTINGS_SERVICE)
-    settings_service.settings.executor_kind = "kind-from-settings"
+    # monkeypatch restores the original kind even if an assertion below fails, so a
+    # mid-test failure can't poison the session-wide settings for later tests. The
+    # finalizer rebuilds the executor service after the kind reverts, so the service
+    # built from the patched kind doesn't linger either.
+    monkeypatch.setattr(settings_service.settings, "executor_kind", "kind-from-settings")
+    request.addfinalizer(lambda: get_service_manager().update(ServiceType.EXECUTOR_SERVICE))
 
     seen: list[str] = []
 
@@ -51,9 +56,6 @@ async def test_coordinator_uses_settings_executor_kind():
 
     assert seen == ["kind-from-settings"]
     assert outputs == ["ok"]
-
-    settings_service.settings.executor_kind = "in-process"
-    get_service_manager().update(ServiceType.EXECUTOR_SERVICE)
 
 
 def test_register_replaces_and_invalidates_cached_coordinator():

--- a/src/lfx/tests/unit/execution/test_graph_arun_routes_through_coordinator.py
+++ b/src/lfx/tests/unit/execution/test_graph_arun_routes_through_coordinator.py
@@ -1,0 +1,71 @@
+import asyncio
+
+import pytest
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.execution import (
+    Coordinator,
+    ExecutorRegistry,
+    get_default_registry,
+    set_default_coordinator,
+)
+from lfx.execution.executor import Executor
+from lfx.execution.types import RunComplete
+from lfx.graph import Graph
+from lfx.graph.schema import RunOutputs
+
+
+def _simple_graph():
+    chat_input = ChatInput(_id="chat_input")
+    chat_input.set(should_store_message=False)
+    chat_output = ChatOutput(input_value="test", _id="chat_output")
+    chat_output.set(sender_name=chat_input.message_response)
+    return Graph(chat_input, chat_output)
+
+
+@pytest.mark.asyncio
+async def test_arun_dispatches_through_coordinator():
+    units_seen: list[object] = []
+
+    class Recording(Executor):
+        kind = "in-process"
+
+        async def execute(self, unit):
+            units_seen.append(unit)
+            yield RunComplete(outputs=[])
+
+    registry = ExecutorRegistry()
+    registry.register(Recording())
+    set_default_coordinator(Coordinator(registry=registry))
+
+    await _simple_graph().arun(inputs=[{"input_value": "hi"}])
+    assert len(units_seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_arun_returns_run_outputs_shape():
+    """Real graph through the default coordinator returns list[RunOutputs]."""
+    # Touch the default registry to pre-warm; conftest resets between tests.
+    assert get_default_registry().get("in-process").kind == "in-process"
+    outputs = await _simple_graph().arun(inputs=[{"input_value": "hi"}])
+    assert isinstance(outputs, list)
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], RunOutputs)
+
+
+@pytest.mark.asyncio
+async def test_arun_handles_concurrent_calls_on_same_graph_instance():
+    graph = _simple_graph()
+    seen: list[str] = []
+
+    async def patched(*, inputs, **kwargs):  # noqa: ARG001
+        seen.append(kwargs.get("session_id") or "")
+        await asyncio.sleep(0.01)
+        return []
+
+    graph._arun_legacy = patched
+
+    await asyncio.gather(
+        graph.arun(inputs=[{"input_value": "a"}], session_id="A"),
+        graph.arun(inputs=[{"input_value": "b"}], session_id="B"),
+    )
+    assert sorted(seen) == ["A", "B"]

--- a/src/lfx/tests/unit/execution/test_graph_arun_routes_through_coordinator.py
+++ b/src/lfx/tests/unit/execution/test_graph_arun_routes_through_coordinator.py
@@ -53,8 +53,13 @@ async def test_arun_returns_run_outputs_shape():
 
 
 @pytest.mark.asyncio
-async def test_arun_handles_concurrent_calls_on_same_graph_instance():
-    graph = _simple_graph()
+async def test_arun_concurrent_on_separate_graphs_keep_options_isolated():
+    """Concurrent arun calls on SEPARATE Graph instances must each see their own kwargs.
+
+    Same-instance concurrent arun is unsafe because _arun_legacy mutates self.session_id
+    and other shared state; that's a pre-existing property of Graph, not introduced by
+    the coordinator seam. The seam guarantees isolation across separate units only.
+    """
     seen: list[str] = []
 
     async def patched(*, inputs, **kwargs):  # noqa: ARG001
@@ -62,10 +67,10 @@ async def test_arun_handles_concurrent_calls_on_same_graph_instance():
         await asyncio.sleep(0.01)
         return []
 
-    graph._arun_legacy = patched
+    async def run_with(session_id):
+        graph = _simple_graph()
+        graph._arun_legacy = patched
+        await graph.arun(inputs=[{"input_value": session_id}], session_id=session_id)
 
-    await asyncio.gather(
-        graph.arun(inputs=[{"input_value": "a"}], session_id="A"),
-        graph.arun(inputs=[{"input_value": "b"}], session_id="B"),
-    )
+    await asyncio.gather(run_with("A"), run_with("B"))
     assert sorted(seen) == ["A", "B"]

--- a/src/lfx/tests/unit/execution/test_graph_arun_routes_through_coordinator.py
+++ b/src/lfx/tests/unit/execution/test_graph_arun_routes_through_coordinator.py
@@ -5,7 +5,6 @@ from lfx.components.input_output import ChatInput, ChatOutput
 from lfx.execution import (
     Coordinator,
     ExecutorRegistry,
-    get_default_registry,
     set_default_coordinator,
 )
 from lfx.execution.executor import Executor
@@ -14,16 +13,8 @@ from lfx.graph import Graph
 from lfx.graph.schema import RunOutputs
 
 
-def _simple_graph():
-    chat_input = ChatInput(_id="chat_input")
-    chat_input.set(should_store_message=False)
-    chat_output = ChatOutput(input_value="test", _id="chat_output")
-    chat_output.set(sender_name=chat_input.message_response)
-    return Graph(chat_input, chat_output)
-
-
 @pytest.mark.asyncio
-async def test_arun_dispatches_through_coordinator():
+async def test_arun_dispatches_through_coordinator(simple_graph):
     units_seen: list[object] = []
 
     class Recording(Executor):
@@ -37,29 +28,25 @@ async def test_arun_dispatches_through_coordinator():
     registry.register(Recording())
     set_default_coordinator(Coordinator(registry=registry))
 
-    await _simple_graph().arun(inputs=[{"input_value": "hi"}])
+    await simple_graph.arun(inputs=[{"input_value": "hi"}])
     assert len(units_seen) == 1
+    seen = units_seen[0]
+    assert seen.inputs == [{"input_value": "hi"}]
+    assert seen.runtime_options.get("_use_arun_legacy") is True
 
 
 @pytest.mark.asyncio
-async def test_arun_returns_run_outputs_shape():
-    """Real graph through the default coordinator returns list[RunOutputs]."""
-    # Touch the default registry to pre-warm; conftest resets between tests.
-    assert get_default_registry().get("in-process").kind == "in-process"
-    outputs = await _simple_graph().arun(inputs=[{"input_value": "hi"}])
+async def test_arun_returns_run_outputs_shape(simple_graph):
+    outputs = await simple_graph.arun(inputs=[{"input_value": "hi"}])
     assert isinstance(outputs, list)
     assert len(outputs) == 1
     assert isinstance(outputs[0], RunOutputs)
+    assert outputs[0].inputs == {"input_value": "hi"}
 
 
 @pytest.mark.asyncio
 async def test_arun_concurrent_on_separate_graphs_keep_options_isolated():
-    """Concurrent arun calls on SEPARATE Graph instances must each see their own kwargs.
-
-    Same-instance concurrent arun is unsafe because _arun_legacy mutates self.session_id
-    and other shared state; that's a pre-existing property of Graph, not introduced by
-    the coordinator seam. The seam guarantees isolation across separate units only.
-    """
+    """Concurrent arun on separate Graph instances keeps kwargs isolated."""
     seen: list[str] = []
 
     async def patched(*, inputs, **kwargs):  # noqa: ARG001
@@ -67,8 +54,15 @@ async def test_arun_concurrent_on_separate_graphs_keep_options_isolated():
         await asyncio.sleep(0.01)
         return []
 
+    def _build():
+        ci = ChatInput(_id="chat_input")
+        ci.set(should_store_message=False)
+        co = ChatOutput(input_value="test", _id="chat_output")
+        co.set(sender_name=ci.message_response)
+        return Graph(ci, co)
+
     async def run_with(session_id):
-        graph = _simple_graph()
+        graph = _build()
         graph._arun_legacy = patched
         await graph.arun(inputs=[{"input_value": session_id}], session_id=session_id)
 

--- a/src/lfx/tests/unit/execution/test_in_process_executor.py
+++ b/src/lfx/tests/unit/execution/test_in_process_executor.py
@@ -22,8 +22,15 @@ def test_in_process_executor_kind():
 
 @pytest.mark.asyncio
 async def test_streams_step_results_then_run_complete_for_real_graph():
+    """Streaming path: empty inputs forces async_start, multiple StepResults yielded."""
+    from lfx.schema.schema import InputValueRequest
+
     graph = _simple_graph()
-    unit = Unit(graph=graph, inputs=[{"input_value": "hello"}])
+    unit = Unit(
+        graph=graph,
+        inputs=[],
+        runtime_options={"initial_inputs": InputValueRequest(input_value="hello")},
+    )
 
     items = [item async for item in InProcessExecutor().execute(unit)]
 
@@ -46,6 +53,9 @@ async def test_run_complete_outputs_match_arun_shape():
 
 @pytest.mark.asyncio
 async def test_event_manager_in_runtime_options_is_used():
+    """Streaming path forwards event_manager into async_start so vertex events fire."""
+    from lfx.schema.schema import InputValueRequest
+
     graph = _simple_graph()
     queue: asyncio.Queue = asyncio.Queue()
     em = EventManager(queue=queue)
@@ -59,8 +69,11 @@ async def test_event_manager_in_runtime_options_is_used():
 
     unit = Unit(
         graph=graph,
-        inputs=[{"input_value": "hi"}],
-        runtime_options={"event_manager": em},
+        inputs=[],
+        runtime_options={
+            "event_manager": em,
+            "initial_inputs": InputValueRequest(input_value="hi"),
+        },
     )
     [_ async for _ in InProcessExecutor().execute(unit)]
 

--- a/src/lfx/tests/unit/execution/test_in_process_executor.py
+++ b/src/lfx/tests/unit/execution/test_in_process_executor.py
@@ -1,19 +1,9 @@
 import asyncio
 
 import pytest
-from lfx.components.input_output import ChatInput, ChatOutput
 from lfx.events.event_manager import EventManager
 from lfx.execution.backends.in_process import InProcessExecutor
 from lfx.execution.types import RunComplete, StepResult, Unit
-from lfx.graph import Graph
-
-
-def _simple_graph():
-    chat_input = ChatInput(_id="chat_input")
-    chat_input.set(should_store_message=False)
-    chat_output = ChatOutput(input_value="test", _id="chat_output")
-    chat_output.set(sender_name=chat_input.message_response)
-    return Graph(chat_input, chat_output)
 
 
 def test_in_process_executor_kind():
@@ -21,32 +11,35 @@ def test_in_process_executor_kind():
 
 
 @pytest.mark.asyncio
-async def test_streams_step_results_then_run_complete_for_real_graph():
-    """Streaming path: empty inputs forces async_start, multiple StepResults yielded."""
+async def test_streams_step_results_then_run_complete_for_real_graph(simple_graph):
+    """Streaming path emits StepResult per vertex build plus a Finish step, then RunComplete."""
+    from lfx.graph.graph.constants import Finish
     from lfx.schema.schema import InputValueRequest
 
-    graph = _simple_graph()
     unit = Unit(
-        graph=graph,
+        graph=simple_graph,
         inputs=[],
-        runtime_options={"initial_inputs": InputValueRequest(input_value="hello")},
+        runtime_options={"initial_inputs": InputValueRequest(input_value="hello world")},
     )
 
     items = [item async for item in InProcessExecutor().execute(unit)]
+    step_payloads = [i.payload for i in items if isinstance(i, StepResult)]
 
     assert isinstance(items[-1], RunComplete)
     assert all(isinstance(i, StepResult) for i in items[:-1])
-    assert len(items) >= 2
+    vertex_ids = [getattr(p, "vertex", None) and p.vertex.id for p in step_payloads]
+    assert "chat_input" in vertex_ids
+    assert "chat_output" in vertex_ids
+    assert any(isinstance(p, Finish) for p in step_payloads)
 
 
 @pytest.mark.asyncio
-async def test_run_complete_outputs_match_arun_shape():
+async def test_run_complete_outputs_match_arun_shape(simple_graph):
     """Legacy path: dict inputs + flag yields list[RunOutputs] from _arun_legacy."""
     from lfx.graph.schema import RunOutputs
 
-    graph = _simple_graph()
     unit = Unit(
-        graph=graph,
+        graph=simple_graph,
         inputs=[{"input_value": "hello world"}],
         runtime_options={"_use_arun_legacy": True},
     )
@@ -56,14 +49,14 @@ async def test_run_complete_outputs_match_arun_shape():
     assert isinstance(rc, RunComplete)
     assert len(rc.outputs) == 1
     assert isinstance(rc.outputs[0], RunOutputs)
+    assert rc.outputs[0].inputs == {"input_value": "hello world"}
 
 
 @pytest.mark.asyncio
-async def test_event_manager_in_runtime_options_is_used():
+async def test_event_manager_in_runtime_options_is_used(simple_graph):
     """Streaming path forwards event_manager into async_start so vertex events fire."""
     from lfx.schema.schema import InputValueRequest
 
-    graph = _simple_graph()
     queue: asyncio.Queue = asyncio.Queue()
     em = EventManager(queue=queue)
 
@@ -75,7 +68,7 @@ async def test_event_manager_in_runtime_options_is_used():
     em.register_event("on_build_start", "build_start", record)
 
     unit = Unit(
-        graph=graph,
+        graph=simple_graph,
         inputs=[],
         runtime_options={
             "event_manager": em,
@@ -85,32 +78,46 @@ async def test_event_manager_in_runtime_options_is_used():
     [_ async for _ in InProcessExecutor().execute(unit)]
 
     assert any(s.startswith("build_start:chat_input") for s in seen)
+    assert any(s.startswith("build_start:chat_output") for s in seen)
 
 
 @pytest.mark.asyncio
-async def test_propagates_graph_errors():
-    graph = _simple_graph()
-
+async def test_propagates_graph_errors(simple_graph):
     async def boom(*args, **kwargs):  # noqa: ARG001
         msg = "boom"
         raise RuntimeError(msg)
 
-    graph._arun_legacy = boom
+    simple_graph._arun_legacy = boom
 
-    unit = Unit(graph=graph, inputs=[{}], runtime_options={"_use_arun_legacy": True})
+    unit = Unit(graph=simple_graph, inputs=[{}], runtime_options={"_use_arun_legacy": True})
     with pytest.raises(RuntimeError, match="boom"):
         async for _ in InProcessExecutor().execute(unit):
             pass
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runs_on_separate_graphs_keep_runtime_options_isolated():
-    """Concurrent executor calls on separate Graph instances must each see their own options.
+async def test_fallback_to_env_vars_forwarded_in_streaming_path():
+    """Regression: the streaming path must forward fallback_to_env_vars to async_start."""
 
-    Same-instance concurrency is unsafe due to shared state mutations inside _arun_legacy
-    (self.session_id and others); the seam doesn't promise to fix that. Separate instances,
-    however, must remain isolated through the executor layer.
-    """
+    class _Stub:
+        seen_fallback: bool | None = None
+
+        async def async_start(self, **kwargs):
+            _Stub.seen_fallback = kwargs.get("fallback_to_env_vars")
+            return
+            yield
+
+    unit = Unit(graph=_Stub(), inputs=[], runtime_options={"fallback_to_env_vars": True})
+    [_ async for _ in InProcessExecutor().execute(unit)]
+    assert _Stub.seen_fallback is True
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_on_separate_graphs_keep_runtime_options_isolated():
+    """Separate Graph instances stay isolated through the executor layer."""
+    from lfx.components.input_output import ChatInput, ChatOutput
+    from lfx.graph import Graph
+
     seen: list[str | None] = []
 
     async def patched_arun_legacy(*, inputs, **kwargs):  # noqa: ARG001
@@ -118,11 +125,18 @@ async def test_concurrent_runs_on_separate_graphs_keep_runtime_options_isolated(
         await asyncio.sleep(0.01)
         return []
 
+    def _build():
+        ci = ChatInput(_id="chat_input")
+        ci.set(should_store_message=False)
+        co = ChatOutput(input_value="test", _id="chat_output")
+        co.set(sender_name=ci.message_response)
+        g = Graph(ci, co)
+        g._arun_legacy = patched_arun_legacy
+        return g
+
     async def run_with(session_id):
-        graph = _simple_graph()
-        graph._arun_legacy = patched_arun_legacy
         unit = Unit(
-            graph=graph,
+            graph=_build(),
             inputs=[{}],
             runtime_options={"session_id": session_id, "_use_arun_legacy": True},
         )

--- a/src/lfx/tests/unit/execution/test_in_process_executor.py
+++ b/src/lfx/tests/unit/execution/test_in_process_executor.py
@@ -41,14 +41,21 @@ async def test_streams_step_results_then_run_complete_for_real_graph():
 
 @pytest.mark.asyncio
 async def test_run_complete_outputs_match_arun_shape():
+    """Legacy path: dict inputs + flag yields list[RunOutputs] from _arun_legacy."""
+    from lfx.graph.schema import RunOutputs
+
     graph = _simple_graph()
-    unit = Unit(graph=graph, inputs=[{"input_value": "hello world"}])
+    unit = Unit(
+        graph=graph,
+        inputs=[{"input_value": "hello world"}],
+        runtime_options={"_use_arun_legacy": True},
+    )
 
     items = [item async for item in InProcessExecutor().execute(unit)]
     rc = items[-1]
     assert isinstance(rc, RunComplete)
-    assert isinstance(rc.outputs, list)
-    assert rc.outputs
+    assert len(rc.outputs) == 1
+    assert isinstance(rc.outputs[0], RunOutputs)
 
 
 @pytest.mark.asyncio
@@ -90,28 +97,36 @@ async def test_propagates_graph_errors():
 
     graph._arun_legacy = boom
 
-    unit = Unit(graph=graph, inputs=[{}])
+    unit = Unit(graph=graph, inputs=[{}], runtime_options={"_use_arun_legacy": True})
     with pytest.raises(RuntimeError, match="boom"):
         async for _ in InProcessExecutor().execute(unit):
             pass
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runs_on_same_graph_dont_share_runtime_options():
-    graph = _simple_graph()
+async def test_concurrent_runs_on_separate_graphs_keep_runtime_options_isolated():
+    """Concurrent executor calls on separate Graph instances must each see their own options.
 
-    seen_session_ids: list[str | None] = []
+    Same-instance concurrency is unsafe due to shared state mutations inside _arun_legacy
+    (self.session_id and others); the seam doesn't promise to fix that. Separate instances,
+    however, must remain isolated through the executor layer.
+    """
+    seen: list[str | None] = []
 
     async def patched_arun_legacy(*, inputs, **kwargs):  # noqa: ARG001
-        seen_session_ids.append(kwargs.get("session_id"))
+        seen.append(kwargs.get("session_id"))
         await asyncio.sleep(0.01)
         return []
 
-    graph._arun_legacy = patched_arun_legacy
-
     async def run_with(session_id):
-        unit = Unit(graph=graph, inputs=[{}], runtime_options={"session_id": session_id})
+        graph = _simple_graph()
+        graph._arun_legacy = patched_arun_legacy
+        unit = Unit(
+            graph=graph,
+            inputs=[{}],
+            runtime_options={"session_id": session_id, "_use_arun_legacy": True},
+        )
         [_ async for _ in InProcessExecutor().execute(unit)]
 
     await asyncio.gather(run_with("A"), run_with("B"))
-    assert sorted(seen_session_ids) == ["A", "B"]
+    assert sorted(seen) == ["A", "B"]

--- a/src/lfx/tests/unit/execution/test_in_process_executor.py
+++ b/src/lfx/tests/unit/execution/test_in_process_executor.py
@@ -1,0 +1,104 @@
+import asyncio
+
+import pytest
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.events.event_manager import EventManager
+from lfx.execution.backends.in_process import InProcessExecutor
+from lfx.execution.types import RunComplete, StepResult, Unit
+from lfx.graph import Graph
+
+
+def _simple_graph():
+    chat_input = ChatInput(_id="chat_input")
+    chat_input.set(should_store_message=False)
+    chat_output = ChatOutput(input_value="test", _id="chat_output")
+    chat_output.set(sender_name=chat_input.message_response)
+    return Graph(chat_input, chat_output)
+
+
+def test_in_process_executor_kind():
+    assert InProcessExecutor().kind == "in-process"
+
+
+@pytest.mark.asyncio
+async def test_streams_step_results_then_run_complete_for_real_graph():
+    graph = _simple_graph()
+    unit = Unit(graph=graph, inputs=[{"input_value": "hello"}])
+
+    items = [item async for item in InProcessExecutor().execute(unit)]
+
+    assert isinstance(items[-1], RunComplete)
+    assert all(isinstance(i, StepResult) for i in items[:-1])
+    assert len(items) >= 2
+
+
+@pytest.mark.asyncio
+async def test_run_complete_outputs_match_arun_shape():
+    graph = _simple_graph()
+    unit = Unit(graph=graph, inputs=[{"input_value": "hello world"}])
+
+    items = [item async for item in InProcessExecutor().execute(unit)]
+    rc = items[-1]
+    assert isinstance(rc, RunComplete)
+    assert isinstance(rc.outputs, list)
+    assert rc.outputs
+
+
+@pytest.mark.asyncio
+async def test_event_manager_in_runtime_options_is_used():
+    graph = _simple_graph()
+    queue: asyncio.Queue = asyncio.Queue()
+    em = EventManager(queue=queue)
+
+    seen: list[str] = []
+
+    def record(*, manager, event_type, data):  # noqa: ARG001
+        seen.append(f"{event_type}:{data.get('id') if isinstance(data, dict) else ''}")
+
+    em.register_event("on_build_start", "build_start", record)
+
+    unit = Unit(
+        graph=graph,
+        inputs=[{"input_value": "hi"}],
+        runtime_options={"event_manager": em},
+    )
+    [_ async for _ in InProcessExecutor().execute(unit)]
+
+    assert any(s.startswith("build_start:chat_input") for s in seen)
+
+
+@pytest.mark.asyncio
+async def test_propagates_graph_errors():
+    graph = _simple_graph()
+
+    async def boom(*args, **kwargs):  # noqa: ARG001
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    graph._arun_legacy = boom
+
+    unit = Unit(graph=graph, inputs=[{}])
+    with pytest.raises(RuntimeError, match="boom"):
+        async for _ in InProcessExecutor().execute(unit):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_on_same_graph_dont_share_runtime_options():
+    graph = _simple_graph()
+
+    seen_session_ids: list[str | None] = []
+
+    async def patched_arun_legacy(*, inputs, **kwargs):  # noqa: ARG001
+        seen_session_ids.append(kwargs.get("session_id"))
+        await asyncio.sleep(0.01)
+        return []
+
+    graph._arun_legacy = patched_arun_legacy
+
+    async def run_with(session_id):
+        unit = Unit(graph=graph, inputs=[{}], runtime_options={"session_id": session_id})
+        [_ async for _ in InProcessExecutor().execute(unit)]
+
+    await asyncio.gather(run_with("A"), run_with("B"))
+    assert sorted(seen_session_ids) == ["A", "B"]

--- a/src/lfx/tests/unit/execution/test_partitioner.py
+++ b/src/lfx/tests/unit/execution/test_partitioner.py
@@ -1,28 +1,17 @@
-from lfx.components.input_output import ChatInput, ChatOutput
 from lfx.execution.partitioner import identity_partition
 from lfx.execution.types import Unit
-from lfx.graph import Graph
 
 
-def _simple_graph():
-    chat_input = ChatInput(_id="chat_input")
-    chat_input.set(should_store_message=False)
-    chat_output = ChatOutput(input_value="test", _id="chat_output")
-    chat_output.set(sender_name=chat_input.message_response)
-    return Graph(chat_input, chat_output)
-
-
-def test_identity_partition_returns_one_unit():
-    graph = _simple_graph()
-    units = identity_partition(graph, inputs=[{"input_value": "hi"}], runtime_options={"session_id": "s1"})
+def test_identity_partition_returns_one_unit(simple_graph):
+    units = identity_partition(simple_graph, inputs=[{"input_value": "hi"}], runtime_options={"session_id": "s1"})
     assert len(units) == 1
     [unit] = units
     assert isinstance(unit, Unit)
-    assert unit.graph is graph
+    assert unit.graph is simple_graph
     assert unit.inputs == [{"input_value": "hi"}]
     assert unit.runtime_options == {"session_id": "s1"}
 
 
-def test_identity_partition_default_runtime_options():
-    units = identity_partition(_simple_graph(), inputs=[])
+def test_identity_partition_default_runtime_options(simple_graph):
+    units = identity_partition(simple_graph, inputs=[])
     assert units[0].runtime_options == {}

--- a/src/lfx/tests/unit/execution/test_partitioner.py
+++ b/src/lfx/tests/unit/execution/test_partitioner.py
@@ -1,0 +1,28 @@
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.execution.partitioner import identity_partition
+from lfx.execution.types import Unit
+from lfx.graph import Graph
+
+
+def _simple_graph():
+    chat_input = ChatInput(_id="chat_input")
+    chat_input.set(should_store_message=False)
+    chat_output = ChatOutput(input_value="test", _id="chat_output")
+    chat_output.set(sender_name=chat_input.message_response)
+    return Graph(chat_input, chat_output)
+
+
+def test_identity_partition_returns_one_unit():
+    graph = _simple_graph()
+    units = identity_partition(graph, inputs=[{"input_value": "hi"}], runtime_options={"session_id": "s1"})
+    assert len(units) == 1
+    [unit] = units
+    assert isinstance(unit, Unit)
+    assert unit.graph is graph
+    assert unit.inputs == [{"input_value": "hi"}]
+    assert unit.runtime_options == {"session_id": "s1"}
+
+
+def test_identity_partition_default_runtime_options():
+    units = identity_partition(_simple_graph(), inputs=[])
+    assert units[0].runtime_options == {}

--- a/src/lfx/tests/unit/execution/test_registry.py
+++ b/src/lfx/tests/unit/execution/test_registry.py
@@ -1,0 +1,31 @@
+import pytest
+from lfx.execution.executor import Executor
+from lfx.execution.registry import ExecutorNotFoundError, ExecutorRegistry
+
+
+class _Stub(Executor):
+    kind = "stub"
+
+    async def execute(self, unit):  # noqa: ARG002
+        return
+        yield
+
+
+def test_register_and_get_by_kind():
+    registry = ExecutorRegistry()
+    registry.register(_Stub())
+    assert registry.get("stub").kind == "stub"
+
+
+def test_get_unknown_raises():
+    with pytest.raises(ExecutorNotFoundError, match="nope"):
+        ExecutorRegistry().get("nope")
+
+
+def test_register_replaces_same_kind():
+    registry = ExecutorRegistry()
+    a = _Stub()
+    b = _Stub()
+    registry.register(a)
+    registry.register(b)
+    assert registry.get("stub") is b

--- a/src/lfx/tests/unit/execution/test_registry.py
+++ b/src/lfx/tests/unit/execution/test_registry.py
@@ -1,6 +1,6 @@
 import pytest
 from lfx.execution.executor import Executor
-from lfx.execution.registry import ExecutorNotFoundError, ExecutorRegistry
+from lfx.execution.registry import ExecutorKindCollisionError, ExecutorNotFoundError, ExecutorRegistry
 
 
 class _Stub(Executor):
@@ -29,3 +29,19 @@ def test_register_replaces_same_kind():
     registry.register(a)
     registry.register(b)
     assert registry.get("stub") is b
+
+
+def test_register_replace_false_raises_on_collision():
+    registry = ExecutorRegistry()
+    first = _Stub()
+    registry.register(first)
+    with pytest.raises(ExecutorKindCollisionError, match="stub"):
+        registry.register(_Stub(), replace=False)
+    assert registry.get("stub") is first
+
+
+def test_has_reflects_registration():
+    registry = ExecutorRegistry()
+    assert not registry.has("stub")
+    registry.register(_Stub())
+    assert registry.has("stub")

--- a/src/lfx/tests/unit/execution/test_types.py
+++ b/src/lfx/tests/unit/execution/test_types.py
@@ -1,0 +1,28 @@
+from lfx.execution.types import RunComplete, StepResult, Unit
+
+
+def test_unit_carries_graph_inputs_and_runtime_options():
+    sentinel = object()
+    unit = Unit(
+        graph=sentinel,
+        inputs=[{"input_value": "hi"}],
+        runtime_options={"event_manager": None, "session_id": "s1"},
+    )
+    assert unit.graph is sentinel
+    assert unit.inputs == [{"input_value": "hi"}]
+    assert unit.runtime_options == {"event_manager": None, "session_id": "s1"}
+
+
+def test_unit_runtime_options_defaults_to_empty_dict():
+    unit = Unit(graph=object(), inputs=[])
+    assert unit.runtime_options == {}
+
+
+def test_run_complete_carries_outputs():
+    rc = RunComplete(outputs=["a", "b"])
+    assert rc.outputs == ["a", "b"]
+
+
+def test_step_result_carries_payload():
+    sr = StepResult(payload={"vertex_id": "x"})
+    assert sr.payload == {"vertex_id": "x"}

--- a/src/lfx/tests/unit/run/test_base.py
+++ b/src/lfx/tests/unit/run/test_base.py
@@ -180,7 +180,7 @@ class TestRunFlowJsonInput:
             mock_graph.edges = []
             mock_graph.prepare = MagicMock()
 
-            async def mock_async_start(_inputs, **_kwargs):
+            async def mock_async_start(_inputs=None, **_kwargs):
                 yield
 
             mock_graph.async_start = mock_async_start
@@ -308,7 +308,7 @@ class TestRunFlowSessionId:
         graph.edges = []
         graph.prepare = MagicMock()
 
-        async def _async_start(_inputs, **_kwargs):
+        async def _async_start(_inputs=None, **_kwargs):
             yield
 
         graph.async_start = _async_start
@@ -469,7 +469,7 @@ class TestRunFlowSessionIdPropagation:
         graph.edges = []
         graph.prepare = MagicMock()
 
-        async def _async_start(_inputs, **_kwargs):
+        async def _async_start(_inputs=None, **_kwargs):
             yield
 
         graph.async_start = _async_start
@@ -574,7 +574,7 @@ class TestRunFlowUserId:
         graph.edges = []
         graph.prepare = MagicMock()
 
-        async def _async_start(_inputs, **_kwargs):
+        async def _async_start(_inputs=None, **_kwargs):
             yield
 
         graph.async_start = _async_start
@@ -671,7 +671,7 @@ class TestRunFlowFallbackToEnvVars:
         graph.edges = []
         graph.prepare = MagicMock()
 
-        async def _async_start(_inputs, **kwargs):
+        async def _async_start(_inputs=None, **kwargs):
             captured.update(kwargs)
             yield
 
@@ -743,7 +743,7 @@ class TestRunFlowGlobalVariables:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def mock_async_start(_inputs, **_kwargs):
+        async def mock_async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = mock_async_start
@@ -784,7 +784,7 @@ graph = Graph(chat_input, chat_output)
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def mock_async_start(_inputs, **_kwargs):
+        async def mock_async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = mock_async_start
@@ -825,7 +825,7 @@ class TestRunFlowOutputFormats:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def mock_async_start(_inputs, **_kwargs):
+        async def mock_async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = mock_async_start
@@ -938,7 +938,7 @@ class TestRunFlowTiming:
         mock_result.vertex.display_name = "TestComponent"
         mock_result.vertex.id = "test-id-123"
 
-        async def mock_async_start(_inputs, **_kwargs):
+        async def mock_async_start(_inputs=None, **_kwargs):
             yield mock_result
 
         mock_graph.async_start = mock_async_start
@@ -1133,7 +1133,7 @@ class TestRunFlowVariableValidation:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def mock_async_start(_inputs, **_kwargs):
+        async def mock_async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = mock_async_start
@@ -1169,7 +1169,7 @@ class TestRunFlowInputValueHandling:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def mock_async_start(_inputs, **_kwargs):
+        async def mock_async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = mock_async_start
@@ -1207,7 +1207,7 @@ class TestRunFlowInputValueHandling:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def mock_async_start(_inputs, **_kwargs):
+        async def mock_async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = mock_async_start
@@ -1264,7 +1264,7 @@ class TestRunFlowJsonFileExecution:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def mock_async_start(_inputs, **_kwargs):
+        async def mock_async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = mock_async_start
@@ -1364,7 +1364,7 @@ class TestRunFlowExecutionErrors:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def failing_async_start(_inputs, **_kwargs):
+        async def failing_async_start(_inputs=None, **_kwargs):
             msg = "Execution failed"
             raise ValueError(msg)
             yield  # Required to make it an async generator
@@ -1662,7 +1662,7 @@ class TestUpgradeFlowOption:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def _async_start(_inputs, **_kwargs):
+        async def _async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = _async_start
@@ -1703,7 +1703,7 @@ class TestUpgradeFlowOption:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def _async_start(_inputs, **_kwargs):
+        async def _async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = _async_start
@@ -1740,7 +1740,7 @@ class TestUpgradeFlowOption:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def _async_start(_inputs, **_kwargs):
+        async def _async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = _async_start
@@ -1783,7 +1783,7 @@ class TestUpgradeFlowOption:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def _async_start(_inputs, **_kwargs):
+        async def _async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = _async_start
@@ -1822,7 +1822,7 @@ class TestUpgradeFlowOption:
         mock_graph.edges = []
         mock_graph.prepare = MagicMock()
 
-        async def _async_start(_inputs, **_kwargs):
+        async def _async_start(_inputs=None, **_kwargs):
             yield
 
         mock_graph.async_start = _async_start

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -176,6 +176,7 @@ EXPECTED_FIELDS = {
     "redis_queue_polling_stale_threshold_s",
     "redis_queue_polling_watchdog_interval_s",
     "max_ingestion_timeout_secs",
+    "executor_kind",
     # UiSettings
     "embedded_mode",
     "hide_getting_started_progress",

--- a/src/lfx/tests/unit/services/test_service_manager.py
+++ b/src/lfx/tests/unit/services/test_service_manager.py
@@ -359,6 +359,27 @@ class TestTeardown:
         # Services should be cleared
         assert ServiceType.STORAGE_SERVICE not in service_manager.services
 
+    @pytest.mark.asyncio
+    async def test_teardown_clears_factories_registered_flag(self, service_manager):
+        """teardown() must clear the factories-registered flag, not just the dict.
+
+        get_service() (both lfx and langflow) re-registers factories only when
+        are_factories_registered() returns False. teardown() empties
+        self.factories, so if it leaves the flag set, every later lookup skips
+        re-registration and raises NoFactoryRegisteredError. That surfaced as
+        flow-execution 500s once Graph.arun routed through the executor service
+        and a sibling test had torn the global manager down.
+        """
+        service_manager.register_service_class(ServiceType.STORAGE_SERVICE, LocalStorageService)
+        service_manager.get(ServiceType.STORAGE_SERVICE)
+        service_manager.set_factory_registered()
+        assert service_manager.are_factories_registered() is True
+
+        await service_manager.teardown()
+
+        assert service_manager.factories == {}
+        assert service_manager.are_factories_registered() is False
+
 
 class TestConfigDirectorySource:
     """Tests for config_dir parameter with real services."""


### PR DESCRIPTION
## Summary

Stacks on #12981. Adds the first external executor implementation for the new seam: a Stepflow-backed executor for Langflow flows.

This PR proves that the executor seam can host a real non-in-process backend, but it remains an MVP.

## What changed

- Adds `src/langflow-stepflow/`, ported from #12015:
  - Langflow-to-Stepflow translator
  - Stepflow worker components
  - execution helpers and tests
- Adds `langflow_stepflow.executor.StepflowExecutor`, implementing `lfx.execution.Executor`.
- Registers the executor through the `lfx.executors` entry-point group.
- Adds the package as a workspace member.
- Adds unit coverage for executor shape, registration, default config, and translation.
- Adds an end-to-end local orchestrator test for a minimal passthrough flow.

## How it runs

`Coordinator` dispatches to `ExecutorRegistry.get("stepflow")`, then:

1. `StepflowExecutor` translates the Langflow graph to a Stepflow flow.
2. The translated flow is stored through `StepflowClient`.
3. A Stepflow run is submitted.
4. Status events are streamed back as `StepResult` payloads.
5. A terminal `RunComplete` is yielded when the Stepflow run completes.

The default local config wires:

- `/builtin` to the built-in Stepflow plugin
- `/langflow` to a Python gRPC worker launched as `python -m langflow_stepflow.worker`

The worker command is injectable so production deployments can use a managed worker pool instead of the default local command.

## Scope boundary

This is a Stepflow executor MVP only. Broader follow-up concerns belong in later PRs after the executor seam and Stepflow backend are reviewable on their own.

## Verification

- Translator works on real Langflow starter projects.
- Local-mode E2E passthrough run reaches `SUCCEEDED`.
- Unit tests cover:
  - executor ABC conformance
  - registry/coordinator routing
  - default Stepflow config shape
  - translation smoke coverage

## Still draft because

- Depends on #12981.
- The integration path needs broader validation beyond the minimal passthrough run.
- Remote `STEPFLOW_ENDPOINT` behavior is wired but not fully exercised.
- Error handling and cleanup around worker/orchestrator failures still need hardening.

## Follow-ups

- Capability-routing work should stack after this as a focused contract layer.
