### PR TITLE
fix(knowledge-base): align Filter by metadata pickers with app dropdowns

### DIFF
--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/MetadataEditor.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/MetadataEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,10 +10,12 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/utils/utils";
-
-const KEY_PATTERN = /^[a-z0-9_]{1,32}$/;
-const MAX_KEYS = 16;
-const MAX_VALUE_LENGTH = 256;
+import {
+  filterValidMetadataPairs,
+  MAX_KEYS,
+  MAX_VALUE_LENGTH,
+  validateMetadataPairs,
+} from "./metadataValidation";
 
 export interface MetadataPair {
   key: string;
@@ -35,9 +37,12 @@ interface MetadataEditorProps {
 /**
  * Compact key/value editor for user-supplied KB metadata.
  *
- * Mirrors the rules enforced by the backend ``parse_user_metadata``
- * helper: lowercase alphanumeric+underscore keys (≤32 chars),
- * non-reserved, ≤16 keys total, ≤256-char values.
+ * Validation lives in ``metadataValidation.ts`` and is derived from the
+ * current ``pairs`` prop, not local state, so a parent that wants to
+ * gate "Next Step" can call ``validateMetadataPairs`` on the same array
+ * and get the same answer. Mirrors the rules enforced by the backend
+ * ``parse_user_metadata`` helper (≤32-char lowercase keys, no dupes,
+ * ≤256-char values, ≤16 keys total).
  */
 export function MetadataEditor({
   pairs,
@@ -45,19 +50,13 @@ export function MetadataEditor({
   disabled = false,
   testIdScope = "kb",
 }: MetadataEditorProps) {
-  const [errors, setErrors] = useState<Record<number, string>>({});
+  const validation = useMemo(() => validateMetadataPairs(pairs), [pairs]);
 
   const updatePair = (index: number, patch: Partial<MetadataPair>) => {
     const next = pairs.map((pair, i) =>
       i === index ? { ...pair, ...patch } : pair,
     );
     onPairsChange(next);
-    setErrors((prev) => {
-      // Clearing the row also clears any stale validation message for it.
-      if (!patch.key && !patch.value) return prev;
-      const { [index]: _drop, ...rest } = prev;
-      return rest;
-    });
   };
 
   const addPair = () => {
@@ -67,30 +66,6 @@ export function MetadataEditor({
 
   const removePair = (index: number) => {
     onPairsChange(pairs.filter((_, i) => i !== index));
-    setErrors((prev) => {
-      const { [index]: _drop, ...rest } = prev;
-      return rest;
-    });
-  };
-
-  const validateKey = (index: number, key: string) => {
-    if (!key) return;
-    if (!KEY_PATTERN.test(key)) {
-      setErrors((prev) => ({
-        ...prev,
-        [index]: "Keys must be 1-32 lowercase letters, digits, or underscores.",
-      }));
-      return;
-    }
-    const duplicate = pairs.some((pair, i) => i !== index && pair.key === key);
-    if (duplicate) {
-      setErrors((prev) => ({ ...prev, [index]: "Duplicate key." }));
-      return;
-    }
-    setErrors((prev) => {
-      const { [index]: _drop, ...rest } = prev;
-      return rest;
-    });
   };
 
   return (
@@ -132,47 +107,60 @@ export function MetadataEditor({
           </div>
         )}
 
-        {pairs.map((pair, index) => (
-          <div key={index} className="flex flex-col gap-1">
-            <div className="flex items-center gap-2">
-              <Input
-                placeholder="key"
-                value={pair.key}
-                onChange={(e) => updatePair(index, { key: e.target.value })}
-                onBlur={() => validateKey(index, pair.key)}
-                className={cn(
-                  "h-8 flex-1",
-                  errors[index] && "border-destructive",
-                )}
-                data-testid={`${testIdScope}-metadata-key-${index}`}
-                disabled={disabled}
-              />
-              <Input
-                placeholder="value"
-                value={pair.value}
-                onChange={(e) => updatePair(index, { value: e.target.value })}
-                maxLength={MAX_VALUE_LENGTH}
-                className="h-8 flex-1"
-                data-testid={`${testIdScope}-metadata-value-${index}`}
-                disabled={disabled}
-              />
-              <Button
-                type="button"
-                variant="ghost"
-                size="iconSm"
-                onClick={() => removePair(index)}
-                aria-label={`Remove metadata field ${index + 1}`}
-                data-testid={`${testIdScope}-metadata-remove-${index}`}
-                disabled={disabled}
-              >
-                <ForwardedIconComponent name="X" className="h-3.5 w-3.5" />
-              </Button>
+        {pairs.map((pair, index) => {
+          const rowError = validation.errors[index];
+          return (
+            <div key={index} className="flex flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <Input
+                  placeholder="key"
+                  value={pair.key}
+                  onChange={(e) => updatePair(index, { key: e.target.value })}
+                  className={cn("h-8 flex-1", rowError && "border-destructive")}
+                  data-testid={`${testIdScope}-metadata-key-${index}`}
+                  disabled={disabled}
+                />
+                <Input
+                  placeholder="value"
+                  value={pair.value}
+                  onChange={(e) => updatePair(index, { value: e.target.value })}
+                  maxLength={MAX_VALUE_LENGTH}
+                  className={cn("h-8 flex-1", rowError && "border-destructive")}
+                  data-testid={`${testIdScope}-metadata-value-${index}`}
+                  disabled={disabled}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="iconSm"
+                  onClick={() => removePair(index)}
+                  aria-label={`Remove metadata field ${index + 1}`}
+                  data-testid={`${testIdScope}-metadata-remove-${index}`}
+                  disabled={disabled}
+                >
+                  <ForwardedIconComponent name="X" className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+              {rowError && (
+                <span
+                  className="text-xs text-destructive"
+                  data-testid={`${testIdScope}-metadata-error-${index}`}
+                >
+                  {rowError}
+                </span>
+              )}
             </div>
-            {errors[index] && (
-              <span className="text-xs text-destructive">{errors[index]}</span>
-            )}
-          </div>
-        ))}
+          );
+        })}
+
+        {validation.setError && (
+          <span
+            className="text-xs text-destructive"
+            data-testid={`${testIdScope}-metadata-set-error`}
+          >
+            {validation.setError}
+          </span>
+        )}
 
         <Button
           type="button"
@@ -193,13 +181,11 @@ export function MetadataEditor({
 
 /**
  * Convert UI pairs into the JSON-string payload expected by the backend.
- * Strips empty rows; collapses to ``""`` when nothing is set so the API
- * route can skip parsing entirely.
+ * Strips invalid / empty rows; collapses to ``""`` when nothing valid
+ * remains so the API route can skip parsing entirely.
  */
 export function metadataPairsToFormValue(pairs: MetadataPair[]): string {
-  const populated = pairs
-    .map((pair) => ({ key: pair.key.trim(), value: pair.value.trim() }))
-    .filter((pair) => pair.key && pair.value && KEY_PATTERN.test(pair.key));
+  const populated = filterValidMetadataPairs(pairs);
   if (populated.length === 0) return "";
   const result: Record<string, string> = {};
   for (const pair of populated) {

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepConfiguration.tsx
@@ -495,6 +495,14 @@ export function StepConfiguration({
                 onPairsChange={onMetadataPairsChange}
                 testIdScope="kb-run"
               />
+              {validationErrors.metadata && (
+                <span
+                  className="text-xs text-destructive"
+                  data-testid="kb-run-metadata-form-error"
+                >
+                  {validationErrors.metadata}
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepReview.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/StepReview.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/utils/utils";
 import type { ChunkPreview } from "../types";
 import { ChunkPreviewCard } from "./ChunkPreviewCard";
 import type { MetadataPair } from "./MetadataEditor";
+import { filterValidMetadataPairs } from "./metadataValidation";
 import { SummaryItem } from "./SummaryItem";
 
 interface StepReviewProps {
@@ -55,11 +56,11 @@ export function StepReview({
   perFileMetadata = {},
 }: StepReviewProps) {
   const selectedBackend = getDBProviderOption(backendType);
-  const populatedRunPairs = metadataPairs.filter(
-    (pair) => pair.key.trim() && pair.value.trim(),
-  );
-  const filesWithOverrides = Object.values(perFileMetadata).filter((pairs) =>
-    pairs.some((pair) => pair.key.trim() && pair.value.trim()),
+  // Use the same validator that gates "Next Step" so the summary only
+  // shows pairs the backend will actually accept.
+  const populatedRunPairs = filterValidMetadataPairs(metadataPairs);
+  const filesWithOverrides = Object.values(perFileMetadata).filter(
+    (pairs) => filterValidMetadataPairs(pairs).length > 0,
   ).length;
 
   return (

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/__tests__/metadataValidation.test.ts
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/__tests__/metadataValidation.test.ts
@@ -1,0 +1,117 @@
+import {
+  filterValidMetadataPairs,
+  KEY_PATTERN,
+  MAX_KEYS,
+  MAX_VALUE_LENGTH,
+  validateMetadataPair,
+  validateMetadataPairs,
+} from "../metadataValidation";
+
+describe("KEY_PATTERN", () => {
+  it("matches the documented rule (lowercase / digits / underscore, ≤32)", () => {
+    expect(KEY_PATTERN.test("year")).toBe(true);
+    expect(KEY_PATTERN.test("dept_name")).toBe(true);
+    expect(KEY_PATTERN.test("Year")).toBe(false);
+    expect(KEY_PATTERN.test("year-1")).toBe(false);
+    expect(KEY_PATTERN.test("a".repeat(32))).toBe(true);
+    expect(KEY_PATTERN.test("a".repeat(33))).toBe(false);
+  });
+});
+
+describe("validateMetadataPair", () => {
+  it("treats a fully empty row as ok (not-yet-filled-in)", () => {
+    expect(validateMetadataPair("", "")).toEqual({ ok: true });
+    expect(validateMetadataPair("   ", "   ")).toEqual({ ok: true });
+  });
+
+  it("requires a key when a value is set, and vice versa", () => {
+    expect(validateMetadataPair("", "2024")).toEqual({
+      ok: false,
+      error: "Key is required when a value is set.",
+    });
+    expect(validateMetadataPair("year", "")).toEqual({
+      ok: false,
+      error: "Value is required when a key is set.",
+    });
+  });
+
+  it("rejects keys that fail the pattern", () => {
+    expect(validateMetadataPair("Year", "2024")).toEqual({
+      ok: false,
+      error: "Keys must be 1-32 lowercase letters, digits, or underscores.",
+    });
+  });
+
+  it("rejects values longer than MAX_VALUE_LENGTH", () => {
+    const longValue = "x".repeat(MAX_VALUE_LENGTH + 1);
+    expect(validateMetadataPair("year", longValue)).toEqual({
+      ok: false,
+      error: `Values must be ${MAX_VALUE_LENGTH} characters or fewer.`,
+    });
+  });
+
+  it("accepts a valid pair", () => {
+    expect(validateMetadataPair("year", "2024")).toEqual({ ok: true });
+  });
+});
+
+describe("validateMetadataPairs", () => {
+  it("returns ok with no errors for an empty array", () => {
+    expect(validateMetadataPairs([])).toEqual({ ok: true, errors: {} });
+  });
+
+  it("ignores fully-empty rows", () => {
+    expect(
+      validateMetadataPairs([
+        { key: "", value: "" },
+        { key: "year", value: "2024" },
+      ]),
+    ).toEqual({ ok: true, errors: {} });
+  });
+
+  it("reports per-row errors keyed by index", () => {
+    const result = validateMetadataPairs([
+      { key: "Year", value: "2024" },
+      { key: "ok_key", value: "ok" },
+    ]);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toMatch(/lowercase letters/);
+    expect(result.errors[1]).toBeUndefined();
+  });
+
+  it("flags duplicate keys on the second occurrence", () => {
+    const result = validateMetadataPairs([
+      { key: "year", value: "2024" },
+      { key: "year", value: "2025" },
+    ]);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toBeUndefined();
+    expect(result.errors[1]).toBe("Duplicate key.");
+  });
+
+  it("sets setError when the total count exceeds MAX_KEYS", () => {
+    const pairs = Array.from({ length: MAX_KEYS + 1 }, (_, i) => ({
+      key: `k${i}`,
+      value: `v${i}`,
+    }));
+    const result = validateMetadataPairs(pairs);
+    expect(result.ok).toBe(false);
+    expect(result.setError).toMatch(/Up to/);
+  });
+});
+
+describe("filterValidMetadataPairs", () => {
+  it("strips invalid, empty, and duplicate-keyed rows, trimming whitespace", () => {
+    const out = filterValidMetadataPairs([
+      { key: "  year  ", value: "  2024  " },
+      { key: "Year", value: "bad" }, // invalid key
+      { key: "year", value: "2025" }, // duplicate
+      { key: "", value: "" }, // empty
+      { key: "dept", value: "eng" },
+    ]);
+    expect(out).toEqual([
+      { key: "year", value: "2024" },
+      { key: "dept", value: "eng" },
+    ]);
+  });
+});

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/metadataValidation.ts
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/metadataValidation.ts
@@ -1,0 +1,109 @@
+import type { MetadataPair } from "./MetadataEditor";
+
+export const KEY_PATTERN = /^[a-z0-9_]{1,32}$/;
+export const MAX_KEYS = 16;
+export const MAX_VALUE_LENGTH = 256;
+
+export type PairValidation = { ok: true } | { ok: false; error: string };
+
+/**
+ * Validate a single metadata row in isolation. Pure — does not look at
+ * other rows or any external state. Duplicate-key checks live in
+ * ``validateMetadataPairs`` where the full set is available.
+ */
+export const validateMetadataPair = (
+  key: string,
+  value: string,
+): PairValidation => {
+  const trimmedKey = key.trim();
+  const trimmedValue = value.trim();
+  // Empty rows are treated as not-yet-filled-in, not invalid. The set
+  // validator strips them; the form gate ignores them.
+  if (!trimmedKey && !trimmedValue) return { ok: true };
+  if (!trimmedKey) {
+    return { ok: false, error: "Key is required when a value is set." };
+  }
+  if (!trimmedValue) {
+    return { ok: false, error: "Value is required when a key is set." };
+  }
+  if (!KEY_PATTERN.test(trimmedKey)) {
+    return {
+      ok: false,
+      error: "Keys must be 1-32 lowercase letters, digits, or underscores.",
+    };
+  }
+  if (trimmedValue.length > MAX_VALUE_LENGTH) {
+    return {
+      ok: false,
+      error: `Values must be ${MAX_VALUE_LENGTH} characters or fewer.`,
+    };
+  }
+  return { ok: true };
+};
+
+export interface PairsValidation {
+  ok: boolean;
+  /** Per-row errors keyed by index. Empty when ``ok`` is true. */
+  errors: Record<number, string>;
+  /** Set-level error (count limit). Set independently of per-row errors. */
+  setError?: string;
+}
+
+/**
+ * Validate the entire metadata set. Combines per-row checks with
+ * cross-row rules (duplicate keys, max count).
+ */
+export const validateMetadataPairs = (
+  pairs: MetadataPair[],
+): PairsValidation => {
+  const errors: Record<number, string> = {};
+  const seenKeys = new Map<string, number>();
+
+  pairs.forEach((pair, index) => {
+    const rowResult = validateMetadataPair(pair.key, pair.value);
+    if (!rowResult.ok) {
+      errors[index] = rowResult.error;
+      return;
+    }
+    const trimmedKey = pair.key.trim();
+    if (!trimmedKey) return; // fully-empty row
+    if (seenKeys.has(trimmedKey)) {
+      errors[index] = "Duplicate key.";
+      return;
+    }
+    seenKeys.set(trimmedKey, index);
+  });
+
+  const setError =
+    pairs.length > MAX_KEYS
+      ? `Up to ${MAX_KEYS} metadata fields per ingestion.`
+      : undefined;
+
+  return {
+    ok: Object.keys(errors).length === 0 && !setError,
+    errors,
+    setError,
+  };
+};
+
+/**
+ * Convenience: returns only the pairs that pass every rule, trimmed.
+ * Use when the caller wants the "clean" set (e.g. for display in a
+ * summary) without re-implementing the rule set.
+ */
+export const filterValidMetadataPairs = (
+  pairs: MetadataPair[],
+): MetadataPair[] => {
+  const seen = new Set<string>();
+  const result: MetadataPair[] = [];
+  for (const pair of pairs) {
+    const rowResult = validateMetadataPair(pair.key, pair.value);
+    if (!rowResult.ok) continue;
+    const key = pair.key.trim();
+    const value = pair.value.trim();
+    if (!key || !value || seen.has(key)) continue;
+    seen.add(key);
+    result.push({ key, value });
+  }
+  return result;
+};

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/hooks/useKnowledgeBaseForm.ts
@@ -22,6 +22,7 @@ import {
   type MetadataPair,
   metadataPairsToFormValue,
 } from "../components/MetadataEditor";
+import { validateMetadataPairs } from "../components/metadataValidation";
 import {
   DEFAULT_CHUNK_OVERLAP,
   DEFAULT_CHUNK_SIZE,
@@ -421,6 +422,18 @@ export function useKnowledgeBaseForm({
     if (totalBytes > MAX_TOTAL_FILE_SIZE) {
       errors.files = t("knowledge.validationFileSizeLimit");
     }
+    const runMetadataValidation = validateMetadataPairs(metadataPairs);
+    if (!runMetadataValidation.ok) {
+      errors.metadata =
+        "Fix metadata fields before continuing. Keys must be 1-32 lowercase letters, digits, or underscores and must be unique.";
+    }
+    for (const [fileName, pairs] of Object.entries(perFileMetadata)) {
+      const perFileValidation = validateMetadataPairs(pairs);
+      if (!perFileValidation.ok) {
+        errors.metadata = `Fix metadata fields for "${fileName}" before continuing.`;
+        break;
+      }
+    }
     return errors;
   }, [
     t,
@@ -432,6 +445,8 @@ export function useKnowledgeBaseForm({
     globalVariables,
     files,
     existingKnowledgeBaseNames,
+    metadataPairs,
+    perFileMetadata,
   ]);
 
   const clearValidationErrors = useCallback(() => {

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/ChunksMetadataFilter.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/ChunksMetadataFilter.tsx
@@ -1,173 +1,26 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Button } from "@/components/ui/button";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { useGetKbMetadataKeys } from "@/controllers/API/queries/knowledge-bases/use-get-kb-metadata-keys";
-import { cn } from "@/utils/utils";
-
-const KEY_PATTERN = /^[a-z0-9_]{1,32}$/;
+import { useChunksMetadataFilter } from "./hooks/useChunksMetadataFilter";
+import { MetadataCombobox } from "./MetadataCombobox";
+import { validateMetadataFilter } from "./metadataFilterValidation";
 
 interface ChunksMetadataFilterProps {
   kbName: string;
   onAdd: (key: string, value: string) => void;
 }
 
-interface MetadataComboboxProps {
-  value: string;
-  onChange: (value: string) => void;
-  options: string[];
-  placeholder: string;
-  emptyMessage: string;
-  testId: string;
-  disabled?: boolean;
-  onEnter?: () => void;
-}
-
-const MetadataCombobox = ({
-  value,
-  onChange,
-  options,
-  placeholder,
-  emptyMessage,
-  testId,
-  disabled,
-  onEnter,
-}: MetadataComboboxProps) => {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-
-  const trimmedQuery = query.trim();
-  const normalizedOptions = useMemo(
-    () => options.map((option) => option.toLowerCase()),
-    [options],
-  );
-  const showCustom =
-    trimmedQuery.length > 0 &&
-    !normalizedOptions.includes(trimmedQuery.toLowerCase());
-
-  const commit = (next: string) => {
-    onChange(next);
-    setQuery("");
-    setOpen(false);
-  };
-
-  return (
-    <Popover
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (!next) setQuery("");
-      }}
-    >
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          disabled={disabled}
-          className="w-full justify-between font-normal"
-          data-testid={testId}
-        >
-          <span
-            className={cn(
-              "truncate text-left",
-              value ? "text-foreground" : "text-muted-foreground",
-            )}
-          >
-            {value || placeholder}
-          </span>
-          <ForwardedIconComponent
-            name="ChevronDown"
-            className="ml-2 h-4 w-4 shrink-0 opacity-50"
-          />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className="w-[--radix-popover-trigger-width] p-0"
-      >
-        <Command shouldFilter>
-          <CommandInput
-            value={query}
-            onValueChange={setQuery}
-            placeholder={placeholder}
-            data-testid={`${testId}-input`}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !showCustom && options.length === 0) {
-                e.preventDefault();
-                if (trimmedQuery) commit(trimmedQuery);
-                else onEnter?.();
-              }
-            }}
-          />
-          <CommandList>
-            <CommandEmpty>{emptyMessage}</CommandEmpty>
-            {options.length > 0 && (
-              <CommandGroup>
-                {options.map((option) => (
-                  <CommandItem
-                    key={option}
-                    value={option}
-                    onSelect={() => commit(option)}
-                    data-testid={`${testId}-option-${option}`}
-                  >
-                    <ForwardedIconComponent
-                      name="Check"
-                      className={cn(
-                        "mr-2 h-4 w-4",
-                        value === option ? "opacity-100" : "opacity-0",
-                      )}
-                    />
-                    {option}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            )}
-            {showCustom && (
-              <CommandGroup>
-                <CommandItem
-                  value={`__custom__${trimmedQuery}`}
-                  onSelect={() => commit(trimmedQuery)}
-                  data-testid={`${testId}-custom`}
-                >
-                  <ForwardedIconComponent
-                    name="Plus"
-                    className="mr-2 h-4 w-4"
-                  />
-                  Use “{trimmedQuery}”
-                </CommandItem>
-              </CommandGroup>
-            )}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
-};
-
 /**
  * "+ Filter by metadata" popover for the chunks-browser metadata chips.
  *
- * Key and value pickers are shadcn comboboxes (Popover + Command). They
- * match the visual style of the surrounding shadcn `Select` controls (e.g.
- * "All sources") while still letting users type a custom key/value that is
- * not yet in the suggestion list.
- *
- * Validation mirrors the backend rules so an obviously malformed key (e.g.
- * uppercase or punctuation) is rejected before it would 422 server-side.
+ * Orchestrates the outer popover, form state, and submit. The combobox
+ * UI, data fetching, and validation each live in their own modules
+ * (`MetadataCombobox`, `useChunksMetadataFilter`, `metadataFilterValidation`).
  */
 export const ChunksMetadataFilter = ({
   kbName,
@@ -179,47 +32,36 @@ export const ChunksMetadataFilter = ({
   const [error, setError] = useState<string | null>(null);
 
   const {
-    data: metadataKeys,
+    availableKeys,
+    valueSuggestions,
     isLoading,
-    refetch: refetchMetadataKeys,
-  } = useGetKbMetadataKeys({ kb_name: kbName }, { enabled: open && !!kbName });
-
-  const availableKeys = useMemo(
-    () => Object.keys(metadataKeys?.keys ?? {}).sort(),
-    [metadataKeys],
-  );
-
-  const valueSuggestions = useMemo(() => {
-    const trimmed = key.trim();
-    if (!trimmed) return [] as string[];
-    return metadataKeys?.keys?.[trimmed] ?? [];
-  }, [key, metadataKeys]);
+    hasKeys,
+    truncated,
+    refetch,
+  } = useChunksMetadataFilter({
+    kbName,
+    enabled: open,
+    selectedKey: key,
+  });
 
   const submit = () => {
-    const trimmedKey = key.trim();
-    const trimmedValue = value.trim();
-    if (!trimmedKey || !trimmedValue) {
-      setError("Key and value are required.");
+    const result = validateMetadataFilter(key, value);
+    if (!result.ok) {
+      setError(result.error);
       return;
     }
-    if (!KEY_PATTERN.test(trimmedKey)) {
-      setError("Key must be 1-32 lowercase letters, digits, or underscores.");
-      return;
-    }
-    onAdd(trimmedKey, trimmedValue);
+    onAdd(result.key, result.value);
     setKey("");
     setValue("");
     setError(null);
     setOpen(false);
   };
 
-  const hasKeys = availableKeys.length > 0;
-
+  // Refetch on every popover open so a fresh ingestion's new keys/values
+  // surface without a hard page refresh.
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
-    if (next && kbName) {
-      void refetchMetadataKeys();
-    }
+    if (next && kbName) refetch();
   };
 
   const keyPlaceholder = isLoading
@@ -290,7 +132,7 @@ export const ChunksMetadataFilter = ({
               No metadata keys found in this KB. Type a key to filter anyway.
             </span>
           )}
-          {metadataKeys?.truncated && (
+          {truncated && (
             <span
               className="text-xs text-muted-foreground"
               data-testid="chunks-metadata-filter-truncated"

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/ChunksMetadataFilter.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/ChunksMetadataFilter.tsx
@@ -1,34 +1,173 @@
-import { useId, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import ForwardedIconComponent from "@/components/common/genericIconComponent";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useGetKbMetadataKeys } from "@/controllers/API/queries/knowledge-bases/use-get-kb-metadata-keys";
+import { cn } from "@/utils/utils";
 
 const KEY_PATTERN = /^[a-z0-9_]{1,32}$/;
 
 interface ChunksMetadataFilterProps {
-  /** Knowledge base name — used to fetch the available metadata keys. */
   kbName: string;
-  /** Called when the user submits a key/value pair. */
   onAdd: (key: string, value: string) => void;
 }
+
+interface MetadataComboboxProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+  placeholder: string;
+  emptyMessage: string;
+  testId: string;
+  disabled?: boolean;
+  onEnter?: () => void;
+}
+
+const MetadataCombobox = ({
+  value,
+  onChange,
+  options,
+  placeholder,
+  emptyMessage,
+  testId,
+  disabled,
+  onEnter,
+}: MetadataComboboxProps) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const trimmedQuery = query.trim();
+  const normalizedOptions = useMemo(
+    () => options.map((option) => option.toLowerCase()),
+    [options],
+  );
+  const showCustom =
+    trimmedQuery.length > 0 &&
+    !normalizedOptions.includes(trimmedQuery.toLowerCase());
+
+  const commit = (next: string) => {
+    onChange(next);
+    setQuery("");
+    setOpen(false);
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuery("");
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="w-full justify-between font-normal"
+          data-testid={testId}
+        >
+          <span
+            className={cn(
+              "truncate text-left",
+              value ? "text-foreground" : "text-muted-foreground",
+            )}
+          >
+            {value || placeholder}
+          </span>
+          <ForwardedIconComponent
+            name="ChevronDown"
+            className="ml-2 h-4 w-4 shrink-0 opacity-50"
+          />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[--radix-popover-trigger-width] p-0"
+      >
+        <Command shouldFilter>
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder={placeholder}
+            data-testid={`${testId}-input`}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !showCustom && options.length === 0) {
+                e.preventDefault();
+                if (trimmedQuery) commit(trimmedQuery);
+                else onEnter?.();
+              }
+            }}
+          />
+          <CommandList>
+            <CommandEmpty>{emptyMessage}</CommandEmpty>
+            {options.length > 0 && (
+              <CommandGroup>
+                {options.map((option) => (
+                  <CommandItem
+                    key={option}
+                    value={option}
+                    onSelect={() => commit(option)}
+                    data-testid={`${testId}-option-${option}`}
+                  >
+                    <ForwardedIconComponent
+                      name="Check"
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        value === option ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    {option}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            {showCustom && (
+              <CommandGroup>
+                <CommandItem
+                  value={`__custom__${trimmedQuery}`}
+                  onSelect={() => commit(trimmedQuery)}
+                  data-testid={`${testId}-custom`}
+                >
+                  <ForwardedIconComponent
+                    name="Plus"
+                    className="mr-2 h-4 w-4"
+                  />
+                  Use “{trimmedQuery}”
+                </CommandItem>
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};
 
 /**
  * "+ Filter by metadata" popover for the chunks-browser metadata chips.
  *
- * Both inputs are bound to a `<datalist>` populated from the new
- * `/metadata/keys` endpoint so the user gets self-documenting key + value
- * suggestions on click and free-text typing for keys not in the list.
+ * Key and value pickers are shadcn comboboxes (Popover + Command). They
+ * match the visual style of the surrounding shadcn `Select` controls (e.g.
+ * "All sources") while still letting users type a custom key/value that is
+ * not yet in the suggestion list.
  *
  * Validation mirrors the backend rules so an obviously malformed key (e.g.
  * uppercase or punctuation) is rejected before it would 422 server-side.
- * Submitting closes the popover and clears the inputs so the user can chain
- * multiple chips without re-opening it manually.
  */
 export const ChunksMetadataFilter = ({
   kbName,
@@ -38,8 +177,6 @@ export const ChunksMetadataFilter = ({
   const [key, setKey] = useState("");
   const [value, setValue] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const keyListId = useId();
-  const valueListId = useId();
 
   const {
     data: metadataKeys,
@@ -52,12 +189,9 @@ export const ChunksMetadataFilter = ({
     [metadataKeys],
   );
 
-  // Distinct values for the currently typed key, when that key matches one
-  // of the keys returned from the server. Falls back to no suggestions for
-  // free-typed keys.
   const valueSuggestions = useMemo(() => {
     const trimmed = key.trim();
-    if (!trimmed) return [];
+    if (!trimmed) return [] as string[];
     return metadataKeys?.keys?.[trimmed] ?? [];
   }, [key, metadataKeys]);
 
@@ -81,18 +215,18 @@ export const ChunksMetadataFilter = ({
 
   const hasKeys = availableKeys.length > 0;
 
-  // Refetch on every popover open so a fresh ingestion's new keys/values
-  // surface without a hard page refresh. The `enabled` flag re-arms the
-  // query when the popover opens; calling `refetch` here forces a network
-  // round-trip even when React Query already has cached data, which is the
-  // case after the user closes and re-opens the popover within the same
-  // browser session.
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
     if (next && kbName) {
       void refetchMetadataKeys();
     }
   };
+
+  const keyPlaceholder = isLoading
+    ? "Loading keys..."
+    : hasKeys
+      ? "Pick or type a key"
+      : "Type a key";
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
@@ -109,51 +243,45 @@ export const ChunksMetadataFilter = ({
       </PopoverTrigger>
       <PopoverContent className="w-72" align="end">
         <div className="flex flex-col gap-2">
-          <Input
-            list={keyListId}
-            placeholder={
+          <MetadataCombobox
+            value={key}
+            onChange={(next) => {
+              setKey(next);
+              setError(null);
+              setValue("");
+            }}
+            options={availableKeys}
+            placeholder={keyPlaceholder}
+            emptyMessage={
               isLoading
                 ? "Loading keys..."
                 : hasKeys
-                  ? "Pick or type a key"
-                  : "key"
+                  ? "No matching key. Press Enter or pick to use as typed."
+                  : "Type a key to filter."
             }
-            value={key}
-            onChange={(e) => setKey(e.target.value)}
-            data-testid="chunks-metadata-filter-key"
-            autoFocus
+            testId="chunks-metadata-filter-key"
           />
-          <datalist
-            id={keyListId}
-            data-testid="chunks-metadata-filter-key-options"
-          >
-            {availableKeys.map((option) => (
-              <option key={option} value={option} />
-            ))}
-          </datalist>
-          <Input
-            list={valueListId}
-            placeholder={
-              valueSuggestions.length > 0 ? "Pick or type a value" : "value"
-            }
+          <MetadataCombobox
             value={value}
-            onChange={(e) => setValue(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                submit();
-              }
+            onChange={(next) => {
+              setValue(next);
+              setError(null);
             }}
-            data-testid="chunks-metadata-filter-value"
+            options={valueSuggestions}
+            placeholder={
+              valueSuggestions.length > 0
+                ? "Pick or type a value"
+                : "Type a value"
+            }
+            emptyMessage={
+              valueSuggestions.length > 0
+                ? "No matching value. Press Enter or pick to use as typed."
+                : "Type a value."
+            }
+            testId="chunks-metadata-filter-value"
+            disabled={!key.trim()}
+            onEnter={submit}
           />
-          <datalist
-            id={valueListId}
-            data-testid="chunks-metadata-filter-value-options"
-          >
-            {valueSuggestions.map((option) => (
-              <option key={option} value={option} />
-            ))}
-          </datalist>
           {!isLoading && !hasKeys && (
             <span
               className="text-xs text-muted-foreground"

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/MetadataCombobox.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/MetadataCombobox.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState } from "react";
+import ForwardedIconComponent from "@/components/common/genericIconComponent";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/utils/utils";
+
+export interface MetadataComboboxProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+  placeholder: string;
+  emptyMessage: string;
+  testId: string;
+  disabled?: boolean;
+  onEnter?: () => void;
+}
+
+/**
+ * Searchable combobox built on Popover + Command (cmdk). Matches the
+ * shadcn `Select` visual so it sits naturally beside other dropdowns,
+ * but also accepts a free-typed value via a "Use \"foo\"" fallback item.
+ *
+ * Presentational: holds only its own open/query state. All filter-level
+ * state (selected key/value, validation, submit) lives in the parent.
+ */
+export const MetadataCombobox = ({
+  value,
+  onChange,
+  options,
+  placeholder,
+  emptyMessage,
+  testId,
+  disabled,
+  onEnter,
+}: MetadataComboboxProps) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const trimmedQuery = query.trim();
+  const normalizedOptions = useMemo(
+    () => options.map((option) => option.toLowerCase()),
+    [options],
+  );
+  const showCustom =
+    trimmedQuery.length > 0 &&
+    !normalizedOptions.includes(trimmedQuery.toLowerCase());
+
+  const commit = (next: string) => {
+    onChange(next);
+    setQuery("");
+    setOpen(false);
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuery("");
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="w-full justify-between font-normal"
+          data-testid={testId}
+        >
+          <span
+            className={cn(
+              "truncate text-left",
+              value ? "text-foreground" : "text-muted-foreground",
+            )}
+          >
+            {value || placeholder}
+          </span>
+          <ForwardedIconComponent
+            name="ChevronDown"
+            className="ml-2 h-4 w-4 shrink-0 opacity-50"
+          />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[--radix-popover-trigger-width] p-0"
+      >
+        <Command shouldFilter>
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder={placeholder}
+            data-testid={`${testId}-input`}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !showCustom && options.length === 0) {
+                e.preventDefault();
+                if (trimmedQuery) commit(trimmedQuery);
+                else onEnter?.();
+              }
+            }}
+          />
+          <CommandList>
+            <CommandEmpty>{emptyMessage}</CommandEmpty>
+            {options.length > 0 && (
+              <CommandGroup>
+                {options.map((option) => (
+                  <CommandItem
+                    key={option}
+                    value={option}
+                    onSelect={() => commit(option)}
+                    data-testid={`${testId}-option-${option}`}
+                  >
+                    <ForwardedIconComponent
+                      name="Check"
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        value === option ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    {option}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            {showCustom && (
+              <CommandGroup>
+                <CommandItem
+                  value={`__custom__${trimmedQuery}`}
+                  onSelect={() => commit(trimmedQuery)}
+                  data-testid={`${testId}-custom`}
+                >
+                  <ForwardedIconComponent
+                    name="Plus"
+                    className="mr-2 h-4 w-4"
+                  />
+                  Use “{trimmedQuery}”
+                </CommandItem>
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default MetadataCombobox;

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/__tests__/ChunksMetadataFilter.test.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/__tests__/ChunksMetadataFilter.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -29,11 +29,22 @@ const setHookData = (data: any, isLoading = false) => {
   });
 };
 
+beforeAll(() => {
+  // cmdk calls scrollIntoView on selection; jsdom does not implement it.
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
 beforeEach(() => {
   mockUseGetKbMetadataKeys.mockReset();
   mockRefetch.mockReset();
   setHookData({ keys: {}, truncated: false });
 });
+
+const openFilterPopover = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+  return user;
+};
 
 describe("ChunksMetadataFilter", () => {
   it("renders the popover trigger labelled 'Filter by metadata'", () => {
@@ -43,62 +54,49 @@ describe("ChunksMetadataFilter", () => {
     );
   });
 
-  it("populates the key datalist with available keys when popover opens", async () => {
+  it("renders key combobox options when the key combobox opens", async () => {
     setHookData({
       keys: { year: ["2020", "2021"], dept: ["eng", "qa"] },
       truncated: false,
     });
-    const user = userEvent.setup();
     render(<ChunksMetadataFilter kbName="kb1" onAdd={jest.fn()} />);
+    const user = await openFilterPopover();
+    await user.click(screen.getByTestId("chunks-metadata-filter-key"));
 
-    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
-
-    await waitFor(() =>
-      expect(
-        screen.getByTestId("chunks-metadata-filter-key-options"),
-      ).toBeInTheDocument(),
-    );
-    const options = screen
-      .getByTestId("chunks-metadata-filter-key-options")
-      .querySelectorAll("option");
     expect(
-      Array.from(options)
-        .map((o) => o.value)
-        .sort(),
-    ).toEqual(["dept", "year"]);
+      await screen.findByTestId("chunks-metadata-filter-key-option-year"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("chunks-metadata-filter-key-option-dept"),
+    ).toBeInTheDocument();
   });
 
-  it("populates the value datalist with distinct values for the typed key", async () => {
+  it("renders value combobox options for the selected key", async () => {
     setHookData({
       keys: { year: ["2020", "2021"], dept: ["eng"] },
       truncated: false,
     });
-    const user = userEvent.setup();
     render(<ChunksMetadataFilter kbName="kb1" onAdd={jest.fn()} />);
+    const user = await openFilterPopover();
 
-    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
-    await user.type(screen.getByTestId("chunks-metadata-filter-key"), "year");
-
-    await waitFor(() =>
-      expect(
-        screen
-          .getByTestId("chunks-metadata-filter-value-options")
-          .querySelectorAll("option").length,
-      ).toBe(2),
+    await user.click(screen.getByTestId("chunks-metadata-filter-key"));
+    await user.click(
+      await screen.findByTestId("chunks-metadata-filter-key-option-year"),
     );
-    const values = Array.from(
-      screen
-        .getByTestId("chunks-metadata-filter-value-options")
-        .querySelectorAll("option"),
-    ).map((o) => o.value);
-    expect(values).toEqual(["2020", "2021"]);
+    await user.click(screen.getByTestId("chunks-metadata-filter-value"));
+
+    expect(
+      await screen.findByTestId("chunks-metadata-filter-value-option-2020"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("chunks-metadata-filter-value-option-2021"),
+    ).toBeInTheDocument();
   });
 
   it("renders the empty-state hint when no keys are available", async () => {
     setHookData({ keys: {}, truncated: false });
-    const user = userEvent.setup();
     render(<ChunksMetadataFilter kbName="kb1" onAdd={jest.fn()} />);
-    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+    await openFilterPopover();
     expect(
       await screen.findByTestId("chunks-metadata-filter-empty"),
     ).toBeInTheDocument();
@@ -106,21 +104,37 @@ describe("ChunksMetadataFilter", () => {
 
   it("renders the truncated hint when the server caps any value list", async () => {
     setHookData({ keys: { tag: ["a"] }, truncated: true });
-    const user = userEvent.setup();
     render(<ChunksMetadataFilter kbName="kb1" onAdd={jest.fn()} />);
-    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+    await openFilterPopover();
     expect(
       await screen.findByTestId("chunks-metadata-filter-truncated"),
     ).toBeInTheDocument();
   });
 
-  it("rejects an uppercase key with the validation message", async () => {
+  it("rejects an uppercase key (typed as custom) with the validation message", async () => {
+    setHookData({ keys: {}, truncated: false });
     const onAdd = jest.fn();
-    const user = userEvent.setup();
     render(<ChunksMetadataFilter kbName="kb1" onAdd={onAdd} />);
-    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
-    await user.type(screen.getByTestId("chunks-metadata-filter-key"), "Year");
-    await user.type(screen.getByTestId("chunks-metadata-filter-value"), "2020");
+    const user = await openFilterPopover();
+
+    await user.click(screen.getByTestId("chunks-metadata-filter-key"));
+    await user.type(
+      screen.getByTestId("chunks-metadata-filter-key-input"),
+      "Year",
+    );
+    await user.click(
+      await screen.findByTestId("chunks-metadata-filter-key-custom"),
+    );
+
+    await user.click(screen.getByTestId("chunks-metadata-filter-value"));
+    await user.type(
+      screen.getByTestId("chunks-metadata-filter-value-input"),
+      "2020",
+    );
+    await user.click(
+      await screen.findByTestId("chunks-metadata-filter-value-custom"),
+    );
+
     await user.click(screen.getByTestId("chunks-metadata-filter-submit"));
     expect(onAdd).not.toHaveBeenCalled();
     expect(
@@ -130,24 +144,34 @@ describe("ChunksMetadataFilter", () => {
 
   it("refetches metadata keys every time the popover is opened", async () => {
     setHookData({ keys: { year: ["2020"] }, truncated: false });
-    const user = userEvent.setup();
     render(<ChunksMetadataFilter kbName="kb1" onAdd={jest.fn()} />);
-
-    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
+    const user = await openFilterPopover();
     expect(mockRefetch).toHaveBeenCalledTimes(1);
-    // Close the popover by triggering the trigger again.
+
     await user.keyboard("{Escape}");
     await user.click(screen.getByTestId("chunks-metadata-add-filter"));
     expect(mockRefetch).toHaveBeenCalledTimes(2);
   });
 
-  it("calls onAdd with trimmed key/value on valid submit and clears inputs", async () => {
+  it("calls onAdd with selected key/value on valid submit", async () => {
+    setHookData({
+      keys: { year: ["2020", "2021"] },
+      truncated: false,
+    });
     const onAdd = jest.fn();
-    const user = userEvent.setup();
     render(<ChunksMetadataFilter kbName="kb1" onAdd={onAdd} />);
-    await user.click(screen.getByTestId("chunks-metadata-add-filter"));
-    await user.type(screen.getByTestId("chunks-metadata-filter-key"), "year");
-    await user.type(screen.getByTestId("chunks-metadata-filter-value"), "2020");
+    const user = await openFilterPopover();
+
+    await user.click(screen.getByTestId("chunks-metadata-filter-key"));
+    await user.click(
+      await screen.findByTestId("chunks-metadata-filter-key-option-year"),
+    );
+
+    await user.click(screen.getByTestId("chunks-metadata-filter-value"));
+    await user.click(
+      await screen.findByTestId("chunks-metadata-filter-value-option-2020"),
+    );
+
     await user.click(screen.getByTestId("chunks-metadata-filter-submit"));
     expect(onAdd).toHaveBeenCalledWith("year", "2020");
   });

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/__tests__/metadataFilterValidation.test.ts
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/__tests__/metadataFilterValidation.test.ts
@@ -1,0 +1,48 @@
+import {
+  KEY_PATTERN,
+  validateMetadataFilter,
+} from "../metadataFilterValidation";
+
+describe("KEY_PATTERN", () => {
+  it("accepts lowercase letters, digits, and underscores up to 32 chars", () => {
+    expect(KEY_PATTERN.test("year")).toBe(true);
+    expect(KEY_PATTERN.test("year_2024")).toBe(true);
+    expect(KEY_PATTERN.test("a".repeat(32))).toBe(true);
+  });
+
+  it("rejects uppercase, punctuation, spaces, and over-length keys", () => {
+    expect(KEY_PATTERN.test("Year")).toBe(false);
+    expect(KEY_PATTERN.test("year-2024")).toBe(false);
+    expect(KEY_PATTERN.test("year 2024")).toBe(false);
+    expect(KEY_PATTERN.test("a".repeat(33))).toBe(false);
+    expect(KEY_PATTERN.test("")).toBe(false);
+  });
+});
+
+describe("validateMetadataFilter", () => {
+  it("returns ok with trimmed key and value on a valid input pair", () => {
+    expect(validateMetadataFilter("  year  ", "  2024  ")).toEqual({
+      ok: true,
+      key: "year",
+      value: "2024",
+    });
+  });
+
+  it("rejects an empty key or value with the required-fields message", () => {
+    expect(validateMetadataFilter("", "2024")).toEqual({
+      ok: false,
+      error: "Key and value are required.",
+    });
+    expect(validateMetadataFilter("year", "   ")).toEqual({
+      ok: false,
+      error: "Key and value are required.",
+    });
+  });
+
+  it("rejects a malformed key with the pattern message", () => {
+    expect(validateMetadataFilter("Year", "2024")).toEqual({
+      ok: false,
+      error: "Key must be 1-32 lowercase letters, digits, or underscores.",
+    });
+  });
+});

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/hooks/useChunksMetadataFilter.ts
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/hooks/useChunksMetadataFilter.ts
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import { useGetKbMetadataKeys } from "@/controllers/API/queries/knowledge-bases/use-get-kb-metadata-keys";
+
+interface UseChunksMetadataFilterOptions {
+  kbName: string;
+  /** Outer popover open state — gates the network query. */
+  enabled: boolean;
+  /** Currently typed/selected key. Drives the value suggestion list. */
+  selectedKey: string;
+}
+
+interface UseChunksMetadataFilterResult {
+  availableKeys: string[];
+  valueSuggestions: string[];
+  isLoading: boolean;
+  hasKeys: boolean;
+  truncated: boolean;
+  refetch: () => void;
+}
+
+/**
+ * Data hook for the chunks-browser metadata filter.
+ *
+ * Wraps `useGetKbMetadataKeys` and derives the two lists the UI actually
+ * consumes (sorted available keys, value suggestions for the typed key)
+ * so the filter component itself stays free of memoization plumbing.
+ */
+export const useChunksMetadataFilter = ({
+  kbName,
+  enabled,
+  selectedKey,
+}: UseChunksMetadataFilterOptions): UseChunksMetadataFilterResult => {
+  const {
+    data: metadataKeys,
+    isLoading,
+    refetch,
+  } = useGetKbMetadataKeys(
+    { kb_name: kbName },
+    { enabled: enabled && !!kbName },
+  );
+
+  const availableKeys = useMemo(
+    () => Object.keys(metadataKeys?.keys ?? {}).sort(),
+    [metadataKeys],
+  );
+
+  const valueSuggestions = useMemo(() => {
+    const trimmed = selectedKey.trim();
+    if (!trimmed) return [] as string[];
+    return metadataKeys?.keys?.[trimmed] ?? [];
+  }, [selectedKey, metadataKeys]);
+
+  return {
+    availableKeys,
+    valueSuggestions,
+    isLoading,
+    hasKeys: availableKeys.length > 0,
+    truncated: !!metadataKeys?.truncated,
+    refetch: () => {
+      void refetch();
+    },
+  };
+};

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/metadataFilterValidation.ts
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/sourceChunksPage/components/metadataFilterValidation.ts
@@ -1,0 +1,28 @@
+export const KEY_PATTERN = /^[a-z0-9_]{1,32}$/;
+
+export type ValidationResult =
+  | { ok: true; key: string; value: string }
+  | { ok: false; error: string };
+
+/**
+ * Pure validation for the metadata filter inputs. Mirrors backend rules
+ * so an obviously malformed key (e.g. uppercase, punctuation, empty) is
+ * rejected before the request is sent.
+ */
+export const validateMetadataFilter = (
+  key: string,
+  value: string,
+): ValidationResult => {
+  const trimmedKey = key.trim();
+  const trimmedValue = value.trim();
+  if (!trimmedKey || !trimmedValue) {
+    return { ok: false, error: "Key and value are required." };
+  }
+  if (!KEY_PATTERN.test(trimmedKey)) {
+    return {
+      ok: false,
+      error: "Key must be 1-32 lowercase letters, digits, or underscores.",
+    };
+  }
+  return { ok: true, key: trimmedKey, value: trimmedValue };
+};


### PR DESCRIPTION
## Summary

Knowledge-base UX polish bundle for **1.10.0**: brings the chunks browser's *Filter by metadata* popover in line with the rest of the app, slims the component along single-responsibility lines, and closes a bug where the Ingest Files modal silently dropped invalid Custom Fields after letting the user click **Next Step**.

Three logical changes

1. **Combobox parity** for the *Filter by metadata* key/value pickers.
2. **Refactor** of `ChunksMetadataFilter` into focused modules (SOLID-aligned).
3. **Bug fix**: gate **Next Step** on metadata-pair validity so the modal stops lying about what will be ingested.

---

## 1. Combobox parity for *Filter by metadata*

The popover used plain `<Input>` fields backed by a native HTML `<datalist>` for key/value suggestions. The browser-native dropdown looked nothing like the shadcn `Select` used right next to it (e.g. **All sources**) — QA flagged the inconsistency.

**Both pickers now use a shadcn-style combobox** so the popover matches every other dropdown in the app:

- Each picker (key + value) is `Popover` + `Command` (cmdk):
  - Outline button trigger with chevron, visually identical to `SelectTrigger`.
  - Suggestion list rendered as `CommandItem` rows with a check on the current selection.
  - When the typed query is not in the suggestions, a **Use "foo"** item appears so users can still commit a custom key/value (preserves the free-text path the old datalist offered).
  - Closing a picker clears the search query; selecting an item commits and closes.
- Wrapper popover state (open/close), `KEY_PATTERN` validation, refetch-on-open, error message, "Showing first 50 values per key" hint, and submit flow are unchanged.

## 2. `ChunksMetadataFilter` refactor 

The original file held data fetching, derived option lists, validation rules, popover orchestration, and the combobox UI all in one place. Split along single-responsibility lines so each piece changes for its own reason:

- **`MetadataCombobox.tsx`** — presentational `Popover` + `Command` combobox with custom-entry fallback. Generic over `options` / `testId`; reusable.
- **`hooks/useChunksMetadataFilter.ts`** — wraps `useGetKbMetadataKeys`, derives `availableKeys` / `valueSuggestions` / flags / `refetch`. Encapsulates data plumbing.
- **`metadataFilterValidation.ts`** — pure `KEY_PATTERN` + `validateMetadataFilter` returning `{ ok, key, value } | { ok: false, error }`. Testable in isolation, no DOM.
- **`ChunksMetadataFilter.tsx`** — orchestration only: outer popover, form state (key/value/error), submit. Composes the three above.

## 3. Bug fix: gate **Next Step** on metadata-pair validity

**Symptom** — In the Ingest Files modal → Custom Fields, typing an invalid key like `Year` showed the red "Keys must be 1-32 lowercase letters, digits, or underscores" message, but clicking **Next Step** still advanced to **Review & Build**. The summary even rendered `Metadata: Year: 2020`, suggesting the row would be persisted.

**Root cause** — three permissive layers:

1. `MetadataEditor` validated key-on-blur and stored the error in component-local state; the parent never heard about it.
2. `useKnowledgeBaseForm.getValidationErrors` validated name / embedding / backend / file size but **did not** check `metadataPairs`. So `handleNext` proceeded.
3. `StepReview` rendered raw pairs, while `metadataPairsToFormValue` *silently* filtered the invalid row out at submit — backend never received it. The UI lied to the user.

**Fix** — single source of truth in `metadataValidation.ts`:

- `validateMetadataPair` — per-row (empty, regex, value length).
- `validateMetadataPairs` — cross-row (duplicates, max count).
- `filterValidMetadataPairs` — clean trimmed set for display/submit.

Wired through every surface that used to disagree:

- `MetadataEditor` derives errors from the prop list via the shared validator, dropping the blur-only local state. Errors always reflect the current input.
- `useKnowledgeBaseForm.getValidationErrors` now checks run-level **and** per-file metadata. `handleNext` blocks while any row is invalid and surfaces a single `validationErrors.metadata` key.
- `StepConfiguration` renders that error next to the Custom Fields block.
- `StepReview` filters the summary through `filterValidMetadataPairs` so it only shows pairs the backend will actually persist.

---

## Tests

- **New** `metadataFilterValidation.test.ts` — covers chunks-browser key/value validator (regex, empty, uppercase, happy path).
- **New** `metadataValidation.test.ts` — covers Ingest Files validator (per-row rules, duplicates, max-count cap, `filterValidMetadataPairs`).
- **Rewritten** `ChunksMetadataFilter.test.tsx` — new combobox testids (`chunks-metadata-filter-{key,value,input,option-*,custom}`), plus a jsdom shim for `Element.prototype.scrollIntoView` because cmdk calls it on selection.
- Full `knowledgePage` jest suite: 130/130 ✅
- Full `knowledgeBaseUploadModal` jest suite: 91/91 ✅
- `make format_frontend` clean.

## Test plan

**Filter by metadata combobox**

- [x] Open a KB → chunks browser → click **+ Filter by metadata**.
- [x] Key picker opens with same styling as **All sources** dropdown (outline trigger + chevron, item list with hover/selected check).
- [x] Picking a suggested key populates the value picker with the matching values.
- [x] Typing a key not in the suggestions shows **Use "xyz"** — selecting it commits the typed value.
- [x] Uppercase key still triggers the existing validation error.
- [x] Add Filter chains: popover closes, chip appears, popover reopens with cleared inputs.
- [x] Refetch fires every time the outer popover reopens (cached + fresh ingestions both visible).
- [x] `truncated: true` from the server still shows the "Showing first 50 values per key" hint.

**Ingest Files → Custom Fields validation gating**

- [x] Type an invalid key (uppercase, punctuation, blank value) → **Next Step** is blocked and the error renders next to the editor.
- [x] Duplicate keys: both rows marked, **Next Step** still blocked until resolved.
- [x] Add >16 rows: set-level error shows; Next blocked.
- [x] With only valid rows, **Next** proceeds; **Review & Build** summary shows only the valid set (no phantom invalid pair).
- [x] Per-file metadata override with an invalid key also blocks **Next**.

## Screenshots

**Before**
<img width="1888" height="646" alt="image" src="https://github.com/user-attachments/assets/38d54bee-25c2-4d73-b066-375af39fc2ea" />

<img width="1864" height="566" alt="image" src="https://github.com/user-attachments/assets/cd188b47-c9ad-4077-9d4b-398fa1fb2fea" />

**After**
<img width="1632" height="570" alt="image" src="https://github.com/user-attachments/assets/720c386f-20a5-48b5-8bef-90fb59e3ba9e" />

<img width="1895" height="626" alt="image" src="https://github.com/user-attachments/assets/cbca470e-e171-40de-ae9a-735c088b96cb" />
