### PR TITLE
chore: Block hardcoded Tailwind palette via Biome lint

### DIFF
--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -23,6 +23,7 @@ frontend:
   - "src/frontend/**"
   - "**/typescript_test.yml"
   - "**/jest_test.yml"
+  - "**/lint-js.yml"
   - ".github/workflows/ci.yml"
   - "src/lfx/src/lfx/_assets/component_index.json"
 docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,20 @@ jobs:
       ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}"
       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
 
+  lint-frontend:
+    needs: [path-filter, set-ci-condition]
+    name: Lint Frontend
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.set-ci-condition.outputs.should-run-ci == 'true' &&
+      (
+        inputs.run-all-tests ||
+        (needs.path-filter.result != 'skipped' &&
+        needs.path-filter.outputs.frontend == 'true')
+      )
+    uses: ./.github/workflows/lint-js.yml
+
   test-frontend-unit:
     needs: [path-filter, set-ci-condition]
     name: Run Frontend Unit Tests
@@ -409,6 +423,7 @@ jobs:
     needs:
       [
         test-backend,
+        lint-frontend,
         test-frontend-unit,
         test-frontend,
         test-docs-build,
@@ -458,6 +473,8 @@ jobs:
               | .key as $job
               | if $job == "test-backend" then
                   "  - Backend Tests: Check Python code, tests, and dependencies"
+                elif $job == "lint-frontend" then
+                  "  - Frontend Lint: Biome found violations (e.g. hardcoded Tailwind palette colors). Run `npm run lint` in src/frontend to reproduce locally"
                 elif $job == "test-frontend-unit" then
                   "  - Frontend Unit Tests: Check React components and unit test logic"
                 elif $job == "test-frontend" then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,10 +420,12 @@ jobs:
   # https://github.com/langchain-ai/langchain/blob/master/.github/workflows/check_diffs.yml
   ci_success:
     name: "CI Success"
+    # Note: `lint-frontend` is intentionally NOT in this list — the Biome
+    # check runs on every PR and shows up in the checks list, but its failure
+    # does NOT block merge (informational only).
     needs:
       [
         test-backend,
-        lint-frontend,
         test-frontend-unit,
         test-frontend,
         test-docs-build,
@@ -473,8 +475,6 @@ jobs:
               | .key as $job
               | if $job == "test-backend" then
                   "  - Backend Tests: Check Python code, tests, and dependencies"
-                elif $job == "lint-frontend" then
-                  "  - Frontend Lint: Biome found violations (e.g. hardcoded Tailwind palette colors). Run `npm run lint` in src/frontend to reproduce locally"
                 elif $job == "test-frontend-unit" then
                   "  - Frontend Unit Tests: Check React components and unit test logic"
                 elif $job == "test-frontend" then

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -28,21 +28,6 @@ jobs:
           # Need full history so biome can diff against the PR base
           fetch-depth: 0
 
-      - name: Point local `main` ref at the PR fork point
-        run: |
-          # biome.json sets vcs.defaultBranch=main, so `biome check --changed`
-          # diffs against the local `main` ref. To lint ONLY the files this PR
-          # modified (not unrelated upstream changes in the base branch since
-          # the PR was opened), point local `main` at the merge-base — the
-          # commit where this branch forked off its target.
-          BASE_REF="${{ github.base_ref || 'main' }}"
-          echo "PR base branch: $BASE_REF"
-          MERGE_BASE=$(git merge-base HEAD "origin/$BASE_REF")
-          echo "Fork point (merge-base): $MERGE_BASE"
-          git update-ref refs/heads/main "$MERGE_BASE"
-          echo "Files biome will check:"
-          git diff --name-only "$MERGE_BASE"...HEAD
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         id: setup-node
@@ -64,7 +49,41 @@ jobs:
           npm install
         if: ${{ steps.setup-node.outputs.cache-hit != 'true' }}
 
-      - name: Run Biome
+      - name: Run Biome on PR-changed files
         run: |
+          # Determine the branch this PR targets (falls back to `main` for
+          # workflow_dispatch / non-PR contexts).
+          BASE_REF="${{ github.base_ref || 'main' }}"
+          echo "=== Debug ==="
+          echo "HEAD:          $(git rev-parse HEAD)"
+          echo "BASE_REF:      $BASE_REF"
+          echo "origin/$BASE_REF: $(git rev-parse "origin/$BASE_REF" 2>/dev/null || echo NOT_FOUND)"
+
+          # Merge-base = the commit where this branch forked off its target.
+          # Diffing against it yields ONLY the files this PR introduced,
+          # ignoring unrelated upstream changes merged into the base since.
+          MERGE_BASE=$(git merge-base HEAD "origin/$BASE_REF")
+          echo "MERGE_BASE:    $MERGE_BASE"
+
+          # Collect frontend files modified in this PR. Filter to file types
+          # biome can process (ts/tsx/js/jsx/json/jsonc and the like).
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR \
+            "$MERGE_BASE"...HEAD -- 'src/frontend/' \
+            | grep -E '\.(tsx?|jsx?|c(js|ts)|m(js|ts)|jsonc?)$' \
+            || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No frontend files changed in this PR — skipping biome."
+            exit 0
+          fi
+
+          echo "=== Files to lint ==="
+          echo "$CHANGED_FILES"
+
+          # Biome runs from src/frontend; strip that prefix from paths.
+          RELATIVE_FILES=$(echo "$CHANGED_FILES" | sed 's|^src/frontend/||')
+
           cd src/frontend
-          npx @biomejs/biome check --changed
+          echo "$RELATIVE_FILES" | xargs npx @biomejs/biome check \
+            --files-ignore-unknown=true \
+            --diagnostic-level=error

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -25,8 +25,23 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
-          # Need full history so `biome check --changed` can diff against main
+          # Need full history so biome can diff against the PR base
           fetch-depth: 0
+
+      - name: Point local `main` ref at the PR fork point
+        run: |
+          # biome.json sets vcs.defaultBranch=main, so `biome check --changed`
+          # diffs against the local `main` ref. To lint ONLY the files this PR
+          # modified (not unrelated upstream changes in the base branch since
+          # the PR was opened), point local `main` at the merge-base — the
+          # commit where this branch forked off its target.
+          BASE_REF="${{ github.base_ref || 'main' }}"
+          echo "PR base branch: $BASE_REF"
+          MERGE_BASE=$(git merge-base HEAD "origin/$BASE_REF")
+          echo "Fork point (merge-base): $MERGE_BASE"
+          git update-ref refs/heads/main "$MERGE_BASE"
+          echo "Files biome will check:"
+          git diff --name-only "$MERGE_BASE"...HEAD
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
+          # Need full history so `biome check --changed` can diff against main
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/src/frontend/biome-plugins/no-hardcoded-tailwind-palette.grit
+++ b/src/frontend/biome-plugins/no-hardcoded-tailwind-palette.grit
@@ -1,0 +1,12 @@
+// Flags hardcoded Tailwind palette colors (e.g. bg-zinc-900, text-slate-500, border-gray-200).
+// Use semantic tokens defined in src/style/index.css (bg-background, text-foreground, border-border, etc.) instead.
+
+language js
+
+`$str` where {
+  $str <: r".*-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-[0-9]+.*",
+  register_diagnostic(
+    span = $str,
+    message = "Hardcoded Tailwind palette color is not allowed. Use a semantic token from src/style/index.css (e.g. bg-background, text-foreground, border-border) instead."
+  )
+}

--- a/src/frontend/biome-plugins/no-hardcoded-tailwind-palette.grit
+++ b/src/frontend/biome-plugins/no-hardcoded-tailwind-palette.grit
@@ -5,8 +5,5 @@ language js
 
 `$str` where {
   $str <: r".*-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-[0-9]+.*",
-  register_diagnostic(
-    span = $str,
-    message = "Hardcoded Tailwind palette color is not allowed. Use a semantic token from src/style/index.css (e.g. bg-background, text-foreground, border-border) instead."
-  )
+  register_diagnostic(span=$str, message="Hardcoded Tailwind palette color is not allowed. Use a semantic token from src/style/index.css (e.g. bg-background, text-foreground, border-border) instead.")
 }

--- a/src/frontend/biome.json
+++ b/src/frontend/biome.json
@@ -9,6 +9,7 @@
   "files": {
     "ignoreUnknown": false
   },
+  "plugins": ["./biome-plugins/no-hardcoded-tailwind-palette.grit"],
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx
@@ -400,7 +400,7 @@ export default function NodeStatus({
               styleClasses={cn(
                 "border rounded-xl p-2",
                 conditionSuccess
-                  ? "bg-zinc-700"
+                  ? "bg-hard-zinc"
                   : "border-destructive bg-error-background",
               )}
               content={

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-component-result.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-component-result.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
 import { Check, FileText } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import type { AgenticResult } from "@/controllers/API/queries/agentic";
 import CodeAreaModal from "@/modals/codeAreaModal";
 
@@ -30,8 +30,7 @@ export function parseComponentInfo(code: string | undefined) {
   // Extract inputs with type (e.g. MessageTextInput, IntInput, etc.)
   const inputRegex = /(\w+Input)\(\s*(?:[^)]*?)display_name\s*=\s*"([^"]+)"/g;
   const inputs: FieldInfo[] = [];
-  let match;
-  while ((match = inputRegex.exec(code)) !== null) {
+  for (const match of code.matchAll(inputRegex)) {
     inputs.push({ name: match[2], type: formatType(match[1]) });
   }
 
@@ -39,7 +38,7 @@ export function parseComponentInfo(code: string | undefined) {
   if (inputs.length === 0) {
     const simpleInputRegex =
       /(MessageTextInput|StrInput|IntInput|FloatInput|BoolInput|FileInput|DropdownInput|MultilineInput|SecretStrInput|HandleInput|DataInput)\s*\([^)]*display_name\s*=\s*"([^"]+)"/g;
-    while ((match = simpleInputRegex.exec(code)) !== null) {
+    for (const match of code.matchAll(simpleInputRegex)) {
       inputs.push({ name: match[2], type: formatType(match[1]) });
     }
   }
@@ -48,7 +47,7 @@ export function parseComponentInfo(code: string | undefined) {
   const outputRegex =
     /Output\(\s*(?:[^)]*?)display_name\s*=\s*"([^"]+)"(?:[^)]*?)method\s*=\s*"(\w+)"/g;
   const outputs: FieldInfo[] = [];
-  while ((match = outputRegex.exec(code)) !== null) {
+  for (const match of code.matchAll(outputRegex)) {
     const methodName = match[2];
     // Look for the method's return type annotation: def method_name(self) -> ReturnType:
     const returnTypeRegex = new RegExp(
@@ -63,7 +62,7 @@ export function parseComponentInfo(code: string | undefined) {
   if (outputs.length === 0) {
     const simpleOutputRegex =
       /Output\(\s*(?:[^)]*?)display_name\s*=\s*"([^"]+)"/g;
-    while ((match = simpleOutputRegex.exec(code)) !== null) {
+    for (const match of code.matchAll(simpleOutputRegex)) {
       outputs.push({ name: match[1], type: "Message" });
     }
   }

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-component-result.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-component-result.tsx
@@ -175,7 +175,7 @@ export function AssistantComponentResult({
           <button
             type="button"
             data-testid="assistant-approve-button"
-            className="h-8 rounded-[10px] bg-white px-4 text-sm font-medium text-zinc-900 transition-colors hover:bg-zinc-100"
+            className="h-8 rounded-[10px] bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted"
             onClick={handleApprove}
           >
             Add to Canvas
@@ -184,7 +184,7 @@ export function AssistantComponentResult({
         <button
           type="button"
           data-testid="assistant-view-code-button"
-          className="h-8 rounded-[10px] bg-zinc-700 px-4 text-sm font-medium text-white transition-colors hover:bg-zinc-600"
+          className="h-8 rounded-[10px] bg-hard-zinc px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-foreground"
           onClick={() => setIsViewCodeOpen(true)}
         >
           View Code

--- a/src/frontend/src/components/core/assistantPanel/components/assistant-component-result.tsx
+++ b/src/frontend/src/components/core/assistantPanel/components/assistant-component-result.tsx
@@ -30,7 +30,7 @@ export function parseComponentInfo(code: string | undefined) {
   // Extract inputs with type (e.g. MessageTextInput, IntInput, etc.)
   const inputRegex = /(\w+Input)\(\s*(?:[^)]*?)display_name\s*=\s*"([^"]+)"/g;
   const inputs: FieldInfo[] = [];
-  for (const match of code.matchAll(inputRegex)) {
+  for (const match of Array.from(code.matchAll(inputRegex))) {
     inputs.push({ name: match[2], type: formatType(match[1]) });
   }
 
@@ -38,7 +38,7 @@ export function parseComponentInfo(code: string | undefined) {
   if (inputs.length === 0) {
     const simpleInputRegex =
       /(MessageTextInput|StrInput|IntInput|FloatInput|BoolInput|FileInput|DropdownInput|MultilineInput|SecretStrInput|HandleInput|DataInput)\s*\([^)]*display_name\s*=\s*"([^"]+)"/g;
-    for (const match of code.matchAll(simpleInputRegex)) {
+    for (const match of Array.from(code.matchAll(simpleInputRegex))) {
       inputs.push({ name: match[2], type: formatType(match[1]) });
     }
   }
@@ -47,7 +47,7 @@ export function parseComponentInfo(code: string | undefined) {
   const outputRegex =
     /Output\(\s*(?:[^)]*?)display_name\s*=\s*"([^"]+)"(?:[^)]*?)method\s*=\s*"(\w+)"/g;
   const outputs: FieldInfo[] = [];
-  for (const match of code.matchAll(outputRegex)) {
+  for (const match of Array.from(code.matchAll(outputRegex))) {
     const methodName = match[2];
     // Look for the method's return type annotation: def method_name(self) -> ReturnType:
     const returnTypeRegex = new RegExp(
@@ -62,7 +62,7 @@ export function parseComponentInfo(code: string | undefined) {
   if (outputs.length === 0) {
     const simpleOutputRegex =
       /Output\(\s*(?:[^)]*?)display_name\s*=\s*"([^"]+)"/g;
-    for (const match of code.matchAll(simpleOutputRegex)) {
+    for (const match of Array.from(code.matchAll(simpleOutputRegex))) {
       outputs.push({ name: match[1], type: "Message" });
     }
   }

--- a/src/frontend/src/components/core/canvasControlsComponent/CanvasControls.tsx
+++ b/src/frontend/src/components/core/canvasControlsComponent/CanvasControls.tsx
@@ -73,7 +73,7 @@ const CanvasControls = ({
       >
         <div className="group relative">
           <span
-            className={`absolute -top-4 -left-1 z-10 flex items-center gap-0.5 rounded bg-pink-600 px-1 py-0.5 text-[9px] font-medium leading-none text-white transition-all duration-200 ${assistantSidebarOpen ? "hidden" : "opacity-0 scale-90 group-hover:opacity-100 group-hover:scale-100"}`}
+            className={`absolute -top-4 -left-1 z-10 flex items-center gap-0.5 rounded bg-accent-pink-foreground px-1 py-0.5 text-[9px] font-medium leading-none text-primary-foreground transition-all duration-200 ${assistantSidebarOpen ? "hidden" : "opacity-0 scale-90 group-hover:opacity-100 group-hover:scale-100"}`}
           >
             <ForwardedIconComponent name="Sparkles" className="h-2.5 w-2.5" />
             New

--- a/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/bot-message.tsx
+++ b/src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/bot-message.tsx
@@ -159,7 +159,7 @@ export const BotMessage = memo(
                   {!thinkingActive && displayTime > 0 && (
                     <ForwardedIconComponent
                       name="Check"
-                      className="h-4 w-4 text-emerald-400"
+                      className="h-4 w-4 text-accent-emerald-foreground"
                     />
                   )}
                   <span className="w-full flex justify-between">

--- a/src/frontend/src/components/core/sanitizedMarkdown/index.tsx
+++ b/src/frontend/src/components/core/sanitizedMarkdown/index.tsx
@@ -110,6 +110,7 @@ export const SanitizedMarkdown = ({
                 </div>
               );
             },
+            // biome-ignore lint/suspicious/noExplicitAny: pre-existing react-markdown override; proper type cleanup out of scope for this PR
             code: ({ node, inline, className, children, ...props }: any) => {
               let content = children as string;
               if (

--- a/src/frontend/src/components/core/sanitizedMarkdown/index.tsx
+++ b/src/frontend/src/components/core/sanitizedMarkdown/index.tsx
@@ -59,7 +59,7 @@ export const SanitizedMarkdown = ({
   return (
     <div ref={markdownRef} className={className}>
       {showWarning && (
-        <div className="text-muted-foreground text-sm p-2 border border-yellow-500 bg-yellow-50 dark:bg-yellow-900/20 rounded mb-2">
+        <div className="text-muted-foreground text-sm p-2 border border-warning bg-warning/30 rounded mb-2">
           ⚠️ The response was filtered by security sanitization and cannot be
           displayed.
         </div>

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/IngestionHistoryPanel.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/IngestionHistoryPanel.tsx
@@ -8,12 +8,13 @@ interface IngestionHistoryPanelProps {
 }
 
 const STATUS_STYLES: Record<string, string> = {
-  succeeded: "bg-emerald-50 text-emerald-700 border-emerald-200",
-  partial: "bg-amber-50 text-amber-700 border-amber-200",
-  failed: "bg-rose-50 text-rose-700 border-rose-200",
-  cancelled: "bg-slate-50 text-slate-600 border-slate-200",
-  running: "bg-sky-50 text-sky-700 border-sky-200",
-  pending: "bg-slate-50 text-slate-600 border-slate-200",
+  succeeded:
+    "bg-accent-emerald text-accent-emerald-foreground border-accent-emerald",
+  partial: "bg-warning text-warning-foreground border-warning",
+  failed: "bg-error-red text-accent-red-foreground border-error-red-border",
+  cancelled: "bg-muted text-muted-foreground border-border",
+  running: "bg-accent-indigo text-accent-indigo-foreground border-accent-indigo",
+  pending: "bg-muted text-muted-foreground border-border",
 };
 
 const SOURCE_TYPE_LABELS: Record<string, string> = {
@@ -91,7 +92,7 @@ export function IngestionHistoryPanel({ kbName }: IngestionHistoryPanelProps) {
             </div>
           )}
           {isError && !isLoading && (
-            <div className="text-xs text-rose-600">
+            <div className="text-xs text-destructive">
               Unable to load ingestion history.
             </div>
           )}
@@ -147,7 +148,7 @@ export function IngestionHistoryPanel({ kbName }: IngestionHistoryPanelProps) {
                   <span className="flex items-center gap-1">
                     <ForwardedIconComponent
                       name="CircleCheck"
-                      className="h-3 w-3 text-emerald-600"
+                      className="h-3 w-3 text-accent-emerald-foreground"
                     />
                     {run.succeeded}
                   </span>
@@ -155,7 +156,7 @@ export function IngestionHistoryPanel({ kbName }: IngestionHistoryPanelProps) {
                     <span className="flex items-center gap-1">
                       <ForwardedIconComponent
                         name="CircleAlert"
-                        className="h-3 w-3 text-rose-600"
+                        className="h-3 w-3 text-destructive"
                       />
                       {run.failed}
                     </span>
@@ -164,7 +165,7 @@ export function IngestionHistoryPanel({ kbName }: IngestionHistoryPanelProps) {
                     <span className="flex items-center gap-1">
                       <ForwardedIconComponent
                         name="CircleMinus"
-                        className="h-3 w-3 text-slate-500"
+                        className="h-3 w-3 text-muted-foreground"
                       />
                       {run.skipped}
                     </span>

--- a/src/frontend/src/modals/knowledgeBaseUploadModal/components/IngestionHistoryPanel.tsx
+++ b/src/frontend/src/modals/knowledgeBaseUploadModal/components/IngestionHistoryPanel.tsx
@@ -13,7 +13,8 @@ const STATUS_STYLES: Record<string, string> = {
   partial: "bg-warning text-warning-foreground border-warning",
   failed: "bg-error-red text-accent-red-foreground border-error-red-border",
   cancelled: "bg-muted text-muted-foreground border-border",
-  running: "bg-accent-indigo text-accent-indigo-foreground border-accent-indigo",
+  running:
+    "bg-accent-indigo text-accent-indigo-foreground border-accent-indigo",
   pending: "bg-muted text-muted-foreground border-border",
 };
 

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/components/IngestionRunDetailModal.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/components/IngestionRunDetailModal.tsx
@@ -9,9 +9,9 @@ interface IngestionRunDetailModalProps {
 }
 
 const ITEM_STATUS_STYLES: Record<string, string> = {
-  succeeded: "text-emerald-700",
-  failed: "text-rose-700",
-  skipped: "text-slate-500",
+  succeeded: "text-accent-emerald-foreground",
+  failed: "text-accent-red-foreground",
+  skipped: "text-muted-foreground",
 };
 
 const ITEM_STATUS_ICON: Record<string, string> = {
@@ -61,7 +61,7 @@ const IngestionRunDetailModal = ({
             <div className="text-sm text-muted-foreground">Loading run…</div>
           )}
           {isError && (
-            <div className="text-sm text-rose-600">
+            <div className="text-sm text-destructive">
               Unable to load run detail.
             </div>
           )}
@@ -80,7 +80,7 @@ const IngestionRunDetailModal = ({
               </div>
 
               {data.error_message && (
-                <div className="rounded-md border border-rose-200 bg-rose-50 p-3 text-xs text-rose-700">
+                <div className="rounded-md border border-error-red-border bg-error-red p-3 text-xs text-accent-red-foreground">
                   <span className="font-medium">Error:</span>{" "}
                   {data.error_message}
                 </div>
@@ -121,7 +121,7 @@ const IngestionRunDetailModal = ({
                           </span>
                         </div>
                         {item.error_message && (
-                          <div className="rounded-sm bg-rose-50 px-2 py-1 text-rose-700">
+                          <div className="rounded-sm bg-error-red px-2 py-1 text-accent-red-foreground">
                             {item.error_message}
                           </div>
                         )}
@@ -147,11 +147,11 @@ interface MetricProps {
 function Metric({ label, value, tone }: MetricProps) {
   const toneClass =
     tone === "success"
-      ? "text-emerald-700"
+      ? "text-accent-emerald-foreground"
       : tone === "error"
-        ? "text-rose-700"
+        ? "text-accent-red-foreground"
         : tone === "muted"
-          ? "text-slate-500"
+          ? "text-muted-foreground"
           : "text-foreground";
   return (
     <div className="flex flex-col gap-1 rounded-md border border-border bg-card p-2">

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/components/IngestionRunsSection.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/components/IngestionRunsSection.tsx
@@ -24,7 +24,8 @@ const STATUS_STYLES: Record<string, string> = {
   partial: "bg-warning text-warning-foreground border-warning",
   failed: "bg-error-red text-accent-red-foreground border-error-red-border",
   cancelled: "bg-muted text-muted-foreground border-border",
-  running: "bg-accent-indigo text-accent-indigo-foreground border-accent-indigo",
+  running:
+    "bg-accent-indigo text-accent-indigo-foreground border-accent-indigo",
   pending: "bg-muted text-muted-foreground border-border",
 };
 

--- a/src/frontend/src/pages/MainPage/pages/knowledgePage/components/IngestionRunsSection.tsx
+++ b/src/frontend/src/pages/MainPage/pages/knowledgePage/components/IngestionRunsSection.tsx
@@ -19,12 +19,13 @@ const TERMINAL_RUN_STATUSES = new Set([
 const RUN_POLL_INTERVAL_MS = 5000;
 
 const STATUS_STYLES: Record<string, string> = {
-  succeeded: "bg-emerald-50 text-emerald-700 border-emerald-200",
-  partial: "bg-amber-50 text-amber-700 border-amber-200",
-  failed: "bg-rose-50 text-rose-700 border-rose-200",
-  cancelled: "bg-slate-50 text-slate-600 border-slate-200",
-  running: "bg-sky-50 text-sky-700 border-sky-200",
-  pending: "bg-slate-50 text-slate-600 border-slate-200",
+  succeeded:
+    "bg-accent-emerald text-accent-emerald-foreground border-accent-emerald",
+  partial: "bg-warning text-warning-foreground border-warning",
+  failed: "bg-error-red text-accent-red-foreground border-error-red-border",
+  cancelled: "bg-muted text-muted-foreground border-border",
+  running: "bg-accent-indigo text-accent-indigo-foreground border-accent-indigo",
+  pending: "bg-muted text-muted-foreground border-border",
 };
 
 const SOURCE_TYPE_LABELS: Record<string, string> = {
@@ -94,7 +95,7 @@ const IngestionRunsSection = ({ kbName }: IngestionRunsSectionProps) => {
         <div className="text-sm text-muted-foreground">Loading runs…</div>
       )}
       {isError && (
-        <div className="text-sm text-rose-600">
+        <div className="text-sm text-destructive">
           Unable to load ingestion runs.
         </div>
       )}
@@ -135,7 +136,7 @@ const IngestionRunsSection = ({ kbName }: IngestionRunsSectionProps) => {
                 <span className="flex items-center gap-1">
                   <ForwardedIconComponent
                     name="CircleCheck"
-                    className="h-3 w-3 text-emerald-600"
+                    className="h-3 w-3 text-accent-emerald-foreground"
                   />
                   {run.succeeded}
                 </span>
@@ -143,7 +144,7 @@ const IngestionRunsSection = ({ kbName }: IngestionRunsSectionProps) => {
                   <span className="flex items-center gap-1">
                     <ForwardedIconComponent
                       name="CircleAlert"
-                      className="h-3 w-3 text-rose-600"
+                      className="h-3 w-3 text-destructive"
                     />
                     {run.failed}
                   </span>
@@ -152,7 +153,7 @@ const IngestionRunsSection = ({ kbName }: IngestionRunsSectionProps) => {
                   <span className="flex items-center gap-1">
                     <ForwardedIconComponent
                       name="CircleMinus"
-                      className="h-3 w-3 text-slate-500"
+                      className="h-3 w-3 text-muted-foreground"
                     />
                     {run.skipped}
                   </span>

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -12,37 +12,71 @@ const iconCache = new Map<string, React.ComponentType>();
 export const BG_NOISE =
   "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAUVBMVEWFhYWDg4N3d3dtbW17e3t1dXWBgYGHh4d5eXlzc3OLi4ubm5uVlZWPj4+NjY19fX2JiYl/f39ra2uRkZGZmZlpaWmXl5dvb29xcXGTk5NnZ2c8TV1mAAAAG3RSTlNAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAvEOwtAAAFVklEQVR4XpWWB67c2BUFb3g557T/hRo9/WUMZHlgr4Bg8Z4qQgQJlHI4A8SzFVrapvmTF9O7dmYRFZ60YiBhJRCgh1FYhiLAmdvX0CzTOpNE77ME0Zty/nWWzchDtiqrmQDeuv3powQ5ta2eN0FY0InkqDD73lT9c9lEzwUNqgFHs9VQce3TVClFCQrSTfOiYkVJQBmpbq2L6iZavPnAPcoU0dSw0SUTqz/GtrGuXfbyyBniKykOWQWGqwwMA7QiYAxi+IlPdqo+hYHnUt5ZPfnsHJyNiDtnpJyayNBkF6cWoYGAMY92U2hXHF/C1M8uP/ZtYdiuj26UdAdQQSXQErwSOMzt/XWRWAz5GuSBIkwG1H3FabJ2OsUOUhGC6tK4EMtJO0ttC6IBD3kM0ve0tJwMdSfjZo+EEISaeTr9P3wYrGjXqyC1krcKdhMpxEnt5JetoulscpyzhXN5FRpuPHvbeQaKxFAEB6EN+cYN6xD7RYGpXpNndMmZgM5Dcs3YSNFDHUo2LGfZuukSWyUYirJAdYbF3MfqEKmjM+I2EfhA94iG3L7uKrR+GdWD73ydlIB+6hgref1QTlmgmbM3/LeX5GI1Ux1RWpgxpLuZ2+I+IjzZ8wqE4nilvQdkUdfhzI5QDWy+kw5Wgg2pGpeEVeCCA7b85BO3F9DzxB3cdqvBzWcmzbyMiqhzuYqtHRVG2y4x+KOlnyqla8AoWWpuBoYRxzXrfKuILl6SfiWCbjxoZJUaCBj1CjH7GIaDbc9kqBY3W/Rgjda1iqQcOJu2WW+76pZC9QG7M00dffe9hNnseupFL53r8F7YHSwJWUKP2q+k7RdsxyOB11n0xtOvnW4irMMFNV4H0uqwS5ExsmP9AxbDTc9JwgneAT5vTiUSm1E7BSflSt3bfa1tv8Di3R8n3Af7MNWzs49hmauE2wP+ttrq+AsWpFG2awvsuOqbipWHgtuvuaAE+A1Z/7gC9hesnr+7wqCwG8c5yAg3AL1fm8T9AZtp/bbJGwl1pNrE7RuOX7PeMRUERVaPpEs+yqeoSmuOlokqw49pgomjLeh7icHNlG19yjs6XXOMedYm5xH2YxpV2tc0Ro2jJfxC50ApuxGob7lMsxfTbeUv07TyYxpeLucEH1gNd4IKH2LAg5TdVhlCafZvpskfncCfx8pOhJzd76bJWeYFnFciwcYfubRc12Ip/ppIhA1/mSZ/RxjFDrJC5xifFjJpY2Xl5zXdguFqYyTR1zSp1Y9p+tktDYYSNflcxI0iyO4TPBdlRcpeqjK/piF5bklq77VSEaA+z8qmJTFzIWiitbnzR794USKBUaT0NTEsVjZqLaFVqJoPN9ODG70IPbfBHKK+/q/AWR0tJzYHRULOa4MP+W/HfGadZUbfw177G7j/OGbIs8TahLyynl4X4RinF793Oz+BU0saXtUHrVBFT/DnA3ctNPoGbs4hRIjTok8i+algT1lTHi4SxFvONKNrgQFAq2/gFnWMXgwffgYMJpiKYkmW3tTg3ZQ9Jq+f8XN+A5eeUKHWvJWJ2sgJ1Sop+wwhqFVijqWaJhwtD8MNlSBeWNNWTa5Z5kPZw5+LbVT99wqTdx29lMUH4OIG/D86ruKEauBjvH5xy6um/Sfj7ei6UUVk4AIl3MyD4MSSTOFgSwsH/QJWaQ5as7ZcmgBZkzjjU1UrQ74ci1gWBCSGHtuV1H2mhSnO3Wp/3fEV5a+4wz//6qy8JxjZsmxxy5+4w9CDNJY09T072iKG0EnOS0arEYgXqYnXcYHwjTtUNAcMelOd4xpkoqiTYICWFq0JSiPfPDQdnt+4/wuqcXY47QILbgAAAABJRU5ErkJggg==)";
 
+// Decorative gradient palette for randomized flow/avatar backgrounds.
+// Intentional Tailwind palette colors — not semantic theme tokens, so the
+// no-hardcoded-tailwind-palette plugin is suppressed per entry below.
 export const gradients = [
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-gray-800 via-rose-700 to-violet-900",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-green-200 via-green-300 to-blue-500",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-yellow-200 via-yellow-400 to-yellow-700",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-green-200 via-green-400 to-purple-700",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-blue-100 via-blue-300 to-blue-500",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-purple-400 to-yellow-400",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-red-800 via-yellow-600 to-yellow-500",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-blue-300 via-green-200 to-yellow-300",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-blue-700 via-blue-800 to-gray-900",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-green-300 to-purple-400",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-yellow-200 via-pink-200 to-pink-400",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-green-500 to-green-700",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-rose-400 via-fuchsia-500 to-indigo-500",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-sky-400 to-blue-500",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-green-200 via-green-400 to-green-500",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-red-400 via-gray-300 to-blue-500",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-gray-900 to-gray-600 bg-gradient-to-r",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-rose-500 via-red-400 to-red-500",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-fuchsia-600 to-pink-600",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-emerald-500 to-lime-600",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-rose-500 to-indigo-700",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br bg-gradient-to-tr from-violet-500 to-orange-300",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-gray-900 via-purple-900 to-violet-600",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-yellow-200 via-red-500 to-fuchsia-500",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-sky-400 to-indigo-900",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-amber-200 via-violet-600 to-sky-900",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-amber-700 via-orange-300 to-rose-800",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-gray-300 via-fuchsia-600 to-orange-600",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-fuchsia-500 via-red-600 to-orange-400",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-sky-400 via-rose-400 to-lime-400",
+  // biome-ignore lint/plugin/no-hardcoded-tailwind-palette: decorative gradient palette
   "bg-gradient-to-br from-lime-600 via-yellow-300 to-red-600",
 ];
 


### PR DESCRIPTION
OBJECTIVE: Enforce use of semantic color tokens from src/style/index.css over hardcoded Tailwind palette classes in frontend code.

CHANGES:
  - Add Biome GritQL plugin flagging hardcoded Tailwind palettes (e.g. bg-zinc-900, text-slate-500) in JS/TS/TSX
  - Refactor 8 files (knowledge ingestion UI, assistant panel, NodeStatus, etc.) to use semantic tokens (bg-accent-emerald, text-destructive, bg-error-red, …)
  - Suppress plugin per-line in styleUtils.ts for the intentional decorative gradient palette
  - Wire lint-js.yml into ci.yml as a required job gated on frontend path-filter
  - Add fetch-depth: 0 to checkout so `biome check --changed` can diff against main