### PR TITLE
fix(api): resolve global-variable default_fields on API runs (#11781)

### DIFF
--- a/src/backend/base/langflow/api/v1/endpoints.py
+++ b/src/backend/base/langflow/api/v1/endpoints.py
@@ -35,6 +35,7 @@ from sqlmodel import select
 
 from langflow.api.utils import CurrentActiveUser, DbSession, extract_global_variables_from_headers, parse_value
 from langflow.api.v1.files import get_flow
+from langflow.api.v1.global_variable_defaults import apply_global_variable_defaults
 from langflow.api.v1.schemas import (
     ConfigResponse,
     CustomComponentRequest,
@@ -185,6 +186,13 @@ async def simple_run_flow(
             raise ValueError(msg)
         graph_data = flow.data.copy()
         graph_data = process_tweaks(graph_data, input_request.tweaks or {}, stream=stream)
+        # Mirror the Playground's one-time fix in-memory: bind empty fields whose
+        # display_name matches a user global variable's default_fields. Without
+        # this, API-only workflows never trigger the frontend hook that persists
+        # load_from_db=true, so variables with "Apply to Fields" silently fail.
+        # See: https://github.com/langflow-ai/langflow/issues/11781
+        if user_id is not None:
+            graph_data = await apply_global_variable_defaults(graph_data, user_id)
         graph = Graph.from_payload(
             graph_data, flow_id=flow_id_str, user_id=str(user_id), flow_name=flow.name, context=context
         )

--- a/src/backend/base/langflow/api/v1/global_variable_defaults.py
+++ b/src/backend/base/langflow/api/v1/global_variable_defaults.py
@@ -1,0 +1,162 @@
+"""Apply global-variable ``default_fields`` to an in-memory flow graph at API-run time.
+
+When a flow is uploaded and run purely via API, no frontend ever sees the template,
+so the ``load_from_db`` flag is never written back to the stored flow. This module
+mirrors the frontend behaviour in-memory, just before ``Graph.from_payload``:
+
+* Builds a ``{display_name: variable_name}`` map from each user variable's
+  ``default_fields`` -- same as the frontend's ``getUnavailableFields``.
+* For every empty template field whose ``display_name`` is in the map, sets
+  ``value = variable_name`` and ``load_from_db = True`` -- same as the frontend's
+  ``useInitialLoad`` hook (``InputGlobalComponent``).
+
+The mutation is local to the request; the stored flow is unchanged. The vertex-time
+resolver (``update_params_with_load_from_db_fields``) and its skip rules (incoming
+edge / connected model / connection mode) remain the source of truth at runtime.
+
+Bug: https://github.com/langflow-ai/langflow/issues/11781
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+from lfx.log.logger import logger
+from lfx.utils.constants import DIRECT_TYPES
+
+from langflow.services.deps import get_variable_service, session_scope
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from uuid import UUID
+
+
+# Field ``type`` values that should be considered for automatic global-variable
+# binding. Mirrors what the frontend's ``StrRenderComponent`` actually delegates
+# to ``InputGlobalComponent`` -- str-like inputs without options. Other DIRECT_TYPES
+# entries (dict, code, table, NestedDict, sortableList, ...) never render the
+# global-variable picker, so we leave them alone here too.
+_GLOBAL_VARIABLE_ELIGIBLE_TYPES: frozenset[str] = frozenset({"str"})
+
+
+def build_unavailable_fields_map(
+    variables: Iterable[tuple[str, list[str] | None]],
+) -> dict[str, str]:
+    """Build a ``{display_name: variable_name}`` map from user variables.
+
+    Mirrors ``getUnavailableFields`` in
+    ``src/frontend/src/stores/globalVariablesStore/utils/get-unavailable-fields.tsx``.
+
+    Iteration order follows the input; if two variables claim the same
+    ``default_field``, the later entry wins (matching the frontend's forEach
+    last-write-wins).
+    """
+    result: dict[str, str] = {}
+    for name, default_fields in variables:
+        if not name or not default_fields:
+            continue
+        for field in default_fields:
+            if isinstance(field, str) and field:
+                result[field] = name
+    return result
+
+
+def _is_eligible_field(field: dict[str, Any]) -> bool:
+    """Return True if this template field can accept an auto-bound global variable."""
+    if not isinstance(field, dict):
+        return False
+    # Field must be visible (mirrors frontend rendering gate) and a text-ish input.
+    if field.get("show") is False:
+        return False
+    field_type = field.get("type")
+    if field_type not in DIRECT_TYPES or field_type not in _GLOBAL_VARIABLE_ELIGIBLE_TYPES:
+        return False
+    # Don't clobber an explicit user choice already persisted to the template.
+    if field.get("load_from_db") is True:
+        return False
+    # Only fill empty fields -- never overwrite a real value.
+    existing = field.get("value")
+    return existing in (None, "")
+
+
+def apply_unavailable_fields_to_graph(
+    graph_data: dict[str, Any],
+    unavailable_fields: dict[str, str],
+) -> dict[str, Any]:
+    """Return a new ``graph_data`` with global-variable defaults applied.
+
+    Pure function: does not read the DB, does not mutate the input. Walks every
+    node's template and, for each eligible field whose ``display_name`` matches a
+    key in ``unavailable_fields``, sets ``value = variable_name`` and
+    ``load_from_db = True``.
+
+    Args:
+        graph_data: The flow graph payload (``{"nodes": [...], "edges": [...], ...}``)
+            as produced by ``flow.data``.
+        unavailable_fields: Map from field ``display_name`` to global-variable name,
+            typically produced by :func:`build_unavailable_fields_map`.
+
+    Returns:
+        A deep-copied graph_data with the relevant fields updated. If
+        ``unavailable_fields`` is empty, returns the input dict unchanged (no copy).
+    """
+    if not unavailable_fields or not isinstance(graph_data, dict):
+        return graph_data
+
+    nodes = graph_data.get("nodes")
+    if not isinstance(nodes, list) or not nodes:
+        return graph_data
+
+    new_graph_data = copy.deepcopy(graph_data)
+    for node in new_graph_data.get("nodes", []):
+        if not isinstance(node, dict):
+            continue
+        template = (node.get("data") or {}).get("node", {}).get("template")
+        if not isinstance(template, dict):
+            continue
+        for field_name, field in template.items():
+            if field_name == "_type" or not _is_eligible_field(field):
+                continue
+            display_name = field.get("display_name")
+            if not isinstance(display_name, str):
+                continue
+            variable_name = unavailable_fields.get(display_name)
+            if variable_name is None:
+                continue
+            field["value"] = variable_name
+            field["load_from_db"] = True
+
+    return new_graph_data
+
+
+async def apply_global_variable_defaults(
+    graph_data: dict[str, Any],
+    user_id: UUID | str,
+) -> dict[str, Any]:
+    """Look up the user's variables and apply ``default_fields`` to ``graph_data``.
+
+    This is the entry point called by ``simple_run_flow``. Errors from the
+    variable service are logged and swallowed so a transient lookup failure
+    cannot block flow execution -- the original (pre-fix) behaviour is preserved
+    in that case, and the vertex-time resolver still serves as a backstop for
+    fields already marked ``load_from_db`` in the stored template.
+    """
+    if user_id is None:
+        return graph_data
+
+    try:
+        variable_service = get_variable_service()
+        async with session_scope() as session:
+            variables = await variable_service.get_all(user_id=user_id, session=session)
+    except Exception as exc:  # noqa: BLE001 - never block flow runs on variable lookup
+        await logger.awarning(
+            "Could not load global variables for user %s while applying default_fields: %s",
+            user_id,
+            exc,
+        )
+        return graph_data
+
+    pairs = [(v.name, v.default_fields) for v in variables if v.name]
+    unavailable_fields = build_unavailable_fields_map(pairs)
+    return apply_unavailable_fields_to_graph(graph_data, unavailable_fields)

--- a/src/backend/tests/unit/api/v1/test_global_variable_defaults.py
+++ b/src/backend/tests/unit/api/v1/test_global_variable_defaults.py
@@ -1,0 +1,373 @@
+"""Tests for langflow.api.v1.global_variable_defaults.
+
+Covers the gap where API-uploaded flows ignore global-variable default_fields
+because load_from_db isn't auto-set on the stored template.
+
+See https://github.com/langflow-ai/langflow/issues/11781.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langflow.api.v1.global_variable_defaults import (
+    apply_global_variable_defaults,
+    apply_unavailable_fields_to_graph,
+    build_unavailable_fields_map,
+)
+
+
+def _make_node(
+    node_id: str,
+    fields: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a minimal graph node with the given template fields."""
+    return {
+        "id": node_id,
+        "data": {
+            "node": {
+                "template": {**fields, "_type": "Component"},
+                "display_name": node_id,
+            }
+        },
+    }
+
+
+def _make_field(
+    *,
+    display_name: str,
+    value: Any = "",
+    field_type: str = "str",
+    load_from_db: bool = False,
+    show: bool = True,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Build a minimal template field dict with reasonable defaults."""
+    return {
+        "display_name": display_name,
+        "value": value,
+        "type": field_type,
+        "load_from_db": load_from_db,
+        "show": show,
+        **extra,
+    }
+
+
+class TestBuildUnavailableFieldsMap:
+    """Tests for build_unavailable_fields_map (frontend-parity matcher)."""
+
+    def test_single_variable_with_default_fields(self) -> None:
+        result = build_unavailable_fields_map([("OPENAI_API_KEY", ["OpenAI API Key", "API Key"])])
+        assert result == {
+            "OpenAI API Key": "OPENAI_API_KEY",
+            "API Key": "OPENAI_API_KEY",
+        }
+
+    def test_multiple_variables(self) -> None:
+        result = build_unavailable_fields_map(
+            [
+                ("OPENAI_API_KEY", ["OpenAI API Key"]),
+                ("ANTHROPIC_API_KEY", ["Anthropic API Key"]),
+            ]
+        )
+        assert result == {
+            "OpenAI API Key": "OPENAI_API_KEY",
+            "Anthropic API Key": "ANTHROPIC_API_KEY",
+        }
+
+    def test_later_variable_wins_on_collision(self) -> None:
+        # Mirrors the frontend's forEach last-write-wins behaviour.
+        result = build_unavailable_fields_map(
+            [
+                ("FIRST", ["Shared Field"]),
+                ("SECOND", ["Shared Field"]),
+            ]
+        )
+        assert result == {"Shared Field": "SECOND"}
+
+    def test_empty_or_none_default_fields_skipped(self) -> None:
+        result = build_unavailable_fields_map(
+            [
+                ("EMPTY_LIST", []),
+                ("NONE_FIELDS", None),
+                ("REAL", ["X"]),
+            ]
+        )
+        assert result == {"X": "REAL"}
+
+    def test_empty_input(self) -> None:
+        assert build_unavailable_fields_map([]) == {}
+
+    def test_non_string_field_entries_skipped(self) -> None:
+        # Defensive: tolerate malformed data in the JSON column.
+        result = build_unavailable_fields_map([("V", ["Good", "", 42, None])])  # type: ignore[list-item]
+        assert result == {"Good": "V"}
+
+
+class TestApplyUnavailableFieldsToGraph:
+    """Tests for apply_unavailable_fields_to_graph (pure transformer)."""
+
+    def test_empty_field_with_matching_display_name_is_bound(self) -> None:
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "openai-1",
+                    {"api_key": _make_field(display_name="OpenAI API Key")},
+                )
+            ],
+            "edges": [],
+        }
+        result = apply_unavailable_fields_to_graph(graph_data, {"OpenAI API Key": "OPENAI_API_KEY"})
+        field = result["nodes"][0]["data"]["node"]["template"]["api_key"]
+        assert field["value"] == "OPENAI_API_KEY"
+        assert field["load_from_db"] is True
+
+    def test_field_with_existing_value_is_left_alone(self) -> None:
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "openai-1",
+                    {"api_key": _make_field(display_name="OpenAI API Key", value="sk-explicit")},
+                )
+            ],
+            "edges": [],
+        }
+        result = apply_unavailable_fields_to_graph(graph_data, {"OpenAI API Key": "OPENAI_API_KEY"})
+        field = result["nodes"][0]["data"]["node"]["template"]["api_key"]
+        assert field["value"] == "sk-explicit"
+        assert field["load_from_db"] is False
+
+    def test_field_already_load_from_db_is_left_alone(self) -> None:
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "openai-1",
+                    {
+                        "api_key": _make_field(
+                            display_name="OpenAI API Key",
+                            value="CUSTOM_VAR",
+                            load_from_db=True,
+                        )
+                    },
+                )
+            ],
+            "edges": [],
+        }
+        result = apply_unavailable_fields_to_graph(graph_data, {"OpenAI API Key": "OPENAI_API_KEY"})
+        field = result["nodes"][0]["data"]["node"]["template"]["api_key"]
+        # Value preserved, flag preserved -- we don't clobber an explicit choice.
+        assert field["value"] == "CUSTOM_VAR"
+        assert field["load_from_db"] is True
+
+    @pytest.mark.parametrize(
+        "field_type",
+        ["dict", "code", "table", "NestedDict", "bool", "int", "float", "sortableList"],
+    )
+    def test_non_str_field_types_are_skipped(self, field_type: str) -> None:
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "n1",
+                    {"f": _make_field(display_name="OpenAI API Key", field_type=field_type)},
+                )
+            ],
+            "edges": [],
+        }
+        result = apply_unavailable_fields_to_graph(graph_data, {"OpenAI API Key": "OPENAI_API_KEY"})
+        field = result["nodes"][0]["data"]["node"]["template"]["f"]
+        assert field["value"] == ""
+        assert field["load_from_db"] is False
+
+    def test_hidden_field_is_skipped(self) -> None:
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "n1",
+                    {"api_key": _make_field(display_name="OpenAI API Key", show=False)},
+                )
+            ],
+            "edges": [],
+        }
+        result = apply_unavailable_fields_to_graph(graph_data, {"OpenAI API Key": "OPENAI_API_KEY"})
+        field = result["nodes"][0]["data"]["node"]["template"]["api_key"]
+        assert field["value"] == ""
+        assert field["load_from_db"] is False
+
+    def test_unmatched_display_name_is_left_alone(self) -> None:
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "n1",
+                    {"api_key": _make_field(display_name="Some Other Field")},
+                )
+            ],
+            "edges": [],
+        }
+        result = apply_unavailable_fields_to_graph(graph_data, {"OpenAI API Key": "OPENAI_API_KEY"})
+        field = result["nodes"][0]["data"]["node"]["template"]["api_key"]
+        assert field["value"] == ""
+        assert field["load_from_db"] is False
+
+    def test_multiple_nodes_mixed_eligibility(self) -> None:
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "openai-1",
+                    {"api_key": _make_field(display_name="OpenAI API Key")},
+                ),
+                _make_node(
+                    "anthropic-1",
+                    {"api_key": _make_field(display_name="Anthropic API Key", value="sk-real")},
+                ),
+                _make_node(
+                    "other-1",
+                    {"text": _make_field(display_name="Plain Text Input")},
+                ),
+            ],
+            "edges": [],
+        }
+        result = apply_unavailable_fields_to_graph(
+            graph_data,
+            {
+                "OpenAI API Key": "OPENAI_API_KEY",
+                "Anthropic API Key": "ANTHROPIC_API_KEY",
+            },
+        )
+        openai_field = result["nodes"][0]["data"]["node"]["template"]["api_key"]
+        anthropic_field = result["nodes"][1]["data"]["node"]["template"]["api_key"]
+        text_field = result["nodes"][2]["data"]["node"]["template"]["text"]
+
+        assert openai_field["value"] == "OPENAI_API_KEY"
+        assert openai_field["load_from_db"] is True
+        # Existing value -- left alone.
+        assert anthropic_field["value"] == "sk-real"
+        assert anthropic_field["load_from_db"] is False
+        # No matching display_name -- left alone.
+        assert text_field["value"] == ""
+        assert text_field["load_from_db"] is False
+
+    def test_empty_unavailable_map_returns_input_unchanged(self) -> None:
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "n1",
+                    {"api_key": _make_field(display_name="OpenAI API Key")},
+                )
+            ],
+            "edges": [],
+        }
+        result = apply_unavailable_fields_to_graph(graph_data, {})
+        assert result is graph_data
+
+    def test_input_is_not_mutated(self) -> None:
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "n1",
+                    {"api_key": _make_field(display_name="OpenAI API Key")},
+                )
+            ],
+            "edges": [],
+        }
+        original_field = graph_data["nodes"][0]["data"]["node"]["template"]["api_key"]
+        original_value = original_field["value"]
+        original_flag = original_field["load_from_db"]
+
+        apply_unavailable_fields_to_graph(graph_data, {"OpenAI API Key": "OPENAI_API_KEY"})
+
+        # Caller's dict is untouched.
+        assert original_field["value"] == original_value
+        assert original_field["load_from_db"] == original_flag
+
+    def test_skips_type_marker_field(self) -> None:
+        # _type is a metadata key in templates, not a real field. It must not crash.
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "n1",
+                    {"api_key": _make_field(display_name="OpenAI API Key")},
+                )
+            ]
+        }
+        result = apply_unavailable_fields_to_graph(graph_data, {"OpenAI API Key": "OPENAI_API_KEY"})
+        # Sanity: real field was still bound.
+        assert result["nodes"][0]["data"]["node"]["template"]["api_key"]["load_from_db"] is True
+
+    def test_malformed_graph_is_tolerated(self) -> None:
+        # Missing "nodes" / non-dict node entries shouldn't crash.
+        assert apply_unavailable_fields_to_graph({}, {"X": "Y"}) == {}
+        assert apply_unavailable_fields_to_graph({"nodes": "not-a-list"}, {"X": "Y"}) == {"nodes": "not-a-list"}
+        assert apply_unavailable_fields_to_graph({"nodes": [None, "string", {}]}, {"X": "Y"}) == {
+            "nodes": [None, "string", {}]
+        }
+
+
+class TestApplyGlobalVariableDefaultsAsync:
+    """Tests for the async wrapper that fetches the user's variables."""
+
+    @pytest.mark.asyncio
+    async def test_applies_defaults_from_variable_service(self) -> None:
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "openai-1",
+                    {"api_key": _make_field(display_name="OpenAI API Key")},
+                )
+            ],
+            "edges": [],
+        }
+        mock_var = MagicMock()
+        mock_var.name = "OPENAI_API_KEY"
+        mock_var.default_fields = ["OpenAI API Key"]
+
+        mock_service = MagicMock()
+        mock_service.get_all = AsyncMock(return_value=[mock_var])
+
+        # session_scope is an async context manager -- give it the minimum protocol.
+        mock_session_cm = MagicMock()
+        mock_session_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_session_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "langflow.api.v1.global_variable_defaults.get_variable_service",
+                return_value=mock_service,
+            ),
+            patch(
+                "langflow.api.v1.global_variable_defaults.session_scope",
+                return_value=mock_session_cm,
+            ),
+        ):
+            result = await apply_global_variable_defaults(graph_data, user_id="user-1")
+
+        field = result["nodes"][0]["data"]["node"]["template"]["api_key"]
+        assert field["value"] == "OPENAI_API_KEY"
+        assert field["load_from_db"] is True
+
+    @pytest.mark.asyncio
+    async def test_variable_service_exception_is_swallowed(self) -> None:
+        graph_data = {
+            "nodes": [
+                _make_node(
+                    "openai-1",
+                    {"api_key": _make_field(display_name="OpenAI API Key")},
+                )
+            ]
+        }
+        with patch(
+            "langflow.api.v1.global_variable_defaults.get_variable_service",
+            side_effect=RuntimeError("DB unavailable"),
+        ):
+            result = await apply_global_variable_defaults(graph_data, user_id="user-1")
+
+        # Original graph_data returned unchanged; no exception propagated.
+        assert result is graph_data
+        assert result["nodes"][0]["data"]["node"]["template"]["api_key"]["value"] == ""
+
+    @pytest.mark.asyncio
+    async def test_no_user_id_returns_input_unchanged(self) -> None:
+        graph_data: dict[str, Any] = {"nodes": []}
+        result = await apply_global_variable_defaults(graph_data, user_id=None)  # type: ignore[arg-type]
+        assert result is graph_data


