### PR TITLE
fix: restore Langfuse feedback trace linking

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3974,7 +3974,7 @@
         "filename": "src/backend/tests/unit/test_messages_endpoints.py",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 58
+        "line_number": 59
       }
     ],
     "src/backend/tests/unit/test_setup_superuser.py": [
@@ -8425,5 +8425,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T12:22:58Z"
+  "generated_at": "2026-05-12T16:46:16Z"
 }

--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlmodel import apaginate
 from sqlmodel import col, delete, select
@@ -27,8 +27,25 @@ from langflow.services.database.models.vertex_builds.crud import (
 )
 from langflow.services.database.models.vertex_builds.model import VertexBuildMapModel
 from langflow.services.deps import get_memory_base_service
+from langflow.services.tracing.langfuse import normalize_langfuse_trace_id, sync_feedback_score
 
 router = APIRouter(prefix="/monitor", tags=["Monitor"])
+
+
+def _get_positive_feedback_value(db_message: MessageTable) -> bool | None:
+    properties = db_message.properties
+    if hasattr(properties, "positive_feedback"):
+        return properties.positive_feedback
+    if isinstance(properties, dict):
+        return properties.get("positive_feedback")
+    return None
+
+
+def _resolve_langfuse_trace_id(db_message: MessageTable) -> str | None:
+    session_metadata = db_message.session_metadata or {}
+    if isinstance(session_metadata, dict):
+        return normalize_langfuse_trace_id(session_metadata.get("langfuse_trace_id"))
+    return None
 
 
 async def _purge_memory_base_session_data(user_id: UUID, session_ids: list[str]) -> None:
