### PR TITLE
fix(ui): inject hidden DialogTitle in dialog-with-no-close for a11y

### DIFF
--- a/src/frontend/src/components/ui/dialog-with-no-close.tsx
+++ b/src/frontend/src/components/ui/dialog-with-no-close.tsx
@@ -26,24 +26,58 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+const VisuallyHidden = React.forwardRef<
+  HTMLSpanElement,
+  React.HTMLAttributes<HTMLSpanElement>
+>(({ children, ...props }, ref) => (
+  <span
+    ref={ref}
+    className="absolute h-px w-px overflow-hidden whitespace-nowrap border-0 p-0"
+    style={{ clip: "rect(0 0 0 0)", clipPath: "inset(50%)" }}
+    {...props}
+  >
+    {children}
+  </span>
+));
+VisuallyHidden.displayName = "VisuallyHidden";
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-3 rounded-xl border bg-background p-3 shadow-lg duration-200 data-[state=closed]:animate-contentHide data-[state=open]:animate-contentShow",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
+>(({ className, children, ...props }, ref) => {
+  const hasDialogTitle = React.Children.toArray(children).some(
+    (child) => React.isValidElement(child) && child.type === DialogTitle,
+  );
+  const hasDialogDescription = React.Children.toArray(children).some(
+    (child) => React.isValidElement(child) && child.type === DialogDescription,
+  );
+
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-3 rounded-xl border bg-background p-3 shadow-lg duration-200 data-[state=closed]:animate-contentHide data-[state=open]:animate-contentShow",
+          className,
+        )}
+        {...props}
+      >
+        {!hasDialogTitle && (
+          <VisuallyHidden>
+            <DialogTitle>Dialog</DialogTitle>
+          </VisuallyHidden>
+        )}
+        {!hasDialogDescription && (
+          <VisuallyHidden>
+            <DialogDescription />
+          </VisuallyHidden>
+        )}
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+});
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({


### PR DESCRIPTION
## Summary
- Mirrors the auto-injection pattern from `dialog.tsx` into `dialog-with-no-close.tsx`. When a caller (e.g. the node list-selection dialog) renders `DialogContent` without an explicit `DialogTitle`, a visually-hidden one is injected so Radix no longer logs the "DialogContent requires a DialogTitle" console warning.
- `DialogDescription` gets the same treatment for parity with `dialog.tsx`.
- Behavior for existing callers that already provide a title/description is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog component to ensure proper accessibility markup is automatically included when needed, maintaining proper semantic structure without affecting visual presentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13078)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->