### PR TITLE
feat(mcp): pass session_id through MCP tool calls

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_utils.py
+++ b/src/backend/base/langflow/api/v1/mcp_utils.py
@@ -296,10 +296,8 @@ async def handle_call_tool(
                 progress_token=progress_token, progress=0.0, total=1.0
             )
 
-        conversation_id = str(uuid4())
-        input_request = SimplifiedAPIRequest(
-            input_value=processed_inputs.get("input_value", ""), session_id=conversation_id
-        )
+        session_id = processed_inputs.pop("session_id", None) or str(uuid4())
+        input_request = SimplifiedAPIRequest(input_value=processed_inputs.get("input_value", ""), session_id=session_id)
 
         async def send_progress_updates(progress_token):
             try:

--- a/src/backend/base/langflow/helpers/flow.py
+++ b/src/backend/base/langflow/helpers/flow.py
@@ -500,4 +500,13 @@ def json_schema_from_flow(flow: Flow) -> dict:
                 if field_data.get("required", False):
                     required.append(field_name)
 
+    if "session_id" not in properties:
+        properties["session_id"] = {
+            "type": "string",
+            "description": (
+                "Optional session identifier used to persist conversation "
+                "history across tool calls. Omit to start a new session."
+            ),
+        }
+
     return {"type": "object", "properties": properties, "required": required}

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -1,8 +1,10 @@
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from langflow.api.utils.core import extract_global_variables_from_headers
 from langflow.api.v1 import mcp_utils
+from langflow.helpers import flow as flow_helpers
 from lfx.interface.components import component_cache
 
 
@@ -370,3 +372,160 @@ async def test_handle_list_tools_requires_current_user_on_global_server(monkeypa
     # No user context set — must return empty.
     tools = await mcp_utils.handle_list_tools()
     assert tools == []
+
+
+# ============================================================================
+# session_id propagation — MCP clients must be able to persist chat history.
+# ============================================================================
+
+
+def _build_fake_server() -> SimpleNamespace:
+    """Build a minimal MCP server stub with progress notifications disabled."""
+    return SimpleNamespace(
+        request_context=SimpleNamespace(
+            meta=SimpleNamespace(progressToken=None),
+            session=SimpleNamespace(send_progress_notification=AsyncMock()),
+        )
+    )
+
+
+async def _invoke_handle_call_tool(monkeypatch, arguments: dict) -> AsyncMock:
+    """Run handle_call_tool with all external deps stubbed; return the simple_run_flow mock."""
+    flow = SimpleNamespace(id="flow-id-1", name="my_flow", folder_id=None)
+
+    async def fake_get_flow_snake_case(*_args, **_kwargs):
+        return flow
+
+    run_response = SimpleNamespace(outputs=[])
+    simple_run_flow_mock = AsyncMock(return_value=run_response)
+
+    monkeypatch.setattr(mcp_utils, "get_flow_snake_case", fake_get_flow_snake_case)
+    monkeypatch.setattr(mcp_utils, "simple_run_flow", simple_run_flow_mock)
+    monkeypatch.setattr(mcp_utils, "with_db_session", lambda operation: operation(SimpleNamespace()))
+    # Force progress notifications off so the test does not exercise that path.
+    mcp_utils.get_mcp_config().enable_progress_notifications = False
+
+    token = mcp_utils.current_user_ctx.set(SimpleNamespace(id="user-1"))
+    try:
+        await mcp_utils.handle_call_tool(
+            name="my_flow",
+            arguments=arguments,
+            server=_build_fake_server(),
+        )
+    finally:
+        mcp_utils.current_user_ctx.reset(token)
+
+    return simple_run_flow_mock
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_uses_provided_session_id(monkeypatch):
+    """When the MCP client supplies session_id, it must be forwarded to simple_run_flow."""
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={"input_value": "hello", "session_id": "user-1-thread-7"},
+    )
+
+    simple_run_flow_mock.assert_awaited_once()
+    forwarded_request = simple_run_flow_mock.await_args.kwargs["input_request"]
+    assert forwarded_request.session_id == "user-1-thread-7"
+    assert forwarded_request.input_value == "hello"
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_generates_session_id_when_omitted(monkeypatch):
+    """When session_id is absent or blank, a non-empty fallback id must be generated."""
+    from uuid import UUID
+
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={"input_value": "hello"},
+    )
+
+    forwarded_request = simple_run_flow_mock.await_args.kwargs["input_request"]
+    # Fallback must be a valid UUID-shaped string.
+    UUID(forwarded_request.session_id)
+
+
+@pytest.mark.asyncio
+async def test_handle_call_tool_falls_back_when_session_id_blank(monkeypatch):
+    """Empty-string session_id must trigger the UUID fallback, not pass through."""
+    from uuid import UUID
+
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={"input_value": "hello", "session_id": ""},
+    )
+
+    forwarded_request = simple_run_flow_mock.await_args.kwargs["input_request"]
+    UUID(forwarded_request.session_id)
+    assert forwarded_request.session_id != ""
+
+
+def test_json_schema_from_flow_includes_optional_session_id(monkeypatch):
+    """json_schema_from_flow must advertise session_id so MCP clients can supply it."""
+
+    class _FakeGraph:
+        def __init__(self):
+            self.vertices = []  # No input nodes — exercises the empty-properties path.
+
+        @classmethod
+        def from_payload(cls, _flow_data):
+            return cls()
+
+    # Patch the lazy import inside json_schema_from_flow.
+    import lfx.graph.graph.base as graph_base_module
+
+    monkeypatch.setattr(graph_base_module, "Graph", _FakeGraph)
+
+    flow = SimpleNamespace(data={"nodes": [], "edges": []})
+    schema = flow_helpers.json_schema_from_flow(flow)
+
+    assert schema["type"] == "object"
+    assert "session_id" in schema["properties"]
+    assert schema["properties"]["session_id"]["type"] == "string"
+    # session_id must be optional so existing MCP clients keep working.
+    assert "session_id" not in schema["required"]
+
+
+def test_json_schema_from_flow_preserves_flow_defined_session_id(monkeypatch):
+    """If a flow already defines a session_id input, do not overwrite it."""
+    custom_session_id_property = {
+        "type": "string",
+        "description": "Flow-defined session id with custom semantics.",
+    }
+
+    class _FakeNode:
+        is_input = True
+        data = {
+            "node": {
+                "template": {
+                    "session_id": {
+                        "show": True,
+                        "advanced": False,
+                        "type": "str",
+                        "info": custom_session_id_property["description"],
+                        "required": True,
+                    }
+                }
+            }
+        }
+
+    class _FakeGraph:
+        def __init__(self):
+            self.vertices = [_FakeNode()]
+
+        @classmethod
+        def from_payload(cls, _flow_data):
+            return cls()
+
+    import lfx.graph.graph.base as graph_base_module
+
+    monkeypatch.setattr(graph_base_module, "Graph", _FakeGraph)
+
+    flow = SimpleNamespace(data={"nodes": [], "edges": []})
+    schema = flow_helpers.json_schema_from_flow(flow)
+
+    # The flow's own definition wins — the reserved injection must not clobber it.
+    assert schema["properties"]["session_id"]["description"] == custom_session_id_property["description"]
+    assert "session_id" in schema["required"]


