### PR TITLE
fix(tracing): sync LangSmith environment variables with official docu…

### DIFF
--- a/src/backend/base/langflow/services/tracing/langsmith.py
+++ b/src/backend/base/langflow/services/tracing/langsmith.py
@@ -76,7 +76,7 @@ class LangSmithTracer(BaseTracer):
         return run_type
 
     def setup_langsmith(self) -> bool:
-        if os.getenv("LANGCHAIN_API_KEY") is None:
+        if os.getenv("LANGSMITH_API_KEY", os.getenv("LANGCHAIN_API_KEY")) is None:
             return False
         try:
             from langsmith import Client
@@ -85,6 +85,7 @@ class LangSmithTracer(BaseTracer):
         except ImportError:
             logger.exception("Could not import langsmith. Please install it with `pip install langsmith`.")
             return False
+        os.environ["LANGSMITH_TRACING"] = "true"
         os.environ["LANGCHAIN_TRACING_V2"] = "true"
         return True
 

--- a/src/backend/base/langflow/services/tracing/service.py
+++ b/src/backend/base/langflow/services/tracing/service.py
@@ -279,7 +279,7 @@ class TracingService(Service):
         if self.deactivated:
             return
         try:
-            project_name = project_name or os.getenv("LANGCHAIN_PROJECT", "Langflow")
+            project_name = project_name or os.getenv("LANGSMITH_PROJECT", os.getenv("LANGCHAIN_PROJECT", "Langflow"))
             trace_context = TraceContext(run_id, run_name, project_name, user_id, session_id, flow_id)
             trace_context_var.set(trace_context)
             await self._start(trace_context)
@@ -452,7 +452,7 @@ class TracingService(Service):
     @property
     def project_name(self):
         if self.deactivated:
-            return os.getenv("LANGCHAIN_PROJECT", "Langflow")
+            return os.getenv("LANGSMITH_PROJECT", os.getenv("LANGCHAIN_PROJECT", "Langflow"))
         trace_context = trace_context_var.get()
         if trace_context is None:
             msg = "called project_name but no trace context found"


### PR DESCRIPTION
## Description
This PR resolves an issue where Langflow's tracing service was strictly looking for legacy `LANGCHAIN_` environment variables. This caused a fragmented tracing experience for users following the current official documentation, which uses `LANGSMITH_` variables.

* The Bug:
If a user only sets `LANGSMITH_API_KEY` (as per the docs), Langflow's custom `LangSmithTracer` fails to initialize and gets disabled. However, the underlying LangChain LLM components natively recognize `LANGSMITH_API_KEY` and trigger their own default tracing. This results in only the isolated LLM calls being traced, completely losing the Langflow graph context and the overall flow structure.

* Changes:
- Updated `setup_langsmith` in `langsmith.py` to check for `LANGSMITH_API_KEY` first, falling back to `LANGCHAIN_API_KEY`.
- Added `os.environ["LANGSMITH_TRACING"] = "true"` to ensure compatibility with the latest LangSmith SDK behavior.
- Updated `TracingService.start_tracers` and `project_name` property in `service.py` to prioritize `LANGSMITH_PROJECT`, then `LANGCHAIN_PROJECT`, before falling back to the default `"Langflow"` string.

### Visual Context

* Tested Flow:
<img width="1219" height="491" alt="flow" src="https://github.com/user-attachments/assets/8912da94-130d-4699-96fd-439ef92e8a4a" />


* Before (Bug): Langflow tracer is deactivated. Only the LLM component trace is logged independently, losing the nested flow structure.

<img width="388" height="131" alt="before-update" src="https://github.com/user-attachments/assets/fca5495d-f65a-47c5-b706-12e192379ea3" />

*After (Fix): Langflow tracer is properly activated. The entire graph is traced correctly with the designated `LANGSMITH_PROJECT` name.

<img width="381" height="258" alt="after-update" src="https://github.com/user-attachments/assets/564b98eb-b535-402d-9a57-fe0b12a48fb3" />



## How Has This Been Tested?
I have performed end-to-end tests to ensure full compatibility with both legacy and new configurations.

- Test 1: Configured `LANGSMITH_API_KEY` and `LANGSMITH_PROJECT` in `.env`. Verified that the Langflow tracer activates correctly, captures the entire graph (not just the LLM), and routes to the specified project.
- Test 2: Configured using only legacy `LANGCHAIN_` variables. Verified that the fallback mechanism works perfectly without breaking existing user setups.

## Related Issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced LangSmith integration with primary support for LANGSMITH_API_KEY and LANGSMITH_PROJECT environment variables.
  * LangSmith tracing is now explicitly enabled during initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/langflow/pull/13119)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->