### PR TITLE
fix: strip 'code' field from custom component build params

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3759,7 +3759,7 @@
         "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
         "hashed_secret": "65882b5e8dbab0e649474b2a626c1d24e1b317f5",
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 43,
         "is_secret": false
       },
       {
@@ -3767,7 +3767,7 @@
         "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
         "hashed_secret": "6af5a378fdb0e7d397c9f47c744e5e14195c0228",
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 52,
         "is_secret": false
       },
       {
@@ -3775,7 +3775,7 @@
         "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
         "hashed_secret": "425697fa9692ea5035739863d2481dbfcddfa31f",
         "is_verified": false,
-        "line_number": 77,
+        "line_number": 101,
         "is_secret": false
       },
       {
@@ -3783,7 +3783,7 @@
         "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
         "hashed_secret": "720e215bd26587c3f3c482b63f7fd9d6a384b076",
         "is_verified": false,
-        "line_number": 96,
+        "line_number": 120,
         "is_secret": false
       },
       {
@@ -3791,7 +3791,7 @@
         "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
         "hashed_secret": "b671351c066092d76821f7f13ed7356e16db335e",
         "is_verified": false,
-        "line_number": 118,
+        "line_number": 142,
         "is_secret": false
       },
       {
@@ -3799,7 +3799,7 @@
         "filename": "src/backend/tests/unit/interface/initialize/test_loading.py",
         "hashed_secret": "8aca50283f32858dc0592c0855803fc70abda920",
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 165,
         "is_secret": false
       }
     ],
@@ -8425,5 +8425,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T12:22:58Z"
+  "generated_at": "2026-05-11T15:42:32Z"
 }

--- a/src/backend/base/langflow/interface/initialize/loading.py
+++ b/src/backend/base/langflow/interface/initialize/loading.py
@@ -36,8 +36,8 @@ def instantiate_class(
         msg = "No base type provided for vertex"
         raise ValueError(msg)
 
+    code = vertex.params.get("code")
     custom_params = get_params(vertex.params)
-    code = custom_params.pop("code")
     class_object: type[CustomComponent | Component] = eval_custom_component_code(code)
     custom_component: CustomComponent | Component = class_object(
         _user_id=user_id,
@@ -79,7 +79,9 @@ def get_params(vertex_params):
     params = vertex_params
     params = convert_params_to_sets(params)
     params = convert_kwargs(params)
-    return params.copy()
+    params = params.copy()
+    params.pop("code", None)
+    return params
 
 
 def convert_params_to_sets(params):

--- a/src/backend/tests/unit/interface/initialize/test_loading.py
+++ b/src/backend/tests/unit/interface/initialize/test_loading.py
@@ -3,9 +3,33 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from lfx.interface.initialize.loading import (
+    get_params,
     update_params_with_load_from_db_fields,
     update_table_params_with_load_from_db_fields,
 )
+
+
+def test_get_params_strips_code_field():
+    """Regression: get_params must drop the synthetic 'code' field.
+
+    The 'code' template field stores the component source for class evaluation
+    and is not a build/runtime parameter. If it leaks through, legacy
+    CustomComponent.build(...) signatures fail with
+    'got an unexpected keyword argument 'code''.
+    """
+    vertex_params = {"code": "class Foo: ...", "api_key": "x", "user_request": "hi"}
+    result = get_params(vertex_params)
+    assert "code" not in result
+    assert result["api_key"] == "x"
+    assert result["user_request"] == "hi"
+    # Input dict must not be mutated.
+    assert "code" in vertex_params
+
+
+def test_get_params_without_code_field_is_unchanged():
+    vertex_params = {"api_key": "x"}
+    result = get_params(vertex_params)
+    assert result == {"api_key": "x"}
 
 
 @pytest.mark.asyncio

--- a/src/lfx/src/lfx/interface/initialize/loading.py
+++ b/src/lfx/src/lfx/interface/initialize/loading.py
@@ -39,8 +39,8 @@ def instantiate_class(
         msg = "No base type provided for vertex"
         raise ValueError(msg)
 
+    code = vertex.params.get("code")
     custom_params = get_params(vertex.params)
-    code = custom_params.pop("code")
     class_object: type[CustomComponent | Component] = eval_custom_component_code(code)
     custom_component: CustomComponent | Component = class_object(
         _user_id=user_id,
@@ -82,7 +82,9 @@ def get_params(vertex_params):
     params = vertex_params
     params = convert_params_to_sets(params)
     params = convert_kwargs(params)
-    return params.copy()
+    params = params.copy()
+    params.pop("code", None)
+    return params
 
 
 def convert_params_to_sets(params):


### PR DESCRIPTION
## Summary

Fixes `TypeError: <Component>.build() got an unexpected keyword argument 'code'` for legacy `CustomComponent` subclasses (e.g. a custom `MiddlewareComponent` / `PolicyCheck` component).

### Root cause

When a graph is loaded, [`Graph._instantiate_components_in_vertices()`](https://github.com/langflow-ai/langflow/blob/release-1.10.0/src/lfx/src/lfx/graph/graph/base.py#L1386) pre-instantiates every vertex's component and stores it on `vertex.custom_component`. Later, when [`Vertex._build()`](https://github.com/langflow-ai/langflow/blob/release-1.10.0/src/lfx/src/lfx/graph/vertex/base.py#L388) runs, `self.custom_component` is truthy, so it takes the else branch:

```python
custom_params = initialize.loading.get_params(self.params)
```

`get_params()` never stripped the synthetic `code` template field — only `instantiate_class()` did, via a local `custom_params.pop("code")`. So in the reused-component path, `code` leaked through to `build_custom_component()`, which calls `custom_component.build(**params)`.

For legacy `CustomComponent` subclasses with an explicit signature like:

```python
def build(self, api_key, middleware_url, user_request):
    ...
```

Python raised `TypeError: MiddlewareComponent.build() got an unexpected keyword argument 'code'`. Modern `Component` subclasses (which use output methods, not `build`) were unaffected, which is why this slipped through.

### Fix

- `get_params()` now drops `"code"` from the returned copy (single point of truth).
- `instantiate_class()` reads `code` from `vertex.params` directly *before* calling `get_params()` so class evaluation still works.
- Applied symmetrically to both copies: `src/lfx/.../loading.py` and `src/backend/base/langflow/.../loading.py`.

## Test plan

- [x] New unit tests: `test_get_params_strips_code_field`, `test_get_params_without_code_field_is_unchanged` in `src/backend/tests/unit/interface/initialize/test_loading.py`.
- [x] Full `test_loading.py` suite passes (17/17).
- [ ] Manual repro: build a legacy `CustomComponent` with `def build(self, api_key, middleware_url, user_request)`, wire to a Text Input, and run — should no longer raise.
- [ ] CI green on this branch.

## Notes

This PR does **not** address the separate "Message → str" connection-compatibility complaint from the original bug report; that's a frontend type-system issue with a different root cause and should be triaged separately.