### PR TITLE
docs: SSRF protection enabled by default

### DIFF
--- a/docs/versioned_docs/version-1.9.0/Develop/api-keys-and-authentication.mdx
+++ b/docs/versioned_docs/version-1.9.0/Develop/api-keys-and-authentication.mdx
@@ -454,9 +454,15 @@ LANGFLOW_CORS_ALLOW_METHODS=["GET","POST","PUT"]
 The following environment variables configure Server-Side Request Forgery (SSRF) protection for the [**API Request** component](/api-request).
 SSRF protection prevents requests to internal or private network resources, such as private IP ranges, loopback addresses, and cloud metadata endpoints.
 
+:::warning
+As of Langflow 1.9.3, SSRF protection is enabled by default and includes DNS rebinding prevention through IP pinning.
+
+If you are upgrading to Langflow 1.9.3 and your flows use the [**API Request** component](/api-request) to call resources that would be blocked by SSRF protection, add those hosts to `LANGFLOW_SSRF_ALLOWED_HOSTS` before upgrading to avoid disruption.
+:::
+
 | Variable | Format | Default | Description |
 |----------|--------|---------|-------------|
-| `LANGFLOW_SSRF_PROTECTION_ENABLED` | Boolean | `False` | Enable SSRF protection for the **API Request** component. When enabled, the component blocks requests to private IP addresses. When disabled, requests are not blocked. |
+| `LANGFLOW_SSRF_PROTECTION_ENABLED` | Boolean | `True` | Enable SSRF protection for the **API Request** component. When enabled, the component blocks requests to private IP addresses. When disabled, requests are not blocked. |
 | `LANGFLOW_SSRF_ALLOWED_HOSTS` | List[String] | Not set | A comma-separated list of allowed hosts, IP addresses, or CIDR ranges that can bypass SSRF protection checks. For example: `192.168.1.0/24,10.0.0.5,*.internal.company.local`.|
 
 ### LANGFLOW_WEBHOOK_AUTH_ENABLE {#langflow-webhook-auth-enable}


### PR DESCRIPTION
#13016 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SSRF protection documentation to reflect that SSRF protection is now enabled by default as of Langflow 1.9.3, with DNS rebinding prevention included.
  * Added upgrade guidance for users with flows calling blocked hosts—configure allowed hosts before upgrading to avoid disruption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13106)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->