### PR DESCRIPTION
## Summary

- Add optional `session_id` parameter to flows exposed via the MCP interface so MCP clients can persist chat history across tool calls.
- `json_schema_from_flow` now advertises `session_id` in each tool's input schema (optional, not in `required`).
- `handle_call_tool` uses the client-provided `session_id` when present and falls back to a generated UUID otherwise (preserves prior behavior).

Reported by Alejandro — MCP clients had no way to maintain chat history because the server unconditionally generated a fresh conversation id per call, so memory components could never see prior turns.

## Files Changed

- `src/backend/base/langflow/helpers/flow.py` — inject optional `session_id` into the generated JSON schema.
- `src/backend/base/langflow/api/v1/mcp_utils.py` — extract `session_id` from arguments; fall back to UUID when absent/blank.
- `src/backend/tests/unit/api/v1/test_mcp_utils.py` — 5 new unit tests covering both pass-through and fallback paths plus the schema additions.

## Test plan

- [x] `uv run pytest src/backend/tests/unit/api/v1/test_mcp_utils.py` — 19/19 pass (5 new).
- [x] `uv run ruff check` / `uv run ruff format --check` on touched files — clean.
- [ ] Manual: call an MCP tool twice with the same `session_id`; second call sees prior turn in chat history.
- [ ] Manual: call without `session_id`; flow still runs as before (fresh session each call).
- [ ] Manual: `tools/list` against the MCP server shows `session_id` in `inputSchema.properties` and **not** in `required`.

## Backward compatibility

Existing MCP clients that do not send `session_id` are unaffected — they continue to get an auto-generated UUID per call, matching today's behavior.