### PR TITLE
fix: Composio Outlook "Send email" Component Build Error 

### DIFF
--- a/src/backend/tests/unit/components/bundles/composio/test_composio_components.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_composio_components.py
@@ -1,11 +1,13 @@
 """Unit tests for Composio components cloud validation."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from lfx.base.composio.composio_base import ComposioBaseComponent
 from lfx.components.composio.composio_api import ComposioAPIComponent
+from lfx.schema.data import Data
+from lfx.schema.message import Message
 
 
 @pytest.mark.unit
@@ -34,3 +36,107 @@ class TestComposioCloudValidation:
 
             error_msg = str(exc_info.value).lower()
             assert "astra" in error_msg or "cloud" in error_msg
+
+
+def _make_component(action_key: str, fields: dict) -> ComposioBaseComponent:
+    """Build a ComposioBaseComponent pre-wired with test data, bypassing real API calls."""
+    with patch.dict(os.environ, {"ASTRA_CLOUD_DISABLE_COMPONENT": "false"}):
+        component = ComposioBaseComponent(api_key="test-key")
+
+    component.entity_id = "default"
+    component.action_button = [{"name": "Send Email"}]
+
+    component._actions_data = {
+        action_key: {
+            "display_name": "Send Email",
+            "action_fields": list(fields.keys()),
+            "version": None,
+        }
+    }
+    component._action_schemas = {
+        action_key: {
+            "input_parameters": {
+                "type": "object",
+                "properties": {k: {"type": "string"} for k in fields},
+                "required": list(fields.keys()),
+            }
+        }
+    }
+    component._display_to_key_map = {"Send Email": action_key}
+    component._key_to_display_map = {action_key: "Send Email"}
+
+    for name, value in fields.items():
+        setattr(component, name, value)
+
+    return component
+
+
+@pytest.mark.unit
+class TestExecuteActionRichTypeCoercion:
+    """Regression: Message and Data objects must be coerced to primitives before
+    being passed to the Composio API.
+
+    When a ChatInput node is wired to a str field (e.g. subject, body), Langflow
+    stores a Message object in the component attribute.  execute_action previously
+    forwarded the raw object to composio.tools.execute, which caused the API call
+    to fail or send a stringified object instead of plain text.
+    """
+
+    ACTION_KEY = "OUTLOOK_SEND_EMAIL"
+
+    def _run(self, fields: dict) -> dict:
+        """Execute the action and return the captured arguments dict."""
+        component = _make_component(self.ACTION_KEY, fields)
+
+        captured = {}
+
+        def fake_execute(**kwargs):
+            captured.update(kwargs.get("arguments", {}))
+            return {"successful": True, "data": {"message": "sent"}}
+
+        mock_composio = MagicMock()
+        mock_composio.tools.execute.side_effect = fake_execute
+
+        with (
+            patch.object(type(component), "_build_wrapper", return_value=mock_composio),
+            patch.object(type(component), "_populate_actions_data"),
+            patch.dict(os.environ, {"ASTRA_CLOUD_DISABLE_COMPONENT": "false"}),
+        ):
+            component.execute_action()
+
+        return captured
+
+    def test_message_coerced_to_text_for_str_field(self):
+        args = self._run({"subject": Message(text="Hello world"), "body": "body text"})
+        assert args["subject"] == "Hello world"
+
+    def test_data_coerced_to_dict_for_object_field(self):
+        payload = {"key": "value"}
+        args = self._run({"subject": "hi", "body": Data(data=payload)})
+        assert args["body"] == payload
+
+    def test_plain_string_passed_through_unchanged(self):
+        args = self._run({"subject": "plain subject", "body": "plain body"})
+        assert args["subject"] == "plain subject"
+        assert args["body"] == "plain body"
+
+    def test_message_with_empty_text_is_skipped(self):
+        args = self._run({"subject": Message(text=""), "body": "body text"})
+        assert "subject" not in args
+
+    def test_multiple_message_fields_all_coerced(self):
+        args = self._run({
+            "subject": Message(text="Subject line"),
+            "body": Message(text="Body content"),
+        })
+        assert args["subject"] == "Subject line"
+        assert args["body"] == "Body content"
+
+    def test_none_field_is_skipped(self):
+        args = self._run({"subject": "hi", "body": None})
+        assert "body" not in args
+
+    def test_message_coercion_happens_before_json_parse(self):
+        # body contains JSON-like text — should be passed as a string (schema type is str)
+        args = self._run({"subject": "hi", "body": Message(text='{"key": "val"}')})
+        assert args["body"] == '{"key": "val"}'

--- a/src/backend/tests/unit/components/bundles/composio/test_composio_components.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_composio_components.py
@@ -74,8 +74,7 @@ def _make_component(action_key: str, fields: dict) -> ComposioOutlookAPIComponen
 
 @pytest.mark.unit
 class TestExecuteActionRichTypeCoercion:
-    """Regression: Message and Data objects must be coerced to primitives before
-    being passed to the Composio API.
+    """Regression: Message and Data objects must be coerced to primitives before being passed to the Composio API.
 
     When a ChatInput node is wired to a str field (e.g. subject, body), Langflow
     stores a Message object in the component attribute.  execute_action previously

--- a/src/backend/tests/unit/components/bundles/composio/test_composio_components.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_composio_components.py
@@ -126,10 +126,12 @@ class TestExecuteActionRichTypeCoercion:
         assert "subject" not in args
 
     def test_multiple_message_fields_all_coerced(self):
-        args = self._run({
-            "subject": Message(text="Subject line"),
-            "body": Message(text="Body content"),
-        })
+        args = self._run(
+            {
+                "subject": Message(text="Subject line"),
+                "body": Message(text="Body content"),
+            }
+        )
         assert args["subject"] == "Subject line"
         assert args["body"] == "Body content"
 

--- a/src/backend/tests/unit/components/bundles/composio/test_composio_components.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_composio_components.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from lfx.base.composio.composio_base import ComposioBaseComponent
 from lfx.components.composio.composio_api import ComposioAPIComponent
+from lfx.components.composio.outlook_composio import ComposioOutlookAPIComponent
 from lfx.schema.data import Data
 from lfx.schema.message import Message
 
@@ -38,10 +39,10 @@ class TestComposioCloudValidation:
             assert "astra" in error_msg or "cloud" in error_msg
 
 
-def _make_component(action_key: str, fields: dict) -> ComposioBaseComponent:
-    """Build a ComposioBaseComponent pre-wired with test data, bypassing real API calls."""
+def _make_component(action_key: str, fields: dict) -> ComposioOutlookAPIComponent:
+    """Build a ComposioOutlookAPIComponent pre-wired with test data, bypassing real API calls."""
     with patch.dict(os.environ, {"ASTRA_CLOUD_DISABLE_COMPONENT": "false"}):
-        component = ComposioBaseComponent(api_key="test-key")
+        component = ComposioOutlookAPIComponent(api_key="test-key")
 
     component.entity_id = "default"
     component.action_button = [{"name": "Send Email"}]

--- a/src/lfx/src/lfx/base/composio/composio_base.py
+++ b/src/lfx/src/lfx/base/composio/composio_base.py
@@ -2434,6 +2434,14 @@ class ComposioBaseComponent(Component):
                     continue
                 value = getattr(self, field)
 
+                # Coerce Langflow rich types to primitives the Composio API can serialise.
+                # A Message connected to a str field (e.g. subject, body) must arrive as
+                # plain text; a Data object should be unwrapped to its dict payload.
+                if isinstance(value, Message):
+                    value = value.text
+                elif isinstance(value, Data):
+                    value = value.data
+
                 # Skip None, empty strings, and empty lists
                 if value is None or value == "" or (isinstance(value, list) and len(value) == 0):
                     continue


### PR DESCRIPTION
Problem

When a user wires a ChatInput node to a string field on a Composio component (e.g. the subject or body field of the Outlook Send Email action), Langflow stores a Message object in the component attribute rather than a plain string. execute_action read the attribute directly with getattr and passed it to composio.tools.execute without any coercion. The Composio API received either a serialisation error or a stringified object ("text='Hello world'") instead of "Hello world", causing the action to fail silently or send malformed data.

The same issue applies to Data objects connected to object-typed fields.

Fix

In execute_action, immediately after reading each field value with getattr, coerce Langflow rich types to the primitives the Composio API expects:

Message → .text (plain string)
Data → .data (dict payload)
The coercion happens before the empty-value skip and the JSON-parse step, so all existing behaviour (required-field validation, optional-field defaults, array splitting) continues to work correctly on the resulting primitive.

Testing

Added TestExecuteActionRichTypeCoercion in test_composio_components.py with 7 cases covering:


Screenshoot
<img width="1646" height="916" alt="Screenshot 2026-05-12 at 12 55 33 PM" src="https://github.com/user-attachments/assets/67a78d24-2cc9-4707-9459-5282e876bf75" />
