### PR TITLE
feat: MCP lock enforcement + UI/tests

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -81,16 +81,6 @@ ALL_INTERFACES_HOST = "0.0.0.0"  # noqa: S104
 router = APIRouter(prefix="/mcp/project", tags=["mcp_projects"])
 
 
-def is_mcp_servers_locked(settings: Any) -> bool:
-    """Return True only when MCP lock is explicitly enabled.
-
-    Some tests patch ``settings`` with ``MagicMock`` objects where unknown
-    attributes resolve to truthy placeholders. Using ``is True`` ensures the
-    lock is enforced only when the flag is explicitly set to ``True``.
-    """
-    return getattr(settings, "mcp_servers_locked", False) is True
-
-
 async def verify_project_auth(
     db: AsyncSession,
     project_id: UUID,

--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -81,6 +81,16 @@ ALL_INTERFACES_HOST = "0.0.0.0"  # noqa: S104
 router = APIRouter(prefix="/mcp/project", tags=["mcp_projects"])
 
 
+def is_mcp_servers_locked(settings: Any) -> bool:
+    """Return True only when MCP lock is explicitly enabled.
+
+    Some tests patch ``settings`` with ``MagicMock`` objects where unknown
+    attributes resolve to truthy placeholders. Using ``is True`` ensures the
+    lock is enforced only when the flag is explicitly set to ``True``.
+    """
+    return getattr(settings, "mcp_servers_locked", False) is True
+
+
 async def verify_project_auth(
     db: AsyncSession,
     project_id: UUID,
@@ -548,8 +558,8 @@ async def update_project_mcp_settings(
 
             # P2: Check if MCP server management is locked for non-superusers
             settings_service = get_settings_service()
-            mcp_locked = getattr(settings_service.settings, "mcp_servers_locked", False)
-            if mcp_locked is True and not current_user.is_superuser:
+            mcp_locked = is_mcp_servers_locked(settings_service.settings)
+            if mcp_locked and not current_user.is_superuser:
                 raise HTTPException(
                     status_code=403,
                     detail=(
@@ -786,7 +796,7 @@ async def install_mcp_config(
     settings_service = get_settings_service()
     # Some tests patch settings with MagicMock objects that return truthy placeholders
     # for unknown attrs. Only enforce this gate when the flag is explicitly True.
-    if getattr(settings_service.settings, "mcp_servers_locked", False) is True and not current_user.is_superuser:
+    if is_mcp_servers_locked(settings_service.settings) and not current_user.is_superuser:
         raise HTTPException(
             status_code=403,
             detail="MCP server configuration is locked. Contact an administrator to manage external MCP servers.",

--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -556,17 +556,6 @@ async def update_project_mcp_settings(
             if not project:
                 raise HTTPException(status_code=404, detail="Project not found")
 
-            # P2: Check if MCP server management is locked for non-superusers
-            settings_service = get_settings_service()
-            mcp_locked = is_mcp_servers_locked(settings_service.settings)
-            if mcp_locked and not current_user.is_superuser:
-                raise HTTPException(
-                    status_code=403,
-                    detail=(
-                        "MCP server configuration is locked. Contact an administrator to manage external MCP servers."
-                    ),
-                )
-
             # Track if MCP Composer needs to be started or stopped
             should_handle_mcp_composer = False
             should_start_composer = False
@@ -791,16 +780,6 @@ async def install_mcp_config(
     client_ip = get_client_ip(request)
     if not is_local_ip(client_ip):
         raise HTTPException(status_code=500, detail="MCP configuration can only be installed from a local connection")
-
-    # P2: Check if MCP server management is locked
-    settings_service = get_settings_service()
-    # Some tests patch settings with MagicMock objects that return truthy placeholders
-    # for unknown attrs. Only enforce this gate when the flag is explicitly True.
-    if is_mcp_servers_locked(settings_service.settings) and not current_user.is_superuser:
-        raise HTTPException(
-            status_code=403,
-            detail="MCP server configuration is locked. Contact an administrator to manage external MCP servers.",
-        )
 
     removed_servers: list[str] = []  # Track removed servers for reinstallation
     try:

--- a/src/backend/base/langflow/api/v1/mcp_projects.py
+++ b/src/backend/base/langflow/api/v1/mcp_projects.py
@@ -546,6 +546,17 @@ async def update_project_mcp_settings(
             if not project:
                 raise HTTPException(status_code=404, detail="Project not found")
 
+            # P2: Check if MCP server management is locked for non-superusers
+            settings_service = get_settings_service()
+            mcp_locked = getattr(settings_service.settings, "mcp_servers_locked", False)
+            if mcp_locked is True and not current_user.is_superuser:
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        "MCP server configuration is locked. Contact an administrator to manage external MCP servers."
+                    ),
+                )
+
             # Track if MCP Composer needs to be started or stopped
             should_handle_mcp_composer = False
             should_start_composer = False
@@ -770,6 +781,16 @@ async def install_mcp_config(
     client_ip = get_client_ip(request)
     if not is_local_ip(client_ip):
         raise HTTPException(status_code=500, detail="MCP configuration can only be installed from a local connection")
+
+    # P2: Check if MCP server management is locked
+    settings_service = get_settings_service()
+    # Some tests patch settings with MagicMock objects that return truthy placeholders
+    # for unknown attrs. Only enforce this gate when the flag is explicitly True.
+    if getattr(settings_service.settings, "mcp_servers_locked", False) is True and not current_user.is_superuser:
+        raise HTTPException(
+            status_code=403,
+            detail="MCP server configuration is locked. Contact an administrator to manage external MCP servers.",
+        )
 
     removed_servers: list[str] = []  # Track removed servers for reinstallation
     try:

--- a/src/backend/base/langflow/api/v2/mcp.py
+++ b/src/backend/base/langflow/api/v2/mcp.py
@@ -30,6 +30,16 @@ router = APIRouter(tags=["MCP"], prefix="/mcp")
 _update_server_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
 
+def is_mcp_servers_locked(settings: object) -> bool:
+    """Return True only when MCP lock is explicitly enabled.
+
+    Some tests patch settings with MagicMock objects where unknown attributes
+    resolve to truthy placeholders. Using ``is True`` ensures lock enforcement
+    only when the flag is explicitly set to ``True``.
+    """
+    return getattr(settings, "mcp_servers_locked", False) is True
+
+
 async def upload_server_config(
     server_config: dict,
     current_user: CurrentActiveUser,
@@ -335,6 +345,12 @@ async def add_server(
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
     settings_service: Annotated[SettingsService, Depends(get_settings_service)],
 ):
+    if is_mcp_servers_locked(settings_service.settings) and not current_user.is_superuser:
+        raise HTTPException(
+            status_code=403,
+            detail="MCP server configuration is locked. Contact an administrator to manage external MCP servers.",
+        )
+
     return await update_server(
         server_name,
         server_config.model_dump(exclude_unset=True),
@@ -356,6 +372,12 @@ async def update_server_endpoint(
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
     settings_service: Annotated[SettingsService, Depends(get_settings_service)],
 ):
+    if is_mcp_servers_locked(settings_service.settings) and not current_user.is_superuser:
+        raise HTTPException(
+            status_code=403,
+            detail="MCP server configuration is locked. Contact an administrator to manage external MCP servers.",
+        )
+
     return await update_server(
         server_name,
         server_config.model_dump(exclude_unset=True),
@@ -375,6 +397,12 @@ async def delete_server(
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
     settings_service: Annotated[SettingsService, Depends(get_settings_service)],
 ):
+    if is_mcp_servers_locked(settings_service.settings) and not current_user.is_superuser:
+        raise HTTPException(
+            status_code=403,
+            detail="MCP server configuration is locked. Contact an administrator to manage external MCP servers.",
+        )
+
     return await update_server(
         server_name,
         {},

--- a/src/backend/tests/unit/api/v1/test_mcp_projects.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects.py
@@ -15,10 +15,10 @@ from langflow.api.v1.mcp_projects import (
     get_project_sse,
     get_project_streamable_http_url,
     init_mcp_servers,
-    is_mcp_servers_locked,
     project_mcp_servers,
     project_sse_transports,
 )
+from langflow.api.v2.mcp import is_mcp_servers_locked
 from langflow.services.auth.utils import create_user_longterm_token, get_password_hash
 from langflow.services.database.models.flow import Flow
 from langflow.services.database.models.folder import Folder
@@ -1635,6 +1635,7 @@ async def test_should_report_available_true_when_config_file_has_corrupt_json(
 
     for entry in results:
         assert entry["available"] is True, f"{entry['name']} should be available (directory exists)"
+        assert entry["installed"] is False, f"{entry['name']} should not be installed (JSON is corrupt)"
 
 
 async def test_handle_list_tools_filters_by_user_id_for_defense_in_depth(
@@ -1746,3 +1747,32 @@ async def test_handle_list_tools_filters_by_user_id_for_defense_in_depth(
             if other_user_flow:
                 await session.delete(other_user_flow)
             await session.commit()
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_v2_mcp_servers_unlocked_allows_non_superuser_add_patch_delete(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    """When is_mcp_servers_locked returns False the gate must not block normal users."""
+    monkeypatch.setattr("langflow.api.v2.mcp.is_mcp_servers_locked", lambda _settings: False)
+
+    server_name = f"lf-unlock-test-{uuid4().hex[:8]}"
+    server_config = {
+        "command": "uvx",
+        "args": ["mcp-proxy", "--transport", "sse", "https://langflow.local/sse"],
+    }
+
+    response = await client.post(f"/api/v2/mcp/servers/{server_name}", json=server_config, headers=logged_in_headers)
+    assert response.status_code == status.HTTP_200_OK
+
+    response = await client.patch(
+        f"/api/v2/mcp/servers/{server_name}",
+        json={"description": "updated"},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    response = await client.delete(f"/api/v2/mcp/servers/{server_name}", headers=logged_in_headers)
+    assert response.status_code == status.HTTP_200_OK

--- a/src/backend/tests/unit/api/v1/test_mcp_projects.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects.py
@@ -15,6 +15,7 @@ from langflow.api.v1.mcp_projects import (
     get_project_sse,
     get_project_streamable_http_url,
     init_mcp_servers,
+    is_mcp_servers_locked,
     project_mcp_servers,
     project_sse_transports,
 )
@@ -887,6 +888,17 @@ def _prepare_install_test_env(monkeypatch, tmp_path, filename="cursor.json"):
     monkeypatch.setattr("langflow.api.v1.mcp_projects.get_settings_service", lambda: dummy_service)
 
     return config_path
+
+
+async def test_is_mcp_servers_locked_does_not_fire_for_magicmock_settings():
+    settings = MagicMock()
+    # Simulate test fixtures where unknown attrs return truthy MagicMock placeholders.
+    assert is_mcp_servers_locked(settings) is False
+
+
+async def test_is_mcp_servers_locked_respects_explicit_true_flag():
+    settings = SimpleNamespace(mcp_servers_locked=True)
+    assert is_mcp_servers_locked(settings) is True
 
 
 async def test_install_mcp_config_defaults_to_sse_transport(

--- a/src/backend/tests/unit/api/v1/test_mcp_projects.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects.py
@@ -28,6 +28,7 @@ from lfx.base.mcp.constants import MAX_MCP_SERVER_NAME_LENGTH
 from lfx.base.mcp.util import sanitize_mcp_name
 from lfx.services.deps import session_scope
 from lfx.services.mcp_composer.service import COMPOSER_BACKEND_AUTH_HEADER
+from lfx.services.settings.base import Settings
 from mcp.server.sse import SseServerTransport
 from sqlmodel import select
 
@@ -899,6 +900,13 @@ async def test_is_mcp_servers_locked_does_not_fire_for_magicmock_settings():
 async def test_is_mcp_servers_locked_respects_explicit_true_flag():
     settings = SimpleNamespace(mcp_servers_locked=True)
     assert is_mcp_servers_locked(settings) is True
+
+
+async def test_settings_model_declares_mcp_servers_locked_field(monkeypatch):
+    """Regression guard: mcp lock must be configurable via Settings/env vars."""
+    assert "mcp_servers_locked" in Settings.model_fields
+    monkeypatch.setenv("LANGFLOW_MCP_SERVERS_LOCKED", "true")
+    assert Settings().mcp_servers_locked is True
 
 
 async def test_v2_mcp_servers_locked_blocks_non_superuser_add_patch_delete(

--- a/src/backend/tests/unit/api/v1/test_mcp_projects.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_projects.py
@@ -901,6 +901,79 @@ async def test_is_mcp_servers_locked_respects_explicit_true_flag():
     assert is_mcp_servers_locked(settings) is True
 
 
+async def test_v2_mcp_servers_locked_blocks_non_superuser_add_patch_delete(
+    client: AsyncClient,
+    logged_in_headers,
+    monkeypatch,
+):
+    monkeypatch.setattr("langflow.api.v2.mcp.is_mcp_servers_locked", lambda _settings: True)
+
+    server_name = f"lf-lock-test-{uuid4().hex[:8]}"
+    server_config = {
+        "command": "uvx",
+        "args": ["mcp-proxy", "--transport", "sse", "https://langflow.local/sse"],
+    }
+
+    response = await client.post(f"/api/v2/mcp/servers/{server_name}", json=server_config, headers=logged_in_headers)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    response = await client.patch(
+        f"/api/v2/mcp/servers/{server_name}",
+        json={"description": "updated"},
+        headers=logged_in_headers,
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    response = await client.delete(f"/api/v2/mcp/servers/{server_name}", headers=logged_in_headers)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_v2_mcp_servers_locked_allows_superuser_add_patch_delete(
+    client: AsyncClient,
+    monkeypatch,
+):
+    monkeypatch.setattr("langflow.api.v2.mcp.is_mcp_servers_locked", lambda _settings: True)
+
+    username = f"super_lock_{uuid4().hex[:8]}"
+    login_password = f"lfx-{uuid4().hex[:12]}"
+    async with session_scope() as session:
+        super_user = User(
+            username=username,
+            password=get_password_hash(login_password),
+            is_active=True,
+            is_superuser=True,
+        )
+        session.add(super_user)
+
+    login_response = await client.post("api/v1/login", data={"username": username, "password": login_password})
+    assert login_response.status_code == status.HTTP_200_OK
+    access_token = login_response.json()["access_token"]
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    server_name = f"lf-lock-super-{uuid4().hex[:8]}"
+    server_config = {
+        "command": "uvx",
+        "args": ["mcp-proxy", "--transport", "sse", "https://langflow.local/sse"],
+    }
+
+    response = await client.post(
+        f"/api/v2/mcp/servers/{server_name}",
+        json=server_config,
+        headers=headers,
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    response = await client.patch(
+        f"/api/v2/mcp/servers/{server_name}",
+        json={"description": "updated"},
+        headers=headers,
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    response = await client.delete(f"/api/v2/mcp/servers/{server_name}", headers=headers)
+    assert response.status_code == status.HTTP_200_OK
+
+
 async def test_install_mcp_config_defaults_to_sse_transport(
     client: AsyncClient,
     user_test_project,

--- a/src/frontend/src/locales/de.json
+++ b/src/frontend/src/locales/de.json
@@ -1059,6 +1059,8 @@
   "mcp.modal.descriptionFlow": "MCP-Server hinzufügen und speichern. Server verwalten in",
   "mcp.modal.descriptionFlowLink": "Einstellungen",
   "mcp.modal.descriptionSettings": "Fügen Sie MCP-Server hinzu und speichern Sie sie, um sie in Ihren Abläufen zu verwenden.",
+  "mcp.modal.lockedTitle": "MCP-Serververwaltung ist gesperrt",
+  "mcp.modal.lockedDescription": "Kontaktiere einen Administrator, um externe MCP-Server zu verwalten.",
   "mcp.modal.errorDuplicateEnvKeys": "In den Umgebungsvariablen wurden doppelte Schlüssel gefunden.",
   "mcp.modal.errorDuplicateHeaders": "In den Kopfzeilen wurden doppelte Schlüssel gefunden.",
   "mcp.modal.errorFailedAdd": "Das Hinzufügen des MCP-Servers ist fehlgeschlagen.",

--- a/src/frontend/src/locales/en.json
+++ b/src/frontend/src/locales/en.json
@@ -537,6 +537,8 @@
   "mcp.modal.tabJson": "JSON",
   "mcp.modal.tabStdio": "STDIO",
   "mcp.modal.tabStreamableHttp": "Streamable HTTP/SSE",
+  "mcp.modal.lockedTitle": "MCP server management is locked",
+  "mcp.modal.lockedDescription": "Contact an administrator to manage external MCP servers.",
   "mcp.modal.jsonTabLabel": "Paste in JSON config",
   "mcp.modal.jsonPlaceholder": "Paste in JSON config to add server",
   "mcp.modal.fieldName": "Name",

--- a/src/frontend/src/locales/es.json
+++ b/src/frontend/src/locales/es.json
@@ -1059,6 +1059,8 @@
   "mcp.modal.descriptionFlow": "Añadir y guardar servidores MCP. Gestionar servidores en",
   "mcp.modal.descriptionFlowLink": "configuración",
   "mcp.modal.descriptionSettings": "Añade y guarda servidores MCP para utilizarlos en todos tus flujos.",
+  "mcp.modal.lockedTitle": "La gestión de servidores MCP está bloqueada",
+  "mcp.modal.lockedDescription": "Contacta con un administrador para gestionar servidores MCP externos.",
   "mcp.modal.errorDuplicateEnvKeys": "Se han encontrado claves duplicadas en las variables de entorno.",
   "mcp.modal.errorDuplicateHeaders": "Se han encontrado claves duplicadas en los encabezados.",
   "mcp.modal.errorFailedAdd": "No se ha podido añadir el servidor MCP.",

--- a/src/frontend/src/locales/fr.json
+++ b/src/frontend/src/locales/fr.json
@@ -1059,6 +1059,8 @@
   "mcp.modal.descriptionFlow": "Ajouter et enregistrer des serveurs MCP. Gérer les serveurs dans",
   "mcp.modal.descriptionFlowLink": "paramètres",
   "mcp.modal.descriptionSettings": "Ajoutez et enregistrez des serveurs MCP pour les utiliser dans tous vos flux.",
+  "mcp.modal.lockedTitle": "La gestion des serveurs MCP est verrouillée",
+  "mcp.modal.lockedDescription": "Contactez un administrateur pour gérer les serveurs MCP externes.",
   "mcp.modal.errorDuplicateEnvKeys": "Des clés en double ont été détectées dans les variables d'environnement.",
   "mcp.modal.errorDuplicateHeaders": "Des clés en double ont été détectées dans les en-têtes.",
   "mcp.modal.errorFailedAdd": "Échec de l'ajout du serveur MCP.",

--- a/src/frontend/src/locales/ja.json
+++ b/src/frontend/src/locales/ja.json
@@ -1059,6 +1059,8 @@
   "mcp.modal.descriptionFlow": "MCPサーバーを追加して保存します。 サーバーを管理する",
   "mcp.modal.descriptionFlowLink": "設定",
   "mcp.modal.descriptionSettings": "フロー間で共有するMCPサーバーを追加して保存します。",
+  "mcp.modal.lockedTitle": "MCPサーバー管理はロックされています",
+  "mcp.modal.lockedDescription": "外部MCPサーバーを管理するには管理者に連絡してください。",
   "mcp.modal.errorDuplicateEnvKeys": "環境変数に重複するキーが見つかりました。",
   "mcp.modal.errorDuplicateHeaders": "ヘッダーに重複するキーが見つかりました。",
   "mcp.modal.errorFailedAdd": "MCPサーバーの追加に失敗しました。",

--- a/src/frontend/src/locales/pt.json
+++ b/src/frontend/src/locales/pt.json
@@ -1059,6 +1059,8 @@
   "mcp.modal.descriptionFlow": "Adicione e salve servidores MCP. Gerenciar servidores em",
   "mcp.modal.descriptionFlowLink": "configurações",
   "mcp.modal.descriptionSettings": "Adicione e salve servidores MCP para usar em todos os seus fluxos.",
+  "mcp.modal.lockedTitle": "O gerenciamento de servidores MCP está bloqueado",
+  "mcp.modal.lockedDescription": "Entre em contato com um administrador para gerenciar servidores MCP externos.",
   "mcp.modal.errorDuplicateEnvKeys": "Foram encontradas chaves duplicadas nas variáveis de ambiente.",
   "mcp.modal.errorDuplicateHeaders": "Foram encontradas chaves duplicadas nos cabeçalhos.",
   "mcp.modal.errorFailedAdd": "Não foi possível adicionar o servidor MCP.",

--- a/src/frontend/src/locales/zh-Hans.json
+++ b/src/frontend/src/locales/zh-Hans.json
@@ -1059,6 +1059,8 @@
   "mcp.modal.descriptionFlow": "添加并保存 MCP 服务器。 在",
   "mcp.modal.descriptionFlowLink": "设置",
   "mcp.modal.descriptionSettings": "添加并保存 MCP 服务器，以便在各个流程中使用。",
+  "mcp.modal.lockedTitle": "MCP 服务器管理已锁定",
+  "mcp.modal.lockedDescription": "请联系管理员以管理外部 MCP 服务器。",
   "mcp.modal.errorDuplicateEnvKeys": "在环境变量中发现了重复的键。",
   "mcp.modal.errorDuplicateHeaders": "在标题中发现了重复的键。",
   "mcp.modal.errorFailedAdd": "无法添加 MCP 服务器。",


### PR DESCRIPTION
## Summary
Implements MCP server management locking by enforcing authentication gates on the v2 MCP server write endpoints that the Langflow UI actually calls. Non-admin users are blocked at both the backend (403) and the frontend (locked modal state).

## Changes
### Backend
- Add `mcp_servers_locked` gate to **POST** `/api/v2/mcp/servers/{server_name}` (add server)
- Add `mcp_servers_locked` gate to **PATCH** `/api/v2/mcp/servers/{server_name}` (update server)
- Add `mcp_servers_locked` gate to **DELETE** `/api/v2/mcp/servers/{server_name}` (remove server)
- Non-superuser requests blocked with 403 Forbidden when flag is enabled
- `mcp_servers_locked` field declared in `Settings` model (env var: `LANGFLOW_MCP_SERVERS_LOCKED`)
- Hardened checks using `getattr(..., False) is True` pattern to handle mocked settings in tests

> **Note on v1 endpoints:** The v1 `POST /{project_id}/install` endpoint writes MCP client config
> files onto the user's local machine (for Cursor/Windsurf/Claude). This is a distinct operation
> from managing external MCP server entries in Langflow and is intentionally not gated here.
> The current UI does not call v1 for MCP server CRUD — all add/edit/delete operations go through v2.

### Frontend
- Update `AddMcpServerModal` to show locked state message when `mcp_servers_locked` is active
- Fix JSX structure (fragment wrapper for proper nesting)

## Security
- Prevents non-admin users from adding/modifying/removing external MCP servers via the UI path (v2)
- ContextForge remains single secure ingress for MCP configuration

## Type
Security/Feature

## Related
Part 2 of 4 in LE-906 split (supersedes combined PR #13089)
Addresses: MCP lock coverage incomplete — gate moved to v2 endpoints which the UI actually uses