@@ -166,6 +183,7 @@ async def update_message(
     message_id: UUID,
     message: MessageUpdate,
     session: DbSession,
+    background_tasks: BackgroundTasks,
     current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     try:
@@ -181,6 +199,7 @@ async def update_message(
         raise HTTPException(status_code=404, detail="Message not found")
 
     try:
+        previous_positive_feedback = _get_positive_feedback_value(db_message)
         message_dict = message.model_dump(exclude_unset=True, exclude_none=True)
         if "text" in message_dict and message_dict["text"] != db_message.text:
             # Keep edit flag consistent for UI/audit consumers when content changes.
@@ -191,6 +210,19 @@ async def update_message(
         await session.refresh(db_message)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+    current_positive_feedback = _get_positive_feedback_value(db_message)
+    langfuse_trace_id = _resolve_langfuse_trace_id(db_message)
+    if current_positive_feedback != previous_positive_feedback and langfuse_trace_id:
+        background_tasks.add_task(
+            sync_feedback_score,
+            message_id=db_message.id,
+            trace_id=langfuse_trace_id,
+            session_id=db_message.session_id,
+            flow_id=db_message.flow_id,
+            sender=db_message.sender,
+            positive_feedback=current_positive_feedback,
+        )
     return db_message
 
 

--- a/src/backend/base/langflow/api/v1/monitor.py
+++ b/src/backend/base/langflow/api/v1/monitor.py
@@ -26,8 +26,13 @@ from langflow.services.database.models.vertex_builds.crud import (
     get_vertex_builds_by_flow_id,
 )
 from langflow.services.database.models.vertex_builds.model import VertexBuildMapModel
-from langflow.services.deps import get_memory_base_service
-from langflow.services.tracing.langfuse import normalize_langfuse_trace_id, sync_feedback_score
+from langflow.services.deps import get_memory_base_service, get_tracing_service
+from langflow.services.tracing.langfuse import (
+    delete_feedback_score,
+    langfuse_is_configured,
+    normalize_langfuse_trace_id,
+    sync_feedback_score,
+)
 
 router = APIRouter(prefix="/monitor", tags=["Monitor"])
 
@@ -46,6 +51,18 @@ def _resolve_langfuse_trace_id(db_message: MessageTable) -> str | None:
     if isinstance(session_metadata, dict):
         return normalize_langfuse_trace_id(session_metadata.get("langfuse_trace_id"))
     return None
+
+
+def _langfuse_feedback_sync_enabled() -> bool:
+    """Check both the global tracing kill switch and Langfuse credentials.
+
+    Used to gate background tasks so we don't enqueue work that would
+    silently no-op when tracing is deactivated or Langfuse is unconfigured.
+    """
+    tracing_service = get_tracing_service()
+    if tracing_service.deactivated:
+        return False
+    return langfuse_is_configured()
 
 
 async def _purge_memory_base_session_data(user_id: UUID, session_ids: list[str]) -> None:
@@ -213,16 +230,26 @@ async def update_message(
 
     current_positive_feedback = _get_positive_feedback_value(db_message)
     langfuse_trace_id = _resolve_langfuse_trace_id(db_message)
-    if current_positive_feedback != previous_positive_feedback and langfuse_trace_id:
-        background_tasks.add_task(
-            sync_feedback_score,
-            message_id=db_message.id,
-            trace_id=langfuse_trace_id,
-            session_id=db_message.session_id,
-            flow_id=db_message.flow_id,
-            sender=db_message.sender,
-            positive_feedback=current_positive_feedback,
-        )
+    if (
+        current_positive_feedback != previous_positive_feedback
+        and langfuse_trace_id
+        and _langfuse_feedback_sync_enabled()
+    ):
+        if current_positive_feedback is None:
+            background_tasks.add_task(
+                delete_feedback_score,
+                message_id=db_message.id,
+            )
+        else:
+            background_tasks.add_task(
+                sync_feedback_score,
+                message_id=db_message.id,
+                trace_id=langfuse_trace_id,
+                session_id=db_message.session_id,
+                flow_id=db_message.flow_id,
+                sender=db_message.sender,
+                positive_feedback=current_positive_feedback,
+            )
     return db_message
 
 

--- a/src/backend/base/langflow/memory.py
+++ b/src/backend/base/langflow/memory.py
@@ -117,15 +117,23 @@ async def aget_messages(
         return [await Message.create(**d.model_dump()) for d in messages]
 
 
-def add_messages(messages: Message | list[Message], flow_id: str | UUID | None = None):
+def add_messages(
+    messages: Message | list[Message],
+    flow_id: str | UUID | None = None,
+    run_id: str | UUID | None = None,
+):
     """DEPRECATED - Add a message to the monitor service.
 
     DEPRECATED: Use `aadd_messages` instead.
     """
-    return run_until_complete(aadd_messages(messages, flow_id=flow_id))
+    return run_until_complete(aadd_messages(messages, flow_id=flow_id, run_id=run_id))
 
 
-async def aadd_messages(messages: Message | list[Message], flow_id: str | UUID | None = None):
+async def aadd_messages(
+    messages: Message | list[Message],
+    flow_id: str | UUID | None = None,
+    run_id: str | UUID | None = None,
+):
     """Add a message to the monitor service."""
     if not isinstance(messages, list):
         messages = [messages]
@@ -142,7 +150,7 @@ async def aadd_messages(messages: Message | list[Message], flow_id: str | UUID |
             raise ValueError(msg)
 
     try:
-        messages_models = [MessageTable.from_message(msg, flow_id=flow_id) for msg in messages]
+        messages_models = [MessageTable.from_message(msg, flow_id=flow_id, run_id=run_id) for msg in messages]
         async with session_scope() as session:
             messages_models = await aadd_messagetables(messages_models, session)
         return [await Message.create(**message.model_dump()) for message in messages_models]
@@ -279,6 +287,7 @@ async def delete_message(id_: str) -> None:
 def store_message(
     message: Message,
     flow_id: str | UUID | None = None,
+    run_id: str | UUID | None = None,
 ) -> list[Message]:
     """DEPRECATED: Stores a message in the memory.
 
@@ -288,6 +297,7 @@ def store_message(
         message (Message): The message to store.
         flow_id (Optional[str | UUID]): The flow ID associated with the message.
             When running from the CustomComponent you can access this using `self.graph.flow_id`.
+        run_id (Optional[str | UUID]): The graph/native run ID associated with the message.
 
     Returns:
         List[Message]: A list of data containing the stored message.
@@ -295,12 +305,13 @@ def store_message(
     Raises:
         ValueError: If any of the required parameters (session_id, sender, sender_name) is not provided.
     """
-    return run_until_complete(astore_message(message, flow_id=flow_id))
+    return run_until_complete(astore_message(message, flow_id=flow_id, run_id=run_id))
 
 
 async def astore_message(
     message: Message,
     flow_id: str | UUID | None = None,
+    run_id: str | UUID | None = None,
 ) -> list[Message]:
     """Stores a message in the memory.
 
@@ -308,6 +319,7 @@ async def astore_message(
         message (Message): The message to store.
         flow_id (Optional[str]): The flow ID associated with the message.
             When running from the CustomComponent you can access this using `self.graph.flow_id`.
+        run_id (Optional[str | UUID]): The graph/native run ID associated with the message.
 
     Returns:
         List[Message]: A list of data containing the stored message.
@@ -334,7 +346,7 @@ async def astore_message(
             await logger.aerror(e)
     if flow_id and not isinstance(flow_id, UUID):
         flow_id = UUID(flow_id)
-    return await aadd_messages([message], flow_id=flow_id)
+    return await aadd_messages([message], flow_id=flow_id, run_id=run_id)
 
 
 class LCBuiltinChatMemory(BaseChatMessageHistory):

--- a/src/backend/base/langflow/services/database/models/message/model.py
+++ b/src/backend/base/langflow/services/database/models/message/model.py
@@ -99,6 +99,8 @@ class MessageBase(SQLModel):
 
         if not flow_id and message.flow_id:
             flow_id = message.flow_id
+        if not run_id and getattr(message, "run_id", None):
+            run_id = message.run_id
 
         message_text = "" if not isinstance(message.text, str) else message.text
 

--- a/src/backend/base/langflow/services/tracing/langfuse.py
+++ b/src/backend/base/langflow/services/tracing/langfuse.py
@@ -42,6 +42,30 @@ def feedback_score_id(message_id: UUID | str) -> str:
     return str(message_id).replace("-", "")
 
 
+def langfuse_is_configured() -> bool:
+    """Whether Langfuse credentials are set in the environment."""
+    return bool(LangFuseTracer._get_config())
+
+
+def _get_langfuse_client():
+    """Return a configured Langfuse client.
+
+    Callers must gate on `langfuse_is_configured()` being truthy; this raises
+    rather than silently no-opping so background-task failures don't
+    disappear into the void.
+    """
+    from langfuse import Langfuse
+
+    config = LangFuseTracer._get_config()
+    if not config:
+        msg = (
+            "Langfuse credentials missing — set LANGFUSE_SECRET_KEY, LANGFUSE_PUBLIC_KEY, "
+            "and LANGFUSE_HOST (or LANGFUSE_BASE_URL)."
+        )
+        raise RuntimeError(msg)
+    return Langfuse(**config)
+
+
 def sync_feedback_score(
     *,
     message_id: UUID | str,
@@ -49,47 +73,46 @@ def sync_feedback_score(
     session_id: str,
     flow_id: UUID | str | None,
     sender: str,
-    positive_feedback: bool | None,
+    positive_feedback: bool,
 ) -> None:
-    """Send message feedback to Langfuse as a trace-linked score."""
+    """Send message feedback to Langfuse as a trace-linked score.
+
+    Callers must gate this on tracing being enabled and Langfuse being
+    configured; this function raises rather than silently no-opping so
+    background-task failures surface in logs.
+    """
     normalized_trace_id = normalize_langfuse_trace_id(trace_id)
-    if not normalized_trace_id or positive_feedback is None:
-        return
+    if not normalized_trace_id:
+        msg = f"Cannot sync feedback score without a Langfuse trace id (message_id={message_id})."
+        raise ValueError(msg)
 
-    try:
-        from langfuse import Langfuse
-    except ImportError:
-        return
+    client = _get_langfuse_client()
+    client.create_score(
+        name=LANGFUSE_FEEDBACK_SCORE_NAME,
+        value=1.0 if positive_feedback else 0.0,
+        trace_id=normalized_trace_id,
+        score_id=feedback_score_id(message_id),
+        data_type="BOOLEAN",
+        comment="positive" if positive_feedback else "negative",
+        metadata={
+            "message_id": str(message_id),
+            "session_id": session_id,
+            "flow_id": str(flow_id) if flow_id else None,
+            "sender": sender,
+        },
+    )
+    client.flush()
 
-    config = LangFuseTracer._get_config()
-    if not config:
-        return
 
-    try:
-        client = Langfuse(**config)
-        client.create_score(
-            name=LANGFUSE_FEEDBACK_SCORE_NAME,
-            value=1.0 if positive_feedback else 0.0,
-            trace_id=normalized_trace_id,
-            score_id=feedback_score_id(message_id),
-            data_type="BOOLEAN",
-            comment="positive" if positive_feedback else "negative",
-            metadata={
-                "message_id": str(message_id),
-                "session_id": session_id,
-                "flow_id": str(flow_id) if flow_id else None,
-                "sender": sender,
-            },
-        )
-        client.flush()
-    except Exception as exc:  # noqa: BLE001
-        logger.error(
-            "Langfuse feedback sync failed for message_id=%s flow_id=%s session_id=%s: %s",
-            message_id,
-            flow_id,
-            session_id,
-            exc,
-        )
+def delete_feedback_score(*, message_id: UUID | str) -> None:
+    """Delete the Langfuse feedback score previously synced for a message.
+
+    Used when a user clears their thumbs up/down so Langfuse stays in sync
+    with Langflow's UI state. Callers must gate on tracing being enabled
+    and Langfuse being configured.
+    """
+    client = _get_langfuse_client()
+    client.api.score.delete(score_id=feedback_score_id(message_id))
 
 
 class LangFuseTracer(BaseTracer):

--- a/src/backend/base/langflow/services/tracing/langfuse.py
+++ b/src/backend/base/langflow/services/tracing/langfuse.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 from lfx.log.logger import logger
 from typing_extensions import override
@@ -12,7 +13,6 @@ from langflow.services.tracing.base import BaseTracer
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from uuid import UUID
 
     from langchain_core.callbacks.base import BaseCallbackHandler
     from langfuse._client.span import LangfuseSpan
@@ -20,6 +20,76 @@ if TYPE_CHECKING:
     from lfx.graph.vertex.base import Vertex
 
     from langflow.services.tracing.schema import Log
+
+
+LANGFUSE_FEEDBACK_SCORE_NAME = "user-feedback"
+
+
+def normalize_langfuse_trace_id(trace_id: UUID | str | None) -> str | None:
+    """Normalize a Langfuse trace identifier to 32-char hex format."""
+    if trace_id is None:
+        return None
+    if isinstance(trace_id, UUID):
+        return trace_id.hex
+    normalized = str(trace_id).replace("-", "").strip()
+    return normalized or None
+
+
+def feedback_score_id(message_id: UUID | str) -> str:
+    """Build a stable Langfuse score id from a message id."""
+    if isinstance(message_id, UUID):
+        return message_id.hex
+    return str(message_id).replace("-", "")
+
+
+def sync_feedback_score(
+    *,
+    message_id: UUID | str,
+    trace_id: UUID | str | None,
+    session_id: str,
+    flow_id: UUID | str | None,
+    sender: str,
+    positive_feedback: bool | None,
+) -> None:
+    """Send message feedback to Langfuse as a trace-linked score."""
+    normalized_trace_id = normalize_langfuse_trace_id(trace_id)
+    if not normalized_trace_id or positive_feedback is None:
+        return
+
+    try:
+        from langfuse import Langfuse
+    except ImportError:
+        return
+
+    config = LangFuseTracer._get_config()
+    if not config:
+        return
+
+    try:
+        client = Langfuse(**config)
+        client.create_score(
+            name=LANGFUSE_FEEDBACK_SCORE_NAME,
+            value=1.0 if positive_feedback else 0.0,
+            trace_id=normalized_trace_id,
+            score_id=feedback_score_id(message_id),
+            data_type="BOOLEAN",
+            comment="positive" if positive_feedback else "negative",
+            metadata={
+                "message_id": str(message_id),
+                "session_id": session_id,
+                "flow_id": str(flow_id) if flow_id else None,
+                "sender": sender,
+            },
+        )
+        client.flush()
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "Langfuse feedback sync failed for message_id=%s flow_id=%s session_id=%s: %s",
+            message_id,
+            flow_id,
+            session_id,
+            exc,
+        )
 
 
 class LangFuseTracer(BaseTracer):
@@ -31,6 +101,7 @@ class LangFuseTracer(BaseTracer):
 
     flow_id: str
     _trace_context: TraceContext
+    langfuse_trace_id: str | None
 
     def __init__(
         self,
@@ -49,6 +120,7 @@ class LangFuseTracer(BaseTracer):
         self.session_id = session_id
         self.flow_id = trace_name.split(" - ")[-1]
         self.spans: dict[str, LangfuseSpan] = OrderedDict()
+        self.langfuse_trace_id = None
 
         config = self._get_config()
         self._ready: bool = self._setup_langfuse(config) if config else False
@@ -80,6 +152,7 @@ class LangFuseTracer(BaseTracer):
 
             # Create a deterministic trace ID from the UUID (v3 requires 32-char hex)
             langfuse_trace_id = Langfuse.create_trace_id(seed=str(self.trace_id))
+            self.langfuse_trace_id = langfuse_trace_id
             # parent_span_id is NotRequired but ty doesn't fully support this yet
             self._trace_context = TraceContext(trace_id=langfuse_trace_id)  # type: ignore[call-arg]
 

--- a/src/backend/tests/unit/test_messages.py
+++ b/src/backend/tests/unit/test_messages.py
@@ -96,6 +96,21 @@ async def test_aadd_messages():
 
 
 @pytest.mark.usefixtures("client")
+async def test_aadd_messages_persists_run_id():
+    run_id = uuid4()
+    message = Message(
+        text="New Test message",
+        sender="User",
+        sender_name="User",
+        session_id="new_session_id_run_id",
+        run_id=str(run_id),
+    )
+    messages = await aadd_messages(message)
+    assert len(messages) == 1
+    assert str(messages[0].run_id) == str(run_id)
+
+
+@pytest.mark.usefixtures("client")
 async def test_aadd_messagetables(async_session):
     messages = [MessageTable(text="New Test message", sender="User", sender_name="User", session_id="new_session_id")]
     added_messages = await aadd_messagetables(messages, async_session)
@@ -1074,6 +1089,23 @@ class TestMessageEdgeCases:
         result = MessageTable.from_message(message, flow_id=flow_id_str)
 
         assert str(result.flow_id) == flow_id_str
+
+    def test_from_message_uses_message_run_id_when_explicit_run_id_missing(self):
+        """Test from_message falls back to message.run_id."""
+        from langflow.services.database.models.message.model import MessageTable
+
+        run_id = uuid4()
+        message = Message(
+            text="Test",
+            sender="User",
+            sender_name="User",
+            session_id="session",
+            run_id=str(run_id),
+        )
+
+        result = MessageTable.from_message(message, flow_id=uuid4())
+
+        assert result.run_id == run_id
 
     def test_from_message_with_iterator_text(self):
         """Test from_message handles iterator text gracefully."""

--- a/src/backend/tests/unit/test_messages_endpoints.py
+++ b/src/backend/tests/unit/test_messages_endpoints.py
@@ -3,10 +3,11 @@ from uuid import UUID, uuid4
 
 import pytest
 from httpx import AsyncClient
-from langflow.memory import aadd_messagetables
-from langflow.schema.validators import str_to_timestamp, timestamp_to_str
 
 # Assuming you have these imports available
+from langflow.api.v1 import monitor as monitor_api
+from langflow.memory import aadd_messagetables
+from langflow.schema.validators import str_to_timestamp, timestamp_to_str
 from langflow.services.auth.utils import get_auth_service
 from langflow.services.database.models.flow.model import Flow
 from langflow.services.database.models.message import MessageCreate, MessageRead, MessageUpdate
@@ -194,6 +195,75 @@ async def test_update_message(client: AsyncClient, logged_in_headers, created_me
     assert response.status_code == 200, response.text
     updated_message = MessageRead(**response.json())
     assert updated_message.text == "Updated content"
+
+
+async def test_update_message_syncs_langfuse_feedback(
+    client: AsyncClient, logged_in_headers, created_message, monkeypatch
+):
+    async with session_scope() as session:
+        db_message = await session.get(MessageTable, created_message.id)
+        assert db_message is not None
+        db_message.run_id = UUID("467ca2ce-4a57-40ce-a911-94ac679d8a79")
+        db_message.session_metadata = {"langfuse_trace_id": "81955a84cb1a1a096639ba1612a48ac0"}
+        session.add(db_message)
+        await session.flush()
+
+    captured = {}
+
+    def fake_sync(**kwargs):
+        captured.update(
+            {
+                "message_id": str(kwargs["message_id"]),
+                "trace_id": kwargs["trace_id"],
+                "positive_feedback": kwargs["positive_feedback"],
+            }
+        )
+
+    monkeypatch.setattr(monitor_api, "sync_feedback_score", fake_sync)
+
+    message_update = MessageUpdate(properties={"positive_feedback": True})
+    response = await client.put(
+        f"api/v1/monitor/messages/{created_message.id}",
+        json=message_update.model_dump(exclude_none=True),
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert captured == {
+        "message_id": str(created_message.id),
+        "trace_id": "81955a84cb1a1a096639ba1612a48ac0",
+        "positive_feedback": True,
+    }
+
+
+async def test_update_message_does_not_sync_langfuse_feedback_without_langfuse_trace_id(
+    client: AsyncClient, logged_in_headers, created_message, monkeypatch
+):
+    async with session_scope() as session:
+        db_message = await session.get(MessageTable, created_message.id)
+        assert db_message is not None
+        db_message.run_id = UUID("467ca2ce-4a57-40ce-a911-94ac679d8a79")
+        db_message.session_metadata = {}
+        session.add(db_message)
+        await session.flush()
+
+    sync_called = False
+
+    def fake_sync(**kwargs):  # noqa: ARG001
+        nonlocal sync_called
+        sync_called = True
+
+    monkeypatch.setattr(monitor_api, "sync_feedback_score", fake_sync)
+
+    message_update = MessageUpdate(properties={"positive_feedback": True})
+    response = await client.put(
+        f"api/v1/monitor/messages/{created_message.id}",
+        json=message_update.model_dump(exclude_none=True),
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert sync_called is False
 
 
 @pytest.mark.api_key_required

--- a/src/backend/tests/unit/test_messages_endpoints.py
+++ b/src/backend/tests/unit/test_messages_endpoints.py
@@ -220,6 +220,7 @@ async def test_update_message_syncs_langfuse_feedback(
         )
 
     monkeypatch.setattr(monitor_api, "sync_feedback_score", fake_sync)
+    monkeypatch.setattr(monitor_api, "_langfuse_feedback_sync_enabled", lambda: True)
 
     message_update = MessageUpdate(properties={"positive_feedback": True})
     response = await client.put(
@@ -254,6 +255,7 @@ async def test_update_message_does_not_sync_langfuse_feedback_without_langfuse_t
         sync_called = True
 
     monkeypatch.setattr(monitor_api, "sync_feedback_score", fake_sync)
+    monkeypatch.setattr(monitor_api, "_langfuse_feedback_sync_enabled", lambda: True)
 
     message_update = MessageUpdate(properties={"positive_feedback": True})
     response = await client.put(
@@ -263,6 +265,73 @@ async def test_update_message_does_not_sync_langfuse_feedback_without_langfuse_t
     )
 
     assert response.status_code == 200, response.text
+    assert sync_called is False
+
+
+async def test_update_message_does_not_sync_when_langfuse_feedback_disabled(
+    client: AsyncClient, logged_in_headers, created_message, monkeypatch
+):
+    async with session_scope() as session:
+        db_message = await session.get(MessageTable, created_message.id)
+        assert db_message is not None
+        db_message.session_metadata = {"langfuse_trace_id": "81955a84cb1a1a096639ba1612a48ac0"}
+        session.add(db_message)
+        await session.flush()
+
+    sync_called = False
+
+    def fake_sync(**kwargs):  # noqa: ARG001
+        nonlocal sync_called
+        sync_called = True
+
+    monkeypatch.setattr(monitor_api, "sync_feedback_score", fake_sync)
+    monkeypatch.setattr(monitor_api, "_langfuse_feedback_sync_enabled", lambda: False)
+
+    message_update = MessageUpdate(properties={"positive_feedback": True})
+    response = await client.put(
+        f"api/v1/monitor/messages/{created_message.id}",
+        json=message_update.model_dump(exclude_none=True),
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert sync_called is False
+
+
+async def test_update_message_deletes_langfuse_feedback_when_cleared(
+    client: AsyncClient, logged_in_headers, created_message, monkeypatch
+):
+    async with session_scope() as session:
+        db_message = await session.get(MessageTable, created_message.id)
+        assert db_message is not None
+        db_message.session_metadata = {"langfuse_trace_id": "81955a84cb1a1a096639ba1612a48ac0"}
+        db_message.properties = {"positive_feedback": True}
+        session.add(db_message)
+        await session.flush()
+
+    delete_calls = []
+    sync_called = False
+
+    def fake_delete(**kwargs):
+        delete_calls.append(str(kwargs["message_id"]))
+
+    def fake_sync(**kwargs):  # noqa: ARG001
+        nonlocal sync_called
+        sync_called = True
+
+    monkeypatch.setattr(monitor_api, "delete_feedback_score", fake_delete)
+    monkeypatch.setattr(monitor_api, "sync_feedback_score", fake_sync)
+    monkeypatch.setattr(monitor_api, "_langfuse_feedback_sync_enabled", lambda: True)
+
+    message_update = MessageUpdate(properties={"positive_feedback": None})
+    response = await client.put(
+        f"api/v1/monitor/messages/{created_message.id}",
+        json=message_update.model_dump(),
+        headers=logged_in_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert delete_calls == [str(created_message.id)]
     assert sync_called is False
 
 

--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -115,6 +115,7 @@ class PlaceholderGraph(NamedTuple):
         flow_id (str | None): Unique identifier for the flow, if applicable.
         user_id (str | None): Identifier of the user associated with the flow, if any.
         session_id (str | None): Identifier for the current session, if applicable.
+        run_id (str | None): Identifier for the current graph run, if applicable.
         context (dict): Additional contextual information for the component's execution.
         flow_name (str | None): Name of the flow, if available.
     """
@@ -122,6 +123,7 @@ class PlaceholderGraph(NamedTuple):
     flow_id: str | None
     user_id: str | None
     session_id: str | None
+    run_id: str | None
     context: dict
     flow_name: str | None
 
@@ -1010,8 +1012,14 @@ class Component(CustomComponent):
             user_id = self._user_id if hasattr(self, "_user_id") else None
             flow_name = self._flow_name if hasattr(self, "_flow_name") else None
             flow_id = self._flow_id if hasattr(self, "_flow_id") else None
+            run_id = self._run_id if hasattr(self, "_run_id") else None
             return PlaceholderGraph(
-                flow_id=flow_id, user_id=str(user_id), session_id=session_id, context={}, flow_name=flow_name
+                flow_id=flow_id,
+                user_id=str(user_id),
+                session_id=session_id,
+                run_id=run_id,
+                context={},
+                flow_name=flow_name,
             )
         msg = f"Attribute {name} not found in {self.__class__.__name__}"
         raise AttributeError(msg)

--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -1873,10 +1873,25 @@ class Component(CustomComponent):
 
     async def _store_message(self, message: Message) -> Message:
         flow_id: str | None = None
+        run_id: str | None = None
+        session_metadata = dict(message.session_metadata or {})
         if hasattr(self, "graph"):
             # Convert UUID to str if needed
             flow_id = str(self.graph.flow_id) if self.graph.flow_id else None
-        stored_messages = await astore_message(message, flow_id=flow_id)
+            graph_run_id = str(self.graph.run_id) if self.graph.run_id else None
+            run_id = graph_run_id
+            if self.tracing_service:
+                langfuse_tracer = self.tracing_service.get_tracer("langfuse")
+                langfuse_trace_id = getattr(langfuse_tracer, "langfuse_trace_id", None)
+                if langfuse_trace_id:
+                    session_metadata["langfuse_trace_id"] = langfuse_trace_id
+                if graph_run_id:
+                    session_metadata["graph_run_id"] = graph_run_id
+        if session_metadata:
+            message.session_metadata = session_metadata
+        if run_id and not getattr(message, "run_id", None):
+            message.run_id = run_id
+        stored_messages = await astore_message(message, flow_id=flow_id, run_id=run_id)
         if len(stored_messages) != 1:
             msg = "Only one message can be stored at a time."
             raise ValueError(msg)

--- a/src/lfx/src/lfx/memory/stubs.py
+++ b/src/lfx/src/lfx/memory/stubs.py
@@ -16,6 +16,7 @@ from lfx.utils.async_helpers import run_until_complete
 async def astore_message(
     message: Message,
     flow_id: str | UUID | None = None,
+    run_id: str | UUID | None = None,
 ) -> list[Message]:
     """Store a message in the memory.
 
@@ -23,6 +24,7 @@ async def astore_message(
         message (Message): The message to store.
         flow_id (Optional[str | UUID]): The flow ID associated with the message.
             When running from the CustomComponent you can access this using `self.graph.flow_id`.
+        run_id (Optional[str | UUID]): The graph/native run ID associated with the message.
 
     Returns:
         List[Message]: A list containing the stored message.
@@ -56,6 +58,10 @@ async def astore_message(
                     "Downstream code that expects a UUID may surface a confusing error."
                 )
         message.flow_id = str(flow_id)
+    if run_id:
+        if isinstance(run_id, UUID):
+            run_id = str(run_id)
+        message.run_id = str(run_id)
 
     # In lfx, we use the service architecture - this is a simplified implementation
     # that doesn't persist to database but maintains the message in memory
@@ -89,6 +95,7 @@ async def astore_message(
 def store_message(
     message: Message,
     flow_id: str | UUID | None = None,
+    run_id: str | UUID | None = None,
 ) -> list[Message]:
     """DEPRECATED: Stores a message in the memory.
 
@@ -98,6 +105,7 @@ def store_message(
         message (Message): The message to store.
         flow_id (Optional[str | UUID]): The flow ID associated with the message.
             When running from the CustomComponent you can access this using `self.graph.flow_id`.
+        run_id (Optional[str | UUID]): The graph/native run ID associated with the message.
 
     Returns:
         List[Message]: A list containing the stored message.
@@ -105,7 +113,7 @@ def store_message(
     Raises:
         ValueError: If any of the required parameters (session_id, sender, sender_name) is not provided.
     """
-    return run_until_complete(astore_message(message, flow_id=flow_id))
+    return run_until_complete(astore_message(message, flow_id=flow_id, run_id=run_id))
 
 
 async def aupdate_messages(messages: Message | list[Message]) -> list[Message]:

--- a/src/lfx/src/lfx/schema/message.py
+++ b/src/lfx/src/lfx/schema/message.py
@@ -67,6 +67,7 @@ class Message(Data):
     files: list[str | Image] | None = Field(default=[])
     session_id: str | UUID | None = Field(default="")
     context_id: str | UUID | None = Field(default="")
+    run_id: str | UUID | None = Field(default=None)
     timestamp: Annotated[str, timestamp_to_str_validator] = Field(
         default_factory=lambda: datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f %Z")
     )
@@ -83,6 +84,13 @@ class Message(Data):
     @field_validator("flow_id", mode="before")
     @classmethod
     def validate_flow_id(cls, value):
+        if isinstance(value, UUID):
+            value = str(value)
+        return value
+
+    @field_validator("run_id", mode="before")
+    @classmethod
+    def validate_run_id(cls, value):
         if isinstance(value, UUID):
             value = str(value)
         return value
@@ -118,6 +126,12 @@ class Message(Data):
 
     @field_serializer("flow_id")
     def serialize_flow_id(self, value):
+        if isinstance(value, UUID):
+            return str(value)
+        return value
+
+    @field_serializer("run_id")
+    def serialize_run_id(self, value):
         if isinstance(value, UUID):
             return str(value)
         return value
@@ -234,6 +248,7 @@ class Message(Data):
             files=data.files,
             session_id=data.session_id,
             context_id=data.context_id,
+            run_id=data.run_id,
             timestamp=data.timestamp,
             flow_id=data.flow_id,
             error=data.error,

--- a/src/lfx/tests/unit/schema/test_schema_message.py
+++ b/src/lfx/tests/unit/schema/test_schema_message.py
@@ -2,6 +2,7 @@ import base64
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
@@ -76,6 +77,13 @@ def test_message_from_ai_text():
 
     assert isinstance(lc_message, AIMessage)
     assert lc_message.content == text
+
+
+def test_message_serializes_run_id_as_string():
+    run_id = uuid4()
+    message = Message(text="hello", run_id=run_id)
+    dumped = message.model_dump()
+    assert dumped["run_id"] == str(run_id)
 
 
 def test_message_with_single_image(sample_image):


### PR DESCRIPTION
## Summary
- store Langfuse trace IDs separately from native run IDs when persisting messages
- sync feedback to Langfuse only when a real stored Langfuse trace ID is available
- keep feedback sync asynchronous and add regression coverage for trace-linked and non-trace-linked messages

https://github.com/user-attachments/assets/e817fc39-6675-415c-b465-f43c7608f75a

