### PR TITLE
test(e2e): re-add Vector Store RAG integration tests for KnowledgeBase template

### DIFF
--- a/src/frontend/tests/core/integrations/Vector Store.spec.ts
+++ b/src/frontend/tests/core/integrations/Vector Store.spec.ts
@@ -4,6 +4,7 @@ import { initialGPTsetup } from "../../utils/initialGPTsetup";
 import { uploadFile } from "../../utils/upload-file";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
+// biome-ignore lint/suspicious/noExplicitAny: process not in tsconfig scope for test files
 declare const process: any;
 
 withEventDeliveryModes(

--- a/src/frontend/tests/core/integrations/Vector Store.spec.ts
+++ b/src/frontend/tests/core/integrations/Vector Store.spec.ts
@@ -29,9 +29,9 @@ withEventDeliveryModes(
     await initialGPTsetup(page);
 
     // Confirm the template uses native Knowledge components (no AstraDB)
-    await expect(
-      page.getByTestId("title-Knowledge Ingestion"),
-    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId("title-Knowledge Ingestion")).toBeVisible({
+      timeout: 10000,
+    });
     await expect(page.getByTestId("title-Knowledge Base")).toBeVisible();
     await expect(page.getByTestId("title-Astra DB")).toHaveCount(0);
 
@@ -82,14 +82,10 @@ withEventDeliveryModes(
     });
 
     // Refresh the KB list so the newly ingested KB appears
-    await knowledgeBaseNode
-      .getByTestId("dropdown_str_knowledge_base")
-      .click();
+    await knowledgeBaseNode.getByTestId("dropdown_str_knowledge_base").click();
     await page.getByTestId("refresh-dropdown-list-knowledge_base").click();
     await page.waitForTimeout(1000);
-    await knowledgeBaseNode
-      .getByTestId("dropdown_str_knowledge_base")
-      .click();
+    await knowledgeBaseNode.getByTestId("dropdown_str_knowledge_base").click();
     await page.getByTestId("test-kb-rag-0-option").click();
 
     // Run the full RAG pipeline
@@ -115,9 +111,7 @@ withEventDeliveryModes(
     await page.waitForSelector("text=this is a test file", {
       timeout: 120000,
     });
-    await expect(
-      page.getByText("this is a test file").last(),
-    ).toBeVisible();
+    await expect(page.getByText("this is a test file").last()).toBeVisible();
   },
   { timeout: 120000 },
 );

--- a/src/frontend/tests/core/integrations/Vector Store.spec.ts
+++ b/src/frontend/tests/core/integrations/Vector Store.spec.ts
@@ -1,14 +1,11 @@
-import path from "path";
 import { expect, test } from "../../fixtures";
-import { adjustScreenView } from "../../utils/adjust-screen-view";
 import { awaitBootstrapTest } from "../../utils/await-bootstrap-test";
 import { initialGPTsetup } from "../../utils/initialGPTsetup";
-import { disableInspectPanel } from "../../utils/open-advanced-options";
+import { uploadFile } from "../../utils/upload-file";
 import { withEventDeliveryModes } from "../../utils/withEventDeliveryModes";
 
-// Add this line to declare Node.js global variables
 declare const process: any;
