### PR TITLE
feat: Hide UI elements in embedded mode

### DIFF
--- a/src/backend/base/langflow/api/v1/schemas/__init__.py
+++ b/src/backend/base/langflow/api/v1/schemas/__init__.py
@@ -453,7 +453,7 @@ class ConfigResponse(BaseConfigResponse):
     default_folder_name: str
     hide_getting_started_progress: bool
     allow_custom_components: bool
-    # P2 feature flags for ICA integration
+    # Embedded mode feature flags
     embedded_mode: bool
     hide_logout_button: bool
     hide_new_project_button: bool
@@ -473,8 +473,6 @@ class ConfigResponse(BaseConfigResponse):
         Returns:
             ConfigResponse: An instance populated with configuration and feature flag values.
         """
-        import os
-
         from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NAME
 
         return cls(
@@ -495,7 +493,7 @@ class ConfigResponse(BaseConfigResponse):
             enable_extension_reload=settings.enable_extension_reload,
             webhook_auth_enable=auth_settings.WEBHOOK_AUTH_ENABLE,
             default_folder_name=DEFAULT_FOLDER_NAME,
-            hide_getting_started_progress=os.getenv("HIDE_GETTING_STARTED_PROGRESS", "").lower() == "true",
+            hide_getting_started_progress=settings.hide_getting_started_progress,
             allow_custom_components=settings.allow_custom_components,
             authz_enabled=bool(getattr(auth_settings, "AUTHZ_ENABLED", False)),
             embedded_mode=settings.embedded_mode,

--- a/src/backend/base/langflow/api/v1/schemas/__init__.py
+++ b/src/backend/base/langflow/api/v1/schemas/__init__.py
@@ -453,6 +453,14 @@ class ConfigResponse(BaseConfigResponse):
     default_folder_name: str
     hide_getting_started_progress: bool
     allow_custom_components: bool
+    # P2 feature flags for ICA integration
+    embedded_mode: bool
+    hide_logout_button: bool
+    hide_new_project_button: bool
+    hide_new_flow_button: bool
+    hide_starter_projects: bool
+    mcp_servers_locked: bool
+    custom_component_admin_only: bool
 
     @classmethod
     def from_settings(cls, settings: Settings, auth_settings) -> "ConfigResponse":
@@ -490,6 +498,13 @@ class ConfigResponse(BaseConfigResponse):
             hide_getting_started_progress=os.getenv("HIDE_GETTING_STARTED_PROGRESS", "").lower() == "true",
             allow_custom_components=settings.allow_custom_components,
             authz_enabled=bool(getattr(auth_settings, "AUTHZ_ENABLED", False)),
+            embedded_mode=settings.embedded_mode,
+            hide_logout_button=settings.hide_logout_button or settings.embedded_mode,
+            hide_new_project_button=settings.hide_new_project_button or settings.embedded_mode,
+            hide_new_flow_button=settings.hide_new_flow_button or settings.embedded_mode,
+            hide_starter_projects=settings.hide_starter_projects or settings.embedded_mode,
+            mcp_servers_locked=settings.mcp_servers_locked,
+            custom_component_admin_only=settings.custom_component_admin_only,
         )
 
 

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -303,7 +303,7 @@ async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient,
     monkeypatch.setattr(settings_service.settings, "hide_new_project_button", False)
     monkeypatch.setattr(settings_service.settings, "hide_new_flow_button", False)
     monkeypatch.setattr(settings_service.settings, "hide_starter_projects", False)
-    monkeypatch.setattr(settings_service.settings, "hide_getting_started_progress", True)
+    monkeypatch.setattr(settings_service.settings, "hide_getting_started_progress", False)
 
     response = await client.get("api/v1/config", headers=logged_in_headers)
     result = response.json()
@@ -314,7 +314,50 @@ async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient,
     assert result["hide_new_project_button"] is True
     assert result["hide_new_flow_button"] is True
     assert result["hide_starter_projects"] is True
+    # This flag is currently a direct passthrough (not part of embedded_mode cascade).
+    assert result["hide_getting_started_progress"] is False
+
+
+async def test_get_config_embedded_mode_false_keeps_individual_hide_flags(
+    client: AsyncClient, logged_in_headers: dict, monkeypatch
+):
+    """When embedded mode is disabled, individual hide flags should retain explicit values."""
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    monkeypatch.setattr(settings_service.settings, "embedded_mode", False)
+    monkeypatch.setattr(settings_service.settings, "hide_logout_button", False)
+    monkeypatch.setattr(settings_service.settings, "hide_new_project_button", False)
+    monkeypatch.setattr(settings_service.settings, "hide_new_flow_button", True)
+    monkeypatch.setattr(settings_service.settings, "hide_starter_projects", False)
+    monkeypatch.setattr(settings_service.settings, "hide_getting_started_progress", True)
+
+    response = await client.get("api/v1/config", headers=logged_in_headers)
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result["embedded_mode"] is False
+    assert result["hide_logout_button"] is False
+    assert result["hide_new_project_button"] is False
+    assert result["hide_new_flow_button"] is True
+    assert result["hide_starter_projects"] is False
     assert result["hide_getting_started_progress"] is True
+
+
+async def test_get_config_returns_mcp_and_admin_only_flags(client: AsyncClient, logged_in_headers: dict, monkeypatch):
+    """Config response should expose lock/admin feature flags from settings."""
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    monkeypatch.setattr(settings_service.settings, "mcp_servers_locked", True)
+    monkeypatch.setattr(settings_service.settings, "custom_component_admin_only", True)
+
+    response = await client.get("api/v1/config", headers=logged_in_headers)
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result["mcp_servers_locked"] is True
+    assert result["custom_component_admin_only"] is True
 
 
 async def test_get_config_returns_mcp_base_url(client: AsyncClient, logged_in_headers: dict):

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -293,6 +293,30 @@ async def test_get_config_authenticated_returns_full_config(client: AsyncClient,
     assert "feature_flags" in result, "Authenticated response must contain 'feature_flags'"
 
 
+async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient, logged_in_headers: dict, monkeypatch):
+    """Embedded mode should force all embedded hide flags to true in full config."""
+    from langflow.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    monkeypatch.setattr(settings_service.settings, "embedded_mode", True)
+    monkeypatch.setattr(settings_service.settings, "hide_logout_button", False)
+    monkeypatch.setattr(settings_service.settings, "hide_new_project_button", False)
+    monkeypatch.setattr(settings_service.settings, "hide_new_flow_button", False)
+    monkeypatch.setattr(settings_service.settings, "hide_starter_projects", False)
+    monkeypatch.setattr(settings_service.settings, "hide_getting_started_progress", True)
+
+    response = await client.get("api/v1/config", headers=logged_in_headers)
+    result = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert result["embedded_mode"] is True
+    assert result["hide_logout_button"] is True
+    assert result["hide_new_project_button"] is True
+    assert result["hide_new_flow_button"] is True
+    assert result["hide_starter_projects"] is True
+    assert result["hide_getting_started_progress"] is True
+
+
 async def test_get_config_returns_mcp_base_url(client: AsyncClient, logged_in_headers: dict):
     """Test that /config includes mcp_base_url for both authenticated and unauthenticated responses."""
     # Authenticated

--- a/src/backend/tests/unit/api/v1/test_endpoints.py
+++ b/src/backend/tests/unit/api/v1/test_endpoints.py
@@ -294,7 +294,7 @@ async def test_get_config_authenticated_returns_full_config(client: AsyncClient,
 
 
 async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient, logged_in_headers: dict, monkeypatch):
-    """Embedded mode should force all embedded hide flags to true in full config."""
+    """Embedded mode should only force UI hide flags, not security lock flags."""
     from langflow.services.deps import get_settings_service
 
     settings_service = get_settings_service()
@@ -304,6 +304,8 @@ async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient,
     monkeypatch.setattr(settings_service.settings, "hide_new_flow_button", False)
     monkeypatch.setattr(settings_service.settings, "hide_starter_projects", False)
     monkeypatch.setattr(settings_service.settings, "hide_getting_started_progress", False)
+    monkeypatch.setattr(settings_service.settings, "mcp_servers_locked", False)
+    monkeypatch.setattr(settings_service.settings, "custom_component_admin_only", False)
 
     response = await client.get("api/v1/config", headers=logged_in_headers)
     result = response.json()
@@ -316,6 +318,9 @@ async def test_get_config_embedded_mode_cascades_hide_flags(client: AsyncClient,
     assert result["hide_starter_projects"] is True
     # This flag is currently a direct passthrough (not part of embedded_mode cascade).
     assert result["hide_getting_started_progress"] is False
+    # Security lock flags are explicit opt-ins and do not cascade from embedded_mode.
+    assert result["mcp_servers_locked"] is False
+    assert result["custom_component_admin_only"] is False
 
 
 async def test_get_config_embedded_mode_false_keeps_individual_hide_flags(

--- a/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/__tests__/account-menu.test.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/__tests__/account-menu.test.tsx
@@ -1,0 +1,101 @@
+import { act, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useUtilityStore } from "@/stores/utilityStore";
+import { AccountMenu } from "../index";
+
+jest.mock("react-icons/fa", () => ({
+  FaDiscord: () => <span data-testid="discord-icon" />,
+  FaGithub: () => <span data-testid="github-icon" />,
+}));
+
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: () => <span data-testid="icon-component" />,
+  ForwardedIconComponent: () => <span data-testid="forwarded-icon-component" />,
+}));
+
+jest.mock("@/controllers/API/queries/auth", () => ({
+  useLogout: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock("@/customization/components/custom-profile-icon", () => ({
+  CustomProfileIcon: () => <div data-testid="custom-profile-icon" />,
+}));
+
+jest.mock("@/customization/hooks/use-custom-navigate", () => ({
+  useCustomNavigate: () => jest.fn(),
+}));
+
+jest.mock("@/customization/feature-flags", () => ({
+  ENABLE_DATASTAX_LANGFLOW: false,
+}));
+
+jest.mock("@/stores/authStore", () => ({
+  __esModule: true,
+  default: (
+    selector: (state: { isAdmin: boolean; autoLogin: boolean }) => unknown,
+  ) => selector({ isAdmin: false, autoLogin: false }),
+}));
+
+jest.mock("@/stores/darkStore", () => ({
+  useDarkStore: (
+    selector: (state: { version: string; latestVersion: string }) => unknown,
+  ) => selector({ version: "1.0.0", latestVersion: "1.0.0" }),
+}));
+
+jest.mock("../../HeaderMenu/index", () => ({
+  HeaderMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  HeaderMenuToggle: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  HeaderMenuItems: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  HeaderMenuItemButton: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
+  HeaderMenuItemLink: ({ children }: { children: ReactNode }) => (
+    <a>{children}</a>
+  ),
+}));
+
+jest.mock("../../ThemeButtons/index", () => ({
+  __esModule: true,
+  default: () => <div data-testid="theme-buttons" />,
+}));
+
+describe("AccountMenu", () => {
+  beforeEach(() => {
+    act(() => {
+      useUtilityStore.setState({ hideLogoutButton: false });
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useUtilityStore.setState({ hideLogoutButton: false });
+    });
+  });
+
+  it("shows logout when hideLogoutButton is false", () => {
+    render(<AccountMenu />);
+
+    expect(screen.getByRole("button", { name: /logout/i })).toBeInTheDocument();
+  });
+
+  it("hides logout when hideLogoutButton is true", () => {
+    act(() => {
+      useUtilityStore.setState({ hideLogoutButton: true });
+    });
+
+    render(<AccountMenu />);
+
+    expect(
+      screen.queryByRole("button", { name: /logout/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
@@ -1,176 +1,189 @@
-import { useState } from "react";
+import { FaDiscord, FaGithub } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
-import ForwardedIconComponent from "@/components/common/genericIconComponent";
-import { Button } from "@/components/ui/button";
-import { SidebarProvider } from "@/components/ui/sidebar";
+import { ForwardedIconComponent } from "@/components/common/genericIconComponent";
+import {
+  DATASTAX_DOCS_URL,
+  DISCORD_URL,
+  DOCS_URL,
+  GITHUB_URL,
+  TWITTER_URL,
+} from "@/constants/constants";
+import { useLogout } from "@/controllers/API/queries/auth";
+import { CustomProfileIcon } from "@/customization/components/custom-profile-icon";
+import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
-import { track } from "@/customization/utils/analytics";
-import useAddFlow from "@/hooks/flows/use-add-flow";
+import useAuthStore from "@/stores/authStore";
+import { useDarkStore } from "@/stores/darkStore";
 import { useUtilityStore } from "@/stores/utilityStore";
-import type { Category } from "@/types/templates/types";
-import { cn } from "@/utils/utils";
-import type { newFlowModalPropsType } from "../../types/components";
-import BaseModal from "../baseModal";
-import GetStartedComponent from "./components/GetStartedComponent";
-import { Nav } from "./components/navComponent";
-import TemplateContentComponent from "./components/TemplateContentComponent";
+import { cn, stripReleaseStageFromVersion } from "@/utils/utils";
+import {
+  HeaderMenu,
+  HeaderMenuItemButton,
+  HeaderMenuItemLink,
+  HeaderMenuItems,
+  HeaderMenuToggle,
+} from "../HeaderMenu";
+import ThemeButtons from "../ThemeButtons";
 
-export default function TemplatesModal({
-  open,
-  setOpen,
-}: newFlowModalPropsType): JSX.Element {
+export const AccountMenu = () => {
   const { t } = useTranslation();
-  const [currentTab, setCurrentTab] = useState("get-started");
-  const [loading, setLoading] = useState(false);
-  const addFlow = useAddFlow();
+  const version = useDarkStore((state) => state.version);
+  const latestVersion = useDarkStore((state) => state.latestVersion);
   const navigate = useCustomNavigate();
-  const { folderId } = useParams();
-  const hideStarterProjects = useUtilityStore(
-    (state) => state.hideStarterProjects,
+  const { mutate: mutationLogout } = useLogout();
+  const hideLogoutButton = useUtilityStore(
+    (state) => state.hideLogoutButton,
   );
 
-  // If starter projects are hidden and we're on the get-started tab, switch to all-templates
-  const effectiveTab = hideStarterProjects && currentTab === "get-started" ? "all-templates" : currentTab;
+  const { isAdmin, autoLogin } = useAuthStore((state) => ({
+    isAdmin: state.isAdmin,
+    autoLogin: state.autoLogin,
+  }));
 
-  const handleFlowCreating = (isCreating: boolean) => {
-    setLoading(isCreating);
+  const handleLogout = () => {
+    mutationLogout();
   };
 
-  const handleCreateBlankFlow = () => {
-    if (loading) return;
+  const isLatestVersion = (() => {
+    if (!version || !latestVersion) return false;
 
-    handleFlowCreating(true);
-    track("New Flow Created", { template: "Blank Flow" });
+    const currentBaseVersion = stripReleaseStageFromVersion(version);
+    const latestBaseVersion = stripReleaseStageFromVersion(latestVersion);
 
-    addFlow()
-      .then((id) => {
-        navigate(`/flow/${id}${folderId ? `/folder/${folderId}` : ""}`);
-      })
-      .finally(() => {
-        handleFlowCreating(false);
-      });
-  };
-
-  // Define categories and their items
-  const categories: Category[] = [
-    {
-      title: t("templatesModal.title"),
-      items: [
-        // Hide "Get Started" tab if starter projects are hidden
-        ...(hideStarterProjects
-          ? []
-          : [
-              {
-                title: t("templatesModal.getStarted"),
-                icon: "SquarePlay",
-                id: "get-started",
-              },
-            ]),
-        {
-          title: t("templatesModal.allTemplates"),
-          icon: "LayoutPanelTop",
-          id: "all-templates",
-        },
-      ],
-    },
-    {
-      title: t("templatesModal.useCases"),
-      items: [
-        {
-          title: t("templatesModal.assistants"),
-          icon: "BotMessageSquare",
-          id: "assistants",
-        },
-        {
-          title: t("templatesModal.classification"),
-          icon: "Tags",
-          id: "classification",
-        },
-        {
-          title: t("templatesModal.coding"),
-          icon: "TerminalIcon",
-          id: "coding",
-        },
-        {
-          title: t("templatesModal.contentGeneration"),
-          icon: "Newspaper",
-          id: "content-generation",
-        },
-        { title: t("templatesModal.qa"), icon: "Database", id: "q-a" },
-        // { title: "Summarization", icon: "Bot", id: "summarization" },
-        // { title: "Web Scraping", icon: "CodeXml", id: "web-scraping" },
-      ],
-    },
-    {
-      title: t("templatesModal.methodology"),
-      items: [
-        {
-          title: t("templatesModal.prompting"),
-          icon: "MessagesSquare",
-          id: "chatbots",
-        },
-        { title: t("templatesModal.rag"), icon: "Database", id: "rag" },
-        { title: t("templatesModal.agents"), icon: "Bot", id: "agents" },
-      ],
-    },
-  ];
+    return currentBaseVersion === latestBaseVersion;
+  })();
 
   return (
-    <BaseModal size="templates" open={open} setOpen={setOpen} className="p-0">
-      <BaseModal.Content className="flex flex-col p-0">
-        <div className="flex h-full">
-          <SidebarProvider width="15rem" defaultOpen={false}>
-            <Nav
-              categories={categories}
-              currentTab={currentTab}
-              setCurrentTab={setCurrentTab}
-            />
-            <main className="flex flex-1 flex-col gap-4 overflow-auto p-6 md:gap-8">
-              {effectiveTab === "get-started" ? (
-                <GetStartedComponent
-                  loading={loading}
-                  onFlowCreating={handleFlowCreating}
-                />
-              ) : (
-                <TemplateContentComponent
-                  currentTab={effectiveTab}
-                  categories={categories.flatMap((category) => category.items)}
-                  loading={loading}
-                  onFlowCreating={handleFlowCreating}
-                />
-              )}
-              <BaseModal.Footer>
-                <div className="flex w-full flex-col justify-between gap-4 pb-4 sm:flex-row sm:items-center">
-                  <div className="flex flex-col items-start justify-center">
-                    <div className="font-semibold">
-                      {t("templatesModal.startFromScratch")}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      {t("templatesModal.startFromScratchDescription")}
-                    </div>
-                  </div>
-                  <Button
-                    onClick={handleCreateBlankFlow}
-                    size="sm"
-                    data-testid="blank-flow"
-                    className={cn(
-                      "shrink-0",
-                      loading ? "cursor-default opacity-80" : "cursor-pointer",
-                    )}
-                  >
-                    <ForwardedIconComponent
-                      name="Plus"
-                      className="h-4 w-4 shrink-0"
-                    />
-                    {t("templatesModal.blankFlow")}
-                  </Button>
-                </div>
-              </BaseModal.Footer>
-            </main>
-          </SidebarProvider>
+    <HeaderMenu>
+      <HeaderMenuToggle>
+        <div
+          className="h-6 w-6 rounded-lg focus-visible:outline-0"
+          data-testid="user-profile-settings"
+        >
+          <CustomProfileIcon />
         </div>
-      </BaseModal.Content>
-    </BaseModal>
+      </HeaderMenuToggle>
+      <HeaderMenuItems position="right" classNameSize="w-[272px]">
+        <div className="divide-y divide-foreground/10">
+          <div>
+            <div className="h-[44px] items-center px-4 pt-3">
+              <div className="flex items-center justify-between">
+                <span
+                  data-testid="menu_version_button"
+                  id="menu_version_button"
+                  className="text-sm"
+                >
+                  {t("account.version")}
+                </span>
+                <div
+                  className={cn(
+                    "float-right text-xs",
+                    isLatestVersion && "text-accent-emerald-foreground",
+                    !isLatestVersion && "text-accent-amber-foreground",
+                  )}
+                >
+                  {version}{" "}
+                  {isLatestVersion
+                    ? t("account.latest")
+                    : t("account.updateAvailable")}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <HeaderMenuItemButton
+              onClick={() => {
+                navigate("/settings");
+              }}
+            >
+              <span
+                data-testid="menu_settings_button"
+                id="menu_settings_button"
+              >
+                {t("account.settings")}
+              </span>
+            </HeaderMenuItemButton>
+
+            {isAdmin && !autoLogin && (
+              <div>
+                <HeaderMenuItemButton
+                  onClick={() => {
+                    navigate("/admin");
+                  }}
+                >
+                  <span
+                    data-testid="menu_admin_page_button"
+                    id="menu_admin_page_button"
+                  >
+                    {t("account.adminPage")}
+                  </span>
+                </HeaderMenuItemButton>
+              </div>
+            )}
+            <HeaderMenuItemLink
+              newPage
+              href={ENABLE_DATASTAX_LANGFLOW ? DATASTAX_DOCS_URL : DOCS_URL}
+            >
+              <span data-testid="menu_docs_button" id="menu_docs_button">
+                {t("account.docs")}
+              </span>
+            </HeaderMenuItemLink>
+          </div>
+
+          <div>
+            <HeaderMenuItemLink newPage href={GITHUB_URL}>
+              <span
+                data-testid="menu_github_button"
+                id="menu_github_button"
+                className="flex items-center gap-2"
+              >
+                <FaGithub className="h-4 w-4" />
+                {t("account.github")}
+              </span>
+            </HeaderMenuItemLink>
+            <HeaderMenuItemLink newPage href={DISCORD_URL}>
+              <span
+                data-testid="menu_discord_button"
+                id="menu_discord_button"
+                className="flex items-center gap-2"
+              >
+                <FaDiscord className="h-4 w-4 text-[#5865F2]" />
+                {t("account.discord")}
+              </span>
+            </HeaderMenuItemLink>
+            <HeaderMenuItemLink newPage href={TWITTER_URL}>
+              <span
+                data-testid="menu_twitter_button"
+                id="menu_twitter_button"
+                className="flex items-center gap-2"
+              >
+                <ForwardedIconComponent
+                  strokeWidth={2}
+                  name="TwitterX"
+                  className="h-4 w-4"
+                />
+                {t("account.twitter")}
+              </span>
+            </HeaderMenuItemLink>
+          </div>
+
+          <div className="flex items-center justify-between px-4 py-[6.5px] text-sm">
+            <span className="">{t("account.theme")}</span>
+            <div className="relative top-[1px] float-right">
+              <ThemeButtons />
+            </div>
+          </div>
+
+          {!autoLogin && !hideLogoutButton && (
+            <div>
+              <HeaderMenuItemButton onClick={handleLogout} icon="log-out">
+                {t("account.logout")}
+              </HeaderMenuItemButton>
+            </div>
+          )}
+        </div>
+      </HeaderMenuItems>
+    </HeaderMenu>
   );
-}
+};

--- a/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
@@ -1,5 +1,5 @@
-import { FaDiscord, FaGithub } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
+import { FaDiscord, FaGithub } from "react-icons/fa";
 import { ForwardedIconComponent } from "@/components/common/genericIconComponent";
 import {
   DATASTAX_DOCS_URL,

--- a/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
@@ -31,9 +31,7 @@ export const AccountMenu = () => {
   const latestVersion = useDarkStore((state) => state.latestVersion);
   const navigate = useCustomNavigate();
   const { mutate: mutationLogout } = useLogout();
-  const hideLogoutButton = useUtilityStore(
-    (state) => state.hideLogoutButton,
-  );
+  const hideLogoutButton = useUtilityStore((state) => state.hideLogoutButton);
 
   const { isAdmin, autoLogin } = useAuthStore((state) => ({
     isAdmin: state.isAdmin,

--- a/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
+++ b/src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx
@@ -1,185 +1,176 @@
-import { FaDiscord, FaGithub } from "react-icons/fa";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ForwardedIconComponent } from "@/components/common/genericIconComponent";
-import {
-  DATASTAX_DOCS_URL,
-  DISCORD_URL,
-  DOCS_URL,
-  GITHUB_URL,
-  TWITTER_URL,
-} from "@/constants/constants";
-import { useLogout } from "@/controllers/API/queries/auth";
-import { CustomProfileIcon } from "@/customization/components/custom-profile-icon";
-import { ENABLE_DATASTAX_LANGFLOW } from "@/customization/feature-flags";
+import { useParams } from "react-router-dom";
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import { SidebarProvider } from "@/components/ui/sidebar";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
-import useAuthStore from "@/stores/authStore";
-import { useDarkStore } from "@/stores/darkStore";
-import { cn, stripReleaseStageFromVersion } from "@/utils/utils";
-import {
-  HeaderMenu,
-  HeaderMenuItemButton,
-  HeaderMenuItemLink,
-  HeaderMenuItems,
-  HeaderMenuToggle,
-} from "../HeaderMenu";
-import ThemeButtons from "../ThemeButtons";
+import { track } from "@/customization/utils/analytics";
+import useAddFlow from "@/hooks/flows/use-add-flow";
+import { useUtilityStore } from "@/stores/utilityStore";
+import type { Category } from "@/types/templates/types";
+import { cn } from "@/utils/utils";
+import type { newFlowModalPropsType } from "../../types/components";
+import BaseModal from "../baseModal";
+import GetStartedComponent from "./components/GetStartedComponent";
+import { Nav } from "./components/navComponent";
+import TemplateContentComponent from "./components/TemplateContentComponent";
 
-export const AccountMenu = () => {
+export default function TemplatesModal({
+  open,
+  setOpen,
+}: newFlowModalPropsType): JSX.Element {
   const { t } = useTranslation();
-  const version = useDarkStore((state) => state.version);
-  const latestVersion = useDarkStore((state) => state.latestVersion);
+  const [currentTab, setCurrentTab] = useState("get-started");
+  const [loading, setLoading] = useState(false);
+  const addFlow = useAddFlow();
   const navigate = useCustomNavigate();
-  const { mutate: mutationLogout } = useLogout();
+  const { folderId } = useParams();
+  const hideStarterProjects = useUtilityStore(
+    (state) => state.hideStarterProjects,
+  );
 
-  const { isAdmin, autoLogin } = useAuthStore((state) => ({
-    isAdmin: state.isAdmin,
-    autoLogin: state.autoLogin,
-  }));
+  // If starter projects are hidden and we're on the get-started tab, switch to all-templates
+  const effectiveTab = hideStarterProjects && currentTab === "get-started" ? "all-templates" : currentTab;
 
-  const handleLogout = () => {
-    mutationLogout();
+  const handleFlowCreating = (isCreating: boolean) => {
+    setLoading(isCreating);
   };
 
-  const isLatestVersion = (() => {
-    if (!version || !latestVersion) return false;
+  const handleCreateBlankFlow = () => {
+    if (loading) return;
 
-    const currentBaseVersion = stripReleaseStageFromVersion(version);
-    const latestBaseVersion = stripReleaseStageFromVersion(latestVersion);
+    handleFlowCreating(true);
+    track("New Flow Created", { template: "Blank Flow" });
 
-    return currentBaseVersion === latestBaseVersion;
-  })();
+    addFlow()
+      .then((id) => {
+        navigate(`/flow/${id}${folderId ? `/folder/${folderId}` : ""}`);
+      })
+      .finally(() => {
+        handleFlowCreating(false);
+      });
+  };
+
+  // Define categories and their items
+  const categories: Category[] = [
+    {
+      title: t("templatesModal.title"),
+      items: [
+        // Hide "Get Started" tab if starter projects are hidden
+        ...(hideStarterProjects
+          ? []
+          : [
+              {
+                title: t("templatesModal.getStarted"),
+                icon: "SquarePlay",
+                id: "get-started",
+              },
+            ]),
+        {
+          title: t("templatesModal.allTemplates"),
+          icon: "LayoutPanelTop",
+          id: "all-templates",
+        },
+      ],
+    },
+    {
+      title: t("templatesModal.useCases"),
+      items: [
+        {
+          title: t("templatesModal.assistants"),
+          icon: "BotMessageSquare",
+          id: "assistants",
+        },
+        {
+          title: t("templatesModal.classification"),
+          icon: "Tags",
+          id: "classification",
+        },
+        {
+          title: t("templatesModal.coding"),
+          icon: "TerminalIcon",
+          id: "coding",
+        },
+        {
+          title: t("templatesModal.contentGeneration"),
+          icon: "Newspaper",
+          id: "content-generation",
+        },
+        { title: t("templatesModal.qa"), icon: "Database", id: "q-a" },
+        // { title: "Summarization", icon: "Bot", id: "summarization" },
+        // { title: "Web Scraping", icon: "CodeXml", id: "web-scraping" },
+      ],
+    },
+    {
+      title: t("templatesModal.methodology"),
+      items: [
+        {
+          title: t("templatesModal.prompting"),
+          icon: "MessagesSquare",
+          id: "chatbots",
+        },
+        { title: t("templatesModal.rag"), icon: "Database", id: "rag" },
+        { title: t("templatesModal.agents"), icon: "Bot", id: "agents" },
+      ],
+    },
+  ];
 
   return (
-    <HeaderMenu>
-      <HeaderMenuToggle>
-        <div
-          className="h-6 w-6 rounded-lg focus-visible:outline-0"
-          data-testid="user-profile-settings"
-        >
-          <CustomProfileIcon />
-        </div>
-      </HeaderMenuToggle>
-      <HeaderMenuItems position="right" classNameSize="w-[272px]">
-        <div className="divide-y divide-foreground/10">
-          <div>
-            <div className="h-[44px] items-center px-4 pt-3">
-              <div className="flex items-center justify-between">
-                <span
-                  data-testid="menu_version_button"
-                  id="menu_version_button"
-                  className="text-sm"
-                >
-                  {t("account.version")}
-                </span>
-                <div
-                  className={cn(
-                    "float-right text-xs",
-                    isLatestVersion && "text-accent-emerald-foreground",
-                    !isLatestVersion && "text-accent-amber-foreground",
-                  )}
-                >
-                  {version}{" "}
-                  {isLatestVersion
-                    ? t("account.latest")
-                    : t("account.updateAvailable")}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div>
-            <HeaderMenuItemButton
-              onClick={() => {
-                navigate("/settings");
-              }}
-            >
-              <span
-                data-testid="menu_settings_button"
-                id="menu_settings_button"
-              >
-                {t("account.settings")}
-              </span>
-            </HeaderMenuItemButton>
-
-            {isAdmin && !autoLogin && (
-              <div>
-                <HeaderMenuItemButton
-                  onClick={() => {
-                    navigate("/admin");
-                  }}
-                >
-                  <span
-                    data-testid="menu_admin_page_button"
-                    id="menu_admin_page_button"
-                  >
-                    {t("account.adminPage")}
-                  </span>
-                </HeaderMenuItemButton>
-              </div>
-            )}
-            <HeaderMenuItemLink
-              newPage
-              href={ENABLE_DATASTAX_LANGFLOW ? DATASTAX_DOCS_URL : DOCS_URL}
-            >
-              <span data-testid="menu_docs_button" id="menu_docs_button">
-                {t("account.docs")}
-              </span>
-            </HeaderMenuItemLink>
-          </div>
-
-          <div>
-            <HeaderMenuItemLink newPage href={GITHUB_URL}>
-              <span
-                data-testid="menu_github_button"
-                id="menu_github_button"
-                className="flex items-center gap-2"
-              >
-                <FaGithub className="h-4 w-4" />
-                {t("account.github")}
-              </span>
-            </HeaderMenuItemLink>
-            <HeaderMenuItemLink newPage href={DISCORD_URL}>
-              <span
-                data-testid="menu_discord_button"
-                id="menu_discord_button"
-                className="flex items-center gap-2"
-              >
-                <FaDiscord className="h-4 w-4 text-[#5865F2]" />
-                {t("account.discord")}
-              </span>
-            </HeaderMenuItemLink>
-            <HeaderMenuItemLink newPage href={TWITTER_URL}>
-              <span
-                data-testid="menu_twitter_button"
-                id="menu_twitter_button"
-                className="flex items-center gap-2"
-              >
-                <ForwardedIconComponent
-                  strokeWidth={2}
-                  name="TwitterX"
-                  className="h-4 w-4"
+    <BaseModal size="templates" open={open} setOpen={setOpen} className="p-0">
+      <BaseModal.Content className="flex flex-col p-0">
+        <div className="flex h-full">
+          <SidebarProvider width="15rem" defaultOpen={false}>
+            <Nav
+              categories={categories}
+              currentTab={currentTab}
+              setCurrentTab={setCurrentTab}
+            />
+            <main className="flex flex-1 flex-col gap-4 overflow-auto p-6 md:gap-8">
+              {effectiveTab === "get-started" ? (
+                <GetStartedComponent
+                  loading={loading}
+                  onFlowCreating={handleFlowCreating}
                 />
-                {t("account.twitter")}
-              </span>
-            </HeaderMenuItemLink>
-          </div>
-
-          <div className="flex items-center justify-between px-4 py-[6.5px] text-sm">
-            <span className="">{t("account.theme")}</span>
-            <div className="relative top-[1px] float-right">
-              <ThemeButtons />
-            </div>
-          </div>
-
-          {!autoLogin && (
-            <div>
-              <HeaderMenuItemButton onClick={handleLogout} icon="log-out">
-                {t("account.logout")}
-              </HeaderMenuItemButton>
-            </div>
-          )}
+              ) : (
+                <TemplateContentComponent
+                  currentTab={effectiveTab}
+                  categories={categories.flatMap((category) => category.items)}
+                  loading={loading}
+                  onFlowCreating={handleFlowCreating}
+                />
+              )}
+              <BaseModal.Footer>
+                <div className="flex w-full flex-col justify-between gap-4 pb-4 sm:flex-row sm:items-center">
+                  <div className="flex flex-col items-start justify-center">
+                    <div className="font-semibold">
+                      {t("templatesModal.startFromScratch")}
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {t("templatesModal.startFromScratchDescription")}
+                    </div>
+                  </div>
+                  <Button
+                    onClick={handleCreateBlankFlow}
+                    size="sm"
+                    data-testid="blank-flow"
+                    className={cn(
+                      "shrink-0",
+                      loading ? "cursor-default opacity-80" : "cursor-pointer",
+                    )}
+                  >
+                    <ForwardedIconComponent
+                      name="Plus"
+                      className="h-4 w-4 shrink-0"
+                    />
+                    {t("templatesModal.blankFlow")}
+                  </Button>
+                </div>
+              </BaseModal.Footer>
+            </main>
+          </SidebarProvider>
         </div>
-      </HeaderMenuItems>
-    </HeaderMenu>
+      </BaseModal.Content>
+    </BaseModal>
   );
-};
+}

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/__tests__/header-buttons.test.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/__tests__/header-buttons.test.tsx
@@ -1,0 +1,95 @@
+import { act, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useUtilityStore } from "@/stores/utilityStore";
+import { HeaderButtons } from "../header-buttons";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("@/components/common/genericIconComponent", () => ({
+  __esModule: true,
+  default: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+jest.mock("@/components/ui/sidebar", () => ({
+  SidebarTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+jest.mock("@/controllers/API/queries/auth", () => ({
+  useUpdateUser: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock(
+  "@/customization/components/custom-get-started-progress",
+  () => () => <div data-testid="custom-get-started-progress" />,
+);
+
+jest.mock("@/stores/authStore", () => ({
+  __esModule: true,
+  default: () => undefined,
+}));
+
+jest.mock("../add-folder-button", () => ({
+  AddFolderButton: ({ disabled }: { disabled?: boolean }) => (
+    <button data-testid="add-folder-btn" disabled={disabled}>
+      Add folder
+    </button>
+  ),
+}));
+
+jest.mock("../upload-folder-button", () => ({
+  UploadFolderButton: ({ disabled }: { disabled?: boolean }) => (
+    <button data-testid="upload-folder-btn" disabled={disabled}>
+      Upload folder
+    </button>
+  ),
+}));
+
+describe("HeaderButtons", () => {
+  const props = {
+    handleUploadFlowsToFolder: jest.fn(),
+    isUpdatingFolder: false,
+    isPending: false,
+    addNewFolder: jest.fn(),
+  };
+
+  beforeEach(() => {
+    act(() => {
+      useUtilityStore.setState({
+        hideGettingStartedProgress: true,
+        hideNewProjectButton: false,
+      });
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useUtilityStore.setState({
+        hideGettingStartedProgress: false,
+        hideNewProjectButton: false,
+      });
+    });
+  });
+
+  it("shows add folder button when hideNewProjectButton is false", () => {
+    render(<HeaderButtons {...props} />);
+
+    expect(screen.getByTestId("add-folder-btn")).toBeInTheDocument();
+  });
+
+  it("hides add folder button when hideNewProjectButton is true", () => {
+    act(() => {
+      useUtilityStore.setState({ hideNewProjectButton: true });
+    });
+
+    render(<HeaderButtons {...props} />);
+
+    expect(screen.queryByTestId("add-folder-btn")).not.toBeInTheDocument();
+    expect(screen.getByTestId("upload-folder-btn")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/get-started-progress.tsx
@@ -1,13 +1,12 @@
 import { type FC, useEffect, useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
 import { FaDiscord, FaGithub } from "react-icons/fa";
 import IconComponent from "@/components/common/genericIconComponent";
-import ShadTooltip from "@/components/common/shadTooltipComponent";
 import { Button } from "@/components/ui/button";
 import { DISCORD_URL, GITHUB_URL } from "@/constants/constants";
 import { useGetUserData, useUpdateUser } from "@/controllers/API/queries/auth";
 import ModalsComponent from "@/pages/MainPage/components/modalsComponent";
 import useFlowsManagerStore from "@/stores/flowsManagerStore";
+import { useUtilityStore } from "@/stores/utilityStore";
 import type { Users } from "@/types/api";
 import { cn } from "@/utils/utils";
 
@@ -17,12 +16,12 @@ export const GetStartedProgress: FC<{
   isDiscordJoined: boolean;
   handleDismissDialog: () => void;
 }> = ({ userData, isGithubStarred, isDiscordJoined, handleDismissDialog }) => {
-  const { t } = useTranslation();
   const [isGithubStarredChild, setIsGithubStarredChild] =
     useState(isGithubStarred);
   const [isDiscordJoinedChild, setIsDiscordJoinedChild] =
     useState(isDiscordJoined);
   const [newProjectModal, setNewProjectModal] = useState(false);
+  const hideNewFlowButton = useUtilityStore((state) => state.hideNewFlowButton);
 
   const flows = useFlowsManagerStore((state) => state.flows);
 
@@ -95,11 +94,10 @@ export const GetStartedProgress: FC<{
         >
           {percentageGetStarted >= 100 ? (
             <>
-              <span>{t("sidebar.allSet")}</span>{" "}
-              <span className="pl-1"> 🎉 </span>
+              <span>All Set</span> <span className="pl-1"> 🎉 </span>
             </>
           ) : (
-            t("sidebar.getStarted")
+            "Get started"
           )}
         </span>
         <button
@@ -158,16 +156,14 @@ export const GetStartedProgress: FC<{
             ) : (
               <FaGithub className="h-4 w-4" />
             )}
-            <ShadTooltip content={t("sidebar.starRepo")} styleClasses="z-50">
-              <span
-                className={cn(
-                  "truncate text-sm",
-                  isGithubStarredChild && "text-muted-foreground line-through",
-                )}
-              >
-                {t("sidebar.starRepo")}
-              </span>
-            </ShadTooltip>
+            <span
+              className={cn(
+                "text-sm",
+                isGithubStarredChild && "text-muted-foreground line-through",
+              )}
+            >
+              Star repo for updates
+            </span>
           </div>
         </Button>
 
@@ -202,52 +198,45 @@ export const GetStartedProgress: FC<{
             ) : (
               <FaDiscord className="h-4 w-4 text-[#5865F2]" />
             )}
-            <ShadTooltip
-              content={t("sidebar.joinCommunity")}
-              styleClasses="z-50"
+            <span
+              className={cn(
+                "text-sm",
+                isDiscordJoinedChild && "text-muted-foreground line-through",
+              )}
             >
-              <span
-                className={cn(
-                  "truncate text-sm",
-                  isDiscordJoinedChild && "text-muted-foreground line-through",
-                )}
-              >
-                {t("sidebar.joinCommunity")}
-              </span>
-            </ShadTooltip>
+              Join the community
+            </span>
           </div>
         </Button>
 
-        <Button
-          unstyled
-          className={cn("w-full", hasFlows && "pointer-events-none")}
-          onClick={() => setNewProjectModal(true)}
-        >
-          <div
-            className={cn(
-              "flex items-center gap-2 rounded-md p-2 py-[10px] hover:bg-muted",
-              hasFlows && "pointer-events-none text-muted-foreground",
-            )}
-            data-testid="create_flow_btn_get_started"
+        {!hideNewFlowButton && (
+          <Button
+            unstyled
+            className={cn("w-full", hasFlows && "pointer-events-none")}
+            onClick={() => setNewProjectModal(true)}
           >
-            <span data-testid="create_flow_icon_get_started">
-              <IconComponent
-                name={hasFlows ? "Check" : "Plus"}
-                className={cn(
-                  "h-4 w-4 text-primary",
-                  hasFlows && "text-accent-emerald-foreground",
-                )}
-              />
-            </span>
-            <ShadTooltip content={t("sidebar.createFlow")} styleClasses="z-50">
-              <span
-                className={cn("truncate text-sm", hasFlows && "line-through")}
-              >
-                {t("sidebar.createFlow")}
+            <div
+              className={cn(
+                "flex items-center gap-2 rounded-md p-2 py-[10px] hover:bg-muted",
+                hasFlows && "pointer-events-none text-muted-foreground",
+              )}
+              data-testid="create_flow_btn_get_started"
+            >
+              <span data-testid="create_flow_icon_get_started">
+                <IconComponent
+                  name={hasFlows ? "Check" : "Plus"}
+                  className={cn(
+                    "h-4 w-4 text-primary",
+                    hasFlows && "text-accent-emerald-foreground",
+                  )}
+                />
               </span>
-            </ShadTooltip>
-          </div>
-        </Button>
+              <span className={cn("text-sm", hasFlows && "line-through")}>
+                Create a flow
+              </span>
+            </div>
+          </Button>
+        )}
       </div>
 
       <ModalsComponent

--- a/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/header-buttons.tsx
+++ b/src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/components/header-buttons.tsx
@@ -25,6 +25,9 @@ export const HeaderButtons = ({
   const hideGettingStartedProgress = useUtilityStore(
     (state) => state.hideGettingStartedProgress,
   );
+  const hideNewProjectButton = useUtilityStore(
+    (state) => state.hideNewProjectButton,
+  );
 
   const [isDismissedDialog, setIsDismissedDialog] = useState(
     userData?.optins?.dialog_dismissed,
@@ -89,11 +92,13 @@ export const HeaderButtons = ({
             onClick={handleUploadFlowsToFolder}
             disabled={isUpdatingFolder}
           />
-          <AddFolderButton
-            onClick={addNewFolder}
-            disabled={isUpdatingFolder}
-            loading={isPending}
-          />
+          {!hideNewProjectButton && (
+            <AddFolderButton
+              onClick={addNewFolder}
+              disabled={isUpdatingFolder}
+              loading={isPending}
+            />
+          )}
         </div>
       </div>
     </>

--- a/src/frontend/src/controllers/API/queries/config/use-get-config.ts
+++ b/src/frontend/src/controllers/API/queries/config/use-get-config.ts
@@ -41,6 +41,13 @@ export interface ConfigResponse extends BaseConfig {
   webhook_auth_enable: boolean;
   default_folder_name: string;
   hide_getting_started_progress: boolean;
+  embedded_mode: boolean;
+  hide_logout_button: boolean;
+  hide_new_project_button: boolean;
+  hide_new_flow_button: boolean;
+  hide_starter_projects: boolean;
+  mcp_servers_locked: boolean;
+  custom_component_admin_only: boolean;
 }
 
 // Union type for the response (can be either public or full config)
@@ -91,6 +98,25 @@ export const useGetConfig: useQueryFunctionType<
   const setEnableExtensionReload = useUtilityStore(
     (state) => state.setEnableExtensionReload,
   );
+  const setEmbeddedMode = useUtilityStore((state) => state.setEmbeddedMode);
+  const setHideLogoutButton = useUtilityStore(
+    (state) => state.setHideLogoutButton,
+  );
+  const setHideNewProjectButton = useUtilityStore(
+    (state) => state.setHideNewProjectButton,
+  );
+  const setHideNewFlowButton = useUtilityStore(
+    (state) => state.setHideNewFlowButton,
+  );
+  const setHideStarterProjects = useUtilityStore(
+    (state) => state.setHideStarterProjects,
+  );
+  const setMcpServersLocked = useUtilityStore(
+    (state) => state.setMcpServersLocked,
+  );
+  const setCustomComponentAdminOnly = useUtilityStore(
+    (state) => state.setCustomComponentAdminOnly,
+  );
 
   const { query } = UseRequestProcessor();
 
@@ -132,6 +158,14 @@ export const useGetConfig: useQueryFunctionType<
         setHideGettingStartedProgress(
           data.hide_getting_started_progress ?? false,
         );
+        // P2 ICA integration flags
+        setEmbeddedMode(data.embedded_mode ?? false);
+        setHideLogoutButton(data.hide_logout_button ?? false);
+        setHideNewProjectButton(data.hide_new_project_button ?? false);
+        setHideNewFlowButton(data.hide_new_flow_button ?? false);
+        setHideStarterProjects(data.hide_starter_projects ?? false);
+        setMcpServersLocked(data.mcp_servers_locked ?? false);
+        setCustomComponentAdminOnly(data.custom_component_admin_only ?? false);
       }
     }
     return data;

--- a/src/frontend/src/controllers/API/queries/config/use-get-config.ts
+++ b/src/frontend/src/controllers/API/queries/config/use-get-config.ts
@@ -158,7 +158,7 @@ export const useGetConfig: useQueryFunctionType<
         setHideGettingStartedProgress(
           data.hide_getting_started_progress ?? false,
         );
-        // P2 ICA integration flags
+        // Embedded mode flags
         setEmbeddedMode(data.embedded_mode ?? false);
         setHideLogoutButton(data.hide_logout_button ?? false);
         setHideNewProjectButton(data.hide_new_project_button ?? false);

--- a/src/frontend/src/modals/templatesModal/__tests__/templatesModal.test.tsx
+++ b/src/frontend/src/modals/templatesModal/__tests__/templatesModal.test.tsx
@@ -1,0 +1,94 @@
+import { act, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useUtilityStore } from "@/stores/utilityStore";
+import TemplatesModal from "../index";
+
+const navProps: Array<Record<string, unknown>> = [];
+
+jest.mock("react-router-dom", () => ({
+  useParams: () => ({}),
+}));
+
+jest.mock("@/customization/hooks/use-custom-navigate", () => ({
+  useCustomNavigate: () => jest.fn(),
+}));
+
+jest.mock("@/customization/utils/analytics", () => ({
+  track: jest.fn(),
+}));
+
+jest.mock("@/hooks/flows/use-add-flow", () => ({
+  __esModule: true,
+  default: () => jest.fn(() => Promise.resolve("flow-id")),
+}));
+
+jest.mock("../../baseModal", () => {
+  const BaseModal = Object.assign(
+    ({ children }: { children: ReactNode }) => <>{children}</>,
+    {
+      Content: ({ children }: { children: ReactNode }) => <>{children}</>,
+      Footer: ({ children }: { children: ReactNode }) => <>{children}</>,
+    },
+  );
+
+  return {
+    __esModule: true,
+    default: BaseModal,
+  };
+});
+
+jest.mock("../components/navComponent", () => ({
+  Nav: (props: Record<string, unknown>) => {
+    navProps.push(props);
+    return <div data-testid="templates-nav" />;
+  },
+}));
+
+jest.mock("../components/GetStartedComponent", () => ({
+  __esModule: true,
+  default: () => <div data-testid="get-started-component" />,
+}));
+
+jest.mock("../components/TemplateContentComponent", () => ({
+  __esModule: true,
+  default: () => <div data-testid="template-content-component" />,
+}));
+
+jest.mock("@/components/ui/sidebar", () => ({
+  SidebarProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+describe("TemplatesModal", () => {
+  beforeEach(() => {
+    navProps.length = 0;
+    act(() => {
+      useUtilityStore.setState({ hideStarterProjects: false });
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useUtilityStore.setState({ hideStarterProjects: false });
+    });
+  });
+
+  it("passes the effective tab to the nav when starter projects are hidden", () => {
+    act(() => {
+      useUtilityStore.setState({ hideStarterProjects: true });
+    });
+
+    render(<TemplatesModal open setOpen={jest.fn()} />);
+
+    expect(screen.getByTestId("templates-nav")).toBeInTheDocument();
+    expect(navProps.at(-1)?.currentTab).toBe("all-templates");
+  });
+
+  it("keeps get-started selected in the nav when starter projects are visible", () => {
+    render(<TemplatesModal open setOpen={jest.fn()} />);
+
+    expect(screen.getByTestId("templates-nav")).toBeInTheDocument();
+    expect(navProps.at(-1)?.currentTab).toBe("get-started");
+  });
+});

--- a/src/frontend/src/modals/templatesModal/__tests__/templatesModal.test.tsx
+++ b/src/frontend/src/modals/templatesModal/__tests__/templatesModal.test.tsx
@@ -83,6 +83,17 @@ describe("TemplatesModal", () => {
 
     expect(screen.getByTestId("templates-nav")).toBeInTheDocument();
     expect(navProps.at(-1)?.currentTab).toBe("all-templates");
+
+    const categories = navProps.at(-1)?.categories as
+      | Array<{ items: Array<{ id: string }> }>
+      | undefined;
+
+    const categoryItemIds =
+      categories?.flatMap((category) =>
+        category.items.map((item) => item.id),
+      ) ?? [];
+
+    expect(categoryItemIds).not.toContain("get-started");
   });
 
   it("keeps get-started selected in the nav when starter projects are visible", () => {

--- a/src/frontend/src/modals/templatesModal/index.tsx
+++ b/src/frontend/src/modals/templatesModal/index.tsx
@@ -123,7 +123,7 @@ export default function TemplatesModal({
           <SidebarProvider width="15rem" defaultOpen={false}>
             <Nav
               categories={categories}
-              currentTab={currentTab}
+              currentTab={effectiveTab}
               setCurrentTab={setCurrentTab}
             />
             <main className="flex flex-1 flex-col gap-4 overflow-auto p-6 md:gap-8">

--- a/src/frontend/src/modals/templatesModal/index.tsx
+++ b/src/frontend/src/modals/templatesModal/index.tsx
@@ -31,7 +31,10 @@ export default function TemplatesModal({
   );
 
   // If starter projects are hidden and we're on the get-started tab, switch to all-templates
-  const effectiveTab = hideStarterProjects && currentTab === "get-started" ? "all-templates" : currentTab;
+  const effectiveTab =
+    hideStarterProjects && currentTab === "get-started"
+      ? "all-templates"
+      : currentTab;
 
   const handleFlowCreating = (isCreating: boolean) => {
     setLoading(isCreating);

--- a/src/frontend/src/modals/templatesModal/index.tsx
+++ b/src/frontend/src/modals/templatesModal/index.tsx
@@ -7,6 +7,7 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { useCustomNavigate } from "@/customization/hooks/use-custom-navigate";
 import { track } from "@/customization/utils/analytics";
 import useAddFlow from "@/hooks/flows/use-add-flow";
+import { useUtilityStore } from "@/stores/utilityStore";
 import type { Category } from "@/types/templates/types";
 import { cn } from "@/utils/utils";
 import type { newFlowModalPropsType } from "../../types/components";
@@ -25,6 +26,12 @@ export default function TemplatesModal({
   const addFlow = useAddFlow();
   const navigate = useCustomNavigate();
   const { folderId } = useParams();
+  const hideStarterProjects = useUtilityStore(
+    (state) => state.hideStarterProjects,
+  );
+
+  // If starter projects are hidden and we're on the get-started tab, switch to all-templates
+  const effectiveTab = hideStarterProjects && currentTab === "get-started" ? "all-templates" : currentTab;
 
   const handleFlowCreating = (isCreating: boolean) => {
     setLoading(isCreating);
@@ -50,11 +57,16 @@ export default function TemplatesModal({
     {
       title: t("templatesModal.title"),
       items: [
-        {
-          title: t("templatesModal.getStarted"),
-          icon: "SquarePlay",
-          id: "get-started",
-        },
+        // Hide "Get Started" tab if starter projects are hidden
+        ...(hideStarterProjects
+          ? []
+          : [
+              {
+                title: t("templatesModal.getStarted"),
+                icon: "SquarePlay",
+                id: "get-started",
+              },
+            ]),
         {
           title: t("templatesModal.allTemplates"),
           icon: "LayoutPanelTop",
@@ -115,14 +127,14 @@ export default function TemplatesModal({
               setCurrentTab={setCurrentTab}
             />
             <main className="flex flex-1 flex-col gap-4 overflow-auto p-6 md:gap-8">
-              {currentTab === "get-started" ? (
+              {effectiveTab === "get-started" ? (
                 <GetStartedComponent
                   loading={loading}
                   onFlowCreating={handleFlowCreating}
                 />
               ) : (
                 <TemplateContentComponent
-                  currentTab={currentTab}
+                  currentTab={effectiveTab}
                   categories={categories.flatMap((category) => category.items)}
                   loading={loading}
                   onFlowCreating={handleFlowCreating}

--- a/src/frontend/src/pages/MainPage/components/header/__tests__/header.test.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/__tests__/header.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
+import { useUtilityStore } from "@/stores/utilityStore";
 import HeaderComponent from "../index";
 
 interface IconProps {
@@ -173,6 +174,15 @@ describe("HeaderComponent - TabIndex Behavior with Bulk Actions", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    act(() => {
+      useUtilityStore.setState({ featureFlags: {} });
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useUtilityStore.setState({ featureFlags: {} });
+    });
   });
 
   describe("DeleteConfirmationModal TabIndex - No Selections", () => {
@@ -233,6 +243,18 @@ describe("HeaderComponent - TabIndex Behavior with Bulk Actions", () => {
       // Delete button should be accessible
       const deleteBtn = screen.getByTestId("delete-bulk-btn");
       expect(deleteBtn).not.toHaveAttribute("tabindex", "-1");
+    });
+
+    it("should hide the New Flow button when the feature flag is enabled", () => {
+      act(() => {
+        useUtilityStore.setState({
+          featureFlags: { hide_new_flow_button: true },
+        });
+      });
+
+      render(<HeaderComponent {...defaultProps} selectedFlows={[]} />);
+
+      expect(screen.queryByTestId("new-project-btn")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/frontend/src/pages/MainPage/components/header/__tests__/header.test.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/__tests__/header.test.tsx
@@ -248,7 +248,7 @@ describe("HeaderComponent - TabIndex Behavior with Bulk Actions", () => {
     it("should hide the New Flow button when the feature flag is enabled", () => {
       act(() => {
         useUtilityStore.setState({
-          featureFlags: { hide_new_flow_button: true },
+          hideNewFlowButton: true,
         });
       });
 

--- a/src/frontend/src/pages/MainPage/components/header/index.tsx
+++ b/src/frontend/src/pages/MainPage/components/header/index.tsx
@@ -90,6 +90,7 @@ const HeaderComponent = ({
   const isDeploymentsEnabled = useUtilityStore(
     (s) => s.featureFlags.wxo_deployments === true,
   );
+  const hideNewFlowButton = useUtilityStore((s) => s.hideNewFlowButton);
 
   // Determine which tabs to show based on feature flags
   const tabTypes = [
@@ -275,27 +276,29 @@ const HeaderComponent = ({
                     </Button>
                   </DeleteConfirmationModal>
                 </div>
-                <ShadTooltip content={t("mainPage.newFlow")} side="bottom">
-                  <Button
-                    variant="default"
-                    size="iconMd"
-                    className="z-50 px-2.5 !text-mmd"
-                    onClick={() =>
-                      onNewFlow ? onNewFlow() : setNewProjectModal(true)
-                    }
-                    id="new-project-btn"
-                    data-testid="new-project-btn"
-                  >
-                    <ForwardedIconComponent
-                      name="Plus"
-                      aria-hidden="true"
-                      className="h-4 w-4"
-                    />
-                    <span className="hidden whitespace-nowrap font-semibold md:inline">
-                      {t("mainPage.newFlow")}
-                    </span>
-                  </Button>
-                </ShadTooltip>
+                {!hideNewFlowButton && (
+                  <ShadTooltip content={t("mainPage.newFlow")} side="bottom">
+                    <Button
+                      variant="default"
+                      size="iconMd"
+                      className="z-50 px-2.5 !text-mmd"
+                      onClick={() =>
+                        onNewFlow ? onNewFlow() : setNewProjectModal(true)
+                      }
+                      id="new-project-btn"
+                      data-testid="new-project-btn"
+                    >
+                      <ForwardedIconComponent
+                        name="Plus"
+                        aria-hidden="true"
+                        className="h-4 w-4"
+                      />
+                      <span className="hidden whitespace-nowrap font-semibold md:inline">
+                        {t("mainPage.newFlow")}
+                      </span>
+                    </Button>
+                  </ShadTooltip>
+                )}
               </div>
             </div>
           )}

--- a/src/frontend/src/pages/MainPage/pages/emptyFolder/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/emptyFolder/index.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Button } from "@/components/ui/button";
 import { useFolderStore } from "@/stores/foldersStore";
+import { useUtilityStore } from "@/stores/utilityStore";
 
 type EmptyFolderProps = {
   setOpenModal: (open: boolean) => void;
@@ -14,6 +15,9 @@ type EmptyFolderProps = {
 export const EmptyFolder = ({ setOpenModal, onNewFlow }: EmptyFolderProps) => {
   const { t } = useTranslation();
   const folders = useFolderStore((state) => state.folders);
+  const hideNewFlowButton = useUtilityStore(
+    (state) => state.featureFlags.hide_new_flow_button === true,
+  );
 
   return (
     <div className="m-0 flex w-full justify-center">
@@ -29,21 +33,23 @@ export const EmptyFolder = ({ setOpenModal, onNewFlow }: EmptyFolderProps) => {
         <p className="pb-5 text-sm text-secondary-foreground">
           {t("emptyPage.description")}
         </p>
-        <Button
-          variant="default"
-          onClick={() => (onNewFlow ? onNewFlow() : setOpenModal(true))}
-          id="new-project-btn"
-          data-testid="new_project_btn_empty_page"
-        >
-          <ForwardedIconComponent
-            name="plus"
-            aria-hidden="true"
-            className="h-4 w-4"
-          />
-          <span className="whitespace-nowrap font-semibold">
-            {t("emptyPage.newFlow")}
-          </span>
-        </Button>
+        {!hideNewFlowButton && (
+          <Button
+            variant="default"
+            onClick={() => (onNewFlow ? onNewFlow() : setOpenModal(true))}
+            id="new-project-btn"
+            data-testid="new_project_btn_empty_page"
+          >
+            <ForwardedIconComponent
+              name="plus"
+              aria-hidden="true"
+              className="h-4 w-4"
+            />
+            <span className="whitespace-nowrap font-semibold">
+              {t("emptyPage.newFlow")}
+            </span>
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/frontend/src/pages/MainPage/pages/emptyFolder/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/emptyFolder/index.tsx
@@ -15,9 +15,7 @@ type EmptyFolderProps = {
 export const EmptyFolder = ({ setOpenModal, onNewFlow }: EmptyFolderProps) => {
   const { t } = useTranslation();
   const folders = useFolderStore((state) => state.folders);
-  const hideNewFlowButton = useUtilityStore(
-    (state) => state.featureFlags.hide_new_flow_button === true,
-  );
+  const hideNewFlowButton = useUtilityStore((state) => state.hideNewFlowButton);
 
   return (
     <div className="m-0 flex w-full justify-center">

--- a/src/frontend/src/pages/MainPage/pages/emptyPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/emptyPage/index.tsx
@@ -4,6 +4,7 @@ import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import CardsWrapComponent from "@/components/core/cardsWrapComponent";
 import { Button } from "@/components/ui/button";
 import { useFolderStore } from "@/stores/foldersStore";
+import { useUtilityStore } from "@/stores/utilityStore";
 import useFileDrop from "../../hooks/use-on-file-drop";
 
 type EmptyPageProps = {
@@ -14,6 +15,9 @@ export const EmptyPage = ({ setOpenModal }: EmptyPageProps) => {
   const { t } = useTranslation();
   const folders = useFolderStore((state) => state.folders);
   const handleFileDrop = useFileDrop(undefined);
+  const hideNewFlowButton = useUtilityStore(
+    (state) => state.featureFlags.hide_new_flow_button === true,
+  );
 
   return (
     <CardsWrapComponent
@@ -38,21 +42,23 @@ export const EmptyPage = ({ setOpenModal }: EmptyPageProps) => {
             >
               {t("emptyPage.description")}
             </p>
-            <Button
-              variant="default"
-              onClick={() => setOpenModal(true)}
-              id="new-project-btn"
-              data-testid="new_project_btn_empty_page"
-            >
-              <ForwardedIconComponent
-                name="Plus"
-                aria-hidden="true"
-                className="h-4 w-4"
-              />
-              <span className="hidden whitespace-nowrap font-semibold md:inline">
-                {t("emptyPage.newFlow")}
-              </span>
-            </Button>
+            {!hideNewFlowButton && (
+              <Button
+                variant="default"
+                onClick={() => setOpenModal(true)}
+                id="new-project-btn"
+                data-testid="new_project_btn_empty_page"
+              >
+                <ForwardedIconComponent
+                  name="Plus"
+                  aria-hidden="true"
+                  className="h-4 w-4"
+                />
+                <span className="hidden whitespace-nowrap font-semibold md:inline">
+                  {t("emptyPage.newFlow")}
+                </span>
+              </Button>
+            )}
           </div>
         </div>
         <div className="gradient-bg">

--- a/src/frontend/src/pages/MainPage/pages/emptyPage/index.tsx
+++ b/src/frontend/src/pages/MainPage/pages/emptyPage/index.tsx
@@ -15,9 +15,7 @@ export const EmptyPage = ({ setOpenModal }: EmptyPageProps) => {
   const { t } = useTranslation();
   const folders = useFolderStore((state) => state.folders);
   const handleFileDrop = useFileDrop(undefined);
-  const hideNewFlowButton = useUtilityStore(
-    (state) => state.featureFlags.hide_new_flow_button === true,
-  );
+  const hideNewFlowButton = useUtilityStore((state) => state.hideNewFlowButton);
 
   return (
     <CardsWrapComponent

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -72,7 +72,7 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   enableExtensionReload: false,
   setEnableExtensionReload: (enableExtensionReload: boolean) =>
     set({ enableExtensionReload }),
-  // P2 ICA integration flags
+  // Embedded mode flags
   embeddedMode: false,
   setEmbeddedMode: (embeddedMode: boolean) => set({ embeddedMode }),
   hideLogoutButton: false,

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -76,8 +76,7 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   embeddedMode: false,
   setEmbeddedMode: (embeddedMode: boolean) => set({ embeddedMode }),
   hideLogoutButton: false,
-  setHideLogoutButton: (hideLogoutButton: boolean) =>
-    set({ hideLogoutButton }),
+  setHideLogoutButton: (hideLogoutButton: boolean) => set({ hideLogoutButton }),
   hideNewProjectButton: false,
   setHideNewProjectButton: (hideNewProjectButton: boolean) =>
     set({ hideNewProjectButton }),
@@ -88,8 +87,7 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   setHideStarterProjects: (hideStarterProjects: boolean) =>
     set({ hideStarterProjects }),
   mcpServersLocked: false,
-  setMcpServersLocked: (mcpServersLocked: boolean) =>
-    set({ mcpServersLocked }),
+  setMcpServersLocked: (mcpServersLocked: boolean) => set({ mcpServersLocked }),
   customComponentAdminOnly: false,
   setCustomComponentAdminOnly: (customComponentAdminOnly: boolean) =>
     set({ customComponentAdminOnly }),

--- a/src/frontend/src/stores/utilityStore.ts
+++ b/src/frontend/src/stores/utilityStore.ts
@@ -72,4 +72,25 @@ export const useUtilityStore = create<UtilityStoreType>((set, get) => ({
   enableExtensionReload: false,
   setEnableExtensionReload: (enableExtensionReload: boolean) =>
     set({ enableExtensionReload }),
+  // P2 ICA integration flags
+  embeddedMode: false,
+  setEmbeddedMode: (embeddedMode: boolean) => set({ embeddedMode }),
+  hideLogoutButton: false,
+  setHideLogoutButton: (hideLogoutButton: boolean) =>
+    set({ hideLogoutButton }),
+  hideNewProjectButton: false,
+  setHideNewProjectButton: (hideNewProjectButton: boolean) =>
+    set({ hideNewProjectButton }),
+  hideNewFlowButton: false,
+  setHideNewFlowButton: (hideNewFlowButton: boolean) =>
+    set({ hideNewFlowButton }),
+  hideStarterProjects: false,
+  setHideStarterProjects: (hideStarterProjects: boolean) =>
+    set({ hideStarterProjects }),
+  mcpServersLocked: false,
+  setMcpServersLocked: (mcpServersLocked: boolean) =>
+    set({ mcpServersLocked }),
+  customComponentAdminOnly: false,
+  setCustomComponentAdminOnly: (customComponentAdminOnly: boolean) =>
+    set({ customComponentAdminOnly }),
 }));

--- a/src/frontend/src/types/zustand/utility/index.ts
+++ b/src/frontend/src/types/zustand/utility/index.ts
@@ -53,7 +53,7 @@ export type UtilityStoreType = {
    */
   enableExtensionReload: boolean;
   setEnableExtensionReload: (enableExtensionReload: boolean) => void;
-  // P2 ICA integration flags
+  // Embedded mode flags
   embeddedMode: boolean;
   setEmbeddedMode: (embeddedMode: boolean) => void;
   hideLogoutButton: boolean;

--- a/src/frontend/src/types/zustand/utility/index.ts
+++ b/src/frontend/src/types/zustand/utility/index.ts
@@ -53,4 +53,19 @@ export type UtilityStoreType = {
    */
   enableExtensionReload: boolean;
   setEnableExtensionReload: (enableExtensionReload: boolean) => void;
+  // P2 ICA integration flags
+  embeddedMode: boolean;
+  setEmbeddedMode: (embeddedMode: boolean) => void;
+  hideLogoutButton: boolean;
+  setHideLogoutButton: (hideLogoutButton: boolean) => void;
+  hideNewProjectButton: boolean;
+  setHideNewProjectButton: (hideNewProjectButton: boolean) => void;
+  hideNewFlowButton: boolean;
+  setHideNewFlowButton: (hideNewFlowButton: boolean) => void;
+  hideStarterProjects: boolean;
+  setHideStarterProjects: (hideStarterProjects: boolean) => void;
+  mcpServersLocked: boolean;
+  setMcpServersLocked: (mcpServersLocked: boolean) => void;
+  customComponentAdminOnly: boolean;
+  setCustomComponentAdminOnly: (customComponentAdminOnly: boolean) => void;
 };

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -503,7 +503,12 @@ class Settings(BaseSettings):
     # Embedded mode flags
     embedded_mode: bool = False
     """Umbrella flag for iframe/embedded mode. When True, hides UI elements specific to
