### PR TITLE
feat: Add embedded mode configuration flags

### DIFF
--- a/src/backend/base/langflow/api/v1/schemas/__init__.py
+++ b/src/backend/base/langflow/api/v1/schemas/__init__.py
@@ -453,7 +453,7 @@ class ConfigResponse(BaseConfigResponse):
     default_folder_name: str
     hide_getting_started_progress: bool
     allow_custom_components: bool
-    # P2 feature flags for ICA integration
+    # Embedded mode feature flags
     embedded_mode: bool
     hide_logout_button: bool
     hide_new_project_button: bool
@@ -473,8 +473,6 @@ class ConfigResponse(BaseConfigResponse):
         Returns:
             ConfigResponse: An instance populated with configuration and feature flag values.
         """
-        import os
-
         from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NAME
 
         return cls(
@@ -495,7 +493,7 @@ class ConfigResponse(BaseConfigResponse):
             enable_extension_reload=settings.enable_extension_reload,
             webhook_auth_enable=auth_settings.WEBHOOK_AUTH_ENABLE,
             default_folder_name=DEFAULT_FOLDER_NAME,
-            hide_getting_started_progress=os.getenv("HIDE_GETTING_STARTED_PROGRESS", "").lower() == "true",
+            hide_getting_started_progress=settings.hide_getting_started_progress,
             allow_custom_components=settings.allow_custom_components,
             authz_enabled=bool(getattr(auth_settings, "AUTHZ_ENABLED", False)),
             embedded_mode=settings.embedded_mode,

--- a/src/backend/base/langflow/api/v1/schemas/__init__.py
+++ b/src/backend/base/langflow/api/v1/schemas/__init__.py
@@ -453,6 +453,14 @@ class ConfigResponse(BaseConfigResponse):
     default_folder_name: str
     hide_getting_started_progress: bool
     allow_custom_components: bool
+    # P2 feature flags for ICA integration
+    embedded_mode: bool
+    hide_logout_button: bool
+    hide_new_project_button: bool
+    hide_new_flow_button: bool
+    hide_starter_projects: bool
+    mcp_servers_locked: bool
+    custom_component_admin_only: bool
 
     @classmethod
     def from_settings(cls, settings: Settings, auth_settings) -> "ConfigResponse":
@@ -490,6 +498,13 @@ class ConfigResponse(BaseConfigResponse):
             hide_getting_started_progress=os.getenv("HIDE_GETTING_STARTED_PROGRESS", "").lower() == "true",
             allow_custom_components=settings.allow_custom_components,
             authz_enabled=bool(getattr(auth_settings, "AUTHZ_ENABLED", False)),
+            embedded_mode=settings.embedded_mode,
+            hide_logout_button=settings.hide_logout_button or settings.embedded_mode,
+            hide_new_project_button=settings.hide_new_project_button or settings.embedded_mode,
+            hide_new_flow_button=settings.hide_new_flow_button or settings.embedded_mode,
+            hide_starter_projects=settings.hide_starter_projects or settings.embedded_mode,
+            mcp_servers_locked=settings.mcp_servers_locked,
+            custom_component_admin_only=settings.custom_component_admin_only,
         )
 
 

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -303,7 +303,7 @@ async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient,
     monkeypatch.setattr(settings_service.settings, "hide_new_project_button", False)
     monkeypatch.setattr(settings_service.settings, "hide_new_flow_button", False)
     monkeypatch.setattr(settings_service.settings, "hide_starter_projects", False)
-    monkeypatch.setattr(settings_service.settings, "hide_getting_started_progress", True)
+    monkeypatch.setattr(settings_service.settings, "hide_getting_started_progress", False)
 
     response = await client.get("api/v1/config", headers=logged_in_headers)
     result = response.json()
@@ -314,7 +314,50 @@ async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient,
     assert result["hide_new_project_button"] is True
     assert result["hide_new_flow_button"] is True
     assert result["hide_starter_projects"] is True
+    # This flag is currently a direct passthrough (not part of embedded_mode cascade).
+    assert result["hide_getting_started_progress"] is False
+
+
+async def test_get_config_embedded_mode_false_keeps_individual_hide_flags(
+    client: AsyncClient, logged_in_headers: dict, monkeypatch
+):
+    """When embedded mode is disabled, individual hide flags should retain explicit values."""
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    monkeypatch.setattr(settings_service.settings, "embedded_mode", False)
+    monkeypatch.setattr(settings_service.settings, "hide_logout_button", False)
+    monkeypatch.setattr(settings_service.settings, "hide_new_project_button", False)
+    monkeypatch.setattr(settings_service.settings, "hide_new_flow_button", True)
+    monkeypatch.setattr(settings_service.settings, "hide_starter_projects", False)
+    monkeypatch.setattr(settings_service.settings, "hide_getting_started_progress", True)
+
+    response = await client.get("api/v1/config", headers=logged_in_headers)
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result["embedded_mode"] is False
+    assert result["hide_logout_button"] is False
+    assert result["hide_new_project_button"] is False
+    assert result["hide_new_flow_button"] is True
+    assert result["hide_starter_projects"] is False
     assert result["hide_getting_started_progress"] is True
+
+
+async def test_get_config_returns_mcp_and_admin_only_flags(client: AsyncClient, logged_in_headers: dict, monkeypatch):
+    """Config response should expose lock/admin feature flags from settings."""
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    monkeypatch.setattr(settings_service.settings, "mcp_servers_locked", True)
+    monkeypatch.setattr(settings_service.settings, "custom_component_admin_only", True)
+
+    response = await client.get("api/v1/config", headers=logged_in_headers)
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result["mcp_servers_locked"] is True
+    assert result["custom_component_admin_only"] is True
 
 
 async def test_get_config_returns_mcp_base_url(client: AsyncClient, logged_in_headers: dict):

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -293,6 +293,30 @@ async def test_get_config_authenticated_returns_full_config(client: AsyncClient,
     assert "feature_flags" in result, "Authenticated response must contain 'feature_flags'"
 
 
+async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient, logged_in_headers: dict, monkeypatch):
+    """Embedded mode should force all embedded hide flags to true in full config."""
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    monkeypatch.setattr(settings_service.settings, "embedded_mode", True)
+    monkeypatch.setattr(settings_service.settings, "hide_logout_button", False)
+    monkeypatch.setattr(settings_service.settings, "hide_new_project_button", False)
+    monkeypatch.setattr(settings_service.settings, "hide_new_flow_button", False)
+    monkeypatch.setattr(settings_service.settings, "hide_starter_projects", False)
+    monkeypatch.setattr(settings_service.settings, "hide_getting_started_progress", True)
+
+    response = await client.get("api/v1/config", headers=logged_in_headers)
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result["embedded_mode"] is True
+    assert result["hide_logout_button"] is True
+    assert result["hide_new_project_button"] is True
+    assert result["hide_new_flow_button"] is True
+    assert result["hide_starter_projects"] is True
+    assert result["hide_getting_started_progress"] is True
+
+
 async def test_get_config_returns_mcp_base_url(client: AsyncClient, logged_in_headers: dict):
     """Test that /config includes mcp_base_url for both authenticated and unauthenticated responses."""
     # Authenticated

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -294,7 +294,7 @@ async def test_get_config_authenticated_returns_full_config(client: AsyncClient,
 
 
 async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient, logged_in_headers: dict, monkeypatch):
-    """Embedded mode should force all embedded hide flags to true in full config."""
+    """Embedded mode should only force UI hide flags, not security lock flags."""
     from langflow.services.deps import get_settings_service
 
     settings_service = get_settings_service()
@@ -304,6 +304,8 @@ async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient,
     monkeypatch.setattr(settings_service.settings, "hide_new_flow_button", False)
     monkeypatch.setattr(settings_service.settings, "hide_starter_projects", False)
     monkeypatch.setattr(settings_service.settings, "hide_getting_started_progress", False)
+    monkeypatch.setattr(settings_service.settings, "mcp_servers_locked", False)
+    monkeypatch.setattr(settings_service.settings, "custom_component_admin_only", False)
 
     response = await client.get("api/v1/config", headers=logged_in_headers)
     result = response.json()
@@ -316,6 +318,9 @@ async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient,
     assert result["hide_starter_projects"] is True
     # This flag is currently a direct passthrough (not part of embedded_mode cascade).
     assert result["hide_getting_started_progress"] is False
+    # Security lock flags are explicit opt-ins and do not cascade from embedded_mode.
+    assert result["mcp_servers_locked"] is False
+    assert result["custom_component_admin_only"] is False
 
 
 async def test_get_config_embedded_mode_false_keeps_individual_hide_flags(

--- a/src/frontend/src/controllers/API/queries/config/use-get-config.ts
+++ b/src/frontend/src/controllers/API/queries/config/use-get-config.ts
@@ -41,6 +41,13 @@ export interface ConfigResponse extends BaseConfig {
   webhook_auth_enable: boolean;
   default_folder_name: string;
   hide_getting_started_progress: boolean;
+  embedded_mode: boolean;
+  hide_logout_button: boolean;
+  hide_new_project_button: boolean;
+  hide_new_flow_button: boolean;
+  hide_starter_projects: boolean;
+  mcp_servers_locked: boolean;
+  custom_component_admin_only: boolean;
 }
 
 // Union type for the response (can be either public or full config)
@@ -91,6 +98,25 @@ export const useGetConfig: useQueryFunctionType<
   const setEnableExtensionReload = useUtilityStore(
     (state) => state.setEnableExtensionReload,
   );
+  const setEmbeddedMode = useUtilityStore((state) => state.setEmbeddedMode);
+  const setHideLogoutButton = useUtilityStore(
+    (state) => state.setHideLogoutButton,
+  );
+  const setHideNewProjectButton = useUtilityStore(
+    (state) => state.setHideNewProjectButton,
+  );
+  const setHideNewFlowButton = useUtilityStore(
+    (state) => state.setHideNewFlowButton,
+  );
+  const setHideStarterProjects = useUtilityStore(
+    (state) => state.setHideStarterProjects,
+  );
+  const setMcpServersLocked = useUtilityStore(
+    (state) => state.setMcpServersLocked,
+  );
+  const setCustomComponentAdminOnly = useUtilityStore(
+    (state) => state.setCustomComponentAdminOnly,
+  );
 
   const { query } = UseRequestProcessor();
 
@@ -132,6 +158,14 @@ export const useGetConfig: useQueryFunctionType<
         setHideGettingStartedProgress(
           data.hide_getting_started_progress ?? false,
         );
+        // P2 ICA integration flags
+        setEmbeddedMode(data.embedded_mode ?? false);
+        setHideLogoutButton(data.hide_logout_button ?? false);
+        setHideNewProjectButton(data.hide_new_project_button ?? false);
+        setHideNewFlowButton(data.hide_new_flow_button ?? false);
+        setHideStarterProjects(data.hide_starter_projects ?? false);
+        setMcpServersLocked(data.mcp_servers_locked ?? false);
+        setCustomComponentAdminOnly(data.custom_component_admin_only ?? false);
       }
     }
     return data;

--- a/src/frontend/src/controllers/API/queries/config/use-get-config.ts
+++ b/src/frontend/src/controllers/API/queries/config/use-get-config.ts
@@ -158,7 +158,7 @@ export const useGetConfig: useQueryFunctionType<
         setHideGettingStartedProgress(
           data.hide_getting_started_progress ?? false,
         );
-        // P2 ICA integration flags
+        // Embedded mode flags
         setEmbeddedMode(data.embedded_mode ?? false);
         setHideLogoutButton(data.hide_logout_button ?? false);
         setHideNewProjectButton(data.hide_new_project_button ?? false);

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -72,7 +72,7 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   enableExtensionReload: false,
   setEnableExtensionReload: (enableExtensionReload: boolean) =>
     set({ enableExtensionReload }),
-  // P2 ICA integration flags
+  // Embedded mode flags
   embeddedMode: false,
   setEmbeddedMode: (embeddedMode: boolean) => set({ embeddedMode }),
   hideLogoutButton: false,

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -76,8 +76,7 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   embeddedMode: false,
   setEmbeddedMode: (embeddedMode: boolean) => set({ embeddedMode }),
   hideLogoutButton: false,
-  setHideLogoutButton: (hideLogoutButton: boolean) =>
-    set({ hideLogoutButton }),
+  setHideLogoutButton: (hideLogoutButton: boolean) => set({ hideLogoutButton }),
   hideNewProjectButton: false,
   setHideNewProjectButton: (hideNewProjectButton: boolean) =>
     set({ hideNewProjectButton }),
@@ -88,8 +87,7 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   setHideStarterProjects: (hideStarterProjects: boolean) =>
     set({ hideStarterProjects }),
   mcpServersLocked: false,
-  setMcpServersLocked: (mcpServersLocked: boolean) =>
-    set({ mcpServersLocked }),
+  setMcpServersLocked: (mcpServersLocked: boolean) => set({ mcpServersLocked }),
   customComponentAdminOnly: false,
   setCustomComponentAdminOnly: (customComponentAdminOnly: boolean) =>
     set({ customComponentAdminOnly }),

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -72,4 +72,25 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   enableExtensionReload: false,
   setEnableExtensionReload: (enableExtensionReload: boolean) =>
     set({ enableExtensionReload }),
+  // P2 ICA integration flags
+  embeddedMode: false,
+  setEmbeddedMode: (embeddedMode: boolean) => set({ embeddedMode }),
+  hideLogoutButton: false,
+  setHideLogoutButton: (hideLogoutButton: boolean) =>
+    set({ hideLogoutButton }),
+  hideNewProjectButton: false,
+  setHideNewProjectButton: (hideNewProjectButton: boolean) =>
+    set({ hideNewProjectButton }),
+  hideNewFlowButton: false,
+  setHideNewFlowButton: (hideNewFlowButton: boolean) =>
+    set({ hideNewFlowButton }),
+  hideStarterProjects: false,
+  setHideStarterProjects: (hideStarterProjects: boolean) =>
+    set({ hideStarterProjects }),
+  mcpServersLocked: false,
+  setMcpServersLocked: (mcpServersLocked: boolean) =>
+    set({ mcpServersLocked }),
+  customComponentAdminOnly: false,
+  setCustomComponentAdminOnly: (customComponentAdminOnly: boolean) =>
+    set({ customComponentAdminOnly }),
 }));

--- a/src/frontend/src/types/zustand/utility/index.ts
+++ b/src/frontend/src/types/zustand/utility/index.ts
@@ -53,7 +53,7 @@ export type UtilityStoreType = {
    */
   enableExtensionReload: boolean;
   setEnableExtensionReload: (enableExtensionReload: boolean) => void;
-  // P2 ICA integration flags
+  // Embedded mode flags
   embeddedMode: boolean;
   setEmbeddedMode: (embeddedMode: boolean) => void;
   hideLogoutButton: boolean;

--- a/src/frontend/src/types/zustand/utility/index.ts
+++ b/src/frontend/src/types/zustand/utility/index.ts
@@ -53,4 +53,19 @@ export type UtilityStoreType = {
    */
   enableExtensionReload: boolean;
   setEnableExtensionReload: (enableExtensionReload: boolean) => void;
+  // P2 ICA integration flags
+  embeddedMode: boolean;
+  setEmbeddedMode: (embeddedMode: boolean) => void;
+  hideLogoutButton: boolean;
+  setHideLogoutButton: (hideLogoutButton: boolean) => void;
+  hideNewProjectButton: boolean;
+  setHideNewProjectButton: (hideNewProjectButton: boolean) => void;
+  hideNewFlowButton: boolean;
+  setHideNewFlowButton: (hideNewFlowButton: boolean) => void;
+  hideStarterProjects: boolean;
+  setHideStarterProjects: (hideStarterProjects: boolean) => void;
+  mcpServersLocked: boolean;
+  setMcpServersLocked: (mcpServersLocked: boolean) => void;
+  customComponentAdminOnly: boolean;
+  setCustomComponentAdminOnly: (customComponentAdminOnly: boolean) => void;
 };

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -503,7 +503,12 @@ class Settings(BaseSettings):
     # Embedded mode flags
     embedded_mode: bool = False
     """Umbrella flag for iframe/embedded mode. When True, hides UI elements specific to