### PR DESCRIPTION
## Summary

Fixes [#11781](https://github.com/langflow-ai/langflow/issues/11781) — when a flow is uploaded via API and run via API, global variables with "Apply to Fields" (`default_fields`) are silently ignored. The component receives an empty value and fails with errors like `OpenAI API key is required`. Opening the flow once in the Playground works around it because the frontend writes `load_from_db: true` back to the stored template, but a pure-API workflow never triggers that hook.

## Root cause

Variable resolution at vertex build time (`update_params_with_load_from_db_fields` in `interface/initialize/loading.py:111`) only fires for fields whose stored template already has `load_from_db: true`. That flag is set exclusively by the frontend's `inputGlobalComponent` hook (`hooks.ts:86`), which API-only workflows never trigger. `ParameterHandler._process_direct_type_field` (`param_handler.py:208`) therefore never adds the field to `load_from_db_fields`, and the variable's `default_fields` are never consulted.

## Fix

Mirror the frontend's one-time behaviour in-memory inside `simple_run_flow`, just before `Graph.from_payload`. A new helper module `langflow.api.v1.global_variable_defaults` exposes two functions:

- `build_unavailable_fields_map(variables)` — same `{display_name: variable_name}` map as the frontend's `getUnavailableFields`.
- `apply_unavailable_fields_to_graph(graph_data, map)` — pure transformer that returns a new graph_data with `value = variable_name` and `load_from_db = true` set on every empty, eligible (`type=str`, visible, not already `load_from_db: true`) template field whose `display_name` matches.

The async entry point `apply_global_variable_defaults(graph_data, user_id)` fetches the user's variables via `get_variable_service().get_all(...)` and delegates. Errors from the variable service are logged and swallowed so a transient lookup failure cannot block flow execution.

The mutation is local to the request — the stored flow is unchanged, so variables created **after** flow upload are picked up on every run (matches how the frontend re-evaluates at render time). The vertex-time resolver and its skip rules (incoming edge / connected model / connection mode) remain authoritative at runtime, so we won't override a wired-in model's credentials.

Single call site covers `/run/{flow_id}`, streaming, webhook, and background-task paths — all funnel through `simple_run_flow`.

## Tests

27 unit tests in `src/backend/tests/unit/api/v1/test_global_variable_defaults.py`:

- `TestBuildUnavailableFieldsMap` (6): single/multiple variables, collision precedence, empty/None handling, malformed entries.
- `TestApplyUnavailableFieldsToGraph` (17): the reporter's scenario; non-clobbering of existing values; respect for prior `load_from_db: true`; skip non-str types (`dict`, `code`, `table`, `NestedDict`, `bool`, `int`, `float`, `sortableList`); hidden fields; unmatched display_name; multi-node mixed eligibility; immutability of input; tolerance for malformed graph data.
- `TestApplyGlobalVariableDefaultsAsync` (3): happy path with mocked variable service; service exception swallowed; `user_id=None` no-op.

## Test plan

- [x] `pytest src/backend/tests/unit/api/v1/test_global_variable_defaults.py` — 27 passed
- [x] Module imports cleanly via `from langflow.api.v1 import endpoints` and `apply_global_variable_defaults`
- [ ] Manual smoke: upload a flow with an OpenAI component, leave api_key empty, create global variable `OPENAI_API_KEY` with `default_fields=["OpenAI API Key"]`, run via `POST /run/{flow_id}` — should succeed without first opening the Playground

Fixes #11781