### PR TITLE
fix: improve security and UI controls for embedded deployments (custom component admin gating, MCP lock, and action visibility)

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -1132,6 +1132,14 @@ async def custom_component(
     user: CurrentActiveUser,
 ) -> CustomComponentResponse:
     settings_service = get_settings_service()
+
+    # P2: Check if custom component editing is restricted to admins only
+    if settings_service.settings.custom_component_admin_only and not user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Custom component creation is restricted to administrators",
+        )
+
     if not settings_service.settings.allow_custom_components:
         # Lazily compute hash lookups if they haven't been built yet
         # (e.g. during startup before the cache is fully populated).
@@ -1183,6 +1191,14 @@ async def custom_component_update(
         SerializationError: If serialization of the updated component node fails.
     """
     settings_service = get_settings_service()
+
+    # P2: Check if custom component editing is restricted to admins only
+    if settings_service.settings.custom_component_admin_only and not user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Custom component editing is restricted to administrators",
+        )
+
     if not settings_service.settings.allow_custom_components:
         get_component_hash_lookups_for_validation()
         all_known = component_cache.all_known_hashes

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -1134,7 +1134,7 @@ async def custom_component(
     settings_service = get_settings_service()
 
     # P2: Check if custom component editing is restricted to admins only
-    if settings_service.settings.custom_component_admin_only and not user.is_superuser:
+    if getattr(settings_service.settings, "custom_component_admin_only", False) is True and not user.is_superuser:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Custom component creation is restricted to administrators",
@@ -1193,7 +1193,7 @@ async def custom_component_update(
     settings_service = get_settings_service()
 
     # P2: Check if custom component editing is restricted to admins only
-    if settings_service.settings.custom_component_admin_only and not user.is_superuser:
+    if getattr(settings_service.settings, "custom_component_admin_only", False) is True and not user.is_superuser:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Custom component editing is restricted to administrators",

--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -773,7 +773,9 @@ async def install_mcp_config(
 
     # P2: Check if MCP server management is locked
     settings_service = get_settings_service()
-    if settings_service.settings.mcp_servers_locked and not current_user.is_superuser:
+    # Some tests patch settings with MagicMock objects that return truthy placeholders
+    # for unknown attrs. Only enforce this gate when the flag is explicitly True.
+    if getattr(settings_service.settings, "mcp_servers_locked", False) is True and not current_user.is_superuser:
         raise HTTPException(
             status_code=403,
             detail="MCP server configuration is locked. Contact an administrator to manage external MCP servers.",

--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -771,6 +771,14 @@ async def install_mcp_config(
     if not is_local_ip(client_ip):
         raise HTTPException(status_code=500, detail="MCP configuration can only be installed from a local connection")
 
+    # P2: Check if MCP server management is locked
+    settings_service = get_settings_service()
+    if settings_service.settings.mcp_servers_locked and not current_user.is_superuser:
+        raise HTTPException(
+            status_code=403,
+            detail="MCP server configuration is locked. Contact an administrator to manage external MCP servers.",
+        )
+
     removed_servers: list[str] = []  # Track removed servers for reinstallation
     try:
         project = await verify_project_access(project_id, current_user)

--- a/src/backend/base/langflow/api/v1/schemas/__init__.py
+++ b/src/backend/base/langflow/api/v1/schemas/__init__.py
@@ -432,6 +432,14 @@ class ConfigResponse(BaseConfigResponse):
     default_folder_name: str
     hide_getting_started_progress: bool
     allow_custom_components: bool
+    # P2 feature flags for ICA integration
+    embedded_mode: bool
+    hide_logout_button: bool
+    hide_new_project_button: bool
+    hide_new_flow_button: bool
+    hide_starter_projects: bool
+    mcp_servers_locked: bool
+    custom_component_admin_only: bool
 
     @classmethod
     def from_settings(cls, settings: Settings, auth_settings) -> "ConfigResponse":
@@ -467,6 +475,13 @@ class ConfigResponse(BaseConfigResponse):
             default_folder_name=DEFAULT_FOLDER_NAME,
             hide_getting_started_progress=os.getenv("HIDE_GETTING_STARTED_PROGRESS", "").lower() == "true",
             allow_custom_components=settings.allow_custom_components,
+            embedded_mode=settings.embedded_mode,
+            hide_logout_button=settings.hide_logout_button or settings.embedded_mode,
+            hide_new_project_button=settings.hide_new_project_button or settings.embedded_mode,
+            hide_new_flow_button=settings.hide_new_flow_button or settings.embedded_mode,
+            hide_starter_projects=settings.hide_starter_projects or settings.embedded_mode,
+            mcp_servers_locked=settings.mcp_servers_locked,
+            custom_component_admin_only=settings.custom_component_admin_only,
         )
 
 

--- a/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
@@ -14,6 +14,7 @@ import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import useAuthStore from "@/stores/authStore";
 import { useDarkStore } from "@/stores/darkStore";
+import { useUtilityStore } from "@/stores/utilityStore";
 import { cn, stripReleaseStageFromVersion } from "@/utils/utils";
 import {
   HeaderMenu,
@@ -35,6 +36,10 @@ export const AccountMenu = () => {
     isAdmin: state.isAdmin,
     autoLogin: state.autoLogin,
   }));
+
+  const hideLogoutButton = useUtilityStore(
+    (state) => state.hideLogoutButton,
+  );
 
   const handleLogout = () => {
     mutationLogout();
@@ -171,7 +176,7 @@ export const AccountMenu = () => {
             </div>
           </div>
 
-          {!autoLogin && (
+          {!autoLogin && !hideLogoutButton && (
             <div>
               <HeaderMenuItemButton onClick={handleLogout} icon="log-out">
                 {t("account.logout")}

--- a/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
@@ -37,9 +37,7 @@ export const AccountMenu = () => {
     autoLogin: state.autoLogin,
   }));
 
-  const hideLogoutButton = useUtilityStore(
-    (state) => state.hideLogoutButton,
-  );
+  const hideLogoutButton = useUtilityStore((state) => state.hideLogoutButton);
 
   const handleLogout = () => {
     mutationLogout();

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/header-buttons.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/header-buttons.tsx
@@ -25,6 +25,9 @@ export const HeaderButtons = ({
   const hideGettingStartedProgress = useUtilityStore(
     (state) => state.hideGettingStartedProgress,
   );
+  const hideNewProjectButton = useUtilityStore(
+    (state) => state.hideNewProjectButton,
+  );
 
   const [isDismissedDialog, setIsDismissedDialog] = useState(
     userData?.optins?.dialog_dismissed,
@@ -89,11 +92,13 @@ export const HeaderButtons = ({
             onClick={handleUploadFlowsToFolder}
             disabled={isUpdatingFolder}
           />
-          <AddFolderButton
-            onClick={addNewFolder}
-            disabled={isUpdatingFolder}
-            loading={isPending}
-          />
+          {!hideNewProjectButton && (
+            <AddFolderButton
+              onClick={addNewFolder}
+              disabled={isUpdatingFolder}
+              loading={isPending}
+            />
+          )}
         </div>
       </div>
     </>

--- a/src/frontend/src/controllers/API/queries/config/use-get-config.ts
+++ b/src/frontend/src/controllers/API/queries/config/use-get-config.ts
@@ -37,6 +37,13 @@ export interface ConfigResponse extends BaseConfig {
   webhook_auth_enable: boolean;
   default_folder_name: string;
   hide_getting_started_progress: boolean;
+  embedded_mode: boolean;
+  hide_logout_button: boolean;
+  hide_new_project_button: boolean;
+  hide_new_flow_button: boolean;
+  hide_starter_projects: boolean;
+  mcp_servers_locked: boolean;
+  custom_component_admin_only: boolean;
 }
 
 // Union type for the response (can be either public or full config)
@@ -84,6 +91,25 @@ export const useGetConfig: useQueryFunctionType<
     (state) => state.setAllowCustomComponents,
   );
   const setMcpBaseUrl = useUtilityStore((state) => state.setMcpBaseUrl);
+  const setEmbeddedMode = useUtilityStore((state) => state.setEmbeddedMode);
+  const setHideLogoutButton = useUtilityStore(
+    (state) => state.setHideLogoutButton,
+  );
+  const setHideNewProjectButton = useUtilityStore(
+    (state) => state.setHideNewProjectButton,
+  );
+  const setHideNewFlowButton = useUtilityStore(
+    (state) => state.setHideNewFlowButton,
+  );
+  const setHideStarterProjects = useUtilityStore(
+    (state) => state.setHideStarterProjects,
+  );
+  const setMcpServersLocked = useUtilityStore(
+    (state) => state.setMcpServersLocked,
+  );
+  const setCustomComponentAdminOnly = useUtilityStore(
+    (state) => state.setCustomComponentAdminOnly,
+  );
 
   const { query } = UseRequestProcessor();
 
@@ -124,6 +150,14 @@ export const useGetConfig: useQueryFunctionType<
         setHideGettingStartedProgress(
           data.hide_getting_started_progress ?? false,
         );
+        // P2 ICA integration flags
+        setEmbeddedMode(data.embedded_mode ?? false);
+        setHideLogoutButton(data.hide_logout_button ?? false);
+        setHideNewProjectButton(data.hide_new_project_button ?? false);
+        setHideNewFlowButton(data.hide_new_flow_button ?? false);
+        setHideStarterProjects(data.hide_starter_projects ?? false);
+        setMcpServersLocked(data.mcp_servers_locked ?? false);
+        setCustomComponentAdminOnly(data.custom_component_admin_only ?? false);
       }
     }
     return data;

--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -104,7 +104,7 @@ export default function AddMcpServerModal({
 
   const location = useLocation();
   const isOnMcpSettingsPage = location.pathname === MCP_SETTINGS_PAGE;
-  
+
   // P2: Check if MCP servers are locked and if user is not admin
   const mcpServersLocked = useUtilityStore((state) => state.mcpServersLocked);
   const isAdmin = useAuthStore((state) => state.isAdmin);
@@ -356,235 +356,240 @@ export default function AddMcpServerModal({
             </div>
           </div>
         ) : (
-          <div className="flex flex-1 w-full flex-col overflow-hidden min-h-0">
-            <div className="flex flex-col gap-3 p-4 tracking-normal">
-              <div className="flex items-center gap-2 text-sm font-medium">
-                <ForwardedIconComponent
-                  name="Mcp"
-                  className="h-4 w-4 text-primary"
-                  aria-hidden="true"
-                />
-                {initialData
-                  ? t("mcp.modal.updateTitle")
-                  : t("mcp.modal.addTitle")}
+          <>
+            <div className="flex flex-1 w-full flex-col overflow-hidden min-h-0">
+              <div className="flex flex-col gap-3 p-4 tracking-normal">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <ForwardedIconComponent
+                    name="Mcp"
+                    className="h-4 w-4 text-primary"
+                    aria-hidden="true"
+                  />
+                  {initialData
+                    ? t("mcp.modal.updateTitle")
+                    : t("mcp.modal.addTitle")}
+                </div>
+                <span className="text-mmd font-normal text-muted-foreground">
+                  {isOnMcpSettingsPage ? (
+                    t("mcp.modal.descriptionSettings")
+                  ) : (
+                    <>
+                      {t("mcp.modal.descriptionFlow")}{" "}
+                      <CustomLink
+                        className="underline"
+                        to={MCP_SETTINGS_PAGE}
+                        onClick={() => setOpen(false)}
+                      >
+                        {t("mcp.modal.descriptionFlowLink")}
+                      </CustomLink>
+                      .
+                    </>
+                  )}
+                </span>
               </div>
-            <span className="text-mmd font-normal text-muted-foreground">
-              {isOnMcpSettingsPage ? (
-                t("mcp.modal.descriptionSettings")
-              ) : (
-                <>
-                  {t("mcp.modal.descriptionFlow")}{" "}
-                  <CustomLink
-                    className="underline"
-                    to={MCP_SETTINGS_PAGE}
-                    onClick={() => setOpen(false)}
+              <Tabs
+                defaultValue={type}
+                onValueChange={changeType}
+                className="flex flex-1 w-full flex-col overflow-hidden min-h-0"
+              >
+                <div className="px-4">
+                  <TabsList className="mb-4 flex w-full gap-2">
+                    <TabsTrigger
+                      className="flex-1"
+                      disabled={!!initialData && type !== "JSON"}
+                      data-testid="json-tab"
+                      value="JSON"
+                    >
+                      JSON
+                    </TabsTrigger>
+                    <TabsTrigger
+                      className="flex-1"
+                      data-testid="stdio-tab"
+                      disabled={!!initialData && type !== "STDIO"}
+                      value="STDIO"
+                    >
+                      STDIO
+                    </TabsTrigger>
+                    <TabsTrigger
+                      className="flex-1"
+                      data-testid="http-tab"
+                      disabled={!!initialData && type !== "HTTP"}
+                      value="HTTP"
+                    >
+                      Streamable HTTP/SSE
+                    </TabsTrigger>
+                  </TabsList>
+                </div>
+                <div
+                  className="flex w-full flex-1 flex-col overflow-y-auto border-y p-4 min-h-0"
+                  id="global-variable-modal-inputs"
+                >
+                  {error && (
+                    <div className="mb-4 rounded-md bg-destructive/10 px-4 py-2 text-xs font-medium text-destructive">
+                      {error}
+                    </div>
+                  )}
+                  <TabsContent value="JSON" className="flex flex-col p-0 m-0">
+                    <Label className="!text-mmd mb-2">
+                      {t("mcp.modal.jsonTabLabel")}
+                    </Label>
+                    <Textarea
+                      value={jsonValue}
+                      data-testid="json-input"
+                      onChange={(e) => setJsonValue(e.target.value)}
+                      className="min-h-[300px] font-mono text-mmd resize-none"
+                      placeholder={t("mcp.modal.jsonPlaceholder")}
+                      disabled={isPending}
+                    />
+                  </TabsContent>
+                  <TabsContent
+                    value="STDIO"
+                    className="flex flex-1 flex-col h-full p-0 m-0"
                   >
-                    {t("mcp.modal.descriptionFlowLink")}
-                  </CustomLink>
-                  .
-                </>
-              )}
-            </span>
-          </div>
-          <Tabs
-            defaultValue={type}
-            onValueChange={changeType}
-            className="flex flex-1 w-full flex-col overflow-hidden min-h-0"
-          >
-            <div className="px-4">
-              <TabsList className="mb-4 flex w-full gap-2">
-                <TabsTrigger
-                  className="flex-1"
-                  disabled={!!initialData && type !== "JSON"}
-                  data-testid="json-tab"
-                  value="JSON"
-                >
-                  JSON
-                </TabsTrigger>
-                <TabsTrigger
-                  className="flex-1"
-                  data-testid="stdio-tab"
-                  disabled={!!initialData && type !== "STDIO"}
-                  value="STDIO"
-                >
-                  STDIO
-                </TabsTrigger>
-                <TabsTrigger
-                  className="flex-1"
-                  data-testid="http-tab"
-                  disabled={!!initialData && type !== "HTTP"}
-                  value="HTTP"
-                >
-                  Streamable HTTP/SSE
-                </TabsTrigger>
-              </TabsList>
+                    <div className="flex h-full flex-col gap-4">
+                      <div className="flex flex-col gap-2">
+                        <Label className="flex items-start gap-1 !text-mmd">
+                          {t("mcp.modal.fieldName")}{" "}
+                          <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                          value={stdioName}
+                          onChange={(e) => setStdioName(e.target.value)}
+                          placeholder={t("mcp.modal.placeholderServerName")}
+                          data-testid="stdio-name-input"
+                          disabled={isPending}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-2">
+                        <Label className="flex items-start gap-1 !text-mmd">
+                          {t("mcp.modal.fieldCommand")}
+                          <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                          value={stdioCommand}
+                          onChange={(e) => setStdioCommand(e.target.value)}
+                          placeholder={t("mcp.modal.placeholderCommand")}
+                          data-testid="stdio-command-input"
+                          disabled={isPending}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-2">
+                        <Label className="!text-mmd">
+                          {t("mcp.modal.fieldArguments")}
+                        </Label>
+                        <InputListComponent
+                          value={stdioArgs}
+                          handleOnNewValue={({ value }) => setStdioArgs(value)}
+                          disabled={isPending}
+                          placeholder={t("mcp.modal.placeholderArgument")}
+                          listAddLabel={t("mcp.modal.addArgumentButton")}
+                          editNode={false}
+                          id="stdio-args"
+                          data-testid="stdio-args-input"
+                        />
+                      </div>
+                      <div className="flex flex-col gap-2">
+                        <Label className="!text-mmd">
+                          {t("mcp.modal.fieldEnvironmentVariables")}
+                        </Label>
+                        <IOKeyPairInput
+                          value={stdioEnv}
+                          onChange={setStdioEnv}
+                          duplicateKey={false}
+                          isList={true}
+                          isInputField={true}
+                          testId="stdio-env"
+                        />
+                      </div>
+                    </div>
+                  </TabsContent>
+                  <TabsContent
+                    value="HTTP"
+                    className="flex flex-1 flex-col h-full p-0 m-0"
+                  >
+                    <div className="flex h-full flex-col gap-4">
+                      <div className="flex flex-col gap-2">
+                        <Label className="flex items-start gap-1 !text-mmd">
+                          {t("mcp.modal.fieldName")}
+                          <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                          value={httpName}
+                          onChange={(e) => setHttpName(e.target.value)}
+                          placeholder={t("mcp.modal.placeholderHttpName")}
+                          data-testid="http-name-input"
+                          disabled={isPending}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-2">
+                        <Label className="flex items-start gap-1 !text-mmd">
+                          {t("mcp.modal.fieldStreamableUrl")}
+                          <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                          value={httpUrl}
+                          onChange={(e) => setHttpUrl(e.target.value)}
+                          placeholder={t("mcp.modal.placeholderHttpUrl")}
+                          data-testid="http-url-input"
+                          disabled={isPending}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-2">
+                        <Label className="!text-mmd">
+                          {t("mcp.modal.fieldHeaders")}
+                        </Label>
+                        <IOKeyPairInputWithVariables
+                          value={httpHeaders}
+                          onChange={setHttpHeaders}
+                          duplicateKey={false}
+                          isList={true}
+                          isInputField={true}
+                          testId="http-headers"
+                          enableGlobalVariables={true}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-2">
+                        <Label className="!text-mmd">
+                          {t("mcp.modal.fieldEnvironmentVariables")}
+                        </Label>
+                        <IOKeyPairInput
+                          value={httpEnv}
+                          onChange={setHttpEnv}
+                          duplicateKey={false}
+                          isList={true}
+                          isInputField={true}
+                          testId="http-env"
+                        />
+                      </div>
+                    </div>
+                  </TabsContent>
+                </div>
+              </Tabs>
             </div>
-            <div
-              className="flex w-full flex-1 flex-col overflow-y-auto border-y p-4 min-h-0"
-              id="global-variable-modal-inputs"
-            >
-              {error && (
-                <div className="mb-4 rounded-md bg-destructive/10 px-4 py-2 text-xs font-medium text-destructive">
-                  {error}
-                </div>
-              )}
-              <TabsContent value="JSON" className="flex flex-col p-0 m-0">
-                <Label className="!text-mmd mb-2">
-                  {t("mcp.modal.jsonTabLabel")}
-                </Label>
-                <Textarea
-                  value={jsonValue}
-                  data-testid="json-input"
-                  onChange={(e) => setJsonValue(e.target.value)}
-                  className="min-h-[300px] font-mono text-mmd resize-none"
-                  placeholder={t("mcp.modal.jsonPlaceholder")}
-                  disabled={isPending}
-                />
-              </TabsContent>
-              <TabsContent
-                value="STDIO"
-                className="flex flex-1 flex-col h-full p-0 m-0"
+            <div className="flex shrink-0 justify-end gap-2 p-4">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setOpen(false)}
               >
-                <div className="flex h-full flex-col gap-4">
-                  <div className="flex flex-col gap-2">
-                    <Label className="flex items-start gap-1 !text-mmd">
-                      {t("mcp.modal.fieldName")}{" "}
-                      <span className="text-destructive">*</span>
-                    </Label>
-                    <Input
-                      value={stdioName}
-                      onChange={(e) => setStdioName(e.target.value)}
-                      placeholder={t("mcp.modal.placeholderServerName")}
-                      data-testid="stdio-name-input"
-                      disabled={isPending}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <Label className="flex items-start gap-1 !text-mmd">
-                      {t("mcp.modal.fieldCommand")}
-                      <span className="text-destructive">*</span>
-                    </Label>
-                    <Input
-                      value={stdioCommand}
-                      onChange={(e) => setStdioCommand(e.target.value)}
-                      placeholder={t("mcp.modal.placeholderCommand")}
-                      data-testid="stdio-command-input"
-                      disabled={isPending}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <Label className="!text-mmd">
-                      {t("mcp.modal.fieldArguments")}
-                    </Label>
-                    <InputListComponent
-                      value={stdioArgs}
-                      handleOnNewValue={({ value }) => setStdioArgs(value)}
-                      disabled={isPending}
-                      placeholder={t("mcp.modal.placeholderArgument")}
-                      listAddLabel={t("mcp.modal.addArgumentButton")}
-                      editNode={false}
-                      id="stdio-args"
-                      data-testid="stdio-args-input"
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <Label className="!text-mmd">
-                      {t("mcp.modal.fieldEnvironmentVariables")}
-                    </Label>
-                    <IOKeyPairInput
-                      value={stdioEnv}
-                      onChange={setStdioEnv}
-                      duplicateKey={false}
-                      isList={true}
-                      isInputField={true}
-                      testId="stdio-env"
-                    />
-                  </div>
-                </div>
-              </TabsContent>
-              <TabsContent
-                value="HTTP"
-                className="flex flex-1 flex-col h-full p-0 m-0"
+                <span className="text-mmd font-normal">
+                  {t("mcp.modal.cancelButton")}
+                </span>
+              </Button>
+              <Button
+                size="sm"
+                onClick={submitForm}
+                data-testid="add-mcp-server-button"
+                loading={isPending}
               >
-                <div className="flex h-full flex-col gap-4">
-                  <div className="flex flex-col gap-2">
-                    <Label className="flex items-start gap-1 !text-mmd">
-                      {t("mcp.modal.fieldName")}
-                      <span className="text-destructive">*</span>
-                    </Label>
-                    <Input
-                      value={httpName}
-                      onChange={(e) => setHttpName(e.target.value)}
-                      placeholder={t("mcp.modal.placeholderHttpName")}
-                      data-testid="http-name-input"
-                      disabled={isPending}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <Label className="flex items-start gap-1 !text-mmd">
-                      {t("mcp.modal.fieldStreamableUrl")}
-                      <span className="text-destructive">*</span>
-                    </Label>
-                    <Input
-                      value={httpUrl}
-                      onChange={(e) => setHttpUrl(e.target.value)}
-                      placeholder={t("mcp.modal.placeholderHttpUrl")}
-                      data-testid="http-url-input"
-                      disabled={isPending}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <Label className="!text-mmd">
-                      {t("mcp.modal.fieldHeaders")}
-                    </Label>
-                    <IOKeyPairInputWithVariables
-                      value={httpHeaders}
-                      onChange={setHttpHeaders}
-                      duplicateKey={false}
-                      isList={true}
-                      isInputField={true}
-                      testId="http-headers"
-                      enableGlobalVariables={true}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <Label className="!text-mmd">
-                      {t("mcp.modal.fieldEnvironmentVariables")}
-                    </Label>
-                    <IOKeyPairInput
-                      value={httpEnv}
-                      onChange={setHttpEnv}
-                      duplicateKey={false}
-                      isList={true}
-                      isInputField={true}
-                      testId="http-env"
-                    />
-                  </div>
-                </div>
-              </TabsContent>
+                <span className="text-mmd">
+                  {initialData
+                    ? t("mcp.modal.updateServerButton")
+                    : t("mcp.modal.addServerButton")}
+                </span>
+              </Button>
             </div>
-          </Tabs>
-        </div>
-        <div className="flex shrink-0 justify-end gap-2 p-4">
-          <Button variant="outline" size="sm" onClick={() => setOpen(false)}>
-            <span className="text-mmd font-normal">
-              {t("mcp.modal.cancelButton")}
-            </span>
-          </Button>
-          <Button
-            size="sm"
-            onClick={submitForm}
-            data-testid="add-mcp-server-button"
-            loading={isPending}
-          >
-            <span className="text-mmd">
-              {initialData
-                ? t("mcp.modal.updateServerButton")
-                : t("mcp.modal.addServerButton")}
-            </span>
-          </Button>
-        </div>
-          </div>
+          </>
         )}
       </BaseModal.Content>
     </BaseModal>

--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -24,6 +24,8 @@ import IOKeyPairInput, {
   type KeyPairRow,
 } from "@/modals/IOModal/components/IOFieldView/components/key-pair-input";
 import IOKeyPairInputWithVariables from "@/modals/IOModal/components/IOFieldView/components/key-pair-input-with-variables";
+import useAuthStore from "@/stores/authStore";
+import { useUtilityStore } from "@/stores/utilityStore";
 import type { MCPServerType } from "@/types/mcp";
 import { extractMcpServersFromJson } from "@/utils/mcpUtils";
 import { parseString } from "@/utils/stringManipulation";
@@ -102,6 +104,11 @@ export default function AddMcpServerModal({
 
   const location = useLocation();
   const isOnMcpSettingsPage = location.pathname === MCP_SETTINGS_PAGE;
+  
+  // P2: Check if MCP servers are locked and if user is not admin
+  const mcpServersLocked = useUtilityStore((state) => state.mcpServersLocked);
+  const isAdmin = useAuthStore((state) => state.isAdmin);
+  const isModalLocked = mcpServersLocked && !isAdmin;
 
   const [type, setType] = useState(
     initialData ? (initialData.command ? "STDIO" : "HTTP") : "JSON",
@@ -332,18 +339,35 @@ export default function AddMcpServerModal({
     >
       <BaseModal.Trigger>{children}</BaseModal.Trigger>
       <BaseModal.Content className="flex flex-1 flex-col overflow-hidden min-h-0">
-        <div className="flex flex-1 w-full flex-col overflow-hidden min-h-0">
-          <div className="flex flex-col gap-3 p-4 tracking-normal">
-            <div className="flex items-center gap-2 text-sm font-medium">
-              <ForwardedIconComponent
-                name="Mcp"
-                className="h-4 w-4 text-primary"
-                aria-hidden="true"
-              />
-              {initialData
-                ? t("mcp.modal.updateTitle")
-                : t("mcp.modal.addTitle")}
+        {isModalLocked ? (
+          <div className="flex flex-col items-center justify-center p-8 text-center gap-4 flex-1">
+            <ForwardedIconComponent
+              name="Lock"
+              className="h-8 w-8 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <div className="flex flex-col gap-2">
+              <h3 className="text-sm font-semibold">
+                {t("mcp.modal.lockedTitle")}
+              </h3>
+              <p className="text-mmd text-muted-foreground">
+                {t("mcp.modal.lockedDescription")}
+              </p>
             </div>
+          </div>
+        ) : (
+          <div className="flex flex-1 w-full flex-col overflow-hidden min-h-0">
+            <div className="flex flex-col gap-3 p-4 tracking-normal">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <ForwardedIconComponent
+                  name="Mcp"
+                  className="h-4 w-4 text-primary"
+                  aria-hidden="true"
+                />
+                {initialData
+                  ? t("mcp.modal.updateTitle")
+                  : t("mcp.modal.addTitle")}
+              </div>
             <span className="text-mmd font-normal text-muted-foreground">
               {isOnMcpSettingsPage ? (
                 t("mcp.modal.descriptionSettings")
@@ -560,6 +584,8 @@ export default function AddMcpServerModal({
             </span>
           </Button>
         </div>
+          </div>
+        )}
       </BaseModal.Content>
     </BaseModal>
   );

--- a/src/frontend/src/modals/templatesModal/index.tsx
+++ b/src/frontend/src/modals/templatesModal/index.tsx
@@ -31,7 +31,10 @@ export default function TemplatesModal({
   );
 
   // If starter projects are hidden and we're on the get-started tab, switch to all-templates
-  const effectiveTab = hideStarterProjects && currentTab === "get-started" ? "all-templates" : currentTab;
+  const effectiveTab =
+    hideStarterProjects && currentTab === "get-started"
+      ? "all-templates"
+      : currentTab;
 
   const handleFlowCreating = (isCreating: boolean) => {
     setLoading(isCreating);

--- a/src/frontend/src/modals/templatesModal/index.tsx
+++ b/src/frontend/src/modals/templatesModal/index.tsx
@@ -7,6 +7,7 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import { track } from "@/customization/utils/analytics";
 import useAddFlow from "@/hooks/flows/use-add-flow";
+import { useUtilityStore } from "@/stores/utilityStore";
 import type { Category } from "@/types/templates/types";
 import { cn } from "@/utils/utils";
 import type { newFlowModalPropsType } from "../../types/components";
@@ -25,6 +26,12 @@ export default function TemplatesModal({
   const addFlow = useAddFlow();
   const navigate = useCustomNavigate();
   const { folderId } = useParams();
+  const hideStarterProjects = useUtilityStore(
+    (state) => state.hideStarterProjects,
+  );
+
+  // If starter projects are hidden and we're on the get-started tab, switch to all-templates
+  const effectiveTab = hideStarterProjects && currentTab === "get-started" ? "all-templates" : currentTab;
 
   const handleFlowCreating = (isCreating: boolean) => {
     setLoading(isCreating);
@@ -50,11 +57,16 @@ export default function TemplatesModal({
     {
       title: t("templatesModal.title"),
       items: [
-        {
-          title: t("templatesModal.getStarted"),
-          icon: "SquarePlay",
-          id: "get-started",
-        },
+        // Hide "Get Started" tab if starter projects are hidden
+        ...(hideStarterProjects
+          ? []
+          : [
+              {
+                title: t("templatesModal.getStarted"),
+                icon: "SquarePlay",
+                id: "get-started",
+              },
+            ]),
         {
           title: t("templatesModal.allTemplates"),
           icon: "LayoutPanelTop",
@@ -115,14 +127,14 @@ export default function TemplatesModal({
               setCurrentTab={setCurrentTab}
             />
             <main className="flex flex-1 flex-col gap-4 overflow-auto p-6 md:gap-8">
-              {currentTab === "get-started" ? (
+              {effectiveTab === "get-started" ? (
                 <GetStartedComponent
                   loading={loading}
                   onFlowCreating={handleFlowCreating}
                 />
               ) : (
                 <TemplateContentComponent
-                  currentTab={currentTab}
+                  currentTab={effectiveTab}
                   categories={categories.flatMap((category) => category.items)}
                   loading={loading}
                   onFlowCreating={handleFlowCreating}

--- a/src/frontend/src/pages/MainPage/components/header/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/index.tsx
@@ -45,6 +45,7 @@ const HeaderComponent = ({
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const isMCPEnabled = ENABLE_MCP;
   const setSuccessData = useAlertStore((state) => state.setSuccessData);
+  const hideNewFlowButton = useUtilityStore((state) => state.hideNewFlowButton);
   // Debounce the setSearch function from the parent
   const debouncedSetSearch = useCallback(
     debounce((value: string) => {
@@ -261,25 +262,27 @@ const HeaderComponent = ({
                     </Button>
                   </DeleteConfirmationModal>
                 </div>
-                <ShadTooltip content={t("mainPage.newFlow")} side="bottom">
-                  <Button
-                    variant="default"
-                    size="iconMd"
-                    className="z-50 px-2.5 !text-mmd"
-                    onClick={() => setNewProjectModal(true)}
-                    id="new-project-btn"
-                    data-testid="new-project-btn"
-                  >
-                    <ForwardedIconComponent
-                      name="Plus"
-                      aria-hidden="true"
-                      className="h-4 w-4"
-                    />
-                    <span className="hidden whitespace-nowrap font-semibold md:inline">
-                      {t("mainPage.newFlow")}
-                    </span>
-                  </Button>
-                </ShadTooltip>
+                {!hideNewFlowButton && (
+                  <ShadTooltip content={t("mainPage.newFlow")} side="bottom">
+                    <Button
+                      variant="default"
+                      size="iconMd"
+                      className="z-50 px-2.5 !text-mmd"
+                      onClick={() => setNewProjectModal(true)}
+                      id="new-project-btn"
+                      data-testid="new-project-btn"
+                    >
+                      <ForwardedIconComponent
+                        name="Plus"
+                        aria-hidden="true"
+                        className="h-4 w-4"
+                      />
+                      <span className="hidden whitespace-nowrap font-semibold md:inline">
+                        {t("mainPage.newFlow")}
+                      </span>
+                    </Button>
+                  </ShadTooltip>
+                )}
               </div>
             </div>
           )}

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -66,4 +66,25 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
     set({ allowCustomComponents }),
   mcpBaseUrl: "",
   setMcpBaseUrl: (mcpBaseUrl: string) => set({ mcpBaseUrl }),
+  // P2 ICA integration flags
+  embeddedMode: false,
+  setEmbeddedMode: (embeddedMode: boolean) => set({ embeddedMode }),
+  hideLogoutButton: false,
+  setHideLogoutButton: (hideLogoutButton: boolean) =>
+    set({ hideLogoutButton }),
+  hideNewProjectButton: false,
+  setHideNewProjectButton: (hideNewProjectButton: boolean) =>
+    set({ hideNewProjectButton }),
+  hideNewFlowButton: false,
+  setHideNewFlowButton: (hideNewFlowButton: boolean) =>
+    set({ hideNewFlowButton }),
+  hideStarterProjects: false,
+  setHideStarterProjects: (hideStarterProjects: boolean) =>
+    set({ hideStarterProjects }),
+  mcpServersLocked: false,
+  setMcpServersLocked: (mcpServersLocked: boolean) =>
+    set({ mcpServersLocked }),
+  customComponentAdminOnly: false,
+  setCustomComponentAdminOnly: (customComponentAdminOnly: boolean) =>
+    set({ customComponentAdminOnly }),
 }));

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -70,8 +70,7 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   embeddedMode: false,
   setEmbeddedMode: (embeddedMode: boolean) => set({ embeddedMode }),
   hideLogoutButton: false,
-  setHideLogoutButton: (hideLogoutButton: boolean) =>
-    set({ hideLogoutButton }),
+  setHideLogoutButton: (hideLogoutButton: boolean) => set({ hideLogoutButton }),
   hideNewProjectButton: false,
   setHideNewProjectButton: (hideNewProjectButton: boolean) =>
     set({ hideNewProjectButton }),
@@ -82,8 +81,7 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   setHideStarterProjects: (hideStarterProjects: boolean) =>
     set({ hideStarterProjects }),
   mcpServersLocked: false,
-  setMcpServersLocked: (mcpServersLocked: boolean) =>
-    set({ mcpServersLocked }),
+  setMcpServersLocked: (mcpServersLocked: boolean) => set({ mcpServersLocked }),
   customComponentAdminOnly: false,
   setCustomComponentAdminOnly: (customComponentAdminOnly: boolean) =>
     set({ customComponentAdminOnly }),

--- a/src/frontend/src/types/zustand/utility/index.ts
+++ b/src/frontend/src/types/zustand/utility/index.ts
@@ -40,4 +40,19 @@ export type UtilityStoreType = {
   setAllowCustomComponents: (allowCustomComponents: boolean) => void;
   mcpBaseUrl: string;
   setMcpBaseUrl: (mcpBaseUrl: string) => void;
+  // P2 ICA integration flags
+  embeddedMode: boolean;
+  setEmbeddedMode: (embeddedMode: boolean) => void;
+  hideLogoutButton: boolean;
+  setHideLogoutButton: (hideLogoutButton: boolean) => void;
+  hideNewProjectButton: boolean;
+  setHideNewProjectButton: (hideNewProjectButton: boolean) => void;
+  hideNewFlowButton: boolean;
+  setHideNewFlowButton: (hideNewFlowButton: boolean) => void;
+  hideStarterProjects: boolean;
+  setHideStarterProjects: (hideStarterProjects: boolean) => void;
+  mcpServersLocked: boolean;
+  setMcpServersLocked: (mcpServersLocked: boolean) => void;
+  customComponentAdminOnly: boolean;
+  setCustomComponentAdminOnly: (customComponentAdminOnly: boolean) => void;
 };

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -427,6 +427,9 @@ class Settings(BaseSettings):
 
     Note: this is a beta feature. For security in a multi-tenant environment,
     use hardware-level isolation to restrict access."""
+    custom_component_admin_only: bool = False
+    """If set to True, only admin users can edit custom component code. Regular editors
+    are blocked from modifying custom component templates."""
 
     # SSRF Protection
     ssrf_protection_enabled: bool = False
@@ -444,6 +447,24 @@ class Settings(BaseSettings):
 
     Note: This setting only takes effect when ssrf_protection_enabled is True.
     When protection is disabled, all hosts are allowed regardless of this setting."""
+
+    # Embedded/iframe mode - ICA integration flags
+    embedded_mode: bool = False
+    """Umbrella flag for iframe/embedded mode. When True, hides UI elements specific to
+    standalone installations (logout button, new project/flow buttons, starter projects, etc.)."""
+    hide_logout_button: bool = False
+    """If set to True, hides the Logout button in the account menu."""
+    hide_new_project_button: bool = False
+    """If set to True, hides the ability to create new projects/folders."""
+    hide_new_flow_button: bool = False
+    """If set to True, hides the ability to create new flows."""
+    hide_starter_projects: bool = False
+    """If set to True, hides starter projects from the UI (does not affect database seeding)."""
+
+    # MCP Server management
+    mcp_servers_locked: bool = False
+    """If set to True, users cannot add or modify MCP servers via the UI. Only admin/superuser
+    can modify them through backend configuration. ContextForge remains the single ingress."""
 
     @field_validator("runtime_port", mode="before")
     @classmethod


### PR DESCRIPTION
Summary
Implements LE-906 P2 security and integrated-environment UX controls across backend and frontend.

What Changed

- Added admin-only custom component authoring control and enforced it in custom component create/update APIs.
- Added embedded/integration visibility controls in settings/config and wired them through frontend hydration/store.
- Added MCP server management lock control and enforced it server-side for non-admin users.
- Updated frontend gating for:
-       Logout button visibility
-       New project/folder creation visibility
-       New flow creation visibility
-       Starter projects/get-started visibility
-       MCP add-server modal lock state
- Added hardening for feature-flag checks to avoid mocked-settings truthiness side effects in tests.
- Repaired JSX structure in AddMcpServerModal.


Commits

- 4d4b53fe60 feat(LE-906): P2 Fixes - Security & UX improvements for integrated environments
- 0bb61641f3 fix(LE-906): harden feature-flag checks against mocked settings
- 6009977afb fix(LE-906): repair AddMcpServerModal JSX structure

Validation

- Backend unit tests run completed successfully (with expected skips/xfails from environment-dependent tests).
- Previously failing targeted tests now pass:
-        test_install_mcp_config_defaults_to_sse_transport
-        test_install_mcp_config_streamable_transport
-        test_multi_process_visibility
- Backend formatting passed.
- Frontend full make format_frontend is currently blocked by broader repo-level Biome/Tailwind parser diagnostics outside LE-906 scope; targeted check/format for AddMcpServerModal passes.

Notes

- Defaults are non-breaking unless the new flags are explicitly enabled.
- Backend enforcement and frontend gating are implemented together so restricted actions are both blocked and clearly represented in UI.
