### PR TITLE
feat: Gate custom component creation for admins only

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -80,6 +80,14 @@ from langflow.services.telemetry.schema import RunPayload
 from langflow.utils.compression import compress_response
 from langflow.utils.version import get_version_info
 
+
+def _requires_component_hash_lookups(settings: object, user: CurrentActiveUser) -> bool:
+    requires_admin_only_hashes = (
+        getattr(settings, "custom_component_admin_only", False) is True and not user.is_superuser
+    )
+    return requires_admin_only_hashes or not settings.allow_custom_components
+
+
 if TYPE_CHECKING:
     from langflow.events.event_manager import EventManager
 
@@ -1334,13 +1342,15 @@ async def custom_component_update(
         SerializationError: If serialization of the updated component node fails.
     """
     settings_service = get_settings_service()
-    get_component_hash_lookups_for_validation()
-    all_known = component_cache.all_known_hashes
-    if all_known is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Component templates are still initializing. Please try again in a few seconds.",
-        )
+    all_known = None
+    if _requires_component_hash_lookups(settings_service.settings, user):
+        get_component_hash_lookups_for_validation()
+        all_known = component_cache.all_known_hashes
+        if all_known is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Component templates are still initializing. Please try again in a few seconds.",
+            )
 
     # In admin-only mode, non-admin users may refresh/update only known server
     # templates. Truly custom code edits remain restricted to administrators.

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -1266,6 +1266,14 @@ async def custom_component(
     request: Request,
 ) -> CustomComponentResponse:
     settings_service = get_settings_service()
+
+    # P2: Check if custom component editing is restricted to admins only
+    if getattr(settings_service.settings, "custom_component_admin_only", False) is True and not user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Custom component creation is restricted to administrators",
+        )
+
     if not settings_service.settings.allow_custom_components:
         # Lazily compute hash lookups if they haven't been built yet
         # (e.g. during startup before the cache is fully populated).
@@ -1326,6 +1334,13 @@ async def custom_component_update(
         SerializationError: If serialization of the updated component node fails.
     """
     settings_service = get_settings_service()
+
+    # P2: Note: The admin gate for custom_component_admin_only applies only to POST /custom_component
+    # (component creation) not to this endpoint (field refresh/update). This endpoint is called
+    # for metadata-only operations like refreshing available models when a provider changes.
+    # Non-admin users need to be able to refresh field metadata, so the gate does not apply here.
+    # See: https://github.com/langflow-ai/langflow/issues/XXX for details on the field refresh use case.
+
     if not settings_service.settings.allow_custom_components:
         get_component_hash_lookups_for_validation()
         all_known = component_cache.all_known_hashes

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -1334,26 +1334,33 @@ async def custom_component_update(
         SerializationError: If serialization of the updated component node fails.
     """
     settings_service = get_settings_service()
+    get_component_hash_lookups_for_validation()
+    all_known = component_cache.all_known_hashes
+    if all_known is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Component templates are still initializing. Please try again in a few seconds.",
+        )
 
-    # P2: Note: The admin gate for custom_component_admin_only applies only to POST /custom_component
-    # (component creation) not to this endpoint (field refresh/update). This endpoint is called
-    # for metadata-only operations like refreshing available models when a provider changes.
-    # Non-admin users need to be able to refresh field metadata, so the gate does not apply here.
-    # See: https://github.com/langflow-ai/langflow/issues/XXX for details on the field refresh use case.
+    # In admin-only mode, non-admin users may refresh/update only known server
+    # templates. Truly custom code edits remain restricted to administrators.
+    if (
+        getattr(settings_service.settings, "custom_component_admin_only", False) is True
+        and not user.is_superuser
+        and not code_hash_matches_any_template(code_request.code, all_known)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Custom component editing is restricted to administrators",
+        )
 
-    if not settings_service.settings.allow_custom_components:
-        get_component_hash_lookups_for_validation()
-        all_known = component_cache.all_known_hashes
-        if all_known is None:
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Component templates are still initializing. Please try again in a few seconds.",
-            )
-        if not code_hash_matches_any_template(code_request.code, all_known):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Custom component creation is disabled",
-            )
+    if not settings_service.settings.allow_custom_components and not code_hash_matches_any_template(
+        code_request.code, all_known
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Custom component creation is disabled",
+        )
 
     try:
         component = Component(_code=code_request.code)

--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -1274,15 +1274,9 @@ async def custom_component(
     request: Request,
 ) -> CustomComponentResponse:
     settings_service = get_settings_service()
-
-    # P2: Check if custom component editing is restricted to admins only
-    if getattr(settings_service.settings, "custom_component_admin_only", False) is True and not user.is_superuser:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Custom component creation is restricted to administrators",
-        )
-
-    if not settings_service.settings.allow_custom_components:
+    settings = settings_service.settings
+    all_known = None
+    if _requires_component_hash_lookups(settings, user):
         # Lazily compute hash lookups if they haven't been built yet
         # (e.g. during startup before the cache is fully populated).
         get_component_hash_lookups_for_validation()
@@ -1292,13 +1286,26 @@ async def custom_component(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Component templates are still initializing. Please try again in a few seconds.",
             )
+
+    # In admin-only mode, non-admin users may create/refresh only known server
+    # templates. Truly custom code creation remains restricted to administrators.
+    if (
+        getattr(settings, "custom_component_admin_only", False) is True
+        and not user.is_superuser
+        and not code_hash_matches_any_template(raw_code.code, all_known)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Custom component creation is restricted to administrators",
+        )
+
+    if not settings.allow_custom_components and not code_hash_matches_any_template(raw_code.code, all_known):
         # Allow updating to a known server template (core component update),
         # but block truly custom code.
-        if not code_hash_matches_any_template(raw_code.code, all_known):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Custom component creation is disabled",
-            )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Custom component creation is disabled",
+        )
 
     component = Component(_code=raw_code.code)
 

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -464,7 +464,7 @@
                   },
                   {
                     "name": "OpenDsStar",
-                    "version": "1.0.26"
+                    "version": null
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
+++ b/src/backend/base/langflow/initial_setup/starter_projects/Structured Data Analysis Agent.json
@@ -464,7 +464,7 @@
                   },
                   {
                     "name": "OpenDsStar",
-                    "version": null
+                    "version": "1.0.26"
                   }
                 ],
                 "total_dependencies": 4

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -165,7 +165,7 @@ class TestMetadataComponent(Component):
     assert "restricted to administrators" in response.json().get("detail", "")
 
 
-async def test_custom_component_create_admin_only_blocks_non_superuser(
+async def test_custom_component_create_admin_only_allows_known_template_refresh(
     client: AsyncClient,
     logged_in_headers: dict,
     monkeypatch,
@@ -230,8 +230,16 @@ async def test_custom_component_create_admin_only_allows_superuser(
     monkeypatch.setitem(settings_service.settings.__dict__, "custom_component_admin_only", admin_only_enabled)
     monkeypatch.setattr(settings_service.settings, "allow_custom_components", True)
 
-    agent_component_file = await asyncio.to_thread(inspect.getsourcefile, AgentComponent)
-    code = await Path(agent_component_file).read_text(encoding="utf-8")
+    code = """
+from lfx.custom import Component
+
+class SuperUserMetadataComponent(Component):
+    display_name = "SuperUser Metadata Component"
+    description = "Test component for superuser bypass"
+
+    def run(self) -> str:
+        return "ok"
+"""
 
     request = CustomComponentRequest(code=code)
     response = await client.post(
@@ -242,6 +250,45 @@ async def test_custom_component_create_admin_only_allows_superuser(
 
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert "data" in response.json()
+
+
+async def test_custom_component_update_admin_only_allows_superuser(
+    client: AsyncClient,
+    logged_in_headers_super_user: dict,
+    monkeypatch,
+):
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    admin_only_enabled = True
+    monkeypatch.setitem(settings_service.settings.__dict__, "custom_component_admin_only", admin_only_enabled)
+    monkeypatch.setattr(settings_service.settings, "allow_custom_components", True)
+
+    component_code = """
+from lfx.custom import Component
+
+class SuperUserUpdateMetadataComponent(Component):
+    display_name = "SuperUser Update Metadata Component"
+    description = "Test component update for superuser bypass"
+
+    def run(self) -> str:
+        return "ok"
+"""
+
+    request = UpdateCustomComponentRequest(
+        code=component_code,
+        frontend_node={"outputs": []},
+        field="tool_mode",
+        field_value=False,
+        template={},
+    )
+    response = await client.post(
+        "api/v1/custom_component/update",
+        json=request.model_dump(),
+        headers=logged_in_headers_super_user,
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
 
 
 async def test_custom_component_endpoint_returns_metadata(client: AsyncClient, logged_in_headers: dict):

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -171,6 +171,60 @@ class TestMetadataComponent(Component):
     assert "restricted to administrators" in response.json().get("detail", "")
 
 
+async def test_custom_component_create_admin_only_blocks_non_superuser(
+    client: AsyncClient,
+    logged_in_headers: dict,
+    monkeypatch,
+):
+    dummy_settings = type(
+        "DummySettings",
+        (),
+        {"custom_component_admin_only": True, "allow_custom_components": True},
+    )()
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_settings_service",
+        lambda: type("DummyService", (), {"settings": dummy_settings})(),
+    )
+
+    agent_component_file = await asyncio.to_thread(inspect.getsourcefile, AgentComponent)
+    code = await Path(agent_component_file).read_text(encoding="utf-8")
+
+    request = CustomComponentRequest(code=code)
+    response = await client.post("api/v1/custom_component", json=request.model_dump(), headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "restricted to administrators" in response.json().get("detail", "")
+
+
+async def test_custom_component_create_admin_only_allows_superuser(
+    client: AsyncClient,
+    logged_in_headers_super_user: dict,
+    monkeypatch,
+):
+    dummy_settings = type(
+        "DummySettings",
+        (),
+        {"custom_component_admin_only": True, "allow_custom_components": True},
+    )()
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_settings_service",
+        lambda: type("DummyService", (), {"settings": dummy_settings})(),
+    )
+
+    agent_component_file = await asyncio.to_thread(inspect.getsourcefile, AgentComponent)
+    code = await Path(agent_component_file).read_text(encoding="utf-8")
+
+    request = CustomComponentRequest(code=code)
+    response = await client.post(
+        "api/v1/custom_component",
+        json=request.model_dump(),
+        headers=logged_in_headers_super_user,
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert "data" in response.json()
+
+
 async def test_custom_component_endpoint_returns_metadata(client: AsyncClient, logged_in_headers: dict):
     """Test that the /custom_component endpoint returns metadata with module and code_hash."""
     component_code = """

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -100,6 +100,77 @@ async def test_update_component_model_name_options(client: AsyncClient, logged_i
     )
 
 
+async def test_custom_component_update_admin_only_allows_known_template_refresh(
+    client: AsyncClient, logged_in_headers: dict, monkeypatch
+):
+    """Non-admin users can refresh known server templates in admin-only mode."""
+    dummy_settings = type(
+        "DummySettings",
+        (),
+        {"custom_component_admin_only": True, "allow_custom_components": True},
+    )()
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_settings_service",
+        lambda: type("DummyService", (), {"settings": dummy_settings})(),
+    )
+
+    component = AgentComponent()
+    component_node, _cc_instance = build_custom_component_template(component)
+    template = component_node["template"]
+
+    agent_component_file = await asyncio.to_thread(inspect.getsourcefile, AgentComponent)
+    code = await Path(agent_component_file).read_text(encoding="utf-8")
+
+    request = UpdateCustomComponentRequest(
+        code=code,
+        frontend_node=component_node,
+        field="model",
+        field_value=[{"provider": "Anthropic", "name": "claude-3-opus-20240229"}],
+        template=template,
+    )
+    response = await client.post("api/v1/custom_component/update", json=request.model_dump(), headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+
+async def test_custom_component_update_admin_only_blocks_unknown_custom_code(
+    client: AsyncClient, logged_in_headers: dict, monkeypatch
+):
+    """Non-admin users cannot edit truly custom code in admin-only mode."""
+    dummy_settings = type(
+        "DummySettings",
+        (),
+        {"custom_component_admin_only": True, "allow_custom_components": True},
+    )()
+    monkeypatch.setattr(
+        "langflow.api.v1.endpoints.get_settings_service",
+        lambda: type("DummyService", (), {"settings": dummy_settings})(),
+    )
+
+    component_code = """
+from lfx.custom import Component
+
+class TestMetadataComponent(Component):
+    display_name = "Test Metadata Component"
+    description = "Test component for metadata"
+
+    def run(self) -> str:
+        return "ok"
+"""
+
+    request = UpdateCustomComponentRequest(
+        code=component_code,
+        frontend_node={"outputs": []},
+        field="tool_mode",
+        field_value=False,
+        template={},
+    )
+    response = await client.post("api/v1/custom_component/update", json=request.model_dump(), headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "restricted to administrators" in response.json().get("detail", "")
+
+
 async def test_custom_component_endpoint_returns_metadata(client: AsyncClient, logged_in_headers: dict):
     """Test that the /custom_component endpoint returns metadata with module and code_hash."""
     component_code = """

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -104,15 +104,12 @@ async def test_custom_component_update_admin_only_allows_known_template_refresh(
     client: AsyncClient, logged_in_headers: dict, monkeypatch
 ):
     """Non-admin users can refresh known server templates in admin-only mode."""
-    dummy_settings = type(
-        "DummySettings",
-        (),
-        {"custom_component_admin_only": True, "allow_custom_components": True},
-    )()
-    monkeypatch.setattr(
-        "langflow.api.v1.endpoints.get_settings_service",
-        lambda: type("DummyService", (), {"settings": dummy_settings})(),
-    )
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    admin_only_enabled = True
+    monkeypatch.setitem(settings_service.settings.__dict__, "custom_component_admin_only", admin_only_enabled)
+    monkeypatch.setattr(settings_service.settings, "allow_custom_components", True)
 
     component = AgentComponent()
     component_node, _cc_instance = build_custom_component_template(component)
@@ -137,15 +134,12 @@ async def test_custom_component_update_admin_only_blocks_unknown_custom_code(
     client: AsyncClient, logged_in_headers: dict, monkeypatch
 ):
     """Non-admin users cannot edit truly custom code in admin-only mode."""
-    dummy_settings = type(
-        "DummySettings",
-        (),
-        {"custom_component_admin_only": True, "allow_custom_components": True},
-    )()
-    monkeypatch.setattr(
-        "langflow.api.v1.endpoints.get_settings_service",
-        lambda: type("DummyService", (), {"settings": dummy_settings})(),
-    )
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    admin_only_enabled = True
+    monkeypatch.setitem(settings_service.settings.__dict__, "custom_component_admin_only", admin_only_enabled)
+    monkeypatch.setattr(settings_service.settings, "allow_custom_components", True)
 
     component_code = """
 from lfx.custom import Component
@@ -176,20 +170,48 @@ async def test_custom_component_create_admin_only_blocks_non_superuser(
     logged_in_headers: dict,
     monkeypatch,
 ):
-    dummy_settings = type(
-        "DummySettings",
-        (),
-        {"custom_component_admin_only": True, "allow_custom_components": True},
-    )()
-    monkeypatch.setattr(
-        "langflow.api.v1.endpoints.get_settings_service",
-        lambda: type("DummyService", (), {"settings": dummy_settings})(),
-    )
+    """Non-admin users can create/refresh known server templates in admin-only mode."""
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    admin_only_enabled = True
+    monkeypatch.setitem(settings_service.settings.__dict__, "custom_component_admin_only", admin_only_enabled)
+    monkeypatch.setattr(settings_service.settings, "allow_custom_components", True)
 
     agent_component_file = await asyncio.to_thread(inspect.getsourcefile, AgentComponent)
     code = await Path(agent_component_file).read_text(encoding="utf-8")
 
     request = CustomComponentRequest(code=code)
+    response = await client.post("api/v1/custom_component", json=request.model_dump(), headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+
+async def test_custom_component_create_admin_only_blocks_unknown_custom_code(
+    client: AsyncClient,
+    logged_in_headers: dict,
+    monkeypatch,
+):
+    """Non-admin users cannot create truly custom code in admin-only mode."""
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    admin_only_enabled = True
+    monkeypatch.setitem(settings_service.settings.__dict__, "custom_component_admin_only", admin_only_enabled)
+    monkeypatch.setattr(settings_service.settings, "allow_custom_components", True)
+
+    component_code = """
+from lfx.custom import Component
+
+class TestMetadataComponent(Component):
+    display_name = "Test Metadata Component"
+    description = "Test component for metadata"
+
+    def run(self) -> str:
+        return "ok"
+"""
+
+    request = CustomComponentRequest(code=component_code)
     response = await client.post("api/v1/custom_component", json=request.model_dump(), headers=logged_in_headers)
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -201,15 +223,12 @@ async def test_custom_component_create_admin_only_allows_superuser(
     logged_in_headers_super_user: dict,
     monkeypatch,
 ):
-    dummy_settings = type(
-        "DummySettings",
-        (),
-        {"custom_component_admin_only": True, "allow_custom_components": True},
-    )()
-    monkeypatch.setattr(
-        "langflow.api.v1.endpoints.get_settings_service",
-        lambda: type("DummyService", (), {"settings": dummy_settings})(),
-    )
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    admin_only_enabled = True
+    monkeypatch.setitem(settings_service.settings.__dict__, "custom_component_admin_only", admin_only_enabled)
+    monkeypatch.setattr(settings_service.settings, "allow_custom_components", True)
 
     agent_component_file = await asyncio.to_thread(inspect.getsourcefile, AgentComponent)
     code = await Path(agent_component_file).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Restricts custom component CODE CREATION to admin users while allowing 
everyone to perform field metadata refreshes. Fixes unintended side effect 
where normal users couldn't refresh field options.

## Changes
- Add custom_component_admin_only gate to POST /custom_component endpoint
  * Blocks non-admin creation of NEW custom component code
  * Applies when flag enabled
  
- **FIX**: Remove gate from POST /custom_component/update endpoint
  * This endpoint handles metadata-only operations (field refresh)
  * Used when users change model providers, API keys, etc.
  * Normal users need access to refresh available options
  * Does not allow code modification

## Rationale
The update endpoint is called for refreshing field metadata when dependencies 
change (e.g., available models when switching LLM providers). Blocking this 
prevented normal users from making model selections when provider configuration 
changed. The gate now only applies to NEW component creation, not metadata updates.

## Type
Security/Bug Fix

## Related
Part 3 of 4 in LE-906 P2 Fixes split
Addresses: Custom component gate affecting normal field refreshes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom component creation can now be restricted to administrators via configuration.
  * Custom component updates now validate against known server templates.

* **Tests**
  * Added tests for custom component admin-only authorization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->