-declare const __dirname: string;
+
 withEventDeliveryModes(
   "Vector Store RAG",
   { tag: ["@release", "@starter-projects"] },
@@ -16,18 +13,6 @@ withEventDeliveryModes(
     test.skip(
       !process?.env?.OPENAI_API_KEY,
       "OPENAI_API_KEY required to run this test",
-    );
-
-    test.skip(
-      !process?.env?.ASTRA_DB_APPLICATION_TOKEN,
-      "ASTRA_DB_APPLICATION_TOKEN required to run this test",
-    );
-
-    // AstraDB Cassandra driver causes infinite retry loops on Windows
-    // (system_virtual_schema permission errors) leading to shard timeouts
-    test.skip(
-      process.platform === "win32",
-      "AstraDB driver is not compatible with Windows CI",
     );
 
     await awaitBootstrapTest(page);
@@ -43,254 +28,96 @@ withEventDeliveryModes(
 
     await initialGPTsetup(page);
 
-    await disableInspectPanel(page);
+    // Confirm the template uses native Knowledge components (no AstraDB)
+    await expect(
+      page.getByTestId("title-Knowledge Ingestion"),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId("title-Knowledge Base")).toBeVisible();
+    await expect(page.getByTestId("title-Astra DB")).toHaveCount(0);
 
-    await page.waitForSelector('[data-testid="title-Astra DB"]', {
-      timeout: 3000,
+    // Upload a test file to the File component
+    await uploadFile(page, "test_file.txt");
+
+    // --- Load Data flow: create a knowledge base and ingest the file ---
+
+    // Scope to the KnowledgeIngestion node to avoid ambiguity with the
+    // KnowledgeBase node, which shares the same dropdown testid.
+    const knowledgeIngestionNode = page.locator(".react-flow__node", {
+      has: page.getByTestId("title-Knowledge Ingestion"),
     });
 
-    await page.waitForTimeout(500);
+    await knowledgeIngestionNode
+      .getByTestId("dropdown_str_knowledge_base")
+      .click();
 
-    adjustScreenView(page);
+    // Click "Create new knowledge" to open the creation dialog
+    await page.getByText("Create new knowledge").click();
 
-    // Astra DB tokens
+    // Fill in the knowledge base name
     await page
-      .getByTestId("popover-anchor-input-token")
-      .nth(0)
-      .fill(process.env.ASTRA_DB_APPLICATION_TOKEN ?? "");
+      .getByTestId("popover-anchor-input-01_new_kb_name")
+      .fill("test-kb-rag");
 
-    await page
-      .locator('[data-testid="dropdown_str_database_name"]')
-      .nth(0)
-      .waitFor({
-        timeout: 15000,
-        state: "visible",
-      });
+    // Choose the first available embedding model (requires OpenAI key set via
+    // initialGPTsetup → selectGptModel → manage-model-providers)
+    await page.getByTestId("model_embedding_model").click();
+    await page.waitForSelector('[role="listbox"]', { timeout: 10000 });
+    await page.getByRole("listbox").getByRole("option").first().click();
 
-    let databaseDropdownCount = await page
-      .locator('[data-testid="dropdown_str_database_name"]')
-      .nth(0)
-      .count();
+    // Submit the dialog — button text comes from functionality: "create"
+    await page.getByRole("button", { name: "create", exact: true }).click();
 
-    while (databaseDropdownCount === 0) {
-      await page
-        .getByTestId("popover-anchor-input-token")
-        .nth(0)
-        .fill(process.env.ASTRA_DB_APPLICATION_TOKEN ?? "");
+    await page.waitForSelector("text=created successfully", { timeout: 30000 });
 
-      await page.waitForTimeout(2000);
-
-      await page
-        .locator('[data-testid="dropdown_str_database_name"]')
-        .nth(0)
-        .waitFor({
-          timeout: 15000,
-          state: "visible",
-        });
-
-      databaseDropdownCount = await page
-        .locator('[data-testid="dropdown_str_database_name"]')
-        .nth(0)
-        .count();
-    }
-
-    await page.waitForTimeout(2000);
-
-    await page.getByTestId("dropdown_str_database_name").nth(0).click();
-
-    await page.waitForTimeout(2000);
-
-    let langflowCount = await page
-      .locator('[data-testid="langflow-0-option"]')
-      .count();
-
-    while (langflowCount === 0) {
-      await page.waitForTimeout(1000);
-      await page.getByTestId("icon-RefreshCcw").click();
-
-      await page.getByTestId("dropdown_str_database_name").nth(0).click();
-
-      await page.waitForTimeout(1000);
-
-      langflowCount = await page
-        .locator('[data-testid="langflow-0-option"]')
-        .count();
-    }
-
-    await page.locator('[data-testid="langflow-0-option"]').nth(0).waitFor({
-      timeout: 15000,
-      state: "visible",
-    });
-
-    await page.getByTestId("langflow-0-option").nth(0).click();
-
-    await page
-      .locator('[data-testid="dropdown_str_collection_name"]')
-      .nth(0)
-      .waitFor({
-        timeout: 15000,
-        state: "visible",
-      });
-
-    await page.waitForTimeout(2000);
-
-    await page.getByTestId("dropdown_str_collection_name").nth(0).click();
-
-    await page.locator('[data-testid="fe_tests-0-option"]').nth(0).waitFor({
-      timeout: 15000,
-      state: "visible",
-    });
-
-    await page.getByTestId("fe_tests-0-option").nth(0).click();
-
-    await page
-      .getByTestId("popover-anchor-input-token")
-      .nth(1)
-      .fill(process.env.ASTRA_DB_APPLICATION_TOKEN ?? "");
-
-    await page
-      .locator('[data-testid="dropdown_str_database_name"]')
-      .nth(1)
-      .waitFor({
-        timeout: 15000,
-        state: "visible",
-      });
-
-    databaseDropdownCount = await page
-      .locator('[data-testid="dropdown_str_database_name"]')
-      .nth(0)
-      .count();
-
-    while (databaseDropdownCount === 0) {
-      await page
-        .getByTestId("popover-anchor-input-token")
-        .nth(0)
-        .fill(process.env.ASTRA_DB_APPLICATION_TOKEN ?? "");
-
-      await page.waitForTimeout(2000);
-
-      await page
-        .locator('[data-testid="dropdown_str_database_name"]')
-        .nth(1)
-        .waitFor({
-          timeout: 15000,
-          state: "visible",
-        });
-
-      databaseDropdownCount = await page
-        .locator('[data-testid="dropdown_str_database_name"]')
-        .nth(0)
-        .count();
-    }
-
-    await page.getByTestId("dropdown_str_database_name").nth(1).click();
-
-    await page.waitForTimeout(2000);
-
-    langflowCount = await page
-      .locator('[data-testid="langflow-0-option"]')
-      .count();
-
-    while (langflowCount === 0) {
-      await page.waitForTimeout(1000);
-      await page.getByTestId("icon-RefreshCcw").click();
-
-      const loadingOptions = page.getByText("Loading options...");
-      await loadingOptions.waitFor({ state: "visible", timeout: 30000 });
-
-      if (await loadingOptions.isVisible()) {
-        await expect(loadingOptions).toBeHidden({ timeout: 120000 });
-      }
-
-      await page.getByTestId("dropdown_str_database_name").nth(1).click();
-
-      await page.waitForTimeout(1000);
-
-      langflowCount = await page
-        .locator('[data-testid="langflow-0-option"]')
-        .count();
-    }
-
-    await page.getByTestId("langflow-0-option").nth(0).click();
-
-    await page.waitForTimeout(2000);
-
-    await page
-      .locator('[data-testid="dropdown_str_collection_name"]')
-      .nth(1)
-      .waitFor({
-        timeout: 15000 * 3,
-        state: "visible",
-      });
-
-    await page.getByTestId("dropdown_str_collection_name").nth(1).click();
-
-    await page.waitForTimeout(2000);
-
-    await page.locator('[data-testid="fe_tests-0-option"]').nth(0).waitFor({
-      timeout: 15000,
-      state: "visible",
-    });
-
-    await page.getByTestId("fe_tests-0-option").nth(0).click();
-
-    await page.getByTestId("input-file-component").last().click();
-    const fileChooserPromise = page.waitForEvent("filechooser");
-    await page.getByTestId("drag-files-component").last().click();
-
-    const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles(
-      path.join(__dirname, "../../assets/test_file.txt"),
-    );
-    await page.getByText("test_file.txt").last().isVisible();
-    await page.waitForSelector("text=file uploaded successfully", {
-      timeout: 10000,
-    });
-    await page.waitForTimeout(3000);
-    await page.getByTestId("select-files-modal-button").click();
-    await page.getByTestId("button_run_astra db").last().click();
+    // Run KnowledgeIngestion to ingest the uploaded file into the new KB
+    await page.getByTestId("button_run_knowledge ingestion").click();
     await page.waitForSelector("text=built successfully", {
-      timeout: 60000 * 2,
+      timeout: 120000,
     });
 
+    // --- Retriever flow: select the KB and run the RAG pipeline ---
+
+    const knowledgeBaseNode = page.locator(".react-flow__node", {
+      has: page.getByTestId("title-Knowledge Base"),
+    });
+
+    // Refresh the KB list so the newly ingested KB appears
+    await knowledgeBaseNode
+      .getByTestId("dropdown_str_knowledge_base")
+      .click();
+    await page.getByTestId("refresh-dropdown-list-knowledge_base").click();
+    await page.waitForTimeout(1000);
+    await knowledgeBaseNode
+      .getByTestId("dropdown_str_knowledge_base")
+      .click();
+    await page.getByTestId("test-kb-rag-0-option").click();
+
+    // Run the full RAG pipeline
     await page.getByTestId("button_run_chat output").click();
     await page.waitForSelector("text=built successfully", {
-      timeout: 60000 * 2,
+      timeout: 120000,
     });
+
+    // --- Playground: verify context-aware retrieval ---
 
     await page.getByRole("button", { name: "Playground", exact: true }).click();
     await page.waitForSelector('[data-testid="input-chat-playground"]', {
       timeout: 60000,
     });
-    await page.getByTestId("input-chat-playground").last().fill("hello");
-    await page.getByTestId("input-chat-playground").last().click();
+
+    await page
+      .getByTestId("input-chat-playground")
+      .last()
+      .fill("what is the text in the file?");
     await page.keyboard.press("Enter");
 
-    await page
-      .getByText("This is a test file.", { exact: true })
-      .last()
-      .isVisible();
-    await page.getByTestId("chat-header-more-menu").last().click();
-    await page.getByLabel("Message logs").click();
-    await page.getByText("timestamp", { exact: true }).last().isVisible();
-    await page.getByText("text", { exact: true }).last().isVisible();
-    await page.getByText("sender", { exact: true }).last().isVisible();
-    await page.getByText("sender_name", { exact: true }).last().isVisible();
-    await page.getByText("session_id", { exact: true }).last().isVisible();
-    await page.getByText("files", { exact: true }).last().isVisible();
-    await page.getByRole("gridcell").last().isVisible();
-    await page.getByRole("checkbox").first().click();
-    await page.getByTestId("delete-row-button").last().click();
-    await page
-      .getByText("No Data Available", { exact: true })
-      .last()
-      .isVisible();
-    await page.getByText("Close").last().click();
-
-    await page.waitForSelector('[data-testid="input-chat-playground"]', {
-      timeout: 60000,
+    // The test file contains "this is a test file" — verify retrieval works
+    await page.waitForSelector("text=this is a test file", {
+      timeout: 120000,
     });
-    await page.getByTestId("input-chat-playground").last().isVisible();
+    await expect(
+      page.getByText("this is a test file").last(),
+    ).toBeVisible();
   },
-  { timeout: 60000 },
+  { timeout: 120000 },
 );

--- a/src/frontend/tests/core/integrations/vector-store-conections.ts
+++ b/src/frontend/tests/core/integrations/vector-store-conections.ts
@@ -19,6 +19,7 @@ test(
 
     // Find the Vector Store RAG starter project — it now uses native
     // KnowledgeIngestion / KnowledgeBase components instead of AstraDB.
+    // biome-ignore lint/suspicious/noExplicitAny: untyped API response
     const vectorStoreProject = responseBody.find((project: any) => {
       return project.name === "Vector Store RAG";
     });
@@ -27,6 +28,7 @@ test(
 
     // Verify the template uses the native Knowledge components
     const nodeTypes: string[] = (vectorStoreProject?.data?.nodes ?? []).map(
+      // biome-ignore lint/suspicious/noExplicitAny: untyped API response
       (node: any) => node.data?.type as string,
     );
 

--- a/src/frontend/tests/core/integrations/vector-store-conections.ts
+++ b/src/frontend/tests/core/integrations/vector-store-conections.ts
@@ -26,9 +26,9 @@ test(
     expect(vectorStoreProject).toBeDefined();
 
     // Verify the template uses the native Knowledge components
-    const nodeTypes: string[] = (
-      vectorStoreProject?.data?.nodes ?? []
-    ).map((node: any) => node.data?.type as string);
+    const nodeTypes: string[] = (vectorStoreProject?.data?.nodes ?? []).map(
+      (node: any) => node.data?.type as string,
+    );
 
     expect(nodeTypes).toContain("KnowledgeIngestion");
     expect(nodeTypes).toContain("KnowledgeBase");

--- a/src/frontend/tests/core/integrations/vector-store-conections.ts
+++ b/src/frontend/tests/core/integrations/vector-store-conections.ts
@@ -7,7 +7,6 @@ test(
   "vector store from starter projects should have its connections and nodes on the flow",
   { tag: ["@release", "@starter-projects", "@mainpage"] },
   async ({ page, request }) => {
-    // Get authentication token
     const authToken = await getAuthToken(request);
 
     const response = await request.get("/api/v1/starter-projects", {
@@ -18,51 +17,22 @@ test(
     expect(response.status()).toBe(200);
     const responseBody = await response.json();
 
-    const astraStarterProject = responseBody.find((project: any) => {
-      if (project.data.nodes) {
-        return project.data.nodes.some((node: any) =>
-          node.id.includes("Astra"),
-        );
-      }
+    // Find the Vector Store RAG starter project — it now uses native
+    // KnowledgeIngestion / KnowledgeBase components instead of AstraDB.
+    const vectorStoreProject = responseBody.find((project: any) => {
+      return project.name === "Vector Store RAG";
     });
 
-    await page.route("**/api/v1/flows/", async (route) => {
-      if (route.request().method() === "GET") {
-        try {
-          // Add authorization header to the request
-          const headers = route.request().headers();
-          headers["Authorization"] = `Bearer ${authToken}`;
+    expect(vectorStoreProject).toBeDefined();
 
-          const response = await route.fetch({
-            headers: headers,
-          });
-          const flowsData = await response.json();
+    // Verify the template uses the native Knowledge components
+    const nodeTypes: string[] = (
+      vectorStoreProject?.data?.nodes ?? []
+    ).map((node: any) => node.data?.type as string);
 
-          const modifiedFlows = flowsData.map((flow: any) => {
-            if (flow.name === "Vector Store RAG" && flow.user_id === null) {
-              return {
-                ...flow,
-                data: astraStarterProject?.data,
-              };
-            }
-            return flow;
-          });
-
-          const modifiedResponse = JSON.stringify(modifiedFlows);
-
-          route.fulfill({
-            status: response.status(),
-            headers: response.headers(),
-            body: modifiedResponse,
-          });
-        } catch (error) {
-          console.error("Error in route handler:", error);
-        }
-      } else {
-        // If not a GET request, continue without modifying
-        await route.continue();
-      }
-    });
+    expect(nodeTypes).toContain("KnowledgeIngestion");
+    expect(nodeTypes).toContain("KnowledgeBase");
+    expect(nodeTypes).not.toContain("AstraDBVectorStore");
 
     await awaitBootstrapTest(page);
 
@@ -71,15 +41,21 @@ test(
       .getByRole("heading", { name: "Vector Store RAG" })
       .first()
       .click();
+    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+      timeout: 100000,
+    });
 
     await adjustScreenView(page);
 
     const edges = await page.locator(".react-flow__edge-interaction").count();
     const nodes = await page.getByTestId("div-generic-node").count();
 
-    const edgesFromServer = astraStarterProject?.data.edges.length;
-    const nodesFromServer = astraStarterProject?.data.nodes.length;
+    const edgesFromServer: number =
+      vectorStoreProject?.data?.edges?.length ?? 0;
+    const nodesFromServer: number =
+      vectorStoreProject?.data?.nodes?.length ?? 0;
 
+    // Allow ±2 edge variance to account for animated/virtual edges
     expect(
       edges === edgesFromServer ||
         edges === edgesFromServer - 1 ||


### PR DESCRIPTION
## Summary

Follow-up to #12629 as requested in #13062 — re-adds the e2e Playwright tests for the Vector Store RAG starter template after it was updated to use native `KnowledgeIngestion` and `KnowledgeBase` components instead of AstraDB.

- **`Vector Store.spec.ts`** — full e2e integration test: uploads a file, creates a knowledge base via the `KnowledgeIngestion` dialog, runs ingestion, selects the KB in the `KnowledgeBase` retrieval component, and verifies the Playground returns context-aware answers. Only requires `OPENAI_API_KEY` (no more `ASTRA_DB_APPLICATION_TOKEN`).
- **`vector-store-conections.ts`** — structural test: looks up the template by name (not by AstraDB node presence), asserts `KnowledgeIngestion` and `KnowledgeBase` nodes are present and `AstraDBVectorStore` is absent, then checks edge/node counts against the server-side template.

## Test plan

- [ ] CI passes with `OPENAI_API_KEY` set
- [ ] `Vector Store RAG - streaming/polling/direct` tests build successfully and the Playground returns "this is a test file"
- [ ] Connections test confirms template has `KnowledgeIngestion` + `KnowledgeBase`, no AstraDB node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored Vector Store RAG integration tests to validate native Knowledge component functionality
  * Enhanced test coverage to confirm the RAG pipeline executes successfully and returns expected results from uploaded knowledge bases

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13076)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->