-    standalone installations (logout button, new project/flow buttons, starter projects, etc.)."""
+    standalone installations (logout button, new project/flow buttons, starter projects, etc.).
+
+    This flag does not implicitly enable security controls such as
+    ``mcp_servers_locked`` or ``custom_component_admin_only``. Configure those
+    explicitly based on your deployment hardening requirements.
+    """
     hide_getting_started_progress: bool = Field(
         default=False,
         validation_alias=AliasChoices(
@@ -523,8 +528,11 @@ class Settings(BaseSettings):
 
     # MCP Server management
     mcp_servers_locked: bool = False
-    """If set to True, users cannot add or modify MCP servers via the UI. Only admin/superuser
-    can modify them through backend configuration. ContextForge remains the single ingress."""
+    """If set to True, users cannot add or modify MCP servers via the UI/API.
+
+    This control is independent from ``embedded_mode`` and must be enabled
+    explicitly when you want to lock MCP server management.
+    """
 
     @field_validator("runtime_port", mode="before")
     @classmethod

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -479,6 +479,9 @@ class Settings(BaseSettings):
 
     Note: this is a beta feature. For security in a multi-tenant environment,
     use hardware-level isolation to restrict access."""
+    custom_component_admin_only: bool = False
+    """If set to True, only admin users can edit custom component code. Regular editors
+    are blocked from modifying custom component templates."""
 
     # SSRF Protection
     ssrf_protection_enabled: bool = True
@@ -496,6 +499,24 @@ class Settings(BaseSettings):
 
     Note: This setting only takes effect when ssrf_protection_enabled is True.
     When protection is disabled, all hosts are allowed regardless of this setting."""
+
+    # Embedded/iframe mode - ICA integration flags
+    embedded_mode: bool = False
+    """Umbrella flag for iframe/embedded mode. When True, hides UI elements specific to
+    standalone installations (logout button, new project/flow buttons, starter projects, etc.)."""
+    hide_logout_button: bool = False
+    """If set to True, hides the Logout button in the account menu."""
+    hide_new_project_button: bool = False
+    """If set to True, hides the ability to create new projects/folders."""
+    hide_new_flow_button: bool = False
+    """If set to True, hides the ability to create new flows."""
+    hide_starter_projects: bool = False
+    """If set to True, hides starter projects from the UI (does not affect database seeding)."""
+
+    # MCP Server management
+    mcp_servers_locked: bool = False
+    """If set to True, users cannot add or modify MCP servers via the UI. Only admin/superuser
+    can modify them through backend configuration. ContextForge remains the single ingress."""
 
     @field_validator("runtime_port", mode="before")
     @classmethod

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -500,10 +500,12 @@ class Settings(BaseSettings):
     Note: This setting only takes effect when ssrf_protection_enabled is True.
     When protection is disabled, all hosts are allowed regardless of this setting."""
 
-    # Embedded/iframe mode - ICA integration flags
+    # Embedded mode flags
     embedded_mode: bool = False
     """Umbrella flag for iframe/embedded mode. When True, hides UI elements specific to
     standalone installations (logout button, new project/flow buttons, starter projects, etc.)."""
+    hide_getting_started_progress: bool = False
+    """If set to True, hides the getting-started onboarding progress UI."""
     hide_logout_button: bool = False
     """If set to True, hides the Logout button in the account menu."""
     hide_new_project_button: bool = False

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 import aiofiles
 import orjson
 import yaml
-from pydantic import Field, field_validator
+from pydantic import AliasChoices, Field, field_validator
 from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings, EnvSettingsSource, PydanticBaseSettingsSource, SettingsConfigDict
 from typing_extensions import override
@@ -504,7 +504,13 @@ class Settings(BaseSettings):
     embedded_mode: bool = False
     """Umbrella flag for iframe/embedded mode. When True, hides UI elements specific to
     standalone installations (logout button, new project/flow buttons, starter projects, etc.)."""
-    hide_getting_started_progress: bool = False
+    hide_getting_started_progress: bool = Field(
+        default=False,
+        validation_alias=AliasChoices(
+            "LANGFLOW_HIDE_GETTING_STARTED_PROGRESS",
+            "HIDE_GETTING_STARTED_PROGRESS",
+        ),
+    )
     """If set to True, hides the getting-started onboarding progress UI."""
     hide_logout_button: bool = False
     """If set to True, hides the Logout button in the account menu."""


### PR DESCRIPTION
## Summary
Implements core plumbing for LE-906 P2 fixes by adding 7 new configuration flags 
and exposing them through the config API.

## Changes
- Add 7 new settings: custom_component_admin_only, embedded_mode, 
  hide_logout_button, hide_new_project_button, hide_new_flow_button, 
  hide_starter_projects, mcp_servers_locked (all default: false)
- All settings configurable via LANGFLOW_* environment variables
- Expose all flags through ConfigResponse schema
- Fix hide_getting_started_progress to read from settings (not env)
- Add frontend type definitions for new flags
- Implement store initialization and hydration logic

## Type
Configuration/Infrastructure

## Related
Part 1 of 4 in LE-906 P2 Fixes split

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embedded mode configuration with controls to hide UI elements (logout, new project/flow buttons, starter projects)
  * Added restriction to limit custom component editing to administrators only
  * Added MCP server configuration locking to prevent user modifications

* **Tests**
  * Added test validating embedded mode configuration behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13095?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->