-    standalone installations (logout button, new project/flow buttons, starter projects, etc.)."""
+    standalone installations (logout button, new project/flow buttons, starter projects, etc.).
+
+    This flag does not implicitly enable security controls such as
+    ``mcp_servers_locked`` or ``custom_component_admin_only``. Configure those
+    explicitly based on your deployment hardening requirements.
+    """
     hide_getting_started_progress: bool = Field(
         default=False,
         validation_alias=AliasChoices(
@@ -523,8 +528,11 @@ class Settings(BaseSettings):
 
     # MCP Server management
     mcp_servers_locked: bool = False
-    """If set to True, users cannot add or modify MCP servers via the UI. Only admin/superuser
-    can modify them through backend configuration. ContextForge remains the single ingress."""
+    """If set to True, users cannot add or modify MCP servers via the UI/API.
+
+    This control is independent from ``embedded_mode`` and must be enabled
+    explicitly when you want to lock MCP server management.
+    """
 
     @field_validator("runtime_port", mode="before")
     @classmethod

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -479,6 +479,9 @@ class Settings(BaseSettings):
 
     Note: this is a beta feature. For security in a multi-tenant environment,
     use hardware-level isolation to restrict access."""
+    custom_component_admin_only: bool = False
+    """If set to True, only admin users can edit custom component code. Regular editors
+    are blocked from modifying custom component templates."""
 
     # SSRF Protection
     ssrf_protection_enabled: bool = True
@@ -496,6 +499,24 @@ class Settings(BaseSettings):
 
     Note: This setting only takes effect when ssrf_protection_enabled is True.
     When protection is disabled, all hosts are allowed regardless of this setting."""
+
+    # Embedded/iframe mode - ICA integration flags
+    embedded_mode: bool = False
+    """Umbrella flag for iframe/embedded mode. When True, hides UI elements specific to
+    standalone installations (logout button, new project/flow buttons, starter projects, etc.)."""
+    hide_logout_button: bool = False
+    """If set to True, hides the Logout button in the account menu."""
+    hide_new_project_button: bool = False
+    """If set to True, hides the ability to create new projects/folders."""
+    hide_new_flow_button: bool = False
+    """If set to True, hides the ability to create new flows."""
+    hide_starter_projects: bool = False
+    """If set to True, hides starter projects from the UI (does not affect database seeding)."""
+
+    # MCP Server management
+    mcp_servers_locked: bool = False
+    """If set to True, users cannot add or modify MCP servers via the UI. Only admin/superuser
+    can modify them through backend configuration. ContextForge remains the single ingress."""
 
     @field_validator("runtime_port", mode="before")
     @classmethod

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -500,10 +500,12 @@ class Settings(BaseSettings):
     Note: This setting only takes effect when ssrf_protection_enabled is True.
     When protection is disabled, all hosts are allowed regardless of this setting."""
 
-    # Embedded/iframe mode - ICA integration flags
+    # Embedded mode flags
     embedded_mode: bool = False
     """Umbrella flag for iframe/embedded mode. When True, hides UI elements specific to
     standalone installations (logout button, new project/flow buttons, starter projects, etc.)."""
+    hide_getting_started_progress: bool = False
+    """If set to True, hides the getting-started onboarding progress UI."""
     hide_logout_button: bool = False
     """If set to True, hides the Logout button in the account menu."""
     hide_new_project_button: bool = False

--- a/src/lfx/src/lfx/services/settings/base.py
+++ b/src/lfx/src/lfx/services/settings/base.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 import aiofiles
 import orjson
 import yaml
-from pydantic import Field, field_validator
+from pydantic import AliasChoices, Field, field_validator
 from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings, EnvSettingsSource, PydanticBaseSettingsSource, SettingsConfigDict
 from typing_extensions import override
@@ -504,7 +504,13 @@ class Settings(BaseSettings):
     embedded_mode: bool = False
     """Umbrella flag for iframe/embedded mode. When True, hides UI elements specific to
     standalone installations (logout button, new project/flow buttons, starter projects, etc.)."""
-    hide_getting_started_progress: bool = False
+    hide_getting_started_progress: bool = Field(
+        default=False,
+        validation_alias=AliasChoices(
+            "LANGFLOW_HIDE_GETTING_STARTED_PROGRESS",
+            "HIDE_GETTING_STARTED_PROGRESS",
+        ),
+    )
     """If set to True, hides the getting-started onboarding progress UI."""
     hide_logout_button: bool = False
     """If set to True, hides the Logout button in the account menu."""

--- a/src/lfx/src/lfx/services/settings/feature_flags.py
+++ b/src/lfx/src/lfx/services/settings/feature_flags.py
@@ -7,6 +7,7 @@ class FeatureFlags(BaseSettings):
     Enable Watsonx Orchestrate deployments.
     """
     mvp_components: bool = False
+    hide_new_flow_button: bool = False
 
     class Config:
         env_prefix = "LANGFLOW_FEATURE_"

--- a/src/lfx/src/lfx/services/settings/feature_flags.py
+++ b/src/lfx/src/lfx/services/settings/feature_flags.py
@@ -7,7 +7,6 @@ class FeatureFlags(BaseSettings):
     Enable Watsonx Orchestrate deployments.
     """
     mvp_components: bool = False
-    hide_new_flow_button: bool = False
 
     class Config:
         env_prefix = "LANGFLOW_FEATURE_"


### PR DESCRIPTION
## Summary
Implements conditional rendering of standalone-only UI elements when running
in embedded/iframe mode. Respects hideLogoutButton, hideNewProjectButton, 
hideNewFlowButton, and hideStarterProjects flags.

## Changes
- Hide logout button from account menu
- Hide new flow creation button from header
- Hide new project/folder button from sidebar
- Hide starter projects tab from templates modal

All controlled by utility store flags populated from server configuration.

## Type
Feature/UX

## Related
Part 4 of 4 in LE-906 P2 Fixes split
Depends on: PR1 (config plumbing must merge first)

## Notes
Pure frontend changes with no breaking changes. Works with any value of 
embedded_mode flag; integrators can enable individual hide flags as needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to conditionally hide the logout button in the account menu.
  * Added configuration option to hide the new project/folder creation button in the sidebar.
  * Added configuration option to hide the starter projects tab and related content in the templates modal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13099?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->