### PR TITLE
fix: Remove redundant Components entry from the left sidebar

### DIFF
--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/__tests__/sidebarSegmentedNav.test.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/__tests__/sidebarSegmentedNav.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { SidebarSection } from "@/components/ui/sidebar";
 import enTranslations from "@/locales/en.json";
 import SidebarSegmentedNav, { NAV_ITEMS } from "../sidebarSegmentedNav";
@@ -186,12 +186,12 @@ describe("SidebarSegmentedNav", () => {
     expect(componentsButton).toHaveAttribute("data-active", "false");
   });
 
-  it("sets active state for search when activeSection is search", () => {
-    mockUseSidebar.activeSection = "search";
+  it("sets active state for bundles when activeSection is bundles", () => {
+    mockUseSidebar.activeSection = "bundles";
     render(<SidebarSegmentedNav />);
 
-    const searchButton = screen.getByTestId("sidebar-nav-search");
-    expect(searchButton).toHaveAttribute("data-active", "true");
+    const bundlesButton = screen.getByTestId("sidebar-nav-bundles");
+    expect(bundlesButton).toHaveAttribute("data-active", "true");
   });
 
   it("calls setActiveSection when clicking on different section", () => {
@@ -256,40 +256,6 @@ describe("SidebarSegmentedNav", () => {
 
     expect(mockUseSearchContext.setSearch).toHaveBeenCalledWith("");
     expect(mockUseSearchContext.setSearch).toHaveBeenCalledTimes(1);
-  });
-
-  it("focuses search input when search section is clicked", async () => {
-    render(<SidebarSegmentedNav />);
-
-    const searchButton = screen.getByTestId("sidebar-nav-search");
-    fireEvent.click(searchButton);
-
-    expect(mockUseSidebar.setActiveSection).toHaveBeenCalledWith("search");
-
-    // Fast-forward the setTimeout
-    jest.advanceTimersByTime(100);
-
-    await waitFor(() => {
-      expect(mockUseSearchContext.focusSearch).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("focuses search input even when sidebar is closed", async () => {
-    mockUseSidebar.open = false;
-    render(<SidebarSegmentedNav />);
-
-    const searchButton = screen.getByTestId("sidebar-nav-search");
-    fireEvent.click(searchButton);
-
-    expect(mockUseSidebar.setActiveSection).toHaveBeenCalledWith("search");
-    expect(mockUseSidebar.toggleSidebar).toHaveBeenCalledTimes(1);
-
-    // Fast-forward the setTimeout
-    jest.advanceTimersByTime(100);
-
-    await waitFor(() => {
-      expect(mockUseSearchContext.focusSearch).toHaveBeenCalledTimes(1);
-    });
   });
 
   it("renders accessibility labels correctly", () => {
@@ -389,38 +355,38 @@ describe("SidebarSegmentedNav", () => {
   });
 
   it("exports NAV_ITEMS correctly", () => {
-    expect(NAV_ITEMS).toHaveLength(7);
+    expect(NAV_ITEMS).toHaveLength(6);
     expect(NAV_ITEMS[0]).toEqual({
-      id: "search",
-      icon: "search",
-      label: "sidebar.nav.search",
-      tooltip: "sidebar.nav.search",
+      id: "components",
+      icon: "component",
+      label: "sidebar.nav.components",
+      tooltip: "sidebar.nav.components",
     });
-    expect(NAV_ITEMS[2]).toEqual({
+    expect(NAV_ITEMS[1]).toEqual({
       id: "mcp",
       icon: "Mcp",
       label: "sidebar.nav.mcp",
       tooltip: "sidebar.nav.mcp",
     });
-    expect(NAV_ITEMS[3]).toEqual({
+    expect(NAV_ITEMS[2]).toEqual({
       id: "bundles",
       icon: "blocks",
       label: "sidebar.nav.bundles",
       tooltip: "sidebar.nav.bundles",
     });
-    expect(NAV_ITEMS[4]).toEqual({
+    expect(NAV_ITEMS[3]).toEqual({
       id: "versions",
       icon: "History",
       label: "sidebar.nav.versions",
       tooltip: "sidebar.nav.versionHistory",
     });
-    expect(NAV_ITEMS[5]).toEqual({
+    expect(NAV_ITEMS[4]).toEqual({
       id: "traces",
       icon: "Activity",
       label: "sidebar.nav.traces",
       tooltip: "sidebar.nav.traces",
     });
-    expect(NAV_ITEMS[6]).toEqual({
+    expect(NAV_ITEMS[5]).toEqual({
       id: "memories",
       icon: "Brain",
       label: "Memories",

--- a/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarSegmentedNav.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarSegmentedNav.tsx
@@ -23,12 +23,6 @@ interface NavItem {
 
 export const NAV_ITEMS: NavItem[] = [
   {
-    id: "search",
-    icon: "search",
-    label: "sidebar.nav.search",
-    tooltip: "sidebar.nav.search",
-  },
-  {
     id: "components",
     icon: "component",
     label: "sidebar.nav.components",
@@ -69,7 +63,7 @@ export const NAV_ITEMS: NavItem[] = [
 const SidebarSegmentedNav = () => {
   const { t } = useTranslation();
   const { activeSection, setActiveSection, toggleSidebar, open } = useSidebar();
-  const { focusSearch, setSearch } = useSearchContext();
+  const { setSearch } = useSearchContext();
   const setPlaygroundOpen = usePlaygroundStore((state) => state.setIsOpen);
   const setPlaygroundFullscreen = usePlaygroundStore(
     (state) => state.setIsFullscreen,
@@ -101,9 +95,6 @@ const SidebarSegmentedNav = () => {
                       setActiveSection(item.id);
                       if (!open) {
                         toggleSidebar();
-                      }
-                      if (item.id === "search") {
-                        setTimeout(() => focusSearch(), 100);
                       }
                     }
                   }}


### PR DESCRIPTION
Description
We want to remove the search bar on the menu sidebar, as it adds unnecessary redundancy, as the search bar is always present


Screenshot
 Before
<img width="1646" height="916" alt="Screenshot 2026-05-12 at 3 30 59 PM" src="https://github.com/user-attachments/assets/6dc824a5-cfc4-4c24-a6ff-27600135a48d" />

After
<img width="1646" height="916" alt="Screenshot 2026-05-12 at 3 30 43 PM" src="https://github.com/user-attachments/assets/0e7c3375-c7f4-4e1e-aec6-cfa2228b57c1" />

